### PR TITLE
Fix redirect from load tab when session is expired

### DIFF
--- a/ajax/common.tabs.php
+++ b/ajax/common.tabs.php
@@ -43,7 +43,7 @@ if (isset($_GET['full_page_tab'])) {
     Html::header_nocache();
 }
 
-if (!str_contains('helpdesk.faq.php', $_GET["_target"])) {
+if (!($CFG_GLPI["use_public_faq"] && str_ends_with($_GET["_target"], '/front/helpdesk.faq.php'))) {
     Session::checkLoginUser();
 }
 

--- a/ajax/common.tabs.php
+++ b/ajax/common.tabs.php
@@ -34,6 +34,7 @@
  */
 
 include('../inc/includes.php');
+$AJAX_INCLUDE = 1;
 
 if (isset($_GET['full_page_tab'])) {
     Html::header('Only tab for debug', $_SERVER['PHP_SELF']);
@@ -42,8 +43,9 @@ if (isset($_GET['full_page_tab'])) {
     Html::header_nocache();
 }
 
-// Not possible to check right for anonymous FAQ
-//Session::checkLoginUser();
+if (!str_contains('helpdesk.faq.php', $_GET["_target"])) {
+    Session::checkLoginUser();
+}
 
 if (!isset($_GET['_glpi_tab'])) {
     exit();

--- a/src/Html.php
+++ b/src/Html.php
@@ -571,7 +571,11 @@ class Html
         }
 
         if (!empty($params)) {
-            $dest .= '&' . $params;
+            if (str_contains('?', $dest)) {
+                $dest .= '&' . $params;
+            } else {
+                $dest .= '?' . $params;
+            }
         }
 
         self::redirect($dest);


### PR DESCRIPTION
Fix redirect from load / switch tab when session is expired

How to test : 
Log in to GLPI and go to  Central page
Open new GLPI tab go to  GLPI Computer list -> then logout
From Central page change tab.

This PR fix this

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24812
