### PR TITLE
fix(timeline):  the img display size in timeline is not correct.

### DIFF
--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -270,21 +270,15 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
                             if (!in_array($docID, $inline_docs)) {
                                 $doc->getFromDB($docID);
 
-                             //find width
-                                $width = null;
-                                if (preg_match("/width=[\"|'](\d+)(\.\d+)?[\"|']/", $matches[0][$pos], $wmatches)) {
-                                      $width = intval($wmatches[1]);
-                                }
-                                $height = null;
-                                if (preg_match("/height=[\"|'](\d+)(\.\d+)?[\"|']/", $matches[0][$pos], $hmatches)) {
-                                    $height = intval($hmatches[1]);
-                                }
+                                //find size from image
+                                $docpath = GLPI_DOC_DIR . '/' . $doc->fields['filepath'];
+                                $imgsize = getimagesize($docpath);
 
                                 $image_path = Document::getImage(
                                     GLPI_DOC_DIR . "/" . $doc->fields['filepath'],
                                     'mail',
-                                    $width,
-                                    $height
+                                    $imgsize[0],
+                                    $imgsize[1]
                                 );
                                 if (
                                     $mmail->AddEmbeddedImage(

--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -270,15 +270,21 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
                             if (!in_array($docID, $inline_docs)) {
                                 $doc->getFromDB($docID);
 
-                                //find size from image
-                                $docpath = GLPI_DOC_DIR . '/' . $doc->fields['filepath'];
-                                $imgsize = getimagesize($docpath);
+                                //find width
+                                $width = null;
+                                if (preg_match("/width=[\"|'](\d+)(\.\d+)?[\"|']/", $matches[0][$pos], $wmatches)) {
+                                    $width = intval($wmatches[1]);
+                                }
+                                $height = null;
+                                if (preg_match("/height=[\"|'](\d+)(\.\d+)?[\"|']/", $matches[0][$pos], $hmatches)) {
+                                    $height = intval($hmatches[1]);
+                                }
 
                                 $image_path = Document::getImage(
                                     GLPI_DOC_DIR . "/" . $doc->fields['filepath'],
                                     'mail',
-                                    $imgsize[0],
-                                    $imgsize[1]
+                                    $width,
+                                    $height
                                 );
                                 if (
                                     $mmail->AddEmbeddedImage(

--- a/src/RichText/RichText.php
+++ b/src/RichText/RichText.php
@@ -355,10 +355,10 @@ final class RichText
                     $gallery = self::imageGallery([
                         [
                             'src' => $docsrc,
-                            'w'   => $imgsize[0], //used by photoSwipe gallery
-                            'h'   => $imgsize[1], //used by photoSwipe gallery
-                            'user_w' => $width, //use from timeline
-                            'user_h' => $height,//use from timeline
+                            'w'   => $imgsize[0],
+                            'h'   => $imgsize[1],
+                            'thumbnail_w' => $width,
+                            'thumbnail_h' => $height,
                         ]
                     ]);
                     $content = str_replace($img_tag, $gallery, $content);

--- a/src/RichText/RichText.php
+++ b/src/RichText/RichText.php
@@ -453,7 +453,9 @@ final class RichText
             }
             $out .= "<figure itemprop='associatedMedia' itemscope itemtype='http://schema.org/ImageObject'>";
             $out .= "<a href='{$img['src']}' itemprop='contentUrl' data-index='0'>";
-            $out .= "<img src='{$img['thumbnail_src']}' itemprop='thumbnail' loading='lazy' width='{$img['user_w']}' height='{$img['user_h']}' >";
+            $width_attr = isset($img['thumbnail_w']) ? "width='{$img['thumbnail_w']}'" : "";
+            $height_attr = isset($img['thumbnail_h']) ? "height='{$img['thumbnail_h']}'" : "";
+            $out .= "<img src='{$img['thumbnail_src']}' itemprop='thumbnail' loading='lazy' {$width_attr} {$height_attr}>";
             $out .= "</a>";
             $out .= "</figure>";
         }

--- a/src/RichText/RichText.php
+++ b/src/RichText/RichText.php
@@ -339,12 +339,27 @@ final class RichText
             if ($document->getFromDB($docid)) {
                 $docpath = GLPI_DOC_DIR . '/' . $document->fields['filepath'];
                 if (Document::isImage($docpath)) {
+
+                    //find width / height define by user
+                    $width = null;
+                    if (preg_match("/width=[\"|'](\d+)(\.\d+)?[\"|']/", $img_tag, $wmatches)) {
+                        $width = intval($wmatches[1]);
+                    }
+                    $height = null;
+                    if (preg_match("/height=[\"|'](\d+)(\.\d+)?[\"|']/", $img_tag, $hmatches)) {
+                        $height = intval($hmatches[1]);
+                    }
+
+                    //find real size from image
                     $imgsize = getimagesize($docpath);
+
                     $gallery = self::imageGallery([
                         [
                             'src' => $docsrc,
-                            'w'   => $imgsize[0],
-                            'h'   => $imgsize[1]
+                            'w'   => $imgsize[0], //used by photoSwipe gallery
+                            'h'   => $imgsize[1], //used by photoSwipe gallery
+                            'user_w' => $width, //use from timeline
+                            'user_h' => $height,//use from timeline
                         ]
                     ]);
                     $content = str_replace($img_tag, $gallery, $content);
@@ -439,7 +454,7 @@ final class RichText
             }
             $out .= "<figure itemprop='associatedMedia' itemscope itemtype='http://schema.org/ImageObject'>";
             $out .= "<a href='{$img['src']}' itemprop='contentUrl' data-index='0'>";
-            $out .= "<img src='{$img['thumbnail_src']}' itemprop='thumbnail' loading='lazy'>";
+            $out .= "<img src='{$img['thumbnail_src']}' itemprop='thumbnail' loading='lazy' width='{$img['user_w']}' height='{$img['user_h']}' >";
             $out .= "</a>";
             $out .= "</figure>";
         }

--- a/src/RichText/RichText.php
+++ b/src/RichText/RichText.php
@@ -339,7 +339,6 @@ final class RichText
             if ($document->getFromDB($docid)) {
                 $docpath = GLPI_DOC_DIR . '/' . $document->fields['filepath'];
                 if (Document::isImage($docpath)) {
-
                     //find width / height define by user
                     $width = null;
                     if (preg_match("/width=[\"|'](\d+)(\.\d+)?[\"|']/", $img_tag, $wmatches)) {


### PR DESCRIPTION
When the user copies/pastes the image from richtext and changes its size (smaller)

on display, the size is reworked by GLPI to match the size of the text area -> perfect

But when GLPI generates the notification, it takes into account the ```width``` and ```height``` in the ```img``` DOM

This PR allow GLPI to handle image size.

**EDIT**
The real issue is -> " the display size in timeline is not correct."
Images are always risize by GLPI even if user change it



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24145
