### PR TITLE
fix(search): counter sometimes wrong

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -1765,7 +1765,7 @@ class Search
         $prehref = $search['target'] . (strpos($search['target'], "?") !== false ? "&" : "?");
         $href    = $prehref . $parameters;
 
-        Session::initNavigateListItems($data['itemtype']);
+        Session::initNavigateListItems($data['itemtype'], '', $href);
 
         TemplateRenderer::getInstance()->display('components/search/display_data.html.twig', [
             'data'                => $data,

--- a/src/Session.php
+++ b/src/Session.php
@@ -306,13 +306,11 @@ class Session
      * @param string $itemtype Device type
      * @param string $title    List title (default '')
      **/
-    public static function initNavigateListItems($itemtype, $title = "")
+    public static function initNavigateListItems($itemtype, $title = "", $url = null)
     {
         global $AJAX_INCLUDE;
 
-        $_SESSION['glpilistitems'][$itemtype] = [];
-
-        if (isset($AJAX_INCLUDE)) {
+        if (isset($AJAX_INCLUDE) && ($url === null)) {
             return;
         }
         if (empty($title)) {
@@ -329,6 +327,7 @@ class Session
         }
 
         $_SESSION['glpilisttitle'][$itemtype] = $title;
+        $_SESSION['glpilistitems'][$itemtype] = [];
         $_SESSION['glpilisturl'][$itemtype]   = $url;
     }
 

--- a/src/Session.php
+++ b/src/Session.php
@@ -316,14 +316,16 @@ class Session
         if (empty($title)) {
             $title = __('List');
         }
-        $url = '';
+        if ($url === null) {
+            $url = '';
 
-        if (!isset($_SERVER['REQUEST_URI']) || (strpos($_SERVER['REQUEST_URI'], "tabs") > 0)) {
-            if (isset($_SERVER['HTTP_REFERER'])) {
-                $url = $_SERVER['HTTP_REFERER'];
+            if (!isset($_SERVER['REQUEST_URI']) || (strpos($_SERVER['REQUEST_URI'], "tabs") > 0)) {
+                if (isset($_SERVER['HTTP_REFERER'])) {
+                    $url = $_SERVER['HTTP_REFERER'];
+                }
+            } else {
+                $url = $_SERVER['REQUEST_URI'];
             }
-        } else {
-            $url = $_SERVER['REQUEST_URI'];
         }
 
         $_SESSION['glpilisttitle'][$itemtype] = $title;

--- a/src/Session.php
+++ b/src/Session.php
@@ -310,6 +310,8 @@ class Session
     {
         global $AJAX_INCLUDE;
 
+        $_SESSION['glpilistitems'][$itemtype] = [];
+
         if (isset($AJAX_INCLUDE)) {
             return;
         }
@@ -327,7 +329,6 @@ class Session
         }
 
         $_SESSION['glpilisttitle'][$itemtype] = $title;
-        $_SESSION['glpilistitems'][$itemtype] = [];
         $_SESSION['glpilisturl'][$itemtype]   = $url;
     }
 


### PR DESCRIPTION
Total counter at top right sometimes wrong

1. I am doing a search with 1 result:

![image](https://user-images.githubusercontent.com/8530352/181248136-c7d581f0-f57a-4087-808e-b66c27b72bc8.png)

2. When opening the ticket in result the counter is wrong:

![image](https://user-images.githubusercontent.com/8530352/181248272-8b78c4b5-50d1-47c8-8012-538e964f0a07.png)

3. If I go back to the list and then back to the same ticket, the counter is correct:

![image](https://user-images.githubusercontent.com/8530352/181248376-5056b653-b41a-45bc-8aeb-490ff702ef0a.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24541
