### PR TITLE
Correct isAllowedStatus return code for non-existent statuses

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -3176,7 +3176,7 @@ abstract class CommonITILObject extends CommonDBTM
                 static::STATUS_MATRIX_FIELD,
                 $_SESSION['glpiactiveprofile']
             )
-            && self::isStatusExists($new)
+            && static::isStatusExists($new)
         ) { // maybe not set for post-only
             return true;
         }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -3176,6 +3176,7 @@ abstract class CommonITILObject extends CommonDBTM
                 static::STATUS_MATRIX_FIELD,
                 $_SESSION['glpiactiveprofile']
             )
+            && isStatusExists($new)
         ) { // maybe not set for post-only
             return true;
         }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -3176,7 +3176,7 @@ abstract class CommonITILObject extends CommonDBTM
                 static::STATUS_MATRIX_FIELD,
                 $_SESSION['glpiactiveprofile']
             )
-            && isStatusExists($new)
+            && self::isStatusExists($new)
         ) { // maybe not set for post-only
             return true;
         }


### PR DESCRIPTION
Fix return value of isAllowedStatus in case status does not exist for given ITIL Object


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11561 
