### PR TITLE
ID in front for all ITIL Objects in Search results

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -637,8 +637,8 @@ class Search
         $to_add_view = array_diff($p['sort'], $data['toview']);
         array_push($data['toview'], ...$to_add_view);
 
-       // Special case for Ticket : put ID in front
-        if ($itemtype == 'Ticket') {
+       // Special case for CommonITILObjects : put ID in front
+        if (is_a($itemtype,'CommonITILObject',true)) {
             array_unshift($data['toview'], 2);
         }
 

--- a/src/Search.php
+++ b/src/Search.php
@@ -638,7 +638,7 @@ class Search
         array_push($data['toview'], ...$to_add_view);
 
        // Special case for CommonITILObjects : put ID in front
-        if (is_a($itemtype,'CommonITILObject',true)) {
+        if (is_a($itemtype, CommonITILObject::class, true)) {
             array_unshift($data['toview'], 2);
         }
 


### PR DESCRIPTION
Why not to have interface of Search results to be same for all ITIL Objects (Ticket, Changes, Problems..)

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | NA
