### PR TITLE
Status dropdown: fix undefined values

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -891,7 +891,7 @@ var templateSelection = function (selection) {
 
 var templateItilStatus = function(option) {
     if (option === false) {
-        // option is false when element does not match searched terms
+        // Option is false when element does not match searched terms
         return null;
     }
     var status = option.id || 0;
@@ -946,6 +946,11 @@ var templateItilStatus = function(option) {
 };
 
 var templateValidation = function(option) {
+    if (option === false) {
+        // Option is false when element does not match searched terms
+        return null;
+    }
+
     var status = option.id || 0;
 
     var classes = "";
@@ -965,10 +970,18 @@ var templateValidation = function(option) {
 };
 
 var templateItilPriority = function(option) {
+    if (option === false) {
+        // Option is false when element does not match searched terms
+        return null;
+    }
+
     var priority = option.id || 0;
     var priority_color = CFG_GLPI['priority_'+priority] || "";
+    var color_badge = "";
 
-    var color_badge = `<i class='fas fa-circle' style='color: ${priority_color}'></i>`;
+    if (priority_color.length > 0) {
+        var color_badge = `<i class='fas fa-circle' style='color: ${priority_color}'></i>`;
+    }
 
     return $(`<span>${color_badge}&nbsp;${option.text}</span>`);
 };

--- a/js/common.js
+++ b/js/common.js
@@ -890,12 +890,11 @@ var templateSelection = function (selection) {
 };
 
 var templateItilStatus = function(option) {
-    var status = option.id || 0;
-
-    // Only show valid items
-    if (option.text == undefined) {
+    if (option === false) {
+        // option is false when element does not match searched terms
         return null;
     }
+    var status = option.id || 0;
 
     var classes = "";
     switch (parseInt(status)) {

--- a/js/common.js
+++ b/js/common.js
@@ -980,7 +980,7 @@ var templateItilPriority = function(option) {
     var color_badge = "";
 
     if (priority_color.length > 0) {
-        var color_badge = `<i class='fas fa-circle' style='color: ${priority_color}'></i>`;
+        color_badge += `<i class='fas fa-circle' style='color: ${priority_color}'></i>`;
     }
 
     return $(`<span>${color_badge}&nbsp;${option.text}</span>`);

--- a/js/common.js
+++ b/js/common.js
@@ -892,6 +892,11 @@ var templateSelection = function (selection) {
 var templateItilStatus = function(option) {
     var status = option.id || 0;
 
+    // Only show valid items
+    if (option.text == undefined) {
+        return null;
+    }
+
     var classes = "";
     switch (parseInt(status)) {
         case 1 :


### PR DESCRIPTION
When filtering the status dropdown, the values that didn't match the filter are shown are shown as "undefined" instead of being hidden from the results.

Before:

![image](https://user-images.githubusercontent.com/42734840/182340488-d3d7be76-4c59-4565-8455-7cb9a74bcf54.png)

After:

![image](https://user-images.githubusercontent.com/42734840/182340578-1e02e5d7-5de0-4dfa-85aa-5c8c7e081337.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
