### PR TITLE
Secure document deletion in timeline

### DIFF
--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -211,10 +211,10 @@ if (isset($_POST["add"])) {
         sprintf(__('%s adds an actor'), $_SESSION["glpiname"])
     );
     Html::redirect(Ticket::getFormURLWithID($id));
-} else if (isset($_REQUEST['delete_document'])) {
-    $track->getFromDB((int)$_REQUEST['tickets_id']);
+} else if (isset($_POST['delete_document'])) {
+    $track->getFromDB((int)$_POST['tickets_id']);
     $doc = new Document();
-    $doc->getFromDB((int)$_REQUEST['documents_id']);
+    $doc->getFromDB((int)$_POST['documents_id']);
     if ($doc->can($doc->getID(), UPDATE)) {
         $document_item = new Document_Item();
         $found_document_items = $document_item->find([

--- a/templates/components/itilobject/timeline/sub_documents.html.twig
+++ b/templates/components/itilobject/timeline/sub_documents.html.twig
@@ -55,11 +55,16 @@
                   {% endif %}
 
                   {% if document['item']['_can_delete'] %}
-                     <a href="{{ delete_link }}"
-                        class="btn btn-sm btn-ghost-secondary" title="{{ _x('button', 'Delete permanently') }}"
-                        data-bs-toggle="tooltip" data-bs-placement="top">
-                        <i class="ti ti-trash"></i>
-                     </a>
+                     <form class="d-inline" method="post" action="{{ item.getFormURL() }}">
+                        <input type="hidden" name="{{ fk }}" value="{{ item.fields['id'] }}">
+                        <input type="hidden" name="documents_id" value="{{ document['item']['id'] }}">
+                        <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
+                        <button type="submit" class="btn btn-sm btn-ghost-secondary" name="delete_document"
+                                title="{{ _x('button', 'Delete permanently') }}"
+                                data-bs-toggle="tooltip" data-bs-placement="top">
+                           <i class="ti ti-trash"></i>
+                        </button>
+                     </form>
                   {% endif %}
                </div>
             </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Reverts #12517 and replace link by a form to ensure CSRF protection.