### PR TITLE
feat(escalation level): increase execution time

### DIFF
--- a/src/LevelAgreementLevel.php
+++ b/src/LevelAgreementLevel.php
@@ -288,7 +288,7 @@ abstract class LevelAgreementLevel extends RuleTicket
             }
         }
 
-        for ($i = 1; $i < 30; $i++) {
+        for ($i = 1; $i <= 100; $i++) {
             if (!in_array($i * DAY_TIMESTAMP, $p['used'])) {
                 $possible_values[$i * DAY_TIMESTAMP] = sprintf(_n('+ %d day', '+ %d days', $i), $i);
             }


### PR DESCRIPTION
Increase the maximum value of the execution time to +/- 100 days (instead of 29)

![image](https://user-images.githubusercontent.com/8530352/189831436-098fbfac-61a1-46db-bb46-0865a48e4748.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24832
