### PR TITLE
move breaking points of itil object layout

### DIFF
--- a/css/includes/components/itilobject/_layout.scss
+++ b/css/includes/components/itilobject/_layout.scss
@@ -36,11 +36,11 @@
         display: none;
     }
 
-    @include media-breakpoint-down(sm) {
+    @include media-breakpoint-down(lg) {
         margin-bottom: 55px; // .itil-footer height
     }
 
-    @include media-breakpoint-up(sm) {
+    @include media-breakpoint-up(lg) {
         height: calc(100vh - 187px);
 
         .itil-left-side,
@@ -107,7 +107,7 @@
 }
 
 #itil-object-container {
-    @include media-breakpoint-up(sm) {
+    @include media-breakpoint-up(lg) {
         &.right-expanded {
             .itil-footer {
                 .collapse-panel {
@@ -164,7 +164,7 @@
 
 .horizontal-layout {
     .itil-object {
-        @include media-breakpoint-up(sm) {
+        @include media-breakpoint-up(lg) {
             height: calc(100vh - 257px);
         }
     }

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -443,7 +443,7 @@
    {% endif %}
 
     <span class="d-none d-md-block">
-        <button type="button" class="switch-panel-width btn btn-sm btn-square btn-icon btn-ghost-secondary position-absolute bottom-0 start-0 mb-2">
+        <button type="button" class="switch-panel-width btn btn-icon btn-ghost-secondary position-absolute bottom-0 start-0 mb-2">
             <i class="fas fa-caret-left"></i>
         </button>
     </span>

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -32,7 +32,7 @@
  #}
 
 {% set timeline_btns_cls = left_regular_cls %}
-{% set form_btns_cls     = is_expanded ? right_expanded_cls : "col-md" %}
+{% set form_btns_cls     = is_expanded ? right_expanded_cls : "col-lg" %}
 {% set switch_btn_cls    = "fa-caret-left" %}
 {% if is_expanded %}
     {% set timeline_btns_cls = left_expanded_cls %}
@@ -42,7 +42,7 @@
 
 <div class="mx-n2 mb-n2 itil-footer itil-footer p-0 border-top" id="itil-footer">
    <div class="buttons-bar d-flex py-2">
-      <div class="{{ timeline_btns_cls }} ps-3 timeline-buttons">
+      <div class="col {{ timeline_btns_cls }} ps-3 timeline-buttons">
          {% if not item.isNewItem() %}
             {% set default_action_data = timeline_itemtypes|first %}
             {% if item.isNotSolved() and default_action_data != false %}
@@ -84,22 +84,23 @@
          {% endif %}
      </div>
 
-      <div class="form-buttons {{ form_btns_cls }} d-flex justify-content-end ms-auto ms-md-0 my-n2 py-2 pe-3 card-footer border-top-0 position-relative">
-         <span class="d-none d-md-block position-absolute top-0 start-0"
+      <div class="form-buttons {{ form_btns_cls }} d-flex justify-content-between ms-auto ms-lg-0 my-n2 py-2 pe-3 card-footer border-top-0 position-relative">
+         <span class="d-none d-lg-block ms-n3"
                data-bs-toggle="tooltip" data-bs-placement="top" title="{{ __('Toggle panels width') }}">
-            <button type="button" class="switch-panel-width btn btn-sm btn-square btn-icon btn-ghost-secondary px-0">
+            <button type="button" class="switch-panel-width btn btn-icon btn-ghost-secondary px-0">
                <i class="fas {{ switch_btn_cls }}"></i>
             </button>
-            <button type="button" class="collapse-panel btn btn-sm btn-square btn-icon btn-ghost-secondary px-0 mr-1">
+            <button type="button" class="collapse-panel btn btn-icon btn-ghost-secondary px-0 mr-1">
                <i class="fas fa-caret-right"></i>
             </button>
          </span>
 
+         <span>
          {% if item.isNewItem() %}
             <button class="btn btn-primary" type="submit" name="add" form="itil-form"
                   title="{{ _x('button', 'Add') }}">
                <i class="fas fa-plus"></i>
-               <span class="d-none d-md-block">{{ _x('button', 'Add') }}</span>
+               <span class="d-none d-lg-block">{{ _x('button', 'Add') }}</span>
             </button>
          {% else %}
 
@@ -109,14 +110,14 @@
                      <button class="btn btn-outline-secondary" type="submit" name="restore" form="itil-form"
                            title="{{ _x('button', 'Restore') }}">
                         <i class="fas fa-trash-restore-alt"></i>
-                        <span class="d-none d-md-block">{{ _x('button', 'Restore') }}</span>
+                        <span class="d-none d-lg-block">{{ _x('button', 'Restore') }}</span>
                      </button>
 
                      <button class="btn btn-outline-danger" type="submit" name="purge" form="itil-form"
                            title="{{ _x('button', 'Delete permanently') }}"
                            onclick="return confirm('{{ __('Confirm the final deletion?') }}');">
                         <i class="ti ti-trash"></i>
-                        <span class="d-none d-md-block">{{ _x('button', 'Delete permanently') }}</span>
+                        <span class="d-none d-lg-block">{{ _x('button', 'Delete permanently') }}</span>
                      </button>
                   {% else %}
                      <button class="btn btn-outline-danger" type="submit" name="delete" form="itil-form"
@@ -139,12 +140,13 @@
                   <button class="btn btn-primary" type="submit" name="update" form="itil-form"
                         title="{{ _x('button', 'Save') }}">
                      <i class="far fa-save"></i>
-                     <span class="d-none d-md-block">{{ _x('button', 'Save') }}</span>
+                     <span class="d-none d-xl-block">{{ _x('button', 'Save') }}</span>
                   </button>
                {% endif %}
             </div>
 
          {% endif %}
+         </span>
       </div>
    </div>
 </div>

--- a/templates/components/itilobject/layout.html.twig
+++ b/templates/components/itilobject/layout.html.twig
@@ -40,11 +40,11 @@
 {% set collapsed_cls = (is_collapsed ? "right-collapsed" : "") %}
 {% set expanded_cls  = (is_expanded == "true" ? "right-expanded" : "") %}
 
-{% set left_regular_cls = "col-xl-8 col-md-10" %}
-{% set right_regular_cls = "col-xl-4 col-md-2" %}
+{% set left_regular_cls = "col-lg-8" %}
+{% set right_regular_cls = "col-lg-4" %}
 
-{% set left_expanded_cls = "col-xxl-4 col-md-4" %}
-{% set right_expanded_cls = "col-xxl-8 col-md-8" %}
+{% set left_expanded_cls = "col-xl-5 col-lg-6" %}
+{% set right_expanded_cls = "col-xl-7 col-lg-6" %}
 
 {% set left_side_cls = left_regular_cls %}
 {% set right_side_cls = right_regular_cls %}
@@ -63,14 +63,14 @@
    <div class="row d-flex flex-column alin-items-stretch itil-object">
       {% set is_timeline_reversed = user_pref('timeline_order') == constant('CommonITILObject::TIMELINE_ORDER_REVERSE') %}
       {% set fl_direction = (item.isNewItem or is_timeline_reversed ? 'flex-column' : 'flex-column-reverse') %}
-      <div class="itil-left-side col-12 {{ left_side_cls }} order-last order-md-first pt-2 pe-2 pe-md-4 d-flex {{ fl_direction }} border-top border-4">
+      <div class="itil-left-side col-12 {{ left_side_cls }} order-last order-lg-first pt-2 pe-2 pe-lg-4 d-flex {{ fl_direction }} border-top border-4">
          {% if item.isNewItem() %}
             {{ include('components/itilobject/timeline/new_form.html.twig') }}
          {% else %}
             {{ include('components/itilobject/timeline/timeline.html.twig') }}
          {% endif %}
       </div>
-      <div class="itil-right-side col-12 {{ right_side_cls }} mt-0 mt-md-n1 card-footer p-0 rounded-0">
+      <div class="itil-right-side col-12 {{ right_side_cls }} mt-0 mt-lg-n1 card-footer p-0 rounded-0">
          {% if not item.isNewItem() %}
             {{ include('components/itilobject/mainform_open.html.twig') }}
          {% endif %}
@@ -127,7 +127,7 @@ $(function() {
          $('.itil-left-side').removeClass("{{ left_regular_cls }}").addClass("{{ left_expanded_cls }}");
          $('.itil-footer .timeline-buttons').removeClass("{{ left_regular_cls }}").addClass("{{ left_expanded_cls }}");
          // Right side
-         $('.itil-footer .form-buttons').removeClass('col-md').addClass("{{ right_expanded_cls }}");
+         $('.itil-footer .form-buttons').removeClass('col-lg').addClass("{{ right_expanded_cls }}");
          $('.itil-right-side').removeClass("{{ right_regular_cls }}").addClass("{{ right_expanded_cls }}");
          // Switcher buttons
          $('.switch-panel-width i.fas').removeClass('fa-caret-left').addClass('fa-caret-right');
@@ -140,7 +140,7 @@ $(function() {
          $('.itil-left-side').removeClass("{{ left_expanded_cls }}").addClass("{{ left_regular_cls }}");
          $('.itil-footer .timeline-buttons').removeClass("{{ left_expanded_cls }}").addClass("{{ left_regular_cls }}");
          // Right side
-         $('.itil-footer .form-buttons').removeClass("{{ right_expanded_cls }}").addClass('col-md');
+         $('.itil-footer .form-buttons').removeClass("{{ right_expanded_cls }}").addClass('col-lg');
          $('.itil-right-side').removeClass("{{ right_expanded_cls }}").addClass("{{ right_regular_cls }}");
          // Switcher buttons
          $('.switch-panel-width i.fas').removeClass('fa-caret-right').addClass('fa-caret-left');

--- a/templates/components/itilobject/timeline/filter_timeline.html.twig
+++ b/templates/components/itilobject/timeline/filter_timeline.html.twig
@@ -81,10 +81,10 @@
    }) %}
 {% endif %}
 
-<div class="filter-timeline d-none d-md-block float-end mt-n2 position-relative">
+<div class="filter-timeline float-end position-relative">
    <span data-bs-toggle="tooltip" data-bs-placement="top" title="{{ __('Timeline filter') }}">
       <button type="button"
-            class="btn btn-sm btn-icon btn-ghost-secondary open-timeline-filter-popover"
+            class="btn btn-icon btn-ghost-secondary open-timeline-filter-popover"
             data-bs-toggle="collapse"
             data-bs-target="#filter-timeline-popover"
             data-bs-trigger="click">
@@ -117,7 +117,7 @@
    {% if get_current_interface() == 'central' %}
       <span data-bs-toggle="tooltip" data-bs-placement="top" title="{{ __('View TODO list') }}">
          <button type="button"
-               class="btn btn-sm btn-icon btn-ghost-secondary view-timeline-todo-list me-1">
+               class="btn btn-icon btn-ghost-secondary view-timeline-todo-list me-1">
             <i class="fas fa-tasks"></i>
          </button>
       </span>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

The previous breakpoint was `-md` (768px) or  `-sm` (576px) for some parts, and the right panel could not be displayed correctly (especially with left menu expanded)

I took the opportunity to quickly fix the secondary buttons in the footer (filter, todo, and collapse/expand)

## MD->LG

Before: 
![image](https://user-images.githubusercontent.com/418844/190663374-57f80ef1-c0cb-454f-a9f3-fe7f3bc1e2ec.png)

After:
![image](https://user-images.githubusercontent.com/418844/190663516-1ead7c78-499c-4537-9ae0-d133365939af.png)

## SM->MD

Before:
![image](https://user-images.githubusercontent.com/418844/190663685-a3302150-a8cc-4cd1-916f-9a98101193ff.png)

After:
![image](https://user-images.githubusercontent.com/418844/190663758-d0d4da23-9e0d-4c78-a772-50c01a06a65c.png)

