### PR TITLE
Ticket validation: restrict auto scroll

### DIFF
--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -1074,7 +1074,8 @@ abstract class CommonITILValidation extends CommonDBChild
 
         TemplateRenderer::getInstance()->display('components/itilobject/timeline/form_validation.html.twig', [
             'item'      => $options['parent'],
-            'subitem'   => $this
+            'subitem'   => $this,
+            'scroll'    => true,
         ]);
 
         return true;

--- a/templates/components/itilobject/timeline/form_validation.html.twig
+++ b/templates/components/itilobject/timeline/form_validation.html.twig
@@ -254,8 +254,10 @@
          </form>
       </div>
 
-      <script type="text/javascript">
-        window.scrollTo(0,document.body.scrollHeight);
-      </script>
+      {% if scroll %}
+         <script type="text/javascript">
+            window.scrollTo(0,document.body.scrollHeight);
+         </script>
+      {% endif %}
    {% endif %}
 {% endblock %}


### PR DESCRIPTION
Some js code from the `from_validation.html.twig` template execute a scroll to the bottom of the page when the new validation form is opened:

![image](https://user-images.githubusercontent.com/42734840/177529780-b6212299-a906-4a8c-b07a-1c926bd0a963.png)

However, it isn't restricted properly as this scroll effect also happens on the ticket timeline.
This happens because we load the validation form as it can also be shown directly in the timeline using this action:

![image](https://user-images.githubusercontent.com/42734840/177530183-da237393-1e27-4e18-8e81-3a2e2eaad60a.png)

IMO, this shouldn't happen as the js code is kinda run "by accident".
If we want to keep the scrolling behavior on the timeline, it should be implemented somewhere else properly and not be caused by some unrelated validation code.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
