### PR TITLE
Fix object locks

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -6375,6 +6375,9 @@ class CommonDBTM extends CommonGLPI
             static::displayHelpdeskHeader($title, $menus);
         }
 
+        if (!isset($options['id'])) {
+            $options['id'] = $id;
+        }
         // Show item
         $options['loaded'] = true;
         $item->display($options);

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -1155,7 +1155,11 @@ class CommonGLPI implements CommonGLPIInterface
 
        // try to lock object
        // $options must contains the id of the object, and if locked by manageObjectLock will contains 'locked' => 1
-        ObjectLock::manageObjectLock(get_class($this), $options);
+        $lock_options = $options;
+        if (isset($_GET['id'])) {
+            $lock_options['id'] = $_GET['id'];
+        }
+        ObjectLock::manageObjectLock(get_class($this), $lock_options);
 
        // manage custom options passed to tabs
         if (isset($_REQUEST['tab_params']) && is_array($_REQUEST['tab_params'])) {

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -1155,11 +1155,7 @@ class CommonGLPI implements CommonGLPIInterface
 
        // try to lock object
        // $options must contains the id of the object, and if locked by manageObjectLock will contains 'locked' => 1
-        $lock_options = $options;
-        if (isset($_GET['id'])) {
-            $lock_options['id'] = $_GET['id'];
-        }
-        ObjectLock::manageObjectLock(get_class($this), $lock_options);
+        ObjectLock::manageObjectLock(get_class($this), $options);
 
        // manage custom options passed to tabs
         if (isset($_REQUEST['tab_params']) && is_array($_REQUEST['tab_params'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11896

The options passed to `ObjectLock::manageObjectLock` did not contain the ID for Tickets at least so they were never used.