### PR TITLE
Fix form header title for default notification translations

### DIFF
--- a/src/NotificationTemplateTranslation.php
+++ b/src/NotificationTemplateTranslation.php
@@ -73,7 +73,7 @@ class NotificationTemplateTranslation extends CommonDBChild
         if ($this->getField('language') != '') {
             return $CFG_GLPI['languages'][$this->getField('language')][0];
         } else {
-            return self::getTypeName(1);
+            return __('Default translation');
         }
 
         return '';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12259

If the translation language is empty (default translation), the form header has "Template translation - Template translation". The second occurance is supposed to be the language name, but the code defaulted to the class's type name instead of "Default translation".