### PR TITLE
Inventory: fix xml errors encoding

### DIFF
--- a/tests/units/Glpi/Inventory/Request.php
+++ b/tests/units/Glpi/Inventory/Request.php
@@ -145,7 +145,7 @@ class Request extends \GLPITestCase
         $request->handleContentType('application/xml');
         $request->handleRequest($data);
         $this->integer($request->getHttpResponseCode())->isIdenticalTo(501);
-        $this->string($request->getResponse())->isIdenticalTo("<?xml version=\"1.0\"?>\n<REPLY><ERROR>Query '$query' is not supported.</ERROR></REPLY>");
+        $this->string($request->getResponse())->isIdenticalTo("<?xml version=\"1.0\"?>\n<REPLY><ERROR><![CDATA[Query '$query' is not supported.]]></ERROR></REPLY>");
     }
 
     public function testAddError()
@@ -153,7 +153,7 @@ class Request extends \GLPITestCase
         $request = new \Glpi\Inventory\Request();
         $request->handleContentType('application/xml');
         $request->addError('Something went wrong.');
-        $this->string($request->getResponse())->isIdenticalTo("<?xml version=\"1.0\"?>\n<REPLY><ERROR>Something went wrong.</ERROR></REPLY>");
+        $this->string($request->getResponse())->isIdenticalTo("<?xml version=\"1.0\"?>\n<REPLY><ERROR><![CDATA[Something went wrong.]]></ERROR></REPLY>");
     }
 
     public function testAddResponse()

--- a/tests/web/Glpi/Inventory/Request.php
+++ b/tests/web/Glpi/Inventory/Request.php
@@ -107,7 +107,7 @@ class Request extends \GLPITestCase
                     ]
                 );
             }
-        )->hasCode(400)->message->contains('<ERROR>XML not well formed!</ERROR>');
+        )->hasCode(400)->message->contains('<ERROR><![CDATA[XML not well formed!]]></ERROR>');
     }
 
     public function testRequestInvalidJSONContent()


### PR DESCRIPTION
Importing the following XML fails (expected) but GLPI doesn't show the error message: 
```xml
<SOFTWARES>
    <ARCH>x86_64</ARCH>
    <FROM>registry</FROM>
    <GUID>GUID 01233456789 - 987654321</GUID>
    <INSTALLDATE>23/02/2021</INSTALLDATE>
    <NAME>Long software name</NAME>
    <PUBLISHER>Publisher of this software</PUBLISHER>
    <SYSTEM_CATEGORY>application</SYSTEM_CATEGORY>
    <UNINSTALL_STRING>"C:\Program Files\Common Files\Publisher of this software\Uninstall\uninstall.exe" option1=value1 option2=value2 option3=value3 option4=value4 option5=value5 option6=value6 option7=value7 option8=value8 option9=value9 option10=value10</UNINSTALL_STRING>
    <VERSION>12.0.13213389.432420033</VERSION>
</SOFTWARES>
```

Behind the scenes, this PHP error will be triggered:
```log
[2022-09-05 10:02:10] glpiphplog.WARNING:   *** PHP Warning (2): Attempt to read property "ERROR" on bool in /home/aclai/localhost/glpi/10.0-bugfixes/src/Inventory/Conf.php at line 254
  Backtrace :
  src/Inventory/Conf.php:187                         Glpi\Inventory\Conf->importContentFile()
  front/inventory.conf.php:47                        Glpi\Inventory\Conf->importFile()
```

The error above happens because the generated xml response is invalid and simplexml_load_string returns `false`.
Here is the faulty generated XML response:
```xml
<?xml version="1.0"?>
<REPLY><ERROR>
JSON does not validate. Violations:
Required property missing: content, data: {"arch":"x86_64","from":"registry","guid":"GUID 01233456789 - 987654321","installdate":"23/02/2021","name":"Long software name","publisher":"Publisher of this software","sy&nbsp;(...)
</ERROR></REPLY>
```

This XML is invalid because there is an unclosed double quote.
This happens because we shorten the json summary found inside the "ERROR" node to a set length, which might leave some double quotes unclosed.

These changes fixes this by wrapping the error message in a `<![CDATA[]]>` node,
We then get the following (valid) response:
```xml
<?xml version="1.0"?>
<REPLY><ERROR>
<![CDATA[JSON does not validate. Violations:
Required property missing: content, data: {"arch":"x86_64","from":"registry","guid":"GUID 01233456789 - 987654321","installdate":"23/02/2021","name":"Long software name","publisher":"Publisher of this software","sy&nbsp;(...)]]>
</ERROR></REPLY>
```

Which is displayed without issues in GLPI:

![image](https://user-images.githubusercontent.com/42734840/188401329-4c389dea-0a63-4b9a-9cf7-4ffae8a07a2d.png)

PS: Weirdly, I did not reproduce the issue using the JSON format, guess some other code already takes care of it ?

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
