### PR TITLE
fix(link): do not generate link for NetworkPortAggregate

### DIFF
--- a/src/Link.php
+++ b/src/Link.php
@@ -418,6 +418,20 @@ class Link extends CommonDBTM
                         'glpi_ipaddresses.name AS ip',
                     ],
                     'FROM'   => 'glpi_networknames',
+                    'JOIN' => [
+                        'glpi_networkports'   => [
+                            'ON' => [
+                                'glpi_networkports'   => 'id',
+                                'glpi_networknames'  => 'networkports_id', [
+                                    'AND' => [
+                                        'NOT' => [
+                                            'glpi_networkports.instantiation_type'  => NetworkPortAggregate::getType()
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ],
                     'INNER JOIN'   => [
                         'glpi_ipaddresses'   => [
                             'ON' => [
@@ -482,7 +496,10 @@ class Link extends CommonDBTM
                 ],
                 'WHERE'        => [
                     'glpi_networkports.items_id'  => $item->getID(),
-                    'glpi_networkports.itemtype'  => $item->getType()
+                    'glpi_networkports.itemtype'  => $item->getType(),
+                    'NOT' => [
+                        'glpi_networkports.instantiation_type'  => NetworkPortAggregate::getType()
+                    ]
                 ]
             ]);
             foreach ($iterator as $data2) {
@@ -500,7 +517,10 @@ class Link extends CommonDBTM
                 'FROM'   => 'glpi_networkports',
                 'WHERE'  => [
                     'glpi_networkports.items_id'  => $item->getID(),
-                    'glpi_networkports.itemtype'  => $item->getType()
+                    'glpi_networkports.itemtype'  => $item->getType(),
+                    'NOT' => [
+                        'glpi_networkports.instantiation_type'  => NetworkPortAggregate::getType()
+                    ]
                 ],
                 'GROUP' => 'glpi_networkports.mac'
             ];


### PR DESCRIPTION

related to 
https://github.com/glpi-project/glpi/pull/12172
https://github.com/glpi-project/glpi/pull/12171

External links take care about ```NetxorkPortaggregate```

This PR prevent this

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |  https://github.com/glpi-project/glpi-inventory-plugin/issues/187
