### PR TITLE
Add fix for null menu param

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -6333,6 +6333,8 @@ class CommonDBTM extends CommonGLPI
         $id = (int) $id;
         $item = new static();
 
+        $menus = is_array($menus) ? $menus : [];
+
         // Check current interface
         $interface = Session::getCurrentInterface();
         if (isset($menus[Session::getCurrentInterface()])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12300

Added check if the `menu` param of `displayFullPageForItem` is null and if so, sets its value to an empty array.
The parameter here and some other places called from within this function can accept a null value based on both PHPDoc types and typehints. I did not see any case where a null value would have been handled differently than an empty array. This fix is just a workaround to avoid issues with the value conflicting with the PHP typehints in the other functions.

If the null value doesn't have a different function than an empty array, maybe that can be deprecated and removed in a later version.