### PR TITLE
fix(inventory): update network port metrics

### DIFF
--- a/src/Inventory/Asset/NetworkPort.php
+++ b/src/Inventory/Asset/NetworkPort.php
@@ -38,6 +38,7 @@ namespace Glpi\Inventory\Asset;
 
 use Glpi\Inventory\Conf;
 use Glpi\Inventory\FilesToJSON;
+use NetworkPort as GlobalNetworkPort;
 use NetworkPortType;
 use QueryParam;
 use RuleImportAssetCollection;
@@ -443,6 +444,26 @@ class NetworkPort extends InventoryAsset
         }
     }
 
+    private function handleMetrics(\stdClass $port, int $netports_id)
+    {
+        $input = (array)$port;
+        //only update networkport metric if needed
+        if (
+            isset($input['ifinbytes'])
+            && isset($input['ifoutbytes'])
+            && isset($input['ifinerrors'])
+            && isset($input['ifouterrors'])
+        ) {
+            $netport = new GlobalNetworkPort();
+            $input_db['id'] = $netports_id;
+            $input_db['ifinbytes']   = $input['ifinbytes'];
+            $input_db['ifoutbytes']  = $input['ifoutbytes'];
+            $input_db['ifinerrors']  = $input['ifinerrors'];
+            $input_db['ifouterrors'] = $input['ifouterrors'];
+            $netport->update($input_db);
+        }
+    }
+
     private function prepareAggregations(\stdClass $port, int $netports_id)
     {
         if (!property_exists($port, 'logical_number')) {
@@ -525,6 +546,7 @@ class NetworkPort extends InventoryAsset
         $this->handleConnections($port, $netports_id);
         $this->handleVlans($port, $netports_id);
         $this->prepareAggregations($port, $netports_id);
+        $this->handleMetrics($port, $netports_id);
     }
 
     /**

--- a/src/Inventory/Asset/NetworkPort.php
+++ b/src/Inventory/Asset/NetworkPort.php
@@ -448,12 +448,7 @@ class NetworkPort extends InventoryAsset
     {
         $input = (array)$port;
         //only update networkport metric if needed
-        if (
-            isset($input['ifinbytes'])
-            && isset($input['ifoutbytes'])
-            && isset($input['ifinerrors'])
-            && isset($input['ifouterrors'])
-        ) {
+        if (isset($input['ifinbytes'], $input['ifoutbytes'], $input['ifinerrors'], $input['ifouterrors'])) {
             $netport = new GlobalNetworkPort();
             $input_db['id'] = $netports_id;
             $input_db['ifinbytes']   = $input['ifinbytes'];

--- a/tests/functionnal/Glpi/Inventory/Assets/NetworkPort.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/NetworkPort.php
@@ -358,369 +358,369 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
     public function testNetworkPortMetrics()
     {
-      $networkport = new \NetworkPort();
-      $networkmetric = new \NetworkPortMetrics();
-      $networkequipment = new \NetworkEquipment();
+        $networkport = new \NetworkPort();
+        $networkmetric = new \NetworkPortMetrics();
+        $networkequipment = new \NetworkEquipment();
 
-      //First step : import NetworkEquipement with only one NetworkPort (Ethernet)
-      //check metrics data (only one)
-      $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
-      <REQUEST>
-        <CONTENT>
-          <DEVICE>
-            <COMPONENTS>
-              <COMPONENT>
-                <CONTAINEDININDEX>0</CONTAINEDININDEX>
-                <DESCRIPTION>WS-C2960-24TC-L</DESCRIPTION>
-                <FIRMWARE>12.2(58)SE1</FIRMWARE>
-                <FRU>2</FRU>
-                <INDEX>1001</INDEX>
-                <MODEL>WS-C2960-24TC-L</MODEL>
-                <NAME>1</NAME>
-                <REVISION>V05</REVISION>
-                <SERIAL>FOC1247X5DX</SERIAL>
-                <TYPE>chassis</TYPE>
+        //First step : import NetworkEquipement with only one NetworkPort (Ethernet)
+        //check metrics data (only one)
+        $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+        <REQUEST>
+          <CONTENT>
+            <DEVICE>
+              <COMPONENTS>
+                <COMPONENT>
+                  <CONTAINEDININDEX>0</CONTAINEDININDEX>
+                  <DESCRIPTION>WS-C2960-24TC-L</DESCRIPTION>
+                  <FIRMWARE>12.2(58)SE1</FIRMWARE>
+                  <FRU>2</FRU>
+                  <INDEX>1001</INDEX>
+                  <MODEL>WS-C2960-24TC-L</MODEL>
+                  <NAME>1</NAME>
+                  <REVISION>V05</REVISION>
+                  <SERIAL>FOC1247X5DX</SERIAL>
+                  <TYPE>chassis</TYPE>
+                  <VERSION>12.2(58)SE1</VERSION>
+                </COMPONENT>
+                <COMPONENT>
+                  <CONTAINEDININDEX>1001</CONTAINEDININDEX>
+                  <DESCRIPTION>WS-C2960-24TC-L - Fixed Module 0</DESCRIPTION>
+                  <FRU>2</FRU>
+                  <INDEX>1002</INDEX>
+                  <NAME>WS-C2960-24TC-L - Fixed Module 0</NAME>
+                  <TYPE>module</TYPE>
+                </COMPONENT>
+              </COMPONENTS>
+              <FIRMWARES>
+                <DESCRIPTION>device firmware</DESCRIPTION>
+                <MANUFACTURER>Cisco</MANUFACTURER>
+                <NAME>Catalyst 2960-24TC</NAME>
+                <TYPE>device</TYPE>
                 <VERSION>12.2(58)SE1</VERSION>
-              </COMPONENT>
-              <COMPONENT>
-                <CONTAINEDININDEX>1001</CONTAINEDININDEX>
-                <DESCRIPTION>WS-C2960-24TC-L - Fixed Module 0</DESCRIPTION>
-                <FRU>2</FRU>
-                <INDEX>1002</INDEX>
-                <NAME>WS-C2960-24TC-L - Fixed Module 0</NAME>
-                <TYPE>module</TYPE>
-              </COMPONENT>
-            </COMPONENTS>
-            <FIRMWARES>
-              <DESCRIPTION>device firmware</DESCRIPTION>
-              <MANUFACTURER>Cisco</MANUFACTURER>
-              <NAME>Catalyst 2960-24TC</NAME>
-              <TYPE>device</TYPE>
-              <VERSION>12.2(58)SE1</VERSION>
-            </FIRMWARES>
-            <INFO>
-              <COMMENTS>Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 12.2(58)SE1, RELEASE SOFTWARE (fc1)
-      Technical Support: http://www.cisco.com/techsupport
-      Copyright (c) 1986-2011 by Cisco Systems, Inc.
-      Compiled Thu 05-May-11 02:53 by prod_rel_team</COMMENTS>
-              <FIRMWARE>12.2(58)SE1</FIRMWARE>
-              <ID>0</ID>
-              <IPS>
-                <IP>192.168.1.27</IP>
-              </IPS>
-              <MAC>00:24:13:ea:a7:00</MAC>
-              <MANUFACTURER>Cisco</MANUFACTURER>
-              <MODEL>Catalyst 2960-24TC</MODEL>
-              <NAME>CB-27.example.com</NAME>
-              <SERIAL>FOC1247X5DX</SERIAL>
-              <TYPE>NETWORKING</TYPE>
-              <UPTIME>38 days, 4:05:41.99</UPTIME>
-            </INFO>
-            <PORTS>
-              <PORT>
-                <IFALIAS>pixin-int1-inside</IFALIAS>
-                <IFDESCR>FastEthernet0/1</IFDESCR>
-                <IFINERRORS>0</IFINERRORS>
-                <IFINOCTETS>3559673658</IFINOCTETS>
-                <IFINTERNALSTATUS>1</IFINTERNALSTATUS>
-                <IFLASTCHANGE>4 days, 3:53:43.54</IFLASTCHANGE>
-                <IFMTU>1500</IFMTU>
-                <IFNAME>Fa0/1</IFNAME>
-                <IFNUMBER>10001</IFNUMBER>
-                <IFOUTERRORS>0</IFOUTERRORS>
-                <IFOUTOCTETS>3257789612</IFOUTOCTETS>
-                <IFPORTDUPLEX>2</IFPORTDUPLEX>
-                <IFSPEED>100000000</IFSPEED>
-                <IFSTATUS>1</IFSTATUS>
-                <IFTYPE>6</IFTYPE>
-                <MAC>00:24:13:ea:a7:01</MAC>
-              </PORT>
-            </PORTS>
-          </DEVICE>
-          <MODULEVERSION>5.1</MODULEVERSION>
-          <PROCESSNUMBER>1</PROCESSNUMBER>
-        </CONTENT>
-        <DEVICEID>foo</DEVICEID>
-        <QUERY>SNMPQUERY</QUERY>
-      </REQUEST>";
-
-      //networkequipement inventory
-      $inventory = $this->doInventory($xml_source, true);
-
-      //check networkequipement
-      $networkquipement_id = $inventory->getItem()->fields['id'];
-      $this->integer($networkquipement_id)->isGreaterThan(0);
-
-      //get networkport
-      $this->boolean($networkport->getFromDbByCrit(['itemtype' => 'NetworkEquipment', 'items_id' => $networkquipement_id, 'instantiation_type' => 'NetworkPortEthernet']))
-      ->isTrue();
-
-      //get networkport metric
-      $this->boolean($networkmetric->getFromDbByCrit(['networkports_id' => $networkport->fields['id']]))
-      ->isTrue();
-
-      $db_input = $networkmetric->fields;
-      unset($db_input['date_creation']);
-      unset($db_input['date_mod']);
-      unset($db_input['id']);
-
-      $expected_input = [
-        "date"            => date('Y-m-d'),
-        "ifinbytes"       => 3559673658,
-        "ifinerrors"      => 0,
-        "ifoutbytes"      => 3257789612,
-        "ifouterrors"     => 0,
-        "networkports_id" => $networkport->fields['id'],
-      ];
-      $this->array($db_input)->isIdenticalTo($expected_input);
-
-      //change 'date' to yesterday to get new metric after reimport (2nd step)
-      $currentDate = new DateTime(date('Y-m-d'));
-      $yesterdayTime = $currentDate->sub(new DateInterval('P1D'));
-      $yesterday = $yesterdayTime->format('Y-m-d');
-      $networkmetric->fields['date'] = $yesterday;
-
-      $this->boolean($networkmetric->update($networkmetric->fields))->isTrue();
-      $this->string($networkmetric->fields['date'])->isIdenticalTo($yesterday);
-
-      //Second step : import NetworkEquipement again but with new metrics
-      //check metrics data for today
-      $xml_source_with_new_metrics = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
-      <REQUEST>
-        <CONTENT>
-          <DEVICE>
-            <COMPONENTS>
-              <COMPONENT>
-                <CONTAINEDININDEX>0</CONTAINEDININDEX>
-                <DESCRIPTION>WS-C2960-24TC-L</DESCRIPTION>
+              </FIRMWARES>
+              <INFO>
+                <COMMENTS>Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 12.2(58)SE1, RELEASE SOFTWARE (fc1)
+        Technical Support: http://www.cisco.com/techsupport
+        Copyright (c) 1986-2011 by Cisco Systems, Inc.
+        Compiled Thu 05-May-11 02:53 by prod_rel_team</COMMENTS>
                 <FIRMWARE>12.2(58)SE1</FIRMWARE>
-                <FRU>2</FRU>
-                <INDEX>1001</INDEX>
-                <MODEL>WS-C2960-24TC-L</MODEL>
-                <NAME>1</NAME>
-                <REVISION>V05</REVISION>
+                <ID>0</ID>
+                <IPS>
+                  <IP>192.168.1.27</IP>
+                </IPS>
+                <MAC>00:24:13:ea:a7:00</MAC>
+                <MANUFACTURER>Cisco</MANUFACTURER>
+                <MODEL>Catalyst 2960-24TC</MODEL>
+                <NAME>CB-27.example.com</NAME>
                 <SERIAL>FOC1247X5DX</SERIAL>
-                <TYPE>chassis</TYPE>
+                <TYPE>NETWORKING</TYPE>
+                <UPTIME>38 days, 4:05:41.99</UPTIME>
+              </INFO>
+              <PORTS>
+                <PORT>
+                  <IFALIAS>pixin-int1-inside</IFALIAS>
+                  <IFDESCR>FastEthernet0/1</IFDESCR>
+                  <IFINERRORS>0</IFINERRORS>
+                  <IFINOCTETS>3559673658</IFINOCTETS>
+                  <IFINTERNALSTATUS>1</IFINTERNALSTATUS>
+                  <IFLASTCHANGE>4 days, 3:53:43.54</IFLASTCHANGE>
+                  <IFMTU>1500</IFMTU>
+                  <IFNAME>Fa0/1</IFNAME>
+                  <IFNUMBER>10001</IFNUMBER>
+                  <IFOUTERRORS>0</IFOUTERRORS>
+                  <IFOUTOCTETS>3257789612</IFOUTOCTETS>
+                  <IFPORTDUPLEX>2</IFPORTDUPLEX>
+                  <IFSPEED>100000000</IFSPEED>
+                  <IFSTATUS>1</IFSTATUS>
+                  <IFTYPE>6</IFTYPE>
+                  <MAC>00:24:13:ea:a7:01</MAC>
+                </PORT>
+              </PORTS>
+            </DEVICE>
+            <MODULEVERSION>5.1</MODULEVERSION>
+            <PROCESSNUMBER>1</PROCESSNUMBER>
+          </CONTENT>
+          <DEVICEID>foo</DEVICEID>
+          <QUERY>SNMPQUERY</QUERY>
+        </REQUEST>";
+
+        //networkequipement inventory
+        $inventory = $this->doInventory($xml_source, true);
+
+        //check networkequipement
+        $networkquipement_id = $inventory->getItem()->fields['id'];
+        $this->integer($networkquipement_id)->isGreaterThan(0);
+
+        //get networkport
+        $this->boolean($networkport->getFromDbByCrit(['itemtype' => 'NetworkEquipment', 'items_id' => $networkquipement_id, 'instantiation_type' => 'NetworkPortEthernet']))
+        ->isTrue();
+
+        //get networkport metric
+        $this->boolean($networkmetric->getFromDbByCrit(['networkports_id' => $networkport->fields['id']]))
+        ->isTrue();
+
+        $db_input = $networkmetric->fields;
+        unset($db_input['date_creation']);
+        unset($db_input['date_mod']);
+        unset($db_input['id']);
+
+        $expected_input = [
+          "date"            => date('Y-m-d'),
+          "ifinbytes"       => 3559673658,
+          "ifinerrors"      => 0,
+          "ifoutbytes"      => 3257789612,
+          "ifouterrors"     => 0,
+          "networkports_id" => $networkport->fields['id'],
+        ];
+        $this->array($db_input)->isIdenticalTo($expected_input);
+
+        //change 'date' to yesterday to get new metric after reimport (2nd step)
+        $currentDate = new DateTime(date('Y-m-d'));
+        $yesterdayTime = $currentDate->sub(new DateInterval('P1D'));
+        $yesterday = $yesterdayTime->format('Y-m-d');
+        $networkmetric->fields['date'] = $yesterday;
+
+        $this->boolean($networkmetric->update($networkmetric->fields))->isTrue();
+        $this->string($networkmetric->fields['date'])->isIdenticalTo($yesterday);
+
+        //Second step : import NetworkEquipement again but with new metrics
+        //check metrics data for today
+        $xml_source_with_new_metrics = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+        <REQUEST>
+          <CONTENT>
+            <DEVICE>
+              <COMPONENTS>
+                <COMPONENT>
+                  <CONTAINEDININDEX>0</CONTAINEDININDEX>
+                  <DESCRIPTION>WS-C2960-24TC-L</DESCRIPTION>
+                  <FIRMWARE>12.2(58)SE1</FIRMWARE>
+                  <FRU>2</FRU>
+                  <INDEX>1001</INDEX>
+                  <MODEL>WS-C2960-24TC-L</MODEL>
+                  <NAME>1</NAME>
+                  <REVISION>V05</REVISION>
+                  <SERIAL>FOC1247X5DX</SERIAL>
+                  <TYPE>chassis</TYPE>
+                  <VERSION>12.2(58)SE1</VERSION>
+                </COMPONENT>
+                <COMPONENT>
+                  <CONTAINEDININDEX>1001</CONTAINEDININDEX>
+                  <DESCRIPTION>WS-C2960-24TC-L - Fixed Module 0</DESCRIPTION>
+                  <FRU>2</FRU>
+                  <INDEX>1002</INDEX>
+                  <NAME>WS-C2960-24TC-L - Fixed Module 0</NAME>
+                  <TYPE>module</TYPE>
+                </COMPONENT>
+              </COMPONENTS>
+              <FIRMWARES>
+                <DESCRIPTION>device firmware</DESCRIPTION>
+                <MANUFACTURER>Cisco</MANUFACTURER>
+                <NAME>Catalyst 2960-24TC</NAME>
+                <TYPE>device</TYPE>
                 <VERSION>12.2(58)SE1</VERSION>
-              </COMPONENT>
-              <COMPONENT>
-                <CONTAINEDININDEX>1001</CONTAINEDININDEX>
-                <DESCRIPTION>WS-C2960-24TC-L - Fixed Module 0</DESCRIPTION>
-                <FRU>2</FRU>
-                <INDEX>1002</INDEX>
-                <NAME>WS-C2960-24TC-L - Fixed Module 0</NAME>
-                <TYPE>module</TYPE>
-              </COMPONENT>
-            </COMPONENTS>
-            <FIRMWARES>
-              <DESCRIPTION>device firmware</DESCRIPTION>
-              <MANUFACTURER>Cisco</MANUFACTURER>
-              <NAME>Catalyst 2960-24TC</NAME>
-              <TYPE>device</TYPE>
-              <VERSION>12.2(58)SE1</VERSION>
-            </FIRMWARES>
-            <INFO>
-              <COMMENTS>Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 12.2(58)SE1, RELEASE SOFTWARE (fc1)
-      Technical Support: http://www.cisco.com/techsupport
-      Copyright (c) 1986-2011 by Cisco Systems, Inc.
-      Compiled Thu 05-May-11 02:53 by prod_rel_team</COMMENTS>
-              <FIRMWARE>12.2(58)SE1</FIRMWARE>
-              <ID>0</ID>
-              <IPS>
-                <IP>192.168.1.27</IP>
-              </IPS>
-              <MAC>00:24:13:ea:a7:00</MAC>
-              <MANUFACTURER>Cisco</MANUFACTURER>
-              <MODEL>Catalyst 2960-24TC</MODEL>
-              <NAME>CB-27.example.com</NAME>
-              <SERIAL>FOC1247X5DX</SERIAL>
-              <TYPE>NETWORKING</TYPE>
-              <UPTIME>38 days, 4:05:41.99</UPTIME>
-            </INFO>
-            <PORTS>
-              <PORT>
-                <IFALIAS>pixin-int1-inside</IFALIAS>
-                <IFDESCR>FastEthernet0/1</IFDESCR>
-                <IFINERRORS>0</IFINERRORS>
-                <IFINOCTETS>7059673658</IFINOCTETS>
-                <IFINTERNALSTATUS>1</IFINTERNALSTATUS>
-                <IFLASTCHANGE>4 days, 3:53:43.54</IFLASTCHANGE>
-                <IFMTU>1500</IFMTU>
-                <IFNAME>Fa0/1</IFNAME>
-                <IFNUMBER>10001</IFNUMBER>
-                <IFOUTERRORS>0</IFOUTERRORS>
-                <IFOUTOCTETS>6457789612</IFOUTOCTETS>
-                <IFPORTDUPLEX>2</IFPORTDUPLEX>
-                <IFSPEED>100000000</IFSPEED>
-                <IFSTATUS>1</IFSTATUS>
-                <IFTYPE>6</IFTYPE>
-                <MAC>00:24:13:ea:a7:01</MAC>
-              </PORT>
-            </PORTS>
-          </DEVICE>
-          <MODULEVERSION>5.1</MODULEVERSION>
-          <PROCESSNUMBER>1</PROCESSNUMBER>
-        </CONTENT>
-        <DEVICEID>foo</DEVICEID>
-        <QUERY>SNMPQUERY</QUERY>
-      </REQUEST>";
-
-      //networkequipement inventory
-      $inventory = $this->doInventory($xml_source_with_new_metrics, true);
-
-      $networkquipement_id = $inventory->getItem()->fields['id'];
-      $this->integer($networkquipement_id)->isGreaterThan(0);
-
-      //get networkEquipement
-      $this->boolean($networkequipment->getFromDB($networkquipement_id))->isTrue();
-
-      //get networkport
-      $this->boolean($networkport->getFromDbByCrit(['itemtype' => 'NetworkEquipment', 'items_id' => $networkquipement_id, 'instantiation_type' => 'NetworkPortEthernet']))
-      ->isTrue();
-
-      //now we have two metrics, one for yesterday and one for today
-      $metrics = $networkmetric->find(['networkports_id' => $networkport->fields['id']]);
-      $this->array($metrics)
-         ->hasSize(2);
-
-      //get networkport metric for today
-      $this->boolean($networkmetric->getFromDbByCrit(['networkports_id' => $networkport->fields['id'], "date" => date('Y-m-d')]))
-      ->isTrue();
-
-      $db_input = $networkmetric->fields;
-      unset($db_input['date_creation']);
-      unset($db_input['date_mod']);
-      unset($db_input['id']);
-
-      //check metrics data
-      $expected_input = [
-        "date"            => date('Y-m-d'),
-        "ifinbytes"       => 7059673658,
-        "ifinerrors"      => 0,
-        "ifoutbytes"      => 6457789612,
-        "ifouterrors"     => 0,
-        "networkports_id" => $networkport->fields['id'],
-      ];
-      $this->array($db_input)->isIdenticalTo($expected_input);
-
-      //THird step : import NetworkEquipement again but with new metrics
-      //check that the previous data are updated
-      $xml_source_with_new_metrics = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
-      <REQUEST>
-        <CONTENT>
-          <DEVICE>
-            <COMPONENTS>
-              <COMPONENT>
-                <CONTAINEDININDEX>0</CONTAINEDININDEX>
-                <DESCRIPTION>WS-C2960-24TC-L</DESCRIPTION>
+              </FIRMWARES>
+              <INFO>
+                <COMMENTS>Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 12.2(58)SE1, RELEASE SOFTWARE (fc1)
+        Technical Support: http://www.cisco.com/techsupport
+        Copyright (c) 1986-2011 by Cisco Systems, Inc.
+        Compiled Thu 05-May-11 02:53 by prod_rel_team</COMMENTS>
                 <FIRMWARE>12.2(58)SE1</FIRMWARE>
-                <FRU>2</FRU>
-                <INDEX>1001</INDEX>
-                <MODEL>WS-C2960-24TC-L</MODEL>
-                <NAME>1</NAME>
-                <REVISION>V05</REVISION>
+                <ID>0</ID>
+                <IPS>
+                  <IP>192.168.1.27</IP>
+                </IPS>
+                <MAC>00:24:13:ea:a7:00</MAC>
+                <MANUFACTURER>Cisco</MANUFACTURER>
+                <MODEL>Catalyst 2960-24TC</MODEL>
+                <NAME>CB-27.example.com</NAME>
                 <SERIAL>FOC1247X5DX</SERIAL>
-                <TYPE>chassis</TYPE>
+                <TYPE>NETWORKING</TYPE>
+                <UPTIME>38 days, 4:05:41.99</UPTIME>
+              </INFO>
+              <PORTS>
+                <PORT>
+                  <IFALIAS>pixin-int1-inside</IFALIAS>
+                  <IFDESCR>FastEthernet0/1</IFDESCR>
+                  <IFINERRORS>0</IFINERRORS>
+                  <IFINOCTETS>7059673658</IFINOCTETS>
+                  <IFINTERNALSTATUS>1</IFINTERNALSTATUS>
+                  <IFLASTCHANGE>4 days, 3:53:43.54</IFLASTCHANGE>
+                  <IFMTU>1500</IFMTU>
+                  <IFNAME>Fa0/1</IFNAME>
+                  <IFNUMBER>10001</IFNUMBER>
+                  <IFOUTERRORS>0</IFOUTERRORS>
+                  <IFOUTOCTETS>6457789612</IFOUTOCTETS>
+                  <IFPORTDUPLEX>2</IFPORTDUPLEX>
+                  <IFSPEED>100000000</IFSPEED>
+                  <IFSTATUS>1</IFSTATUS>
+                  <IFTYPE>6</IFTYPE>
+                  <MAC>00:24:13:ea:a7:01</MAC>
+                </PORT>
+              </PORTS>
+            </DEVICE>
+            <MODULEVERSION>5.1</MODULEVERSION>
+            <PROCESSNUMBER>1</PROCESSNUMBER>
+          </CONTENT>
+          <DEVICEID>foo</DEVICEID>
+          <QUERY>SNMPQUERY</QUERY>
+        </REQUEST>";
+
+        //networkequipement inventory
+        $inventory = $this->doInventory($xml_source_with_new_metrics, true);
+
+        $networkquipement_id = $inventory->getItem()->fields['id'];
+        $this->integer($networkquipement_id)->isGreaterThan(0);
+
+        //get networkEquipement
+        $this->boolean($networkequipment->getFromDB($networkquipement_id))->isTrue();
+
+        //get networkport
+        $this->boolean($networkport->getFromDbByCrit(['itemtype' => 'NetworkEquipment', 'items_id' => $networkquipement_id, 'instantiation_type' => 'NetworkPortEthernet']))
+        ->isTrue();
+
+        //now we have two metrics, one for yesterday and one for today
+        $metrics = $networkmetric->find(['networkports_id' => $networkport->fields['id']]);
+        $this->array($metrics)
+          ->hasSize(2);
+
+        //get networkport metric for today
+        $this->boolean($networkmetric->getFromDbByCrit(['networkports_id' => $networkport->fields['id'], "date" => date('Y-m-d')]))
+        ->isTrue();
+
+        $db_input = $networkmetric->fields;
+        unset($db_input['date_creation']);
+        unset($db_input['date_mod']);
+        unset($db_input['id']);
+
+        //check metrics data
+        $expected_input = [
+          "date"            => date('Y-m-d'),
+          "ifinbytes"       => 7059673658,
+          "ifinerrors"      => 0,
+          "ifoutbytes"      => 6457789612,
+          "ifouterrors"     => 0,
+          "networkports_id" => $networkport->fields['id'],
+        ];
+        $this->array($db_input)->isIdenticalTo($expected_input);
+
+        //THird step : import NetworkEquipement again but with new metrics
+        //check that the previous data are updated
+        $xml_source_with_new_metrics = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+        <REQUEST>
+          <CONTENT>
+            <DEVICE>
+              <COMPONENTS>
+                <COMPONENT>
+                  <CONTAINEDININDEX>0</CONTAINEDININDEX>
+                  <DESCRIPTION>WS-C2960-24TC-L</DESCRIPTION>
+                  <FIRMWARE>12.2(58)SE1</FIRMWARE>
+                  <FRU>2</FRU>
+                  <INDEX>1001</INDEX>
+                  <MODEL>WS-C2960-24TC-L</MODEL>
+                  <NAME>1</NAME>
+                  <REVISION>V05</REVISION>
+                  <SERIAL>FOC1247X5DX</SERIAL>
+                  <TYPE>chassis</TYPE>
+                  <VERSION>12.2(58)SE1</VERSION>
+                </COMPONENT>
+                <COMPONENT>
+                  <CONTAINEDININDEX>1001</CONTAINEDININDEX>
+                  <DESCRIPTION>WS-C2960-24TC-L - Fixed Module 0</DESCRIPTION>
+                  <FRU>2</FRU>
+                  <INDEX>1002</INDEX>
+                  <NAME>WS-C2960-24TC-L - Fixed Module 0</NAME>
+                  <TYPE>module</TYPE>
+                </COMPONENT>
+              </COMPONENTS>
+              <FIRMWARES>
+                <DESCRIPTION>device firmware</DESCRIPTION>
+                <MANUFACTURER>Cisco</MANUFACTURER>
+                <NAME>Catalyst 2960-24TC</NAME>
+                <TYPE>device</TYPE>
                 <VERSION>12.2(58)SE1</VERSION>
-              </COMPONENT>
-              <COMPONENT>
-                <CONTAINEDININDEX>1001</CONTAINEDININDEX>
-                <DESCRIPTION>WS-C2960-24TC-L - Fixed Module 0</DESCRIPTION>
-                <FRU>2</FRU>
-                <INDEX>1002</INDEX>
-                <NAME>WS-C2960-24TC-L - Fixed Module 0</NAME>
-                <TYPE>module</TYPE>
-              </COMPONENT>
-            </COMPONENTS>
-            <FIRMWARES>
-              <DESCRIPTION>device firmware</DESCRIPTION>
-              <MANUFACTURER>Cisco</MANUFACTURER>
-              <NAME>Catalyst 2960-24TC</NAME>
-              <TYPE>device</TYPE>
-              <VERSION>12.2(58)SE1</VERSION>
-            </FIRMWARES>
-            <INFO>
-              <COMMENTS>Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 12.2(58)SE1, RELEASE SOFTWARE (fc1)
-      Technical Support: http://www.cisco.com/techsupport
-      Copyright (c) 1986-2011 by Cisco Systems, Inc.
-      Compiled Thu 05-May-11 02:53 by prod_rel_team</COMMENTS>
-              <FIRMWARE>12.2(58)SE1</FIRMWARE>
-              <ID>0</ID>
-              <IPS>
-                <IP>192.168.1.27</IP>
-              </IPS>
-              <MAC>00:24:13:ea:a7:00</MAC>
-              <MANUFACTURER>Cisco</MANUFACTURER>
-              <MODEL>Catalyst 2960-24TC</MODEL>
-              <NAME>CB-27.example.com</NAME>
-              <SERIAL>FOC1247X5DX</SERIAL>
-              <TYPE>NETWORKING</TYPE>
-              <UPTIME>38 days, 4:05:41.99</UPTIME>
-            </INFO>
-            <PORTS>
-              <PORT>
-                <IFALIAS>pixin-int1-inside</IFALIAS>
-                <IFDESCR>FastEthernet0/1</IFDESCR>
-                <IFINERRORS>0</IFINERRORS>
-                <IFINOCTETS>8059673658</IFINOCTETS>
-                <IFINTERNALSTATUS>1</IFINTERNALSTATUS>
-                <IFLASTCHANGE>4 days, 3:53:43.54</IFLASTCHANGE>
-                <IFMTU>1500</IFMTU>
-                <IFNAME>Fa0/1</IFNAME>
-                <IFNUMBER>10001</IFNUMBER>
-                <IFOUTERRORS>0</IFOUTERRORS>
-                <IFOUTOCTETS>7457789612</IFOUTOCTETS>
-                <IFPORTDUPLEX>2</IFPORTDUPLEX>
-                <IFSPEED>100000000</IFSPEED>
-                <IFSTATUS>1</IFSTATUS>
-                <IFTYPE>6</IFTYPE>
-                <MAC>00:24:13:ea:a7:01</MAC>
-              </PORT>
-            </PORTS>
-          </DEVICE>
-          <MODULEVERSION>5.1</MODULEVERSION>
-          <PROCESSNUMBER>1</PROCESSNUMBER>
-        </CONTENT>
-        <DEVICEID>foo</DEVICEID>
-        <QUERY>SNMPQUERY</QUERY>
-      </REQUEST>";
+              </FIRMWARES>
+              <INFO>
+                <COMMENTS>Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 12.2(58)SE1, RELEASE SOFTWARE (fc1)
+        Technical Support: http://www.cisco.com/techsupport
+        Copyright (c) 1986-2011 by Cisco Systems, Inc.
+        Compiled Thu 05-May-11 02:53 by prod_rel_team</COMMENTS>
+                <FIRMWARE>12.2(58)SE1</FIRMWARE>
+                <ID>0</ID>
+                <IPS>
+                  <IP>192.168.1.27</IP>
+                </IPS>
+                <MAC>00:24:13:ea:a7:00</MAC>
+                <MANUFACTURER>Cisco</MANUFACTURER>
+                <MODEL>Catalyst 2960-24TC</MODEL>
+                <NAME>CB-27.example.com</NAME>
+                <SERIAL>FOC1247X5DX</SERIAL>
+                <TYPE>NETWORKING</TYPE>
+                <UPTIME>38 days, 4:05:41.99</UPTIME>
+              </INFO>
+              <PORTS>
+                <PORT>
+                  <IFALIAS>pixin-int1-inside</IFALIAS>
+                  <IFDESCR>FastEthernet0/1</IFDESCR>
+                  <IFINERRORS>0</IFINERRORS>
+                  <IFINOCTETS>8059673658</IFINOCTETS>
+                  <IFINTERNALSTATUS>1</IFINTERNALSTATUS>
+                  <IFLASTCHANGE>4 days, 3:53:43.54</IFLASTCHANGE>
+                  <IFMTU>1500</IFMTU>
+                  <IFNAME>Fa0/1</IFNAME>
+                  <IFNUMBER>10001</IFNUMBER>
+                  <IFOUTERRORS>0</IFOUTERRORS>
+                  <IFOUTOCTETS>7457789612</IFOUTOCTETS>
+                  <IFPORTDUPLEX>2</IFPORTDUPLEX>
+                  <IFSPEED>100000000</IFSPEED>
+                  <IFSTATUS>1</IFSTATUS>
+                  <IFTYPE>6</IFTYPE>
+                  <MAC>00:24:13:ea:a7:01</MAC>
+                </PORT>
+              </PORTS>
+            </DEVICE>
+            <MODULEVERSION>5.1</MODULEVERSION>
+            <PROCESSNUMBER>1</PROCESSNUMBER>
+          </CONTENT>
+          <DEVICEID>foo</DEVICEID>
+          <QUERY>SNMPQUERY</QUERY>
+        </REQUEST>";
 
-      //networkequipement inventory
-      $inventory = $this->doInventory($xml_source_with_new_metrics, true);
+        //networkequipement inventory
+        $inventory = $this->doInventory($xml_source_with_new_metrics, true);
 
-      $networkquipement_id = $inventory->getItem()->fields['id'];
-      $this->integer($networkquipement_id)->isGreaterThan(0);
+        $networkquipement_id = $inventory->getItem()->fields['id'];
+        $this->integer($networkquipement_id)->isGreaterThan(0);
 
-      //get networkEquipement
-      $this->boolean($networkequipment->getFromDB($networkquipement_id))->isTrue();
+        //get networkEquipement
+        $this->boolean($networkequipment->getFromDB($networkquipement_id))->isTrue();
 
-      //get networkport
-      $this->boolean($networkport->getFromDbByCrit(['itemtype' => 'NetworkEquipment', 'items_id' => $networkquipement_id, 'instantiation_type' => 'NetworkPortEthernet']))
-      ->isTrue();
+        //get networkport
+        $this->boolean($networkport->getFromDbByCrit(['itemtype' => 'NetworkEquipment', 'items_id' => $networkquipement_id, 'instantiation_type' => 'NetworkPortEthernet']))
+        ->isTrue();
 
-      //now we have two metrics, one for yesterday and one for today
-      $metrics = $networkmetric->find(['networkports_id' => $networkport->fields['id']]);
-      $this->array($metrics)
-         ->hasSize(2);
+        //now we have two metrics, one for yesterday and one for today
+        $metrics = $networkmetric->find(['networkports_id' => $networkport->fields['id']]);
+        $this->array($metrics)
+          ->hasSize(2);
 
-      //get networkport metric for today
-      $this->boolean($networkmetric->getFromDbByCrit(['networkports_id' => $networkport->fields['id'], "date" => date('Y-m-d')]))
-      ->isTrue();
+        //get networkport metric for today
+        $this->boolean($networkmetric->getFromDbByCrit(['networkports_id' => $networkport->fields['id'], "date" => date('Y-m-d')]))
+        ->isTrue();
 
-      $db_input = $networkmetric->fields;
-      unset($db_input['date_creation']);
-      unset($db_input['date_mod']);
-      unset($db_input['id']);
+        $db_input = $networkmetric->fields;
+        unset($db_input['date_creation']);
+        unset($db_input['date_mod']);
+        unset($db_input['id']);
 
-      //check metrics data
-      $expected_input = [
-        "date"            => date('Y-m-d'),
-        "ifinbytes"       => 8059673658,
-        "ifinerrors"      => 0,
-        "ifoutbytes"      => 7457789612,
-        "ifouterrors"     => 0,
-        "networkports_id" => $networkport->fields['id'],
-      ];
-      $this->array($db_input)->isIdenticalTo($expected_input);
+        //check metrics data
+        $expected_input = [
+          "date"            => date('Y-m-d'),
+          "ifinbytes"       => 8059673658,
+          "ifinerrors"      => 0,
+          "ifoutbytes"      => 7457789612,
+          "ifouterrors"     => 0,
+          "networkports_id" => $networkport->fields['id'],
+        ];
+        $this->array($db_input)->isIdenticalTo($expected_input);
     }
 }

--- a/tests/functionnal/Glpi/Inventory/Assets/NetworkPort.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/NetworkPort.php
@@ -508,16 +508,6 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         //networkequipement inventory
         $inventory = $this->doInventory($xml_source, true);
 
-        $networkquipement_id = $inventory->getItem()->fields['id'];
-        $this->integer($networkquipement_id)->isGreaterThan(0);
-
-        //get networkEquipement
-        $this->boolean($networkequipment->getFromDB($networkquipement_id))->isTrue();
-
-        //get networkport
-        $this->boolean($networkport->getFromDbByCrit(['itemtype' => 'NetworkEquipment', 'items_id' => $networkquipement_id, 'instantiation_type' => 'NetworkPortEthernet']))
-        ->isTrue();
-
         //now we have two metrics, one for yesterday and one for today
         $metrics = $networkmetric->find(['networkports_id' => $networkport->fields['id']]);
         $this->array($metrics)
@@ -564,15 +554,6 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         //networkequipement inventory
         $inventory = $this->doInventory($xml_source, true);
 
-        $networkquipement_id = $inventory->getItem()->fields['id'];
-        $this->integer($networkquipement_id)->isGreaterThan(0);
-
-        //get networkEquipement
-        $this->boolean($networkequipment->getFromDB($networkquipement_id))->isTrue();
-
-        //get networkport
-        $this->boolean($networkport->getFromDbByCrit(['itemtype' => 'NetworkEquipment', 'items_id' => $networkquipement_id, 'instantiation_type' => 'NetworkPortEthernet']))
-        ->isTrue();
 
         //we still have two metrics, but today metrics are updated
         $metrics = $networkmetric->find(['networkports_id' => $networkport->fields['id']]);

--- a/tests/functionnal/Glpi/Inventory/Assets/NetworkPort.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/NetworkPort.php
@@ -468,12 +468,12 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         unset($db_input['id']);
 
         $expected_input = [
-          "date"            => date('Y-m-d'),
-          "ifinbytes"       => $ifinbytes,
-          "ifinerrors"      => 0,
-          "ifoutbytes"      => $ifoutbytes,
-          "ifouterrors"     => 0,
-          "networkports_id" => $networkport->fields['id'],
+            "date"            => date('Y-m-d'),
+            "ifinbytes"       => $ifinbytes,
+            "ifinerrors"      => 0,
+            "ifoutbytes"      => $ifoutbytes,
+            "ifouterrors"     => 0,
+            "networkports_id" => $networkport->fields['id'],
         ];
         $this->array($db_input)->isIdenticalTo($expected_input);
 
@@ -526,12 +526,12 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
         //check metrics data
         $expected_input = [
-          "date"            => date('Y-m-d'),
-          "ifinbytes"       => $ifinbytes,
-          "ifinerrors"      => 0,
-          "ifoutbytes"      => $ifoutbytes,
-          "ifouterrors"     => 0,
-          "networkports_id" => $networkport->fields['id'],
+            "date"            => date('Y-m-d'),
+            "ifinbytes"       => $ifinbytes,
+            "ifinerrors"      => 0,
+            "ifoutbytes"      => $ifoutbytes,
+            "ifouterrors"     => 0,
+            "networkports_id" => $networkport->fields['id'],
         ];
         $this->array($db_input)->isIdenticalTo($expected_input);
 
@@ -576,12 +576,12 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
         //check metrics data
         $expected_input = [
-          "date"            => date('Y-m-d'),
-          "ifinbytes"       => $ifinbytes,
-          "ifinerrors"      => 0,
-          "ifoutbytes"      => $ifoutbytes,
-          "ifouterrors"     => 0,
-          "networkports_id" => $networkport->fields['id'],
+            "date"            => date('Y-m-d'),
+            "ifinbytes"       => $ifinbytes,
+            "ifinerrors"      => 0,
+            "ifoutbytes"      => $ifoutbytes,
+            "ifouterrors"     => 0,
+            "networkports_id" => $networkport->fields['id'],
         ];
         $this->array($db_input)->isIdenticalTo($expected_input);
     }

--- a/tests/functionnal/Glpi/Inventory/Assets/NetworkPort.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/NetworkPort.php
@@ -362,8 +362,10 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $networkmetric = new \NetworkPortMetrics();
         $networkequipment = new \NetworkEquipment();
 
-        $ifinbytes  = 3559673658;
-        $ifoutbytes = 3257789612;
+        $ifinbytes    = 3559673658;
+        $ifoutbytes   = 3257789612;
+        $ifouterrors  = 2316546841;
+        $ifinerrors   = 8974561231;
 
         //First step : import NetworkEquipement with only one NetworkPort (Ethernet)
         //check metrics data (only one)
@@ -423,14 +425,14 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
                 <PORT>
                   <IFALIAS>pixin-int1-inside</IFALIAS>
                   <IFDESCR>FastEthernet0/1</IFDESCR>
-                  <IFINERRORS>0</IFINERRORS>
+                  <IFINERRORS>$ifinerrors</IFINERRORS>
                   <IFINOCTETS>$ifinbytes</IFINOCTETS>
                   <IFINTERNALSTATUS>1</IFINTERNALSTATUS>
                   <IFLASTCHANGE>4 days, 3:53:43.54</IFLASTCHANGE>
                   <IFMTU>1500</IFMTU>
                   <IFNAME>Fa0/1</IFNAME>
                   <IFNUMBER>10001</IFNUMBER>
-                  <IFOUTERRORS>0</IFOUTERRORS>
+                  <IFOUTERRORS>$ifouterrors</IFOUTERRORS>
                   <IFOUTOCTETS>$ifoutbytes</IFOUTOCTETS>
                   <IFPORTDUPLEX>2</IFPORTDUPLEX>
                   <IFSPEED>100000000</IFSPEED>
@@ -470,9 +472,9 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $expected_input = [
             "date"            => date('Y-m-d'),
             "ifinbytes"       => $ifinbytes,
-            "ifinerrors"      => 0,
+            "ifinerrors"      => $ifinerrors,
             "ifoutbytes"      => $ifoutbytes,
-            "ifouterrors"     => 0,
+            "ifouterrors"     => $ifouterrors,
             "networkports_id" => $networkport->fields['id'],
         ];
         $this->array($db_input)->isIdenticalTo($expected_input);
@@ -488,14 +490,20 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
         //Second step : import NetworkEquipement again but with new metrics
         //check metrics data for today
-        $old_ifinbytes = $ifinbytes;
-        $old_ifoutbytes = $ifoutbytes;
+        $old_ifinbytes    = $ifinbytes;
+        $old_ifoutbytes   = $ifoutbytes;
+        $old_ifinerrors   = $ifinerrors;
+        $old_ifouterrors  = $ifouterrors;
 
-        $ifinbytes  = 7059673658;
-        $ifoutbytes = 6457789612;
+        $ifinbytes    = 7059673658;
+        $ifoutbytes   = 6457789612;
+        $ifinerrors   = 7894567922;
+        $ifouterrors  = 1423578578;
 
         $xml_source = str_replace($old_ifinbytes, $ifinbytes, $xml_source);
         $xml_source = str_replace($old_ifoutbytes, $ifoutbytes, $xml_source);
+        $xml_source = str_replace($old_ifinerrors, $ifinerrors, $xml_source);
+        $xml_source = str_replace($old_ifouterrors, $ifouterrors, $xml_source);
 
         //networkequipement inventory
         $inventory = $this->doInventory($xml_source, true);
@@ -528,24 +536,30 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $expected_input = [
             "date"            => date('Y-m-d'),
             "ifinbytes"       => $ifinbytes,
-            "ifinerrors"      => 0,
+            "ifinerrors"      => $ifinerrors,
             "ifoutbytes"      => $ifoutbytes,
-            "ifouterrors"     => 0,
+            "ifouterrors"     => $ifouterrors,
             "networkports_id" => $networkport->fields['id'],
         ];
         $this->array($db_input)->isIdenticalTo($expected_input);
 
-        //THird step : import NetworkEquipement again but with new metrics
+        //Third step : import NetworkEquipement again but with new metrics
         //check that the previous data are updated
 
-        $old_ifinbytes = $ifinbytes;
-        $old_ifoutbytes = $ifoutbytes;
+        $old_ifinbytes    = $ifinbytes;
+        $old_ifoutbytes   = $ifoutbytes;
+        $old_ifinerrors   = $ifinerrors;
+        $old_ifouterrors  = $ifouterrors;
 
-        $ifinbytes  = 8059673658;
-        $ifoutbytes = 7457789612;
+        $ifinbytes    = 8059673658;
+        $ifoutbytes   = 7457789612;
+        $ifinerrors   = 7894561232;
+        $ifouterrors  = 4521358975;
 
         $xml_source = str_replace($old_ifinbytes, $ifinbytes, $xml_source);
         $xml_source = str_replace($old_ifoutbytes, $ifoutbytes, $xml_source);
+        $xml_source = str_replace($old_ifinerrors, $ifinerrors, $xml_source);
+        $xml_source = str_replace($old_ifouterrors, $ifouterrors, $xml_source);
 
         //networkequipement inventory
         $inventory = $this->doInventory($xml_source, true);
@@ -560,7 +574,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $this->boolean($networkport->getFromDbByCrit(['itemtype' => 'NetworkEquipment', 'items_id' => $networkquipement_id, 'instantiation_type' => 'NetworkPortEthernet']))
         ->isTrue();
 
-        //now we have two metrics, one for yesterday and one for today
+        //we still have two metrics, but today metrics are updated
         $metrics = $networkmetric->find(['networkports_id' => $networkport->fields['id']]);
         $this->array($metrics)
           ->hasSize(2);
@@ -578,9 +592,9 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $expected_input = [
             "date"            => date('Y-m-d'),
             "ifinbytes"       => $ifinbytes,
-            "ifinerrors"      => 0,
+            "ifinerrors"      => $ifinerrors,
             "ifoutbytes"      => $ifoutbytes,
-            "ifouterrors"     => 0,
+            "ifouterrors"     => $ifouterrors,
             "networkports_id" => $networkport->fields['id'],
         ];
         $this->array($db_input)->isIdenticalTo($expected_input);

--- a/tests/functionnal/Glpi/Inventory/Assets/NetworkPort.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/NetworkPort.php
@@ -35,6 +35,9 @@
 
 namespace tests\units\Glpi\Inventory\Asset;
 
+use DateInterval;
+use DateTime;
+
 include_once __DIR__ . '/../../../../abstracts/AbstractInventoryAsset.php';
 
 /* Test for inc/inventory/asset/processos.class.php */
@@ -351,5 +354,373 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $this->array($asset->getPart('connections'))->isEqualTo((array)json_decode($connections), json_encode($asset->getPart('connections')));
         $this->array($asset->getPart('vlans'))->isEqualTo((array)json_decode($vlans), json_encode($asset->getPart('vlans')));
         $this->array($asset->getPart('aggregates'))->isEqualTo(json_decode($aggregates, true), json_encode($asset->getPart('aggregates')));
+    }
+
+    public function testNetworkPortMetrics()
+    {
+      $networkport = new \NetworkPort();
+      $networkmetric = new \NetworkPortMetrics();
+      $networkequipment = new \NetworkEquipment();
+
+      //First step : import NetworkEquipement with only one NetworkPort (Ethernet)
+      //check metrics data (only one)
+      $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+      <REQUEST>
+        <CONTENT>
+          <DEVICE>
+            <COMPONENTS>
+              <COMPONENT>
+                <CONTAINEDININDEX>0</CONTAINEDININDEX>
+                <DESCRIPTION>WS-C2960-24TC-L</DESCRIPTION>
+                <FIRMWARE>12.2(58)SE1</FIRMWARE>
+                <FRU>2</FRU>
+                <INDEX>1001</INDEX>
+                <MODEL>WS-C2960-24TC-L</MODEL>
+                <NAME>1</NAME>
+                <REVISION>V05</REVISION>
+                <SERIAL>FOC1247X5DX</SERIAL>
+                <TYPE>chassis</TYPE>
+                <VERSION>12.2(58)SE1</VERSION>
+              </COMPONENT>
+              <COMPONENT>
+                <CONTAINEDININDEX>1001</CONTAINEDININDEX>
+                <DESCRIPTION>WS-C2960-24TC-L - Fixed Module 0</DESCRIPTION>
+                <FRU>2</FRU>
+                <INDEX>1002</INDEX>
+                <NAME>WS-C2960-24TC-L - Fixed Module 0</NAME>
+                <TYPE>module</TYPE>
+              </COMPONENT>
+            </COMPONENTS>
+            <FIRMWARES>
+              <DESCRIPTION>device firmware</DESCRIPTION>
+              <MANUFACTURER>Cisco</MANUFACTURER>
+              <NAME>Catalyst 2960-24TC</NAME>
+              <TYPE>device</TYPE>
+              <VERSION>12.2(58)SE1</VERSION>
+            </FIRMWARES>
+            <INFO>
+              <COMMENTS>Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 12.2(58)SE1, RELEASE SOFTWARE (fc1)
+      Technical Support: http://www.cisco.com/techsupport
+      Copyright (c) 1986-2011 by Cisco Systems, Inc.
+      Compiled Thu 05-May-11 02:53 by prod_rel_team</COMMENTS>
+              <FIRMWARE>12.2(58)SE1</FIRMWARE>
+              <ID>0</ID>
+              <IPS>
+                <IP>192.168.1.27</IP>
+              </IPS>
+              <MAC>00:24:13:ea:a7:00</MAC>
+              <MANUFACTURER>Cisco</MANUFACTURER>
+              <MODEL>Catalyst 2960-24TC</MODEL>
+              <NAME>CB-27.example.com</NAME>
+              <SERIAL>FOC1247X5DX</SERIAL>
+              <TYPE>NETWORKING</TYPE>
+              <UPTIME>38 days, 4:05:41.99</UPTIME>
+            </INFO>
+            <PORTS>
+              <PORT>
+                <IFALIAS>pixin-int1-inside</IFALIAS>
+                <IFDESCR>FastEthernet0/1</IFDESCR>
+                <IFINERRORS>0</IFINERRORS>
+                <IFINOCTETS>3559673658</IFINOCTETS>
+                <IFINTERNALSTATUS>1</IFINTERNALSTATUS>
+                <IFLASTCHANGE>4 days, 3:53:43.54</IFLASTCHANGE>
+                <IFMTU>1500</IFMTU>
+                <IFNAME>Fa0/1</IFNAME>
+                <IFNUMBER>10001</IFNUMBER>
+                <IFOUTERRORS>0</IFOUTERRORS>
+                <IFOUTOCTETS>3257789612</IFOUTOCTETS>
+                <IFPORTDUPLEX>2</IFPORTDUPLEX>
+                <IFSPEED>100000000</IFSPEED>
+                <IFSTATUS>1</IFSTATUS>
+                <IFTYPE>6</IFTYPE>
+                <MAC>00:24:13:ea:a7:01</MAC>
+              </PORT>
+            </PORTS>
+          </DEVICE>
+          <MODULEVERSION>5.1</MODULEVERSION>
+          <PROCESSNUMBER>1</PROCESSNUMBER>
+        </CONTENT>
+        <DEVICEID>foo</DEVICEID>
+        <QUERY>SNMPQUERY</QUERY>
+      </REQUEST>";
+
+      //networkequipement inventory
+      $inventory = $this->doInventory($xml_source, true);
+
+      //check networkequipement
+      $networkquipement_id = $inventory->getItem()->fields['id'];
+      $this->integer($networkquipement_id)->isGreaterThan(0);
+
+      //get networkport
+      $this->boolean($networkport->getFromDbByCrit(['itemtype' => 'NetworkEquipment', 'items_id' => $networkquipement_id, 'instantiation_type' => 'NetworkPortEthernet']))
+      ->isTrue();
+
+      //get networkport metric
+      $this->boolean($networkmetric->getFromDbByCrit(['networkports_id' => $networkport->fields['id']]))
+      ->isTrue();
+
+      $db_input = $networkmetric->fields;
+      unset($db_input['date_creation']);
+      unset($db_input['date_mod']);
+      unset($db_input['id']);
+
+      $expected_input = [
+        "date"            => date('Y-m-d'),
+        "ifinbytes"       => 3559673658,
+        "ifinerrors"      => 0,
+        "ifoutbytes"      => 3257789612,
+        "ifouterrors"     => 0,
+        "networkports_id" => $networkport->fields['id'],
+      ];
+      $this->array($db_input)->isIdenticalTo($expected_input);
+
+      //change 'date' to yesterday to get new metric after reimport (2nd step)
+      $currentDate = new DateTime(date('Y-m-d'));
+      $yesterdayTime = $currentDate->sub(new DateInterval('P1D'));
+      $yesterday = $yesterdayTime->format('Y-m-d');
+      $networkmetric->fields['date'] = $yesterday;
+
+      $this->boolean($networkmetric->update($networkmetric->fields))->isTrue();
+      $this->string($networkmetric->fields['date'])->isIdenticalTo($yesterday);
+
+      //Second step : import NetworkEquipement again but with new metrics
+      //check metrics data for today
+      $xml_source_with_new_metrics = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+      <REQUEST>
+        <CONTENT>
+          <DEVICE>
+            <COMPONENTS>
+              <COMPONENT>
+                <CONTAINEDININDEX>0</CONTAINEDININDEX>
+                <DESCRIPTION>WS-C2960-24TC-L</DESCRIPTION>
+                <FIRMWARE>12.2(58)SE1</FIRMWARE>
+                <FRU>2</FRU>
+                <INDEX>1001</INDEX>
+                <MODEL>WS-C2960-24TC-L</MODEL>
+                <NAME>1</NAME>
+                <REVISION>V05</REVISION>
+                <SERIAL>FOC1247X5DX</SERIAL>
+                <TYPE>chassis</TYPE>
+                <VERSION>12.2(58)SE1</VERSION>
+              </COMPONENT>
+              <COMPONENT>
+                <CONTAINEDININDEX>1001</CONTAINEDININDEX>
+                <DESCRIPTION>WS-C2960-24TC-L - Fixed Module 0</DESCRIPTION>
+                <FRU>2</FRU>
+                <INDEX>1002</INDEX>
+                <NAME>WS-C2960-24TC-L - Fixed Module 0</NAME>
+                <TYPE>module</TYPE>
+              </COMPONENT>
+            </COMPONENTS>
+            <FIRMWARES>
+              <DESCRIPTION>device firmware</DESCRIPTION>
+              <MANUFACTURER>Cisco</MANUFACTURER>
+              <NAME>Catalyst 2960-24TC</NAME>
+              <TYPE>device</TYPE>
+              <VERSION>12.2(58)SE1</VERSION>
+            </FIRMWARES>
+            <INFO>
+              <COMMENTS>Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 12.2(58)SE1, RELEASE SOFTWARE (fc1)
+      Technical Support: http://www.cisco.com/techsupport
+      Copyright (c) 1986-2011 by Cisco Systems, Inc.
+      Compiled Thu 05-May-11 02:53 by prod_rel_team</COMMENTS>
+              <FIRMWARE>12.2(58)SE1</FIRMWARE>
+              <ID>0</ID>
+              <IPS>
+                <IP>192.168.1.27</IP>
+              </IPS>
+              <MAC>00:24:13:ea:a7:00</MAC>
+              <MANUFACTURER>Cisco</MANUFACTURER>
+              <MODEL>Catalyst 2960-24TC</MODEL>
+              <NAME>CB-27.example.com</NAME>
+              <SERIAL>FOC1247X5DX</SERIAL>
+              <TYPE>NETWORKING</TYPE>
+              <UPTIME>38 days, 4:05:41.99</UPTIME>
+            </INFO>
+            <PORTS>
+              <PORT>
+                <IFALIAS>pixin-int1-inside</IFALIAS>
+                <IFDESCR>FastEthernet0/1</IFDESCR>
+                <IFINERRORS>0</IFINERRORS>
+                <IFINOCTETS>7059673658</IFINOCTETS>
+                <IFINTERNALSTATUS>1</IFINTERNALSTATUS>
+                <IFLASTCHANGE>4 days, 3:53:43.54</IFLASTCHANGE>
+                <IFMTU>1500</IFMTU>
+                <IFNAME>Fa0/1</IFNAME>
+                <IFNUMBER>10001</IFNUMBER>
+                <IFOUTERRORS>0</IFOUTERRORS>
+                <IFOUTOCTETS>6457789612</IFOUTOCTETS>
+                <IFPORTDUPLEX>2</IFPORTDUPLEX>
+                <IFSPEED>100000000</IFSPEED>
+                <IFSTATUS>1</IFSTATUS>
+                <IFTYPE>6</IFTYPE>
+                <MAC>00:24:13:ea:a7:01</MAC>
+              </PORT>
+            </PORTS>
+          </DEVICE>
+          <MODULEVERSION>5.1</MODULEVERSION>
+          <PROCESSNUMBER>1</PROCESSNUMBER>
+        </CONTENT>
+        <DEVICEID>foo</DEVICEID>
+        <QUERY>SNMPQUERY</QUERY>
+      </REQUEST>";
+
+      //networkequipement inventory
+      $inventory = $this->doInventory($xml_source_with_new_metrics, true);
+
+      $networkquipement_id = $inventory->getItem()->fields['id'];
+      $this->integer($networkquipement_id)->isGreaterThan(0);
+
+      //get networkEquipement
+      $this->boolean($networkequipment->getFromDB($networkquipement_id))->isTrue();
+
+      //get networkport
+      $this->boolean($networkport->getFromDbByCrit(['itemtype' => 'NetworkEquipment', 'items_id' => $networkquipement_id, 'instantiation_type' => 'NetworkPortEthernet']))
+      ->isTrue();
+
+      //now we have two metrics, one for yesterday and one for today
+      $metrics = $networkmetric->find(['networkports_id' => $networkport->fields['id']]);
+      $this->array($metrics)
+         ->hasSize(2);
+
+      //get networkport metric for today
+      $this->boolean($networkmetric->getFromDbByCrit(['networkports_id' => $networkport->fields['id'], "date" => date('Y-m-d')]))
+      ->isTrue();
+
+      $db_input = $networkmetric->fields;
+      unset($db_input['date_creation']);
+      unset($db_input['date_mod']);
+      unset($db_input['id']);
+
+      //check metrics data
+      $expected_input = [
+        "date"            => date('Y-m-d'),
+        "ifinbytes"       => 7059673658,
+        "ifinerrors"      => 0,
+        "ifoutbytes"      => 6457789612,
+        "ifouterrors"     => 0,
+        "networkports_id" => $networkport->fields['id'],
+      ];
+      $this->array($db_input)->isIdenticalTo($expected_input);
+
+      //THird step : import NetworkEquipement again but with new metrics
+      //check that the previous data are updated
+      $xml_source_with_new_metrics = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+      <REQUEST>
+        <CONTENT>
+          <DEVICE>
+            <COMPONENTS>
+              <COMPONENT>
+                <CONTAINEDININDEX>0</CONTAINEDININDEX>
+                <DESCRIPTION>WS-C2960-24TC-L</DESCRIPTION>
+                <FIRMWARE>12.2(58)SE1</FIRMWARE>
+                <FRU>2</FRU>
+                <INDEX>1001</INDEX>
+                <MODEL>WS-C2960-24TC-L</MODEL>
+                <NAME>1</NAME>
+                <REVISION>V05</REVISION>
+                <SERIAL>FOC1247X5DX</SERIAL>
+                <TYPE>chassis</TYPE>
+                <VERSION>12.2(58)SE1</VERSION>
+              </COMPONENT>
+              <COMPONENT>
+                <CONTAINEDININDEX>1001</CONTAINEDININDEX>
+                <DESCRIPTION>WS-C2960-24TC-L - Fixed Module 0</DESCRIPTION>
+                <FRU>2</FRU>
+                <INDEX>1002</INDEX>
+                <NAME>WS-C2960-24TC-L - Fixed Module 0</NAME>
+                <TYPE>module</TYPE>
+              </COMPONENT>
+            </COMPONENTS>
+            <FIRMWARES>
+              <DESCRIPTION>device firmware</DESCRIPTION>
+              <MANUFACTURER>Cisco</MANUFACTURER>
+              <NAME>Catalyst 2960-24TC</NAME>
+              <TYPE>device</TYPE>
+              <VERSION>12.2(58)SE1</VERSION>
+            </FIRMWARES>
+            <INFO>
+              <COMMENTS>Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 12.2(58)SE1, RELEASE SOFTWARE (fc1)
+      Technical Support: http://www.cisco.com/techsupport
+      Copyright (c) 1986-2011 by Cisco Systems, Inc.
+      Compiled Thu 05-May-11 02:53 by prod_rel_team</COMMENTS>
+              <FIRMWARE>12.2(58)SE1</FIRMWARE>
+              <ID>0</ID>
+              <IPS>
+                <IP>192.168.1.27</IP>
+              </IPS>
+              <MAC>00:24:13:ea:a7:00</MAC>
+              <MANUFACTURER>Cisco</MANUFACTURER>
+              <MODEL>Catalyst 2960-24TC</MODEL>
+              <NAME>CB-27.example.com</NAME>
+              <SERIAL>FOC1247X5DX</SERIAL>
+              <TYPE>NETWORKING</TYPE>
+              <UPTIME>38 days, 4:05:41.99</UPTIME>
+            </INFO>
+            <PORTS>
+              <PORT>
+                <IFALIAS>pixin-int1-inside</IFALIAS>
+                <IFDESCR>FastEthernet0/1</IFDESCR>
+                <IFINERRORS>0</IFINERRORS>
+                <IFINOCTETS>8059673658</IFINOCTETS>
+                <IFINTERNALSTATUS>1</IFINTERNALSTATUS>
+                <IFLASTCHANGE>4 days, 3:53:43.54</IFLASTCHANGE>
+                <IFMTU>1500</IFMTU>
+                <IFNAME>Fa0/1</IFNAME>
+                <IFNUMBER>10001</IFNUMBER>
+                <IFOUTERRORS>0</IFOUTERRORS>
+                <IFOUTOCTETS>7457789612</IFOUTOCTETS>
+                <IFPORTDUPLEX>2</IFPORTDUPLEX>
+                <IFSPEED>100000000</IFSPEED>
+                <IFSTATUS>1</IFSTATUS>
+                <IFTYPE>6</IFTYPE>
+                <MAC>00:24:13:ea:a7:01</MAC>
+              </PORT>
+            </PORTS>
+          </DEVICE>
+          <MODULEVERSION>5.1</MODULEVERSION>
+          <PROCESSNUMBER>1</PROCESSNUMBER>
+        </CONTENT>
+        <DEVICEID>foo</DEVICEID>
+        <QUERY>SNMPQUERY</QUERY>
+      </REQUEST>";
+
+      //networkequipement inventory
+      $inventory = $this->doInventory($xml_source_with_new_metrics, true);
+
+      $networkquipement_id = $inventory->getItem()->fields['id'];
+      $this->integer($networkquipement_id)->isGreaterThan(0);
+
+      //get networkEquipement
+      $this->boolean($networkequipment->getFromDB($networkquipement_id))->isTrue();
+
+      //get networkport
+      $this->boolean($networkport->getFromDbByCrit(['itemtype' => 'NetworkEquipment', 'items_id' => $networkquipement_id, 'instantiation_type' => 'NetworkPortEthernet']))
+      ->isTrue();
+
+      //now we have two metrics, one for yesterday and one for today
+      $metrics = $networkmetric->find(['networkports_id' => $networkport->fields['id']]);
+      $this->array($metrics)
+         ->hasSize(2);
+
+      //get networkport metric for today
+      $this->boolean($networkmetric->getFromDbByCrit(['networkports_id' => $networkport->fields['id'], "date" => date('Y-m-d')]))
+      ->isTrue();
+
+      $db_input = $networkmetric->fields;
+      unset($db_input['date_creation']);
+      unset($db_input['date_mod']);
+      unset($db_input['id']);
+
+      //check metrics data
+      $expected_input = [
+        "date"            => date('Y-m-d'),
+        "ifinbytes"       => 8059673658,
+        "ifinerrors"      => 0,
+        "ifoutbytes"      => 7457789612,
+        "ifouterrors"     => 0,
+        "networkports_id" => $networkport->fields['id'],
+      ];
+      $this->array($db_input)->isIdenticalTo($expected_input);
     }
 }

--- a/tests/functionnal/Glpi/Inventory/Assets/NetworkPort.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/NetworkPort.php
@@ -362,6 +362,9 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $networkmetric = new \NetworkPortMetrics();
         $networkequipment = new \NetworkEquipment();
 
+        $ifinbytes  = 3559673658;
+        $ifoutbytes = 3257789612;
+
         //First step : import NetworkEquipement with only one NetworkPort (Ethernet)
         //check metrics data (only one)
         $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
@@ -421,14 +424,14 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
                   <IFALIAS>pixin-int1-inside</IFALIAS>
                   <IFDESCR>FastEthernet0/1</IFDESCR>
                   <IFINERRORS>0</IFINERRORS>
-                  <IFINOCTETS>3559673658</IFINOCTETS>
+                  <IFINOCTETS>$ifinbytes</IFINOCTETS>
                   <IFINTERNALSTATUS>1</IFINTERNALSTATUS>
                   <IFLASTCHANGE>4 days, 3:53:43.54</IFLASTCHANGE>
                   <IFMTU>1500</IFMTU>
                   <IFNAME>Fa0/1</IFNAME>
                   <IFNUMBER>10001</IFNUMBER>
                   <IFOUTERRORS>0</IFOUTERRORS>
-                  <IFOUTOCTETS>3257789612</IFOUTOCTETS>
+                  <IFOUTOCTETS>$ifoutbytes</IFOUTOCTETS>
                   <IFPORTDUPLEX>2</IFPORTDUPLEX>
                   <IFSPEED>100000000</IFSPEED>
                   <IFSTATUS>1</IFSTATUS>
@@ -466,9 +469,9 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
         $expected_input = [
           "date"            => date('Y-m-d'),
-          "ifinbytes"       => 3559673658,
+          "ifinbytes"       => $ifinbytes,
           "ifinerrors"      => 0,
-          "ifoutbytes"      => 3257789612,
+          "ifoutbytes"      => $ifoutbytes,
           "ifouterrors"     => 0,
           "networkports_id" => $networkport->fields['id'],
         ];
@@ -485,88 +488,17 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
         //Second step : import NetworkEquipement again but with new metrics
         //check metrics data for today
-        $xml_source_with_new_metrics = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
-        <REQUEST>
-          <CONTENT>
-            <DEVICE>
-              <COMPONENTS>
-                <COMPONENT>
-                  <CONTAINEDININDEX>0</CONTAINEDININDEX>
-                  <DESCRIPTION>WS-C2960-24TC-L</DESCRIPTION>
-                  <FIRMWARE>12.2(58)SE1</FIRMWARE>
-                  <FRU>2</FRU>
-                  <INDEX>1001</INDEX>
-                  <MODEL>WS-C2960-24TC-L</MODEL>
-                  <NAME>1</NAME>
-                  <REVISION>V05</REVISION>
-                  <SERIAL>FOC1247X5DX</SERIAL>
-                  <TYPE>chassis</TYPE>
-                  <VERSION>12.2(58)SE1</VERSION>
-                </COMPONENT>
-                <COMPONENT>
-                  <CONTAINEDININDEX>1001</CONTAINEDININDEX>
-                  <DESCRIPTION>WS-C2960-24TC-L - Fixed Module 0</DESCRIPTION>
-                  <FRU>2</FRU>
-                  <INDEX>1002</INDEX>
-                  <NAME>WS-C2960-24TC-L - Fixed Module 0</NAME>
-                  <TYPE>module</TYPE>
-                </COMPONENT>
-              </COMPONENTS>
-              <FIRMWARES>
-                <DESCRIPTION>device firmware</DESCRIPTION>
-                <MANUFACTURER>Cisco</MANUFACTURER>
-                <NAME>Catalyst 2960-24TC</NAME>
-                <TYPE>device</TYPE>
-                <VERSION>12.2(58)SE1</VERSION>
-              </FIRMWARES>
-              <INFO>
-                <COMMENTS>Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 12.2(58)SE1, RELEASE SOFTWARE (fc1)
-        Technical Support: http://www.cisco.com/techsupport
-        Copyright (c) 1986-2011 by Cisco Systems, Inc.
-        Compiled Thu 05-May-11 02:53 by prod_rel_team</COMMENTS>
-                <FIRMWARE>12.2(58)SE1</FIRMWARE>
-                <ID>0</ID>
-                <IPS>
-                  <IP>192.168.1.27</IP>
-                </IPS>
-                <MAC>00:24:13:ea:a7:00</MAC>
-                <MANUFACTURER>Cisco</MANUFACTURER>
-                <MODEL>Catalyst 2960-24TC</MODEL>
-                <NAME>CB-27.example.com</NAME>
-                <SERIAL>FOC1247X5DX</SERIAL>
-                <TYPE>NETWORKING</TYPE>
-                <UPTIME>38 days, 4:05:41.99</UPTIME>
-              </INFO>
-              <PORTS>
-                <PORT>
-                  <IFALIAS>pixin-int1-inside</IFALIAS>
-                  <IFDESCR>FastEthernet0/1</IFDESCR>
-                  <IFINERRORS>0</IFINERRORS>
-                  <IFINOCTETS>7059673658</IFINOCTETS>
-                  <IFINTERNALSTATUS>1</IFINTERNALSTATUS>
-                  <IFLASTCHANGE>4 days, 3:53:43.54</IFLASTCHANGE>
-                  <IFMTU>1500</IFMTU>
-                  <IFNAME>Fa0/1</IFNAME>
-                  <IFNUMBER>10001</IFNUMBER>
-                  <IFOUTERRORS>0</IFOUTERRORS>
-                  <IFOUTOCTETS>6457789612</IFOUTOCTETS>
-                  <IFPORTDUPLEX>2</IFPORTDUPLEX>
-                  <IFSPEED>100000000</IFSPEED>
-                  <IFSTATUS>1</IFSTATUS>
-                  <IFTYPE>6</IFTYPE>
-                  <MAC>00:24:13:ea:a7:01</MAC>
-                </PORT>
-              </PORTS>
-            </DEVICE>
-            <MODULEVERSION>5.1</MODULEVERSION>
-            <PROCESSNUMBER>1</PROCESSNUMBER>
-          </CONTENT>
-          <DEVICEID>foo</DEVICEID>
-          <QUERY>SNMPQUERY</QUERY>
-        </REQUEST>";
+        $old_ifinbytes = $ifinbytes;
+        $old_ifoutbytes = $ifoutbytes;
+
+        $ifinbytes  = 7059673658;
+        $ifoutbytes = 6457789612;
+
+        $xml_source = str_replace($old_ifinbytes, $ifinbytes, $xml_source);
+        $xml_source = str_replace($old_ifoutbytes, $ifoutbytes, $xml_source);
 
         //networkequipement inventory
-        $inventory = $this->doInventory($xml_source_with_new_metrics, true);
+        $inventory = $this->doInventory($xml_source, true);
 
         $networkquipement_id = $inventory->getItem()->fields['id'];
         $this->integer($networkquipement_id)->isGreaterThan(0);
@@ -595,9 +527,9 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         //check metrics data
         $expected_input = [
           "date"            => date('Y-m-d'),
-          "ifinbytes"       => 7059673658,
+          "ifinbytes"       => $ifinbytes,
           "ifinerrors"      => 0,
-          "ifoutbytes"      => 6457789612,
+          "ifoutbytes"      => $ifoutbytes,
           "ifouterrors"     => 0,
           "networkports_id" => $networkport->fields['id'],
         ];
@@ -605,88 +537,18 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
         //THird step : import NetworkEquipement again but with new metrics
         //check that the previous data are updated
-        $xml_source_with_new_metrics = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
-        <REQUEST>
-          <CONTENT>
-            <DEVICE>
-              <COMPONENTS>
-                <COMPONENT>
-                  <CONTAINEDININDEX>0</CONTAINEDININDEX>
-                  <DESCRIPTION>WS-C2960-24TC-L</DESCRIPTION>
-                  <FIRMWARE>12.2(58)SE1</FIRMWARE>
-                  <FRU>2</FRU>
-                  <INDEX>1001</INDEX>
-                  <MODEL>WS-C2960-24TC-L</MODEL>
-                  <NAME>1</NAME>
-                  <REVISION>V05</REVISION>
-                  <SERIAL>FOC1247X5DX</SERIAL>
-                  <TYPE>chassis</TYPE>
-                  <VERSION>12.2(58)SE1</VERSION>
-                </COMPONENT>
-                <COMPONENT>
-                  <CONTAINEDININDEX>1001</CONTAINEDININDEX>
-                  <DESCRIPTION>WS-C2960-24TC-L - Fixed Module 0</DESCRIPTION>
-                  <FRU>2</FRU>
-                  <INDEX>1002</INDEX>
-                  <NAME>WS-C2960-24TC-L - Fixed Module 0</NAME>
-                  <TYPE>module</TYPE>
-                </COMPONENT>
-              </COMPONENTS>
-              <FIRMWARES>
-                <DESCRIPTION>device firmware</DESCRIPTION>
-                <MANUFACTURER>Cisco</MANUFACTURER>
-                <NAME>Catalyst 2960-24TC</NAME>
-                <TYPE>device</TYPE>
-                <VERSION>12.2(58)SE1</VERSION>
-              </FIRMWARES>
-              <INFO>
-                <COMMENTS>Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 12.2(58)SE1, RELEASE SOFTWARE (fc1)
-        Technical Support: http://www.cisco.com/techsupport
-        Copyright (c) 1986-2011 by Cisco Systems, Inc.
-        Compiled Thu 05-May-11 02:53 by prod_rel_team</COMMENTS>
-                <FIRMWARE>12.2(58)SE1</FIRMWARE>
-                <ID>0</ID>
-                <IPS>
-                  <IP>192.168.1.27</IP>
-                </IPS>
-                <MAC>00:24:13:ea:a7:00</MAC>
-                <MANUFACTURER>Cisco</MANUFACTURER>
-                <MODEL>Catalyst 2960-24TC</MODEL>
-                <NAME>CB-27.example.com</NAME>
-                <SERIAL>FOC1247X5DX</SERIAL>
-                <TYPE>NETWORKING</TYPE>
-                <UPTIME>38 days, 4:05:41.99</UPTIME>
-              </INFO>
-              <PORTS>
-                <PORT>
-                  <IFALIAS>pixin-int1-inside</IFALIAS>
-                  <IFDESCR>FastEthernet0/1</IFDESCR>
-                  <IFINERRORS>0</IFINERRORS>
-                  <IFINOCTETS>8059673658</IFINOCTETS>
-                  <IFINTERNALSTATUS>1</IFINTERNALSTATUS>
-                  <IFLASTCHANGE>4 days, 3:53:43.54</IFLASTCHANGE>
-                  <IFMTU>1500</IFMTU>
-                  <IFNAME>Fa0/1</IFNAME>
-                  <IFNUMBER>10001</IFNUMBER>
-                  <IFOUTERRORS>0</IFOUTERRORS>
-                  <IFOUTOCTETS>7457789612</IFOUTOCTETS>
-                  <IFPORTDUPLEX>2</IFPORTDUPLEX>
-                  <IFSPEED>100000000</IFSPEED>
-                  <IFSTATUS>1</IFSTATUS>
-                  <IFTYPE>6</IFTYPE>
-                  <MAC>00:24:13:ea:a7:01</MAC>
-                </PORT>
-              </PORTS>
-            </DEVICE>
-            <MODULEVERSION>5.1</MODULEVERSION>
-            <PROCESSNUMBER>1</PROCESSNUMBER>
-          </CONTENT>
-          <DEVICEID>foo</DEVICEID>
-          <QUERY>SNMPQUERY</QUERY>
-        </REQUEST>";
+
+        $old_ifinbytes = $ifinbytes;
+        $old_ifoutbytes = $ifoutbytes;
+
+        $ifinbytes  = 8059673658;
+        $ifoutbytes = 7457789612;
+
+        $xml_source = str_replace($old_ifinbytes, $ifinbytes, $xml_source);
+        $xml_source = str_replace($old_ifoutbytes, $ifoutbytes, $xml_source);
 
         //networkequipement inventory
-        $inventory = $this->doInventory($xml_source_with_new_metrics, true);
+        $inventory = $this->doInventory($xml_source, true);
 
         $networkquipement_id = $inventory->getItem()->fields['id'];
         $this->integer($networkquipement_id)->isGreaterThan(0);
@@ -715,9 +577,9 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         //check metrics data
         $expected_input = [
           "date"            => date('Y-m-d'),
-          "ifinbytes"       => 8059673658,
+          "ifinbytes"       => $ifinbytes,
           "ifinerrors"      => 0,
-          "ifoutbytes"      => 7457789612,
+          "ifoutbytes"      => $ifoutbytes,
           "ifouterrors"     => 0,
           "networkports_id" => $networkport->fields['id'],
         ];


### PR DESCRIPTION
Actually ```NetworkPortMetric``` are never update / added after first import of ```NetworkPort```

This PR fix this


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12483
