### PR TITLE
fix(tinymce): disable text_patterns

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -3885,6 +3885,7 @@ JS;
                link_default_target: '_blank',
                branding: false,
                selector: '#{$id}',
+               text_patterns: false,
 
                plugins: {$pluginsjs},
 


### PR DESCRIPTION
Disable the default option of tinymce "text_patterns"

[](https://www.tiny.cloud/docs/tinymce/6/content-behavior-options/#text_patterns)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24929
