### PR TITLE
give itemtype the ability to modify their data before add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ The present file will list all changes made to the project; according to the
 
 ### Added
 
-- `CommonDBTM::pre_addToDB()` added.
-
 ### Changed
 
 ### Deprecated
@@ -18,6 +16,8 @@ The present file will list all changes made to the project; according to the
 ### API changes
 
 #### Added
+
+- `CommonDBTM::pre_addToDB()` added.
 
 #### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The present file will list all changes made to the project; according to the
 
 ### Added
 
+- `CommonDBTM::pre_addToDB()` added.
+
 ### Changed
 
 ### Deprecated

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1291,6 +1291,8 @@ class CommonDBTM extends CommonGLPI
             $this->fields = [];
             $table_fields = $DB->listFields($this->getTable());
 
+            $this->pre_addInDB();
+
             // fill array for add
             $this->cleanLockedsOnAdd();
             foreach (array_keys($this->input) as $key) {
@@ -1928,6 +1930,18 @@ class CommonDBTM extends CommonGLPI
 
 
     /**
+     * Actions done before the ADD of the item in the database
+     *
+     * @since 10.0.3
+     *
+     * @return void
+     */
+    public function pre_addInDB()
+    {
+    }
+
+
+     /**
      * Actions done before the UPDATE of the item in the database
      *
      * @return void


### PR DESCRIPTION
Similar to CommonDBTM::pre_updateInDB()

A use case would  be the management of a complex data which is hard / useless to store il multiple fields. It could be JSON encoded in a single field of the DB, but for manipulation should be decoded. 

Combined with post_getFromDB and pre_updateInDb(), the new method pre_addInDB() could handle the JSON encode/decode process without hassle, maintaining in RAM the data as an array or an object, at developer's convenience.


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
