### PR TITLE
Remove getSpecificValue from Problem

### DIFF
--- a/src/Problem.php
+++ b/src/Problem.php
@@ -660,56 +660,6 @@ class Problem extends CommonITILObject
     }
 
     /**
-     * @since 0.84
-     *
-     * @param $field
-     * @param $values
-     * @param $options   array
-     **/
-    public static function getSpecificValueToDisplay($field, $values, array $options = [])
-    {
-
-        if (!is_array($values)) {
-            $values = [$field => $values];
-        }
-
-        switch ($field) {
-            case 'status':
-                return Problem::getStatus($values[$field]);
-        }
-        return parent::getSpecificValueToDisplay($field, $values, $options);
-    }
-
-
-    /**
-     * @since 0.84
-     *
-     * @param $field
-     * @param $name            (default '')
-     * @param $values          (default '')
-     * @param $options   array
-     *
-     * @return string
-     **/
-    public static function getSpecificValueToSelect($field, $name = '', $values = '', array $options = [])
-    {
-
-        if (!is_array($values)) {
-            $values = [$field => $values];
-        }
-        $options['display'] = false;
-
-        switch ($field) {
-            case 'status':
-                return Problem::dropdownStatus(['name' => $name,
-                    'value' => $values[$field],
-                    'display' => false
-                ]);
-        }
-        return parent::getSpecificValueToSelect($field, $name, $values, $options);
-    }
-
-    /**
      * get the problem status list
      *
      * @param $withmetaforsearch  boolean  (false by default)


### PR DESCRIPTION
getSpecificValueToDisplay and getSpecificValueToSelect does not contain any specifics for Problems
CommonITILObject is defining everything necessary

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #12217
