### PR TITLE
fix(inventory): UUID is empty

### DIFF
--- a/src/RuleImportAsset.php
+++ b/src/RuleImportAsset.php
@@ -331,8 +331,6 @@ class RuleImportAsset extends Rule
 
             case Rule::PATTERN_EXISTS:
             case Rule::PATTERN_DOES_NOT_EXISTS:
-            case Rule::PATTERN_FIND:
-            case RuleImportAsset::PATTERN_IS_EMPTY:
                 Dropdown::showYesNo($name, 1, 0);
                 return true;
         }
@@ -381,7 +379,7 @@ class RuleImportAsset extends Rule
             $criteria = $this->getCriteriaByID($criterion);
             if (!empty($criteria)) {
                 foreach ($criteria as $crit) {
-                    if (!isset($input[$criterion]) || $input[$criterion] == '') {
+                    if (!isset($input[$criterion]) || ($input[$criterion] == '' && $crit->fields['condition'] != self::PATTERN_IS_EMPTY)) {
                         $definition_criteria = $this->getCriteria($crit->fields['criteria']);
                         if ($crit->fields["criteria"] == 'link_criteria_port') {
                             $this->link_criteria_port = true;
@@ -395,7 +393,7 @@ class RuleImportAsset extends Rule
                             trigger_error('A value seems missing, criterion was: ' . $criterion, E_USER_WARNING);
                             return false;
                         }
-                    } else if ($crit->fields["condition"] == Rule::PATTERN_FIND) {
+                    } else if (in_array($crit->fields["condition"], [Rule::PATTERN_FIND, Rule::PATTERN_IS_EMPTY])) {
                         $this->complex_criteria[] = $crit;
                         ++$this->found_criteria;
                     } else if ($crit->fields["condition"] == Rule::PATTERN_EXISTS) {
@@ -837,7 +835,16 @@ class RuleImportAsset extends Rule
                     break;
 
                 case 'uuid':
-                    $it_criteria['WHERE'][] = ['uuid' => $input['uuid']];
+                    if ($criterion->fields['condition'] == self::PATTERN_IS_EMPTY) {
+                        $it_criteria['WHERE'][] = [
+                            'OR' => [
+                                ["$itemtable.uuid" => ''],
+                                ["$itemtable.uuid" => null]
+                            ]
+                        ];
+                    } else {
+                        $it_criteria['WHERE'][] = ["$itemtable.uuid" => $input['uuid']];
+                    }
                     break;
 
                 case 'device_id':
@@ -1341,6 +1348,35 @@ class RuleImportAsset extends Rule
                 [
                     'criteria'  => 'uuid',
                     'condition' => Rule::PATTERN_EXISTS,
+                    'pattern'   => 1
+                ]
+            ],
+            'action'    => '_link'
+        ];
+
+        $rules[] = [
+            'name'      => 'Computer update (by serial + uuid is empty in GLPI)',
+            'match'     => 'AND',
+            'is_active' => 1,
+            'criteria'  => [
+                [
+                    'criteria'  => 'itemtype',
+                    'condition' => Rule::PATTERN_IS,
+                    'pattern'   => 'Computer'
+                ],
+                [
+                    'criteria'  => 'serial',
+                    'condition' => Rule::PATTERN_FIND,
+                    'pattern'   => 1
+                ],
+                [
+                    'criteria'  => 'serial',
+                    'condition' => Rule::PATTERN_EXISTS,
+                    'pattern'   => 1
+                ],
+                [
+                    'criteria'  => 'uuid',
+                    'condition' => Rule::PATTERN_IS_EMPTY,
                     'pattern'   => 1
                 ]
             ],

--- a/tests/functionnal/RuleImportAsset.php
+++ b/tests/functionnal/RuleImportAsset.php
@@ -1115,4 +1115,37 @@ class RuleImportAsset extends DbTestCase
             ->array($this->testedInstance->addMoreCriteria($criterion))
             ->isIdenticalTo($expected);
     }
+
+    public function testCreateComputerSerial_emptyUUID()
+    {
+        $computer = getItemByTypeName('Computer', '_test_pc01');
+        $fields   = $computer->fields;
+        unset($fields['id']);
+        unset($fields['date_creation']);
+        unset($fields['date_mod']);
+        $fields['name'] = $this->getUniqueString();
+        $fields['serial'] = '75F4BFC';
+        $this->integer((int)$computer->add(\Toolbox::addslashes_deep($fields)))->isGreaterThan(0);
+
+        $input = [
+            'itemtype' => 'Computer',
+            'name'     => 'pc-02',
+            'serial'   => '75F4BFC',
+            'uuid'     => '01391796-50A4-0246-955B-417652A8AF14',
+            'entities_id' => 0
+        ];
+
+        $ruleCollection = new \RuleImportAssetCollection();
+        $rule = new \RuleImportAsset();
+
+        $data = $ruleCollection->processAllRules($input, [], ['class' => $this]);
+
+        $this->array($data)->hasKey('_ruleid');
+        $_rule_id = (int)$data['_ruleid'];
+        $this->integer($_rule_id)->isGreaterThan(0);
+
+        $this->boolean($rule->getFromDB($_rule_id))->isTrue();
+        $this->string($rule->fields['name'])->isIdenticalTo("Computer update (by serial + uuid is empty in GLPI)");
+        $this->string($this->itemtype)->isIdenticalTo('Computer');
+    }
 }


### PR DESCRIPTION
The criterion "is empty" on the UUID was ignored during the execution of the rule.

The addition of the rule "Computer update (by serial + uuid is empty in GLPI)" fixes the case where the asset is created (manually) with a serial and no UUID, because before the default rules created a duplicate.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24715
