### PR TITLE
Display message with ID of ticket for all ITIL Objects

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -2557,6 +2557,19 @@ abstract class CommonITILObject extends CommonDBTM
         $this->manageValidationAdd($this->input);
 
         parent::post_addItem();
+        
+        if (isset($_SESSION['glpiis_ids_visible']) && !$_SESSION['glpiis_ids_visible']) {
+                __('%1$s (%2$s)'),
+                __('Your ticket has been registered.'),
+            Session::addMessageAfterRedirect(sprintf(
+                sprintf(
+                    __('%1$s: %2$s'),
+                    $this->getTypeName(1),
+                    "<a href='" . $this->getFormURLWithID($this->fields['id']) . "'>" .
+                    $this->fields['id'] . "</a>"
+                )
+            ));
+        }
     }
 
     /**

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -2559,11 +2559,10 @@ abstract class CommonITILObject extends CommonDBTM
         parent::post_addItem();
         
         if (isset($_SESSION['glpiis_ids_visible']) && !$_SESSION['glpiis_ids_visible']) {
-                __('%1$s (%2$s)'),
-                __('Your ticket has been registered.'),
             Session::addMessageAfterRedirect(sprintf(
+                __('%1$s: %2$s'),
+                __('Your ticket has been registered.'),
                 sprintf(
-                    __('%1$s: %2$s'),
                     $this->getTypeName(1),
                     "<a href='" . $this->getFormURLWithID($this->fields['id']) . "'>" .
                     $this->fields['id'] . "</a>"

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2120,19 +2120,6 @@ class Ticket extends CommonITILObject
             }
             NotificationEvent::raiseEvent($type, $this);
         }
-
-        if (isset($_SESSION['glpiis_ids_visible']) && !$_SESSION['glpiis_ids_visible']) {
-            Session::addMessageAfterRedirect(sprintf(
-                __('%1$s (%2$s)'),
-                __('Your ticket has been registered.'),
-                sprintf(
-                    __('%1$s: %2$s'),
-                    Ticket::getTypeName(1),
-                    "<a href='" . Ticket::getFormURLWithID($this->fields['id']) . "'>" .
-                    $this->fields['id'] . "</a>"
-                )
-            ));
-        }
     }
 
 


### PR DESCRIPTION
Display ID of opened ticket for all ITIL Objects not just Tickets (in case it is not displayed by glpiis_ids_visible).
Message still contains "Your ticket has been registered". Or should we use $this->getTypeName(1) instead of ticket?

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A


