### PR TITLE
Use dropdown limit option for actor fields

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -3949,7 +3949,7 @@ class Dropdown
             'itiltemplate_class' => 'TicketTemplate',
             'itiltemplates_id'   => 0,
             'returned_itemtypes' => ['User', 'Group', 'Supplier'],
-            'limit'              => $CFG_GLPI['dropdown_max'],
+            'page_limit'         => $CFG_GLPI['dropdown_max'],
         ];
         $post = array_merge($defaults, $post);
 
@@ -3979,7 +3979,7 @@ class Dropdown
                 $post['used'],
                 $post['searchText'],
                 0,
-                (int) $post['limit'],
+                -1,
                 $post['inactive_deleted'],
             );
             foreach ($users_iterator as $ID => $user) {
@@ -4080,11 +4080,20 @@ class Dropdown
         ]);
 
         $results = $hook_results['actors'] ?? [];
+        $total_results = count($results);
+
+        $start = ($post['page'] - 1) * $post['page_limit'];
+        $results = array_slice($results, $start, $post['page_limit']);
 
         $return = [
             'results' => $results,
             'count'   => count($results),
         ];
+        if ($total_results > count($results)) {
+            $return['pagination'] = [
+                'more' => true,
+            ];
+        }
 
         return ($json === true)
          ? json_encode($return)

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -3931,6 +3931,8 @@ class Dropdown
 
     public static function getDropdownActors($post, $json = true)
     {
+        global $CFG_GLPI;
+
         if (!Session::validateIDOR($post)) {
             return;
         }
@@ -3947,6 +3949,7 @@ class Dropdown
             'itiltemplate_class' => 'TicketTemplate',
             'itiltemplates_id'   => 0,
             'returned_itemtypes' => ['User', 'Group', 'Supplier'],
+            'limit'              => $CFG_GLPI['dropdown_max'],
         ];
         $post = array_merge($defaults, $post);
 
@@ -3976,7 +3979,7 @@ class Dropdown
                 $post['used'],
                 $post['searchText'],
                 0,
-                -1,
+                (int) $post['limit'],
                 $post['inactive_deleted'],
             );
             foreach ($users_iterator as $ID => $user) {

--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -248,6 +248,7 @@
                   items_id: {{ item.isNewItem() ? -1 : item.fields['id'] }},
                   item: {{ item.fields|json_encode|raw }},
                   returned_itemtypes: {{ (returned_itemtypes ?? ['User', 'Group', 'Supplier'])|json_encode()|raw }},
+                  page: params.page || 1
                };
             },
          }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12520

Limit the results for the user search query to the `dropdown_max` config option instead of being unlimited to improve performance in cases where a lot of users could be matched.