### PR TITLE
Display ID in linking dropdown for Common ITIL objects

### DIFF
--- a/src/Change_Problem.php
+++ b/src/Change_Problem.php
@@ -172,6 +172,7 @@ class Change_Problem extends CommonDBRelation
                 'used'        => $used,
                 'entity'      => $problem->getEntityID(),
                 'entity_sons' => $problem->isRecursive(),
+                'displaywith' => ['id'],
             ]);
             echo "</td><td class='center'>";
             echo "<input type='submit' name='add' value=\"" . _sx('button', 'Add') . "\" class='btn btn-primary'>";
@@ -293,7 +294,8 @@ class Change_Problem extends CommonDBRelation
             Problem::dropdown([
                 'used'   => $used,
                 'entity' => $change->getEntityID(),
-                'condition' => Problem::getOpenCriteria()
+                'condition' => Problem::getOpenCriteria(),
+                'displaywith' => ['id'],
             ]);
             echo "</td><td class='center'>";
             echo "<input type='submit' name='add' value=\"" . _sx('button', 'Add') . "\" class='btn btn-primary'>";

--- a/src/Change_Ticket.php
+++ b/src/Change_Ticket.php
@@ -413,6 +413,7 @@ class Change_Ticket extends CommonDBRelation
             Change::dropdown([
                 'used'      => $used,
                 'entity'    => $ticket->getEntityID(),
+                'displaywith' => ['id'],
                 'condition' => Change::getOpenCriteria(),
             ]);
             echo "</td><td class='center'>";

--- a/src/Problem_Ticket.php
+++ b/src/Problem_Ticket.php
@@ -418,7 +418,8 @@ class Problem_Ticket extends CommonDBRelation
             Problem::dropdown([
                 'used'      => $used,
                 'entity'    => $ticket->getEntityID(),
-                'condition' => Problem::getOpenCriteria()
+                'condition' => Problem::getOpenCriteria(),
+                'displaywith' => ['id'],
             ]);
             echo "</td><td class='center'>";
             echo "<input type='submit' name='add' value=\"" . _sx('button', 'Add') . "\" class='btn btn-primary'>";


### PR DESCRIPTION
Dropdowns shown for linking of Common ITIL objects together (Chnage_Ticket, Problem_Ticket, Change_Problem) display currently ID just for Ticket type.
Display it also for other type of linking as in larger deployments it can contain multiple items with same name.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
