### PR TITLE
CommonITILs: restore status icon in header

### DIFF
--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -1033,7 +1033,7 @@ class CommonGLPI implements CommonGLPIInterface
 
             if ($this instanceof CommonITILObject) {
                 echo "<h3 class='navigationheader-title strong d-flex align-items-center'>";
-                echo "<i class='" . $this->getIcon() . " me-1'></i>";
+                echo "<span class='me-1'>" . $this->getStatusIcon($this->fields['status']) . '</span>';
                 echo $this->getNameID([
                     'forceid' => $this instanceof CommonITILObject
                 ]);


### PR DESCRIPTION
* Restore the "status icon" in tickets/changes/problems headers.

Before:

![image](https://user-images.githubusercontent.com/42734840/181021883-d6d49f13-f291-45b7-a712-0c116fe8101f.png)

After: 

![image](https://user-images.githubusercontent.com/42734840/181021966-dd3f49d6-9d83-4260-9db2-451ed092a6c5.png)

It seems like the status icon was removed from the header when migrating to the new UI.
I've had a few requests to restore it as it help identify quickly the ticket status.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24543
