### PR TITLE
Plugin: fix 'isInstalled' check

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1104,13 +1104,7 @@ class Plugin extends CommonDBTM
      */
     public function isInstalled($directory)
     {
-
-        if ($this->isPluginLoaded($directory)) {
-           // If plugin is loaded, it is because it is installed and active. No need to query DB on this case.
-            return true;
-        }
-
-       // If plugin is not loaded, check on DB as plugins may have not been loaded yet.
+        // If plugin is not loaded, check on DB as plugins may have not been loaded yet.
         if ($this->getFromDBbyDir($directory)) {
             return in_array($this->fields['state'], [self::ACTIVATED, self::TOBECONFIGURED, self::NOTACTIVATED])
             && $this->isLoadable($directory);


### PR DESCRIPTION
`Plugin:->isInstalled()` rely on `Plugin->isPluginLoaded()` which can't be trusted every page, for example every plugin are always loaded on `front/plugin.php` if their name are displayed: 

![image](https://user-images.githubusercontent.com/42734840/180719172-031eb989-362b-4fc3-b601-05b22f8d122b.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
