### PR TITLE
fix right item width in timeline (with 2k+ screens)

### DIFF
--- a/css/includes/components/itilobject/_timeline.scss
+++ b/css/includes/components/itilobject/_timeline.scss
@@ -100,6 +100,7 @@
         position: relative;
         border-top-left-radius: 0;
         max-width: 700px;
+        min-width: 100%;
         word-break: break-word;
 
         @include media-breakpoint-up(sm) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

f573edca31b7c2289028681b71b64dd9d33c45fa : 
on large screen (1440p + ) the limitation of 700px (added on #12153) cause the right timeline items to be shifted:
before
![image](https://user-images.githubusercontent.com/418844/190609076-95fc4f00-ab6a-42d0-9746-5f3602e7075c.png)
after 
![image](https://user-images.githubusercontent.com/418844/190608949-1a610f73-4738-41f2-ad36-c8ca4422cb8e.png)


