### PR TITLE
E-mails with no message-ids block retrieving by collector

### DIFF
--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -1476,12 +1476,9 @@ class MailCollector extends CommonDBTM
             $subject = '';
         }
 
-       // secu on message_id setting
-        try {
-            $message_id = $message->getHeader('message_id')->getFieldValue();
-        } catch (Laminas\Mail\Storage\Exception\InvalidArgumentException $e) {
-            $message_id = '';
-        }  
+        $message_id = $message->getHeaders()->has('message-id')
+            ? $message->getHeader('message-id')->getFieldValue()
+            : 'MISSING_ID_' . sha1($message->getHeaders()->toString());
 
         $mail_details = [
             'from'       => Toolbox::strtolower($sender_email),

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -1476,12 +1476,19 @@ class MailCollector extends CommonDBTM
             $subject = '';
         }
 
+       // secu on message_id setting
+        try {
+            $message_id = $message->getHeader('message_id')->getFieldValue();
+        } catch (Laminas\Mail\Storage\Exception\InvalidArgumentException $e) {
+            $message_id = '';
+        }  
+
         $mail_details = [
             'from'       => Toolbox::strtolower($sender_email),
             'subject'    => $subject,
             'reply-to'   => $reply_to_addr !== null ? Toolbox::strtolower($reply_to_addr) : null,
             'to'         => $to !== null ? Toolbox::strtolower($to) : null,
-            'message_id' => $message->getHeader('message_id')->getFieldValue(),
+            'message_id' => $message_id,
             'tos'        => $tos,
             'ccs'        => $ccs,
             'date'       => $date

--- a/tests/emails-tests/34-no-message-id-header.eml
+++ b/tests/emails-tests/34-no-message-id-header.eml
@@ -1,0 +1,9 @@
+Date: Thu, 7 Jun 2018 12:05:51 +0200 (CEST)
+From: Normal User <normal@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>
+Subject: 34 - Message with no MessageID header
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+Message with no MessageID header

--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -699,6 +699,7 @@ class MailCollector extends DbTestCase
                     '31 - HTML message without body',
                     '32 - HTML message with attributes on body tag',
                     '33 - HTML message with unwanted tags inside body tag',
+                    '34 - Message with no MessageID header',
                 ]
             ],
          // Mails having "normal" user as observer (add_cc_to_observer = true)


### PR DESCRIPTION
RFC 2822 says in 3.6.4 that though optional, every message SHOULD have a "Message-ID:" field, but sometimes emails have not this field, a Laminas exception is raised in the collecting process and the whole emails queue stops getting imported into GLPI.

So the idea is to catch Laminas exception during mail collector action as it is already done for the Subject field.

The same issue can be observed in both 9.5 and 10 GLPI branches.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
