### PR TITLE
Allow marking classes as having non-itemized records

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -6340,28 +6340,36 @@ class CommonDBTM extends CommonGLPI
             $menus = $menus[Session::getCurrentInterface()];
         }
 
-        if (static::isNewID($id)) {
-            // New item, check create rights
-            if (!static::canCreate()) {
-                static::displayAccessDeniedPage($menus);
-                return;
-            }
+        if (static::$record_type === static::RECORD_ITEMIZED) {
+            if (static::isNewID($id)) {
+                // New item, check create rights
+                if (!static::canCreate()) {
+                    static::displayAccessDeniedPage($menus);
+                    return;
+                }
 
-            // Tab name will be generic (item isn't saved yet)
-            $title = static::getBrowserTabNameForNewItem();
+                // Tab name will be generic (item isn't saved yet)
+                $title = static::getBrowserTabNameForNewItem();
+            } else {
+                // Existing item, try to load it and check read rights
+                if (!$item->getFromDB($id)) {
+                    static::displayItemNotFoundPage($menus);
+                    return;
+                }
+
+                if (!$item->can($id, READ)) {
+                    static::displayAccessDeniedPage($menus);
+                    return;
+                }
+
+                // Tab name will be specific to the loaded item
+                $title = $item->getBrowserTabName();
+            }
         } else {
-            // Existing item, try to load it and check read rights
-            if (!$item->getFromDB($id)) {
-                static::displayItemNotFoundPage($menus);
-                return;
-            }
-
-            if (!$item->can($id, READ)) {
+            if (!$item::canView()) {
                 static::displayAccessDeniedPage($menus);
                 return;
             }
-
-            // Tab name will be specific to the loaded item
             $title = $item->getBrowserTabName();
         }
 

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -73,6 +73,20 @@ class CommonGLPI implements CommonGLPIInterface
     public $get_item_to_display_tab = false;
     protected static $othertabs     = [];
 
+    /**
+     * The class can represent multiple distinct objects.
+     * @var int
+     */
+    public const RECORD_ITEMIZED = 0;
+
+    /**
+     * The class can represent a single object but may have multiple records, for example key/value pairs, to represent different attributes of the singleton item.
+     * @var int
+     */
+    public const RECORD_SINGLETON = 1;
+
+    public static int $record_type = self::RECORD_ITEMIZED;
+
 
     public function __construct()
     {

--- a/src/Config.php
+++ b/src/Config.php
@@ -70,6 +70,7 @@ class Config extends CommonDBTM
         'ldap_pass', // this one should not exist anymore, but may be present when admin restored config dump after migration
     ];
     public static $saferUndisclosedFields = ['admin_email', 'replyto_email'];
+    public static int $record_type = self::RECORD_SINGLETON;
 
     public static function getTypeName($nb = 0)
     {

--- a/src/NotificationSetting.php
+++ b/src/NotificationSetting.php
@@ -41,6 +41,7 @@ abstract class NotificationSetting extends CommonDBTM
     public $table           = 'glpi_configs';
     protected $displaylist  = false;
     public static $rightname       = 'config';
+    public static int $record_type = self::RECORD_SINGLETON;
 
     public static function getTypeName($nb = 0)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12267

Allows marking classes as having `Itemized` or `Singleton` record types.
This PR marks Config and NotificationSetting (and subclasses) as having `Singleton` type of records. This PR also changes the `CommonDBTM::displayFullPageForItem` method so that it ignores the provided ID when the record type is `Singleton` as individual IDs/records do not represent a full item. This should prevent issues in cases when a key/value table like `glpi_configs` does not have a record with ID 1 (which is currently hard-coded as the ID for the method in the front file for Config).

- Itemized: Each record represents a single item.
- Singleton: Each record represents an attribute of an item.

`glpi_configs` and the classes that used it seemed like the only cases where there would be an issue based on having a hard-coded ID in the front files. I also didn't see any other case where the `Singleton` record type was needed.