### PR TITLE
fix(ticket): assign to editable without assign right

### DIFF
--- a/templates/components/itilobject/actors/main.html.twig
+++ b/templates/components/itilobject/actors/main.html.twig
@@ -119,7 +119,7 @@
          'entities_id': entities_id,
          'itiltemplate': itiltemplate,
          'params': params,
-         'canupdate': (canupdate or canassign),
+         'canupdate': canassign,
          'disable_assign_to_me': disable_assign_to_me ?? false,
          'main_rand': main_rand,
       }, with_context = false) }}


### PR DESCRIPTION
The "assign to" field was editable, even without the "assign" right. However, the data was not saved.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24764
