### PR TITLE
add new options for deleted users : disable and remove groups 

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -95,6 +95,12 @@ class AuthLDAP extends CommonDBTM
     const DELETED_USER_DISABLEANDWITHDRAWDYNINFO = 4;
 
     /**
+     * Deleted user strategy: disable user and withdraw groups.
+     * @var integer
+     */
+    const DELETED_USER_DISABLEANDDELETEGROUPS = 5;
+
+    /**
      * Restored user strategy: Make no change to GLPI user
      * @var integer
      * @since 10.0.0
@@ -4020,6 +4026,7 @@ class AuthLDAP extends CommonDBTM
             self::DELETED_USER_WITHDRAWDYNINFO           => __('Withdraw dynamic authorizations and groups'),
             self::DELETED_USER_DISABLE                   => __('Disable'),
             self::DELETED_USER_DISABLEANDWITHDRAWDYNINFO => __('Disable') . ' + ' . __('Withdraw dynamic authorizations and groups'),
+            self::DELETED_USER_DISABLEANDDELETEGROUPS => __('Disable') . ' + ' . __('Withdraw groups'),
         ];
     }
 

--- a/src/User.php
+++ b/src/User.php
@@ -5072,6 +5072,12 @@ HTML;
                 Profile_User::deleteRights($users_id, true);
                 Group_User::deleteGroups($users_id, true);
                 break;
+
+            case AuthLDAP::DELETED_USER_DISABLEANDDELETEGROUPS:
+                $tmp['is_active'] = 0;
+                $myuser->update($tmp);
+                Group_User::deleteGroups($users_id, true);
+                break;
         }
        /*
        $changes[0] = '0';


### PR DESCRIPTION
same as DELETED_USER_DISABLEANDWITHDRAWDYNINFO but without authorization removal

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://discord.com/channels/402399026168725505/402416991849414656/1012380128451514428

Suggestion of @kabassanov 
