### PR TITLE
fix computeTakeIntoAccountDelayStat to use SLA TTO calendar

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1547,9 +1547,19 @@ class Ticket extends CommonITILObject
             isset($this->fields['id'])
             && !empty($this->fields['date'])
         ) {
+	   // If SLA TTO calendar is defined use it for Take Into Account, if not, fallback to previous method (SLA TTR)
             $calendars_id = $this->getCalendar();
             $calendar     = new Calendar();
-
+            if (isset($this->fields['slas_id_tto']) && $this->fields['slas_id_tto'] > 0){
+                    $sla = new SLA();
+                    if($sla->getFromDB($this->fields['slas_id_tto'])){
+                        if($sla->fields['use_ticket_calendar']){
+                                $calendars_id = parent::getCalendar();
+                        } else {
+                                $calendars_id = $sla->getField('calendars_id');
+                        }
+                    }
+            }
            // Using calendar
             if (($calendars_id > 0) && $calendar->getFromDB($calendars_id)) {
                 return max(1, $calendar->getActiveTimeBetween(


### PR DESCRIPTION
Computation of delay is using Ticket::getCalendar() which returns id of SLA TTR calendar. If it is not defined is calls parent::getCalendar() which returns calendar defined on entity of ticket.
It can happen that SLA TTO and SLA TTR are using different calendars and in that case computeTakeIntoAccountDelayStat produces incorrect result as it would use SLA TTR calendar.
This PR fixes computeTakeIntoAccountDelayStat to use SLA TTO calendar, if defined and if not, it reverts Ticket::getCalendar() back to provide previous behavior.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | NA