### PR TITLE
Do not present deleted actors to BR for Tickets

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1146,7 +1146,8 @@ class Ticket extends CommonITILObject
             foreach ($existing_actors as $actor_itemtype => $actors) {
                 $field = getForeignKeyFieldForItemType($actor_itemtype);
                 $input_key = '_' . $field . '_' . $t;
-                $removed = is_array($input[$input_key . "_deleted"]) ? array_column($input[$input_key . "_deleted"], "items_id") : [];
+                $deleted_key = $input_key . '_deleted';
+                $deleted_actors = array_key_existst($deleted_key, $input) && is_array($input[$deleted_key]) ? array_column($input[$deleted_key], 'items_id') : [];
                 foreach ($actors as $actor) {
                     if (
                         !isset($input[$input_key])
@@ -1161,7 +1162,7 @@ class Ticket extends CommonITILObject
                         } elseif (!is_array($input[$input_key])) {
                             $input[$input_key] = [$input[$input_key]];
                         }
-                        if(!in_array($actor[$field],$removed)){
+                        if (!in_array($actor[$field], $deleted_actors)) {
                            $input[$input_key][]             = $actor[$field];
                            $tocleanafterrules[$input_key][] = $actor[$field];
                         }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1147,7 +1147,7 @@ class Ticket extends CommonITILObject
                 $field = getForeignKeyFieldForItemType($actor_itemtype);
                 $input_key = '_' . $field . '_' . $t;
                 $deleted_key = $input_key . '_deleted';
-                $deleted_actors = array_key_existst($deleted_key, $input) && is_array($input[$deleted_key]) ? array_column($input[$deleted_key], 'items_id') : [];
+                $deleted_actors = array_key_exists($deleted_key, $input) && is_array($input[$deleted_key]) ? array_column($input[$deleted_key], 'items_id') : [];
                 foreach ($actors as $actor) {
                     if (
                         !isset($input[$input_key])

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1163,8 +1163,8 @@ class Ticket extends CommonITILObject
                             $input[$input_key] = [$input[$input_key]];
                         }
                         if (!in_array($actor[$field], $deleted_actors)) {
-                           $input[$input_key][]             = $actor[$field];
-                           $tocleanafterrules[$input_key][] = $actor[$field];
+                            $input[$input_key][]             = $actor[$field];
+                            $tocleanafterrules[$input_key][] = $actor[$field];
                         }
                     }
                 }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1146,6 +1146,7 @@ class Ticket extends CommonITILObject
             foreach ($existing_actors as $actor_itemtype => $actors) {
                 $field = getForeignKeyFieldForItemType($actor_itemtype);
                 $input_key = '_' . $field . '_' . $t;
+                $removed = is_array($input[$input_key . "_deleted"]) ? array_column($input[$input_key . "_deleted"], "items_id") : [];
                 foreach ($actors as $actor) {
                     if (
                         !isset($input[$input_key])
@@ -1160,8 +1161,10 @@ class Ticket extends CommonITILObject
                         } elseif (!is_array($input[$input_key])) {
                             $input[$input_key] = [$input[$input_key]];
                         }
-                        $input[$input_key][]             = $actor[$field];
-                        $tocleanafterrules[$input_key][] = $actor[$field];
+                        if(!in_array($actor[$field],$removed)){
+                           $input[$input_key][]             = $actor[$field];
+                           $tocleanafterrules[$input_key][] = $actor[$field];
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Currently BR receive also actors from $this->fields not accounting deleted actors on $input["_actors"]
Present new values instead (without deleted actors), utilizing "_deleted" keys which come from transformActorsInput()

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11671
