### PR TITLE
Drop irrelevant comments

### DIFF
--- a/src/Inventory/Asset/NetworkPort.php
+++ b/src/Inventory/Asset/NetworkPort.php
@@ -264,7 +264,7 @@ class NetworkPort extends InventoryAsset
             return;
         }
 
-       //reset, will be populated from rulepassed
+        //reset, will be populated from rulepassed
         $this->connection_ports = [];
         $this->current_port = $port;
         $netport = new \NetworkPort();
@@ -281,7 +281,6 @@ class NetworkPort extends InventoryAsset
         }
 
         $found_macs = [];
-        //FIXME Static analysis says this property is always an empty array. I don't see it get set even within the rule(s)
         foreach ($this->connection_ports as $ids) {
             $found_macs += $ids;
         }
@@ -290,8 +289,7 @@ class NetworkPort extends InventoryAsset
             return;
         }
 
-       // Try detect phone + computer on this port
-        //FIXME Static analysis says this property is always an empty array. I don't see it get set even within the rule(s)
+        // Try to detect phone + computer on this port
         if (isset($this->connection_ports['Phone']) && count($found_macs) == 2) {
             trigger_error('Phone/Computer MAC linked', E_USER_WARNING);
             return;
@@ -303,7 +301,6 @@ class NetworkPort extends InventoryAsset
             }
             $this->handleHub($found_macs, $netports_id);
         } else { // One mac on port
-            //FIXME Static analysis says this property is always an empty array. I don't see it get set even within the rule(s)
             if (count($this->connection_ports)) {
                 $connections_id = current(current($this->connection_ports));
                 $this->addPortsWiring($netports_id, $connections_id);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Static analysis is wrong. The array is populated from the `rulepassed` method, which is called by `processAllRules` call (we pass the `class` parameter).