### PR TITLE
fix(inventory): duplicated logs

### DIFF
--- a/src/RuleImportAsset.php
+++ b/src/RuleImportAsset.php
@@ -935,14 +935,15 @@ class RuleImportAsset extends Rule
                              $items_id = current($inventory);
                              $output['found_inventories'] = [$items_id, $itemtype, $rules_id];
                             if (!isset($params['return'])) {
-                                $inputrulelog = $inputrulelog + [
-                                    'items_id'  => $items_id,
-                                    'itemtype'  => $itemtype
-                                ];
-                                $rulesmatched->add($inputrulelog);
-                                $rulesmatched->cleanOlddata($items_id, $itemtype);
                                 if ($class) {
                                     $class->rulepassed($items_id, $itemtype, $rules_id, $this->criterias_results['found_port']);
+                                } else {
+                                    $inputrulelog = $inputrulelog + [
+                                        'items_id'  => $items_id,
+                                        'itemtype'  => $itemtype
+                                    ];
+                                    $rulesmatched->add($inputrulelog);
+                                    $rulesmatched->cleanOlddata($items_id, $itemtype);
                                 }
                             }
                             return $output;

--- a/tests/functionnal/Glpi/Inventory/Inventory.php
+++ b/tests/functionnal/Glpi/Inventory/Inventory.php
@@ -1792,7 +1792,7 @@ class Inventory extends InventoryTestCase
         $mlogs = new \RuleMatchedLog();
         $found = $mlogs->find(['NOT' => ['id' => array_keys($mrules_found)]]);
         $mrules_criteria['WHERE'] = ['NOT' => [\RuleMatchedLog::getTable() . '.id' => array_keys($mrules_found)]];
-        $this->array($found)->hasSize(5);
+        $this->array($found)->hasSize(3);
 
         $monitor_criteria = $mrules_criteria;
         $monitor_criteria['WHERE'][] = ['itemtype' => \Monitor::getType()];
@@ -1805,7 +1805,7 @@ class Inventory extends InventoryTestCase
         $computer_criteria['WHERE'][] = ['itemtype' => \Computer::getType()];
         $iterator = $DB->request($computer_criteria);
 
-        $this->integer(count($iterator))->isIdenticalTo(4);
+        $this->integer(count($iterator))->isIdenticalTo(2);
         foreach ($iterator as $rmlog) {
             $this->string($rmlog['name'])->isIdenticalTo('Computer update (by serial + uuid)');
             $this->integer($rmlog['items_id'])->isIdenticalTo($agent['items_id']);


### PR DESCRIPTION
The import logs were duplicated with the update rules, as `rulepassed` also adds the logs.

![image](https://user-images.githubusercontent.com/8530352/188397686-70681133-d563-412c-868a-be177396f40f.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
