### PR TITLE
Make getDefaultActor() consistent for ITIL Objects

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -1209,7 +1209,18 @@ abstract class CommonITILObject extends CommonDBTM
 
        /// TODO own_ticket -> own_itilobject
         if ($type == CommonITILActor::ASSIGN) {
-            if (Session::haveRight("ticket", Ticket::OWN)) {
+            if (
+                Session::haveRight("ticket", Ticket::OWN)
+                && $_SESSION['glpiset_default_tech']
+            ) {
+                return Session::getLoginUserID();
+            }
+        }
+        if ($type == CommonITILActor::REQUESTER) {
+            if (
+                Session::haveRight(static::$rightname, CREATE)
+                && $_SESSION['glpiset_default_requester']
+            ) {
                 return Session::getLoginUserID();
             }
         }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -642,31 +642,6 @@ class Ticket extends CommonITILObject
         return static::canDelete();
     }
 
-    /**
-     * @see CommonITILObject::getDefaultActor()
-     **/
-    public function getDefaultActor($type)
-    {
-
-        if ($type == CommonITILActor::ASSIGN) {
-            if (
-                Session::haveRight(self::$rightname, self::OWN)
-                && $_SESSION['glpiset_default_tech']
-            ) {
-                return Session::getLoginUserID();
-            }
-        }
-        if ($type == CommonITILActor::REQUESTER) {
-            if (
-                Session::haveRight(self::$rightname, CREATE)
-                && $_SESSION['glpiset_default_requester']
-            ) {
-                return Session::getLoginUserID();
-            }
-        }
-        return 0;
-    }
-
 
     /**
      * @see CommonITILObject::getDefaultActorRightSearch()


### PR DESCRIPTION
Make getDefaultActor() consistent for all ITIL Objects and use ``glpiset_default_tech`` and ``glpiset_default_requester``.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12188
