### PR TITLE
fix(dashboard): fix draggable item and grid-stack size

### DIFF
--- a/css/standalone/dashboard.scss
+++ b/css/standalone/dashboard.scss
@@ -89,6 +89,7 @@ $break_tablet: 1400px;
         margin-bottom: -10px;
         z-index: 1;
         box-sizing: content-box;
+        height: 100px;
 
         & + .search_page {
             z-index: 2;

--- a/src/Search.php
+++ b/src/Search.php
@@ -163,7 +163,7 @@ class Search
             $itemtype == "Ticket"
             && $default = Glpi\Dashboard\Grid::getDefaultDashboardForMenu('mini_ticket', true)
         ) {
-            $dashboard = new Glpi\Dashboard\Grid($default, 33, 1);
+            $dashboard = new Glpi\Dashboard\Grid($default, 33, 2);
             $dashboard->show(true);
         }
 


### PR DESCRIPTION
Drag feature not work on mini dahsboard because ```$grid_rows``` is defined to ```1``` instead of ```2``` (from GLPI 9.5)

Need to fix ```height``` to prevent empty space between ```cell-add``` ```div``` (from ```grid-guide```)

![image](https://user-images.githubusercontent.com/7335054/187683407-1b39551c-02f7-4814-80bd-7574c0f3c5fe.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24801
