### PR TITLE
fix(dashboard): profil rights

### DIFF
--- a/src/Dashboard/Dashboard.php
+++ b/src/Dashboard/Dashboard.php
@@ -479,7 +479,7 @@ class Dashboard extends \CommonDBTM
        // check specific rights
         if (
             count(array_intersect($rights['entities_id'], $_SESSION['glpiactiveentities']))
-            || count(array_intersect($rights['profiles_id'], array_keys($_SESSION['glpiprofiles'])))
+            || in_array($_SESSION["glpiactiveprofile"]['id'], $rights['profiles_id'])
             || in_array($_SESSION['glpiID'], $rights['users_id'])
             || count(array_intersect($rights['groups_id'], $_SESSION['glpigroups']))
         ) {

--- a/tests/functionnal/Glpi/Dashboard/Dashboard.php
+++ b/tests/functionnal/Glpi/Dashboard/Dashboard.php
@@ -303,7 +303,7 @@ class Dashboard extends DbTestCase
         ];
 
         $_SESSION['glpiactiveentities'] = [];
-        $_SESSION['glpiprofiles'] = [];
+        $_SESSION['glpiactiveprofile'] = ['id' => 1];
         $_SESSION['glpigroups'] = [];
         $_SESSION['glpiID'] = 1;
 
@@ -313,10 +313,10 @@ class Dashboard extends DbTestCase
         $this->boolean(\Glpi\Dashboard\Dashboard::checkRights($rights))->isTrue();
 
         $_SESSION['glpiactiveentities'] = [];
-        $_SESSION['glpiprofiles'] = [3 => 3];
+        $_SESSION['glpiactiveprofile'] = ['id' => 3];
         $this->boolean(\Glpi\Dashboard\Dashboard::checkRights($rights))->isTrue();
 
-        $_SESSION['glpiprofiles'] = [];
+        $_SESSION['glpiactiveprofile'] = ['id' => 1];
         $_SESSION['glpiID'] = 2;
         $this->boolean(\Glpi\Dashboard\Dashboard::checkRights($rights))->isTrue();
 


### PR DESCRIPTION
The rights were tested with all the user's profiles instead of the active profile, so the "Dashboard" tab could appear even if the active profile did not allow it.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24541
