### PR TITLE
Force ID to be visible for CommonITILObjects in dropdownAllItems

### DIFF
--- a/ajax/dropdownAllItems.php
+++ b/ajax/dropdownAllItems.php
@@ -60,7 +60,7 @@ if ($_POST["idtable"] && class_exists($_POST["idtable"])) {
         'valuename'           => Dropdown::EMPTY_VALUE,
         'itemtype'            => $_POST["idtable"],
         'display_emptychoice' => true,
-        'displaywith'         => ['otherserial', 'serial'],
+        'displaywith'         => is_a($_POST['idtable'],CommonITILObject::class,true) ? ['id'] : ['otherserial', 'serial'],
         '_idor_token'         => Session::getNewIDORToken($_POST["idtable"]),
     ];
     if (isset($_POST['value'])) {

--- a/ajax/dropdownAllItems.php
+++ b/ajax/dropdownAllItems.php
@@ -60,7 +60,7 @@ if ($_POST["idtable"] && class_exists($_POST["idtable"])) {
         'valuename'           => Dropdown::EMPTY_VALUE,
         'itemtype'            => $_POST["idtable"],
         'display_emptychoice' => true,
-        'displaywith'         => is_a($_POST['idtable'],CommonITILObject::class,true) ? ['id'] : ['otherserial', 'serial'],
+        'displaywith'         => is_a($_POST['idtable'], CommonITILObject::class, true) ? ['id'] : ['otherserial', 'serial'],
         '_idor_token'         => Session::getNewIDORToken($_POST["idtable"]),
     ];
     if (isset($_POST['value'])) {


### PR DESCRIPTION
Make ID visible in dropdownAllItems in case it is CommonITILObject, it is now used in fields panel to link any to any ITIL object..
Without ID it will be quite a problem to match correct ticket in many cases..

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | NA
