### PR TITLE
fix(inventory): rights check

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -33,6 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Inventory\Conf;
 use Glpi\Socket;
 use Glpi\Toolbox\Sanitizer;
 
@@ -7641,11 +7642,11 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'inventory',
-                'rights' => READ,
+                'rights' => READ | Conf::IMPORTFROMFILE | Conf::UPDATECONFIG,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'inventory',
-                'rights' => READ,
+                'rights' => READ | Conf::IMPORTFROMFILE | Conf::UPDATECONFIG,
             ], [
                 'profiles_id' => self::PROFILE_HOTLINER,
                 'name' => 'inventory',

--- a/install/migrations/update_10.0.2_to_10.0.3/inventory.php
+++ b/install/migrations/update_10.0.2_to_10.0.3/inventory.php
@@ -41,4 +41,4 @@ use Glpi\Inventory\Conf;
  */
 
 //new right value for inventory
-$migration->updateRight('inventory', READ + Conf::IMPORTFROMFILE + Conf::UPDATECONFIG, ['config' => UPDATE, 'inventory' => READ]);
+$migration->updateRight('inventory', READ | Conf::IMPORTFROMFILE | Conf::UPDATECONFIG, ['config' => UPDATE, 'inventory' => READ]);

--- a/install/migrations/update_10.0.2_to_10.0.3/inventory.php
+++ b/install/migrations/update_10.0.2_to_10.0.3/inventory.php
@@ -41,21 +41,4 @@ use Glpi\Inventory\Conf;
  */
 
 //new right value for inventory
-//give full rights to profiles having config right
-foreach ($DB->request("glpi_profilerights", "`name` = 'config'") as $profrights) {
-    if ($profrights['rights'] && (Conf::UPDATECONFIG + Conf::IMPORTFROMFILE)) {
-        $rightValue = READ + Conf::UPDATECONFIG + Conf::IMPORTFROMFILE;
-    } else {
-        $rightValue = 0;
-    }
-    $DB->update(
-        "glpi_profilerights",
-        [
-            'rights' => $rightValue
-        ],
-        [
-            'profiles_id' => $profrights['profiles_id'],
-            'name'        => 'inventory'
-        ]
-    );
-}
+$migration->updateRight('inventory', READ + Conf::IMPORTFROMFILE + Conf::UPDATECONFIG, ['config' => UPDATE, 'inventory' => READ]);

--- a/src/Inventory/Conf.php
+++ b/src/Inventory/Conf.php
@@ -951,7 +951,7 @@ class Conf extends CommonGLPI
             'long'  => __('Import from file')
         ];
         $values[self::UPDATECONFIG] = ['short' => __('Configure'),
-            'long'  => __('Configure importation')
+            'long'  => __('Import configuration')
         ];
 
         return $values;

--- a/src/Inventory/Conf.php
+++ b/src/Inventory/Conf.php
@@ -141,6 +141,11 @@ class Conf extends CommonGLPI
 
     public const STALE_AGENT_ACTION_STATUS = 1;
 
+    public static $rightname = 'inventory';
+
+    const IMPORTFROMFILE     = 1024;
+    const UPDATECONFIG       = 2048;
+
     /**
      * Display form for import the XML
      *
@@ -296,10 +301,13 @@ class Conf extends CommonGLPI
     {
         switch ($item->getType()) {
             case __CLASS__:
-                $tabs = [
-                    1 => __('Configuration'),
-                    2 => __('Import from file')
-                ];
+                $tabs = [];
+                if (Session::haveRight(self::$rightname, self::UPDATECONFIG)) {
+                    $tabs[1] = __('Configuration');
+                }
+                if (Session::haveRight(self::$rightname, self::IMPORTFROMFILE)) {
+                    $tabs[2] = __('Import from file');
+                }
                 return $tabs;
         }
         return '';
@@ -938,7 +946,15 @@ class Conf extends CommonGLPI
 
     public function getRights($interface = 'central')
     {
-        return [ READ => __('Read')];
+        $values = [ READ => __('Read')];
+        $values[self::IMPORTFROMFILE] = ['short' => __('Import'),
+            'long'  => __('Import from file')
+        ];
+        $values[self::UPDATECONFIG] = ['short' => __('Configure'),
+            'long'  => __('Configure importation')
+        ];
+
+        return $values;
     }
 
     /**

--- a/src/Inventory/Inventory.php
+++ b/src/Inventory/Inventory.php
@@ -85,8 +85,6 @@ class Inventory
     private $request_query;
     /** @var bool */
     private bool $is_discovery = false;
-    /** @var string */
-    public static $rightname = 'inventory';
 
     /**
      * @param mixed   $data   Inventory data, optional
@@ -459,7 +457,7 @@ class Inventory
 
     public static function getMenuContent()
     {
-        if (!Session::haveRight(self::$rightname, Conf::IMPORTFROMFILE)) {
+        if (!Session::haveRight(Conf::$rightname, Conf::IMPORTFROMFILE)) {
             return false;
         }
 

--- a/src/Inventory/Inventory.php
+++ b/src/Inventory/Inventory.php
@@ -85,6 +85,8 @@ class Inventory
     private $request_query;
     /** @var bool */
     private bool $is_discovery = false;
+    /** @var string */
+    public static $rightname = 'inventory';
 
     /**
      * @param mixed   $data   Inventory data, optional
@@ -457,8 +459,7 @@ class Inventory
 
     public static function getMenuContent()
     {
-        // Require config update permission globally
-        if (!Session::haveRight('config', UPDATE)) {
+        if (!Session::haveRight(self::$rightname, Conf::IMPORTFROMFILE)) {
             return false;
         }
 

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -1233,7 +1233,7 @@ class Migration
      *
      * @return void
      */
-    public function updateRight($name, $rights = ALLSTANDARDRIGHT, $requiredrights = ['config' => READ | UPDATE])
+    public function updateRight($name, $rights, $requiredrights = ['config' => READ | UPDATE])
     {
         global $DB;
 

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -1222,12 +1222,12 @@ class Migration
 
     /**
      * Update right to profiles that match rights requirements
-     *    Default is to give rights to profiles with READ and UPDATE rights on config
+     *    Default is to update rights of profiles with READ and UPDATE rights on config
      *
      * @param string  $name   Right name
-     * @param integer $rights Right to set (defaults to ALLSTANDARDRIGHT)
+     * @param integer $rights Right to set
      * @param array   $requiredrights Array of right name => value
-     *                   A profile must have these rights in order to get the new right.
+     *                   A profile must have these rights in order to get its rights updated.
      *                   This array can be empty to add the right to every profile.
      *                   Default is ['config' => READ | UPDATE].
      *

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -1266,7 +1266,7 @@ class Migration
         );
 
         foreach ($prof_iterator as $profile) {
-            $DB->updateOrDie(
+            $DB->updateOrInsert(
                 'glpi_profilerights',
                 [
                     'rights'       => $rights


### PR DESCRIPTION
Since GLPI 10.0, the inventory is native, but the management of the rights is much less precise than before, because it depends only on the right UPDATE on the general configuration.

This PR, adds 2 rights corresponding to the 2 tabs of the inventory menu:

![image](https://user-images.githubusercontent.com/8530352/189160600-152d6ec8-a905-4f45-a809-cbcae5398df4.png)

![image](https://user-images.githubusercontent.com/8530352/189160151-88884708-09f1-4678-997c-8dda60e3ffa1.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24880
