### PR TITLE
timeline : exclamation mark in circle is not centered

### DIFF
--- a/css/includes/components/itilobject/_dates_timelines.scss
+++ b/css/includes/components/itilobject/_dates_timelines.scss
@@ -122,7 +122,7 @@
 
             &::before {
                 content: "\21";
-                padding-left: 4px;
+                padding-left: 8px;
                 color: #e54e5a;
             }
         }


### PR DESCRIPTION
There is a centering problem with some items in the timeline
![image](https://user-images.githubusercontent.com/14139801/183020330-27227828-0c39-4089-80a9-98d25e2deb32.png)

The fix adjusts the position of the exclamation mark

![image](https://user-images.githubusercontent.com/14139801/183020523-47406213-b4a4-4317-9dd3-786f070feda5.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
