### PR TITLE
Ignore invalid mail headers in mail collector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -121,11 +121,13 @@
         "lint": "parallel-lint  --exclude files --exclude marketplace --exclude plugins --exclude vendor --exclude tools/vendor .",
         "post-install-cmd": [
             "@php -r \"file_put_contents('.composer.hash', sha1_file('composer.lock'));\"",
-            "@php -f vendor/bin/build_hw_jsons"
+            "@php -f vendor/bin/build_hw_jsons",
+            "patch -f -p1 -d vendor/laminas/laminas-mail/ < tools/patches/laminas-mail-invalid-header-ignore.patch || true"
         ],
         "post-update-cmd": [
             "@php -r \"file_put_contents('.composer.hash', sha1_file('composer.lock'));\"",
-            "@php -f vendor/bin/build_hw_jsons"
+            "@php -f vendor/bin/build_hw_jsons",
+            "patch -f -p1 -d vendor/laminas/laminas-mail/ < tools/patches/laminas-mail-invalid-header-ignore.patch || true"
         ],
         "build": [
             "bin/console dependencies install && bin/console locales:compile"

--- a/tests/emails-tests/35-message-with-some-invalid-headers.eml
+++ b/tests/emails-tests/35-message-with-some-invalid-headers.eml
@@ -1,0 +1,10 @@
+Date: Thu, 7 Jun 2018 12:05:51 +0200 (CEST)
+X-Invalid-Encoding: ⤏ is not a valid char ⤎
+From: Normal User <normal@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>
+Subject: 35 - Message with some invalid headers
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+This message has some invalid headers, but it should collected anyways.

--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -700,6 +700,7 @@ class MailCollector extends DbTestCase
                     '32 - HTML message with attributes on body tag',
                     '33 - HTML message with unwanted tags inside body tag',
                     '34 - Message with no MessageID header',
+                    '35 - Message with some invalid headers',
                 ]
             ],
          // Mails having "normal" user as observer (add_cc_to_observer = true)
@@ -754,6 +755,9 @@ HTML,
     
     <p>tags.</p>
 HTML,
+            '35 - Message with some invalid headers' => <<<PLAINTEXT
+This message has some invalid headers, but it should collected anyways.
+PLAINTEXT,
         ];
 
         foreach ($actors_specs as $actor_specs) {

--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -586,7 +586,7 @@ class MailCollector extends DbTestCase
         $this->doConnect();
         $this->collector->maxfetch_emails = 1000; // Be sure to fetch all mails from test suite
 
-        $expected_errors = [
+        $expected_logged_errors = [
             // 05-empty-from.eml
             'The input is not a valid email address. Use the basic format local-part@hostname' => LogLevel::CRITICAL,
             // 17-malformed-email.eml
@@ -596,12 +596,20 @@ class MailCollector extends DbTestCase
         $msg = null;
         $this->output(
             function () use (&$msg) {
-                $msg = $this->collector->collect($this->mailgate_id);
+                $this->when(
+                    function () use (&$msg) {
+                        $msg = $this->collector->collect($this->mailgate_id);
+                    }
+                )
+                ->error()
+                    ->withType(E_USER_WARNING)
+                    ->withMessage('Invalid header "X-Invalid-Encoding"')
+                    ->exists();
             }
-        )->matches('/^(.*\n){' . count($expected_errors) . '}$/'); // Ensure that output has same count of lines than expected error count
+        )->matches('/^(.*\n){' . count($expected_logged_errors) . '}$/'); // Ensure that output has same count of lines than expected error count
 
         // Check error log and clean it (to prevent test failure, see GLPITestCase::afterTestMethod()).
-        foreach ($expected_errors as $error_message => $error_level) {
+        foreach ($expected_logged_errors as $error_message => $error_level) {
             $this->hasPhpLogRecordThatContains($error_message, $error_level);
         }
 

--- a/tools/patches/laminas-mail-invalid-header-ignore.patch
+++ b/tools/patches/laminas-mail-invalid-header-ignore.patch
@@ -1,0 +1,26 @@
+diff --git a/src/Headers.php b/src/Headers.php
+index 23475bc..8cdb76f 100644
+--- a/src/Headers.php
++++ b/src/Headers.php
+@@ -278,10 +278,17 @@ class Headers implements Countable, Iterator
+         }
+ 
+         if ($fieldValue === null) {
+-            $headers = $this->loadHeader($headerFieldNameOrLine);
+-            $headers = is_array($headers) ? $headers : [$headers];
+-            foreach ($headers as $header) {
+-                $this->addHeader($header);
++            try {
++                $headers = $this->loadHeader($headerFieldNameOrLine);
++                $headers = is_array($headers) ? $headers : [$headers];
++                foreach ($headers as $header) {
++                    $this->addHeader($header);
++                }
++            } catch (\Laminas\Mail\Header\Exception\InvalidArgumentException $e) {
++                // Header line cannot be parsed, ignore it and add a warning
++                $parts = explode(':', $headerFieldNameOrLine, 2);
++                $msg = count($parts) !== 2 ? $e->getMessage() : sprintf('Invalid header "%s"', $parts[0]);
++                trigger_error($msg, E_USER_WARNING);
+             }
+         } elseif (is_array($fieldValue)) {
+             foreach ($fieldValue as $i) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1st commit is made to ensure that added test case triggers a failure (see https://github.com/glpi-project/glpi/runs/7407454092).
2nd commit fixes the issue, by patching laminas-mail to ignore invalid headers, instead of throwing an exception.