### PR TITLE
Fix Add Emails To Notimported Emails

### DIFF
--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -911,9 +911,12 @@ class MailCollector extends CommonDBTM
                         } else {
                             $rejinput['reason'] = NotImportedEmail::MATCH_NO_RULE;
                         }
-                        $refused++;
-                        $rejected->add($rejinput);
-                        $delete[$uid] =  self::REFUSED_FOLDER;
+                        if (!empty($rejinput['to'])) {
+                            $rejected->add($rejinput);
+                        } else {
+                            $refused++;
+                            $delete[$uid] =  self::REFUSED_FOLDER;
+                        }
                     }
 
                   // Clean mail author used for notification settings


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

If the emails do not match the rules, they are automatically rejected and do not appear in the list of unimported emails. This commit fixes that. (Tested with several clients)
