### PR TITLE
Console: fix build:compile_scss in production builds

### DIFF
--- a/src/Console/Build/CompileScssCommand.php
+++ b/src/Console/Build/CompileScssCommand.php
@@ -175,10 +175,17 @@ class CompileScssCommand extends Command
      */
     private function getLicenceHeaderString(): string
     {
-       // Extract header lines
-        $lines = file(GLPI_ROOT . '/tools/HEADER');
+        // Extract header lines
+        $header_file = GLPI_ROOT . '/tools/HEADER';
 
-       // Add * prefix on all lines
+        if (!file_exists($header_file)) {
+            // Production build, there is no tools/HEADER file
+            return "";
+        }
+
+        $lines = file($header_file);
+
+        // Add * prefix on all lines
         $lines = array_map(
             function ($line) {
                 $line_prefix = ' * ';
@@ -187,7 +194,7 @@ class CompileScssCommand extends Command
             $lines
         );
 
-       // Surround by opening and closing lines
+        // Surround by opening and closing lines
         $lines = array_merge(["/**\n"], $lines, [" */\n\n"]);
 
         return implode($lines);

--- a/src/Console/Build/CompileScssCommand.php
+++ b/src/Console/Build/CompileScssCommand.php
@@ -119,8 +119,6 @@ class CompileScssCommand extends Command
             }
         }
 
-        $licence_header = $this->getLicenceHeaderString();
-
         foreach ($files as $file) {
             $output->writeln(
                 '<comment>' . sprintf('Processing "%s".', $file) . '</comment>',
@@ -133,14 +131,6 @@ class CompileScssCommand extends Command
                     'file'    => $file,
                     'nocache' => true,
                 ]
-            );
-
-            // Insert licence header after the "@charset" directive.
-            $css = preg_replace(
-                '/^(@charset [^;]+;)/',
-                '$0' . PHP_EOL . $licence_header,
-                $css,
-                1
             );
 
             if ($dry_run) {
@@ -166,37 +156,5 @@ class CompileScssCommand extends Command
         }
 
         return 0; // Success
-    }
-
-    /**
-     * Get lincence header string.
-     *
-     * @return string
-     */
-    private function getLicenceHeaderString(): string
-    {
-        // Extract header lines
-        $header_file = GLPI_ROOT . '/tools/HEADER';
-
-        if (!file_exists($header_file)) {
-            // Production build, there is no tools/HEADER file
-            return "";
-        }
-
-        $lines = file($header_file);
-
-        // Add * prefix on all lines
-        $lines = array_map(
-            function ($line) {
-                $line_prefix = ' * ';
-                return (preg_match('/^\s+$/', $line) ? rtrim($line_prefix) : $line_prefix) . $line;
-            },
-            $lines
-        );
-
-        // Surround by opening and closing lines
-        $lines = array_merge(["/**\n"], $lines, [" */\n\n"]);
-
-        return implode($lines);
     }
 }


### PR DESCRIPTION
The `tools` folder doesn't exist in GLPI official releases.
Therefore,  `tools/HEADER` can't be fetched by the `build:compile_scss` command.

We must either:
*  Include this file in the releases
*  Have a fallback to an empty string when it's missing (which is the change proposed by this PR)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
