### PR TITLE
Streamline Search::show logic

### DIFF
--- a/src/Search/Input/QueryBuilder.php
+++ b/src/Search/Input/QueryBuilder.php
@@ -905,7 +905,7 @@ JAVASCRIPT;
      *
      * @param class-string<\CommonDBTM>  $itemtype Item type to manage
      * @param array   $params          Params to parse
-     * @param boolean $usesession      Use datas save in session (true by default)
+     * @param boolean $usesession      Use data saved in the session (true by default)
      * @param boolean $forcebookmark   Force trying to load parameters from default bookmark:
      *                                  used for global search (false by default)
      *
@@ -983,7 +983,7 @@ JAVASCRIPT;
             $user_default_values = \SavedSearch_User::getDefault(\Session::getLoginUserID(), $itemtype);
             if ($user_default_values) {
                 $_SESSION['glpisearch'][$itemtype] = [];
-                // Only get datas for bookmarks
+                // Only get data for bookmarks
                 if ($forcebookmark) {
                     $params = $user_default_values;
                 } else {

--- a/src/Search/Output/AbstractSearchOutput.php
+++ b/src/Search/Output/AbstractSearchOutput.php
@@ -35,12 +35,47 @@
 
 namespace Glpi\Search\Output;
 
+use CommonGLPI;
+
 /**
  *
  * @internal Not for use outside {@link Search} class and the "Glpi\Search" namespace.
  */
 abstract class AbstractSearchOutput
 {
+    /**
+     * Modify the search parameters before the search is executed.
+     *
+     * This is useful if some criteria need injected such as the Location in the case of the Map output.
+     * This is called after the search input form is shown, so any new criteria will be hidden.
+     * @param class-string<CommonGLPI> $itemtype
+     * @param array $params
+     * @return array
+     */
+    public static function prepareInputParams(string $itemtype, array $params): array
+    {
+        return $params;
+    }
+
+    /**
+     * Display some content before the search input form and results
+     * @param class-string<CommonGLPI> $itemtype
+     * @return void
+     */
+    public static function showPreSearchDisplay(string $itemtype): void
+    {
+    }
+
+    /**
+     * Display the search results
+     *
+     * @param array $data Array of search data prepared to get data
+     * @param array $params The original search parameters
+     *
+     * @return void|false
+     **/
+    abstract public static function displayData(array $data, array $params);
+
     /**
      * Print generic normal Item Cell
      *

--- a/src/Search/Output/ExportSearchOutput.php
+++ b/src/Search/Output/ExportSearchOutput.php
@@ -163,14 +163,7 @@ abstract class ExportSearchOutput extends AbstractSearchOutput
         return $out;
     }
 
-    /**
-     * Output data (for export in CSV, PDF, ...).
-     *
-     * @param array $data Array of search datas prepared to get datas
-     *
-     * @return void|false
-     **/
-    public static function outputData(array $data)
+    public static function displayData(array $data, array $params)
     {
         global $CFG_GLPI;
 

--- a/src/Search/Output/HTMLSearchOutput.php
+++ b/src/Search/Output/HTMLSearchOutput.php
@@ -36,7 +36,9 @@
 namespace Glpi\Search\Output;
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Dashboard\Grid;
 use Glpi\Toolbox\Sanitizer;
+use Ticket;
 
 /**
  *
@@ -44,14 +46,18 @@ use Glpi\Toolbox\Sanitizer;
  */
 abstract class HTMLSearchOutput extends AbstractSearchOutput
 {
-    /**
-     * Display datas extracted from DB
-     *
-     * @param array $data Array of search datas prepared to get datas
-     *
-     * @return void|false
-     **/
-    public static function displayData(array $data)
+    public static function showPreSearchDisplay(string $itemtype): void
+    {
+        if (
+            $itemtype === Ticket::class
+            && $default = Grid::getDefaultDashboardForMenu('mini_ticket', true)
+        ) {
+            $dashboard = new Grid($default, 33, 2);
+            $dashboard->show(true);
+        }
+    }
+
+    public static function displayData(array $data, array $params)
     {
         global $CFG_GLPI;
 

--- a/src/Search/Output/MapSearchOutput.php
+++ b/src/Search/Output/MapSearchOutput.php
@@ -43,22 +43,14 @@ use Glpi\Toolbox\Sanitizer;
  */
 final class MapSearchOutput extends HTMLSearchOutput
 {
-    /**
-     * Display result table for search engine for an item type as a map
-     *
-     * @param string $itemtype Item type to manage
-     * @param array  $params   Search params passed to prepareDatasForSearch function
-     *
-     * @return void
-     **/
-    public static function showMap($itemtype, $params): void
+    public static function prepareInputParams(string $itemtype, array $params): array
     {
-        global $CFG_GLPI;
+        $params = parent::prepareInputParams($itemtype, $params);
 
-        if ($itemtype == 'Location') {
+        if ($itemtype === 'Location') {
             $latitude = 21;
             $longitude = 20;
-        } else if ($itemtype == 'Entity') {
+        } else if ($itemtype === 'Entity') {
             $latitude = 67;
             $longitude = 68;
         } else {
@@ -79,9 +71,14 @@ final class MapSearchOutput extends HTMLSearchOutput
             'value'        => 'NULL'
         ];
 
-        $data = \Search::getDatas($itemtype, $params);
-        \Search::displayData($data);
+        return $params;
+    }
 
+    public static function displayData(array $data, array $params): void
+    {
+        global $CFG_GLPI;
+
+        $itemtype = $data['itemtype'];
         if ($data['data']['totalcount'] > 0) {
             $target = $data['search']['target'];
             $criteria = $data['search']['criteria'];
@@ -89,7 +86,7 @@ final class MapSearchOutput extends HTMLSearchOutput
             array_pop($criteria);
             $criteria[] = [
                 'link'         => 'AND',
-                'field'        => ($itemtype == 'Location' || $itemtype == 'Entity') ? 1 : (($itemtype == 'Ticket') ? 83 : 3),
+                'field'        => ($itemtype === 'Location' || $itemtype === 'Entity') ? 1 : (($itemtype === 'Ticket') ? 83 : 3),
                 'searchtype'   => 'equals',
                 'value'        => 'CURLOCATION'
             ];

--- a/src/Search/Output/SYLKSearchOutput.php
+++ b/src/Search/Output/SYLKSearchOutput.php
@@ -134,7 +134,7 @@ final class SYLKSearchOutput extends ExportSearchOutput
             $out .= "C;N;K\"$val\"\n";
             $out .= "\n";
         }
-        // Datas
+        // Data
         foreach ($SYLK_ARRAY as $row => $tab) {
             foreach ($tab as $num => $val) {
                 $out .= "F;P3;FG0L;" . ($num == 1 ? "Y" . $row . ";" : "") . "X$num\n";

--- a/src/Search/Provider/SQLProvider.php
+++ b/src/Search/Provider/SQLProvider.php
@@ -48,6 +48,13 @@ use Session;
  */
 final class SQLProvider implements SearchProviderInterface
 {
+    public static function prepareData(array &$data, array $options = []): array
+    {
+        self::constructSQL($data);
+        self::constructData($data, $options['only_count'] ?? false);
+        return $data;
+    }
+
     private static function buildSelect(array $data, string $itemtable): string
     {
         // request currentuser for SQL supervision, not displayed
@@ -2852,7 +2859,7 @@ final class SQLProvider implements SearchProviderInterface
      *                    may be an array a request : need to add counts
      *                    maybe empty : use search one to count
      *
-     * @param array $data Array of search datas prepared to generate SQL
+     * @param array $data Array of search data prepared to generate SQL
      * @return false|void
      */
     public static function constructSQL(array &$data)
@@ -3571,7 +3578,7 @@ final class SQLProvider implements SearchProviderInterface
     }
 
     /**
-     * Retrieve datas from DB : construct data array containing columns definitions and rows datas
+     * Retrieve data from DB : construct data array containing columns definitions and rows data
      *
      * add to data array a field data containing :
      *      cols : columns definition
@@ -3765,7 +3772,7 @@ final class SQLProvider implements SearchProviderInterface
                 $newrow        = [];
                 $newrow['raw'] = $row;
 
-                // Parse datas
+                // Parse data
                 foreach ($newrow['raw'] as $key => $val) {
                     if (preg_match('/ITEM(_(\w[^\d]+))?_(\d+)(_(.+))?/', $key, $matches)) {
                         $j = $matches[3];

--- a/src/Search/Provider/SearchProviderInterface.php
+++ b/src/Search/Provider/SearchProviderInterface.php
@@ -44,4 +44,5 @@ namespace Glpi\Search\Provider;
  */
 interface SearchProviderInterface
 {
+    public static function prepareData(array &$data, array $options): array;
 }

--- a/src/Search/SearchEngine.php
+++ b/src/Search/SearchEngine.php
@@ -35,9 +35,17 @@
 
 namespace Glpi\Search;
 
+use CommonGLPI;
 use CommonITILObject;
+use Glpi\Agent\Communication\Headers\Common;
+use Glpi\Application\View\TemplateRenderer;
+use Glpi\Features\TreeBrowse;
+use Glpi\Plugin\Hooks;
+use Glpi\Search\Input\QueryBuilder;
+use Glpi\Search\Input\SearchInputInterface;
 use Glpi\Search\Output\AbstractSearchOutput;
 use Glpi\Search\Output\CSVSearchOutput;
+use Glpi\Search\Output\ExportSearchOutput;
 use Glpi\Search\Output\GlobalSearchOutput;
 use Glpi\Search\Output\MapSearchOutput;
 use Glpi\Search\Output\NamesListSearchOutput;
@@ -45,6 +53,9 @@ use Glpi\Search\Output\PDFLandscapeSearchOutput;
 use Glpi\Search\Output\PDFPortraitSearchOutput;
 use Glpi\Search\Output\SYLKSearchOutput;
 use Glpi\Search\Output\TableSearchOutput;
+use Glpi\Search\Provider\SearchProviderInterface;
+use Glpi\Search\Provider\SQLProvider;
+use Plugin;
 
 /**
  * The search engine.
@@ -245,7 +256,7 @@ final class SearchEngine
      *
      * @return array prepare to be used for a search (include criteria and others needed information)
      **/
-    public static function prepareDatasForSearch($itemtype, array $params, array $forcedisplay = []): array
+    public static function prepareDataForSearch($itemtype, array $params, array $forcedisplay = []): array
     {
         global $CFG_GLPI;
 
@@ -540,5 +551,87 @@ final class SearchEngine
     public static function getOrigTableName(string $itemtype): string
     {
         return (is_a($itemtype, \CommonDBTM::class, true)) ? $itemtype::getTable() : getTableForItemType($itemtype);
+    }
+
+    /**
+     * @param array $params
+     * @return class-string<SearchInputInterface>
+     */
+    private static function getSearchInputClass(array $params = []): string
+    {
+        // TODO Maybe have a plugin hook here for custom search input classes
+        return QueryBuilder::class;
+    }
+
+    /**
+     * @param array $params
+     * @return class-string<SearchProviderInterface>
+     */
+    private static function getSearchProviderClass(array $params = []): string
+    {
+        // TODO Maybe have a plugin hook here for custom search provider classes
+        return SQLProvider::class;
+    }
+
+    /**
+     * @param class-string<CommonGLPI> $itemtype
+     * @param array $params
+     * @return void
+     */
+    public static function show(string $itemtype, array $params = []): void
+    {
+        Plugin::doHook(Hooks::PRE_ITEM_LIST, ['itemtype' => $itemtype, 'options' => []]);
+
+        /** @var SearchInputInterface $search_input_class */
+        $search_input_class = self::getSearchInputClass($params);
+        $params = array_merge($params, $search_input_class::manageParams($itemtype, $_GET));
+
+        if (!isset($params['display_type'])) {
+            $params['display_type'] = \Search::HTML_OUTPUT;
+        }
+
+        echo "<div class='search_page row'>";
+        TemplateRenderer::getInstance()->display('layout/parts/saved_searches.html.twig', [
+            'itemtype' => $itemtype,
+        ]);
+        echo "<div class='col search-container'>";
+
+        $output = self::getOutputForLegacyKey($params['display_type'], $params);
+        $output::showPreSearchDisplay($itemtype);
+
+        $search_input_class::showGenericSearch($itemtype, $params);
+        $params = $output::prepareInputParams($itemtype, $params);
+        if ((int) $params['browse'] === 1 && \Toolbox::hasTrait($itemtype, TreeBrowse::class)) {
+            $itemtype::showBrowseView($itemtype, $params);
+        } else {
+            self::showOutput($itemtype, $params);
+        }
+        echo "</div>";
+        echo "</div>";
+
+        Plugin::doHook(Hooks::POST_ITEM_LIST, ['itemtype' => $itemtype, 'options' => []]);
+    }
+
+    public static function getData(string $itemtype, array $params, array $forced_display = []): array
+    {
+        $data = self::prepareDataForSearch($itemtype, $params, $forced_display);
+        $search_provider_class = self::getSearchProviderClass($params);
+        $search_provider_class::constructSQL($data);
+        $search_provider_class::constructData($data);
+
+        return $data;
+    }
+
+    /**
+     * @param string $itemtype The itemtype being displayed
+     * @param array $params The search parameters
+     * @param array $forced_display Array of columns to display (default empty = empty use display pref and search criterias)
+     * @return void
+     */
+    public static function showOutput(string $itemtype, array $params, array $forced_display = []): void
+    {
+        $output = self::getOutputForLegacyKey($params['display_type'] ?? \Search::HTML_OUTPUT, $params);
+        $data = self::getData($itemtype, $params, $forced_display);
+        $output::displayData($data, $params);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

- Move logic for `Search::show` to new classes.
- Improved handling of Map HTML output by adding a new `prepareInputParams` method for search output classes. This allows forcing some criteria so the location fields are included in the Map view
- Added `showPreSearchDisplay` method for search output classes to handle showing widgets before the search input form such as the mini dashboard shown for the HTML output for Tickets
- Unified the method naming for displaying/outputting the results
- Moved the remaining method logic left in `Search`