### PR TITLE
Log full profile information to user record on profile add or suppression

### DIFF
--- a/src/Profile_User.php
+++ b/src/Profile_User.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Toolbox\Sanitizer;
+
 /**
  * Profile_User Class
  **/
@@ -49,15 +51,8 @@ class Profile_User extends CommonDBRelation
     public static $items_id_2                    = 'profiles_id';
     public static $checkItem_2_Rights            = self::DONT_CHECK_ITEM_RIGHTS;
 
-   // Specific log system
-    public static $logs_for_item_2               = false;
-    public static $logs_for_item_1               = true;
-    public static $log_history_1_add             = Log::HISTORY_ADD_SUBITEM;
-    public static $log_history_1_delete          = Log::HISTORY_DELETE_SUBITEM;
-
    // Manage Entity properties forwarding
     public static $disableAutoEntityForwarding   = true;
-
 
     /**
      * @since 0.84
@@ -1223,5 +1218,105 @@ class Profile_User extends CommonDBRelation
             count($authorizations_ids) == 1 // Only one super admin auth
             && $authorizations_ids[0] == $this->fields['id'] // Id match this auth
         ;
+    }
+
+    public function post_addItem()
+    {
+        $this->logOperation('add');
+    }
+
+    public function post_deleteFromDB()
+    {
+        $this->logOperation('delete');
+    }
+
+    /**
+     * Log add/delete operation.
+     * @param string $type
+     */
+    private function logOperation(string $type): void
+    {
+        if ((isset($this->input['_no_history']) && $this->input['_no_history'])) {
+            return;
+        }
+
+        $profile_flags = [];
+        if ((bool)$this->fields['is_dynamic']) {
+            //TRANS: letter 'D' for Dynamic
+            $profile_flags[] = __('D');
+        }
+        if ((bool)$this->fields['is_recursive']) {
+            //TRANS: letter 'D' for Dynamic
+            $profile_flags[] = __('R');
+        }
+
+        $user    = User::getById($this->fields['users_id']);
+        $profile = Profile::getById($this->fields['profiles_id']);
+        $entity  = Entity::getById($this->fields['entities_id']);
+
+        $username    = $user->getNameID(['forceid' => true, 'complete' => 1]);
+        $profilename = $profile->getNameID(['forceid' => true, 'complete' => 1]);
+        $entityname  = $entity->getNameID(['forceid' => true, 'complete' => 1]);
+
+        // Log on user
+        if ($user->dohistory) {
+            $log_entry = sprintf(__('%1$s, %2$s'), $entityname, $profilename);
+            if (count($profile_flags) > 0) {
+                $log_entry = sprintf(__('%s (%s)'), $log_entry, implode(', ', $profile_flags));
+            }
+            $log_entry = Sanitizer::dbEscape($log_entry);
+            $changes = [
+                '0',
+                $type === 'delete' ? $log_entry : '',
+                $type === 'add' ? $log_entry : '',
+            ];
+            Log::history(
+                $user->getID(),
+                $user->getType(),
+                $changes,
+                $profile->getType(),
+                constant(sprintf('Log::HISTORY_%s_SUBITEM', strtoupper($type)))
+            );
+        }
+
+        // Log on profile
+        if ($profile->dohistory) {
+            $log_entry = sprintf(__('%1$s, %2$s'), $username, $entityname);
+            if (count($profile_flags) > 0) {
+                $log_entry = sprintf(__('%s (%s)'), $log_entry, implode(', ', $profile_flags));
+            }
+            $changes = [
+                '0',
+                $type === 'delete' ? $log_entry : '',
+                $type === 'add' ? $log_entry : '',
+            ];
+            Log::history(
+                $profile->getID(),
+                $profile->getType(),
+                $changes,
+                $user->getType(),
+                constant(sprintf('Log::HISTORY_%s_SUBITEM', strtoupper($type)))
+            );
+        }
+
+        // Log on entity
+        if ($entity->dohistory) {
+            $log_entry = sprintf(__('%1$s, %2$s'), $username, $profilename);
+            if (count($profile_flags) > 0) {
+                $log_entry = sprintf(__('%s (%s)'), $log_entry, implode(', ', $profile_flags));
+            }
+            $changes = [
+                '0',
+                $type === 'delete' ? $log_entry : '',
+                $type === 'add' ? $log_entry : '',
+            ];
+            Log::history(
+                $entity->getID(),
+                $entity->getType(),
+                $changes,
+                $user->getType(),
+                constant(sprintf('Log::HISTORY_%s_SUBITEM', strtoupper($type)))
+            );
+        }
     }
 }

--- a/tests/functional/Transfer.php
+++ b/tests/functional/Transfer.php
@@ -66,53 +66,25 @@ class Transfer extends DbTestCase
                 '/^DB.*/',
                 '/^SlaLevel.*/',
                 '/^OlaLevel.*/',
-                'Reservation',
-                'ReservationItem',
                 'Event',
                 'Glpi\\Event',
                 'KnowbaseItem',
-                'NetworkPortMigration',
-                '/^TicketTemplate.*/',
-                '/^Computer_Software.*/',
                 '/SavedSearch.*/',
                 '/.*Notification.*/',
-                '/.*Cost.*/',
-                '/^Item_.*/',
                 '/^Device.*/',
-                '/.*Validation$/',
                 '/^Network.*/',
-                'CalendarSegment',
-                'IPAddress',
                 'IPNetwork',
                 'FQDN',
                 '/^SoftwareVersion.*/',
                 '/^SoftwareLicense.*/',
-                '/.*Predefined.*/',
-                '/.*Mandatory.*/',
-                '/.*Hidden.*/',
-                'Entity_Reminder',
-                'Document_Item',
-                'Cartridge',
-                '/.*Task.*/',
-                'Entity_RSSFeed',
-                'ComputerVirtualMachine',
                 'FieldUnicity',
                 'PurgeLogs',
-                '/.*_?KnowbaseItem_?.*/',
-                'Consumable',
-                'Infocom',
-                'ComputerAntivirus',
                 'TicketRecurrent',
                 'Agent',
-                'Printer_CartridgeInfo',
-                'PrinterLog',
                 'USBVendor',
                 'PCIVendor',
                 'PendingReasonCron',
-                'Database',
-                'Socket',
                 'Netpoint',
-                'Link_Itemtype',
             ]
         );
 
@@ -127,6 +99,11 @@ class Transfer extends DbTestCase
 
         $count = 0;
         foreach ($itemtypeslist as $itemtype) {
+            if (is_a($itemtype, \CommonDBConnexity::class, true)) {
+                // Do not check transfer of child items, they are not supposed to be transfered directly.
+                continue;
+            }
+
             $item_class = new \ReflectionClass($itemtype);
             if ($item_class->isAbstract()) {
                 continue;


### PR DESCRIPTION
When a profile is attached to a user account, it is defined by both entity and the profile itseilf. Actually, only this second part is logged to the user history and this information is meaningless without the entity environment it is attached to.

The proposd approach is probably not the best one and any other way to do this is welcome.