### PR TITLE
fix(reservation): check if is_template fields exist

### DIFF
--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -992,30 +992,38 @@ class ReservationItem extends CommonDBChild
 
         if ($post['idtable'] && class_exists($post['idtable'])) {
             $itemtype = $post['idtable'];
+            $itemtype_obj = new $itemtype();
 
             $item_table = $itemtype::getTable();
             $resi_table = ReservationItem::getTable();
-            $result = $DB->request([
-                'SELECT' => [
-                    "$resi_table.id",
-                    "$item_table.name"
-                ],
-                'FROM' => $item_table,
-                'INNER JOIN' => [
-                    $resi_table => [
-                        'ON' => [
-                            $resi_table => 'items_id',
-                            $item_table => 'id',
-                            ['AND' => ["$resi_table.itemtype" => $itemtype]],
+
+            $criteria = [
+                    'SELECT' => [
+                        "$resi_table.id",
+                        "$item_table.name"
+                    ],
+                    'FROM' => $item_table,
+                    'INNER JOIN' => [
+                        $resi_table => [
+                            'ON' => [
+                                $resi_table => 'items_id',
+                                $item_table => 'id',
+                                ['AND' => ["$resi_table.itemtype" => $itemtype]],
+                            ]
                         ]
+                    ],
+                    'WHERE' => [
+                        "$resi_table.is_active"   => 1,
+                        "$item_table.is_deleted"  => 0,
                     ]
-                ],
-                'WHERE' => [
-                    "$resi_table.is_active"   => 1,
-                    "$item_table.is_deleted"  => 0,
-                    "$item_table.is_template" => 0
-                ]
-            ]);
+                ];
+
+            if ($itemtype_obj->maybeTemplate()) {
+                $criteria['WHERE']["$item_table.is_template"] = 0;
+            }
+
+            $result = $DB->request($criteria);
+
             if ($result->count() == 0) {
                  echo __('No reservable item!');
             } else {

--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -998,25 +998,25 @@ class ReservationItem extends CommonDBChild
             $resi_table = ReservationItem::getTable();
 
             $criteria = [
-                    'SELECT' => [
-                        "$resi_table.id",
-                        "$item_table.name"
-                    ],
-                    'FROM' => $item_table,
-                    'INNER JOIN' => [
-                        $resi_table => [
-                            'ON' => [
-                                $resi_table => 'items_id',
-                                $item_table => 'id',
-                                ['AND' => ["$resi_table.itemtype" => $itemtype]],
-                            ]
+                'SELECT' => [
+                    "$resi_table.id",
+                    "$item_table.name"
+                ],
+                'FROM' => $item_table,
+                'INNER JOIN' => [
+                    $resi_table => [
+                        'ON' => [
+                            $resi_table => 'items_id',
+                            $item_table => 'id',
+                            ['AND' => ["$resi_table.itemtype" => $itemtype]],
                         ]
-                    ],
-                    'WHERE' => [
-                        "$resi_table.is_active"   => 1,
-                        "$item_table.is_deleted"  => 0,
                     ]
-                ];
+                ],
+                'WHERE' => [
+                    "$resi_table.is_active"   => 1,
+                    "$item_table.is_deleted"  => 0,
+                ]
+            ];
 
             if ($itemtype_obj->maybeTemplate()) {
                 $criteria['WHERE']["$item_table.is_template"] = 0;


### PR DESCRIPTION
If we try to do a reservation for a GenericObject object

SQL error appears

```shell
[2022-08-31 08:21:54] glpisqllog.ERROR: DBmysql::query() in /home/GLPI/10.0-bugfixes/src/DBmysql.php line 370
  *** MySQL query error:
  SQL: SELECT `glpi_reservationitems`.`id`, `glpi_plugin_genericobject_tests`.`name` FROM `glpi_plugin_genericobject_tests` INNER JOIN `glpi_reservationitems` ON (`glpi_reservationitems`.`items_id` = `glpi_plugin_genericobject_tests`.`id` AND `glpi_reservationitems`.`itemtype` = 'PluginGenericobjectTest') WHERE `glpi_reservationitems`.`is_active` = '1' AND `glpi_plugin_genericobject_tests`.`is_deleted` = '0' AND `glpi_plugin_genericobject_tests`.`is_template` = '0'
  Error: Unknown column 'glpi_plugin_genericobject_tests.is_template' in 'where clause'
  Backtrace :
  src/DBmysqlIterator.php:110                        
  src/DBmysql.php:1048                               DBmysqlIterator->execute()
  src/ReservationItem.php:1016                       DBmysql->request()
  ajax/reservable_items.php:48                       ReservationItem::ajaxDropdown()
```

Check if ```is_template``` exist before add ```WHERE``` clause.


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 7192 (cloud)
