### PR TITLE
fix(discovery): allow networkport update from discovery only for printer

### DIFF
--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -43,6 +43,7 @@ use Dropdown;
 use Glpi\Inventory\Conf;
 use Glpi\Inventory\Request;
 use Lockedfield;
+use NetworkEquipment;
 use RefusedEquipment;
 use RuleImportAssetCollection;
 use RuleImportEntityCollection;
@@ -706,7 +707,8 @@ abstract class MainAsset extends InventoryAsset
             $_SESSION['glpiactive_entity']         = $entities_id;
         }
 
-        if ($this->is_discovery === true && !$this->isNew()) {
+        if ($this->is_discovery === true && !$this->isNew() && $itemtype == NetworkEquipment::getType()) {
+            //do not update from network discoveries (only for NetworkEquipement)
             //prevents discoveries to remove all ports, IPs and so on found with network inventory
             //only update autoupdatesystems_id, last_inventory_update, snmpcredentials_id
             $input = $this->handleInput($val);

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -710,29 +710,25 @@ abstract class MainAsset extends InventoryAsset
         }
 
         if ($this->is_discovery === true && !$this->isNew()) {
-            //only update autoupdatesystems_id, last_inventory_update, snmpcredentials_id
-            $input = $this->handleInput($val);
-            $this->item->update(['id' => $input['id'],
-                'autoupdatesystems_id'  => $input['autoupdatesystems_id'],
-                'last_inventory_update' => $input['last_inventory_update'],
-                'snmpcredentials_id'    => $input['snmpcredentials_id'],
-                'is_dynamic'            => true
-            ]);
-
-
-            //do not update NetworkEquipment from network discoveries
-            //prevents discoveries to remove all ports, IPs and so on found with network inventory
-            if ($itemtype == NetworkEquipment::getType()) {
-                return;
-            }
-
-
-            //update Printer from network discoveries only when printer IP has changed
-            //prevents discoveries to remove all ports, IPs found with network inventory
+            //if NetworkEquipement
+            //Or printer that has not changed its IP
+            //do not update to prevents discoveries to remove all ports, IPs and so on found with network inventory
             if (
+                $itemtype == NetworkEquipment::getType()
+                ||
+                (
                 $itemtype == Printer::getType()
                 && !AssetPrinter::needToBeUpdatedFromDiscovery($this->item, $val)
+                )
             ) {
+                //only update autoupdatesystems_id, last_inventory_update, snmpcredentials_id
+                $input = $this->handleInput($val);
+                $this->item->update(['id' => $input['id'],
+                    'autoupdatesystems_id'  => $input['autoupdatesystems_id'],
+                    'last_inventory_update' => $input['last_inventory_update'],
+                    'snmpcredentials_id'    => $input['snmpcredentials_id'],
+                    'is_dynamic'            => true
+                ]);
                 return;
             }
         }

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -710,7 +710,6 @@ abstract class MainAsset extends InventoryAsset
         }
 
         if ($this->is_discovery === true && !$this->isNew()) {
-
             //only update autoupdatesystems_id, last_inventory_update, snmpcredentials_id
             $input = $this->handleInput($val);
             $this->item->update(['id' => $input['id'],

--- a/src/Inventory/Asset/Printer.php
+++ b/src/Inventory/Asset/Printer.php
@@ -37,6 +37,7 @@
 namespace Glpi\Inventory\Asset;
 
 use CommonDBTM;
+use IPAddress;
 use Printer as GPrinter;
 use PrinterLog;
 use PrinterModel;
@@ -331,5 +332,30 @@ class Printer extends NetworkEquipment
         } else {
             $metrics->add($input, [], false);
         }
+    }
+
+    /**
+     * Try to know if printer need to be updated from discovery
+     * Only if IP has changed
+     * @return boolean
+     */
+    public static function needToBeUpdatedFromDiscovery(CommonDBTM $item, $val)
+    {
+        if (property_exists($val, 'ips') && isset($val->ips[0])) {
+            $ip = $val->ips[0];
+            //try to find IP (get from discovery) from known IP of Printer
+            //if found refuse update
+            //if no, printer IP have changed so  we allow the update from discovery
+            $ipadress = new IPAddress($ip);
+            $tmp['mainitems_id'] = $item->fields['id'];
+            $tmp['mainitemtype'] = $item::getType();
+            $tmp['is_dynamic']   = 1;
+            $tmp['name']         = $ipadress->getTextual();
+            if ($ipadress->getFromDBByCrit($tmp)) {
+                return false;
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/tests/functionnal/Glpi/Inventory/Assets/Printer.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Printer.php
@@ -35,6 +35,8 @@
 
 namespace tests\units\Glpi\Inventory\Asset;
 
+use Toolbox;
+
 include_once __DIR__ . '/../../../../abstracts/AbstractInventoryAsset.php';
 
 /* Test for inc/inventory/asset/printer.class.php */
@@ -1182,5 +1184,276 @@ class Printer extends AbstractInventoryAsset
         //printer present in the inventory source is dynamic
         $printers = $item_printer->find(['itemtype' => 'printer', 'computers_id' => $computers_id, 'is_dynamic' => 1]);
         $this->integer(count($printers))->isIdenticalTo(1);
+    }
+
+    public function testSnmpPrinterDiscoveryUpdateAllowed()
+    {
+        //first step do a standard discovery
+        $date_now = date('Y-m-d H:i:s');
+        $_SESSION['glpi_currenttime'] = $date_now;
+        $json_str = file_get_contents(self::INV_FIXTURES . 'printer_1.json');
+
+        $json = json_decode($json_str);
+
+        $printer = new \Printer();
+
+        $data = (array)$json->content;
+        $inventory = new \Glpi\Inventory\Inventory();
+        $this->boolean($inventory->setData($json))->isTrue();
+
+        $agent = new \Agent();
+        $this->integer($agent->handleAgent($inventory->extractMetadata()))->isIdenticalTo(0);
+
+        $main = new \Glpi\Inventory\Asset\Printer($printer, $json);
+        $main->setAgent($agent)->setExtraData($data);
+        $main->checkConf(new \Glpi\Inventory\Conf());
+        $main->setDiscovery(true);
+        $result = $main->prepare();
+        $this->array($result)->hasSize(1);
+        $this->array((array)$result[0])->isIdenticalTo([
+            'autoupdatesystems_id' => 'GLPI Native Inventory',
+            'last_inventory_update' => $date_now,
+            'firmware' => '2409048_052887',
+            'ips' => ['10.59.29.175'],
+            'mac' => '00:68:eb:f2:be:10',
+            'manufacturer' => 'Hewlett-Packard',
+            'model' => 'HP LaserJet M507',
+            'name' => 'NPIF2BE10',
+            'serial' => 'PHCVN191TG',
+            'type' => 'Printer',
+            'uptime' => '7 days, 01:26:41.98',
+            'printermodels_id' => 'HP LaserJet M507',
+            'printertypes_id' => 'Printer',
+            'manufacturers_id' => 'Hewlett-Packard',
+            'snmpcredentials_id' => 4,
+            'have_usb' => 0,
+            'have_ethernet' => 1,
+            'memory_size' => 512,
+            'last_pages_counter' => 1802,
+        ]);
+
+       //get one management port only, since iftype 24 is not importable per default
+        $this->array($main->getNetworkPorts())->isIdenticalTo([]);
+        $this->array($mports = $main->getManagementPorts())->hasSize(1)->hasKey('management');
+        $this->array((array)$mports['management'])->isIdenticalTo([
+            'mac' => '00:68:eb:f2:be:10',
+            'name' => 'Management',
+            'netname' => 'internal',
+            'instantiation_type' => 'NetworkPortAggregate',
+            'is_internal' => true,
+            'ipaddress' => [
+                '10.59.29.175'
+            ]
+        ]);
+
+        $main->handle();
+        $inventory->doInventory();
+
+        //check data
+        $this->boolean($printer->getFromDB($printer->fields['id']))->isTrue();
+        $this->integer($printer->fields['last_pages_counter'])->isIdenticalTo(1802);
+        $this->string($printer->fields['name'])->isIdenticalTo('NPIF2BE10');
+
+        //second step do a standard discovery but change IP to update last page counter
+        //GLPI allows the update
+        $json = json_decode($json_str);
+
+        //update inventory data
+        $new_ip = "10.59.29.180";
+        $new_name = 'BE10NPIF2';
+        $json->content->network_device->name = $new_name;
+        $json->content->network_device->ips[0] = $new_ip;
+        $json->content->network_ports[1]->ips = [$new_ip];
+
+        $printer = new \Printer();
+
+        $printer = new \Printer();
+        $data = (array)$json->content;
+
+        $inventory = new \Glpi\Inventory\Inventory();
+        $this->boolean($inventory->setData($json))->isTrue();
+
+        $agent = new \Agent();
+        $this->integer($agent->handleAgent($inventory->extractMetadata()))->isIdenticalTo(0);
+
+        $main = new \Glpi\Inventory\Asset\Printer($printer, $json);
+        $main->setAgent($agent)->setExtraData($data);
+        $main->checkConf(new \Glpi\Inventory\Conf());
+        $main->setDiscovery(true);
+        $result = $main->prepare();
+        $this->array($result)->hasSize(1);
+        $this->array((array)$result[0])->isIdenticalTo([
+            'autoupdatesystems_id' => 'GLPI Native Inventory',
+            'last_inventory_update' => $date_now,
+            'firmware' => '2409048_052887',
+            'ips' => [$new_ip],
+            'mac' => '00:68:eb:f2:be:10',
+            'manufacturer' => 'Hewlett-Packard',
+            'model' => 'HP LaserJet M507',
+            'name' => $new_name,
+            'serial' => 'PHCVN191TG',
+            'type' => 'Printer',
+            'uptime' => '7 days, 01:26:41.98',
+            'printermodels_id' => 'HP LaserJet M507',
+            'printertypes_id' => 'Printer',
+            'manufacturers_id' => 'Hewlett-Packard',
+            'snmpcredentials_id' => 4,
+            'have_usb' => 0,
+            'have_ethernet' => 1,
+            'memory_size' => 512,
+            'last_pages_counter' => 1802,
+        ]);
+
+       //get one management port only, since iftype 24 is not importable per default
+        $this->array($main->getNetworkPorts())->isIdenticalTo([]);
+        $this->array($mports = $main->getManagementPorts())->hasSize(1)->hasKey('management');
+        $this->array((array)$mports['management'])->isIdenticalTo([
+            'mac' => '00:68:eb:f2:be:10',
+            'name' => 'Management',
+            'netname' => 'internal',
+            'instantiation_type' => 'NetworkPortAggregate',
+            'is_internal' => true,
+            'ipaddress' => [
+                $new_ip
+            ]
+        ]);
+
+        $main->handle();
+        $inventory->doInventory();
+
+        $this->boolean($printer->getFromDB($printer->fields['id']))->isTrue();
+        $this->string($printer->fields['name'])->isIdenticalTo($new_name);
+    }
+
+    public function testSnmpPrinterDiscoveryUpdateRefused()
+    {
+
+        //first step do a standard discovery
+        $date_now = date('Y-m-d H:i:s');
+        $_SESSION['glpi_currenttime'] = $date_now;
+        $json_str = file_get_contents(self::INV_FIXTURES . 'printer_1.json');
+
+        $json = json_decode($json_str);
+        $printer = new \Printer();
+
+        $data = (array)$json->content;
+        $inventory = new \Glpi\Inventory\Inventory();
+        $this->boolean($inventory->setData($json))->isTrue();
+
+        $agent = new \Agent();
+        $this->integer($agent->handleAgent($inventory->extractMetadata()))->isIdenticalTo(0);
+
+        $main = new \Glpi\Inventory\Asset\Printer($printer, $json);
+        $main->setAgent($agent)->setExtraData($data);
+        $main->checkConf(new \Glpi\Inventory\Conf());
+        $main->setDiscovery(true);
+        $result = $main->prepare();
+        $this->array($result)->hasSize(1);
+        $this->array((array)$result[0])->isIdenticalTo([
+            'autoupdatesystems_id' => 'GLPI Native Inventory',
+            'last_inventory_update' => $date_now,
+            'firmware' => '2409048_052887',
+            'ips' => ['10.59.29.175'],
+            'mac' => '00:68:eb:f2:be:10',
+            'manufacturer' => 'Hewlett-Packard',
+            'model' => 'HP LaserJet M507',
+            'name' => 'NPIF2BE10',
+            'serial' => 'PHCVN191TG',
+            'type' => 'Printer',
+            'uptime' => '7 days, 01:26:41.98',
+            'printermodels_id' => 'HP LaserJet M507',
+            'printertypes_id' => 'Printer',
+            'manufacturers_id' => 'Hewlett-Packard',
+            'snmpcredentials_id' => 4,
+            'have_usb' => 0,
+            'have_ethernet' => 1,
+            'memory_size' => 512,
+            'last_pages_counter' => 1802,
+        ]);
+
+       //get one management port only, since iftype 24 is not importable per default
+        $this->array($main->getNetworkPorts())->isIdenticalTo([]);
+        $this->array($mports = $main->getManagementPorts())->hasSize(1)->hasKey('management');
+        $this->array((array)$mports['management'])->isIdenticalTo([
+            'mac' => '00:68:eb:f2:be:10',
+            'name' => 'Management',
+            'netname' => 'internal',
+            'instantiation_type' => 'NetworkPortAggregate',
+            'is_internal' => true,
+            'ipaddress' => [
+                '10.59.29.175'
+            ]
+        ]);
+
+        $main->handle();
+
+        $this->boolean($printer->getFromDB($printer->fields['id']))->isTrue();
+        $this->integer($printer->fields['last_pages_counter'])->isIdenticalTo(1802);
+
+        //second step do a standard discovery but change only printer name
+        //GLPI must not allow updates
+        $json_str = file_get_contents(self::INV_FIXTURES . 'printer_1.json');
+        $json = json_decode($json_str);
+
+        //update inventory data
+        $new_name = 'BE10NPIF2';
+        $old_name = 'NPIF2BE10';
+        $json->content->network_device->name = $new_name;
+
+        $printer = new \Printer();
+        $data = (array)$json->content;
+
+        $inventory = new \Glpi\Inventory\Inventory();
+        $this->boolean($inventory->setData($json))->isTrue();
+
+        $agent = new \Agent();
+        $this->integer($agent->handleAgent($inventory->extractMetadata()))->isIdenticalTo(0);
+
+        $main = new \Glpi\Inventory\Asset\Printer($printer, $json);
+        $main->setAgent($agent)->setExtraData($data);
+        $main->setDiscovery(true);
+        $main->checkConf(new \Glpi\Inventory\Conf());
+        $result = $main->prepare();
+        $this->array($result)->hasSize(1);
+        $this->array((array)$result[0])->isIdenticalTo([
+            'autoupdatesystems_id' => 'GLPI Native Inventory',
+            'last_inventory_update' => $date_now,
+            'firmware' => '2409048_052887',
+            'ips' => ["10.59.29.175"],
+            'mac' => '00:68:eb:f2:be:10',
+            'manufacturer' => 'Hewlett-Packard',
+            'model' => 'HP LaserJet M507',
+            'name' => $new_name,
+            'serial' => 'PHCVN191TG',
+            'type' => 'Printer',
+            'uptime' => '7 days, 01:26:41.98',
+            'printermodels_id' => 'HP LaserJet M507',
+            'printertypes_id' => 'Printer',
+            'manufacturers_id' => 'Hewlett-Packard',
+            'snmpcredentials_id' => 4,
+            'have_usb' => 0,
+            'have_ethernet' => 1,
+            'memory_size' => 512,
+            'last_pages_counter' => 1802,
+        ]);
+
+       //get one management port only, since iftype 24 is not importable per default
+        $this->array($main->getNetworkPorts())->isIdenticalTo([]);
+        $this->array($mports = $main->getManagementPorts())->hasSize(1)->hasKey('management');
+        $this->array((array)$mports['management'])->isIdenticalTo([
+            'mac' => '00:68:eb:f2:be:10',
+            'name' => 'Management',
+            'netname' => 'internal',
+            'instantiation_type' => 'NetworkPortAggregate',
+            'is_internal' => true,
+            'ipaddress' => [
+                "10.59.29.175"
+            ]
+        ]);
+
+        $main->handle();
+
+        $this->boolean($printer->getFromDB($printer->fields['id']))->isTrue();
+        $this->string($printer->fields['name'])->isIdenticalTo($old_name);
     }
 }

--- a/tests/functionnal/Glpi/Inventory/Assets/Printer.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Printer.php
@@ -35,8 +35,6 @@
 
 namespace tests\units\Glpi\Inventory\Asset;
 
-use Toolbox;
-
 include_once __DIR__ . '/../../../../abstracts/AbstractInventoryAsset.php';
 
 /* Test for inc/inventory/asset/printer.class.php */


### PR DESCRIPTION
allow networkport update from discovery only for printer

Usefull when printer changes IP

Only network information are deleted (is the goal)
other inforamtions , page counter, Sysdescr, serial number, model , manufacturer are still present .


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | [#192](https://github.com/glpi-project/glpi-inventory-plugin/issues/192)
