### PR TITLE
Pending reasons: fix auto solve date display

### DIFF
--- a/templates/components/itilobject/timeline/pending_reasons_messages.html.twig
+++ b/templates/components/itilobject/timeline/pending_reasons_messages.html.twig
@@ -54,7 +54,7 @@
 
          {% set resolve = pending_reason_item_parent.getAutoResolvedate() %}
          {% if resolve %}
-            <i class="fas fa-stop ms-2" title="{{ __("Automatic resolution scheduled on %s")|format(call("Html::convDate", [next_bump])) }}"
+            <i class="fas fa-stop ms-2" title="{{ __("Automatic resolution scheduled on %s")|format(call("Html::convDate", [resolve])) }}"
                data-bs-toggle="tooltip"></i>
          {% endif %}
       {% endif %}


### PR DESCRIPTION
Regarding this feature: 

![image](https://user-images.githubusercontent.com/42734840/183647592-1f9ff516-c031-42cc-a4a3-c83c418ce572.png)

The code was referencing the wrong variable, seems like some code get pasted too quickly when migrating to twig ;)

Btw, it's only a visual issue - it won't affect the actual automatic resolution of a ticket.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24642
