### PR TITLE
Allow dependabot to increase version of dev dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,24 +7,48 @@ updates:
     schedule:
       interval: "weekly"
 
-  # Strategy for npm dependencies on main branch.
+  # Strategy production dependencies on main branch.
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "monthly"
     allow:
       - dependency-type: "direct"
+      - dependency-type: "production"
     open-pull-requests-limit: 100
     target-branch: "main"
     versioning-strategy: "lockfile-only"
 
-  # Strategy for composer dependencies on main branch.
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
       interval: "monthly"
     allow:
       - dependency-type: "direct"
+      - dependency-type: "production"
     open-pull-requests-limit: 100
     target-branch: "main"
     versioning-strategy: "lockfile-only"
+
+  # Strategy for development dependencies on main branch.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-type: "direct"
+      - dependency-type: "development"
+    open-pull-requests-limit: 100
+    target-branch: "main"
+    versioning-strategy: "increase-if-necessary"
+
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-type: "direct"
+      - dependency-type: "development"
+    open-pull-requests-limit: 100
+    target-branch: "main"
+    versioning-strategy: "increase-if-necessary"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

It is releavant to prevent dependabot to increase version of production dependencies, as it will most of the time require a manual handling of BC-breaks, but this kind of problem is less likely to occur with dev dependencies.

So I propose to allow dependabot to open PR to increase dev dependencies versions.