### PR TITLE
fix(search): prevent error for ambigous column

### DIFF
--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1401,7 +1401,7 @@ class NetworkPort extends CommonDBChild
             'massiveaction'      => false,
             'joinparams'         => ['jointype' => 'itemtype_item',
                 'condition' => ['NOT' => [
-                    'instantiation_type'  => NetworkPortAggregate::getType()
+                    'NEWTABLE.instantiation_type'  => NetworkPortAggregate::getType()
                 ]
                 ],
             ]


### PR DESCRIPTION
Fix ambigous column when trying to display ```IP``` and ```MAC```

Before : 
![image](https://user-images.githubusercontent.com/7335054/178006836-383ff4d2-d6ad-4f9d-bc0c-f7c25bc90d88.png)

After : 
![image](https://user-images.githubusercontent.com/7335054/178006920-42e1dd21-2344-4393-a562-9c3b03970302.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
