### PR TITLE
Use isSolved() method for checking Solved status

### DIFF
--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -276,7 +276,7 @@ class ITILFollowup extends CommonDBChild
         if (
             isset($this->input["_close"])
             && $this->input["_close"]
-            && ($parentitem->fields["status"] == CommonITILObject::SOLVED)
+            && ($parentitem->isSolved())
         ) {
             $update = [
                 'id'        => $parentitem->fields['id'],


### PR DESCRIPTION
ITIL objects can have multiple Solved statuses (Changes for example). Approbation form is displayed in any of those, so accept closure from those as well

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
