### PR TITLE
Limit max processes used by PHPStan

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,6 @@
 parameters:
+    parallel:
+        maximumNumberOfProcesses: 2
     level: 0
     bootstrapFiles:
         - inc/based_config.php


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

PHPStan spawn as many processes as there are available threads on the machine. PHPStan uses almost about 1.5GB per thread, probably because GLPI code does not use strict type hinting, so PHPStan has to analyse really long execution chains to detect errors.
On my machine, when running the `tests/run_tests.sh` script, it spawns 8 processes, that are so using up to 12GB of memory and my system completely freezes, with a 50+ load average. I guess `docker` tries to use swap memory. Last time I tried to let PHPStan finishes its job, I had to reboot my machine after 3 hours because I was not even able to unlock my Ubuntu session.

So I propose to limit number of processes to 2, even if it make the job a little longer.