### PR TITLE
fix(rule): fix rule name

### DIFF
--- a/src/RuleImportAsset.php
+++ b/src/RuleImportAsset.php
@@ -1055,7 +1055,7 @@ class RuleImportAsset extends Rule
         ];
 
         $rules[] = [
-            'name'      => 'Device update (by mac+ifnumber restricted port)',
+            'name'      => 'Global update (by mac+ifnumber restricted port)',
             'match'     => 'AND',
             'is_active' => 1,
             'criteria'  => [
@@ -1094,7 +1094,7 @@ class RuleImportAsset extends Rule
         ];
 
         $rules[] = [
-            'name'      => 'Device update (by mac+ifnumber not restricted port)',
+            'name'      => 'Global update (by mac+ifnumber not restricted port)',
             'match'     => 'AND',
             'is_active' => 1,
             'criteria'  => [
@@ -1128,7 +1128,7 @@ class RuleImportAsset extends Rule
         ];
 
         $rules[] = [
-            'name'      => 'Device import (by mac+ifnumber)',
+            'name'      => 'Global import (by mac+ifnumber)',
             'match'     => 'AND',
             'is_active' => 1,
             'criteria'  => [
@@ -1152,7 +1152,7 @@ class RuleImportAsset extends Rule
         ];
 
         $rules[] = [
-            'name'      => 'Device update (by ip+ifdescr restricted port)',
+            'name'      => 'Global update (by ip+ifdescr restricted port)',
             'match'     => 'AND',
             'is_active' => 1,
             'criteria'  => [
@@ -1191,7 +1191,7 @@ class RuleImportAsset extends Rule
         ];
 
         $rules[] = [
-            'name'      => 'Device update (by ip+ifdescr not restricted port)',
+            'name'      => 'Global update (by ip+ifdescr not restricted port)',
             'match'     => 'AND',
             'is_active' => 1,
             'criteria'  => [
@@ -1225,7 +1225,7 @@ class RuleImportAsset extends Rule
         ];
 
         $rules[] = [
-            'name'      => 'Device import (by ip+ifdescr)',
+            'name'      => 'Global import (by ip+ifdescr)',
             'match'     => 'AND',
             'is_active' => 1,
             'criteria'  => [
@@ -1832,7 +1832,7 @@ class RuleImportAsset extends Rule
         ];
 
         $rules[] = [
-            'name'      => 'Peripheral update (by serial)',
+            'name'      => 'Device update (by serial)',
             'match'     => 'AND',
             'is_active' => 1,
             'criteria'  => [
@@ -1856,7 +1856,7 @@ class RuleImportAsset extends Rule
         ];
 
         $rules[] = [
-            'name'      => 'Peripheral import (by serial)',
+            'name'      => 'Device import (by serial)',
             'match'     => 'AND',
             'is_active' => 1,
             'criteria'  => [
@@ -1875,7 +1875,7 @@ class RuleImportAsset extends Rule
         ];
 
         $rules[] = [
-            'name'      => 'Peripheral import denied',
+            'name'      => 'Device import denied',
             'match'     => 'AND',
             'is_active' => 1,
             'criteria'  => [

--- a/tests/functionnal/Glpi/Inventory/Inventory.php
+++ b/tests/functionnal/Glpi/Inventory/Inventory.php
@@ -2148,7 +2148,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         $iterator = $DB->request($unmanaged_criteria);
         $this->integer(count($iterator))->isIdenticalTo(5);
         foreach ($iterator as $unmanaged) {
-            $this->string($unmanaged['name'])->isIdenticalTo('Device import (by ip+ifdescr)');
+            $this->string($unmanaged['name'])->isIdenticalTo('Global import (by ip+ifdescr)');
             $this->string($unmanaged['method'])->isIdenticalTo(\Glpi\Inventory\Request::INVENT_QUERY);
         }
     }
@@ -3688,7 +3688,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         $iterator = $DB->request($unmanaged_criteria);
         $this->integer(count($iterator))->isIdenticalTo(count($unmanageds));
         foreach ($iterator as $unmanaged) {
-            $this->string($unmanaged['name'])->isIdenticalTo('Device import (by ip+ifdescr)');
+            $this->string($unmanaged['name'])->isIdenticalTo('Global import (by ip+ifdescr)');
             $this->string($unmanaged['method'])->isIdenticalTo(\Glpi\Inventory\Request::INVENT_QUERY);
         }
     }

--- a/tests/functionnal/RuleImportAsset.php
+++ b/tests/functionnal/RuleImportAsset.php
@@ -711,7 +711,7 @@ class RuleImportAsset extends DbTestCase
         $this->integer($_rule_id)->isGreaterThan(0);
 
         $this->boolean($rule->getFromDB($_rule_id))->isTrue();
-        $this->string($rule->fields['name'])->isIdenticalTo("Device import (by mac+ifnumber)");
+        $this->string($rule->fields['name'])->isIdenticalTo("Global import (by mac+ifnumber)");
         $this->integer($this->items_id)->isIdenticalTo(0);
         $this->string($this->itemtype)->isIdenticalTo('Unmanaged'); //not handled yet...
         $this->integer($this->ports_id)->isIdenticalTo(0);
@@ -766,7 +766,7 @@ class RuleImportAsset extends DbTestCase
         $this->integer($_rule_id)->isGreaterThan(0);
 
         $this->boolean($rule->getFromDB($_rule_id))->isTrue();
-        $this->string($rule->fields['name'])->isIdenticalTo("Device update (by mac+ifnumber restricted port)");
+        $this->string($rule->fields['name'])->isIdenticalTo("Global update (by mac+ifnumber restricted port)");
         $this->integer($this->items_id)->isIdenticalTo($networkEquipments_id);
         $this->string($this->itemtype)->isIdenticalTo('NetworkEquipment');
         $this->integer($this->ports_id)->isIdenticalTo($ports_id);
@@ -836,7 +836,7 @@ class RuleImportAsset extends DbTestCase
         $this->integer($_rule_id)->isGreaterThan(0);
 
         $this->boolean($rule->getFromDB($_rule_id))->isTrue();
-        $this->string($rule->fields['name'])->isIdenticalTo("Device update (by ip+ifdescr restricted port)");
+        $this->string($rule->fields['name'])->isIdenticalTo("Global update (by ip+ifdescr restricted port)");
         $this->integer($this->items_id)->isIdenticalTo($networkEquipments_id);
         $this->string($this->itemtype)->isIdenticalTo('NetworkEquipment');
         $this->integer($this->ports_id)->isIdenticalTo($ports_id_1);
@@ -921,7 +921,7 @@ class RuleImportAsset extends DbTestCase
         $this->integer((int)$data['_ruleid'])->isGreaterThan(0);
 
         $this->boolean($rule->getFromDB($data['_ruleid']))->isTrue();
-        $this->string($rule->fields['name'])->isIdenticalTo('Device update (by ip+ifdescr not restricted port)');
+        $this->string($rule->fields['name'])->isIdenticalTo('Global update (by ip+ifdescr not restricted port)');
         $this->integer($this->items_id)->isIdenticalTo($networkEquipments_id);
         $this->string($this->itemtype)->isIdenticalTo('NetworkEquipment');
         $this->integer($this->ports_id)->isIdenticalTo($ports_id);


### PR DESCRIPTION
Only for fresh install.
some rules name are wrong

```Device``` to ```Global``` if ```itemtype``` criteria is not a ```is``` condition (use to group s by itemtype)
```Perihperal``` to ```Device``` because ```Perihperal``` class have type name ```Device```

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11950
