### PR TITLE
Drop support of MySQL 5.7 and MariaDB 10.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,9 +108,7 @@ jobs:
           # test other PHP versions
           - {php-version: "8.0", db-image: "mariadb:10.8", always: false}
           # test other DB servers/versions
-          - {php-version: "8.1", db-image: "mariadb:10.2", always: false}
-          - {php-version: "8.1", db-image: "mysql:5.7", always: false}
-          - {php-version: "8.1", db-image: "percona:5.7", always: false}
+          - {php-version: "8.1", db-image: "mariadb:10.3", always: false}
           - {php-version: "8.1", db-image: "percona:8.0", always: false}
     env:
       # Skip jobs that should not be always run on pull requests or on push on tier repository (to limit workers usage).

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ It is distributed under the GNU GENERAL PUBLIC LICENSE Version 3 - please consul
 ## Prerequisites
 
 * A web server (Apache, Nginx, IIS, etc.)
-* MariaDB >= 10.2 or MySQL >= 5.7
+* MariaDB >= 10.3 or MySQL >= 8.0
 * PHP (See compatibility matrix below)
 
     | GLPI Version | Minimum PHP | Maximum PHP |

--- a/src/Config.php
+++ b/src/Config.php
@@ -2805,10 +2805,10 @@ HTML;
         $server  = preg_match('/-MariaDB/', $raw) ? 'MariaDB' : 'MySQL';
         $version = preg_replace('/^((\d+\.?)+).*$/', '$1', $raw);
 
-       // MySQL >= 5.7 || MariaDB >= 10.2
+        // MySQL >= 8.0 || MariaDB >= 10.3
         $is_supported = $server === 'MariaDB'
-         ? version_compare($version, '10.2', '>=')
-         : version_compare($version, '5.7', '>=');
+            ? version_compare($version, '10.3', '>=')
+            : version_compare($version, '8.0', '>=');
 
         return [$version => $is_supported];
     }

--- a/src/System/Requirement/DbConfiguration.php
+++ b/src/System/Requirement/DbConfiguration.php
@@ -57,17 +57,7 @@ class DbConfiguration extends AbstractRequirement
 
     protected function check()
     {
-        $version = preg_replace('/^((\d+\.?)+).*$/', '$1', $this->db->getVersion());
-
-       // "innodb_large_prefix" was required for "utf8mb4" indexes of VARCHAR(255) on older DB versions.
-       // This variable has been removed in MySQL 8.0 and in MariaDB 10.3.
-        $check_large_prefix = version_compare($version, '8.0', '<') // MySQL
-         || (version_compare($version, '10.0', '>=') && version_compare($version, '10.3', '<')); // MariaDB
-
         $query = 'SELECT @@GLOBAL.' . $this->db->quoteName('innodb_page_size as innodb_page_size');
-        if ($check_large_prefix) {
-            $query .= ', @@GLOBAL.' . $this->db->quoteName('innodb_large_prefix as innodb_large_prefix');
-        }
 
         if (($db_config_res = $this->db->query($query)) === false) {
             $this->validated = false;
@@ -77,9 +67,6 @@ class DbConfiguration extends AbstractRequirement
         $db_config = $db_config_res->fetch_assoc();
 
         $incompatibilities = [];
-        if ($check_large_prefix && (int)$db_config['innodb_large_prefix'] == 0) {
-            $incompatibilities[] = __('"innodb_large_prefix" must be enabled.');
-        }
         if ((int)$db_config['innodb_page_size'] < 8192) {
             $incompatibilities[] = '"innodb_page_size" must be >= 8KB.';
         }

--- a/src/System/Requirement/DbEngine.php
+++ b/src/System/Requirement/DbEngine.php
@@ -62,11 +62,11 @@ class DbEngine extends AbstractRequirement
 
         switch ($server) {
             case 'MariaDB':
-                $min_version = '10.2';
+                $min_version = '10.3';
                 break;
             case 'MySQL':
             default:
-                $min_version = '5.7';
+                $min_version = '8.0';
                 break;
         }
         $is_supported = version_compare($version, $min_version, '>=');

--- a/tests/functionnal/Config.php
+++ b/tests/functionnal/Config.php
@@ -463,7 +463,7 @@ class Config extends DbTestCase
             ], [
                 'raw'       => '10.2.14-MariaDB',
                 'version'   => '10.2.14',
-                'compat'    => true
+                'compat'    => false
             ], [
                 'raw'       => '10.3.28-MariaDB',
                 'version'   => '10.3.28',
@@ -477,13 +477,17 @@ class Config extends DbTestCase
                 'version'   => '10.5.9',
                 'compat'    => true
             ], [
+                'raw'       => '10.6.7-MariaDB-1:10.6.7-2ubuntu1.1',
+                'version'   => '10.6.7',
+                'compat'    => true
+            ], [
                 'raw'       => '5.6.38-log',
                 'version'   => '5.6.38',
                 'compat'    => false
             ],  [
                 'raw'       => '5.7.50-log',
                 'version'   => '5.7.50',
-                'compat'    => true
+                'compat'    => false
             ], [
                 'raw'       => '8.0.23-standard',
                 'version'   => '8.0.23',

--- a/tests/units/Glpi/System/Requirement/DbConfiguration.php
+++ b/tests/units/Glpi/System/Requirement/DbConfiguration.php
@@ -41,33 +41,6 @@ class DbConfiguration extends \GLPITestCase
     {
         return [
             [
-            // Default variables on MySQL 5.7
-                'version'   => '5.7.34-standard',
-                'variables' => [
-                    'innodb_file_format'  => 'Barracuda',
-                    'innodb_large_prefix' => 1,
-                    'innodb_page_size'    => 16384,
-                ],
-                'validated' => true,
-                'messages'  => [
-                    'Database configuration is OK.',
-                ]
-            ],
-            [
-            // Incompatible variables on MySQL 5.7
-                'version'   => '5.7.34-standard',
-                'variables' => [
-                    'innodb_file_format'  => 'Antelope', // Not a problem, will enforce Barracuda for Dynamic tables
-                    'innodb_large_prefix' => 0,
-                    'innodb_page_size'    => 4096,
-                ],
-                'validated' => false,
-                'messages'  => [
-                    '"innodb_large_prefix" must be enabled.',
-                    '"innodb_page_size" must be >= 8KB.',
-                ]
-            ],
-            [
             // Default variables on MySQL 8.0
                 'version'   => '8.0.24-standard',
                 'variables' => [
@@ -97,73 +70,6 @@ class DbConfiguration extends \GLPITestCase
                 ],
                 'validated' => false,
                 'messages'  => [
-                    '"innodb_page_size" must be >= 8KB.',
-                ]
-            ],
-            [
-            // Default variables on MariaDB 10.1
-                'version'   => '10.1.48-MariaDB',
-                'variables' => [
-                    'innodb_file_format'  => 'Antelope',
-                    'innodb_large_prefix' => 0,
-                    'innodb_page_size'    => 16384,
-                ],
-                'validated' => false,
-                'messages'  => [
-                    '"innodb_large_prefix" must be enabled.',
-                ]
-            ],
-            [
-            // Required variables on MariaDB 10.1
-                'version'   => '10.1.48-MariaDB',
-                'variables' => [
-                    'innodb_file_format'  => 'Antelope',
-                    'innodb_large_prefix' => 1,
-                    'innodb_page_size'    => 16384,
-                ],
-                'validated' => true,
-                'messages'  => [
-                    'Database configuration is OK.',
-                ]
-            ],
-            [
-            // Incompatible variables on MariaDB 10.1
-                'version'   => '10.1.48-MariaDB',
-                'variables' => [
-                    'innodb_file_format'  => 'Antelope', // Not a problem, will enforce Barracuda for Dynamic tables
-                    'innodb_large_prefix' => 0,
-                    'innodb_page_size'    => 4096,
-                ],
-                'validated' => false,
-                'messages'  => [
-                    '"innodb_large_prefix" must be enabled.',
-                    '"innodb_page_size" must be >= 8KB.',
-                ]
-            ],
-            [
-            // Default variables on MariaDB 10.2
-                'version'   => '10.2.36-MariaDB',
-                'variables' => [
-                    'innodb_file_format'  => 'Barracuda',
-                    'innodb_large_prefix' => 1,
-                    'innodb_page_size'    => 16384,
-                ],
-                'validated' => true,
-                'messages'  => [
-                    'Database configuration is OK.',
-                ]
-            ],
-            [
-            // Incompatible variables on MariaDB 10.2
-                'version'   => '10.2.36-MariaDB',
-                'variables' => [
-                    'innodb_file_format'  => 'Antelope', // Not a problem, will enforce Barracuda for Dynamic tables
-                    'innodb_large_prefix' => 0,
-                    'innodb_page_size'    => 4096,
-                ],
-                'validated' => false,
-                'messages'  => [
-                    '"innodb_large_prefix" must be enabled.',
                     '"innodb_page_size" must be >= 8KB.',
                 ]
             ],

--- a/tests/units/Glpi/System/Requirement/DbEngine.php
+++ b/tests/units/Glpi/System/Requirement/DbEngine.php
@@ -52,7 +52,7 @@ class DbEngine extends \GLPITestCase
             ],
             [
                 'version'   => '5.7.50-log',
-                'validated' => true,
+                'validated' => false,
                 'messages'  => ['Database engine version (5.7.50) is not supported. Minimum required version is MySQL 8.0.'],
             ],
             [
@@ -67,7 +67,7 @@ class DbEngine extends \GLPITestCase
             ],
             [
                 'version'   => '10.2.36-MariaDB',
-                'validated' => true,
+                'validated' => false,
                 'messages'  => ['Database engine version (10.2.36) is not supported. Minimum required version is MariaDB 10.3.'],
             ],
             [

--- a/tests/units/Glpi/System/Requirement/DbEngine.php
+++ b/tests/units/Glpi/System/Requirement/DbEngine.php
@@ -43,17 +43,17 @@ class DbEngine extends \GLPITestCase
             [
                 'version'   => '5.5.38-0ubuntu0.14.04.1',
                 'validated' => false,
-                'messages'  => ['Database engine version (5.5.38) is not supported. Minimum required version is MySQL 5.7.'],
+                'messages'  => ['Database engine version (5.5.38) is not supported. Minimum required version is MySQL 8.0.'],
             ],
             [
                 'version'   => '5.6.46-log',
                 'validated' => false,
-                'messages'  => ['Database engine version (5.6.46) is not supported. Minimum required version is MySQL 5.7.'],
+                'messages'  => ['Database engine version (5.6.46) is not supported. Minimum required version is MySQL 8.0.'],
             ],
             [
                 'version'   => '5.7.50-log',
                 'validated' => true,
-                'messages'  => ['Database engine version (5.7.50) is supported.'],
+                'messages'  => ['Database engine version (5.7.50) is not supported. Minimum required version is MySQL 8.0.'],
             ],
             [
                 'version'   => '8.0.23-standard',
@@ -63,12 +63,12 @@ class DbEngine extends \GLPITestCase
             [
                 'version'   => '10.1.48-MariaDB',
                 'validated' => false,
-                'messages'  => ['Database engine version (10.1.48) is not supported. Minimum required version is MariaDB 10.2.'],
+                'messages'  => ['Database engine version (10.1.48) is not supported. Minimum required version is MariaDB 10.3.'],
             ],
             [
                 'version'   => '10.2.36-MariaDB',
                 'validated' => true,
-                'messages'  => ['Database engine version (10.2.36) is supported.'],
+                'messages'  => ['Database engine version (10.2.36) is not supported. Minimum required version is MariaDB 10.3.'],
             ],
             [
                 'version'   => '10.3.28-MariaDB',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

MySQL 5.7 is still supported until 10/2023, but has been released in 10/2015 and 8.0 is widely available now.
MariaDB 10.2 is not supported anymore.

| OS | Release date | MySQL version | MariaDB version |
| -------- | -------- | -------- | -------- |
| RHEL 8.3     | 10/2020     | 8.0     | 10.3     |
| RHEL 8.4     | 05/2021     | 8.0     | 10.5     |
| RHEL 8.5     | 11/2021     | 8.0     | 10.5     |
| RHEL 8.6     | 05/2022     | 8.0     | 10.5     |
| Debian Buster     | 07/2019     | 8.0 (using MySQL PPA)     | 10.3     |
| Debian Bullseye     | 08/2021     | 8.0 (using MySQL PPA)     | 10.5     |
| Ubuntu 20.04 LTS     | 04/2020     | 8.0     | 10.3     |
| Ubuntu 22.04 LTS     | 04/2022     | 8.0     | 10.6     |
