### PR TITLE
Fix softwarecategories import update

### DIFF
--- a/src/Inventory/Asset/Software.php
+++ b/src/Inventory/Asset/Software.php
@@ -362,7 +362,7 @@ class Software extends InventoryAsset
                 $software_to_update->update([
                     "id" => $db_software_data[$key_wo_version]['softid'],
                     "softwarecategories_id" => $val->softwarecategories_id
-                ]);
+                ], 0);
             }
 
             if (isset($db_software[$key_w_version])) {

--- a/src/Inventory/Asset/Software.php
+++ b/src/Inventory/Asset/Software.php
@@ -145,8 +145,25 @@ class Software extends InventoryAsset
                     $val->version = $res_rule["version"];
                 }
 
+                //If the software categorie has been modified or set by the rules engine
                 if (isset($res_rule["softwarecategories_id"])) {
                     $val->softwarecategories_id = $res_rule["softwarecategories_id"];
+                } else if (
+                    property_exists($val, '_system_category')
+                    && $val->_system_category != ''
+                    && $val->_system_category != '0'
+                ) {
+                    if (!isset($mids[$val->_system_category])) {
+                        $new_value = Dropdown::importExternal(
+                            'SoftwareCategory',
+                            addslashes($val->_system_category),
+                            $this->entities_id
+                        );
+                        $mids[$val->_system_category] = $new_value;
+                    }
+                    $val->softwarecategories_id = $mids[$val->_system_category];
+                } else {
+                    $val->softwarecategories_id = 0;
                 }
 
                 //If the manufacturer has been modified or set by the rules engine
@@ -272,6 +289,7 @@ class Software extends InventoryAsset
                 'glpi_softwareversions.arch',
                 'glpi_softwares.manufacturers_id',
                 'glpi_softwares.entities_id',
+                'glpi_softwares.softwarecategories_id',
                 'glpi_softwares.is_recursive',
                 'glpi_softwareversions.operatingsystems_id',
             ],
@@ -309,6 +327,12 @@ class Software extends InventoryAsset
                 'version'   => $data['version'],
                 'name'      => $data['name'],
             ];
+            $db_software_data[$key_wo_version] = [
+                'softid'             => $data['softid'],
+                'softwarecategories' => $data['softwarecategories_id'],
+                'name'               => $data['name'],
+                'manufacturer'       => $data['manufacturers_id'],
+            ];
         }
 
         //check for existing links
@@ -327,6 +351,20 @@ class Software extends InventoryAsset
             $new_version = $val->version;
 
             $dedup_vkey = $key_w_version . $this->getVersionKey($val, 0);
+
+            //update softwarecategories if needed
+            //reconciles the software without the version (no needed here)
+            if (
+                isset($db_software_data[$key_wo_version])
+                && $db_software_data[$key_wo_version]['softwarecategories'] != $val->softwarecategories_id
+            ) {
+                $software_to_update = new GSoftware();
+                $software_to_update->update([
+                    "id" => $db_software_data[$key_wo_version]['softid'],
+                    "softwarecategories_id" => $val->softwarecategories_id
+                ]);
+            }
+
             if (isset($db_software[$key_w_version])) {
                 // software exist with the same version
                 unset($this->data[$k]);

--- a/tests/functionnal/Glpi/Inventory/Assets/Software.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Software.php
@@ -56,7 +56,7 @@ class Software extends AbstractInventoryAsset
       <INSTALLDATE>03/09/2018</INSTALLDATE>
       <NAME>gimp</NAME>
       <PUBLISHER>Fedora Project</PUBLISHER>
-      <SYSTEM_CATEGORY>Unspecified</SYSTEM_CATEGORY>
+      <SYSTEM_CATEGORY>Application</SYSTEM_CATEGORY>
       <VERSION>2.8.22-7.fc28</VERSION>
     </SOFTWARES>
     <VERSIONCLIENT>FusionInventory-Inventory_v2.4.1-2.fc28</VERSIONCLIENT>
@@ -64,7 +64,7 @@ class Software extends AbstractInventoryAsset
   <DEVICEID>glpixps.teclib.infra-2018-10-03-08-42-36</DEVICEID>
   <QUERY>INVENTORY</QUERY>
   </REQUEST>",
-                'expected'  => '{"arch": "x86_64", "comments": "GNU Image Manipulation Program", "filesize": 67382735, "from": "rpm", "name": "gimp", "publisher": "Fedora Project", "system_category": "Unspecified", "version": "2.8.22-7.fc28", "install_date": "2018-09-03", "manufacturers_id": "Feodra Project", "comment": "GNU Image Manipulation Program", "_system_category": "Unspecified", "operatingsystems_id": 0, "entities_id": 0, "is_template_item": 0, "is_deleted_item": 0, "is_recursive": 0, "date_install": "2018-09-03"}'
+                'expected'  => '{"arch": "x86_64", "comments": "GNU Image Manipulation Program", "filesize": 67382735, "from": "rpm", "name": "gimp", "publisher": "Fedora Project", "system_category": "Application", "version": "2.8.22-7.fc28", "install_date": "2018-09-03", "manufacturers_id": "Feodra Project", "comment": "GNU Image Manipulation Program", "_system_category": "Application", "operatingsystems_id": 0, "entities_id": 0, "is_template_item": 0, "is_deleted_item": 0, "is_recursive": 0, "date_install": "2018-09-03"}'
             ],
             [
                 'xml' => "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
@@ -88,7 +88,7 @@ class Software extends AbstractInventoryAsset
       <INSTALLDATE>03/09/2018</INSTALLDATE>
       <NAME>gimp</NAME>
       <PUBLISHER>Fedora Project</PUBLISHER>
-      <SYSTEM_CATEGORY>Unspecified</SYSTEM_CATEGORY>
+      <SYSTEM_CATEGORY>System Component</SYSTEM_CATEGORY>
       <VERSION>2.8.22-7.fc28</VERSION>
     </SOFTWARES>
     <VERSIONCLIENT>FusionInventory-Inventory_v2.4.1-2.fc28</VERSIONCLIENT>
@@ -96,7 +96,7 @@ class Software extends AbstractInventoryAsset
   <DEVICEID>glpixps.teclib.infra-2018-10-03-08-42-36</DEVICEID>
   <QUERY>INVENTORY</QUERY>
   </REQUEST>",
-                'expected'  => '{"arch": "x86_64", "comments": "GNU Image Manipulation Program", "filesize": 67382735, "from": "rpm", "name": "gimp", "publisher": "Fedora Project", "system_category": "Unspecified", "version": "2.8.22-7.fc28", "install_date": "2018-09-03", "manufacturers_id": "Feodra Project", "comment": "GNU Image Manipulation Program", "_system_category": "Unspecified", "operatingsystems_id": 0, "entities_id": 0, "is_template_item": 0, "is_deleted_item": 0, "is_recursive": 0, "date_install": "2018-09-03"}'
+                'expected'  => '{"arch": "x86_64", "comments": "GNU Image Manipulation Program", "filesize": 67382735, "from": "rpm", "name": "gimp", "publisher": "Fedora Project", "system_category": "System Component", "version": "2.8.22-7.fc28", "install_date": "2018-09-03", "manufacturers_id": "Feodra Project", "comment": "GNU Image Manipulation Program", "_system_category": "System Component", "operatingsystems_id": 0, "entities_id": 0, "is_template_item": 0, "is_deleted_item": 0, "is_recursive": 0, "date_install": "2018-09-03"}'
             ]
         ];
     }
@@ -117,9 +117,15 @@ class Software extends AbstractInventoryAsset
 
        //Manufacturer has been imported into db...
         $expected = json_decode($expected);
+
         $manu = new \Manufacturer();
         $this->boolean($manu->getFromDbByCrit(['name' => $result[0]->publisher]))->isTrue();
         $expected->manufacturers_id = $manu->fields['id'];
+
+        $softCate = new \SoftwareCategory();
+        $this->boolean($softCate->getFromDbByCrit(['name' => $result[0]->system_category]))->isTrue();
+        $expected->softwarecategories_id = $softCate->fields['id'];
+
         $this->object($result[0])->isEqualTo($expected);
     }
 
@@ -147,6 +153,9 @@ class Software extends AbstractInventoryAsset
         $manu = new \Manufacturer();
         $this->boolean($manu->getFromDbByCrit(['name' => $result[0]->publisher]))->isTrue();
         $expected->manufacturers_id = $manu->fields['id'];
+        $softCate = new \SoftwareCategory();
+        $this->boolean($softCate->getFromDbByCrit(['name' => $result[0]->system_category]))->isTrue();
+        $expected->softwarecategories_id = $softCate->fields['id'];
         $this->object($result[0])->isEqualTo($expected);
 
        //handle
@@ -183,6 +192,9 @@ class Software extends AbstractInventoryAsset
         $manu = new \Manufacturer();
         $this->boolean($manu->getFromDbByCrit(['name' => $result[0]->publisher]))->isTrue();
         $expected->manufacturers_id = $manu->fields['id'];
+        $softCate = new \SoftwareCategory();
+        $this->boolean($softCate->getFromDbByCrit(['name' => $result[0]->system_category]))->isTrue();
+        $expected->softwarecategories_id = $softCate->fields['id'];
         $this->object($result[0])->isEqualTo($expected);
 
        //handle
@@ -231,10 +243,12 @@ class Software extends AbstractInventoryAsset
 
     public function testInventoryUpdate()
     {
+        global $DB;
         $computer = new \Computer();
         $soft = new \Software();
         $version = new \SoftwareVersion();
         $item_version = new \Item_SoftwareVersion();
+        $software_categorie = new \SoftwareCategory();
 
         $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
 <REQUEST>
@@ -247,7 +261,7 @@ class Software extends AbstractInventoryAsset
       <INSTALLDATE>03/10/2021</INSTALLDATE>
       <NAME>gimp</NAME>
       <PUBLISHER>Fedora Project</PUBLISHER>
-      <SYSTEM_CATEGORY>Unspecified</SYSTEM_CATEGORY>
+      <SYSTEM_CATEGORY>Application</SYSTEM_CATEGORY>
       <VERSION>2.10.28-1.fc34</VERSION>
     </SOFTWARES>
     <SOFTWARES>
@@ -291,6 +305,54 @@ class Software extends AbstractInventoryAsset
         $versions = $version->find(['NOT' => ['name' => ['LIKE', '_test_%']]]);
         $this->integer(count($versions))->isIdenticalTo(2);
 
+
+        //check that sofware exist with softwarecategories
+        $criteria = [
+            'FROM' => \Software::getTable(),
+            'LEFT JOIN' => [
+                \SoftwareCategory::getTable() => [
+                    'ON' => [
+                        \Software::getTable() => 'softwarecategories_id',
+                        \SoftwareCategory::getTable() => 'id'
+                    ]
+                ]
+            ],
+            'WHERE' => [
+                \Software::getTable() . ".name" => "gimp",
+                \SoftwareCategory::getTable() . ".name" => "Application"
+            ]
+        ];
+
+        $iterator = $DB->request($criteria);
+        $this->integer(count($iterator))->isIdenticalTo(1);
+
+        $criteria = [
+            'FROM' => \Software::getTable(),
+            'LEFT JOIN' => [
+                \SoftwareCategory::getTable() => [
+                    'ON' => [
+                        \Software::getTable() => 'softwarecategories_id',
+                        \SoftwareCategory::getTable() => 'id'
+                    ]
+                ]
+            ],
+            'WHERE' => [
+                \Software::getTable() . ".name" => "php-cli",
+                \SoftwareCategory::getTable() . ".name" => "Development/Languages"
+            ]
+        ];
+
+        $iterator = $DB->request($criteria);
+        $this->integer(count($iterator))->isIdenticalTo(1);
+
+
+
+        //check software categories
+        /*$this->boolean($software_categorie->getFromDbByCrit(['name' => "Application"]))
+        ->isTrue();
+        $this->boolean($software_categorie->getFromDbByCrit(['name' => "Development/Languages"]))
+        ->isTrue();*/
+
        //we have 2 softwareversion items linked to the computer
         $item_versions = $item_version->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
         $this->integer(count($item_versions))->isIdenticalTo(2);
@@ -299,7 +361,7 @@ class Software extends AbstractInventoryAsset
         $item_versions = $item_version->find(['itemtype' => 'Computer', 'items_id' => $computers_id, 'is_dynamic' => 1]);
         $this->integer(count($item_versions))->isIdenticalTo(2);
 
-       //Redo inventory, but with removed "php-cli" software
+       //Redo inventory, but with removed "php-cli" software and change softwareCategories
         $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
 <REQUEST>
   <CONTENT>
@@ -311,7 +373,7 @@ class Software extends AbstractInventoryAsset
       <INSTALLDATE>03/10/2021</INSTALLDATE>
       <NAME>gimp</NAME>
       <PUBLISHER>Fedora Project</PUBLISHER>
-      <SYSTEM_CATEGORY>Unspecified</SYSTEM_CATEGORY>
+      <SYSTEM_CATEGORY>Web App</SYSTEM_CATEGORY>
       <VERSION>2.10.28-1.fc34</VERSION>
     </SOFTWARES>
     <HARDWARE>
@@ -333,6 +395,26 @@ class Software extends AbstractInventoryAsset
         $this->integer(count($softs))->isIdenticalTo(2);
         $versions = $version->find(['NOT' => ['name' => ['LIKE', '_test_%']]]);
         $this->integer(count($versions))->isIdenticalTo(2);
+
+        //check that sofware still exist but with different softwarecategories
+        $criteria = [
+            'FROM' => \Software::getTable(),
+            'LEFT JOIN' => [
+                \SoftwareCategory::getTable() => [
+                    'ON' => [
+                        \Software::getTable() => 'softwarecategories_id',
+                        \SoftwareCategory::getTable() => 'id'
+                    ]
+                ]
+            ],
+            'WHERE' => [
+                \Software::getTable() . ".name" => "gimp",
+                \SoftwareCategory::getTable() . ".name" => "Web App"
+            ]
+        ];
+        $iterator = $DB->request($criteria);
+        $this->integer(count($iterator))->isIdenticalTo(1);
+
 
        //we now have 1 softwareversion items linked to the computer
         $item_versions = $item_version->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);

--- a/tests/functionnal/Glpi/Inventory/Assets/Software.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Software.php
@@ -407,7 +407,6 @@ class Software extends AbstractInventoryAsset
         $iterator = $DB->request($criteria);
         $this->integer(count($iterator))->isIdenticalTo(1);
 
-
        //we now have 1 softwareversion items linked to the computer
         $item_versions = $item_version->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
         $this->integer(count($item_versions))->isIdenticalTo(1);

--- a/tests/functionnal/Glpi/Inventory/Assets/Software.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Software.php
@@ -345,14 +345,6 @@ class Software extends AbstractInventoryAsset
         $iterator = $DB->request($criteria);
         $this->integer(count($iterator))->isIdenticalTo(1);
 
-
-
-        //check software categories
-        /*$this->boolean($software_categorie->getFromDbByCrit(['name' => "Application"]))
-        ->isTrue();
-        $this->boolean($software_categorie->getFromDbByCrit(['name' => "Development/Languages"]))
-        ->isTrue();*/
-
        //we have 2 softwareversion items linked to the computer
         $item_versions = $item_version->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
         $this->integer(count($item_versions))->isIdenticalTo(2);

--- a/tests/functionnal/Glpi/Inventory/Assets/Software.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Software.php
@@ -305,7 +305,6 @@ class Software extends AbstractInventoryAsset
         $versions = $version->find(['NOT' => ['name' => ['LIKE', '_test_%']]]);
         $this->integer(count($versions))->isIdenticalTo(2);
 
-
         //check that sofware exist with softwarecategories
         $criteria = [
             'FROM' => \Software::getTable(),

--- a/tests/functionnal/Glpi/Inventory/Inventory.php
+++ b/tests/functionnal/Glpi/Inventory/Inventory.php
@@ -1755,7 +1755,7 @@ class Inventory extends InventoryTestCase
             'OFFSET' => $nblogsnow,
         ]);
 
-        $this->integer(count($logs))->isIdenticalTo(4375);
+        $this->integer(count($logs))->isIdenticalTo(4443);
 
         $expected_types_count = [
             0 => 3, //Agent version, disks usage
@@ -1764,7 +1764,7 @@ class Inventory extends InventoryTestCase
             \Log::HISTORY_ADD_SUBITEM => 3243,//network port/name, ip address, VMs, Software
             \Log::HISTORY_UPDATE_SUBITEM => 828,//disks usage, software updates
             \Log::HISTORY_DELETE_SUBITEM => 99,//networkport and networkname, Software?
-            \Log::HISTORY_CREATE_ITEM => 197, //virtual machines, os, manufacturer, net ports, net names, ...
+            \Log::HISTORY_CREATE_ITEM => 265, //virtual machines, os, manufacturer, net ports, net names, software category ...
             \Log::HISTORY_UPDATE_RELATION => 2,//kernel version
         ];
 


### PR DESCRIPTION
Handle software categories correctly

On first import ```softwarecategories_id``` are never handle exept if ```value``` has been modified or set by the rules engine

Add capability of ```inventory``` to update ```softwarecategories_id``` of ```Software``` if needed (useful for straighten up data data already imported)


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
