### PR TITLE
Disable contextual character replacements by default

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -319,6 +319,7 @@ kbd {
     white-space: nowrap;
 }
 
-body, body input {
+body,
+body input {
     font-variant-ligatures: no-contextual;
 }

--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -318,3 +318,7 @@ table {
 kbd {
     white-space: nowrap;
 }
+
+body, body input {
+    font-variant-ligatures: no-contextual;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In some cases, the browser may try making "smart" replacements while rendering certain characters which may not be wanted most of the time in GLPI. For example, `Windows 10 x86` has the `x` replaced with a multiplication sign because there are numbers on both sides of it.

Tabler only has a CSS rule `font-feature-settings: "liga" 0"` which disables ligatures (joining of letters). However, the Inter font family changed the multiplication sign replacement from being in the "liga" feature to the "calt" (contextual alternates) feature starting in version 3.12 (2020) so it doesn't apply.

Some other replacements that this would disable:
- Replacing dash/hyphen with minus sign
- Arrows like `=>`, `->` and `<=>` replaced by unicode arrow characters that combine the individual characters like `⇔` (<=>)