### PR TITLE
Fix ASSIGNED status automatic computation

### DIFF
--- a/src/Change.php
+++ b/src/Change.php
@@ -179,8 +179,6 @@ class Change extends CommonITILObject
                     $input = $this->setTechAndGroupFromItilCategory($input);
                     break;
             }
-
-            $input = $this->assign($input);
         }
 
         return $input;

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8273,6 +8273,7 @@ abstract class CommonITILObject extends CommonDBTM
      */
     protected function assign(array $input)
     {
+        // FIXME Deprecate this method in GLPI 10.1.
         if (!in_array(self::ASSIGNED, array_keys($this->getAllStatusArray()))) {
             return $input;
         }

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -312,8 +312,6 @@ class Problem extends CommonITILObject
                     $input = $this->setTechAndGroupFromItilCategory($input);
                     break;
             }
-
-            $input = $this->assign($input);
         }
 
         return $input;

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1912,8 +1912,6 @@ class Ticket extends CommonITILObject
                     $input = $this->setTechAndGroupFromHardware($input, $item);
                     break;
             }
-
-            $input = $this->assign($input);
         }
 
         if (!isset($input['_skip_sla_assign']) || $input['_skip_sla_assign'] === false) {

--- a/tests/functionnal/ITILSolution.php
+++ b/tests/functionnal/ITILSolution.php
@@ -81,6 +81,7 @@ class ITILSolution extends DbTestCase
         ]))->isGreaterThan(0);
 
         $this->boolean($ticket->isNewItem())->isFalse();
+        $this->boolean($ticket->getFromDB($ticket->getID()))->isTrue(); //reload from DB
         $this->variable($ticket->getField('status'))->isIdenticalTo($ticket::ASSIGNED);
 
         $solution = new \ITILSolution();
@@ -184,6 +185,7 @@ class ITILSolution extends DbTestCase
         ]))->isGreaterThan(0);
 
         $this->boolean($problem->isNewItem())->isFalse();
+        $this->boolean($problem->getFromDB($problem->getID()))->isTrue(); //reload from DB
         $this->variable($problem->getField('status'))->isIdenticalTo($problem::ASSIGNED);
 
         $solution = new \ITILSolution();
@@ -303,6 +305,7 @@ class ITILSolution extends DbTestCase
         ]))->isGreaterThan(0);
 
         $this->boolean($ticket->isNewItem())->isFalse();
+        $this->boolean($ticket->getFromDB($ticket->getID()))->isTrue(); //reload from DB
         $this->variable($ticket->getField('status'))->isIdenticalTo($ticket::ASSIGNED);
 
         $solution = new \ITILSolution();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12120, #12131

The switch from `NEW` to `ASSIGNED` is now done on `post_addItem/post_updateItem` methods, based on new actors detected.
This existing call is not required anymore. Thus, as existing actors are always defined in `$input[*_assign]` when update is done from UI, the check was wrong as it was also considering already assigned actors as a new assignment.