### PR TITLE
Clone profiles

### DIFF
--- a/src/Features/Clonable.php
+++ b/src/Features/Clonable.php
@@ -76,7 +76,8 @@ trait Clonable
             'date_mod',
             'date_creation',
             'template_name',
-            'is_template'
+            'is_template',
+            'is_default'
         ];
         foreach ($properties_to_clean as $property) {
             if (array_key_exists($property, $input)) {

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -38,6 +38,7 @@
  **/
 class Profile extends CommonDBTM
 {
+    use \Glpi\Features\Clonable;
    // Specific ones
 
    /// Helpdesk fields of helpdesk profiles
@@ -119,7 +120,6 @@ class Profile extends CommonDBTM
 
         $forbidden   = parent::getForbiddenStandardMassiveAction();
         $forbidden[] = 'update';
-        $forbidden[] = 'clone';
         return $forbidden;
     }
 
@@ -303,6 +303,13 @@ class Profile extends CommonDBTM
        // PROFILES and UNIQUE_PROFILE in RuleMailcollector
         Rule::cleanForItemCriteria($this, 'PROFILES');
         Rule::cleanForItemCriteria($this, 'UNIQUE_PROFILE');
+    }
+
+    public function getCloneRelations(): array
+    {
+        return [
+            ProfileRight::class
+        ];
     }
 
 

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -39,6 +39,7 @@
 class Profile extends CommonDBTM
 {
     use \Glpi\Features\Clonable;
+
    // Specific ones
 
    /// Helpdesk fields of helpdesk profiles

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -513,9 +513,26 @@ class Profile extends CommonDBTM
             $input["ticket_status"] = exportArrayToDB($cycle);
         }
 
+        $other_array_fields = ['ticket_status', 'problem_status', 'change_status'];
+        foreach ($other_array_fields as $array_field) {
+            if (isset($input[$array_field])) {
+                $input[$array_field] = exportArrayToDB($input[$array_field]);
+            }
+        }
+
         return $input;
     }
 
+    public function prepareInputForClone($input)
+    {
+        $input_arrays = ['helpdesk_item_type', 'managed_domainrecordtypes', 'ticket_status', 'problem_status', 'change_status'];
+        foreach ($input_arrays as $array_field) {
+            if (isset($input[$array_field])) {
+                $input[$array_field] = importArrayFromDB(Toolbox::stripslashes_deep($input[$array_field]));
+            }
+        }
+        return $input;
+    }
 
     /**
      * Unset unused rights for helpdesk

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Toolbox\Sanitizer;
+
 /**
  * Profile class
  **/
@@ -515,7 +517,7 @@ class Profile extends CommonDBTM
 
         $other_array_fields = ['ticket_status', 'problem_status', 'change_status'];
         foreach ($other_array_fields as $array_field) {
-            if (isset($input[$array_field])) {
+            if (isset($input[$array_field]) && is_array($input[$array_field])) {
                 $input[$array_field] = exportArrayToDB($input[$array_field]);
             }
         }
@@ -528,7 +530,7 @@ class Profile extends CommonDBTM
         $input_arrays = ['helpdesk_item_type', 'managed_domainrecordtypes', 'ticket_status', 'problem_status', 'change_status'];
         foreach ($input_arrays as $array_field) {
             if (isset($input[$array_field])) {
-                $input[$array_field] = importArrayFromDB(Toolbox::stripslashes_deep($input[$array_field]));
+                $input[$array_field] = importArrayFromDB(Sanitizer::dbUnescape($input[$array_field]));
             }
         }
         return $input;

--- a/src/ProfileRight.php
+++ b/src/ProfileRight.php
@@ -47,6 +47,12 @@ class ProfileRight extends CommonDBChild
     public static $items_id = 'profiles_id'; // Field name
     public $dohistory       = true;
 
+    /**
+     * {@inheritDoc}
+     * @note Unlike the default implementation, this one handles the fact that some or all profile rights
+     *       are already in the DB (but set to 0) when the cloned profile is created.
+     *       Therefore, we need to use update or insert DB queries rather than `CommonDBTM::add`.
+     */
     public function clone(array $override_input = [], bool $history = true)
     {
         global $DB;

--- a/src/ProfileRight.php
+++ b/src/ProfileRight.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Toolbox\Sanitizer;
+
 /**
  * Profile class
  *
@@ -53,7 +55,7 @@ class ProfileRight extends CommonDBChild
             return false;
         }
         $new_item = new static();
-        $input = Toolbox::addslashes_deep($this->fields);
+        $input = Sanitizer::dbEscapeRecursive($this->fields);
         $input['profiles_id'] = $override_input['profiles_id'];
         unset($input['id']);
 

--- a/tests/functionnal/MassiveAction.php
+++ b/tests/functionnal/MassiveAction.php
@@ -93,8 +93,8 @@ class MassiveAction extends DbTestCase
             ], [
                 'itemtype'     => 'Profile',
                 'items_id'     => 'Super-Admin',
-                'allcount'     => 2,
-                'singlecount'  => 1
+                'allcount'     => 3,
+                'singlecount'  => 2
             ]
         ];
     }

--- a/tests/functionnal/Profile.php
+++ b/tests/functionnal/Profile.php
@@ -194,4 +194,53 @@ class Profile extends DbTestCase
             $this->integer(($profile->fields['ticket'] & $right))->isEqualTo($right);
         }
     }
+
+    public function testClone()
+    {
+        global $DB;
+
+        // Get default "Admin" profile
+        $profile = new \Profile();
+        $this->boolean($profile->getFromDB(3))->isTrue();
+
+        // Clone it
+        $cloned_profile = new \Profile();
+        $clone_profiles_id = $profile->clone([
+            'name' => __FUNCTION__,
+        ]);
+        $this->integer($clone_profiles_id)->isGreaterThan(0);
+        $cloned_profile->getFromDB($clone_profiles_id);
+
+        // Verify the original profile still references the source profile
+        $this->integer($profile->fields['id'])->isEqualTo(3);
+
+        // Some fields in the Profile itself to check that they are cloned
+        $core_fields = ['interface', 'helpdesk_hardware', 'helpdesk_item_type'];
+        foreach ($core_fields as $field) {
+            if ($field === 'helpdesk_item_type') {
+                $this->array(importArrayFromDB($cloned_profile->fields[$field]))->isEqualTo(importArrayFromDB($profile->fields[$field]));
+            } else {
+                $this->variable($cloned_profile->fields[$field])->isEqualTo($profile->fields[$field]);
+            }
+        }
+
+        $rights_iterator = $DB->request([
+            'SELECT' => ['profiles_id', 'name', 'rights'],
+            'FROM'   => \ProfileRight::getTable(),
+            'WHERE'  => ['profiles_id' => [3, $clone_profiles_id]],
+        ]);
+        // Check that all rights with profiles_id 3 exist with the clone ID as well
+        $rights = [
+            3 => [],
+            $clone_profiles_id => [],
+        ];
+        foreach ($rights_iterator as $right) {
+            $rights[$right['profiles_id']][$right['name']] = $right['rights'];
+        }
+        $this->integer(count($rights[$clone_profiles_id]))->isGreaterThanOrEqualTo(count($rights[3]));
+
+        foreach ($rights[3] as $right => $value) {
+            $this->integer($rights[$clone_profiles_id][$right])->isEqualTo($value);
+        }
+    }
 }

--- a/tests/functionnal/Profile.php
+++ b/tests/functionnal/Profile.php
@@ -209,7 +209,7 @@ class Profile extends DbTestCase
             'name' => __FUNCTION__,
         ]);
         $this->integer($clone_profiles_id)->isGreaterThan(0);
-        $cloned_profile->getFromDB($clone_profiles_id);
+        $this->boolean($cloned_profile->getFromDB($clone_profiles_id))->isTrue();
 
         // Verify the original profile still references the source profile
         $this->integer($profile->fields['id'])->isEqualTo(3);
@@ -237,7 +237,7 @@ class Profile extends DbTestCase
         foreach ($rights_iterator as $right) {
             $rights[$right['profiles_id']][$right['name']] = $right['rights'];
         }
-        $this->integer(count($rights[$clone_profiles_id]))->isGreaterThanOrEqualTo(count($rights[3]));
+        $this->integer(count($rights[$clone_profiles_id]))->isEqualTo(count($rights[3]));
 
         foreach ($rights[3] as $right => $value) {
             $this->integer($rights[$clone_profiles_id][$right])->isEqualTo($value);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Enable cloning for profiles. This will be useful for admins by letting them start from an existing profile rather than going through every tab and manually adding all the different rights they want.