### PR TITLE
Drop PHP 7.4 support

### DIFF
--- a/.github/workflows/branch_build.yml
+++ b/.github/workflows/branch_build.yml
@@ -6,7 +6,7 @@ on:
       php-version:
         description: "PHP version"
         required: true
-        default: "7.4"
+        default: "8.0"
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {php-version: "7.4"} # Lint on lower PHP version to detected too early usage of new syntaxes
+          - {php-version: "8.0"} # Lint on lower PHP version to detected too early usage of new syntaxes
           - {php-version: "8.1"} # Lint on higher PHP version to detected deprecated elements usage
     env:
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml"
@@ -107,7 +107,6 @@ jobs:
           - {php-version: "8.1", db-image: "mysql:8.0", always: true}
           # test other PHP versions
           - {php-version: "8.0", db-image: "mariadb:10.8", always: false}
-          - {php-version: "7.4", db-image: "mariadb:10.8", always: false}
           # test other DB servers/versions
           - {php-version: "8.1", db-image: "mariadb:10.2", always: false}
           - {php-version: "8.1", db-image: "mysql:5.7", always: false}

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -22,7 +22,7 @@ jobs:
           # build on lower supported version to ensure building tools are compatible with this version
           - {branch: "9.5/bugfixes", php-version: "7.2"}
           - {branch: "10.0/bugfixes", php-version: "7.4"}
-          - {branch: "main", php-version: "7.4"}
+          - {branch: "main", php-version: "8.0"}
     services:
       app:
         image: "ghcr.io/glpi-project/githubactions-php:${{ matrix.php-version }}"

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ It is distributed under the GNU GENERAL PUBLIC LICENSE Version 3 - please consul
 
     | GLPI Version | Minimum PHP | Maximum PHP |
     | ------------ | ----------- | ----------- |
-    | 9.4.X        | 5.6         | 7.4         |
     | 9.5.X        | 7.2         | 8.0         |
     | 10.0.X       | 7.4         | 8.1         |
+    | 10.1.X       | 8.0         | 8.1         |
 * Mandatory PHP extensions:
     - dom, fileinfo, json, session, simplexml (these are enabled in PHP by default)
     - curl (access to remote resources, like inventory agents, marketplace API, RSS feeds, ...)

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "docs": "https://github.com/glpi-project/doc"
     },
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.0",
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-fileinfo": "*",
@@ -96,7 +96,7 @@
     "config": {
         "optimize-autoloader": true,
         "platform": {
-            "php": "7.4.0"
+            "php": "8.0.0"
         },
         "sort-packages": true
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "88a8f1bb0e3b1c3678961789960cfc39",
+    "content-hash": "d4a69c0a0e6f449f9a2771ed5e554d11",
     "packages": [
         {
             "name": "blueimp/jquery-file-upload",
@@ -870,7 +870,7 @@
             "authors": [
                 {
                     "name": "Santosh Patnaik",
-                    "email": "drpatnaik@yahoo.com",
+                    "email": "drpatnaikREMOVEALLCAPS@yahoo.com",
                     "role": "Developer"
                 }
             ],
@@ -5991,7 +5991,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4",
+        "php": ">=8.0",
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-fileinfo": "*",
@@ -6008,7 +6008,7 @@
         "ext-xml": "*"
     },
     "platform-overrides": {
-        "php": "7.4.0"
+        "php": "8.0.0"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/inc/define.php
+++ b/inc/define.php
@@ -52,7 +52,7 @@ if (!defined('GLPI_MARKETPLACE_PRERELEASES')) {
     define('GLPI_MARKETPLACE_PRERELEASES', preg_match('/-(dev|alpha\d*|beta\d*|rc\d*)$/', GLPI_VERSION) === 1);
 }
 
-define('GLPI_MIN_PHP', '7.4.0'); // Must also be changed in top of index.php
+define('GLPI_MIN_PHP', '8.0.0'); // Must also be changed in top of index.php
 define('GLPI_MAX_PHP', '8.2.0'); // (Exclusive) Must also be changed in top of index.php
 define('GLPI_YEAR', '2022');
 

--- a/index.php
+++ b/index.php
@@ -36,10 +36,10 @@
 // Check PHP version not to have trouble
 // Need to be the very fist step before any include
 if (
-    version_compare(PHP_VERSION, '7.4.0', '<') ||
+    version_compare(PHP_VERSION, '8.0.0', '<') ||
     version_compare(PHP_VERSION, '8.2.0', '>=')
 ) {
-    die('PHP 7.4.0 - 8.2.0 (exclusive) required');
+    die('PHP 8.0.0 - 8.2.0 (exclusive) required');
 }
 
 use Glpi\Application\View\TemplateRenderer;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -153,7 +153,7 @@ fi
 APPLICATION_ROOT=$(readlink -f "$WORKING_DIR/..")
 [[ ! -z "$APP_CONTAINER_HOME" ]] || APP_CONTAINER_HOME=$(mktemp -d -t glpi-tests-home-XXXXXXXXXX)
 [[ ! -z "$DB_IMAGE" ]] || DB_IMAGE=githubactions-mysql:8.0
-[[ ! -z "$PHP_IMAGE" ]] || PHP_IMAGE=githubactions-php:7.4
+[[ ! -z "$PHP_IMAGE" ]] || PHP_IMAGE=githubactions-php:8.0
 
 # Backup configuration files
 BACKUP_DIR=$(mktemp -d -t glpi-tests-backup-XXXXXXXXXX)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

PHP 7.4 support ends on november. We could drop support of this version in GLPI 10.1 which will be released after this date.