### PR TITLE
fix(twig): fix Software HTML form

### DIFF
--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -101,7 +101,7 @@
                      {% endif %}
 
                      {% set fk = item.getForeignKeyField() %}
-                     {% if item.isField(fk) %}
+                     {% if item.isField(fk) and item_type != 'Software' %}
                         {{ fields.dropdownField(
                            item_type,
                            fk,

--- a/templates/pages/assets/software.html.twig
+++ b/templates/pages/assets/software.html.twig
@@ -48,7 +48,7 @@
         item.fields['is_update'],
         __('Upgrade'),
         field_options|merge({
-            add_field_html: dd_software
+            add_field_html: __('from') ~ dd_software
         })
     ) }}
 


### PR DESCRIPTION
```softwares_id``` is duplicate from ```Software``` form

as it is, the "Child of" field does not work because GLPI checks that the 'update' input is true

![image](https://user-images.githubusercontent.com/7335054/183649767-d5ca5911-b651-46e2-8953-65d104438513.png)

1. is added by ```generic_show_form.html.twig``` because ```Sofware``` have a 1-1 relation to it self
2. is added by  ```software.html.twig``` because in this context ```softwares_id``` is use to know if a software is an add-on / update from another one

From GLPI 9.5 it is the second option that is used

![image](https://user-images.githubusercontent.com/7335054/183650437-ed05e5c2-fc06-4034-8756-20e8755a5453.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24618
