### PR TITLE
Fix isAllowedStatus call in canMassiveAction()

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -756,7 +756,7 @@ abstract class CommonITILObject extends CommonDBTM
             case 'update':
                 switch ($field) {
                     case 'status':
-                        if (!self::isAllowedStatus($this->fields['status'], $value)) {
+                        if (!static::isAllowedStatus($this->fields['status'], $value)) {
                             return false;
                         }
                         break;


### PR DESCRIPTION
change from self::isAllowedStatus() to static::isAllowedStatus() to allow redefining in ITIL classes
Sorry for copy&paste bug, missed this in #12470

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12469 
