### PR TITLE
fix(networkport): correctly display metrics

### DIFF
--- a/front/networkport.form.php
+++ b/front/networkport.form.php
@@ -151,6 +151,7 @@ if (isset($_POST["add"])) {
         $_GET["instantiation_type"] = "";
     }
 
-    $menus = ['assets'];
+    $menus[0] = 'assets';
+    $menus[1] = 'networkport';
     NetworkPort::displayFullPageForItem($_GET["id"], $menus, $_GET);
 }

--- a/inc/define.php
+++ b/inc/define.php
@@ -553,11 +553,12 @@ $CFG_GLPI['javascript'] = [
         ], $dashboard_libs)
     ],
     'assets'    => [
-        'dashboard' => $dashboard_libs,
-        'rack'      => ['gridstack', 'rack'],
-        'printer'   => $dashboard_libs,
-        'cable'     => ['cable'],
-        'socket'    => ['cable'],
+        'dashboard'   => $dashboard_libs,
+        'rack'        => ['gridstack', 'rack'],
+        'printer'     => $dashboard_libs,
+        'cable'       => ['cable'],
+        'socket'      => ['cable'],
+        'networkport' => $dashboard_libs,
     ],
     'helpdesk'  => [
         'dashboard' => $dashboard_libs,

--- a/src/Dashboard/Widget.php
+++ b/src/Dashboard/Widget.php
@@ -1513,20 +1513,14 @@ JAVASCRIPT;
             })";
         }
 
-        $height = "calc(100% - 1px)";
         $legend_options = "";
         if ($p['legend']) {
-            $height = "calc(100% - 40px)";
             $legend_options = "
             Chartist.plugins.legend(),";
         }
 
         $html = <<<HTML
       <style>
-         /** fix chrome resizing height when animating svg (don't know why) **/
-      #{$chart_id} .ct-chart-line {
-         min-height: $height;
-      }
 
       #{$chart_id} {
          background-color: {$p['color']};
@@ -1564,11 +1558,13 @@ JAVASCRIPT;
       {$palette_style}
       </style>
 
-      <div class="card g-chart $class"
-           id="{$chart_id}">
-         <div class="chart ct-chart"></div>
-         <span class="main-label">{$p['label']}</span>
-         <i class="main-icon {$p['icon']}"></i>
+      <div>
+          <div class="card g-chart $class"
+               id="{$chart_id}">
+             <div class="chart ct-chart"></div>
+             <span class="main-label">{$p['label']}</span>
+             <i class="main-icon {$p['icon']}"></i>
+          </div>
       </div>
 HTML;
 
@@ -1585,7 +1581,6 @@ HTML;
             series: {$json_series},
          }, {
             width: '100%',
-            height: '{$height}',
             fullWidth: true,
             chartPadding: {
                right: 40

--- a/src/Dashboard/Widget.php
+++ b/src/Dashboard/Widget.php
@@ -593,11 +593,13 @@ HTML;
 
          {$palette_style}
       </style>
-      <div class="card g-chart {$class}"
-           id="{$chart_id}">
-         <div class="chart ct-chart">{$no_data_html}</div>
-         <span class="main-label">{$p['label']}</span>
-         <i class="main-icon {$p['icon']}"></i>
+      <div>
+         <div class="card g-chart {$class}"
+            id="{$chart_id}">
+            <div class="chart ct-chart">{$no_data_html}</div>
+            <span class="main-label">{$p['label']}</span>
+            <i class="main-icon {$p['icon']}"></i>
+         </div>
       </div>
 HTML;
 
@@ -650,7 +652,6 @@ HTML;
         }
 
         $donut  = $p['donut'] ? 'true' : 'false';
-        $height = $p['half'] ? '180%' : '100%';
         $animation_duration = self::$animation_duration;
 
         $js = <<<JAVASCRIPT
@@ -660,7 +661,6 @@ HTML;
             series: {$series},
          }, {
             width: 'calc(100% - 5px)',
-            height: 'calc({$height} - 5px)',
             chartPadding: {$chartPadding},
             donut: {$donut},
             $donut_opts
@@ -1057,10 +1057,8 @@ JAVASCRIPT;
             <span>";
         }
 
-        $height = "calc(100% - 5px)";
         $legend_options = "";
         if ($p['legend']) {
-            $height = "calc(100% - 40px)";
             $legend_options = "
             Chartist.plugins.legend(),";
         }
@@ -1093,18 +1091,16 @@ JAVASCRIPT;
          stroke: {$dark_line_color};
       }
 
-      /** fix chrome resizing height when animating svg (don't know why) **/
-      #{$chart_id} .ct-chart-bar {
-         min-height: $height;
-      }
       {$palette_style}
       </style>
 
-      <div class="card g-chart $class"
-            id="{$chart_id}">
-         <div class="chart ct-chart">$no_data_html</div>
-         <span class="main-label">{$p['label']}</span>
-         <i class="main-icon {$p['icon']}"></i>
+      <div>
+         <div class="card g-chart $class"
+               id="{$chart_id}">
+            <div class="chart ct-chart">$no_data_html</div>
+            <span class="main-label">{$p['label']}</span>
+            <i class="main-icon {$p['icon']}"></i>
+         </div>
       </div>
 HTML;
 
@@ -1156,7 +1152,6 @@ HTML;
             series: {$json_series},
          }, {
             width: '100%',
-            height: '{$height}',
             seriesBarDistance: 10,
             chartPadding: 0,
             $distributed_options

--- a/src/NetworkPortMetrics.php
+++ b/src/NetworkPortMetrics.php
@@ -142,27 +142,24 @@ class NetworkPortMetrics extends CommonDBChild
         $bytes_series = [];
         $errors_series = [];
         $labels = [];
-        $i = 0;
         foreach ($raw_metrics as $metrics) {
             $date = new \DateTime($metrics['date']);
             $labels[] = $date->format(__('Y-m-d'));
-            unset($metrics['id'], $metrics['date'], $metrics[static::$items_id]);
+            unset($metrics['id'], $metrics['date'], $metrics['date_creation'], $metrics['date_mod'], $metrics[static::$items_id]);
 
             $bytes_metrics = $metrics;
             unset($bytes_metrics['ifinerrors'], $bytes_metrics['ifouterrors']);
             foreach ($bytes_metrics as $key => $value) {
                 $bytes_series[$key]['name'] = $this->getLabelFor($key);
-                $bytes_series[$key]['data'][] = $value;
+                $bytes_series[$key]['data'][] = round($value / 1024 / 1024, 0); //convert bytes to megabytes
             }
 
             $errors_metrics = $metrics;
             unset($errors_metrics['ifinbytes'], $errors_metrics['ifoutbytes']);
             foreach ($errors_metrics as $key => $value) {
                 $errors_series[$key]['name'] = $this->getLabelFor($key);
-                $errors_series[$key]['data'][] = $value;
+                $errors_series[$key]['data'][] = round($value / 1024 / 1024, 0); //convert bytes to megabytes
             }
-
-            ++$i;
         }
 
         $bytes_bar_conf = [
@@ -176,9 +173,8 @@ class NetworkPortMetrics extends CommonDBChild
             'distributed' => false
         ];
 
-       //display graph
-        Html::requireJs('charts');
-        echo "<div class='dashboard netports_metrics bytes'>";
+       //display bytes graph
+        echo "<div class='netports_metrics bytes'>";
         echo Widget::multipleLines($bytes_bar_conf);
         echo "</div>";
 
@@ -193,8 +189,10 @@ class NetworkPortMetrics extends CommonDBChild
             'distributed' => false
         ];
 
-       //display graph
-        echo "<div class='dashboard netports_metrics'>";
+        echo "</br>";
+
+       //display error graph
+        echo "<div class='netports_metrics'>";
         echo Widget::multipleLines($errors_bar_conf);
         echo "</div>";
     }
@@ -203,9 +201,9 @@ class NetworkPortMetrics extends CommonDBChild
     {
         switch ($key) {
             case 'ifinbytes':
-                return __('Input bytes');
+                return __('Input megabytes');
             case 'ifoutbytes':
-                return __('Output bytes');
+                return __('Output megabytes');
             case 'ifinerrors':
                 return __('Input errors');
             case 'ifouterrors':

--- a/src/NetworkPortMetrics.php
+++ b/src/NetworkPortMetrics.php
@@ -167,7 +167,7 @@ class NetworkPortMetrics extends CommonDBChild
                 'labels' => $labels,
                 'series' => array_values($bytes_series),
             ],
-            'label' => __('Input/Output bytes'),
+            'label' => __('Input/Output megabytes'),
             'icon'  => $params['icon'],
             'color' => '#ffffff',
             'distributed' => false


### PR DESCRIPTION
Correctly display NetworkPort metrics

![image](https://user-images.githubusercontent.com/7335054/186361625-64a90fdf-dc6a-4569-b41f-fb4bbe32b7bd.png)

- Fix load of chartist js library 
- Convert bytes to megabytes (dashboard label more readable)

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12472
