### PR TITLE
Richtext: open links in new tab by default

### DIFF
--- a/css/includes/components/_richtext.scss
+++ b/css/includes/components/_richtext.scss
@@ -62,7 +62,7 @@ body.mce-content-body {
     }
 
     a[target="_blank"]::before {
-        font-family: "tabler-icons";
+        font-family: tabler-icons;
         content: "\ea99";
         padding-right: 4px;
     }

--- a/css/includes/components/_richtext.scss
+++ b/css/includes/components/_richtext.scss
@@ -61,10 +61,10 @@ body.mce-content-body {
         max-width: 100%;
     }
 
-    a[target="_blank"]::after {
+    a[target="_blank"]::before {
         font-family: "tabler-icons";
         content: "\ea99";
-        padding-left: 4px;
+        padding-right: 4px;
     }
 }
 

--- a/css/includes/components/_richtext.scss
+++ b/css/includes/components/_richtext.scss
@@ -60,6 +60,12 @@ body.mce-content-body {
     img {
         max-width: 100%;
     }
+
+    a[target="_blank"]::after {
+        font-family: "tabler-icons";
+        content: "\ea99";
+        padding-left: 4px;
+    }
 }
 
 .user-mention,

--- a/src/Html.php
+++ b/src/Html.php
@@ -3880,6 +3880,7 @@ JS;
 
             // init editor
             tinyMCE.init(Object.assign({
+               link_default_target: '_blank',
                branding: false,
                selector: '#{$id}',
 

--- a/src/RichText/RichText.php
+++ b/src/RichText/RichText.php
@@ -250,7 +250,7 @@ final class RichText
 
         if ($enhanced_html) {
             // URLs have to be transformed into <a> tags.
-            $content = autolink($content, false);
+            $content = autolink($content, false, ' target="_blank"');
         }
 
         return $content;

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -60,6 +60,7 @@ module.exports = {
             {
                 "ignoreFontFamilies": [
                     "Font Awesome 5 Free",
+                    "tabler-icons",
                 ],
             }
         ],

--- a/tests/units/Glpi/RichText/RichText.php
+++ b/tests/units/Glpi/RichText/RichText.php
@@ -117,8 +117,8 @@ PLAINTEXT,
 1. br should be added for each "\\r?\\n"<br />
 <br />
 2. contained URL should be transformed into links:<br />
- - <a href="http://www.glpi-project.org">www.glpi-project.org</a><br />
- - <a href="mailto:test@glpi-project.org">mailto:test@glpi-project.org</a><br />
+ - <a href="http://www.glpi-project.org" target="_blank">www.glpi-project.org</a><br />
+ - <a href="mailto:test@glpi-project.org" target="_blank">mailto:test@glpi-project.org</a><br />
 </p>
 HTML,
         ];


### PR DESCRIPTION
Links made with the TinyMCE's link plugin (right click -> link) will now target a new tab by default.

![image](https://user-images.githubusercontent.com/42734840/189348982-f0631cdb-af93-4894-94fc-ce7f3d825a6f.png)

Links added with the autolink PHP lib will always be in a new tab.

As suggested by @cedric-anne, I've also added an icon to hint at this new behavior:
![image](https://user-images.githubusercontent.com/42734840/189348526-961c8ff5-4b12-4abb-b923-8b4074490446.png)

The icon could also be placed on the left, let me know which one is better:

![image](https://user-images.githubusercontent.com/42734840/189348761-d3b50123-0047-43f2-8207-61ebe4b4cc3a.png)


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24845
