### PR TITLE
Fix header fg color in darker

### DIFF
--- a/css/palettes/darker.scss
+++ b/css/palettes/darker.scss
@@ -51,7 +51,7 @@ $mainmenu_bg: #414141;
 $mainmenu_fg: #f4f6fa;
 $logo: "../pics/logos/logo-GLPI-100-white.png";
 $logo_reduced: "../pics/logos/logo-G-100-white.png";
-$header-fg: #1f1f1f;
+$header-fg: $light;
 $header-border-color: transparent;
 $header-badge-bg: $light;
 $header-badge-fg: $dark;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12597

Before:
![Before](https://user-images.githubusercontent.com/107202756/188629626-c683eed9-47e9-4984-9f71-d4001f5d0fcd.png)

After:
![Selection_103](https://user-images.githubusercontent.com/17678637/188632700-aae233b3-db14-49a4-8d70-5ab35329eee2.png)

This also fixes the color of the large title and smaller section titles within the asset forms.