### PR TITLE
PoC: allow inheritance in itemtype

### DIFF
--- a/src/CommonDBRelation.php
+++ b/src/CommonDBRelation.php
@@ -2142,9 +2142,9 @@ abstract class CommonDBRelation extends CommonDBConnexity
      */
     public static function getMemberPosition(string $class): int
     {
-        if ($class == static::$itemtype_1) {
+        if (is_a($class, static::$itemtype_1, true)) {
             return 1;
-        } elseif ($class == static::$itemtype_2) {
+        } elseif (is_a($class, static::$itemtype_2, true)) {
             return 2;
         } elseif (
             preg_match('/^itemtype/', static::$itemtype_1) === 1


### PR DESCRIPTION
This PR allows in a specific case to use inheritance between 2 classes reprensenting an itemtype.

It solves a bug in a case where a plugin enhances an other plugin.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
