### PR TITLE
Clean unwanted tags in collected email

### DIFF
--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -1746,6 +1746,18 @@ class MailCollector extends CommonDBTM
                     $content = $body_matches['body'];
                 }
 
+                // Strip <style> and <script> tags located in HTML body.
+                // They could be neutralized by RichText::getSafeHtml(), but their content would be displayed,
+                // and end-user would probably prefer having them completely removed.
+                $content = preg_replace(
+                    [
+                        '/<style[^>]*>.*?<\/style>/s',
+                        '/<script[^>]*>.*?<\/script>/s',
+                    ],
+                    '',
+                    $content
+                );
+
                 // do not check for text part if we found html one.
                 break;
             }

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -312,7 +312,7 @@ class Toolbox
     public static function getHtmLawedSafeConfig(): array
     {
         $config = [
-            'elements'           => '* -applet -canvas -embed -form -object -script -link',
+            'elements'           => '* -applet -canvas -embed -form -object -script -link -meta',
             'deny_attribute'     => 'on*, srcdoc',
             'comment'            => 1, // 1: remove HTML comments (and do not display their contents)
             'cdata'              => 1, // 1: remove CDATA sections (and do not display their contents)

--- a/tests/emails-tests/33-html-with-unwanted-tags-inside-body.eml
+++ b/tests/emails-tests/33-html-with-unwanted-tags-inside-body.eml
@@ -1,0 +1,42 @@
+Date: Thu, 7 Jun 2018 12:05:51 +0200 (CEST)
+From: Normal User <normal@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>
+Message-ID: <1695134010.1757889.1528365951040.JavaMail.zimbra@glpi-project.org>
+Subject: 33 - HTML message with unwanted tags inside body tag
+MIME-Version: 1.0
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  </head>
+  <body dir="auto">
+    <p>This HTML message constains style, scripts and meta tags.</p>
+    <style>
+      p, li, div {
+        font-size: 12px;
+        font-family: sans-serif;
+      }
+    </style>
+    <p>It also contains text,</p>
+    <style type="text/css">
+      p {
+        text-decoration: underline;
+      }
+    </style>
+    <p>between</p>
+    <script type="text/javascript">
+      p {
+        text-decoration: underline;
+      }
+    </script>
+    <p>these unwanted</p>
+    <script>
+      p {
+        text-decoration: underline;
+      }
+    </script>
+    <p>tags.</p>
+  </body>
+</html>

--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -698,6 +698,7 @@ class MailCollector extends DbTestCase
                     '30 - &#60;GLPI&#62; Special &#38; chars',
                     '31 - HTML message without body',
                     '32 - HTML message with attributes on body tag',
+                    '33 - HTML message with unwanted tags inside body tag',
                 ]
             ],
          // Mails having "normal" user as observer (add_cc_to_observer = true)
@@ -740,6 +741,17 @@ This HTML message does not have a <i>body</i> tag.
 HTML,
             '32 - HTML message with attributes on body tag' => <<<HTML
 This HTML message has an attribut on its <i>body</i> tag.
+HTML,
+            '33 - HTML message with unwanted tags inside body tag' => <<<HTML
+<p>This HTML message constains style, scripts and meta tags.</p>
+    
+    <p>It also contains text,</p>
+    
+    <p>between</p>
+    
+    <p>these unwanted</p>
+    
+    <p>tags.</p>
 HTML,
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | see #12184

Sometimes, collected email contains `<style>` in their body. If we do not remove them, they may be applied to the whole GLPI interface when corresponding ticket is displayed.