### PR TITLE
Fix handling of compiled SCSS files path

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -5390,6 +5390,9 @@ HTML;
             $url .= '?v=' . FrontEnd::getVersionCacheKey($version);
         }
 
+        // Convert filesystem path to URL path (fix issues with Windows directory separator)
+        $url = str_replace(DIRECTORY_SEPARATOR, '/', $url);
+
         return sprintf('<script type="%s" src="%s"></script>', $type, $url);
     }
 
@@ -5473,6 +5476,9 @@ HTML;
 
             $url .= ((strpos($url, '?') !== false) ? '&' : '?') . 'v=' . FrontEnd::getVersionCacheKey($version);
         }
+
+        // Convert filesystem path to URL path (fix issues with Windows directory separator)
+        $url = str_replace(DIRECTORY_SEPARATOR, '/', $url);
 
         return sprintf(
             '<link rel="stylesheet" type="text/css" href="%s" %s>',
@@ -6917,13 +6923,7 @@ CSS;
     {
         $file = preg_replace('/\.scss$/', '', $file);
 
-        return implode(
-            DIRECTORY_SEPARATOR,
-            [
-                self::getScssCompileDir(),
-                str_replace('/', '_', $file) . '.min.css',
-            ]
-        );
+        return self::getScssCompileDir() . '/' . str_replace('/', '_', $file) . '.min.css';
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12189

Not sure it fixes #12189, as I have no Windows server to try to reproduce.

Value returned by `Html::getScssCompilePath()` is used to both operations on filesystem and usage in a URL.
 - In filesystem operations, always using `/` is not a problem (actually path already contains a `/` as `Html::getScssCompileDir()` returns `GLPI_ROOT . '/css_compiled'`).
 - In URL path, using `\` is not correct.
So solution is to always use `/` in SCSS file path.

I also added a replacement operation on `Html::script()` and `Html::csslink()` to automatically fix this kind of issues.