### PR TITLE
maintain sync between itil object and its state in DB

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8177,6 +8177,7 @@ abstract class CommonITILObject extends CommonDBTM
                             '_from_assignment'                => true
                         ]
                     );
+                    $this->fields['status'] = $self->fields['status'];
                 }
             }
             // Update existing actors

--- a/tests/functionnal/ITILSolution.php
+++ b/tests/functionnal/ITILSolution.php
@@ -81,7 +81,6 @@ class ITILSolution extends DbTestCase
         ]))->isGreaterThan(0);
 
         $this->boolean($ticket->isNewItem())->isFalse();
-        $this->boolean($ticket->getFromDB($ticket->getID()))->isTrue(); //reload from DB
         $this->variable($ticket->getField('status'))->isIdenticalTo($ticket::ASSIGNED);
 
         $solution = new \ITILSolution();
@@ -185,7 +184,6 @@ class ITILSolution extends DbTestCase
         ]))->isGreaterThan(0);
 
         $this->boolean($problem->isNewItem())->isFalse();
-        $this->boolean($problem->getFromDB($problem->getID()))->isTrue(); //reload from DB
         $this->variable($problem->getField('status'))->isIdenticalTo($problem::ASSIGNED);
 
         $solution = new \ITILSolution();
@@ -305,7 +303,6 @@ class ITILSolution extends DbTestCase
         ]))->isGreaterThan(0);
 
         $this->boolean($ticket->isNewItem())->isFalse();
-        $this->boolean($ticket->getFromDB($ticket->getID()))->isTrue(); //reload from DB
         $this->variable($ticket->getField('status'))->isIdenticalTo($ticket::ASSIGNED);
 
         $solution = new \ITILSolution();


### PR DESCRIPTION
This PR avoid the need to reload tickets, change or problem to get ots final status after creation

see https://github.com/glpi-project/glpi/pull/12149


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
