### PR TITLE
Fix deprecation notice on recurrent ticket creation

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -3994,10 +3994,10 @@ JAVASCRIPT;
                 'alternative_email' => ['']
             ],
             '_groups_id_observer'       => 0,
-            // FIXME Use new format
             '_link'                     => [
-                'tickets_id_2' => '',
-                'link'         => ''
+                'itemtype_1' => Ticket::class,
+                'items_id_1' => 0,
+                'link'       => ''
             ],
             '_suppliers_id_assign'      => 0,
             '_suppliers_id_assign_notif' => ['use_notification'  => [$default_use_notif],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Found while validating #11304. Recurrent ticket creation uses default values, and its triggers a deprecation warning here:
https://github.com/glpi-project/glpi/blob/03ca90d110be22c4a9f95e6db963ffbf3c49bb9a/src/CommonITILObject.php#L1466-L1478