### PR TITLE
fix(search): do not display managmement port from list (NetworkPortAggregate)

### DIFF
--- a/src/NetworkName.php
+++ b/src/NetworkName.php
@@ -228,8 +228,13 @@ class NetworkName extends FQDNLabel
             'forcegroupby'       => true,
             'massiveaction'      => false,
             'joinparams'         => [
-                'jointype'  => 'mainitemtype_mainitem',
-                'condition' => ['NEWTABLE.is_deleted' => 0]
+                'jointype'  => 'itemtype_item',
+                'specific_itemtype' => NetworkName::getType(),
+                'condition' => ['NEWTABLE.is_deleted' => 0],
+                'beforejoin' => [
+                    'table'      => 'glpi_networknames',
+                    'joinparams' => $joinparams
+                ]
             ]
         ];
 

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1415,11 +1415,11 @@ class NetworkPort extends CommonDBChild
 
         $networkNameJoin = ['jointype'          => 'itemtype_item',
             'specific_itemtype' => 'NetworkPort',
-             'condition'        => ['NEWTABLE.is_deleted' => 0 ,
-                                    'NOT' => [
-                                        'REFTABLE.instantiation_type'  => NetworkPortAggregate::getType()
-                                        ]
-                                    ],
+            'condition'        => ['NEWTABLE.is_deleted' => 0 ,
+                'NOT' => [
+                    'REFTABLE.instantiation_type'  => NetworkPortAggregate::getType()
+                ]
+            ],
             'beforejoin'        => ['table'      => 'glpi_networkports',
                 'joinparams' => $joinparams
             ]

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1415,7 +1415,11 @@ class NetworkPort extends CommonDBChild
 
         $networkNameJoin = ['jointype'          => 'itemtype_item',
             'specific_itemtype' => 'NetworkPort',
-            'condition'         => ['NEWTABLE.is_deleted' => 0],
+             'condition'        => ['NEWTABLE.is_deleted' => 0 ,
+                                    'NOT' => [
+                                        'REFTABLE.instantiation_type'  => NetworkPortAggregate::getType()
+                                        ]
+                                    ],
             'beforejoin'        => ['table'      => 'glpi_networkports',
                 'joinparams' => $joinparams
             ]


### PR DESCRIPTION
From Asset list, GLPI display all IPAddress.

Management port (NetworkPortAggregate) are displayed too 

This PR exclude ```NetworkPortAggregate``` from list.

Before : 
![image](https://user-images.githubusercontent.com/7335054/177948561-f80f22db-dabc-4598-908b-b18848269d4e.png)



After : 
![image](https://user-images.githubusercontent.com/7335054/177948308-3444298f-41e6-4fd5-8611-9881859f0715.png)




| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
