### PR TITLE
Handle emptyness of menu title

### DIFF
--- a/src/Application/View/Extension/DataHelpersExtension.php
+++ b/src/Application/View/Extension/DataHelpersExtension.php
@@ -140,14 +140,14 @@ class DataHelpersExtension extends AbstractExtension
     /**
      * Return string having its shortcut letter underlined.
      *
-     * @param string $string
+     * @param string|null $string
      * @param string $shortcut
      *
      * @return string
      */
-    public function underlineShortcutLetter(string $string, string $shortcut_letter): string
+    public function underlineShortcutLetter(?string $string, string $shortcut_letter): string
     {
-        if (empty($shortcut_letter)) {
+        if (empty($string) || empty($shortcut_letter)) {
             return $string;
         }
         return Toolbox::shortcut($string, $shortcut_letter);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12534

It may appears that plugin produces a menu item that has no title. In this case, the proposed change will prevent a fatal error that would break the whole UI.