### PR TITLE
Force display of ID for all ITIL Objects in CommonDBTB without any specific message

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1469,8 +1469,9 @@ class CommonDBTM extends CommonGLPI
                     $this->fields['id']
                 );
             }
-            $display = (isset($this->input['_no_message_link']) ? $this->getNameID()
-                                                            : $this->getLink());
+            $opt = [ 'forceid' => $this instanceof CommonITILObject ];
+            $display = (isset($this->input['_no_message_link']) ? $this->getNameID($opt)
+                                                            : $this->getLink($opt));
 
            // Do not display quotes
            //TRANS : %s is the description of the added item

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2120,19 +2120,6 @@ class Ticket extends CommonITILObject
             }
             NotificationEvent::raiseEvent($type, $this);
         }
-
-        if (isset($_SESSION['glpiis_ids_visible']) && !$_SESSION['glpiis_ids_visible']) {
-            Session::addMessageAfterRedirect(sprintf(
-                __('%1$s (%2$s)'),
-                __('Your ticket has been registered.'),
-                sprintf(
-                    __('%1$s: %2$s'),
-                    Ticket::getTypeName(1),
-                    "<a href='" . Ticket::getFormURLWithID($this->fields['id']) . "'>" .
-                    $this->fields['id'] . "</a>"
-                )
-            ));
-        }
     }
 
 

--- a/tests/functionnal/ProjectTask.php
+++ b/tests/functionnal/ProjectTask.php
@@ -164,13 +164,6 @@ class ProjectTask extends DbTestCase
         $this->boolean($ticket->isNewItem())->isFalse();
         $tid = (int)$ticket->fields['id'];
 
-        $this->hasSessionMessages(
-            INFO,
-            [
-                "Your ticket has been registered. (Ticket: <a href='" . \Ticket::getFormURLWithID($tid) . "'>$tid</a>)"
-            ]
-        );
-
         $ttask = new \TicketTask();
         $ttask_id = (int)$ttask->add([
             'name'               => 'A ticket task in bounds',

--- a/tests/functionnal/TicketTask.php
+++ b/tests/functionnal/TicketTask.php
@@ -65,13 +65,6 @@ class TicketTask extends DbTestCase
         $this->boolean($ticket->isNewItem())->isFalse();
         $tid = (int)$ticket->fields['id'];
 
-        $this->hasSessionMessages(
-            INFO,
-            [
-                "Your ticket has been registered. (Ticket: <a href='" . \Ticket::getFormURLWithID($tid) . "'>$tid</a>)"
-            ]
-        );
-
         return ($as_object ? $ticket : $tid);
     }
 


### PR DESCRIPTION
Display ID of opened ticket for all ITIL Objects not just Tickets in Common code with forceid option.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N.A

