### PR TITLE
Fix document size error for weblink doc

### DIFF
--- a/templates/components/itilobject/timeline/form_document_item.html.twig
+++ b/templates/components/itilobject/timeline/form_document_item.html.twig
@@ -60,9 +60,11 @@
             </div>
          {% endif %}
 
-         <div class="col-auto text-muted ms-2">
-            {{ entry_i['filepath']|document_size }}
-         </div>
+         {% if entry_i['filepath'] is defined and entry_i['filepath'] is not null %}
+            <div class="col-auto text-muted ms-2">
+               {{ entry_i['filepath']|document_size }}
+            </div>
+         {% endif %}
 
          <div class="col-auto">
             <div class="list-group-item-actions">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

If a document has no file path, usually because it has a link to an external resource instead, the null file path would get passed to `document_size` which is not allowed. This section of the form in the timeline can be excluded completely if there is no file path.