### PR TITLE
No longer throw an exception; closes #12609

### DIFF
--- a/src/Inventory/Asset/NetworkPort.php
+++ b/src/Inventory/Asset/NetworkPort.php
@@ -774,7 +774,8 @@ class NetworkPort extends InventoryAsset
     private function addPortsWiring(int $netports_id_1, int $netports_id_2): bool
     {
         if ($netports_id_1 == $netports_id_2) {
-            throw new \RuntimeException('Cannot wire a port to itself!');
+            //no wiring
+            return false;
         }
 
         $wire = new \NetworkPort_NetworkPort();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12609

The main idea throwing an exception was to see when that case was reached, and try to fix it. Since it's been implemented, there were no case such a try was really valid.

So, maybe there is a logic issue when the original array is completed, but when that fails, there is never a real connection to be made - as far as I see.
If inventory results seems OK ignoring self wiring case; it's certainly ok.