### PR TITLE
fix(pendingreason): correctly render content from automatic actions

### DIFF
--- a/src/PendingReasonCron.php
+++ b/src/PendingReasonCron.php
@@ -155,7 +155,7 @@ class PendingReasonCron extends CommonDBTM
                     'itemtype' => $item::getType(),
                     'items_id' => $item->getID(),
                     'users_id' => $config['system_user'],
-                    'content' => addslashes($fup_template->fields['content']),
+                    'content' => addslashes($fup_template->getRenderedContent($item)),
                     'is_private' => $fup_template->fields['is_private'],
                     'requesttypes_id' => $fup_template->fields['requesttypes_id'],
                     'timeline_position' => CommonITILObject::TIMELINE_RIGHT,
@@ -182,7 +182,7 @@ class PendingReasonCron extends CommonDBTM
                     'itemtype'         => $item::getType(),
                     'items_id'         => $item->getID(),
                     'solutiontypes_id' => $solution_template->fields['solutiontypes_id'],
-                    'content'          => addslashes($solution_template->fields['content']),
+                    'content'          => addslashes($solution_template->getRenderedContent($item)),
                     'users_id'         => $config['system_user'],
                 ]);
                 $task->addVolume(1);


### PR DESCRIPTION
Automatic action does not convert template tags for pending reason

This PR fix this.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24688
