### PR TITLE
Fix handling of search input tokens with spaces

### DIFF
--- a/js/modules/SearchTokenizer/SearchInput.js
+++ b/js/modules/SearchTokenizer/SearchInput.js
@@ -579,10 +579,10 @@ export default class SearchInput {
         this.displayed_input.find('.search-input-tag').each((i, node) => {
             const n = $(node);
             if (n.data('token') !== undefined) {
-                raw_input += n.data('token').raw;
+                raw_input += n.data('token').raw + ' ';
             }
         });
-        return raw_input;
+        return raw_input.trim();
     }
 
     refreshPopover() {

--- a/js/modules/SearchTokenizer/SearchInput.js
+++ b/js/modules/SearchTokenizer/SearchInput.js
@@ -486,9 +486,9 @@ export default class SearchInput {
             tag.removeClass('search-input-tag');
             tag.addClass('search-input-tag-input');
             tag.attr('contenteditable', 'true');
-            const v = tag.text().trim();
+            const token = tag.data('token');
             tag.empty();
-            tag.text(v);
+            tag.text(token.raw);
             tag.focus();
             // place cursor at end of the tag text
             this.placeCaretAtEndOfNode(tag.get(0));
@@ -575,7 +575,14 @@ export default class SearchInput {
     }
 
     getRawInput() {
-        return this.displayed_input.get(0).textContent;
+        let raw_input = '';
+        this.displayed_input.find('.search-input-tag').each((i, node) => {
+            const n = $(node);
+            if (n.data('token') !== undefined) {
+                raw_input += n.data('token').raw;
+            }
+        });
+        return raw_input;
     }
 
     refreshPopover() {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | InfotelGLPI/tasklists#48

The tokenized/taggified search input was re-tokenizing the text content of the input instead of using the raw input from the individual tokens. This caused it to ignore any quoted text as the quotes were not put into the text value of the displayed tags.

This caused a filter of: `group:"Security Team"` to be interpreted as two tokens. The first being `group:Security` and a second plain-text token of `Team`.

This PR also ensures that the quotes show when editing the tag if they were present to avoid issues when re-parsing the text.