### PR TITLE
fix(inventory): use old_val from lock instead of current inventory value (not handle yet)

### DIFF
--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -182,7 +182,6 @@ abstract class InventoryAsset
 
         $blacklist = new Blacklist();
         $lockedfield = new Lockedfield();
-        $locks = $lockedfield->getLockedValues($this->item->getType(), $this->item->fields['id'] ?? 0);
 
         $data = $this->data;
         foreach ($data as &$value) {
@@ -200,15 +199,6 @@ abstract class InventoryAsset
                 }
 
                 $known_key = md5($key . $val);
-
-                //locked fields
-                foreach ($locks as $lock_key => $lock_val) {
-                    if ($key == $lock_key) {
-                        $this->known_links[$known_key] = $lock_val;
-                        continue 2;
-                    }
-                }
-
                 if ($key == "manufacturers_id" || $key == 'bios_manufacturers_id') {
                     $manufacturer = new Manufacturer();
                     $value->$key  = $manufacturer->processName($value->$key);

--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -182,7 +182,7 @@ abstract class InventoryAsset
 
         $blacklist = new Blacklist();
         $lockedfield = new Lockedfield();
-        $locks = $lockedfield->getLockedNames($this->item->getType(), $this->item->fields['id'] ?? 0);
+        $locks = $lockedfield->getLockedValues($this->item->getType(), $this->item->fields['id'] ?? 0);
 
         $data = $this->data;
         foreach ($data as &$value) {
@@ -202,9 +202,9 @@ abstract class InventoryAsset
                 $known_key = md5($key . $val);
 
                 //locked fields
-                foreach ($locks as $lock) {
-                    if ($key == $lock) {
-                        $this->known_links[$known_key] = $val;
+                foreach ($locks as $lock_key => $lock_val) {
+                    if ($key == $lock_key) {
+                        $this->known_links[$known_key] = $lock_val;
                         continue 2;
                     }
                 }


### PR DESCRIPTION
If an asset have a lock on a ```foreignKey``` like ```manufacturers_id``` field

Inventory set current inventory value instead of lock value.

```json
    "batteries": [
      {
        "capacity": 52945,
        "chemistry": "Li-poly",
        "date": "2015-06-17",
        "manufacturer": "SMP",
        "name": "DELL 0N7T653",
        "real_capacity": 19902,
        "serial": 158,
        "voltage": 7640
      }
```
For example with this batterie, GLPI inventory put ```SMP``` as ```manufacturers_id``` val


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | [#220](https://github.com/glpi-project/glpi/issues/12654)
