### PR TITLE
fix(inventory): do not unset data switch LockedField

### DIFF
--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -646,17 +646,6 @@ abstract class MainAsset extends InventoryAsset
         $_SESSION['glpiactiveentities_string'] = $entities_id;
         $_SESSION['glpiactive_entity']         = $entities_id;
 
-        //locked fields
-        $lockedfield = new Lockedfield();
-        $locks = $lockedfield->getLocks($this->item->getType(), $items_id);
-        foreach ($this->data as &$data) {
-            foreach ($locks as $lock) {
-                if (property_exists($data, $lock)) {
-                    unset($data->$lock);
-                }
-            }
-        }
-
         //handleLinks relies on $this->data; update it before the call
         $this->handleLinks();
 

--- a/tests/functionnal/Lockedfield.php
+++ b/tests/functionnal/Lockedfield.php
@@ -299,8 +299,8 @@ class Lockedfield extends DbTestCase
         $this->boolean($computer->getFromDB($computers_id))->isTrue();
         $this->integer($computer->fields['manufacturers_id'])->isEqualTo(0);
 
-        //ensure no new manufacturer has been added
-        $this->integer(countElementsInTable(\Manufacturer::getTable()))->isIdenticalTo($existing_manufacturers);
+        //ensure new manufacturer has been added -> usefull for 'value' column from LockedField in the case that it refers to a ForeignKey
+        $this->integer(countElementsInTable(\Manufacturer::getTable()))->isIdenticalTo($existing_manufacturers + 1);
     }
 
     public function testNoLocation()
@@ -420,8 +420,8 @@ class Lockedfield extends DbTestCase
         $this->boolean($printer->getFromDB($printers_id))->isTrue();
         $this->integer($printer->fields['locations_id'])->isEqualTo($locations_id);
 
-        //ensure no new location has been added
-        $this->integer(countElementsInTable(\Location::getTable()))->isIdenticalTo($existing_locations);
+        //ensure new location has been added -> usefull for 'value' column from LockedField in the case that it refers to a ForeignKey
+        $this->integer(countElementsInTable(\Location::getTable()))->isIdenticalTo($existing_locations + 1);
     }
 
     public function testNoLocationGlobal()
@@ -496,7 +496,7 @@ class Lockedfield extends DbTestCase
         $this->boolean($printer->getFromDB($printers_id))->isTrue();
         $this->integer($printer->fields['locations_id'])->isEqualTo(0);
 
-        //ensure no new location has been added
-        $this->integer(countElementsInTable(\Location::getTable()))->isIdenticalTo($existing_locations);
+        //ensure new location has been added -> usefull for 'value' column from LockedField in the case that it refers to a ForeignKey
+        $this->integer(countElementsInTable(\Location::getTable()))->isIdenticalTo($existing_locations + 1);
     }
 }


### PR DESCRIPTION
Do not unset data switch ```LockedField```

Data are handled (after) by ```CommonDBTM->update``` to fill into ```value``` column from ```LockedField```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
