### PR TITLE
Clean legacy search class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,14 @@ The present file will list all changes made to the project; according to the
 
 #### Removed
 - Usage of `csrf_compliant` plugins hook.
+- `Search::computeTitle()`
+- `Search::csv_clean()`
+- `Search::findCriteriaInSession()`
+- `Search::getDefaultCriteria()`
+- `Search::getLogicalOperators()`
+- `Search::getMetaReferenceItemtype()`
+- `Search::outputData()`
+- `Search::sylk_clean()`
 
 ## [10.0.3] unreleased
 

--- a/src/Search.php
+++ b/src/Search.php
@@ -46,6 +46,10 @@ use Glpi\Search\Output\SYLKSearchOutput;
 use Glpi\Search\Provider\SQLProvider;
 use Glpi\Search\SearchEngine;
 use Glpi\Search\SearchOption;
+use Glpi\Search\Output\PDFLandscapeSearchOutput;
+use Glpi\Search\Output\PDFPortraitSearchOutput;
+use Glpi\Search\Output\NamesListSearchOutput;
+use Glpi\Search\Output\GlobalSearchOutput;
 
 /**
  * Search Class
@@ -218,16 +222,26 @@ class Search
 
         switch ($data['display_type']) {
             case self::CSV_OUTPUT:
+                CSVSearchOutput::outputData($data);
+                break;
             case self::PDF_OUTPUT_LANDSCAPE:
+                PDFLandscapeSearchOutput::outputData($data);
+                break;
             case self::PDF_OUTPUT_PORTRAIT:
+                PDFPortraitSearchOutput::outputData($data);
+                break;
             case self::SYLK_OUTPUT:
+                SYLKSearchOutput::outputData($data);
+                break;
             case self::NAMES_OUTPUT:
-                self::outputData($data);
+                NamesListSearchOutput::outputData($data);
                 break;
             case self::GLOBAL_SEARCH:
+                GlobalSearchOutput::displayData($data);
+                break;
             case self::HTML_OUTPUT:
             default:
-                self::displayData($data);
+                HTMLSearchOutput::displayData($data);
                 break;
         }
     }
@@ -388,33 +402,6 @@ class Search
     }
 
     /**
-     * Output data (for export in CSV, PDF, ...).
-     *
-     * @param array $data Array of search datas prepared to get datas
-     *
-     * @return void
-     **/
-    public static function outputData(array $data)
-    {
-        /** @var ExportSearchOutput $output */
-        $output = SearchEngine::getOutputForLegacyKey($data['display_type']);
-        return $output::outputData($data);
-    }
-
-
-    /**
-     * Compute title (use case of PDF OUTPUT)
-     *
-     * @param array $data Array data of search
-     *
-     * @return string Title
-     **/
-    public static function computeTitle($data)
-    {
-        return PDFSearchOutput::computeTitle($data);
-    }
-
-    /**
      * Get meta types available for search engine
      *
      * @param class-string<CommonDBTM> $itemtype Type to display the form
@@ -424,57 +411,6 @@ class Search
     public static function getMetaItemtypeAvailable($itemtype)
     {
         return SearchEngine::getMetaItemtypeAvailable($itemtype);
-    }
-
-    /**
-     * Returns parents itemtypes having subitems defined in given config key.
-     * This list is filtered and is only valid in a "meta" search context.
-     *
-     * @param string $config_key
-     *
-     * @return string[]
-     */
-    private static function getMetaParentItemtypesForTypesConfig(string $config_key): array
-    {
-        return SearchEngine::getMetaParentItemtypesForTypesConfig($config_key);
-    }
-
-    /**
-     * Check if an itemtype is a possible subitem of another itemtype in a "meta" search context.
-     *
-     * @param string $parent_itemtype
-     * @param string $child_itemtype
-     *
-     * @return boolean
-     */
-    private static function isPossibleMetaSubitemOf(string $parent_itemtype, string $child_itemtype)
-    {
-        return SearchEngine::isPossibleMetaSubitemOf($parent_itemtype, $child_itemtype);
-    }
-
-    /**
-     * Gets the class to use if the specified itemtype extends one of the known reference types.
-     *
-     * @param class-string<CommonDBTM> $itemtype
-     *
-     * @return string|false The reference class name. If the provided itemtype is from a plugin, the provided itemtype is returned.
-     *                      If the itemtype is not from a plugin and not exactly or extended from a reference itemtype, false will be returned.
-     * @since 0.85
-     */
-    public static function getMetaReferenceItemtype($itemtype)
-    {
-        return SearchEngine::getMetaReferenceItemtype($itemtype);
-    }
-
-
-    /**
-     * Get dropdown options of logical operators.
-     * @return string[]|array<string, string>
-     * @since 0.85
-     **/
-    public static function getLogicalOperators($only_not = false)
-    {
-        return SearchEngine::getLogicalOperators($only_not);
     }
 
 
@@ -538,36 +474,6 @@ class Search
     public static function displayCriteriaGroup($request = [])
     {
         QueryBuilder::displayCriteriaGroup($request);
-    }
-
-    /**
-     * Retrieve a single criteria in Session by its index
-     *
-     * @since 9.4
-     *
-     * @param  string  $itemtype    which glpi type we must search in session
-     * @param  integer $num         index of the criteria
-     * @param  array   $parents_num node indexes of the parents (@see displayCriteriaGroup)
-     *
-     * @return array|false The found criteria array or false if nothing found
-     */
-    public static function findCriteriaInSession($itemtype = '', $num = 0, $parents_num = [])
-    {
-        return QueryBuilder::findCriteriaInSession($itemtype, $num, $parents_num);
-    }
-
-    /**
-     * construct the default criteria for an itemtype
-     *
-     * @since 9.4
-     *
-     * @param  class-string<CommonDBTM> $itemtype
-     *
-     * @return array  criteria
-     */
-    public static function getDefaultCriteria($itemtype = '')
-    {
-        return QueryBuilder::getDefaultCriteria($itemtype);
     }
 
     /**
@@ -1114,30 +1020,6 @@ class Search
     public static function computeComplexJoinID(array $joinparams)
     {
         return SQLProvider::computeComplexJoinID($joinparams);
-    }
-
-    /**
-     * Clean display value for csv export
-     *
-     * @param string $value value
-     *
-     * @return string Clean value
-     **/
-    public static function csv_clean($value)
-    {
-        return CSVSearchOutput::cleanValue((string) $value);
-    }
-
-    /**
-     * Clean display value for sylk export
-     *
-     * @param string $value value
-     *
-     * @return string Clean value
-     **/
-    public static function sylk_clean($value)
-    {
-        return SYLKSearchOutput::cleanValue((string) $value);
     }
 
     /**

--- a/src/Search/Input/QueryBuilder.php
+++ b/src/Search/Input/QueryBuilder.php
@@ -1065,7 +1065,7 @@ JAVASCRIPT;
      *
      * @return array Criteria
      */
-    public static function getDefaultCriteria($itemtype = ''): array
+    private static function getDefaultCriteria($itemtype = ''): array
     {
         global $CFG_GLPI;
 
@@ -1104,7 +1104,7 @@ JAVASCRIPT;
      *
      * @return array|false The found criteria array or false if nothing found
      */
-    public static function findCriteriaInSession($itemtype = '', $num = 0, $parents_num = [])
+    private static function findCriteriaInSession($itemtype = '', $num = 0, $parents_num = [])
     {
         if (!isset($_SESSION['glpisearch'][$itemtype]['criteria'])) {
             return false;

--- a/src/Search/Output/PDFSearchOutput.php
+++ b/src/Search/Output/PDFSearchOutput.php
@@ -51,7 +51,7 @@ abstract class PDFSearchOutput extends ExportSearchOutput
      *
      * @return string Title
      **/
-    public static function computeTitle(array $data): string
+    final protected static function computeTitle(array $data): string
     {
         $title = "";
 

--- a/src/Search/Output/PDFSearchOutput.php
+++ b/src/Search/Output/PDFSearchOutput.php
@@ -51,7 +51,7 @@ abstract class PDFSearchOutput extends ExportSearchOutput
      *
      * @return string Title
      **/
-    final protected static function computeTitle(array $data): string
+    protected static function computeTitle(array $data): string
     {
         $title = "";
 

--- a/src/Search/Provider/SQLProvider.php
+++ b/src/Search/Provider/SQLProvider.php
@@ -3345,7 +3345,7 @@ final class SQLProvider implements SearchProviderInterface
 
                 if (
                     isset($criterion['link'])
-                    && in_array($criterion['link'], array_keys(\Search::getLogicalOperators()))
+                    && in_array($criterion['link'], array_keys(SearchEngine::getLogicalOperators()))
                 ) {
                     if (strstr($criterion['link'], "NOT")) {
                         $tmplink = " " . str_replace(" NOT", "", $criterion['link']);

--- a/src/Search/SearchEngine.php
+++ b/src/Search/SearchEngine.php
@@ -137,7 +137,7 @@ final class SearchEngine
      *
      * @return string[]
      */
-    public static function getMetaParentItemtypesForTypesConfig(string $config_key): array
+    private static function getMetaParentItemtypesForTypesConfig(string $config_key): array
     {
         $matches = [];
         if (preg_match('/^(.+)_types$/', $config_key, $matches) === 0) {

--- a/src/Search/SearchOption.php
+++ b/src/Search/SearchOption.php
@@ -77,7 +77,7 @@ final class SearchOption implements \ArrayAccess
         return isset($this->search_opt_array[$offset]);
     }
 
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->search_opt_array[$offset];

--- a/src/Search/SearchOption.php
+++ b/src/Search/SearchOption.php
@@ -35,8 +35,6 @@
 
 namespace Glpi\Search;
 
-use ReturnTypeWillChange;
-
 /**
  * Object representing a search option.
  *
@@ -112,7 +110,7 @@ final class SearchOption implements \ArrayAccess
      *
      * @return array The reference to the array of search options for the given item type
      **/
-    final public static function &getOptionsForItemtype($itemtype, $withplugins = true): array
+    public static function &getOptionsForItemtype($itemtype, $withplugins = true): array
     {
         global $CFG_GLPI;
         $item = null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Some `Search` class legacy methods are not used by plugins and could so be removed.

I was not able to perform more cleaning quickly, as many moved methods are still used from the legacy `Search` class.