### PR TITLE
fix(tickettemplate): fix predefined date not working

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4094,7 +4094,7 @@ JAVASCRIPT;
             'priority'                  => self::computePriority(3, 3),
             'requesttypes_id'           => $requesttype,
             'actiontime'                => 0,
-            'date'                      => null,
+            'date'                      => 'NULL',
             'entities_id'               => $entity,
             'status'                    => self::INCOMING,
             'followup'                  => [],


### PR DESCRIPTION
Predefined field ```date``` (```opening date```) not working

Because of ```null``` default value and this check
https://github.com/glpi-project/glpi/blob/bbce75d025fd8379329c3f53410ef74fe6644c82/src/CommonITILObject.php#L513

This PR fix this.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24821
