### PR TITLE
Search results: increase links font weight

### DIFF
--- a/css/includes/pages/_search.scss
+++ b/css/includes/pages/_search.scss
@@ -118,6 +118,10 @@
                 border-collapse: separate;
                 border-spacing: 0;
 
+                a {
+                    font-weight: 500;
+                }
+
                 @include media-breakpoint-up(lg) {
                     thead:first-child {
                         th {


### PR DESCRIPTION
We've had some feedback that links are hard to identify in the new UI.

For comparison, here are GLPI 9.5 search results:

![image](https://user-images.githubusercontent.com/42734840/181250253-0b65486f-752b-48e7-9a6c-c689e95b5b9a.png)

And GLPI 10:

![image](https://user-images.githubusercontent.com/42734840/181250376-f8692a40-9cbc-497d-8958-9f1d87223a14.png)

This is how to looks like if we increase the font weigth to 500 (one step above the 'default' font weight which is 400):

![image](https://user-images.githubusercontent.com/42734840/181250908-3d276725-f1cb-45bb-9ec8-1fa0949799e1.png)

Same for 600 (two steps above):

![image](https://user-images.githubusercontent.com/42734840/181251189-626bf6e7-d36f-44d7-8baa-e863627f2c1c.png)

And finally, 700 (= standard bold)

![image](https://user-images.githubusercontent.com/42734840/181251391-b33c8600-8021-4e5e-a619-17cf06a193a5.png)

In my opinion, full bold (700) is too much.
I'm fine with either 500 and 600, which both gave a noticeable difference to the links and make them stand apart from the rest of the values.
I was leaning more to 500 at first (which is the value included in this PR) but now that I'm looking at all the images side by side I may pick 600 as the best.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24376
