### PR TITLE
revert(commit): revert fix for duplicate IP / MAC

### DIFF
--- a/src/NetworkName.php
+++ b/src/NetworkName.php
@@ -228,13 +228,8 @@ class NetworkName extends FQDNLabel
             'forcegroupby'       => true,
             'massiveaction'      => false,
             'joinparams'         => [
-                'jointype'  => 'itemtype_item',
-                'specific_itemtype' => NetworkName::getType(),
-                'condition' => ['NEWTABLE.is_deleted' => 0],
-                'beforejoin' => [
-                    'table'      => 'glpi_networknames',
-                    'joinparams' => $joinparams
-                ]
+                'jointype'  => 'mainitemtype_mainitem',
+                'condition' => ['NEWTABLE.is_deleted' => 0]
             ]
         ];
 

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1399,12 +1399,7 @@ class NetworkPort extends CommonDBChild
             'datatype'           => 'mac',
             'forcegroupby'       => true,
             'massiveaction'      => false,
-            'joinparams'         => ['jointype' => 'itemtype_item',
-                'condition' => ['NOT' => [
-                    'NEWTABLE.instantiation_type'  => NetworkPortAggregate::getType()
-                ]
-                ],
-            ]
+            'joinparams'         => $joinparams
         ];
 
         $tab[] = [
@@ -1420,11 +1415,7 @@ class NetworkPort extends CommonDBChild
 
         $networkNameJoin = ['jointype'          => 'itemtype_item',
             'specific_itemtype' => 'NetworkPort',
-            'condition'        => ['NEWTABLE.is_deleted' => 0 ,
-                'NOT' => [
-                    'REFTABLE.instantiation_type'  => NetworkPortAggregate::getType()
-                ]
-            ],
+            'condition'         => ['NEWTABLE.is_deleted' => 0],
             'beforejoin'        => ['table'      => 'glpi_networkports',
                 'joinparams' => $joinparams
             ]


### PR DESCRIPTION
revert fix for duplicate IP and MAC from ```Printer``` list

This behavior is not due to GLPI, but rather of the native inventory which add 
port management (```ǸetworkPortAggregate``` even if IP is known from list port IPs)

revert : 
https://github.com/glpi-project/glpi/pull/12176
https://github.com/glpi-project/glpi/pull/12172
https://github.com/glpi-project/glpi/pull/12171

See : https://github.com/glpi-project/glpi/pull/12197

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
