### PR TITLE
Enhance sanitizer performances

### DIFF
--- a/tests/units/Glpi/Toolbox/Sanitizer.php
+++ b/tests/units/Glpi/Toolbox/Sanitizer.php
@@ -102,6 +102,21 @@ class Sanitizer extends \GLPITestCase
             'htmlencoded_value' => '&#60;p&#62;HTML containing a code snippet&#60;/p&#62;&#60;pre&#62;&#38;lt;a href=&#38;quot;/test&#38;quot;&#38;gt;link&#38;lt;/a&#38;gt;&#60;/pre&#62;',
             'dbescaped_value'   => '<p>HTML containing a code snippet</p><pre>&lt;a href=&quot;/test&quot;&gt;link&lt;/a&gt;</pre>',
         ];
+        yield [
+            'value'             => 'text many backslashes ' . str_repeat('\\', 3), // 3 backslashes
+            'sanitized_value'   => 'text many backslashes ' . str_repeat('\\', 6), // escaped to 6 backslashes
+            'htmlencoded_value' => 'text many backslashes ' . str_repeat('\\', 3),
+            'dbescaped_value'   => 'text many backslashes ' . str_repeat('\\', 6),
+        ];
+
+        // Long string with many escapable chars should not be a problem
+        $multiplier = 100000;
+        yield [
+            'value'             => str_repeat("<strong>text with slashable chars ' \n \"</strong>", $multiplier),
+            'sanitized_value'   => str_repeat("&#60;strong&#62;text with slashable chars \' \\n \\\"&#60;/strong&#62;", $multiplier),
+            'htmlencoded_value' => str_repeat("&#60;strong&#62;text with slashable chars ' \n \"&#60;/strong&#62;", $multiplier),
+            'dbescaped_value'   => str_repeat("<strong>text with slashable chars \' \\n \\\"</strong>", $multiplier),
+        ];
 
         // Strings in array should be sanitized
         yield [
@@ -127,7 +142,7 @@ class Sanitizer extends \GLPITestCase
             'sanitized_value' => ['itemtype' => 'Glpi\Dashboard\Dashboard'],
         ];
 
-        //  syntax should not be sanitized
+        // callable syntax should not be sanitized
         yield [
             'value'           => 'Glpi\Socket:update',
             'sanitized_value' => 'Glpi\Socket:update',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12184

We had 2 performances issues on Sanitizer logic.

1. During sanitize/unsanitize operations, string was parsed char by char using `for ($i = 0; $i < strlen($value); $i++) {`. For all these parsing operations, as we know which char we are searching for, using a `while (($i = strpos($value, $char, $i)) !== false) { ... $i++ }` loop is more efficient.

2. During unsanitize operation, a call to `substr_replace()` was made for every char to unescape. In #12184, the string to handle is 4.5MB length and is containing 120 000 escaped chars (60 000 `\r\n`), so with previous logic, we were doing 120 000 chars replacement on a 4.5MB string and reaffect the result to the same variable.
With new logic, the result is build by concat operations, which are done really fast, even on large strings. On my machine, for the new test case, `tests\units\Glpi\Toolbox\Sanitizer::testUnanitize()` was done in 10 minutes with previous logic, and is done in less than 5 seconds with new logic.