### PR TITLE
Allow any object in URL to a document

### DIFF
--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2618,21 +2618,22 @@ class Toolbox
                         $document->getFromDB($id)
                         && strpos($document->fields['mime'], 'image/') !== false
                     ) {
-                        // append itil object reference in image link
-                        $itil_object = null;
-                        if ($item instanceof CommonITILObject) {
-                            $itil_object = $item;
-                        } else if (
-                            isset($item->input['_job'])
+                        // append object reference in image link
+                        $linked_object = null;
+                        if (
+                              !($item instanceof CommonITILObject)
+                              && isset($item->input['_job'])
                               && $item->input['_job'] instanceof CommonITILObject
                         ) {
-                            $itil_object = $item->input['_job'];
+                            $linked_object = $item->input['_job'];
+                        } else if ($item instanceof CommonDBTM) {
+                            $linked_object = $item;
                         }
-                        $itil_url_param = null !== $itil_object
-                        ? "&{$itil_object->getForeignKeyField()}={$itil_object->fields['id']}"
+                        $object_url_param = null !== $linked_object
+                        ? sprintf('&itemtype=%s&items_id=%s', $linked_object->getType(), $linked_object->fields['id'])
                         : "";
                         $img = "<img alt='" . $image['tag'] . "' src='" . $base_path .
-                          "/front/document.send.php?docid=" . $id . $itil_url_param . "'/>";
+                          "/front/document.send.php?docid=" . $id . $object_url_param . "'/>";
 
                       // 1 - Replace direct tag (with prefix and suffix) by the image
                         $content_text = preg_replace(
@@ -2669,7 +2670,7 @@ class Toolbox
                                 $width,
                                 $height,
                                 true,
-                                $itil_url_param
+                                $object_url_param
                             );
                             if (empty($new_image)) {
                                   $new_image = '#' . $image['tag'] . '#';

--- a/tests/functionnal/Toolbox.php
+++ b/tests/functionnal/Toolbox.php
@@ -536,8 +536,9 @@ class Toolbox extends DbTestCase
             $item->fields['id'] = mt_rand(1, 50);
 
             $img_url = '/front/document.send.php?docid={docid}'; //{docid} to replace by generated doc id
-            if ($item instanceof \CommonITILObject) {
-                $img_url .= '&' . $item->getForeignKeyField() . '=' . $item->fields['id'];
+            if ($item instanceof \CommonDBTM) {
+                $img_url .= '&itemtype=' . $item->getType();
+                $img_url .= '&items_id=' . $item->fields['id'];
             }
 
             $data[] = [
@@ -622,7 +623,8 @@ class Toolbox extends DbTestCase
         $item->fields['id'] = mt_rand(1, 50);
 
         $img_url = '/front/document.send.php?docid={docid}'; //{docid} to replace by generated doc id
-        $img_url .= '&tickets_id=' . $item->fields['id'];
+        $img_url .= '&itemtype=' . $item->getType();
+        $img_url .= '&items_id=' . $item->fields['id'];
 
         return [
             [
@@ -727,7 +729,9 @@ class Toolbox extends DbTestCase
         $content_text    = '';
         $expected_result = '';
         foreach ($doc_data as $doc_id => $doc) {
-            $expected_url    = '/front/document.send.php?docid=' . $doc_id . '&tickets_id=' . $item->fields['id'];
+            $expected_url    = '/front/document.send.php?docid=' . $doc_id;
+            $expected_url    .= '&itemtype=' . $item->getType();
+            $expected_url    .= '&items_id=' . $item->fields['id'];
             $content_text    .= '<img id="' . $doc['tag'] . '" width="10" height="10" />';
             $expected_result .= '<a href="' . $expected_url . '" target="_blank" ><img alt="' . $doc['tag'] . '" width="10" src="' . $expected_url . '" /></a>';
         }
@@ -779,9 +783,13 @@ class Toolbox extends DbTestCase
         $this->integer((int)$doc_id_2)->isGreaterThan(0);
 
         $content_text    = '<img id="' . $img_tag . '" width="10" height="10" />';
-        $expected_url_1    = '/front/document.send.php?docid=' . $doc_id_1 . '&tickets_id=' . $item->fields['id'];
+        $expected_url_1    = '/front/document.send.php?docid=' . $doc_id_1;
+        $expected_url_1     .= '&itemtype=' . $item->getType();
+        $expected_url_1     .= '&items_id=' . $item->fields['id'];
         $expected_result_1 = '<a href="' . $expected_url_1 . '" target="_blank" ><img alt="' . $img_tag . '" width="10" src="' . $expected_url_1 . '" /></a>';
-        $expected_url_2    = '/front/document.send.php?docid=' . $doc_id_2 . '&tickets_id=' . $item->fields['id'];
+        $expected_url_2    = '/front/document.send.php?docid=' . $doc_id_2;
+        $expected_url_2     .= '&itemtype=' . $item->getType();
+        $expected_url_2     .= '&items_id=' . $item->fields['id'];
         $expected_result_2 = '<a href="' . $expected_url_2 . '" target="_blank" ><img alt="' . $img_tag . '" width="10" src="' . $expected_url_2 . '" /></a>';
 
 
@@ -833,7 +841,9 @@ class Toolbox extends DbTestCase
 
         $content_text     = '<img id="' . $img_tag . '" width="10" height="10" />';
         $content_text    .= $content_text;
-        $expected_url     = '/front/document.send.php?docid=' . $doc_id . '&tickets_id=' . $item->fields['id'];
+        $expected_url     = '/front/document.send.php?docid=' . $doc_id;
+        $expected_url    .= '&itemtype=' . $item->getType();
+        $expected_url    .= '&items_id=' . $item->fields['id'];
         $expected_result  = '<a href="' . $expected_url . '" target="_blank" ><img alt="' . $img_tag . '" width="10" src="' . $expected_url . '" /></a>';
         $expected_result .= $expected_result;
 


### PR DESCRIPTION
Related to #10945

Formcreator needs to create URL to documents with query parameters itemtype=xxxx&items_id=xxxx . (see https://github.com/pluginsGLPI/formcreator/pull/2907)

This PR avoids code duplication currently added in the above PR.

