### PR TITLE
Fix missing self service ticket form defaults

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -355,12 +355,13 @@ abstract class CommonITILObject extends CommonDBTM
      * @param integer $ID The item ID
      * @param array $options ITIL Object options array passed to showFormXXXX functions. This is passed by reference and will be modified by this function.
      * @param ?array $overriden_defaults If specified, these values will be used as the defaults instead of the ones from the {@link getDefaultValues()} function.
+     * @param bool $force_set_defaults If true, the defaults are set for missing options even if the item is not new.
      * @return void
      * @see getDefaultOptions()
      * @see restoreInput()
      * @see restoreSavedValues()
      */
-    protected function restoreInputAndDefaults($ID, array &$options, ?array $overriden_defaults = null): void
+    protected function restoreInputAndDefaults($ID, array &$options, ?array $overriden_defaults = null, bool $force_set_defaults = false): void
     {
         $default_values = $overriden_defaults ?? static::getDefaultValues();
 
@@ -371,7 +372,7 @@ abstract class CommonITILObject extends CommonDBTM
         $this->restoreSavedValues($options['_saved']);
 
         // Set default options
-        if (static::isNewID($ID)) {
+        if ($force_set_defaults || static::isNewID($ID)) {
             foreach ($default_values as $key => $val) {
                 if (!isset($options[$key])) {
                     if (isset($options['_saved'][$key])) {

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -3898,7 +3898,7 @@ JAVASCRIPT;
             $options['name'] = str_replace($order, $replace, $options['name']);
         }
 
-        $this->restoreInputAndDefaults($ID, $options, $default_values);
+        $this->restoreInputAndDefaults($ID, $options, $default_values, true);
 
        // Check category / type validity
         if ($options['itilcategories_id']) {
@@ -4139,7 +4139,7 @@ JAVASCRIPT;
             $options['entities_id'] = $item->fields['entities_id'];
         }
 
-        $this->restoreInputAndDefaults($ID, $options);
+        $this->restoreInputAndDefaults($ID, $options, null, true);
 
         if (isset($options['content'])) {
             $order              = ["\\'", '\\"', "\\\\"];

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -3898,22 +3898,7 @@ JAVASCRIPT;
             $options['name'] = str_replace($order, $replace, $options['name']);
         }
 
-        // Restore saved value or override with page parameter
-        $options['_saved'] = $this->restoreInput();
-
-        // Restore saved values and override $this->fields
-        $this->restoreSavedValues($options['_saved']);
-
-        // Populate $options with defaults
-        foreach ($default_values as $name => $value) {
-            if (!isset($options[$name])) {
-                if (isset($options['_saved'][$name])) {
-                    $options[$name] = $options['_saved'][$name];
-                } else {
-                    $options[$name] = $value;
-                }
-            }
-        }
+        $this->restoreInputAndDefaults($ID, $options, $default_values);
 
        // Check category / type validity
         if ($options['itilcategories_id']) {
@@ -4154,23 +4139,7 @@ JAVASCRIPT;
             $options['entities_id'] = $item->fields['entities_id'];
         }
 
-        $default_values = self::getDefaultValues();
-
-        // Restore saved value or override with page parameter
-        $options['_saved'] = $this->restoreInput();
-
-        // Restore saved values and override $this->fields
-        $this->restoreSavedValues($options['_saved']);
-
-        foreach ($default_values as $name => $value) {
-            if (!isset($options[$name])) {
-                if (isset($options['_saved'][$name])) {
-                    $options[$name] = $options['_saved'][$name];
-                } else {
-                    $options[$name] = $value;
-                }
-            }
-        }
+        $this->restoreInputAndDefaults($ID, $options);
 
         if (isset($options['content'])) {
             $order              = ["\\'", '\\"', "\\\\"];
@@ -4315,7 +4284,7 @@ JAVASCRIPT;
         );
 
         // override current fields in options with template fields and return the array of these predefined fields
-        $predefined_fields = $this->setPredefinedFields($tt, $options, $default_values);
+        $predefined_fields = $this->setPredefinedFields($tt, $options, self::getDefaultValues());
 
         // check right used for this ticket
         $canupdate     = !$ID

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -3904,6 +3904,17 @@ JAVASCRIPT;
         // Restore saved values and override $this->fields
         $this->restoreSavedValues($options['_saved']);
 
+        // Populate $options with defaults
+        foreach ($default_values as $name => $value) {
+            if (!isset($options[$name])) {
+                if (isset($options['_saved'][$name])) {
+                    $options[$name] = $options['_saved'][$name];
+                } else {
+                    $options[$name] = $value;
+                }
+            }
+        }
+
        // Check category / type validity
         if ($options['itilcategories_id']) {
             $cat = new ITILCategory();
@@ -3952,6 +3963,7 @@ JAVASCRIPT;
             'selfservice'             => true,
             'item'                    => $this,
             'params'                  => $options,
+            'entities_id'             => $options['entities_id'],
             'itiltemplate_key'        => self::getTemplateFormFieldName(),
             'itiltemplate'            => $tt,
             'delegating'              => $delegating,

--- a/templates/components/itilobject/selfservice.html.twig
+++ b/templates/components/itilobject/selfservice.html.twig
@@ -195,7 +195,7 @@
 
                      {{ include('components/itilobject/actors/main.html.twig', {
                         'item': item,
-                        'entities_id': params['entities_id'],
+                        'entities_id': entities_id,
                         'itiltemplate': itiltemplate,
                         'field_options': right_field_options,
                         'canupdate': true,

--- a/templates/components/itilobject/selfservice.html.twig
+++ b/templates/components/itilobject/selfservice.html.twig
@@ -247,7 +247,7 @@
       {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::POST_ITEM_FORM'), {'item': item, 'options': params}) }}
 
         <div class="card-footer text-center">
-            <input type="hidden" name="entities_id" value="{{ params['entities_id'] }}" />
+            <input type="hidden" name="entities_id" value="{{ entities_id }}" />
             <button type="submit" class="btn btn-primary" name="add">
                 <i class="fas fa-plus"></i>
                 <span>{{ __('Submit message') }}</span>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12427

When a ticket template is used in the self-service ticket creation form, multiple options are not set properly from the default values.
This PR fixes that and also changes how the `entities_id` is referenced within the template to match the regular ITIL Object form.