### PR TITLE
fix(ticket): hide added group when it is hiddenfield in template

### DIFF
--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -329,6 +329,13 @@
             return openNotifyModal(event);
          }
       }, {capture: true})
+
+      {% if itiltemplate.isHiddenField('_users_id_' ~ actortype) %}
+         $(".actor_entry[data-itemtype=\"User\"][data-actortype=\"{{ actortype }}\"]").parent().css("display", "none");
+      {% endif %}
+      {% if itiltemplate.isHiddenField('_groups_id_' ~ actortype) %}
+         $(".actor_entry[data-itemtype=\"Group\"][data-actortype=\"{{ actortype }}\"]").parent().css("display", "none");
+      {% endif %}
    });
    </script>
 {% endif %}

--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -59,6 +59,9 @@
             data-itemtype="{{ actor['itemtype'] }}" data-items-id="{{ actor['items_id'] }}"
             data-use-notification="{{ actor['use_notification'] }}"
             data-alternative-email="{{ actor['alternative_email'] }}"
+            {% if (actor['itemtype'] == 'User' and itiltemplate.isHiddenField('_users_id_' ~ actortype)) or (actor['itemtype'] == 'Group' and itiltemplate.isHiddenField('_groups_id_' ~ actortype)) %}
+               disabled="disabled" style="display: none;"
+            {% endif %}
             data-text="{{ actor['text']|verbatim_value }}" data-title="{{ actor['title']|verbatim_value }}" data-glpi-popover-source="content{{ unique_id }}">
          {{ actor['title']|verbatim_value }}
       </option>


### PR DESCRIPTION
If the template hides the requesting group, the requesters field is visible, because the template user can add users, but not groups: the desired behavior.

![image](https://user-images.githubusercontent.com/8530352/187143480-9a8ffb65-b854-40a6-a54a-79b343089b48.png)

If this field already contains a group, it was displayed and the user could delete it.

_Same thing with the other actor fields (observers, assigned to) and in the opposite direction: visible group, hidden user._


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24765
