### PR TITLE
Timeline: fix delete document action

### DIFF
--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -211,10 +211,10 @@ if (isset($_POST["add"])) {
         sprintf(__('%s adds an actor'), $_SESSION["glpiname"])
     );
     Html::redirect(Ticket::getFormURLWithID($id));
-} else if (isset($_POST['delete_document'])) {
-    $track->getFromDB((int)$_POST['tickets_id']);
+} else if (isset($_REQUEST['delete_document'])) {
+    $track->getFromDB((int)$_REQUEST['tickets_id']);
     $doc = new Document();
-    $doc->getFromDB((int)$_POST['documents_id']);
+    $doc->getFromDB((int)$_REQUEST['documents_id']);
     if ($doc->can($doc->getID(), UPDATE)) {
         $document_item = new Document_Item();
         $found_document_items = $document_item->find([


### PR DESCRIPTION
The "delete" document action in the timeline is a simple link:

![image](https://user-images.githubusercontent.com/42734840/187390371-f00752a9-3f57-4db2-a47c-c0a27fb09ef6.png)

However, the front file expect data from an actual form.

I've fixed this by using `$_REQUEST`, which should work both for `POST` and `GET` request.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24772
