### PR TITLE
Timeline: fix documents actions visibility

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -6737,7 +6737,6 @@ abstract class CommonITILObject extends CommonDBTM
                 $this->getAssociatedDocumentsCriteria($params['bypass_rights']),
                 'timeline_position'  => ['>', self::NO_TIMELINE]
             ]);
-            $can_view_documents = Document::canView();
             foreach ($document_items as $document_item) {
                 $document_obj->getFromDB($document_item['documents_id']);
 
@@ -6752,8 +6751,8 @@ abstract class CommonITILObject extends CommonDBTM
                 $item['documents_item_id'] = $document_item['id'];
 
                 $item['timeline_position'] = $document_item['timeline_position'];
-                $item['_can_edit'] = $can_view_documents && $document_obj->canUpdateItem();
-                $item['_can_delete'] = $can_view_documents && $document_obj->canDeleteItem() && $canupdate_parent;
+                $item['_can_edit'] = Document::canUpdate() && $document_obj->canUpdateItem();
+                $item['_can_delete'] = Document::canDelete() && $document_obj->canDeleteItem() && $canupdate_parent;
 
                 $timeline_key = $document_item['itemtype'] . "_" . $document_item['items_id'];
                 if ($document_item['itemtype'] == static::getType()) {


### PR DESCRIPTION
Users that can view documents have access to these actions in the timeline even if they can't edit/delete documents:

![image](https://user-images.githubusercontent.com/42734840/187165159-8e63d9ec-83ee-49d9-ba04-dfca252e845b.png)

These is caused by two incorrect conditions where `Document::canView()` is used instead of the respective `canEdit` and `canDelete` methods.

I think the developer who wrote this assumed that `canUpdateItem` and `canDeleteItem` would call these methods.
Maybe they should (in another PR) ? 

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24772
