### PR TITLE
Allow only contains and not contains search for Antivirus name

### DIFF
--- a/src/ComputerAntivirus.php
+++ b/src/ComputerAntivirus.php
@@ -153,7 +153,8 @@ class ComputerAntivirus extends CommonDBChild
             'datatype'           => 'dropdown',
             'joinparams'         => [
                 'jointype'           => 'child'
-            ]
+            ],
+            'searchtype'         => ['contains'],
         ];
 
         $tab[] = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12258

Currently, is/is not search types are broken with computer antiviruses because they do not have an entity field (SQL error) but the classes `isEntityAssign` returns true because their parent item type is assigned to entities.
Since antiviruses are only a child itemtype, I do not think it makes sense to have this search type at this time even if it had the `entities_id` field. There could be duplicate entries in the dropdown with different values where each selection only matched the antivirus of a single computer even if the names were exactly the same in other computers.