### PR TITLE
fix(rule right): rules not applied with SSO

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -2167,8 +2167,10 @@ class User extends CommonDBTM
         if (!$DB->isSlave()) {
            //Instanciate the affectation's rule
             $rule = new RuleRightCollection();
+            $groups = Group_User::getUserGroups($this->fields['id']);
+            $groups_id = array_column($groups, 'id');
 
-            $this->fields = $rule->processAllRules([], Toolbox::stripslashes_deep($this->fields), [
+            $this->fields = $rule->processAllRules($groups_id, Toolbox::stripslashes_deep($this->fields), [
                 'type'   => Auth::EXTERNAL,
                 'email'  => $this->fields["_emails"],
                 'login'  => $this->fields["name"]


### PR DESCRIPTION
Rules did not apply with an SSO login.

With the same user, the rule applied if you login with the local password, but it did not apply in SSO (_example provider: Google_)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24646
