### PR TITLE
Debounce actor field AJAX requests

### DIFF
--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -233,6 +233,7 @@
             url: '{{ path('/ajax/actors.php') }}',
             datatype: 'json',
             type: 'POST',
+            delay:250,
             data: function (params) {
                var is_new_item = {{ item.isNewItem() ? "true" : "false" }};
                return {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Partially addresses #12520 but doesn't resolve the bulk of the performance issue

Currently, the select2 inputs for the actor fields send AJAX requests after each character typed. This results in many unneeded requests, extra server processing time, and extra bandwidth usage. By using the `delay` option, the requests can be debounced. This PR sets the `delay` option to 250 which results in a single request being made 250ms after the user stops typing.