### PR TITLE
fix(savedsearch): public search visible without right

### DIFF
--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -807,19 +807,11 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
                 ]
                 ]
             ],
-            'WHERE'     => [
-                'OR' => [
-                    [
-                        "$table.is_private" => 0,
-                    ] + getEntitiesRestrictCriteria($table, '', '', true),
-                    "$table.users_id"   => Session::getLoginUserID()
-                ]
-            ],
             'ORDERBY'   => [
                 'itemtype',
                 'name'
             ]
-        ];
+        ] + self::getVisibilityCriteria();
 
         if ($itemtype != null) {
             if (!$inverse) {


### PR DESCRIPTION
Public saved searches were visible, even on a profile that did not have the right to see them.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24794
