### PR TITLE
Fix sql warning from ip order

### DIFF
--- a/src/NetworkName.php
+++ b/src/NetworkName.php
@@ -231,7 +231,8 @@ class NetworkName extends FQDNLabel
             'joinparams'         => [
                 'jointype'  => 'mainitemtype_mainitem',
                 'condition' => ['NEWTABLE.is_deleted' => 0,
-                                'NOT' => ['NEWTABLE.name' => '']]
+                'NOT' => ['NEWTABLE.name' => '']
+                ]
             ]
         ];
 

--- a/src/NetworkName.php
+++ b/src/NetworkName.php
@@ -230,7 +230,8 @@ class NetworkName extends FQDNLabel
             'massiveaction'      => false,
             'joinparams'         => [
                 'jointype'  => 'mainitemtype_mainitem',
-                'condition' => ['NEWTABLE.is_deleted' => 0]
+                'condition' => ['NEWTABLE.is_deleted' => 0,
+                                'NOT' => ['NEWTABLE.name' => '']]
             ]
         ];
 

--- a/src/NetworkName.php
+++ b/src/NetworkName.php
@@ -231,7 +231,7 @@ class NetworkName extends FQDNLabel
             'joinparams'         => [
                 'jointype'  => 'mainitemtype_mainitem',
                 'condition' => ['NEWTABLE.is_deleted' => 0,
-                'NOT' => ['NEWTABLE.name' => '']
+                    'NOT' => ['NEWTABLE.name' => '']
                 ]
             ]
         ];

--- a/src/Search.php
+++ b/src/Search.php
@@ -3687,7 +3687,7 @@ JAVASCRIPT;
                    //FIXME glpi_networkequipments.ip seems like a dead case
                     case "glpi_networkequipments.ip":
                     case "glpi_ipaddresses.name":
-                        $criterion = "INET_ATON(`$table$addtable`.`$field`) $order";
+                        $criterion = "INET6_ATON(`$table$addtable`.`$field`) $order";
                         break;
                 }
             }

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -1101,11 +1101,11 @@ class Search extends DbTestCase
          // Simple Hard-coded cases
             [
                 'IPAddress', 1, 'ASC',
-                ' ORDER BY INET_ATON(`glpi_ipaddresses`.`name`) ASC '
+                ' ORDER BY INET6_ATON(`glpi_ipaddresses`.`name`) ASC '
             ],
             [
                 'IPAddress', 1, 'DESC',
-                ' ORDER BY INET_ATON(`glpi_ipaddresses`.`name`) DESC '
+                ' ORDER BY INET6_ATON(`glpi_ipaddresses`.`name`) DESC '
             ],
             [
                 'User', 1, 'ASC',
@@ -1165,7 +1165,7 @@ class Search extends DbTestCase
                         'searchopt_id' => 1,
                         'order'        => 'ASC'
                     ]
-                ], ' ORDER BY INET_ATON(`glpi_ipaddresses`.`name`) ASC '
+                ], ' ORDER BY INET6_ATON(`glpi_ipaddresses`.`name`) ASC '
             ],
             [
                 'IPAddress',
@@ -1174,7 +1174,7 @@ class Search extends DbTestCase
                         'searchopt_id' => 1,
                         'order'        => 'DESC'
                     ]
-                ], ' ORDER BY INET_ATON(`glpi_ipaddresses`.`name`) DESC '
+                ], ' ORDER BY INET6_ATON(`glpi_ipaddresses`.`name`) DESC '
             ],
             [
                 'User',


### PR DESCRIPTION
If we sort the IP column

it results in an SQL warning about the ```inet_aton``` function.

```shell
SQL Warnings: 1411: Incorrect string value: 'glpidb.glpi_ipaddresses_937b8c393ea02752d06397f2628684f5.name' for function inet_aton
```
There are currently 2 ways to trigger this error

- Empty IP
- ```IPV6``` format (from ```name``` column)

Rather than using the ```inet_aton``` function that is only compatible with ```IPV4```, I suggest using the ```IPV6``` version  ```inet6_aton```.

Sort order seems OK with ```inet6_aton```

```sql

mysql> select id, name, inet6_aton(name) from glpi_ipaddresses where mainitems_id = 7 and mainitemtype = 'Computer' order by inet6_aton(`glpi_ipaddresses`.`name`) asc;
+-----+-------------------------+------------------------------------+
| id  | name                    | inet6_aton(name)                   |
+-----+-------------------------+------------------------------------+
| 171 |                         | NULL                               |
| 165 | 0.0.0.0                 | 0x00000000                         |
| 166 | 192.168.1.3             | 0xC0A80103                         |
| 168 | 192.168.1.4             | 0xC0A80104                         |
| 169 | 192.168.1.5             | 0xC0A80105                         |
| 127 | fe80::10ce:c2fa:6b:e145 | 0xFE8000000000000010CEC2FA006BE145 |
| 160 | fe80::10ce:c2fa:6b:e145 | 0xFE8000000000000010CEC2FA006BE145 |
| 156 | fe80::10ce:c2fa:6b:e146 | 0xFE8000000000000010CEC2FA006BE146 |
| 157 | fe80::10ce:c2fa:6b:e147 | 0xFE8000000000000010CEC2FA006BE147 |
| 158 | fe80::10ce:c2fa:6b:e148 | 0xFE8000000000000010CEC2FA006BE148 |
| 159 | fe80::10ce:c2fa:6b:e149 | 0xFE8000000000000010CEC2FA006BE149 |
+-----+-------------------------+------------------------------------+


mysql> select id, name, inet6_aton(name) from glpi_ipaddresses where mainitems_id = 7 and mainitemtype = 'Computer' order by inet6_aton(`glpi_ipaddresses`.`name`) desc;
+-----+-------------------------+------------------------------------+
| id  | name                    | inet6_aton(name)                   |
+-----+-------------------------+------------------------------------+
| 159 | fe80::10ce:c2fa:6b:e149 | 0xFE8000000000000010CEC2FA006BE149 |
| 158 | fe80::10ce:c2fa:6b:e148 | 0xFE8000000000000010CEC2FA006BE148 |
| 157 | fe80::10ce:c2fa:6b:e147 | 0xFE8000000000000010CEC2FA006BE147 |
| 156 | fe80::10ce:c2fa:6b:e146 | 0xFE8000000000000010CEC2FA006BE146 |
| 127 | fe80::10ce:c2fa:6b:e145 | 0xFE8000000000000010CEC2FA006BE145 |
| 160 | fe80::10ce:c2fa:6b:e145 | 0xFE8000000000000010CEC2FA006BE145 |
| 169 | 192.168.1.5             | 0xC0A80105                         |
| 168 | 192.168.1.4             | 0xC0A80104                         |
| 166 | 192.168.1.3             | 0xC0A80103                         |
| 165 | 0.0.0.0                 | 0x00000000                         |
| 171 |                         | NULL                               |
+-----+-------------------------+------------------------------------+
```
In addition, now we exclude empty IPs from ```JOIN``` clause.


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12488
