### PR TITLE
User tooltip: add phone2 if exist

### DIFF
--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -1689,6 +1689,7 @@ final class DbUtils
                         $user_params = array_merge($user_params, [
                             'email'              => UserEmail::getDefaultForUser($ID),
                             'phone'              => $data["phone"],
+                            'phone2'             => $data["phone2"],
                             'mobile'             => $data["mobile"],
                             'locations_id'       => $data['locations_id'],
                             'usertitles_id'      => $data['usertitles_id'],

--- a/templates/components/user/info_card.html.twig
+++ b/templates/components/user/info_card.html.twig
@@ -59,18 +59,16 @@
                   <a href="mailto:{{ user['email'] }}">{{ user['email'] }}</a>
                </div>
             {% endif %}
-            {% if not user['phone'] is empty or not user['phone2'] is empty %}
+            {% if not user['phone'] is empty %}
                <div>
                   <i class="fas fa-fw fa-phone"></i>
-                  {% if not user['phone'] is empty %}
-                     <a href="tel:{{ user['phone'] }}">{{ user['phone'] }}</a>
-                  {% endif %}
-                  {% if not user['phone'] is empty and not user['phone2'] is empty %}
-                     <span> - </span>
-                  {% endif %}
-                  {% if not user['phone2'] is empty %}
-                     <a href="tel:{{ user['phone2'] }}">{{ user['phone2'] }}</a>
-                  {% endif %}
+                  <a href="tel:{{ user['phone'] }}">{{ user['phone'] }}</a>
+               </div>
+            {% endif %}
+            {% if not user['phone2'] is empty %}
+               <div>
+                  <i class="fas fa-fw fa-phone"></i>
+                  <a href="tel:{{ user['phone2'] }}">{{ user['phone2'] }}</a>
                </div>
             {% endif %}
             {% if user['mobile']|length > 0 %}

--- a/templates/components/user/info_card.html.twig
+++ b/templates/components/user/info_card.html.twig
@@ -59,10 +59,18 @@
                   <a href="mailto:{{ user['email'] }}">{{ user['email'] }}</a>
                </div>
             {% endif %}
-            {% if user['phone']|length > 0 %}
+            {% if not user['phone'] is empty or not user['phone2'] is empty %}
                <div>
                   <i class="fas fa-fw fa-phone"></i>
-                  <a href="tel:{{ user['phone'] }}">{{ user['phone'] }}</a>
+                  {% if not user['phone'] is empty %}
+                     <a href="tel:{{ user['phone'] }}">{{ user['phone'] }}</a>
+                  {% endif %}
+                  {% if not user['phone'] is empty and not user['phone2'] is empty %}
+                     <span> - </span>
+                  {% endif %}
+                  {% if not user['phone2'] is empty %}
+                     <a href="tel:{{ user['phone2'] }}">{{ user['phone2'] }}</a>
+                  {% endif %}
                </div>
             {% endif %}
             {% if user['mobile']|length > 0 %}

--- a/templates/components/user/info_card.html.twig
+++ b/templates/components/user/info_card.html.twig
@@ -61,14 +61,15 @@
             {% endif %}
             {% if not user['phone'] is empty or not user['phone2'] is empty %}
                <div>
-                  <i class="fas fa-fw fa-phone"></i>
                   {% if not user['phone'] is empty %}
+                     <i class="fas fa-fw fa-phone"></i>
                      <a href="tel:{{ user['phone'] }}">{{ user['phone'] }}</a>
                   {% endif %}
                   {% if not user['phone'] is empty and not user['phone2'] is empty %}
                      <span> - </span>
                   {% endif %}
                   {% if not user['phone2'] is empty %}
+                     <i class="fas fa-fw fa-phone"></i>
                      <a href="tel:{{ user['phone2'] }}">{{ user['phone2'] }}</a>
                   {% endif %}
                </div>

--- a/templates/components/user/info_card.html.twig
+++ b/templates/components/user/info_card.html.twig
@@ -59,16 +59,18 @@
                   <a href="mailto:{{ user['email'] }}">{{ user['email'] }}</a>
                </div>
             {% endif %}
-            {% if not user['phone'] is empty %}
+            {% if not user['phone'] is empty or not user['phone2'] is empty %}
                <div>
                   <i class="fas fa-fw fa-phone"></i>
-                  <a href="tel:{{ user['phone'] }}">{{ user['phone'] }}</a>
-               </div>
-            {% endif %}
-            {% if not user['phone2'] is empty %}
-               <div>
-                  <i class="fas fa-fw fa-phone"></i>
-                  <a href="tel:{{ user['phone2'] }}">{{ user['phone2'] }}</a>
+                  {% if not user['phone'] is empty %}
+                     <a href="tel:{{ user['phone'] }}">{{ user['phone'] }}</a>
+                  {% endif %}
+                  {% if not user['phone'] is empty and not user['phone2'] is empty %}
+                     <span> - </span>
+                  {% endif %}
+                  {% if not user['phone2'] is empty %}
+                     <a href="tel:{{ user['phone2'] }}">{{ user['phone2'] }}</a>
+                  {% endif %}
                </div>
             {% endif %}
             {% if user['mobile']|length > 0 %}


### PR DESCRIPTION
A small feature that can go into the bf branch:

![image](https://user-images.githubusercontent.com/42734840/190110237-897c24f9-d438-40ed-bcb3-bddd07d36ce3.png)

I've set the milestone to target 10.0.4 as it is not urgent, but It can be changed if you want it in 10.0.3.

Also, I've noted that the user picture seems distorted in this tooltip (unrelated to changes).
Maybe something you could look into before 10.0.3 is released ?

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
