### PR TITLE
Fix missing no status column

### DIFF
--- a/src/Project.php
+++ b/src/Project.php
@@ -2171,7 +2171,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
             ];
         } else {
             // Avoid fetching everything when nothing is needed
-            return [];
+            return $columns;
         }
         $items      = self::getDataToDisplayOnKanban($ID, $criteria);
 

--- a/src/Project.php
+++ b/src/Project.php
@@ -2169,9 +2169,6 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
             $criteria = [
                 'projectstates_id'   => $column_ids
             ];
-        } else {
-            // Avoid fetching everything when nothing is needed
-            return $columns;
         }
         $items      = self::getDataToDisplayOnKanban($ID, $criteria);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The "No Status" column should always be sent to the Project Kanban.