### PR TITLE
missing constants for dashboard hooks

### DIFF
--- a/src/Dashboard/Filter.php
+++ b/src/Dashboard/Filter.php
@@ -35,6 +35,7 @@
 
 namespace Glpi\Dashboard;
 
+use Glpi\Plugin\Hooks;
 use Group;
 use Html;
 use ITILCategory;
@@ -72,7 +73,7 @@ class Filter extends \CommonDBChild
             'user_tech'    => __("Technician"),
         ];
 
-        $more_filters = Plugin::doHookFunction("dashboard_filters");
+        $more_filters = Plugin::doHookFunction(Hooks::DASHBOARD_FILTERS);
         if (is_array($more_filters)) {
             $filters = array_merge($filters, $more_filters);
         }

--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -38,6 +38,7 @@ namespace Glpi\Dashboard;
 use DBConnection;
 use Dropdown;
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Plugin\Hooks;
 use Html;
 use Plugin;
 use Ramsey\Uuid\Uuid;
@@ -1442,7 +1443,7 @@ HTML;
                 ]
             ];
 
-            $more_cards = Plugin::doHookFunction("dashboard_cards");
+            $more_cards = Plugin::doHookFunction(Hooks::DASHBOARD_CARDS);
             if (is_array($more_cards)) {
                 $cards = array_merge($cards, $more_cards);
             }

--- a/src/Dashboard/Widget.php
+++ b/src/Dashboard/Widget.php
@@ -35,6 +35,7 @@
 
 namespace Glpi\Dashboard;
 
+use Glpi\Plugin\Hooks;
 use Glpi\RichText\RichText;
 use Html;
 use Mexitek\PHPColors\Color;
@@ -247,7 +248,7 @@ class Widget
             ],
         ];
 
-        $more_types = Plugin::doHookFunction("dashboard_types");
+        $more_types = Plugin::doHookFunction(Hooks::DASHBOARD_TYPES);
         if (is_array($more_types)) {
             $types = array_merge($types, $more_types);
         }

--- a/src/Plugin/Hooks.php
+++ b/src/Plugin/Hooks.php
@@ -138,6 +138,11 @@ class Hooks
     const HELPDESK_MENU_ENTRY = 'helpdesk_menu_entry';
     const HELPDESK_MENU_ENTRY_ICON = 'helpdesk_menu_entry_icon';
 
+    // Dashboard hooks
+    const DASHBOARD_CARDS   = 'dashboard_cards';
+    const DASHBOARD_FILTERS = 'dashboard_filters';
+    const DASHBOARD_TYPES   = 'dashboard_types';
+
     /**
      * Get file hooks
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

While working on plugin dev training document, i noticed that dashboard hooks was still using direct text notation.
