### PR TITLE
Ignore criteria case for RuleRight

### DIFF
--- a/src/RuleRightCollection.php
+++ b/src/RuleRightCollection.php
@@ -216,8 +216,8 @@ class RuleRightCollection extends RuleCollection
      *
      * @see RuleCollection::prepareInputDataForProcess()
      *
-     * @param $input  input datas
-     * @param $params extra parameters given
+     * @param array $input  input datas
+     * @param array $params extra parameters given
      *
      * @return an array of attributes
      **/
@@ -228,32 +228,35 @@ class RuleRightCollection extends RuleCollection
             $groups = $input;
         }
 
+        // Some of the rule criteria is uppercase, but most other rule criterias are lowercase only
+        $params_lower = array_change_key_case($params, CASE_LOWER);
+
        //common parameters
         $rule_parameters = [
-            'TYPE'       => $params["type"] ?? "",
-            'LOGIN'      => $params["login"] ?? "",
-            'MAIL_EMAIL' => $params["email"] ?? $params["mail_email"] ?? "",
+            'TYPE'       => $params_lower["type"] ?? "",
+            'LOGIN'      => $params_lower["login"] ?? "",
+            'MAIL_EMAIL' => $params_lower["email"] ?? $params_lower["mail_email"] ?? "",
             '_groups_id' => $groups
         ];
 
        //IMAP/POP login method
-        if ($params["type"] == Auth::MAIL) {
-            $rule_parameters["MAIL_SERVER"] = $params["mail_server"] ?? "";
+        if ($params_lower["type"] == Auth::MAIL) {
+            $rule_parameters["MAIL_SERVER"] = $params_lower["mail_server"] ?? "";
         }
 
        //LDAP type method
-        if ($params["type"] == Auth::LDAP) {
+        if ($params_lower["type"] == Auth::LDAP) {
            //Get all the field to retrieve to be able to process rule matching
             $rule_fields = $this->getFieldsToLookFor();
 
            //Get all the datas we need from ldap to process the rules
             $sz         = @ldap_read(
-                $params["connection"],
-                $params["userdn"],
+                $params_lower["connection"],
+                $params_lower["userdn"],
                 "objectClass=*",
                 $rule_fields
             );
-            $rule_input = AuthLDAP::get_entries_clean($params["connection"], $sz);
+            $rule_input = AuthLDAP::get_entries_clean($params_lower["connection"], $sz);
 
             if (count($rule_input)) {
                 $rule_input = $rule_input[0];
@@ -262,7 +265,7 @@ class RuleRightCollection extends RuleCollection
                 foreach ($fields as $field) {
                     switch (Toolbox::strtoupper($field)) {
                         case "LDAP_SERVER":
-                            $rule_parameters["LDAP_SERVER"] = $params["ldap_server"];
+                            $rule_parameters["LDAP_SERVER"] = $params_lower["ldap_server"];
                             break;
 
                         default: // ldap criteria (added by user)

--- a/tests/functionnal/RuleRightCollection.php
+++ b/tests/functionnal/RuleRightCollection.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2022 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use DbTestCase;
+
+class RuleRightCollection extends DbTestCase
+{
+    protected function prepateInputDataForProcessProvider()
+    {
+        return [
+            [
+                [],
+                ['type' => \Auth::DB_GLPI, 'login' => 'glpi'],
+                ['TYPE' => \Auth::DB_GLPI, 'LOGIN' => 'glpi']
+            ],
+            [
+                [],
+                ['TYPE' => \Auth::DB_GLPI, 'loGin' => 'glpi'],
+                ['TYPE' => \Auth::DB_GLPI, 'LOGIN' => 'glpi']
+            ],
+            [
+                [],
+                ['type' => \Auth::MAIL, 'login' => 'glpi', 'mail_server' => 'mail.example.com'],
+                ['TYPE' => \Auth::MAIL, 'LOGIN' => 'glpi', 'MAIL_SERVER' => 'mail.example.com']
+            ],
+            [
+                [],
+                ['type' => \Auth::MAIL, 'login' => 'glpi', 'MAIL_server' => 'mail.example.com'],
+                ['TYPE' => \Auth::MAIL, 'LOGIN' => 'glpi', 'MAIL_SERVER' => 'mail.example.com']
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider prepateInputDataForProcessProvider
+     */
+    public function testPrepareInputDataForProcess($input, $params, $expected)
+    {
+        $collection = new \RuleRightCollection();
+
+        // Expect the result to have at least the key/values from the $expected array
+        $result = $collection->prepareInputDataForProcess($input, $params);
+        foreach ($expected as $key => $value) {
+            $this->array($result)->hasKey($key);
+            $this->variable($result[$key])->isEqualTo($value);
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12304

Some of the criteria for authorization rules are uppercase when every other rule criteria in GLPI are all lowercase. The `prepareInputDataForProcess` function for `RuleRight` only partially accounted for the uppercase criteria. At least temporarily to avoid other issues (not sure how else this method could be called), I added logic to the mentioned method to create a new array from the `params` array with all keys in lowercase. The result array keys are still in the correct case depending on how the criteria were declared.