### PR TITLE
CORS must allow app-token header

### DIFF
--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -231,7 +231,7 @@ abstract class API
 
             if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'])) {
                 header("Access-Control-Allow-Headers: " .
-                   "origin, content-type, accept, session-token, authorization");
+                   "origin, content-type, accept, session-token, authorization, app-token");
             }
             exit(0);
         }

--- a/tests/web/APIRest.php
+++ b/tests/web/APIRest.php
@@ -239,7 +239,8 @@ class APIRest extends APIBaseClass
          ->contains('content-type')
          ->contains('accept')
          ->contains('session-token')
-         ->contains('authorization');
+         ->contains('authorization')
+         ->contains('app-token');
     }
 
     /**


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number 

I did not open a ticket.

app-token was prohibited by CORS policy. 
(Angular does a preflight test, and this header is mandatory glpi-client typescript library )

I added it to the list of allowed headers.
I also put this header in test, and changed a Tab for spaces.
