### PR TITLE
HookManager: fix enableCSRF

### DIFF
--- a/src/Plugin/HookManager.php
+++ b/src/Plugin/HookManager.php
@@ -49,6 +49,8 @@ class HookManager
      */
     public function enableCSRF(): void
     {
+        global $PLUGIN_HOOKS;
+
         $PLUGIN_HOOKS[Hooks::CSRF_COMPLIANT][$this->plugin] = true;
     }
 


### PR DESCRIPTION
Missing global var.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
