### PR TITLE
fix(discovery): add is_dynamic key to prevent last_inventory_update to be locked

### DIFF
--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -713,7 +713,8 @@ abstract class MainAsset extends InventoryAsset
             $this->item->update(['id' => $input['id'],
                 'autoupdatesystems_id'  => $input['autoupdatesystems_id'],
                 'last_inventory_update' => $input['last_inventory_update'],
-                'snmpcredentials_id'    => $input['snmpcredentials_id']
+                'snmpcredentials_id'    => $input['snmpcredentials_id'],
+                'is_dynamic'            => true
             ]);
 
             return;


### PR DESCRIPTION
Add is_dynamic key to prevent last_inventory_update to be locked


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
