### PR TITLE
Fix 'Support' system user migration

### DIFF
--- a/install/migrations/update_9.5.x_to_10.0.0/pendingreason.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/pendingreason.php
@@ -97,16 +97,17 @@ if (empty($config['system_user'])) {
     if ($user->getFromDBbyName($system_user_name)) {
         $system_user_name .= '-' . Toolbox::getRandomString(8);
     }
-    $id = $user->add([
-        'name'     => $system_user_name,
-        'realname' => 'Support',
-    ]);
-
-    if (!$id) {
+    $system_user_params = [
+        'name'          => $system_user_name,
+        'realname'      => 'Support',
+        'password'      => '',
+        'authtype'      => 1,
+    ];
+    if (!$DB->insert('glpi_users', $system_user_params)) {
         die("Can't add 'glpi-system' user");
     }
 
-    Config::setConfigurationValues('core', ['system_user' => $id]);
+    Config::setConfigurationValues('core', ['system_user' => $DB->insertId()]);
 }
 
 // Add crontask for auto bump and auto solve


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fixes following non blocking error during migration to 10.0.0.
```
SQL Error "1054": Unknown column 'is_global' in 'where clause' in query "SELECT * FROM `glpi_lockedfields` WHERE `itemtype` = 'Profile_User' AND ((`items_id` = '0' OR `is_global` = '1'))"
```

This error was due to usage of `User::add()`, which seemed to create a dynamic profile. The `is_dynamic` attribute presence on `Profile_User::add()` was trigerring a call to `Lockedfield::getLocks()` in `CommonDBTM::cleanLockedsOnAdd()`.

There is maybe something to enhance in `CommonDBTM` to prevent usage of `Lockedfield` logic on `Group_User`, `Profile_User` and `UserEmail` items, but the easier way to fix the initial issue is to create the `Support` system user using directly `DBmysql::add()`, as it is done during install process.