### PR TITLE
Fix duplicate click handlers for Kanban team management

### DIFF
--- a/js/modules/Kanban/Kanban.js
+++ b/js/modules/Kanban/Kanban.js
@@ -2490,6 +2490,10 @@ class GLPIKanbanRights {
             <button type="button" name="add" class="btn btn-primary">${_x('button', 'Add')}</button>
          `;
             const modal = $('#kanban-modal');
+            // Remove old click handlers
+            modal.off('click', 'button[name="add"]');
+            modal.off('click', 'button[name="delete"]');
+
             modal.on('click', 'button[name="add"]', () => {
                 const itemtype = modal.find('select[name="itemtype"]').val();
                 const items_id = modal.find('select[name="items_id"]').val();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Each time the team member modal was shown, a new click handler was added for the related card instead of replacing the existing handlers. This led to an issue where team members could be added to the wrong cards or a non-fatal issue where duplicate team members were added to the same card item.