### PR TITLE
Add option to reset Kanban state

### DIFF
--- a/ajax/kanban.php
+++ b/ajax/kanban.php
@@ -220,6 +220,11 @@ if (($_POST['action'] ?? null) === 'update') {
         'timestamp' => $_SESSION['glpi_currenttime']
     ];
     echo json_encode($response, JSON_FORCE_OBJECT);
+} else if ($_REQUEST['action'] === 'clear_column_state') {
+    $checkParams(['items_id']);
+    $result = Item_Kanban::clearStateForItem($_REQUEST['itemtype'], $_REQUEST['items_id']);
+    http_response_code($result ? 200 : 500);
+    return;
 } else if ($_REQUEST['action'] === 'list_columns') {
     $checkParams(['column_field']);
     header("Content-Type: application/json; charset=UTF-8", true);

--- a/js/modules/Kanban/Kanban.js
+++ b/js/modules/Kanban/Kanban.js
@@ -35,7 +35,7 @@ import SearchInput from "../SearchTokenizer/SearchInput.js";
 
 /* global escapeMarkupText */
 /* global sortable */
-/* global glpi_toast_error */
+/* global glpi_toast_error, glpi_confirm */
 
 /**
  * Kanban rights structure
@@ -519,12 +519,29 @@ class GLPIKanbanRights {
 
         const buildToolbar = function() {
             $(self.element).trigger('kanban:pre_build_toolbar');
+            const extra_toolbar_options = [];
+
             let toolbar = $("<div class='kanban-toolbar card flex-column flex-md-row'></div>").appendTo(self.element);
             $("<select name='kanban-board-switcher'></select>").appendTo(toolbar);
             let filter_input = $(`<input name='filter' class='form-control ms-1' type='text' placeholder="${__('Search or filter results')}" autocomplete="off"/>`).appendTo(toolbar);
             if (self.rights.canModifyView()) {
                 let add_column = "<button class='kanban-add-column btn btn-outline-secondary ms-1'>" + __('Add column') + "</button>";
                 toolbar.append(add_column);
+                extra_toolbar_options.push(`
+                <li class="dropdown-item cursor-pointer" data-action="clearState">
+                    <span>
+                      <i class="ti ti-trash"></i>${__('Reset view')}
+                   </span>
+                </li>
+                `);
+            }
+
+            if (extra_toolbar_options.length > 0) {
+                toolbar.append(`<button type="button" class="btn btn-outline-secondary ms-1 kanban-extra-toolbar-options"><i class="ti ti-dots-vertical"></i></button>`);
+                let extra_toolbar_dropdown = "<ul class='kanban-dropdown dropdown-menu kanban-extra-toolbar-options-menu' style='display: none'>";
+                extra_toolbar_dropdown += extra_toolbar_options.join('');
+                extra_toolbar_dropdown += '</ul>';
+                toolbar.append(extra_toolbar_dropdown);
             }
 
             self.filter_input = new SearchInput(filter_input, {
@@ -718,6 +735,11 @@ class GLPIKanbanRights {
                         }
                     }
                 }
+                if ($(e.target).closest(self.element + ' .kanban-extra-toolbar-options').length === 0) {
+                    $(self.element + ' .kanban-extra-toolbar-options-menu').css({
+                        display: 'none'
+                    });
+                }
             });
 
             if (Object.keys(self.supported_itemtypes).length > 0) {
@@ -823,6 +845,30 @@ class GLPIKanbanRights {
             $(self.element).on('click', '.kanban-add-column', function() {
                 refreshAddColumnForm();
             });
+            $(self.element).on('click', '.kanban-extra-toolbar-options', (e) => {
+                const toolbar = $(self.element + ' .kanban-toolbar');
+                const dropdown_element = $(e.currentTarget).siblings('.kanban-extra-toolbar-options-menu');
+                dropdown_element.css({
+                    display: 'block',
+                    position: 'fixed',
+                    left: toolbar.offset().left + toolbar.outerWidth(true) - dropdown_element.outerWidth(true),
+                    top: (toolbar.offset().top + toolbar.outerHeight(true)) - 10
+                });
+            });
+            const extra_toolbar_options_menu = $(self.element + ' .kanban-extra-toolbar-options-menu');
+            extra_toolbar_options_menu.on('click', 'li', (e) => {
+                const option = $(e.currentTarget);
+                if (option.attr('data-action') === 'clearState' && self.rights.canModifyView()) {
+                    glpi_confirm({
+                        title: __('Reset view'),
+                        message: __('Resetting the view will reset the shown columns and remove custom card ordering'),
+                        confirm_callback: () => {
+                            clearState();
+                        }
+                    });
+                }
+            });
+
             $(self.add_column_form).on('input', "input[name='column-name-filter']", function() {
                 const filter_input = $(this);
                 $(self.add_column_form + ' li').hide();
@@ -1048,7 +1094,7 @@ class GLPIKanbanRights {
                     display: 'block',
                     position: 'fixed',
                     left: toolbar.offset().left + toolbar.outerWidth(true) - column_dialog.outerWidth(true),
-                    top: toolbar.offset().top + toolbar.outerHeight(true)
+                    top: (toolbar.offset().top + toolbar.outerHeight(true)) - 10
                 });
             });
         };
@@ -2668,6 +2714,23 @@ class GLPIKanbanRights {
                 if (always) {
                     always();
                 }
+            });
+        };
+
+        const clearState = () => {
+            $.ajax({
+                type: "POST",
+                url: (self.ajax_root + "kanban.php"),
+                data: {
+                    action: "clear_column_state",
+                    itemtype: self.item.itemtype,
+                    items_id: self.item.items_id
+                }
+            }).done(function() {
+                // Reload page
+                window.location.reload();
+            }).fail(function() {
+                glpi_toast_error(__('Failed to reset Kanban view'), __('Error'));
             });
         };
 

--- a/src/Item_Kanban.php
+++ b/src/Item_Kanban.php
@@ -1,5 +1,7 @@
 <?php
 
+use Glpi\Features\Kanban;
+
 /**
  * ---------------------------------------------------------------------
  *
@@ -134,6 +136,33 @@ class Item_Kanban extends CommonDBRelation
         } else {
            // State is not saved
             return [];
+        }
+    }
+
+    /**
+     * Clear the state of a Kanban's columns for a specific item for the current user or globally.
+     * @since 10.1.0
+     * @param string $itemtype Type of the item.
+     * @param int $items_id ID of the item.
+     * @return bool True if successful
+     */
+    public static function clearStateForItem(string $itemtype, int $items_id)
+    {
+        global $DB;
+
+        try {
+            /** @var Kanban|CommonDBTM $item */
+            $item = new $itemtype();
+            $item->getFromDB($items_id);
+            $force_global = $item->forceGlobalState();
+
+            return (bool) $DB->delete('glpi_items_kanbans', [
+                'users_id' => $force_global ? 0 : Session::getLoginUserID(),
+                'itemtype' => $itemtype,
+                'items_id' => $items_id
+            ]);
+        } catch (\Exception $e) {
+            return false;
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In some cases, the Kanban state may become corrupt or the user may want to reset it for some other reason and there is no way for it to be cleared except directly in the database.
If the user can modify the state, an option will show in the toolbar to reset the view now.
Resetting the view will reset the shown columns and remove custom card ordering.