### PR TITLE
fix table alias naming in nested join

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -5691,6 +5691,9 @@ JAVASCRIPT;
                     if (!isset($tab['joinparams']['nolink']) || !$tab['joinparams']['nolink']) {
                         $cleanrt     = $intertable;
                         $complexjoin = self::computeComplexJoinID($interjoinparams);
+                        if (!empty($interlinkfield) && ($interlinkfield != getForeignKeyFieldForTable($intertable))) {
+                            $intertable .= "_" . $interlinkfield;
+                        }
                         if (!empty($complexjoin)) {
                             $intertable .= "_" . $complexjoin;
                         }

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -1035,7 +1035,8 @@ class Search extends DbTestCase
                         ON (`glpi_contacts_id_d36f89b191ea44cf6f7c8414b12e1e50`.`id` = `glpi_projectteams`.`items_id`
                         AND `glpi_projectteams`.`itemtype` = 'Contact'
                          )"
-            ]],
+            ]
+            ],
             'special_fk' => [[
                 'itemtype'           => 'Computer',
                 'table'              => \User::getTable(),
@@ -1045,7 +1046,8 @@ class Search extends DbTestCase
                 'meta_type'          => null,
                 'joinparams'         => [],
                 'sql' => "LEFT JOIN `glpi_users` AS `glpi_users_users_id_tech` ON (`glpi_computers`.`users_id_tech` = `glpi_users_users_id_tech`.`id` )"
-            ]],
+            ]
+            ],
             'regular_fk' => [[
                 'itemtype'           => 'Computer',
                 'table'              => \User::getTable(),
@@ -1055,7 +1057,8 @@ class Search extends DbTestCase
                 'meta_type'          => null,
                 'joinparams'         => [],
                 'sql' => "LEFT JOIN `glpi_users` ON (`glpi_computers`.`users_id` = `glpi_users`.`id` )"
-            ]],
+            ]
+            ],
 
             'linkfield in beforejoin' => [[
                 'itemtype'           => 'Ticket',
@@ -1093,7 +1096,8 @@ class Search extends DbTestCase
                 . "ON (`glpi_users_users_id_validate_57751ba960bd8511d2ad8a01bd8487f4`.`id` = `glpi_validatorsubstitutes_f1e9cbef8429d6d41e308371824d1632`.`users_id` )"
                 . "LEFT JOIN `glpi_validatorsubstitutes` AS `glpi_validatorsubstitutes_c9b716cdcdcfe62bc267613fce4d1f48` "
                 . "ON (`glpi_validatorsubstitutes_f1e9cbef8429d6d41e308371824d1632`.`validatorsubstitutes_id` = `glpi_validatorsubstitutes_c9b716cdcdcfe62bc267613fce4d1f48`.`id` )"
-            ]],
+            ]
+            ],
         ];
     }
 


### PR DESCRIPTION
While designing a search option I found the new need to mention a linkfield in a nested ['beforejoin' array](https://glpi-developer-documentation.readthedocs.io/en/master/devapi/search.html#join-parameters).

Thre is no place in GLPI where such search option exists, and the search engine fails to build the JOIN chain with such context.

I found that 2 consecutive JOIN are broken because of a misnamed table alias. The inner linkfield is missing.



| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
