### PR TITLE
Fix nightly build of main branch

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -22,7 +22,7 @@ jobs:
           # build on lower supported version to ensure building tools are compatible with this version
           - {branch: "9.5/bugfixes", php-version: "7.2"}
           - {branch: "10.0/bugfixes", php-version: "7.4"}
-          - {branch: "main", php-version: "7.4"}
+          - {branch: "main", php-version: "8.0"}
     services:
       app:
         image: "ghcr.io/glpi-project/githubactions-php:${{ matrix.php-version }}"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The nightly build of the main branch has been failing because it was trying to use PHP 7.4, but the minimum for the main branch is now 8.0.