### PR TITLE
fix(core): load 'inventory' context to CFG_GLPI

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -3027,8 +3027,9 @@ HTML;
         } else {
            // multiple rows = 0.85+ config
             $values = [];
+            $allowed_context = ['core', 'inventory'];
             foreach ($iterator as $row) {
-                if ('core' !== $row['context']) {
+                if (!in_array($row['context'], $allowed_context)) {
                     continue;
                 }
                 $values[$row['name']] = $row['value'];


### PR DESCRIPTION
From inventory context, ```$CFG_GLPI['inventory_frequency']``` is always set to ```DEFAULT_FREQUENCY``` because

GLPI only load  legacy configuration with ```core``` context

Fix agent expiration always set to 24 hours

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12116
