### PR TITLE
feat(rule ticket): add mail headers as criteria

### DIFF
--- a/src/RuleTicket.php
+++ b/src/RuleTicket.php
@@ -649,6 +649,26 @@ class RuleTicket extends Rule
         $criterias['_x-priority']['table']                    = '';
         $criterias['_x-priority']['type']                     = 'text';
 
+        $criterias['_from']['name']                           = __('From email header');
+        $criterias['_from']['table']                          = '';
+        $criterias['_from']['type']                           = 'text';
+
+        $criterias['_subject']['name']                        = __('Subject email header');
+        $criterias['_subject']['table']                       = '';
+        $criterias['_subject']['type']                        = 'text';
+
+        $criterias['_reply-to']['name']                       = __('Reply-To email header');
+        $criterias['_reply-to']['table']                      = '';
+        $criterias['_reply-to']['type']                       = 'text';
+
+        $criterias['_in_reply-to']['name']                    = __('In-Reply-To email header');
+        $criterias['_in_reply-to']['table']                   = '';
+        $criterias['_in_reply-to']['type']                    = 'text';
+
+        $criterias['_to']['name']                             = __('To email header');
+        $criterias['_to']['table']                            = '';
+        $criterias['_to']['type']                             = 'text';
+
         $criterias['slas_id_ttr']['table']                    = 'glpi_slas';
         $criterias['slas_id_ttr']['field']                    = 'name';
         $criterias['slas_id_ttr']['name']                     = sprintf(

--- a/src/RuleTicket.php
+++ b/src/RuleTicket.php
@@ -661,9 +661,9 @@ class RuleTicket extends Rule
         $criterias['_reply-to']['table']                      = '';
         $criterias['_reply-to']['type']                       = 'text';
 
-        $criterias['_in_reply-to']['name']                    = __('In-Reply-To email header');
-        $criterias['_in_reply-to']['table']                   = '';
-        $criterias['_in_reply-to']['type']                    = 'text';
+        $criterias['_in-reply-to']['name']                    = __('In-Reply-To email header');
+        $criterias['_in-reply-to']['table']                   = '';
+        $criterias['_in-reply-to']['type']                    = 'text';
 
         $criterias['_to']['name']                             = __('To email header');
         $criterias['_to']['table']                            = '';

--- a/src/RuleTicketCollection.php
+++ b/src/RuleTicketCollection.php
@@ -108,10 +108,36 @@ class RuleTicketCollection extends RuleCollection
     public function prepareInputDataForProcess($input, $params)
     {
 
-       // Pass x-priority header if exists
+        // Pass x-priority header if exists
         if (isset($input['_head']['x-priority'])) {
             $input['_x-priority'] = $input['_head']['x-priority'];
         }
+
+        // Pass From header if exists
+        if (isset($input['_head']['from'])) {
+            $input['_from'] = $input['_head']['from'];
+        }
+
+        // Pass Subject header if exists
+        if (isset($input['_head']['subject'])) {
+            $input['_subject'] = $input['_head']['subject'];
+        }
+
+        // Pass Reply-To header if exists
+        if (isset($input['_head']['reply-to'])) {
+            $input['_reply-to'] = $input['_head']['reply-to'];
+        }
+
+        // Pass In-Reply-To header if exists
+        if (isset($input['_head']['in-reply-to'])) {
+            $input['_in-reply-to'] = $input['_head']['in-reply-to'];
+        }
+
+        // Pass To header if exists
+        if (isset($input['_head']['to'])) {
+            $input['_to'] = $input['_head']['to'];
+        }
+
         $input['_groups_id_of_requester'] = [];
        // Get groups of users
         if (isset($input['_users_id_requester'])) {

--- a/tests/functionnal/RuleTicket.php
+++ b/tests/functionnal/RuleTicket.php
@@ -2257,6 +2257,10 @@ class RuleTicket extends DbTestCase
         string $pattern,
         string $header
     ) {
+        // clean right singleton
+        \SingletonRuleList::getInstance("RuleTicket", 0)->load = 0;
+        \SingletonRuleList::getInstance("RuleTicket", 0)->list = [];
+
         $this->login();
 
         $ruleticket = new \RuleTicket();


### PR DESCRIPTION
Add new criterias to rule ticket engine (like ```x-priority```)

- from
- subject
- reply-to
- to
- in-reply-to

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24256
