### PR TITLE
Dashboard: fix 'myself' search criteria in generated URLs

### DIFF
--- a/src/Dashboard/Provider.php
+++ b/src/Dashboard/Provider.php
@@ -1758,16 +1758,19 @@ class Provider
 
         if (
             isset($apply_filters['user_tech'])
-            && (int) $apply_filters['user_tech'] > 0
+            && (
+                (int) $apply_filters['user_tech'] > 0
+                || $apply_filters['user_tech'] == 'myself'
+            )
         ) {
             if ($DB->fieldExists($table, 'users_id_tech')) {
                 $s_criteria['criteria'][] = [
                     'link'       => 'AND',
                     'field'      => self::getSearchOptionID($table, 'users_id_tech', 'glpi_users'),// tech
                     'searchtype' => 'equals',
-                    'value'      =>  (int) $apply_filters['user_tech']
+                    'value'      =>  (int) $apply_filters['user_tech'] ?: (int) Session::getLoginUserID()
                 ];
-            } else if (
+            } elseif (
                 in_array($table, [
                     Ticket::getTable(),
                     Change::getTable(),
@@ -1778,7 +1781,7 @@ class Provider
                     'link'       => 'AND',
                     'field'      => 5,// tech
                     'searchtype' => 'equals',
-                    'value'      =>  (int) $apply_filters['user_tech']
+                    'value'      =>  (int) $apply_filters['user_tech'] ?: $apply_filters['user_tech']
                 ];
             }
         }

--- a/src/Dashboard/Provider.php
+++ b/src/Dashboard/Provider.php
@@ -1768,7 +1768,7 @@ class Provider
                     'link'       => 'AND',
                     'field'      => self::getSearchOptionID($table, 'users_id_tech', 'glpi_users'),// tech
                     'searchtype' => 'equals',
-                    'value'      =>  (int) $apply_filters['user_tech'] ?: (int) Session::getLoginUserID()
+                    'value'      =>  $apply_filters['user_tech'] == 'myself' ? (int) Session::getLoginUserID() : (int) $apply_filters['user_tech']
                 ];
             } elseif (
                 in_array($table, [
@@ -1781,7 +1781,7 @@ class Provider
                     'link'       => 'AND',
                     'field'      => 5,// tech
                     'searchtype' => 'equals',
-                    'value'      =>  (int) $apply_filters['user_tech'] ?: $apply_filters['user_tech']
+                    'value'      =>  is_numeric($apply_filters['user_tech']) ? (int) $apply_filters['user_tech'] : $apply_filters['user_tech']
                 ];
             }
         }


### PR DESCRIPTION
Let's take the following dashboard:

![image](https://user-images.githubusercontent.com/42734840/178437598-4e6fb178-b09d-498f-b81f-f49004dbceab.png)

Clicking on the card send you to the wrong search page (default search):

![image](https://user-images.githubusercontent.com/42734840/178437995-c1acd2a4-877c-4585-b1d8-e295c6c45fd6.png)

After fix, the links take you to the correct search:

![image](https://user-images.githubusercontent.com/42734840/178437638-ec8aab31-ba93-470b-b7ee-5bd2ac71c73b.png)

This issue also indirectly impacted the advanced dashboard plugin, as it allow users to create cards from search results.
This "search results" cards would show the wrong data if the `myself` criteria was used, as they rely on the search options to apply the filter to their content.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24446
