### PR TITLE
fix(inventory): only update SNMP, last update, autoupdatesystems from NetworkEquipement discoveries

### DIFF
--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -707,8 +707,15 @@ abstract class MainAsset extends InventoryAsset
         }
 
         if ($this->is_discovery === true && !$this->isNew()) {
-            //do not update from network discoveries
             //prevents discoveries to remove all ports, IPs and so on found with network inventory
+            //only update autoupdatesystems_id, last_inventory_update, snmpcredentials_id
+            $input = $this->handleInput($val);
+            $this->item->update(['id' => $input['id'],
+                'autoupdatesystems_id'  => $input['autoupdatesystems_id'],
+                'last_inventory_update' => $input['last_inventory_update'],
+                'snmpcredentials_id'    => $input['snmpcredentials_id']
+            ]);
+
             return;
         }
 


### PR DESCRIPTION
Allows you to update only

- Last inventory update
- SNMP Credential
- Auto update system

for NetworkEquipement and from discoveries



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | [#209](https://github.com/glpi-project/glpi-inventory-plugin/issues/209)
