### PR TITLE
WIP: add saved search menu entry

### DIFF
--- a/templates/layout/parts/user_header.html.twig
+++ b/templates/layout/parts/user_header.html.twig
@@ -82,7 +82,14 @@
                   {% endif %}
                {% endif %}
 
-               {# @TODO Saved searches panel #}
+               {% if not anonymous %}
+                  {% if has_itemtype_right('SavedSearch', constant('READ')) %}
+                     <a href="{{ path('/front/savedsearch.php') }}" class="dropdown-item" title="{{ 'SavedSearch'|itemtype_name }}">
+                        <i class="ti ti-bookmarks"></i>
+                        {{ 'SavedSearch'|itemtype_name }}
+                     </a>
+                  {% endif %}
+               {% endif %}
 
                <div class="dropdown-item">
                   <i class="ti fa-fw ti-language"></i>


### PR DESCRIPTION
It seems that a menu entry to access saved searches is missing in the user dropdown menu (top right corner)
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
