### PR TITLE
ITIL Timeline: restore rich-text-container class

### DIFF
--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -44,7 +44,7 @@
 
 {% block timeline_card %}
    {% if form_mode == 'view' %}
-      <div class="read-only-content">
+      <div class="read-only-content rich_text_container">
          {{ entry_i['content']|enhanced_html({
             'user_mentions': true,
             'images_gallery': true

--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -44,7 +44,7 @@
 
 {% block timeline_card %}
    {% if form_mode == 'view' %}
-      <div class="read-only-content ">
+      <div class="read-only-content">
          <div class="rich_text_container">
             {{ entry_i['content']|enhanced_html({
                'user_mentions': true,

--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -44,11 +44,13 @@
 
 {% block timeline_card %}
    {% if form_mode == 'view' %}
-      <div class="read-only-content rich_text_container">
-         {{ entry_i['content']|enhanced_html({
-            'user_mentions': true,
-            'images_gallery': true
-         }) }}
+      <div class="read-only-content ">
+         <div class= "rich_text_container">
+            {{ entry_i['content']|enhanced_html({
+               'user_mentions': true,
+               'images_gallery': true
+            }) }}
+         </div>
 
          <div class="timeline-badges">
             {% if entry_i['sourceitems_id'] %}

--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -45,7 +45,7 @@
 {% block timeline_card %}
    {% if form_mode == 'view' %}
       <div class="read-only-content ">
-         <div class= "rich_text_container">
+         <div class="rich_text_container">
             {{ entry_i['content']|enhanced_html({
                'user_mentions': true,
                'images_gallery': true

--- a/templates/components/itilobject/timeline/form_solution.html.twig
+++ b/templates/components/itilobject/timeline/form_solution.html.twig
@@ -47,10 +47,10 @@
    {% if form_mode == 'view' %}
       <div class="read-only-content">
          <div class= "rich_text_container">
-         {{ entry_i['content']|enhanced_html({
-            'user_mentions': true,
-            'images_gallery': true
-         }) }}
+            {{ entry_i['content']|enhanced_html({
+               'user_mentions': true,
+               'images_gallery': true
+            }) }}
          </div>
 
          <div class="timeline-badges">

--- a/templates/components/itilobject/timeline/form_solution.html.twig
+++ b/templates/components/itilobject/timeline/form_solution.html.twig
@@ -45,7 +45,7 @@
 
 {% block timeline_card %}
    {% if form_mode == 'view' %}
-      <div class="read-only-content">
+      <div class="read-only-content rich_text_container">
          {{ entry_i['content']|enhanced_html({
             'user_mentions': true,
             'images_gallery': true

--- a/templates/components/itilobject/timeline/form_solution.html.twig
+++ b/templates/components/itilobject/timeline/form_solution.html.twig
@@ -45,11 +45,13 @@
 
 {% block timeline_card %}
    {% if form_mode == 'view' %}
-      <div class="read-only-content rich_text_container">
+      <div class="read-only-content">
+         <div class= "rich_text_container">
          {{ entry_i['content']|enhanced_html({
             'user_mentions': true,
             'images_gallery': true
          }) }}
+         </div>
 
          <div class="timeline-badges">
             {% if entry_i['solutiontypes_id'] %}

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -44,7 +44,7 @@
 
 {% block timeline_card %}
    {% if form_mode == 'view' %}
-      <div class="read-only-content {{ entry_i['state'] is constant('Planning::DONE') ? 'done' : '' }}">
+      <div class="read-only-content rich_text_container {{ entry_i['state'] is constant('Planning::DONE') ? 'done' : '' }}">
          <div class="text-content" data-bs-html="true" data-bs-custom-class="todo-list-tooltip"
               title="{{ entry_i['content']|html_to_text }}" data-bs-toggle="tooltip">
             {{ entry_i['content']|enhanced_html({

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -44,8 +44,8 @@
 
 {% block timeline_card %}
    {% if form_mode == 'view' %}
-      <div class="read-only-content rich_text_container {{ entry_i['state'] is constant('Planning::DONE') ? 'done' : '' }}">
-         <div class="text-content" data-bs-html="true" data-bs-custom-class="todo-list-tooltip"
+      <div class="read-only-content {{ entry_i['state'] is constant('Planning::DONE') ? 'done' : '' }}">
+         <div class="rich_text_container text-content" data-bs-html="true" data-bs-custom-class="todo-list-tooltip"
               title="{{ entry_i['content']|html_to_text }}" data-bs-toggle="tooltip">
             {{ entry_i['content']|enhanced_html({
                'user_mentions': true,

--- a/templates/components/itilobject/timeline/form_validation.html.twig
+++ b/templates/components/itilobject/timeline/form_validation.html.twig
@@ -38,7 +38,7 @@
 
 {% block timeline_card %}
    {% if form_mode == 'view' %}
-      <div class="read-only-content w-100">
+      <div class="read-only-content rich_text_container w-100">
          {{ entry_i['content']|raw }}
 
          {% if entry_i['comment_submission']|length %}

--- a/templates/components/itilobject/timeline/form_validation.html.twig
+++ b/templates/components/itilobject/timeline/form_validation.html.twig
@@ -38,14 +38,14 @@
 
 {% block timeline_card %}
    {% if form_mode == 'view' %}
-      <div class="read-only-content rich_text_container w-100">
+      <div class="read-only-content w-100">
          {{ entry_i['content']|raw }}
 
          {% if entry_i['comment_submission']|length %}
             <div class='alert alert-info mt-2'>
                 <div class='d-flex'>
                     <div><i class='ti ti-quote me-2'></i></div>
-                    <div>
+                    <div class="rich_text_container">
                         {{ entry_i['comment_submission']|enhanced_html({
                             'user_mentions': true,
                             'images_gallery': true
@@ -58,7 +58,7 @@
             <div class='alert alert-info mt-2'>
                 <div class='d-flex'>
                     <div><i class='ti ti-quote me-2'></i></div>
-                    <div>
+                    <div class="rich_text_container">
                         {{ entry_i['comment_validation']|enhanced_html({
                             'user_mentions': true,
                             'images_gallery': true

--- a/templates/components/itilobject/timeline/main_description.html.twig
+++ b/templates/components/itilobject/timeline/main_description.html.twig
@@ -73,17 +73,19 @@
                   </button>
                </div>
 
-               <div class="read-only-content rich_text_container">
+               <div class="read-only-content">
                   {% if not itiltemplate.isHiddenField('name') %}
                      <div class="card-title card-header mx-n3 mt-n3">
                         {{ item.fields['name']|verbatim_value }}
                      </div>
                   {% endif %}
                   {% if not itiltemplate.isHiddenField('content') %}
-                     {{ item.fields['content']|enhanced_html({
-                        'user_mentions': true,
-                        'images_gallery': true
-                     }) }}
+                     <div class="rich_text_container">
+                        {{ item.fields['content']|enhanced_html({
+                           'user_mentions': true,
+                           'images_gallery': true
+                        }) }}
+                     </div>
                   {% endif %}
                </div>
                <div class="edit-content collapse">

--- a/templates/components/itilobject/timeline/main_description.html.twig
+++ b/templates/components/itilobject/timeline/main_description.html.twig
@@ -73,7 +73,7 @@
                   </button>
                </div>
 
-               <div class="read-only-content">
+               <div class="read-only-content rich_text_container">
                   {% if not itiltemplate.isHiddenField('name') %}
                      <div class="card-title card-header mx-n3 mt-n3">
                         {{ item.fields['name']|verbatim_value }}

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -156,7 +156,7 @@
                            {% endif %}
                         {% endif %}
                      {% else %}
-                        <div class="read-only-content">
+                        <div class="read-only-content rich_text_container">
                            {{ entry_i['content']|safe_html }}
                         </div>
                      {% endif %}

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -156,7 +156,7 @@
                            {% endif %}
                         {% endif %}
                      {% else %}
-                        <div class="read-only-content rich_text_container">
+                        <div class="read-only-content">
                            {{ entry_i['content']|safe_html }}
                         </div>
                      {% endif %}


### PR DESCRIPTION
All rich text content should be wrapped with the `rich-text-container` class.
It seems to be missing on the timeline.

I've found that the `read-only-content` content class was applied to every timeline items so I've added the `rich-text-container` next to it which should cover every rich text elements hopefully.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
