### PR TITLE
Fix handling of pasted images and uploaded files

### DIFF
--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -41,13 +41,18 @@ function uploadFile(file, editor) {
     insertIntoEditor[file.name] = isImage(file);
 
     // Search for fileupload container.
-    // First try to find it in editor siblings, and fallback to any container found in current form.
-    var fileupload_container = $(editor.getElement()).siblings('.fileupload');
-    if (fileupload_container.length === 0) {
-        fileupload_container = $(editor.getElement()).closest('form').find('.fileupload');
+    // First try to find an uplaoder having same name as editor element.
+    var uploader = $('[data-uploader-name="' + editor.getElement().name + '"]');
+    if (uploader.length === 0) {
+        // Fallback to uploader using default name
+        uploader = $(editor.getElement()).closest('form').find('[data-uploader-name="filename"]');
+    }
+    if (uploader.length === 0) {
+        // Fallback to any uploader found in current form
+        uploader = $(editor.getElement()).closest('form').find('[data-uploader-name=]').first();
     }
 
-    fileupload_container.find('[type="file"]').fileupload('add', {files: [file]});
+    uploader.fileupload('add', {files: [file]});
 }
 
 var handleUploadedFile = function (files, files_data, input_name, container, editor_id) {

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -1793,22 +1793,8 @@ abstract class CommonITILObject extends CommonDBTM
        // Handle "_solutiontemplates_id" special input
         $this->handleSolutionTemplateInput();
 
-       // Handle files pasted in the file field
-        $this->input = $this->addFiles($this->input);
-
-       // Handle files pasted in the text area
-        if (!isset($this->input['_donotadddocs']) || !$this->input['_donotadddocs']) {
-            $options = [
-                'force_update' => true,
-                'name' => 'content',
-                'content_field' => 'content',
-            ];
-            if (isset($this->input['solution'])) {
-                $options['name'] = 'solution';
-                $options['content_field'] = 'solution';
-            }
-            $this->input = $this->addFiles($this->input, $options);
-        }
+        // Handle rich-text images and uploaded documents
+        $this->input = $this->addFiles($this->input, ['force_update' => true]);
 
        // handle actors changes
         $this->updateActors();
@@ -2533,10 +2519,8 @@ abstract class CommonITILObject extends CommonDBTM
        // Handle "_solutiontemplates_id" special input
         $this->handleSolutionTemplateInput();
 
-       // Add document if needed, without notification for file input
+        // Handle rich-text images and uploaded documents
         $this->input = $this->addFiles($this->input, ['force_update' => true]);
-       // Add document if needed, without notification for textarea
-        $this->input = $this->addFiles($this->input, ['name' => 'content', 'force_update' => true]);
 
        // Add default document if set in template
         if (

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -360,10 +360,8 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
     {
         global $CFG_GLPI;
 
-       // Add document if needed, without notification for file input
+        // Handle rich-text images and uploaded documents
         $this->input = $this->addFiles($this->input, ['force_update' => true]);
-       // Add document if needed, without notification for textarea
-        $this->input = $this->addFiles($this->input, ['name' => 'content', 'force_update' => true]);
 
         if (in_array("begin", $this->updates)) {
             PlanningRecall::managePlanningUpdates(
@@ -568,10 +566,8 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
     {
         global $CFG_GLPI;
 
-       // Add document if needed, without notification for file input
+        // Handle rich-text images and uploaded documents
         $this->input = $this->addFiles($this->input, ['force_update' => true]);
-       // Add document if needed, without notification for textarea
-        $this->input = $this->addFiles($this->input, ['name' => 'content', 'force_update' => true]);
 
         if (isset($this->input['_planningrecall'])) {
             $this->input['_planningrecall']['items_id'] = $this->fields['id'];

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -293,34 +293,17 @@ abstract class CommonITILValidation extends CommonDBChild
     {
         global $CFG_GLPI;
 
-
-        if (array_key_exists('comment_submission', $this->input)) {
-            // Add screenshots if needed, without notification
+        // Handle rich-text images
+        foreach (['comment_submission', 'comment_validation'] as $content_field) {
             $this->input = $this->addFiles($this->input, [
                 'force_update'  => true,
-                'name'          => 'filename',
-                'content_field' => 'comment_submission',
-            ]);
-            // Add documents if needed, without notification
-            $this->input = $this->addFiles($this->input, [
-                'force_update'  => true,
-                'name'          => 'comment_submission',
-                'content_field' => 'comment_submission',
-            ]);
-        } else {
-            // Add screenshots if needed, without notification
-            $this->input = $this->addFiles($this->input, [
-                'force_update'  => true,
-                'name'          => 'filename',
-                'content_field' => 'comment_validation',
-            ]);
-            // Add documents if needed, without notification
-            $this->input = $this->addFiles($this->input, [
-                'force_update'  => true,
-                'name'          => 'comment_validation',
-                'content_field' => 'comment_validation',
+                'name'          => $content_field,
+                'content_field' => $content_field,
             ]);
         }
+
+        // Handle uploaded documents
+        $this->input = $this->addFiles($this->input);
 
         $item     = new static::$itemtype();
         $mailsend = false;
@@ -434,19 +417,17 @@ abstract class CommonITILValidation extends CommonDBChild
             $donotif = false;
         }
 
-       // Add screenshots if needed, without notification
-        $this->input = $this->addFiles($this->input, [
-            'force_update'  => true,
-            'name'          => 'comment_submission',
-            'content_field' => 'comment_submission',
-        ]);
+        // Handle rich-text images
+        foreach (['comment_submission', 'comment_validation'] as $content_field) {
+            $this->input = $this->addFiles($this->input, [
+                'force_update'  => true,
+                'name'          => $content_field,
+                'content_field' => $content_field,
+            ]);
+        }
 
-       // Add documents if needed, without notification
-        $this->input = $this->addFiles($this->input, [
-            'force_update'  => true,
-            'name'          => 'filename',
-            'content_field' => 'comment_validation',
-        ]);
+        // Handle uploaded documents
+        $this->input = $this->addFiles($this->input);
 
         if ($item->getFromDB($this->fields[static::$items_id])) {
             if (

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -213,7 +213,6 @@ class Document_Item extends CommonDBRelation
             $input  = [
                 'id'              => $this->fields['items_id'],
                 'date_mod'        => $_SESSION["glpi_currenttime"],
-                '_donotadddocs'   => true
             ];
 
             if (!isset($this->input['_do_notif']) || $this->input['_do_notif']) {
@@ -242,7 +241,6 @@ class Document_Item extends CommonDBRelation
             $input = [
                 'id'              => $this->fields['items_id'],
                 'date_mod'        => $_SESSION["glpi_currenttime"],
-                '_donotadddocs'   => true
             ];
 
             if (!isset($this->input['_do_notif']) || $this->input['_do_notif']) {

--- a/src/Html.php
+++ b/src/Html.php
@@ -5580,6 +5580,7 @@ HTML;
         $display .= "<input id='fileupload{$p['rand']}' type='file' name='_uploader_" . $p['name'] . "[]'
                       class='form-control'
                       $required
+                      data-uploader-name=\"{$p['name']}\"
                       data-url='" . $CFG_GLPI["root_doc"] . "/ajax/fileupload.php'
                       data-form-data='{\"name\": \"_uploader_" . $p['name'] . "\", \"showfilesize\": \"" . $p['showfilesize'] . "\"}'"
                       . ($p['multiple'] ? " multiple='multiple'" : "")

--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -233,17 +233,9 @@ class ITILFollowup extends CommonDBChild
 
         global $CFG_GLPI;
 
-       // Add screenshots if needed, without notification
+        // Handle rich-text images and uploaded documents
         $this->input = $this->addFiles($this->input, [
-            'force_update'  => true,
-            'name'          => 'content',
-            'content_field' => 'content',
-            'date' => $this->fields['date'],
-        ]);
-
-       // Add documents if needed, without notification
-        $this->input = $this->addFiles($this->input, [
-            'force_update'  => true,
+            'force_update' => true,
             'date' => $this->fields['date'],
         ]);
 
@@ -558,16 +550,10 @@ class ITILFollowup extends CommonDBChild
             return;
         }
 
-       // Add screenshots if needed, without notification
+        // Handle rich-text images and uploaded documents
         $this->input = $this->addFiles($this->input, [
             'force_update' => true,
-            'name'          => 'content',
-            'content_field' => 'content',
-        ]);
-
-       // Add documents if needed, without notification
-        $this->input = $this->addFiles($this->input, [
-            'force_update' => true,
+            'date' => $this->fields['date'],
         ]);
 
        //Get user_id when not logged (from mailgate)

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -286,21 +286,9 @@ class ITILSolution extends CommonDBChild
 
         $item = $this->item;
 
-       // Replace inline pictures
+        // Handle rich-text images and uploaded documents
         $this->input["_job"] = $this->item;
-        $this->input = $this->addFiles(
-            $this->input,
-            [
-                'force_update' => true,
-                'name' => 'content',
-                'content_field' => 'content',
-            ]
-        );
-
-        // Add documents if needed, without notification
-        $this->input = $this->addFiles($this->input, [
-            'force_update' => true,
-        ]);
+        $this->input = $this->addFiles($this->input, ['force_update' => true]);
 
         // Add solution to duplicates
         if ($this->item->getType() == 'Ticket' && !isset($this->input['_linked_ticket'])) {
@@ -354,18 +342,8 @@ class ITILSolution extends CommonDBChild
 
     public function post_updateItem($history = 1)
     {
-       // Replace inline pictures
-        $options = [
-            'force_update' => true,
-            'name' => 'content',
-            'content_field' => 'content',
-        ];
-        $this->input = $this->addFiles($this->input, $options);
-
-        // Add documents if needed, without notification
-        $this->input = $this->addFiles($this->input, [
-            'force_update' => true,
-        ]);
+        // Handle rich-text images and uploaded documents
+        $this->input = $this->addFiles($this->input, ['force_update' => true]);
 
         parent::post_updateItem($history);
     }

--- a/src/Item_Ticket.php
+++ b/src/Item_Ticket.php
@@ -97,7 +97,6 @@ class Item_Ticket extends CommonItilObject_Item
         $ticket = new Ticket();
         $input  = ['id'            => $this->fields['tickets_id'],
             'date_mod'      => $_SESSION["glpi_currenttime"],
-            '_donotadddocs' => true
         ];
 
         if (!isset($this->input['_do_notif']) || $this->input['_do_notif']) {
@@ -118,7 +117,6 @@ class Item_Ticket extends CommonItilObject_Item
         $ticket = new Ticket();
         $input = ['id'            => $this->fields['tickets_id'],
             'date_mod'      => $_SESSION["glpi_currenttime"],
-            '_donotadddocs' => true
         ];
 
         if (!isset($this->input['_do_notif']) || $this->input['_do_notif']) {

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -321,19 +321,14 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
      **/
     public function post_addItem()
     {
-
-       // add screenshots
+        // Handle rich-text images and uploaded documents
         $this->input = $this->addFiles(
             $this->input,
             [
                 'force_update'  => true,
                 'content_field' => 'answer',
-                'name'          => 'answer',
             ]
         );
-
-       // Add documents
-        $this->input = $this->addFiles($this->input, ['force_update' => true]);
 
         if (
             isset($this->input["_visibility"])
@@ -735,21 +730,12 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
 
     public function post_updateItem($history = 1)
     {
-       // Update screenshots
+        // Handle rich-text images and uploaded documents
         $this->input = $this->addFiles(
             $this->input,
             [
                 'force_update'  => true,
                 'content_field' => 'answer',
-                'name'          => 'answer',
-            ]
-        );
-
-       // add uploaded documents
-        $this->input = $this->addFiles(
-            $this->input,
-            [
-                'force_update'  => true,
             ]
         );
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1275,8 +1275,6 @@ class Ticket extends CommonITILObject
         if (isset($input['content'])) {
             if (isset($input['_filename']) || isset($input['_content'])) {
                 $input['_disablenotif'] = true;
-            } else {
-                $input['_donotadddocs'] = true;
             }
         }
 

--- a/templates/components/itilobject/timeline/form_validation.html.twig
+++ b/templates/components/itilobject/timeline/form_validation.html.twig
@@ -87,10 +87,21 @@
                         'full_width': true,
                         'enable_richtext': true,
                         'is_horizontal': false,
-                        'enable_fileupload': true,
+                        'enable_fileupload': false,
                         'enable_mentions': true,
                         'rand': rand,
                      }
+                  ) }}
+
+                  {{ fields.fileField(
+                      'filename',
+                      null,
+                      '',
+                      {
+                          'multiple': true,
+                          'full_width': true,
+                          'no_label': true,
+                      }
                   ) }}
                </div>
 
@@ -126,10 +137,21 @@
                   'full_width': true,
                   'enable_richtext': true,
                   'is_horizontal': false,
-                  'enable_fileupload': true,
+                  'enable_fileupload': false,
                   'enable_mentions': true,
                   'rand': rand,
                }
+            ) }}
+
+            {{ fields.fileField(
+                'filename',
+                null,
+                '',
+                {
+                    'multiple': true,
+                    'full_width': true,
+                    'no_label': true,
+                }
             ) }}
          </div>
 
@@ -218,9 +240,19 @@
                     {
                     'full_width': true,
                     'enable_richtext': true,
-                    'enable_fileupload': true,
+                    'enable_fileupload': false,
                     'enable_mentions': true,
                     'rand': rand,
+                    }
+                ) }}
+
+                {{ fields.fileField(
+                    'filename',
+                    null,
+                    '',
+                    {
+                        'multiple': true,
+                        'full_width': true,
                     }
                 ) }}
             </div>

--- a/tests/functionnal/ITILFollowup.php
+++ b/tests/functionnal/ITILFollowup.php
@@ -421,13 +421,13 @@ class ITILFollowup extends DbTestCase
 <p><img id="3e29dffe-0237ea21-5e5e7034b1d1a1.00000000" src="data:image/png;base64,{$base64Image}" width="12" height="12"></p>
 HTML
             ),
-            '_content' => [
+            '_filename' => [
                 $filename,
             ],
-            '_tag_content' => [
+            '_tag_filename' => [
                 '3e29dffe-0237ea21-5e5e7034b1d1a1.00000000',
             ],
-            '_prefix_content' => [
+            '_prefix_filename' => [
                 '5e5e92ffd9bd91.11111111',
             ]
         ];
@@ -450,13 +450,13 @@ HTML
 <p><img id="3e29dffe-0237ea21-5e5e7034b1d1a1.33333333" src="data:image/png;base64,{$base64Image}" width="12" height="12"></p>
 HTML
             ),
-            '_content' => [
+            '_filename' => [
                 $filename,
             ],
-            '_tag_content' => [
+            '_tag_filename' => [
                 '3e29dffe-0237ea21-5e5e7034b1d1a1.33333333',
             ],
-            '_prefix_content' => [
+            '_prefix_filename' => [
                 '5e5e92ffd9bd91.44444444',
             ]
         ]);

--- a/tests/functionnal/ITILSolution.php
+++ b/tests/functionnal/ITILSolution.php
@@ -357,13 +357,13 @@ class ITILSolution extends DbTestCase
 <p><img id="3e29dffe-0237ea21-5e5e7034b1d1a1.00000000" src="data:image/png;base64,{$base64Image}" width="12" height="12"></p>
 HTML
             ),
-            '_content' => [
+            '_filename' => [
                 $filename,
             ],
-            '_tag_content' => [
+            '_tag_filename' => [
                 '3e29dffe-0237ea21-5e5e7034b1d1a1.00000000',
             ],
-            '_prefix_content' => [
+            '_prefix_filename' => [
                 '5e5e92ffd9bd91.11111111',
             ]
         ];
@@ -386,13 +386,13 @@ HTML
 <p><img id="3e29dffe-0237ea21-5e5e7034b1d1a1.33333333" src="data:image/png;base64,{$base64Image}" width="12" height="12"></p>
 HTML
             ),
-            '_content' => [
+            '_filename' => [
                 $filename,
             ],
-            '_tag_content' => [
+            '_tag_filename' => [
                 '3e29dffe-0237ea21-5e5e7034b1d1a1.33333333',
             ],
-            '_prefix_content' => [
+            '_prefix_filename' => [
                 '5e5e92ffd9bd91.44444444',
             ]
         ]);

--- a/tests/functionnal/KnowbaseItem.php
+++ b/tests/functionnal/KnowbaseItem.php
@@ -199,13 +199,13 @@ class KnowbaseItem extends DbTestCase
 <p><img id="3e29dffe-0237ea21-5e5e7034b1d1a1.00000000" src="data:image/png;base64,{$base64Image}" width="12" height="12"></p>
 HTML
             ),
-            '_answer' => [
+            '_filename' => [
                 $filename,
             ],
-            '_tag_answer' => [
+            '_tag_filename' => [
                 '3e29dffe-0237ea21-5e5e7034b1d1a1.00000000',
             ],
-            '_prefix_answer' => [
+            '_prefix_filename' => [
                 '5e5e92ffd9bd91.11111111',
             ],
             'is_faq'   => 0,
@@ -231,13 +231,13 @@ HTML
 <p><img id="3e29dffe-0237ea21-5e5e7034b1ffff.33333333" src="data:image/png;base64,{$base64Image}" width="12" height="12"></p>
 HTML
             ),
-            '_answer' => [
+            '_filename' => [
                 $filename,
             ],
-            '_tag_answer' => [
+            '_tag_filename' => [
                 '3e29dffe-0237ea21-5e5e7034b1ffff.33333333',
             ],
-            '_prefix_answer' => [
+            '_prefix_filename' => [
                 '5e5e92ffd9bd91.44444444',
             ],
         ]);
@@ -259,13 +259,13 @@ HTML
         $input = [
             'name'    => 'a kb item',
             'answer' => 'testUploadDocuments',
-            '_answer' => [
+            '_filename' => [
                 $filename,
             ],
-            '_tag_answer' => [
+            '_tag_filename' => [
                 '3e29dffe-0237ea21-5e5e7034b1ffff.00000000',
             ],
-            '_prefix_answer' => [
+            '_prefix_filename' => [
                 '5e5e92ffd9bd91.11111111',
             ]
         ];
@@ -285,13 +285,13 @@ HTML
         $success = $instance->update([
             'id' => $instance->getID(),
             'answer' => 'update testUploadDocuments',
-            '_answer' => [
+            '_filename' => [
                 $filename,
             ],
-            '_tag_answer' => [
+            '_tag_filename' => [
                 '3e29dffe-0237ea21-5e5e7034b1d1a1.33333333',
             ],
-            '_prefix_answer' => [
+            '_prefix_filename' => [
                 '5e5e92ffd9bd91.44444444',
             ]
         ]);

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -3509,13 +3509,13 @@ class Ticket extends DbTestCase
 <p><img id="3e29dffe-0237ea21-5e5e7034b1d1a1.00000000" src="data:image/png;base64,{$base64Image}" width="12" height="12"></p>
 HTML
             ),
-            '_content' => [
+            '_filename' => [
                 $filename,
             ],
-            '_tag_content' => [
+            '_tag_filename' => [
                 '3e29dffe-0237ea21-5e5e7034b1d1a1.00000000',
             ],
-            '_prefix_content' => [
+            '_prefix_filename' => [
                 '5e5e92ffd9bd91.11111111',
             ]
         ];
@@ -3536,13 +3536,13 @@ HTML
 <p><img id="3e29dffe-0237ea21-5e5e7034b1d1a1.33333333" src="data:image/png;base64,{$base64Image}" width="12" height="12"></p>
 HTML
             ),
-            '_content' => [
+            '_filename' => [
                 $filename,
             ],
-            '_tag_content' => [
+            '_tag_filename' => [
                 '3e29dffe-0237ea21-5e5e7034b1d1a1.33333333',
             ],
-            '_prefix_content' => [
+            '_prefix_filename' => [
                 '5e5e92ffd9bd91.44444444',
             ]
         ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12276

Name of field that contains uploaded files can be:
 - `filename`, if richtext editor is initialized using `enable_fileupload: true` (file uploader can be used to attach documents),
 - same as richtext editor name, if richtext editor is initialized using `enable_fileupload: false` (file uploader is hidden, and is used only when pasting images).

See https://github.com/glpi-project/glpi/blob/e91180444200389eb6612fe9834488632c9eb39d/src/Html.php#L5726-L5738

IMHO, both feature should be technically separated, as it is corresponding to 2 distinct features (pasting images in rich text VS attaching documents to an item), but it cannot be changed in a bugfix version.

So this PR fixes multiple issues.

1. Handling of pasted images in KnowbaseItem `answer` was broken. Indeed, editor is initialized using `enable_fileupload: true`, so `CommonDBTM::addFiles()` have to be call using `name=filename` (which is the default value).
2. In `CommonITILObject` and `CommonITILTask`, `CommonDBTM::addFiles()` was called twice. First time using default `name` parameter value (i.e. `content`), and then using explicitely `name=content` parameter. So it result in two identical calls, and second one can be dropped.
3. In `ITILFollowup` and `ITILSolution`, editor is initialized using `enable_fileupload: true`, so uploaded files are handled by call to `CommonDBTM::addFiles()` using default `name` parameter value. Second call using `name=content` was useless.
4. In `CommonITILObject`, the `solution` field was handled. This field is not anymore handled (i.e. it does not create an `ITILSolution`), so code i dead and can be removed.
5. In `CommonITILValidation`, as there can be 2 content fields, I updated forms to handle separately richtext and documents (using `enable_fileupload: false`). It makes the logic more robust and prevent any issue if both `comment_submission` and `comment_validation` are present in input (in a plugin request or in an API request).
6. The JS code that is used to call the uploader when an image is pasted from TinyMCE was working only due to fallback to any uploader present in form. I encountered a case where, having 2 uploaders in same form, my file was uploaded twice. I fixed logic by adding a `data-uploader-name` property that make DOM selection easier. I keep a fallback to prevent BC-break.
7. I removed the `_donotadddocs` handlming that seemed obsolete.