### PR TITLE
Fix uploaded files names

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -1389,7 +1389,7 @@ function flashIconButton(button, button_classes, icon_classes, duration) {
 function uniqid(prefix = "", more_entropy = false) {
     const sec = Date.now() * 1000 + Math.random() * 1000;
     const id = sec.toString(16).replace(/\./g, "").padEnd(14, "0");
-    return `${prefix}${id}${more_entropy ? `.${Math.trunc(Math.random() * 100000000)}`:""}`;
+    return `${prefix}${id}${more_entropy ? `.${Math.floor(10000000 + Math.random() * 90000000)}`:""}`;
 }
 
 /**

--- a/js/common.js
+++ b/js/common.js
@@ -1389,7 +1389,10 @@ function flashIconButton(button, button_classes, icon_classes, duration) {
 function uniqid(prefix = "", more_entropy = false) {
     const sec = Date.now() * 1000 + Math.random() * 1000;
     const id = sec.toString(16).replace(/\./g, "").padEnd(14, "0");
-    return `${prefix}${id}${more_entropy ? `.${Math.floor(10000000 + Math.random() * 90000000)}`:""}`;
+    const suffix = more_entropy
+        ? '.' + Math.floor(Math.random() * 100000000).toString().padStart(8, '0')
+        : '';
+    return `${prefix}${id}${suffix}`;
 }
 
 /**


### PR DESCRIPTION
I've recently spotted that some uploaded files had their first letter truncated:

![image](https://user-images.githubusercontent.com/42734840/190993987-b0b71c78-1fb7-4aa9-8fcd-da338be49fe4.png)

After some digging I found out that our `uniqid` function would return a 22 (~10% of the time) or 23 (~90% of the time) chars string, while our backend always expect a 23 chars string.

This is explained by this part of the `uniqid` function code, which may return random numbers of different sizes:

![image](https://user-images.githubusercontent.com/42734840/190994455-359d3f0c-58be-4c09-9839-cf96dfb4de64.png)

The new code ensure the random number will be at least `10000000`, thus always having the same size. 

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
