### PR TITLE
Prevent plugin langs to be reloaded multiple time

### DIFF
--- a/src/Console/Plugin/ActivateCommand.php
+++ b/src/Console/Plugin/ActivateCommand.php
@@ -125,8 +125,7 @@ class ActivateCommand extends AbstractPluginCommand
         $plugin = new Plugin();
 
        // Check that directory is valid
-        $informations = $plugin->getInformationsFromDirectory($directory);
-        if (empty($informations)) {
+        if (!$plugin->isLoadable($directory)) {
             $this->output->writeln(
                 '<error>' . sprintf(__('Invalid plugin directory "%s".'), $directory) . '</error>',
                 OutputInterface::VERBOSITY_QUIET

--- a/src/Console/Plugin/DeactivateCommand.php
+++ b/src/Console/Plugin/DeactivateCommand.php
@@ -125,8 +125,7 @@ class DeactivateCommand extends AbstractPluginCommand
         $plugin = new Plugin();
 
        // Check that directory is valid
-        $informations = $plugin->getInformationsFromDirectory($directory);
-        if (empty($informations)) {
+        if (!$plugin->isLoadable($directory)) {
             $this->output->writeln(
                 '<error>' . sprintf(__('Invalid plugin directory "%s".'), $directory) . '</error>',
                 OutputInterface::VERBOSITY_QUIET

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1091,7 +1091,7 @@ class Plugin extends CommonDBTM
      */
     public function isLoadable($directory)
     {
-        return !empty($this->getInformationsFromDirectory($directory));
+        return !empty($this->getInformationsFromDirectory($directory, false));
     }
 
 
@@ -1609,23 +1609,26 @@ class Plugin extends CommonDBTM
      */
     public static function getPluginFilesVersion(string $key): ?string
     {
-        return (new self())->getInformationsFromDirectory($key)['version'] ?? null;
+        return (new self())->getInformationsFromDirectory($key, false)['version'] ?? null;
     }
 
     /**
      * Returns plugin information from directory.
      *
      * @param string $directory
+     * @param bool $with_lang
      *
      * @return array
      */
-    public function getInformationsFromDirectory($directory)
+    public function getInformationsFromDirectory($directory, bool $with_lang = true)
     {
         if (!$this->loadPluginSetupFile($directory)) {
             return [];
         }
 
-        self::loadLang($directory);
+        if ($with_lang) {
+            self::loadLang($directory);
+        }
         return Toolbox::addslashes_deep(self::getInfo($directory));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Translator service has no "deduplication" logic, so calling `Translator::addFile()` multiple times for the same file will result in loading a file multiple time. As translator overrides existing translations when it loads a file, it may also erase overrides made by plugins (e.g. `localeoverride`).

Plugin locales files are always loaded in `Plugin::getInformationsFromDirectory()`, but this method is indirectly used multiple times  in each request, and loading lang is often useless, for instance if method is used to check if plugin can be loaded (i.e. we can fetch informations, no matter the current locale is) or if method is used to get plugin version.
