### PR TITLE
Do not remove locked data in inventory prepare

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1755,6 +1755,8 @@ class CommonDBTM extends CommonGLPI
                     $lockedfield->setLastValue($this->getType(), $this->fields['id'], $lock, $this->input[$lock]);
                     unset($this->updates[$idx]);
                     unset($this->input[$lock]);
+                    $this->fields[$lock] = $this->oldvalues[$lock];
+                    unset($this->oldvalues[$lock]);
                 }
             }
             $this->updates = array_values($this->updates);

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1754,6 +1754,7 @@ class CommonDBTM extends CommonGLPI
                 if ($idx !== false) {
                     $lockedfield->setLastValue($this->getType(), $this->fields['id'], $lock, $this->input[$lock]);
                     unset($this->updates[$idx]);
+                    unset($this->input[$lock]);
                 }
             }
             $this->updates = array_values($this->updates);

--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -404,18 +404,10 @@ abstract class InventoryAsset
     protected function handleInput(\stdClass $value): array
     {
         $input = [];
-        $lockedfield = new Lockedfield();
-        $locks = $lockedfield->getLockedNames($this->item->getType(), $this->item->fields['id'] ?? 0);
-
         foreach ($value as $key => $val) {
             if (is_object($val) || is_array($val)) {
                 continue;
             }
-
-            if (in_array($key, $locks)) {
-                continue;
-            }
-
             $known_key = md5($key . $val);
             if (isset($this->known_links[$known_key])) {
                 $input[$key] = $this->known_links[$known_key];

--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -404,10 +404,18 @@ abstract class InventoryAsset
     protected function handleInput(\stdClass $value): array
     {
         $input = [];
+        $lockedfield = new Lockedfield();
+        $locks = $lockedfield->getLockedNames($this->item->getType(), $this->item->fields['id'] ?? 0);
+
         foreach ($value as $key => $val) {
             if (is_object($val) || is_array($val)) {
                 continue;
             }
+
+            if (in_array($key, $locks)) {
+                continue;
+            }
+
             $known_key = md5($key . $val);
             if (isset($this->known_links[$known_key])) {
                 $input[$key] = $this->known_links[$known_key];

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -646,15 +646,8 @@ abstract class MainAsset extends InventoryAsset
         $_SESSION['glpiactiveentities_string'] = $entities_id;
         $_SESSION['glpiactive_entity']         = $entities_id;
 
-        //locked fields
-        $lockedfield = new Lockedfield();
-        $locks = $lockedfield->getLockedNames($this->item->getType(), $items_id);
-        foreach ($this->data as &$data) {
-            foreach ($locks as $lock) {
-                if (property_exists($data, $lock)) {
-                    unset($data->$lock);
-                }
-            }
+        if ($items_id != 0) {
+            $this->item->getFromDB($items_id);
         }
 
         //handleLinks relies on $this->data; update it before the call
@@ -666,8 +659,6 @@ abstract class MainAsset extends InventoryAsset
             unset($input['firmware']);
             $items_id = $this->item->add(Toolbox::addslashes_deep($input));
             $this->setNew();
-        } else {
-            $this->item->getFromDB($items_id);
         }
 
         if (in_array($itemtype, $CFG_GLPI['agent_types'])) {

--- a/src/Lockedfield.php
+++ b/src/Lockedfield.php
@@ -178,16 +178,7 @@ class Lockedfield extends CommonDBTM
             if ($fields_only === true) {
                 $locks[] = $row['field'];
             } else {
-                $value = $row['value'];
-                //if it refers to a ForeignKey get dropdown name
-                if (
-                    $row['value'] !== null
-                    && isForeignKeyField($row['field'])
-                    && is_a($itemtype = getItemtypeForForeignKeyField($row['field']), CommonDropdown::class, true)
-                ) {
-                    $value = Dropdown::getDropdownName(getTableForItemType($itemtype), $row['value'], 0, true, false, $row['value']);
-                }
-                $locks[$row['field']] = $value;
+                $locks[$row['field']] = $row['value'];
             }
         }
         return $locks;

--- a/tests/functionnal/Lockedfield.php
+++ b/tests/functionnal/Lockedfield.php
@@ -421,6 +421,8 @@ class Lockedfield extends DbTestCase
 
         //ensure no new location has been added
         $this->integer(countElementsInTable(\Location::getTable()))->isIdenticalTo($existing_locations);
+
+        $this->array($lockedfield->getLockedValues($printer->getType(), $printers_id))->isIdenticalTo(['locations_id' => 'Greffe Charron']);
     }
 
     public function testNoLocationGlobal()

--- a/tests/functionnal/Lockedfield.php
+++ b/tests/functionnal/Lockedfield.php
@@ -500,4 +500,106 @@ class Lockedfield extends DbTestCase
         //ensure no new location has been added
         $this->integer(countElementsInTable(\Location::getTable()))->isIdenticalTo($existing_locations);
     }
+
+    public function testLockedDdValue()
+    {
+        global $DB;
+
+        //Play, with a location
+        $xml = "<?xml version=\"1.0\"?>
+<REQUEST><CONTENT><DEVICE>
+      <INFO>
+        <COMMENTS>Brother NC-6800h, Firmware Ver.1.01  (08.12.12),MID 84UB03</COMMENTS>
+        <ID>1907</ID>
+        <IPS>
+          <IP>10.75.230.125</IP>
+        </IPS>
+        <LOCATION>Greffe Charron</LOCATION>
+        <MAC>00:1b:a9:12:11:f2</MAC>
+        <MANUFACTURER>Brother</MANUFACTURER>
+        <MEMORY>32</MEMORY>
+        <MODEL>Brother HL-5350DN series</MODEL>
+        <NAME>CE75I09008</NAME>
+        <RAM>32</RAM>
+        <SERIAL>D9J230159</SERIAL>
+        <TYPE>PRINTER</TYPE>
+        <UPTIME>14 days, 22:48:33.30</UPTIME>
+      </INFO>
+    </DEVICE>
+  </CONTENT><QUERY>SNMP</QUERY><DEVICEID>glpixps.teclib.infra-2018-10-03-08-42-36</DEVICEID></REQUEST>
+";
+
+        $existing_locations = countElementsInTable(\Location::getTable());
+        $lockedfield = new \Lockedfield();
+
+        $converter = new \Glpi\Inventory\Converter();
+        $data = $converter->convert($xml);
+        $json = json_decode($data);
+
+        $inventory = new \Glpi\Inventory\Inventory($json);
+
+        if ($inventory->inError()) {
+            $this->dump($inventory->getErrors());
+        }
+        $this->boolean($inventory->inError())->isFalse();
+        $this->array($inventory->getErrors())->isEmpty();
+
+        //check matchedlogs
+        $criteria = [
+            'FROM' => \RuleMatchedLog::getTable(),
+            'LEFT JOIN' => [
+                \Rule::getTable() => [
+                    'ON' => [
+                        \RuleMatchedLog::getTable() => 'rules_id',
+                        \Rule::getTable() => 'id'
+                    ]
+                ]
+            ],
+            'WHERE' => []
+        ];
+        $iterator = $DB->request($criteria);
+        $this->string($iterator->current()['name'])->isIdenticalTo('Printer import (by serial)');
+
+        $printers_id = $inventory->getItem()->fields['id'];
+        $this->integer($printers_id)->isGreaterThan(0);
+
+        $printer = new \Printer();
+        $this->boolean($printer->getFromDB($printers_id))->isTrue();
+        $this->integer($printer->fields['locations_id'])->isGreaterThan(0);
+
+        //ensure new location has been added
+        ++$existing_locations;
+        $this->integer(countElementsInTable(\Location::getTable()))->isIdenticalTo($existing_locations);
+
+        //manually update to lock locations_id field
+        $locations_id = getItemByTypeName('Location', '_location02', true);
+        $this->boolean(
+            $printer->update([
+                'id' => $printers_id,
+                'locations_id' => $locations_id,
+                'id_dynamic' => true
+            ])
+        )->isTrue();
+        $this->array($lockedfield->getLockedValues($printer->getType(), $printers_id))->isIdenticalTo(['locations_id' => null]);
+
+        //Replay, with a location, to ensure location has not been updated, and locked value is correct.
+        $data = $converter->convert($xml);
+        $json = json_decode($data);
+
+        $inventory = new \Glpi\Inventory\Inventory($json);
+
+        if ($inventory->inError()) {
+            $this->dump($inventory->getErrors());
+        }
+        $this->boolean($inventory->inError())->isFalse();
+        $this->array($inventory->getErrors())->isEmpty();
+
+        $this->boolean($printer->getFromDB($printers_id))->isTrue();
+        $this->integer($printer->fields['locations_id'])->isEqualTo($locations_id);
+
+        //ensure no new location has been added
+        $this->integer(countElementsInTable(\Location::getTable()))->isIdenticalTo($existing_locations);
+
+        $this->array($lockedfield->getLockedValues($printer->getType(), $printers_id))->isIdenticalTo(['locations_id' => 'Greffe Charron']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

Removing locked data in inventory preparation causes values not to be stored in locked fields table.
This PR removes that, but still prevents locked relations to be created.