### PR TITLE
fix(search): do not display MAC related to NetworkPortAggregate

### DIFF
--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1399,7 +1399,11 @@ class NetworkPort extends CommonDBChild
             'datatype'           => 'mac',
             'forcegroupby'       => true,
             'massiveaction'      => false,
-            'joinparams'         => $joinparams
+            'joinparams'         => ['jointype' => 'itemtype_item',
+            'condition'          => ['NOT' => [
+                                        'instantiation_type'  => NetworkPortAggregate::getType()
+                                        ]
+                                    ],]
         ];
 
         $tab[] = [


### PR DESCRIPTION
Do not display MAC related to NetworkPortAggregate

Before : 
![image](https://user-images.githubusercontent.com/7335054/177950464-bb68a69f-108e-4db5-b570-b5ac28fa4d83.png)


After : 
![image](https://user-images.githubusercontent.com/7335054/177950341-a59f58ab-3cf9-4514-a46d-07a929d8a6a3.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
