### PR TITLE
Restore pre/post_show_item hooks in timeline

### DIFF
--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -44,6 +44,7 @@
    {% set status_closed = (item.fields['status'] in item.getClosedStatusArray()) %}
    {% for entry in timeline %}
       {% set entry_i = entry['item'] %}
+      {% set entry_object = get_item(entry['type'], entry_i['id']) %}
       {% set users_id = entry_i['users_id'] %}
       {% set is_private = entry_i['is_private'] ?? false %}
       {% set date_creation = entry_i['date_creation'] ?? entry_i['date'] %}
@@ -102,6 +103,9 @@
       <div class="timeline-item mb-3 {{ itiltype }} {{ state_class }} {{ entry['class'] }} {{ 'right' in item_position ? 'ms-auto' : '' }}"
             data-itemtype="{{ entry['type'] }}" data-items-id="{{ entry_i['id'] }}"
             {% if entry['item_action'] is defined %}data-item-action="{{ entry['item_action'] }}"{% endif %}>
+
+         {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::PRE_SHOW_ITEM'), {'item': entry_object, 'options': {'parent': item, 'rand': entry_rand}}) }}
+
          <div class="row">
             <div class="col-auto todo-list-state {{ 'left' in item_position ? 'ms-auto ms-0 order-sm-last' : '' }}">
                {% if entry_i['state'] is constant('Planning::TODO') and can_edit_i %}
@@ -170,6 +174,8 @@
                {% endif %}
             </div>
          </div>
+
+         {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::POST_SHOW_ITEM'), {'item': entry_object, 'options': {'parent': item, 'rand': entry_rand}}) }}
       </div>
    {% endfor %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12025

Restore hooks calls that were present in GLPI 9.5
https://github.com/glpi-project/glpi/blob/5da35e463619ba6174d9c1fee940c3f22282e08e/inc/commonitilobject.class.php#L7176-L7186
https://github.com/glpi-project/glpi/blob/5da35e463619ba6174d9c1fee940c3f22282e08e/inc/commonitilobject.class.php#L7591-L7593

A small difference with GLPI 9.5 behaviour is that `$options` is not anymore passed by reference. I am not sure it was really usefull, and I am not even sure reference was passed in the whole chain.