### PR TITLE
lazy loading for tickets images

### DIFF
--- a/src/RichText/RichText.php
+++ b/src/RichText/RichText.php
@@ -415,7 +415,7 @@ final class RichText
             }
             $out .= "<figure itemprop='associatedMedia' itemscope itemtype='http://schema.org/ImageObject'>";
             $out .= "<a href='{$img['src']}' itemprop='contentUrl' data-index='0'>";
-            $out .= "<img src='{$img['thumbnail_src']}' itemprop='thumbnail'>";
+            $out .= "<img src='{$img['thumbnail_src']}' itemprop='thumbnail' loading='lazy'>";
             $out .= "</a>";
             $out .= "</figure>";
         }

--- a/src/RichText/RichText.php
+++ b/src/RichText/RichText.php
@@ -305,7 +305,7 @@ final class RichText
      */
     private static function loadImagesLazy(string $content): string
     {
-       return preg_replace(
+        return preg_replace(
             '/<img([\w\W]+?)\/+>/',
             '<img$1 loading="lazy">',
             $content

--- a/src/RichText/RichText.php
+++ b/src/RichText/RichText.php
@@ -269,23 +269,47 @@ final class RichText
     public static function getEnhancedHtml(?string $content, array $params = []): string
     {
         $p = [
-            'images_gallery'           => false,
-            'user_mentions'            => true,
+            'images_gallery' => false,
+            'user_mentions'  => true,
+            'images_lazy'    => true,
         ];
         $p = array_replace($p, $params);
 
        // Sanitize content first (security and to decode HTML entities)
         $content = self::getSafeHtml($content);
 
-        if (isset($p['user_mentions'])) {
+        if ($p['user_mentions']) {
             $content = UserMention::refreshUserMentionsHtmlToDisplay($content);
         }
 
-        if (isset($p['images_gallery'])) {
+        if ($p['images_lazy']) {
+            $content = self::loadImagesLazy($content);
+        }
+
+        if ($p['images_gallery']) {
             $content = self::replaceImagesByGallery($content);
         }
 
         return $content;
+    }
+
+
+    /**
+     * insert `loading="lazy" into img tag
+     *
+     * @since 10.0.3
+     *
+     * @param string  $content
+     *
+     * @return string
+     */
+    private static function loadImagesLazy(string $content): string
+    {
+       return preg_replace(
+            '/<img([\w\W]+?)\/+>/',
+            '<img$1 loading="lazy">',
+            $content
+        );
     }
 
     /**

--- a/src/Search.php
+++ b/src/Search.php
@@ -6956,10 +6956,10 @@ JAVASCRIPT;
                             __('%1$s %2$s'),
                             $out,
                             Html::showToolTip(
-                                RichText::getEnhancedHtml($data[$ID][0]['content']),
-                                ['applyto' => $itemtype .
-                                                                                $data[$ID][0]['id'],
-                                    'display' => false
+                                RichText::getEnhancedHtml($data[$ID][0]['content']), [
+                                    'applyto'        => $itemtype . $data[$ID][0]['id'],
+                                    'display'        => false,
+                                    'images_gallery' => false, // don't show photoswipe gallery in tooltips
                                 ]
                             )
                         );

--- a/src/Search.php
+++ b/src/Search.php
@@ -6956,7 +6956,8 @@ JAVASCRIPT;
                             __('%1$s %2$s'),
                             $out,
                             Html::showToolTip(
-                                RichText::getEnhancedHtml($data[$ID][0]['content']), [
+                                RichText::getEnhancedHtml($data[$ID][0]['content']),
+                                [
                                     'applyto'        => $itemtype . $data[$ID][0]['id'],
                                     'display'        => false,
                                     'images_gallery' => false, // don't show photoswipe gallery in tooltips


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal ref !24694

Initially, a work around for an issue with a big image (10MB) in a tooltip in tickets list crashing chrome (don't know why).
But i though always deferring loading of images in tickets contents (timeline mainly) could be a plus on performance, loading times, server load, etc.

