### PR TITLE
Fix simplified ticket template preview

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -3892,6 +3892,7 @@ JAVASCRIPT;
             '_tag_filename'             => [],
             '_tasktemplates_id'         => []
         ];
+        $options = [];
 
        // Get default values from posted values on reload form
         if (!$ticket_template) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When viewing the simplified interface preview in a ticket template, the `$options` array is not initialized so an error occurs when it tries passing a null value when an array is required.