### PR TITLE
Tabs in modals

### DIFF
--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -1123,6 +1123,7 @@ class CommonGLPI implements CommonGLPIInterface
      * @since 0.85
      *
      * @param array $options Options
+     *                       show_nav_header (default true): show navigation header (link to list of items)
      *
      * @return void
      */
@@ -1171,7 +1172,9 @@ class CommonGLPI implements CommonGLPIInterface
             ]);
         }
         echo "<div class='col'>";
-        $this->showNavigationHeader($options);
+        if (($options['show_nav_header'] ?? true)) {
+            $this->showNavigationHeader($options);
+        }
         $this->showTabsContent($options);
         echo "</div>";
         echo "</div>";


### PR DESCRIPTION
Formcreator features are constantly growing. The questions design system becomes messy because there are too many settings. 

As dropping the modal to design a question is very likely a bad idea, I'm experimenting the use of tabs in a modal. See below:

![Peek 13-09-2022 08-59](https://user-images.githubusercontent.com/14139801/189840201-c5a308c3-c476-4ad3-9165-de8bba183d18.gif)

This PR allows to not render the navigation header we can see in the top of the modal. Going back to a list of items is not relevant here and pollutes the modal.

![image](https://user-images.githubusercontent.com/14139801/189849842-2d188f39-afc6-4003-a0f7-6fa37ae787fa.png)



| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
