### PR TITLE
fix(ticket): category FAQ link missing

### DIFF
--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -920,15 +920,19 @@ abstract class CommonDropdown extends CommonDBTM
         ) {
             $title = __s('FAQ');
 
+            $condition = [
+                KnowbaseItem::getTable() . '.id'  => KnowbaseItem::getForCategory($this->fields['knowbaseitemcategories_id'])
+            ];
+
             if (Session::getCurrentInterface() == 'central') {
                 $title = __s('Knowledge base');
+            } else {
+                $condition[KnowbaseItem::getTable() . '.is_faq'] = 1;
             }
 
             $rand = mt_rand();
             $kbitem = new KnowbaseItem();
-            $found_kbitem = $kbitem->find([
-                KnowbaseItem::getTable() . '.id'  => KnowbaseItem::getForCategory($this->fields['knowbaseitemcategories_id'])
-            ]);
+            $found_kbitem = $kbitem->find($condition);
 
             if (count($found_kbitem)) {
                 $kbitem->getFromDB(reset($found_kbitem)['id']);
@@ -961,9 +965,7 @@ abstract class CommonDropdown extends CommonDBTM
                         'value'     => reset($found_kbitem)['id'],
                         'display'   => false,
                         'rand'      => $rand,
-                        'condition' => [
-                            KnowbaseItem::getTable() . '.id' => KnowbaseItem::getForCategory($this->fields['knowbaseitemcategories_id'])
-                        ],
+                        'condition' => $condition,
                         'on_change' => "getKnowbaseItemAnswer$rand()"
                     ]);
                     $ret .= "<div class='faqadd_block_content' id='faqadd_block_content$rand'>";

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -367,7 +367,7 @@ class Dropdown
 
            // KB links
             if (
-                $item->isField('knowbaseitemcategories_id') && Session::haveRight('knowbase', READ)
+                $item->isField('knowbaseitemcategories_id') && Session::haveRightsOr('knowbase', [READ, KnowbaseItem::READFAQ])
                 && method_exists($item, 'getLinks')
             ) {
                 $paramskblinks = [
@@ -384,6 +384,9 @@ class Dropdown
                     $paramskblinks,
                     false
                 );
+                if ($item->fields['knowbaseitemcategories_id'] != $params['value']) {
+                    $item->getFromDB($params['value']);
+                }
                 $icons .= "<span id='$kblink_id'>";
                 $icons .= '&nbsp;' . $item->getLinks();
                 $icons .= "</span>";

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -384,7 +384,9 @@ class Dropdown
                     $paramskblinks,
                     false
                 );
-                if ($item->fields['knowbaseitemcategories_id'] != $params['value']) {
+                // With the self-service profile, $item (whose itemtype = ITILCategory) is empty,
+                //  as the profile does not have rights to ITILCategory to initialise it before.
+                if ($item->isNewItem()) {
                     $item->getFromDB($params['value']);
                 }
                 $icons .= "<span id='$kblink_id'>";


### PR DESCRIPTION
Since GLPI 10.0, the link to the FAQ related to the category had disappeared in simplified interface.

![image](https://user-images.githubusercontent.com/8530352/181510330-33f3b9ba-27c2-4821-9cb5-30cc3807c40b.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | portal 6922
