### PR TITLE
API: decode html

### DIFF
--- a/apirest.md
+++ b/apirest.md
@@ -1655,6 +1655,16 @@ $ curl -X GET \
 
 The body of the answer contains the raw image.
 
+### Sanitized content
+
+By default, the API will return sanitized content.  
+This mean that all HTML special characters will be encoded.  
+You can disable this feature by adding the following header to your request:  
+
+```
+X-GLPI-Sanitized-Content: false
+```
+
 ## Errors
 
 ### ERROR_ITEM_NOT_FOUND

--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -1845,8 +1845,15 @@ abstract class API
                     if ($new_id === false) {
                         $failed++;
                     }
+
+                    $message = $this->getGlpiLastMessage();
+                    if (!$this->returnSanitizedContent()) {
+                        // Message may contains the created item name, which may
+                        // contains some encoded html
+                        $message = html_entity_decode($message);
+                    }
                     $current_res = ['id'      => $new_id,
-                        'message' => $this->getGlpiLastMessage()
+                        'message' => $message
                     ];
                 }
 
@@ -2330,7 +2337,7 @@ abstract class API
     /**
      * Get last message added in $_SESSION by Session::addMessageAfterRedirect
      *
-     * @return array  of messages
+     * @return string Last message
      */
     private function getGlpiLastMessage()
     {

--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -1028,7 +1028,12 @@ abstract class API
         }
 
         // Decode HTML
-        $fields = array_map(fn ($f) => is_string($f) ? html_entity_decode($f) : $f, $fields);
+        if (!$this->returnSanitizedContent()) {
+            $fields = array_map(
+                fn ($f) => is_string($f) ? html_entity_decode($f) : $f,
+                $fields
+            );
+        }
 
         return $fields;
     }
@@ -1300,7 +1305,12 @@ abstract class API
             }
 
             // Decode HTML
-            $fields = array_map(fn ($f) => is_string($f) ? html_entity_decode($f) : $f, $fields);
+            if (!$this->returnSanitizedContent()) {
+                $fields = array_map(
+                    fn ($f) => is_string($f) ? html_entity_decode($f) : $f,
+                    $fields
+                );
+            }
         }
        // Break reference
         unset($fields);
@@ -3361,5 +3371,15 @@ abstract class API
             "changeActiveEntities",
             "changeActiveProfile",
         ];
+    }
+
+    /**
+     * Will the API content be sanitized ?
+     *
+     * @return bool
+     */
+    public function returnSanitizedContent(): bool
+    {
+        return true;
     }
 }

--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -1030,7 +1030,7 @@ abstract class API
         // Decode HTML
         if (!$this->returnSanitizedContent()) {
             $fields = array_map(
-                fn ($f) => is_string($f) ? html_entity_decode($f) : $f,
+                fn ($f) => is_string($f) ? Sanitizer::decodeHtmlSpecialChars($f) : $f,
                 $fields
             );
         }
@@ -1307,7 +1307,7 @@ abstract class API
             // Decode HTML
             if (!$this->returnSanitizedContent()) {
                 $fields = array_map(
-                    fn ($f) => is_string($f) ? html_entity_decode($f) : $f,
+                    fn ($f) => is_string($f) ? Sanitizer::decodeHtmlSpecialChars($f) : $f,
                     $fields
                 );
             }
@@ -1850,7 +1850,7 @@ abstract class API
                     if (!$this->returnSanitizedContent()) {
                         // Message may contains the created item name, which may
                         // contains some encoded html
-                        $message = html_entity_decode($message);
+                        $message = Sanitizer::decodeHtmlSpecialChars($message);
                     }
                     $current_res = ['id'      => $new_id,
                         'message' => $message

--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -1027,6 +1027,9 @@ abstract class API
             );
         }
 
+        // Decode HTML
+        $fields = array_map(fn ($f) => is_string($f) ? html_entity_decode($f) : $f, $fields);
+
         return $fields;
     }
 
@@ -1295,6 +1298,9 @@ abstract class API
                     ];
                 }
             }
+
+            // Decode HTML
+            $fields = array_map(fn ($f) => is_string($f) ? html_entity_decode($f) : $f, $fields);
         }
        // Break reference
         unset($fields);

--- a/src/Api/APIRest.php
+++ b/src/Api/APIRest.php
@@ -648,4 +648,15 @@ class APIRest extends API
         }
         exit;
     }
+
+    /**
+     * Read X-GLPI-Sanitized-Content header value (default: true)
+     *
+     * @return bool
+     */
+    public function returnSanitizedContent(): bool
+    {
+        $sanitized_content = $_SERVER['HTTP_X_GLPI_SANITIZED_CONTENT'] ?? true;
+        return filter_var($sanitized_content, FILTER_VALIDATE_BOOLEAN);
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -101,7 +101,7 @@ function loadDataset()
    // Unit test data definition
     $data = [
       // bump this version to force reload of the full dataset, when content change
-        '_version' => '4.7',
+        '_version' => '4.8',
 
       // Type => array of entries
         'Entity' => [
@@ -146,6 +146,10 @@ function loadDataset()
             ], [
                 'name'        => '_test_pc22',
                 'entities_id' => '_test_child_2',
+            ], [
+                'name'        => '_test_pc_with_encoded_comment',
+                'entities_id' => '_test_root_entity',
+                'comment'     => '&#60;&#62;', // "&#60;" => "<", "&#62;" => ">"
             ]
         ], 'ComputerModel' => [
             [

--- a/tests/functionnal/Computer.php
+++ b/tests/functionnal/Computer.php
@@ -367,7 +367,7 @@ class Computer extends DbTestCase
             }
         )->error()
          ->withType(E_USER_WARNING)
-         ->withMessage('getFromDBByCrit expects to get one result, 8 found in query "SELECT `id` FROM `glpi_computers` WHERE `name` LIKE \'_test%\'".')
+         ->withMessage('getFromDBByCrit expects to get one result, 9 found in query "SELECT `id` FROM `glpi_computers` WHERE `name` LIKE \'_test%\'".')
          ->exists();
     }
 

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -409,7 +409,7 @@ class DbUtils extends DbTestCase
             ['_test_root_entity', true, 'glpi_computers', ['name' => '_test_pc11'], 1],
             ['_test_root_entity', true, 'glpi_computers', ['name' => '_test_pc01'], 1],
 
-            ['_test_root_entity', false, 'glpi_computers', [], 3],
+            ['_test_root_entity', false, 'glpi_computers', [], 4],
             ['_test_root_entity', false, 'glpi_computers', ['name' => '_test_pc11'], 0],
             ['_test_root_entity', false, 'glpi_computers', ['name' => '_test_pc01'], 1],
 

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -405,7 +405,7 @@ class DbUtils extends DbTestCase
     protected function dataCountMyEntities()
     {
         return [
-            ['_test_root_entity', true, 'glpi_computers', [], 8],
+            ['_test_root_entity', true, 'glpi_computers', [], 9],
             ['_test_root_entity', true, 'glpi_computers', ['name' => '_test_pc11'], 1],
             ['_test_root_entity', true, 'glpi_computers', ['name' => '_test_pc01'], 1],
 
@@ -444,7 +444,7 @@ class DbUtils extends DbTestCase
     protected function dataCountEntities()
     {
         return [
-            ['_test_root_entity', 'glpi_computers', [], 3],
+            ['_test_root_entity', 'glpi_computers', [], 4],
             ['_test_root_entity', 'glpi_computers', ['name' => '_test_pc11'], 0],
             ['_test_root_entity', 'glpi_computers', ['name' => '_test_pc01'], 1],
 

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -1746,7 +1746,7 @@ class Search extends DbTestCase
 
         $data = $this->doSearch('Computer', $search_params);
 
-        $this->integer($data['data']['totalcount'])->isIdenticalTo(8);
+        $this->integer($data['data']['totalcount'])->isIdenticalTo(9);
     }
 
     public function testSearchWithMultipleFkeysOnSameTable()
@@ -1982,6 +1982,7 @@ class Search extends DbTestCase
                     'as_map'       => 0,
                 ],
                 'expected' => [
+                    '_test_pc_with_encoded_comment',
                     '_test_pc01',
                     '_test_pc02',
                     '_test_pc03',

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -1734,7 +1734,7 @@ class Search extends DbTestCase
         ];
         $data = $this->doSearch('Computer', $search_params);
 
-        $this->integer($data['data']['totalcount'])->isIdenticalTo(8);
+        $this->integer($data['data']['totalcount'])->isIdenticalTo(9);
 
         $displaypref = new \DisplayPreference();
         $input = [

--- a/tests/web/APIRest.php
+++ b/tests/web/APIRest.php
@@ -1287,7 +1287,8 @@ class APIRest extends APIBaseClass
      *
      * @return void
      */
-    public function testReturnSanitizedContentFunctional(): void {
+    public function testReturnSanitizedContentFunctional(): void
+    {
         // Get computer with encoded comment
         $computers_id = getItemByTypeName(
             "Computer",

--- a/tests/web/APIRest.php
+++ b/tests/web/APIRest.php
@@ -1227,4 +1227,94 @@ class APIRest extends APIBaseClass
             $after_test();
         }
     }
+
+    /**
+     * Data provider for testReturnSanitizedContentUnit
+     *
+     * @return array
+     */
+    protected function testReturnSanitizedContentUnitProvider(): array
+    {
+        return [
+            [null, true],
+            ["", false],
+            ["true", true],
+            ["false", false],
+            ["on", true],
+            ["off", false],
+            ["1", true],
+            ["0", false],
+            ["yes", true],
+            ["no", false],
+            ["asfbhueshf", false],
+        ];
+    }
+
+    /**
+     * Unit test for the "returnSanitizedContent" method
+     *
+     * @dataProvider testReturnSanitizedContentUnitProvider
+     *
+     * @param string $header_value    Header value to be tested
+     * @param bool   $expected_output Expected output for this header
+     *
+     * @return void
+     */
+    public function testReturnSanitizedContentUnit(
+        ?string $header_value,
+        bool $expected_output
+    ): void {
+        $api = new \Glpi\Api\APIRest();
+
+        if ($header_value === null) {
+            // Simulate missing header
+            unset($_SERVER['HTTP_X_GLPI_SANITIZED_CONTENT']);
+        } else {
+            $_SERVER['HTTP_X_GLPI_SANITIZED_CONTENT'] = $header_value;
+        }
+
+        // Run test
+        $this->boolean(
+            $api->returnSanitizedContent()
+        )->isEqualTo($expected_output);
+
+        // Clean header
+        unset($_SERVER['HTTP_X_GLPI_SANITIZED_CONTENT']);
+    }
+
+    /**
+     * Functional test for the "returnSanitizedContent" method
+     *
+     * @return void
+     */
+    public function testReturnSanitizedContentFunctional(): void {
+        // Get computer with encoded comment
+        $computers_id = getItemByTypeName(
+            "Computer",
+            "_test_pc_with_encoded_comment",
+            true
+        );
+
+        // Request params
+        $url = "/Computer/$computers_id";
+        $method = "GET";
+        $headers = ['Session-Token' => $this->session_token];
+
+        // Execute first test (keep encoded content)
+        $data = $this->query($url, [
+            'headers' => $headers,
+            'verb'    => $method,
+        ], 200);
+        $this->string($data['comment'])->isEqualTo("&#60;&#62;");
+
+        // Add additional header
+        $headers['X-GLPI-Sanitized-Content'] = "false";
+
+        // Execute second test (expect decoded content)
+        $data = $this->query($url, [
+            'headers' => $headers,
+            'verb'    => $method,
+        ], 200);
+        $this->string($data['comment'])->isEqualTo("<>");
+    }
 }


### PR DESCRIPTION
One issue with our API is that results are returned with encoded HTML:

![image](https://user-images.githubusercontent.com/42734840/181511596-6c1165ee-c58b-43d7-a05c-a0017166e636.png)

![image](https://user-images.githubusercontent.com/42734840/181512526-58e989ab-75e2-4de1-9b3a-6a28d2e281c9.png)

It happens because we store HTML encoded data in the database (bad practice), but I don't see us changing that soon because of how much work would be involved.

What we can do now is decode the data before sending it in the API response.

Regarding the impact on existing code that use the API, I expect most code would already be decoding the content.
In this case, decoding a second time shouldn't break anything.

Is there some use case we should be worried about breaking with this change ?

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24579
