### PR TITLE
fix width of timeline item when displayed within todo layout

### DIFF
--- a/css/includes/components/itilobject/_timeline.scss
+++ b/css/includes/components/itilobject/_timeline.scss
@@ -492,6 +492,7 @@
 
                 .timeline-content {
                     border-radius: 0;
+                    max-width: initial;
 
                     .card-body {
                         padding: 0.5rem;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
