### PR TITLE
fix(ticket): empty service levels

### DIFF
--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -293,26 +293,32 @@
    {% endif %}
 
    {% if item.getType() == 'Ticket' %}
-      {% set nb_la = (item.fields['slas_id_tto'] > 0 ? 1 : 0) + (item.fields['slas_id_ttr'] > 0 ? 1 : 0) + (item.fields['olas_id_tto'] > 0 ? 1 : 0) + (item.fields['olas_id_ttr'] > 0 ? 1 : 0) %}
-      {% set servicelevels_show = headers_states['service-levels'] is defined and headers_states['service-levels'] == "true" ? true : false %}
-      <div class="accordion-item">
-         <h2 class="accordion-header" id="service-levels-heading" title="{{ _n('Service level', 'Service levels', get_plural_number()) }}" data-bs-toggle="tooltip">
-            <button class="accordion-button {{ servicelevels_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#service-levels" aria-expanded="true" aria-controls="service-levels">
-               <i class="ti ti-alarm me-1"></i>
-               <span class="item-title">
-                    {{ _n('Service level', 'Service levels', get_plural_number()) }}
-               </span>
-               {% if nb_la > 0 %}
-                  <span class="badge bg-secondary ms-2">{{ nb_la }}</span>
-               {% endif %}
-            </button>
-         </h2>
-         <div id="service-levels" class="accordion-collapse collapse {{ servicelevels_show ? "show" : "" }}" aria-labelledby="service-levels-heading">
-            <div class="accordion-body row m-0 mt-n2">
-               {{ include('components/itilobject/service_levels.html.twig') }}
+      {% set la_content %}
+         {{ include('components/itilobject/service_levels.html.twig') }}
+      {% endset %}
+
+      {% if la_content|trim|length > 0 %}
+         {% set nb_la = (item.fields['slas_id_tto'] > 0 ? 1 : 0) + (item.fields['slas_id_ttr'] > 0 ? 1 : 0) + (item.fields['olas_id_tto'] > 0 ? 1 : 0) + (item.fields['olas_id_ttr'] > 0 ? 1 : 0) %}
+         {% set servicelevels_show = headers_states['service-levels'] is defined and headers_states['service-levels'] == "true" ? true : false %}
+         <div class="accordion-item">
+            <h2 class="accordion-header" id="service-levels-heading" title="{{ _n('Service level', 'Service levels', get_plural_number()) }}" data-bs-toggle="tooltip">
+               <button class="accordion-button {{ servicelevels_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#service-levels" aria-expanded="true" aria-controls="service-levels">
+                  <i class="ti ti-alarm me-1"></i>
+                  <span class="item-title">
+                     {{ _n('Service level', 'Service levels', get_plural_number()) }}
+                  </span>
+                  {% if nb_la > 0 %}
+                     <span class="badge bg-secondary ms-2">{{ nb_la }}</span>
+                  {% endif %}
+               </button>
+            </h2>
+            <div id="service-levels" class="accordion-collapse collapse {{ servicelevels_show ? "show" : "" }}" aria-labelledby="service-levels-heading">
+               <div class="accordion-body row m-0 mt-n2">
+                  {{ la_content }}
+               </div>
             </div>
          </div>
-      </div>
+      {% endif %}
    {% endif %}
 
    {% if item.getType() in ['Problem', 'Change'] %}

--- a/templates/components/itilobject/service_levels.html.twig
+++ b/templates/components/itilobject/service_levels.html.twig
@@ -76,6 +76,7 @@
    }
 ]) %}
 
+{% set isEmpty = true %}
 
 {% for la_field in la_fields %}
    {% set rand = random() %}
@@ -83,6 +84,7 @@
    {% set la_displayed = field_options.fields_template is not defined or not field_options.fields_template.isHiddenField(la_field.lafieldname) %}
 
    {% if date_displayed or la_displayed %}
+      {% set isEmpty = false %}
       {% set la_html %}
          {% if la_field.la.getDataForTicket(item.fields['id'], la_field.type) %}
             {% if date_displayed %}
@@ -232,3 +234,9 @@
       ) }}
    {% endif %}
 {% endfor %}
+
+{% if isEmpty %}
+   <script type="text/javascript">
+      $('#service-levels-heading').closest('.accordion-item').hide();
+   </script>
+{% endif %}

--- a/templates/components/itilobject/service_levels.html.twig
+++ b/templates/components/itilobject/service_levels.html.twig
@@ -76,7 +76,7 @@
    }
 ]) %}
 
-{% set isEmpty = true %}
+{% set is_empty = true %}
 
 {% for la_field in la_fields %}
    {% set rand = random() %}
@@ -84,7 +84,7 @@
    {% set la_displayed = field_options.fields_template is not defined or not field_options.fields_template.isHiddenField(la_field.lafieldname) %}
 
    {% if date_displayed or la_displayed %}
-      {% set isEmpty = false %}
+      {% set is_empty = false %}
       {% set la_html %}
          {% if la_field.la.getDataForTicket(item.fields['id'], la_field.type) %}
             {% if date_displayed %}
@@ -235,8 +235,8 @@
    {% endif %}
 {% endfor %}
 
-{% if isEmpty %}
+{% if is_empty %}
    <script type="text/javascript">
-      $('#service-levels-heading').closest('.accordion-item').hide();
+      /$('#service-levels-heading').closest('.accordion-item').hide();
    </script>
 {% endif %}

--- a/templates/components/itilobject/service_levels.html.twig
+++ b/templates/components/itilobject/service_levels.html.twig
@@ -76,7 +76,6 @@
    }
 ]) %}
 
-{% set is_empty = true %}
 
 {% for la_field in la_fields %}
    {% set rand = random() %}
@@ -84,7 +83,6 @@
    {% set la_displayed = field_options.fields_template is not defined or not field_options.fields_template.isHiddenField(la_field.lafieldname) %}
 
    {% if date_displayed or la_displayed %}
-      {% set is_empty = false %}
       {% set la_html %}
          {% if la_field.la.getDataForTicket(item.fields['id'], la_field.type) %}
             {% if date_displayed %}
@@ -234,9 +232,3 @@
       ) }}
    {% endif %}
 {% endfor %}
-
-{% if is_empty %}
-   <script type="text/javascript">
-      /$('#service-levels-heading').closest('.accordion-item').hide();
-   </script>
-{% endif %}


### PR DESCRIPTION
If the template hides all the fields in "Service Levels", the area was visible in the ticket, but empty and therefore useless.

![image](https://user-images.githubusercontent.com/8530352/181256378-d046838a-e05f-43a5-96c1-1cf32d99dbbb.png)

![image](https://user-images.githubusercontent.com/8530352/181256133-2be6fe15-4020-4193-a981-cc99571f3af9.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24541
