### PR TITLE
Enable Pending button for isAllowed status

### DIFF
--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -209,7 +209,7 @@
                         <i class="fas fa-plus"></i>
                         <span>{{ _x('button', 'Add') }}</span>
                      </button>
-                     {% if get_current_interface() == 'central' %}
+                     {% if get_current_interface() == 'central' and item.isAllowedStatus(item.fields['status'], constant('CommonITILObject::WAITING')) %}
                         <span class="input-group-text bg-yellow-lt py-0 pe-0" id="pending-reasons-control-{{ rand }}">
                            <span class="d-inline-flex align-items-center" title="{{ __("Set the status to pending") }}"
                                  data-bs-toggle="tooltip" data-bs-placement="top" role="button">


### PR DESCRIPTION
Allow Pending status just in case Pending is allowed in Matrix as target status

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12214 
