### PR TITLE
Timeline: limit items size

### DIFF
--- a/css/includes/components/itilobject/_timeline.scss
+++ b/css/includes/components/itilobject/_timeline.scss
@@ -99,7 +99,7 @@
     .timeline-content {
         position: relative;
         border-top-left-radius: 0;
-        max-width: 100%;
+        max-width: 700px;
         word-break: break-word;
 
         @include media-breakpoint-up(sm) {


### PR DESCRIPTION
There is currently no limits to the size of timeline items:

![image](https://user-images.githubusercontent.com/42734840/177546770-64099930-e1da-423d-9027-36e2687a1a28.png)

This isn't recommended because long lines are hard to follow and read properly.

After adding a 700px hard limit (almost 90 chars max, which is still quite generous):

![image](https://user-images.githubusercontent.com/42734840/177546936-dd763bc0-8fa3-4a06-956f-c3ecec26e952.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
