### PR TITLE
Fix global approval and dropdowns field display

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -271,8 +271,7 @@ class Dropdown
         }
 
        // Display comment
-        $icons = "";
-        $icon_count = 0;
+        $icon_array = [];
         if ($params['comments']) {
             $comment_id      = Html::cleanId("comment_" . $params['name'] . $params['rand']);
             $link_id         = Html::cleanId("comment_link_" . $params['name'] . $params['rand']);
@@ -312,7 +311,7 @@ class Dropdown
             }
 
             // Comment icon
-            $icons .= Ajax::updateItemOnSelectEvent(
+            $comment_icon = Ajax::updateItemOnSelectEvent(
                 $field_id,
                 $comment_id,
                 $CFG_GLPI["root_doc"] . "/ajax/comments.php",
@@ -320,8 +319,8 @@ class Dropdown
                 false
             );
             $options_tooltip['link_class'] = 'btn btn-outline-secondary';
-            $icons .= Html::showToolTip($comment, $options_tooltip);
-            $icon_count++;
+            $comment_icon .= Html::showToolTip($comment, $options_tooltip);
+            $icon_array[] = $comment_icon;
 
             // Add icon
             if (
@@ -330,37 +329,36 @@ class Dropdown
                 && !isset($_REQUEST['_in_modal'])
                 && $params['addicon']
             ) {
-                  $icons .= $add_item_icon;
-                  $icon_count++;
+                  $icon_array[] = $add_item_icon;
             }
 
            // Supplier Links
             if ($itemtype == "Supplier") {
                 if ($item->getFromDB($params['value'])) {
-                    $icons .= '<div>';
-                    $icons .= $item->getLinks();
-                    $icons .= '</div>';
-                    $icon_count++;
+                    $link_icon = '<div>';
+                    $link_icon .= $item->getLinks();
+                    $link_icon .= '</div>';
+                    $icon_array[] = $link_icon;
                 }
             }
 
            // Location icon
             if ($itemtype == 'Location') {
-                $icons .= '<div class="btn btn-outline-secondary">';
-                $icons .= "<span title='" . __s('Display on map') . "' data-bs-toggle='tooltip' onclick='showMapForLocation(this)' data-fid='$field_id'>
+                $location_icon = '<div class="btn btn-outline-secondary">';
+                $location_icon .= "<span title='" . __s('Display on map') . "' data-bs-toggle='tooltip' onclick='showMapForLocation(this)' data-fid='$field_id'>
                <i class='fa-fw ti ti-map'></i>
             </span>";
-                $icons .= '</div>';
-                $icon_count++;
+                $location_icon .= '</div>';
+                $icon_array[] = $location_icon;
             }
 
             if ($params['display_dc_position']) {
                 if ($rack = $item->isRackPart($itemtype, $params['value'], true)) {
-                    $icons .= "<span id='" . $breadcrumb_id . "' title='" . __s('Display on datacenter') . "'>";
-                    $icons .= "&nbsp;<a class='fas fa-crosshairs' href='" . $rack->getLinkURL() . "'></a>";
-                    $icons .= "</span>";
+                    $dc_icon = "<span id='" . $breadcrumb_id . "' title='" . __s('Display on datacenter') . "'>";
+                    $dc_icon .= "&nbsp;<a class='fas fa-crosshairs' href='" . $rack->getLinkURL() . "'></a>";
+                    $dc_icon .= "</span>";
                     $paramscomment['with_dc_position'] = $breadcrumb_id;
-                    $icon_count++;
+                    $icon_array[] = $dc_icon;
                 }
             }
 
@@ -375,8 +373,8 @@ class Dropdown
                     '_idor_token' => Session::getNewIDORToken($itemtype),
                     'withlink'    => $kblink_id,
                 ];
-                $icons .= '<div>';
-                $icons .= Ajax::updateItemOnSelectEvent(
+                $kb_link_icon = '<div>';
+                $kb_link_icon .= Ajax::updateItemOnSelectEvent(
                     $field_id,
                     $kblink_id,
                     $CFG_GLPI["root_doc"] . "/ajax/kblink.php",
@@ -388,21 +386,21 @@ class Dropdown
                 if ($item->isNewItem()) {
                     $item->getFromDB($params['value']);
                 }
-                $icons .= "<span id='$kblink_id'>";
-                $icons .= '&nbsp;' . $item->getLinks();
-                $icons .= "</span>";
-                $icons .= '</div>';
-                $icon_count++;
+                $kb_link_icon .= "<span id='$kblink_id'>";
+                $kb_link_icon .= '&nbsp;' . $item->getLinks();
+                $kb_link_icon .= "</span>";
+                $kb_link_icon .= '</div>';
+                $icon_array[] = $kb_link_icon;
             }
         }
 
         // Trick to get the "+" button to work with dropdowns that support multiple values
-        if (strlen($icons) == 0 && strlen($add_item_icon) > 0) {
-            $icons .= $add_item_icon;
-            $icon_count++;
+        if (count($icon_array) === 0 && $add_item_icon !== '') {
+            $icon_array[] .= $add_item_icon;
         }
 
-        if ($icon_count > 0) {
+        if (count($icon_array) > 0) {
+            $icon_count = count($icon_array);
             $original_width = $params['width'];
             if ($original_width === '100%') {
                 $calc_width = "calc(100% - (({$icon_count} * 0.9em) + (18px * {$icon_count})))";
@@ -414,6 +412,7 @@ class Dropdown
                 $params['url'],
                 $p
             );
+            $icons = implode('', $icon_array);
             $output = "<div class='btn-group btn-group-sm' role='group'
                 style='width: {$original_width}'>{$output} {$icons}</div>";
         } else {

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -252,13 +252,6 @@ class Dropdown
             }
         }
 
-        $output .= Html::jsAjaxDropdown(
-            $params['name'],
-            $field_id,
-            $params['url'],
-            $p
-        );
-
         // Add icon
         $add_item_icon = "";
         if (
@@ -279,6 +272,7 @@ class Dropdown
 
        // Display comment
         $icons = "";
+        $icon_count = 0;
         if ($params['comments']) {
             $comment_id      = Html::cleanId("comment_" . $params['name'] . $params['rand']);
             $link_id         = Html::cleanId("comment_link_" . $params['name'] . $params['rand']);
@@ -327,6 +321,7 @@ class Dropdown
             );
             $options_tooltip['link_class'] = 'btn btn-outline-secondary';
             $icons .= Html::showToolTip($comment, $options_tooltip);
+            $icon_count++;
 
             // Add icon
             if (
@@ -336,6 +331,7 @@ class Dropdown
                 && $params['addicon']
             ) {
                   $icons .= $add_item_icon;
+                  $icon_count++;
             }
 
            // Supplier Links
@@ -344,6 +340,7 @@ class Dropdown
                     $icons .= '<div>';
                     $icons .= $item->getLinks();
                     $icons .= '</div>';
+                    $icon_count++;
                 }
             }
 
@@ -354,6 +351,7 @@ class Dropdown
                <i class='fa-fw ti ti-map'></i>
             </span>";
                 $icons .= '</div>';
+                $icon_count++;
             }
 
             if ($params['display_dc_position']) {
@@ -362,6 +360,7 @@ class Dropdown
                     $icons .= "&nbsp;<a class='fas fa-crosshairs' href='" . $rack->getLinkURL() . "'></a>";
                     $icons .= "</span>";
                     $paramscomment['with_dc_position'] = $breadcrumb_id;
+                    $icon_count++;
                 }
             }
 
@@ -393,16 +392,37 @@ class Dropdown
                 $icons .= '&nbsp;' . $item->getLinks();
                 $icons .= "</span>";
                 $icons .= '</div>';
+                $icon_count++;
             }
         }
 
         // Trick to get the "+" button to work with dropdowns that support multiple values
         if (strlen($icons) == 0 && strlen($add_item_icon) > 0) {
             $icons .= $add_item_icon;
+            $icon_count++;
         }
 
-        if (strlen($icons) > 0) {
-            $output = "<div class='btn-group btn-group-sm " . ($params['width'] == "100%" ? "w-150" : "") . "' role='group'>{$output} {$icons}</div>";
+        if ($icon_count > 0) {
+            $original_width = $params['width'];
+            if ($original_width === '100%') {
+                $calc_width = "calc(100% - (({$icon_count} * 0.9em) + (18px * {$icon_count})))";
+                $p['width'] = $calc_width;
+            }
+            $output .= Html::jsAjaxDropdown(
+                $params['name'],
+                $field_id,
+                $params['url'],
+                $p
+            );
+            $output = "<div class='btn-group btn-group-sm " . ($original_width == "100%" ? "" : "") . "' role='group'
+                style='width: {$original_width}'>{$output} {$icons}</div>";
+        } else {
+            $output .= Html::jsAjaxDropdown(
+                $params['name'],
+                $field_id,
+                $params['url'],
+                $p
+            );
         }
 
         $output .= Ajax::commonDropdownUpdateItem($params, false);

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -396,7 +396,7 @@ class Dropdown
 
         // Trick to get the "+" button to work with dropdowns that support multiple values
         if (count($icon_array) === 0 && $add_item_icon !== '') {
-            $icon_array[] .= $add_item_icon;
+            $icon_array[] = $add_item_icon;
         }
 
         if (count($icon_array) > 0) {

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -414,7 +414,7 @@ class Dropdown
                 $params['url'],
                 $p
             );
-            $output = "<div class='btn-group btn-group-sm " . ($original_width == "100%" ? "" : "") . "' role='group'
+            $output = "<div class='btn-group btn-group-sm' role='group'
                 style='width: {$original_width}'>{$output} {$icons}</div>";
         } else {
             $output .= Html::jsAjaxDropdown(

--- a/templates/components/itilobject/fields/global_validation.html.twig
+++ b/templates/components/itilobject/fields/global_validation.html.twig
@@ -80,9 +80,7 @@
                 'global_validation',
                 call('TicketValidation::getStatus', [item.fields['global_validation'], true]),
                 "CommonITILValidation"|itemtype_name,
-                {
-                    'full_width': true,
-                }
+                field_options
             ) }}
         {% endif %}
    {% endif %}


### PR DESCRIPTION
 Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12677

The global approval field in ITIL Objects was not aligned properly if it was supposed to be in the second column.

There was also an issue with the dropdown widths when they had icon buttons. This seemed to be from changing `w-100` class to `w-150` when icons were present which fixed the display in the search engine, but inside a form it caused the dropdown to overflow into the next column.