### PR TITLE
Prevent itemtype migration to fail on unexpected id field

### DIFF
--- a/src/Migration.php
+++ b/src/Migration.php
@@ -1462,6 +1462,8 @@ class Migration
                         ['column_name'  => 'itemtype'],
                         ['column_name'  => ['LIKE', 'itemtype_%']],
                     ],
+                    // Handle edge case where an id column (i.e. a kind of foreign key) is prefixed by `itemtype_`.
+                    ['NOT' => ['column_name'  => ['LIKE', '%_id']]],
                 ],
                 'ORDER'  => 'TABLE_NAME',
             ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Even if https://github.com/glpi-project/glpi-inventory-plugin/issues/195 is not due to `Migration::renameItemtype()`, same kind of failure may happens.