### PR TITLE
Ticket: fix reopen by requester group

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -887,7 +887,8 @@ abstract class CommonITILObject extends CommonDBTM
      *
      * @return bool
      **/
-    public function isGroup(int $type, int $groups_id): bool
+    // FIXME add params typehint in GLPI 10.1
+    public function isGroup($type, $groups_id): bool
     {
         if (isset($this->groups[$type])) {
             foreach ($this->groups[$type] as $data) {

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -759,11 +759,23 @@ abstract class CommonITILObject extends CommonDBTM
         $my_id    = Session::getLoginUserID();
         $my_groups = $_SESSION["glpigroups"] ?? [];
 
+        // Compute requester groups
+        $requester_groups = array_filter(
+            $my_groups,
+            fn($group) => $this->isGroup(CommonITILActor::REQUESTER, $group)
+        );
+
+        // Compute assigned groups
+        $assigned_groups = array_filter(
+            $my_groups,
+            fn($group) => $this->isGroup(CommonITILActor::ASSIGN, $group)
+        );
+
         $ami_requester       = $this->isUser(CommonITILActor::REQUESTER, $my_id);
-        $ami_requester_group = $this->isGroup(CommonITILActor::REQUESTER, $my_groups);
+        $ami_requester_group = count($requester_groups) > 0;
 
         $ami_assignee        = $this->isUser(CommonITILActor::ASSIGN, $my_id);
-        $ami_assignee_group  = $this->isGroup(CommonITILActor::ASSIGN, $my_groups);
+        $ami_assignee_group  = count($assigned_groups) > 0;
 
         return in_array($this->fields["status"], static::getReopenableStatusArray())
             && ($ami_requester || $ami_requester_group)
@@ -870,14 +882,13 @@ abstract class CommonITILObject extends CommonDBTM
     /**
      * Is a group linked to the object ?
      *
-     * @param integer $type      type to search (see constants)
-     * @param integer $groups_id group ID
+     * @param int $type      type to search (see constants)
+     * @param int $groups_id group ID
      *
-     * @return boolean
+     * @return bool
      **/
-    public function isGroup($type, $groups_id)
+    public function isGroup(int $type, int $groups_id): bool
     {
-
         if (isset($this->groups[$type])) {
             foreach ($this->groups[$type] as $data) {
                 if ($data['groups_id'] == $groups_id) {

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -4891,6 +4891,15 @@ HTML
 
         $tech_id     = getItemByTypeName('User', 'tech', true);
         $postonly_id = getItemByTypeName('User', 'post-only', true);
+        $normal_id   = getItemByTypeName('User', 'normal', true);
+
+        $requester_group = $this->createItem("Group", [
+            'name' => "testNeedReopen"
+        ]);
+        $this->createItem("Group_User", [
+            'users_id' => $normal_id,
+            'groups_id' => $requester_group->getID(),
+        ]);
 
         $ticket = new \Ticket();
         $tickets_id = $ticket->add([
@@ -4933,6 +4942,23 @@ HTML
         $this->boolean((bool)$ticket->getFromDB($ticket->getID()))->isTrue();
         $this->integer($ticket->fields['status'])->isEqualTo(\Ticket::ASSIGNED);
         $this->boolean((bool)$ticket->needReopen())->isFalse();
+
+        // Test reopen as a member of a requester group
+        $ticket = $this->createItem('Ticket', [
+            'name'                => 'testNeedReopen requester group',
+            'content'             => 'testNeedReopen requester group',
+            '_users_id_requester' => $postonly_id,
+            '_groups_id_requester'=> $requester_group->getID(),
+            '_users_id_assign'    => $tech_id,
+        ]);
+
+        $this->updateItem('Ticket', $ticket->getID(), [
+            'status' => \Ticket::WAITING,
+        ]);
+        $ticket->getFromDB($ticket->getID());
+
+        $this->login('normal', 'normal');
+        $this->boolean((bool)$ticket->needReopen())->isTrue();
     }
 
     protected function assignFromCategoryOrItemProvider(): iterable

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -4945,11 +4945,11 @@ HTML
 
         // Test reopen as a member of a requester group
         $ticket = $this->createItem('Ticket', [
-            'name'                => 'testNeedReopen requester group',
-            'content'             => 'testNeedReopen requester group',
-            '_users_id_requester' => $postonly_id,
-            '_groups_id_requester'=> $requester_group->getID(),
-            '_users_id_assign'    => $tech_id,
+            'name'                 => 'testNeedReopen requester group',
+            'content'              => 'testNeedReopen requester group',
+            '_users_id_requester'  => $postonly_id,
+            '_groups_id_requester' => $requester_group->getID(),
+            '_users_id_assign'     => $tech_id,
         ]);
 
         $this->updateItem('Ticket', $ticket->getID(), [


### PR DESCRIPTION
Here `post-only` is part of the `Pro services` group and add a new followup to a pending ticket.

![image](https://user-images.githubusercontent.com/42734840/184317524-5326d19c-8017-47a0-b9d2-e932a4a7fb07.png)
-> Ticket is still pending which is incorrect: the ticket must be "reopened" when a requester add a followup.

The issue comes from `needReopen` calling `isGroup` incorrectly (sending an array of groups id instead of a single group id).
These changes:
- Fix the incorrect method parameter sent in `needReopen`
- Enforce types in `isGroup` to prevent future issues
- Improve unit tests coverage

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
