### PR TITLE
Fix notice in ITIL item lists when an asset type has no name field

### DIFF
--- a/src/Change_Item.php
+++ b/src/Change_Item.php
@@ -173,7 +173,7 @@ class Change_Item extends CommonItilObject_Item
                 $prem = true;
                 foreach ($iterator as $data) {
                     $link     = $itemtype::getFormURLWithID($data['id']);
-                    $linkname = $data["name"];
+                    $linkname = $data["name"] ?? '';
                     if (
                         $_SESSION["glpiis_ids_visible"]
                         || empty($data["name"])

--- a/src/Item_Problem.php
+++ b/src/Item_Problem.php
@@ -167,7 +167,7 @@ class Item_Problem extends CommonItilObject_Item
 
                 $prem = true;
                 foreach ($iterator as $data) {
-                    $name = $data["name"];
+                    $name = $data["name"] ?? '';
                     if (
                         $_SESSION["glpiis_ids_visible"]
                         || empty($data["name"])

--- a/src/Item_Ticket.php
+++ b/src/Item_Ticket.php
@@ -468,7 +468,7 @@ class Item_Ticket extends CommonItilObject_Item
 
                 $prem = true;
                 foreach ($iterator as $data) {
-                    $name = $data["name"];
+                    $name = $data["name"] ?? '';
                     if (
                         $_SESSION["glpiis_ids_visible"]
                         || empty($data["name"])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

If an asset linked with a Ticket, Change or Problem has no name field, there is a PHP notice when accessing the missing array element. This didn't affect the functionality or display of the items.