### PR TITLE
Fix default recipients for assign group in ticket notification

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -3860,7 +3860,7 @@ $empty_data_builder = new class
                 'notifications_id' => '63',
             ], [
                 'id' => '129',
-                'items_id' => '23',
+                'items_id' => '9',
                 'type' => '1',
                 'notifications_id' => '64',
             ], [

--- a/install/migrations/update_10.0.2_to_10.0.3/notifications.php
+++ b/install/migrations/update_10.0.2_to_10.0.3/notifications.php
@@ -42,7 +42,7 @@ use Glpi\Toolbox\Sanitizer;
 
 $itil_types = ['Ticket', 'Change', 'Problem'];
 $iterator = $DB->request([
-    'SELECT' => ['id'],
+    'SELECT' => ['id', 'event'],
     'FROM'   => 'glpi_notifications',
     'WHERE'  => [
         'itemtype' => $itil_types,
@@ -74,7 +74,7 @@ foreach ($iterator as $notification) {
             ]);
             if ((int) $target['items_id'] === Notification::ITEM_TECH_GROUP_IN_CHARGE) {
                 $removed_item_group = true;
-            };
+            }
         }
         if ((int) $target['items_id'] === Notification::ASSIGN_GROUP) {
             $found_assigned_group = true;

--- a/install/migrations/update_10.0.2_to_10.0.3/notifications.php
+++ b/install/migrations/update_10.0.2_to_10.0.3/notifications.php
@@ -63,20 +63,20 @@ foreach ($iterator as $notification) {
     }
     $removed_item_group = false;
     $found_assigned_group = false;
-    foreach ($targets as $target_id => $target) {
+    foreach ($targets as $target_id => $items_id) {
         if (
-            (int) $target['items_id'] === Notification::ITEM_TECH_GROUP_IN_CHARGE
-            || (int) $target['items_id'] === Notification::ITEM_TECH_IN_CHARGE
-            || (int) $target['items_id'] === Notification::ITEM_USER
+            $items_id === Notification::ITEM_TECH_GROUP_IN_CHARGE
+            || $items_id === Notification::ITEM_TECH_IN_CHARGE
+            || $items_id === Notification::ITEM_USER
         ) {
             $DB->deleteOrDie('glpi_notificationtargets', [
                 'id' => $target['id'],
             ]);
-            if ((int) $target['items_id'] === Notification::ITEM_TECH_GROUP_IN_CHARGE) {
+            if ($items_id === Notification::ITEM_TECH_GROUP_IN_CHARGE) {
                 $removed_item_group = true;
             }
         }
-        if ((int) $target['items_id'] === Notification::ASSIGN_GROUP) {
+        if ($items_id === Notification::ASSIGN_GROUP) {
             $found_assigned_group = true;
         }
     }

--- a/install/migrations/update_10.0.2_to_10.0.3/notifications.php
+++ b/install/migrations/update_10.0.2_to_10.0.3/notifications.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2022 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+use Glpi\Toolbox\Sanitizer;
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+$itil_types = ['Ticket', 'Change', 'Problem'];
+$iterator = $DB->request([
+    'SELECT' => ['id'],
+    'FROM'   => 'glpi_notifications',
+    'WHERE'  => [
+        'itemtype' => $itil_types,
+        'event'    => 'assign_group',
+    ],
+]);
+
+foreach ($iterator as $notification) {
+    $target_iterator = $DB->request([
+        'SELECT' => ['id', 'items_id'],
+        'FROM'   => 'glpi_notificationtargets',
+        'WHERE'  => [
+            'notifications_id' => $notification['id']
+        ],
+    ]);
+    $targets = [];
+    foreach ($target_iterator as $target) {
+        $targets[$target['id']] = $target['items_id'];
+    }
+    $removed_item_group = false;
+    foreach ($targets as $target_id => $target) {
+        if ((int) $target['items_id'] === Notification::ITEM_TECH_GROUP_IN_CHARGE) {
+            $DB->deleteOrDie('glpi_notificationtargets', [
+                'id' => $target['id'],
+            ]);
+            $removed_item_group = true;
+            unset($targets[$target_id]);
+        }
+    }
+    // If no targets remain, add a new one with items_id = Notification::ASSIGN_GROUP
+    if (count($targets) === 0) {
+        $DB->insertOrDie('glpi_notificationtargets', [
+            'notifications_id'  => $notification['id'],
+            'type'              => Notification::USER_TYPE,
+            'items_id'          => Notification::ASSIGN_GROUP,
+        ]);
+    }
+}

--- a/src/NotificationTargetCommonITILObject.php
+++ b/src/NotificationTargetCommonITILObject.php
@@ -840,18 +840,9 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                 Notification::REQUESTER_GROUP_WITHOUT_SUPERVISOR,
                 __("Requester group except manager users")
             );
-            $this->addTarget(
-                Notification::ITEM_TECH_IN_CHARGE,
-                __('Technician in charge of the hardware')
-            );
-            $this->addTarget(
-                Notification::ITEM_TECH_GROUP_IN_CHARGE,
-                __('Group in charge of the hardware')
-            );
             $this->addTarget(Notification::ASSIGN_TECH, __('Technician in charge of the ticket'));
             $this->addTarget(Notification::REQUESTER_GROUP, _n('Requester group', 'Requester groups', 1));
             $this->addTarget(Notification::AUTHOR, _n('Requester', 'Requesters', 1));
-            $this->addTarget(Notification::ITEM_USER, __('Hardware user'));
             $this->addTarget(Notification::ASSIGN_GROUP, __('Group in charge of the ticket'));
             $this->addTarget(Notification::OBSERVER_GROUP, _n('Watcher group', 'Watcher groups', 1));
             $this->addTarget(Notification::OBSERVER, _n('Watcher', 'Watchers', 1));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Change default recipient for the "New group in assignees" ticket notification from "Group in charge of the hardware" to "Group in charge of the ticket". This matches up with the other notifications related to new actors.