### PR TITLE
Fix tests

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -1374,9 +1374,9 @@ abstract class CommonITILObject extends CommonDBTM
         $iterator = $DB->request([
             'FROM'      => $this->getTable(),
             'LEFT JOIN' => [
-                "glpi_items_${class_l_pl}" => [
+                "glpi_items_{$class_l_pl}" => [
                     'ON' => [
-                        "glpi_items_${class_l_pl}" => "${class_l_pl}_id",
+                        "glpi_items_{$class_l_pl}" => "{$class_l_pl}_id",
                         $this->getTable()    => 'id'
                     ]
                 ]

--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -675,46 +675,48 @@ class Migration extends \GLPITestCase
     {
         global $DB;
 
+        // Clean DB to handle potential failure of previous test
         $DB->delete('glpi_profilerights', [
             'name' => [
-                'testright1', 'testright2', 'testright3', 'testright4'
+                'test_addright_1', 'test_addright_2', 'test_addright_3', 'test_addright_4'
             ]
         ]);
+
         //Test adding a READ right when profile has READ and UPDATE config right (Default)
         $this->output(
             function () {
-                $this->migration->addRight('testright1', READ);
+                $this->migration->addRight('test_addright_1', READ);
             }
-        )->isEqualTo('New rights has been added for testright1, you should review ACLs after update');
+        )->isEqualTo('New rights has been added for test_addright_1, you should review ACLs after update');
 
         //Test adding a READ right when profile has UPDATE group right
         $this->output(
             function () {
-                $this->migration->addRight('testright2', READ, ['group' => UPDATE]);
+                $this->migration->addRight('test_addright_2', READ, ['group' => UPDATE]);
             }
-        )->isEqualTo('New rights has been added for testright2, you should review ACLs after update');
+        )->isEqualTo('New rights has been added for test_addright_2, you should review ACLs after update');
 
         //Test adding an UPDATE right when profile has READ and UPDATE group right and CREATE entity right
         $this->output(
             function () {
-                $this->migration->addRight('testright3', UPDATE, [
+                $this->migration->addRight('test_addright_3', UPDATE, [
                     'group'  => READ | UPDATE,
                     'entity' => CREATE
                 ]);
             }
-        )->isEqualTo('New rights has been added for testright3, you should review ACLs after update');
+        )->isEqualTo('New rights has been added for test_addright_3, you should review ACLs after update');
 
         //Test adding a READ right when profile with no requirements
         $this->output(
             function () {
-                $this->migration->addRight('testright4', READ, []);
+                $this->migration->addRight('test_addright_4', READ, []);
             }
-        )->isEqualTo('New rights has been added for testright4, you should review ACLs after update');
+        )->isEqualTo('New rights has been added for test_addright_4, you should review ACLs after update');
 
         $right1 = $DB->request([
             'FROM' => 'glpi_profilerights',
             'WHERE'  => [
-                'name'   => 'testright1',
+                'name'   => 'test_addright_1',
                 'rights' => READ
             ]
         ]);
@@ -723,7 +725,7 @@ class Migration extends \GLPITestCase
         $right1 = $DB->request([
             'FROM' => 'glpi_profilerights',
             'WHERE'  => [
-                'name'   => 'testright2',
+                'name'   => 'test_addright_2',
                 'rights' => READ
             ]
         ]);
@@ -732,7 +734,7 @@ class Migration extends \GLPITestCase
         $right1 = $DB->request([
             'FROM' => 'glpi_profilerights',
             'WHERE'  => [
-                'name'   => 'testright3',
+                'name'   => 'test_addright_3',
                 'rights' => UPDATE
             ]
         ]);
@@ -741,7 +743,7 @@ class Migration extends \GLPITestCase
         $right1 = $DB->request([
             'FROM' => 'glpi_profilerights',
             'WHERE'  => [
-                'name'   => 'testright4',
+                'name'   => 'test_addright_4',
                 'rights' => READ
             ]
         ]);
@@ -750,23 +752,30 @@ class Migration extends \GLPITestCase
         //Test adding a READ right only on profiles where it has not been set yet
         $DB->delete('glpi_profilerights', [
             'profiles_id' => [1, 2, 3, 4],
-            'name' => 'testright4'
+            'name' => 'test_addright_4'
         ]);
 
         $this->output(
             function () {
-                $this->migration->addRight('testright4', READ | UPDATE, []);
+                $this->migration->addRight('test_addright_4', READ | UPDATE, []);
             }
-        )->isEqualTo('New rights has been added for testright4, you should review ACLs after update');
+        )->isEqualTo('New rights has been added for test_addright_4, you should review ACLs after update');
 
         $right4 = $DB->request([
             'FROM' => 'glpi_profilerights',
             'WHERE'  => [
-                'name'   => 'testright4',
+                'name'   => 'test_addright_4',
                 'rights' => READ | UPDATE
             ]
         ]);
         $this->integer(count($right4))->isEqualTo(4);
+
+        // Clean DB after test
+        $DB->delete('glpi_profilerights', [
+            'name' => [
+                'test_addright_1', 'test_addright_2', 'test_addright_3', 'test_addright_4'
+            ]
+        ]);
     }
 
     public function testRenameTable()
@@ -1108,23 +1117,24 @@ class Migration extends \GLPITestCase
     {
         global $DB;
 
+        // Clean DB to handle potential failure of previous test
         $DB->delete('glpi_profilerights', [
             'name' => [
-                'testright1', 'testright2', 'testright3'
+                'test_updateright_1', 'test_updateright_2', 'test_updateright_3'
             ]
         ]);
 
         //Test updating a UPDATE right when profile has READ and UPDATE config right (Default)
         $this->output(
             function () {
-                $this->migration->updateRight('testright1', READ);
+                $this->migration->updateRight('test_updateright_1', READ);
             }
-        )->isEqualTo('Rights has been updated for testright1, you should review ACLs after update');
+        )->isEqualTo('Rights has been updated for test_updateright_1, you should review ACLs after update');
 
         $right1 = $DB->request([
             'FROM' => 'glpi_profilerights',
             'WHERE'  => [
-                'name'   => 'testright1',
+                'name'   => 'test_updateright_1',
                 'rights' => READ
             ]
         ]);
@@ -1133,14 +1143,14 @@ class Migration extends \GLPITestCase
         //Test updating a READ right when profile has UPDATE group right
         $this->output(
             function () {
-                $this->migration->updateRight('testright2', READ, ['group' => UPDATE]);
+                $this->migration->updateRight('test_updateright_2', READ, ['group' => UPDATE]);
             }
-        )->isEqualTo('Rights has been updated for testright2, you should review ACLs after update');
+        )->isEqualTo('Rights has been updated for test_updateright_2, you should review ACLs after update');
 
         $right1 = $DB->request([
             'FROM' => 'glpi_profilerights',
             'WHERE'  => [
-                'name'   => 'testright2',
+                'name'   => 'test_updateright_2',
                 'rights' => READ
             ]
         ]);
@@ -1149,17 +1159,17 @@ class Migration extends \GLPITestCase
         //Test updating an UPDATE right when profile has READ and UPDATE group right and CREATE entity right
         $this->output(
             function () {
-                $this->migration->updateRight('testright2', UPDATE, [
+                $this->migration->updateRight('test_updateright_2', UPDATE, [
                     'group'  => READ | UPDATE,
                     'entity' => CREATE
                 ]);
             }
-        )->isEqualTo('Rights has been updated for testright2, you should review ACLs after update');
+        )->isEqualTo('Rights has been updated for test_updateright_2, you should review ACLs after update');
 
         $right1 = $DB->request([
             'FROM' => 'glpi_profilerights',
             'WHERE'  => [
-                'name'   => 'testright2',
+                'name'   => 'test_updateright_2',
                 'rights' => UPDATE
             ]
         ]);
@@ -1168,17 +1178,24 @@ class Migration extends \GLPITestCase
         //Test updating a READ right when profile with no requirements
         $this->output(
             function () {
-                $this->migration->updateRight('testright3', READ, []);
+                $this->migration->updateRight('test_updateright_3', READ, []);
             }
-        )->isEqualTo('Rights has been updated for testright3, you should review ACLs after update');
+        )->isEqualTo('Rights has been updated for test_updateright_3, you should review ACLs after update');
 
         $right1 = $DB->request([
             'FROM' => 'glpi_profilerights',
             'WHERE'  => [
-                'name'   => 'testright3',
+                'name'   => 'test_updateright_3',
                 'rights' => READ
             ]
         ]);
         $this->integer(count($right1))->isEqualTo(8);
+
+        // Clean DB after test
+        $DB->delete('glpi_profilerights', [
+            'name' => [
+                'test_updateright_1', 'test_updateright_2', 'test_updateright_3'
+            ]
+        ]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`Migration::updateRights()` test was checking removal of rights on a profile, leading to have a right with `0` value. Profile cloning was not cloning this value, as it correspond to having no right on given element.
While this could be probably handled better on both profile cloning and `Migration::updateRights()` methods, I propose to quickly fix tests by adding a cleaning routine on migration tests. Thus, to ensure that migration tests cannot conflict, I renamed rightnames.
