### PR TITLE
Fix search checkbox shift click

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -191,10 +191,9 @@ $.fn.shiftSelectable = function() {
         }
 
         if (evt.shiftKey) {
-            evt.preventDefault();
             var start = $boxes.index(selected_checkbox);
             var end = $boxes.index(lastChecked);
-            $boxes.slice(Math.min(start, end), Math.max(start, end) + 1)
+            $boxes.slice(Math.min(start, end), Math.max(start, end))
                 .prop('checked', $(lastChecked).is(':checked'))
                 .trigger('change');
         }

--- a/js/modules/Search/Table.js
+++ b/js/modules/Search/Table.js
@@ -209,7 +209,7 @@ window.GLPI.Search.Table = class Table extends GenericView {
 
     // permit to [shift] select checkboxes
     shiftSelectAllCheckbox() {
-        $('#'+this.element_id+' input[type="checkbox"]').shiftSelectable();
+        $('#'+this.element_id+' tbody input[type="checkbox"]').shiftSelectable();
     }
 
     registerListeners() {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12667

Two issues:
1. The fluid search feature was making the "Select all" checkbox shift-clickable. This didn't seem related to the reported issue.
2. The shift-click would work, but the selected checkbox would uncheck immediately afterwards. The only fix I found was to only check the boxes between the last checked and the the currently selected one (exclusive) and let the default event handling check the currently selected box.

This was tested in Chrome and Firefox.