### PR TITLE
Impact analysis: fix dirty workspace icon

### DIFF
--- a/js/impact.js
+++ b/js/impact.js
@@ -2414,8 +2414,6 @@ var GLPIImpact = {
         $(GLPIImpact.selectors.save).removeClass('dirty');
         $(GLPIImpact.selectors.save).removeClass('clean'); // Needed for animations if the workspace is not dirty
         $(GLPIImpact.selectors.save).addClass('clean');
-        $(GLPIImpact.selectors.save).find('i').removeClass("fas fa-exclamation-triangle");
-        $(GLPIImpact.selectors.save).find('i').addClass("fas fa-check");
     },
 
     /**
@@ -2424,8 +2422,6 @@ var GLPIImpact = {
     showDirtyWorkspaceStatus: function() {
         $(GLPIImpact.selectors.save).removeClass('clean');
         $(GLPIImpact.selectors.save).addClass('dirty');
-        $(GLPIImpact.selectors.save).find('i').removeClass("fas fa-check");
-        $(GLPIImpact.selectors.save).find('i').addClass("fas fa-exclamation-triangle");
     },
 
     /**


### PR DESCRIPTION
Before: 

![image](https://user-images.githubusercontent.com/42734840/179479669-484d325d-0e75-4606-a40b-59d61507d3e1.png)

After: 

![image](https://user-images.githubusercontent.com/42734840/179479707-7c69ae63-dd08-4299-8168-c187d16492d0.png)

The removed code seems to be some obsolete icon changes, probably forgot to remove it.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
