### PR TITLE
fix(session): destroy session when ssologout_url is used

### DIFF
--- a/front/logout.php
+++ b/front/logout.php
@@ -45,6 +45,9 @@ if (
     $CFG_GLPI["ssovariables_id"] > 0
     && strlen($CFG_GLPI['ssologout_url']) > 0
 ) {
+    Session::destroy();
+    //Remove cookie to allow new login
+    Auth::setRememberMeCookie('');
     Html::redirect($CFG_GLPI["ssologout_url"]);
 }
 


### PR DESCRIPTION
destroy session when ssologout_url is used


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24805
