### PR TITLE
Do not add rule of loaded but not active plugins

### DIFF
--- a/src/RuleImportAsset.php
+++ b/src/RuleImportAsset.php
@@ -2258,7 +2258,7 @@ class RuleImportAsset extends Rule
         if ($with_plugins && isset($PLUGIN_HOOKS['add_rules'])) {
             $ria = new self();
             foreach ($PLUGIN_HOOKS['add_rules'] as $plugin => $val) {
-                if (!Plugin::isPluginLoaded($plugin)) {
+                if (!Plugin::isPluginActive($plugin)) {
                     continue;
                 }
                 $rules = array_merge(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

A `TOBECONFIGURED` plugin would have its rules loaded, but it should not.