### PR TITLE
Fix index key name for deleted actors

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -9155,6 +9155,7 @@ abstract class CommonITILObject extends CommonDBTM
                             }
                         }
                         if ($found === false) {
+                            $input_key = $get_input_key($existing['itemtype'], $actor_type);
                             $input[sprintf('%s_deleted', $input_key)][] = $existing;
                         }
                     }


### PR DESCRIPTION
Deleted actors were indexed to confusing indexes as value from previous loop was used.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
