### PR TITLE
Ensure charset directive is first in compiled CSS

### DIFF
--- a/src/Console/Build/CompileScssCommand.php
+++ b/src/Console/Build/CompileScssCommand.php
@@ -137,7 +137,7 @@ class CompileScssCommand extends Command
 
             // Insert licence header after the "@charset" directive.
             $css = preg_replace(
-                '/^(@charset .+;)/',
+                '/^(@charset [^;]+;)/',
                 '$0' . PHP_EOL . $licence_header,
                 $css,
                 1

--- a/src/Console/Build/CompileScssCommand.php
+++ b/src/Console/Build/CompileScssCommand.php
@@ -135,7 +135,13 @@ class CompileScssCommand extends Command
                 ]
             );
 
-            $css = $licence_header . $css;
+            // Insert licence header after the "@charset" directive.
+            $css = preg_replace(
+                '/^(@charset .+;)/',
+                '$0' . PHP_EOL . $licence_header,
+                $css,
+                1
+            );
 
             if ($dry_run) {
                 $message = sprintf('"%s" compiled successfully.', $file);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This attempts to fix a random issue where some FontAwesome icons are displayed as Unicode characters instead of icons. The compiled CSS seems to remain the same between times it works and times it does not. It seems to only really happen with icons specified in `::before` selectors. Those `content` property values are unicode characters like "" in the compiled CSS rather then the code representations like "\f100".
It seems like the browser randomly interprets the encoding of the CSS file wrong.

The charset directive needs to be the first element in the stylesheet for it to be valid, but I did not see anything on MDN that said if having a comment before it was valid or not. I did see that a space before the directive wasn't valid though, so it is possible. ONe third-party resource mentioned that not even comments were valid before the directive. I modified the compile SCSS command to add the license header after this directive instead of at the beginning of the file.

Since I cannot get the issue to show again, and it never showed on my own instance, I cannot say this will resolve the issue.