### PR TITLE
Delegate session cookies security to sysadmin

### DIFF
--- a/css/install.scss
+++ b/css/install.scss
@@ -116,6 +116,10 @@ p {
     color: red;
 }
 
+.missing {
+    color: orange;
+}
+
 .migred {
     color: white;
     background-color: red;

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -1841,12 +1841,25 @@ class Auth extends CommonGLPI
         $cookie_path     = ini_get('session.cookie_path');
         $cookie_domain   = ini_get('session.cookie_domain');
         $cookie_secure   = (bool)ini_get('session.cookie_secure');
+        $cookie_httponly = (bool)ini_get('session.cookie_httponly');
+        $cookie_samesite = ini_get('session.cookie_samesite');
 
         if (empty($cookie_value) && !isset($_COOKIE[$cookie_name])) {
             return;
         }
 
-        setcookie($cookie_name, $cookie_value, $cookie_lifetime, $cookie_path, $cookie_domain, $cookie_secure, true);
+        setcookie(
+            $cookie_name,
+            $cookie_value,
+            [
+                'expires'  => $cookie_lifetime,
+                'path'     => $cookie_path,
+                'domain'   => $cookie_domain,
+                'secure'   => $cookie_secure,
+                'httponly' => $cookie_httponly,
+                'samesite' => $cookie_samesite,
+            ]
+        );
 
         if (empty($cookie_value)) {
             unset($_COOKIE[$cookie_name]);

--- a/src/Session.php
+++ b/src/Session.php
@@ -218,9 +218,7 @@ class Session
     {
 
         if (session_status() === PHP_SESSION_NONE) {
-           // Force session to use cookies and prevent JS scripts to access to them
-            ini_set('session.cookie_httponly', '1');
-            ini_set('session.use_only_cookies', '1');
+            ini_set('session.use_only_cookies', '1'); // Force session to use cookies
 
             session_name("glpi_" . md5(realpath(GLPI_ROOT)));
 

--- a/src/System/Requirement/SessionsSecurityConfiguration.php
+++ b/src/System/Requirement/SessionsSecurityConfiguration.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2022 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\System\Requirement;
+
+/**
+ * @since 10.0.3
+ */
+class SessionsSecurityConfiguration extends AbstractRequirement
+{
+    public function __construct()
+    {
+        $this->title = __('Security configuration for sessions');
+        $this->description = __('Ensure security is enforced on session cookies.');
+        $this->optional = true;
+    }
+
+    protected function check()
+    {
+        $cookie_secure   = (bool)ini_get('session.cookie_secure');
+        $cookie_httponly = (bool)ini_get('session.cookie_httponly');
+        $cookie_samesite = ini_get('session.cookie_samesite');
+
+        $is_https_request = ($_SERVER['HTTPS'] ?? 'off') === 'on' || (int)($_SERVER['SERVER_PORT'] ?? null) == 443;
+
+        $validated = true;
+        if ($is_https_request && !$cookie_secure) {
+            $this->validation_messages[] = __('PHP directive "session.cookie_secure" should be set to "on" when GLPI can be accessed on HTTPS protocol.');
+            $validated = false;
+        }
+        if (!$cookie_httponly) {
+            $this->validation_messages[] = __('PHP directive "session.cookie_httponly" should be set to "on" to prevent client-side script to access cookie values.');
+            $validated = false;
+        }
+
+        // 'session.cookie_samesite' can be:
+        // - 'None':        Cookie will be sent in all cross-origin requests (even POST requests).
+        //                  This may be dangerous, even if we have CSRF protection on POST requests.
+        // - 'Lax':         Cookie will not be sent in POST cross-origin requests.
+        //                  GET requests should not be used to write data, so it should be OK.
+        // - 'Strict':      Cookie will not be sent in cross-origin requests (even GET requests).
+        //                  This is the best security, but it will kill session in all requests that came from another app.
+        //                  For instance, it will break oauthsso/oauthimap plugins.
+        //                  We should consider it as valid, but we should not recommand it.
+        // - '' (empty):    directive will not be sent to the browser, and browser should apply the Lax policy.
+        if (!in_array(strtolower($cookie_samesite), ['lax', 'strict', ''])) {
+            $this->validation_messages[] = __('PHP directive "session.cookie_samesite" should be set, at least, to "Lax", to prevent cookie to be sent on cross-origin POST requests.');
+            $validated = false;
+        }
+
+        $this->validated = $validated;
+
+        if ($validated) {
+            $this->validation_messages[] = __s('Sessions configuration is secured.');
+        }
+    }
+}

--- a/src/System/RequirementsManager.php
+++ b/src/System/RequirementsManager.php
@@ -49,6 +49,7 @@ use Glpi\System\Requirement\PhpVersion;
 use Glpi\System\Requirement\ProtectedWebAccess;
 use Glpi\System\Requirement\SeLinux;
 use Glpi\System\Requirement\SessionsConfiguration;
+use Glpi\System\Requirement\SessionsSecurityConfiguration;
 
 /**
  * @since 9.5.0
@@ -133,6 +134,7 @@ class RequirementsManager
 
        // Below requirements are optionals
 
+        $requirements[] = new SessionsSecurityConfiguration();
         $requirements[] = new Extension(
             'exif',
             true,

--- a/tests/units/Glpi/System/Requirement/SessionsSecurityConfiguration.php
+++ b/tests/units/Glpi/System/Requirement/SessionsSecurityConfiguration.php
@@ -1,0 +1,181 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2022 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\System\Requirement;
+
+class SessionsSecurityConfiguration extends \GLPITestCase
+{
+    protected function configProvider(): iterable
+    {
+        $invalid_secure_msg   = 'PHP directive "session.cookie_secure" should be set to "on" when GLPI can be accessed on HTTPS protocol.';
+        $invalid_httponly_msg = 'PHP directive "session.cookie_httponly" should be set to "on" to prevent client-side script to access cookie values.';
+        $invalid_samesite_msg = 'PHP directive "session.cookie_samesite" should be set, at least, to "Lax", to prevent cookie to be sent on cross-origin POST requests.';
+        $valid_msg            = 'Sessions configuration is secured.';
+
+        // Totally unsecure config
+        yield [
+            'cookie_secure'   => '0',
+            'cookie_httponly' => '0',
+            'cookie_samesite' => 'none',
+            'server_https'    => 'on',
+            'server_port'     => '443',
+            'is_valid'        => false,
+            'messages'        => [$invalid_secure_msg, $invalid_httponly_msg, $invalid_samesite_msg],
+        ];
+
+        // Strict config
+        yield [
+            'cookie_secure'   => '1',
+            'cookie_httponly' => '1',
+            'cookie_samesite' => 'strict',
+            'server_https'    => 'on',
+            'server_port'     => '443',
+            'is_valid'        => true,
+            'messages'        => [$valid_msg],
+        ];
+
+        // cookie_secure can be 0 if query is not on HTTPS
+        yield [
+            'cookie_secure'   => '0',
+            'cookie_httponly' => '1',
+            'cookie_samesite' => 'strict',
+            'server_https'    => 'off',
+            'server_port'     => '80',
+            'is_valid'        => true,
+            'messages'        => [$valid_msg],
+        ];
+
+        // cookie_secure should be 1 if query is on HTTPS (detected from $_SERVER['HTTPS'])
+        yield [
+            'cookie_secure'   => '0',
+            'cookie_httponly' => '1',
+            'cookie_samesite' => 'strict',
+            'server_https'    => 'on',
+            'server_port'     => null,
+            'is_valid'        => false,
+            'messages'        => [$invalid_secure_msg],
+        ];
+
+        // cookie_secure should be 1 if query is on HTTPS (detected from $_SERVER['SERVER_PORT'])
+        yield [
+            'cookie_secure'   => '0',
+            'cookie_httponly' => '1',
+            'cookie_samesite' => 'strict',
+            'server_https'    => null,
+            'server_port'     => '443',
+            'is_valid'        => false,
+            'messages'        => [$invalid_secure_msg],
+        ];
+
+        // cookie_httponly should be 1
+        yield [
+            'cookie_secure'   => '0',
+            'cookie_httponly' => '0',
+            'cookie_samesite' => 'strict',
+            'server_https'    => 'off',
+            'server_port'     => '80',
+            'is_valid'        => false,
+            'messages'        => [$invalid_httponly_msg],
+        ];
+
+        // cookie_samesite should be 'Lax', 'Strict', or ''
+        $samesite_is_valid = [
+            'None' => false,
+            'Lax' => true,
+            'Strict' => true,
+            ''    => true,
+            'NotAnExpectedValue' => false,
+        ];
+        foreach ($samesite_is_valid as $samesite => $is_valid) {
+            yield [
+                'cookie_secure'   => '0',
+                'cookie_httponly' => '1',
+                'cookie_samesite' => $samesite,
+                'server_https'    => 'off',
+                'server_port'     => '80',
+                'is_valid'        => $is_valid,
+                'messages'        => $is_valid ? [$valid_msg] : [$invalid_samesite_msg],
+            ];
+            yield [
+                'cookie_secure'   => '0',
+                'cookie_httponly' => '1',
+                'cookie_samesite' => strtolower($samesite),
+                'server_https'    => 'off',
+                'server_port'     => '80',
+                'is_valid'        => $is_valid,
+                'messages'        => $is_valid ? [$valid_msg] : [$invalid_samesite_msg],
+            ];
+        }
+    }
+
+    /**
+     * @dataProvider configProvider
+     */
+    public function testCheckWithLowercaseLaxSameSiteConfig(
+        string $cookie_secure,
+        string $cookie_httponly,
+        string $cookie_samesite,
+        ?string $server_https,
+        ?string $server_port,
+        bool $is_valid,
+        array $messages
+    ) {
+        $this->function->ini_get = function ($name) use ($cookie_secure, $cookie_httponly, $cookie_samesite) {
+            switch ($name) {
+                case 'session.cookie_secure':
+                    return $cookie_secure;
+                    break;
+                case 'session.cookie_httponly':
+                    return $cookie_httponly;
+                    break;
+                case 'session.cookie_samesite':
+                    return $cookie_samesite;
+                    break;
+            }
+            return '';
+        };
+
+        if ($server_https !== null) {
+            $_SERVER['HTTPS'] = $server_https;
+        }
+        if ($server_port !== null) {
+            $_SERVER['SERVER_PORT'] = $server_port;
+        }
+
+        $this->newTestedInstance();
+        $this->boolean($this->testedInstance->isValidated())->isEqualTo($is_valid);
+        $this->array($this->testedInstance->getValidationMessages())->isEqualTo($messages);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

PHP directives can be used to secure session cookies, but forcing some values on GLPI side may cause a degraded experience for some users. Indeed, using `SameSite=Strict` result in not sending session cookies when acces to GLPI is made from another website. For instance, if a user is redirected from any website to GLPI, its session cookies will not be received by GLPI and will therefore be erased, and user will have to log-in again.

I propose to add a new optionnal "requirement" on installation process, in order to inform administrator about these PHP directives. With this, we would be able to removed hard-coded `session.cookie_httponly` configuration value.
![image](https://user-images.githubusercontent.com/33253653/181008430-f4cdf5dd-3f2c-4429-80c3-d4a6a18216dd.png)
