### PR TITLE
Breadcrumbs: fix for dropdowns

### DIFF
--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -216,7 +216,7 @@ abstract class CommonDropdown extends CommonDBTM
         ?string $title = null,
         ?array $menus = null
     ): void {
-        if (is_null($menus)) {
+        if (empty($menus)) {
             $dropdown = new static();
 
             $menus = [


### PR DESCRIPTION
This code rely on detecting null values:
![image](https://user-images.githubusercontent.com/42734840/187194941-570c556c-0481-42e9-ac35-077a5019d73b.png)

https://github.com/glpi-project/glpi/pull/12307 replaced the null value by an empty array, so we need to check with `empty` instead.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
