### PR TITLE
Printers: fix printed pages graph for big datasets

### DIFF
--- a/css/includes/_includes.scss
+++ b/css/includes/_includes.scss
@@ -66,6 +66,7 @@ $is-dark: false !default;
 @import "components/itilobject/dates_timelines";
 @import "components/itilobject/status";
 @import "components/setup/dropdowns_list";
+@import "components/chartist/chartist";
 @import "pages/search";
 @import "../legacy/includes/inputs";
 @import "../legacy/includes/styles";

--- a/css/includes/components/chartist/_chartist.scss
+++ b/css/includes/components/chartist/_chartist.scss
@@ -1,3 +1,36 @@
+/*!
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2022 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
 $break_s_screen: 1400px;
 
 // Fix last label wrapping on the X-axis

--- a/css/includes/components/chartist/_chartist.scss
+++ b/css/includes/components/chartist/_chartist.scss
@@ -1,0 +1,9 @@
+$break_s_screen: 1400px;
+
+// Fix last label wrapping on the X-axis
+// See https://github.com/chartist-js/chartist/issues/557#issuecomment-169358908
+@media screen and (min-width: $break_s_screen) {
+    .printer_barchart .ct-label.ct-horizontal {
+        white-space: nowrap;
+    }
+}

--- a/src/Dashboard/Widget.php
+++ b/src/Dashboard/Widget.php
@@ -1590,6 +1590,20 @@ HTML;
             chartPadding: {
                right: 40
             },
+            axisY: {
+               labelInterpolationFnc: function(value) {
+                  if (value < 1e3) {
+                     // less than 1K
+                     return value;
+                  } else if (value < 1e6) {
+                     // More than 1k, less than 1M
+                     return value / 1e3 + "K";
+                  } else {
+                     // More than 1M
+                     return value / 1e6 + "M";
+                  }
+               },
+            },
             {$area_options}
             plugins: [
                {$legend_options}

--- a/src/PrinterLog.php
+++ b/src/PrinterLog.php
@@ -121,7 +121,7 @@ class PrinterLog extends CommonDBChild
             ] + $filters
         ]);
 
-        $series = iterator_to_array($iterator);
+        $series = iterator_to_array($iterator, false);
 
         // Reduce the data to 25 points
         $count = count($series);

--- a/src/PrinterLog.php
+++ b/src/PrinterLog.php
@@ -180,8 +180,9 @@ class PrinterLog extends CommonDBChild
             unset($metrics['id'], $metrics['date'], $metrics['printers_id']);
 
             foreach ($metrics as $key => $value) {
-                if ($value > 0) {
-                    $series[$key]['name'] = $this->getLabelFor($key);
+                $label = $this->getLabelFor($key);
+                if ($label && $value > 0) {
+                    $series[$key]['name'] = $label;
                     $series[$key]['data'][] = $value;
                 }
             }
@@ -204,7 +205,15 @@ class PrinterLog extends CommonDBChild
         echo "</div>";
     }
 
-    private function getLabelFor($key)
+    /**
+     * Get the label for a given column of glpi_printerlogs.
+     * To be used when displaying the printed pages graph.
+     *
+     * @param string $key
+     *
+     * @return null|string null if the key didn't match any valid field
+     */
+    private function getLabelFor($key): ?string
     {
         switch ($key) {
             case 'total_pages':
@@ -232,5 +241,7 @@ class PrinterLog extends CommonDBChild
             case 'faxed':
                 return __('Fax');
         }
+
+        return null;
     }
 }

--- a/src/PrinterLog.php
+++ b/src/PrinterLog.php
@@ -131,7 +131,7 @@ class PrinterLog extends CommonDBChild
             $modulo = round($count / $max_size);
             $series = array_filter(
                 $series,
-                fn($k) => ($k % $modulo) == 0,
+                fn($k) => (($count - ($k + 1)) % $modulo) == 0,
                 ARRAY_FILTER_USE_KEY
             );
         }


### PR DESCRIPTION
Page counters get a bit messy with big datasets:

![image](https://user-images.githubusercontent.com/42734840/187616077-680839dc-be56-4472-a7f5-b15d95e1d2d3.png)

Note the labels on the X axis which are unreadable, and the ones on the Y-axis are truncated (it's supposed to go from 0 to 35k in this example).

Proposed changes:

![image](https://user-images.githubusercontent.com/42734840/187632644-8a84d9ca-a15f-4668-b116-b9c404ecb77d.png)

* Limit the dataset to 25 items, spread equally across the set
* Change the graph from bars to areas. 
   This help by reducing the Y scale (areas graph seems to start the Y scale from the lowest value (here 15k) instead of 0 and are also easier to read in my opinion
* Rewrite Y axis label to use K or M prefix for big numbers
* Rewrite X axis label to remove the year (this graph will only show the last 365 dates so we can part with this data) and use the month name (more easily readable, especially on small screens if the labels get spread on multiples lines).


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23397
