### PR TITLE
Fix saved search visiblity

### DIFF
--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -796,15 +796,11 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
             ],
             'FROM'      => $table,
             'LEFT JOIN' => [
-                $utable => ['ON' => [
-                    $utable  => 'savedsearches_id',
-                    $table   => 'id', [
-                        'AND' => [
-                            "$table.itemtype"  => new \QueryExpression("$utable.itemtype"),
-                            "$utable.users_id" => Session::getLoginUserID()
-                        ]
+                $utable => [
+                    'ON' => [
+                        $utable  => 'savedsearches_id',
+                        $table   => 'id'
                     ]
-                ]
                 ]
             ],
             'ORDERBY'   => [

--- a/tests/functionnal/SavedSearch.php
+++ b/tests/functionnal/SavedSearch.php
@@ -115,6 +115,22 @@ class SavedSearch extends DbTestCase
                 'url'          => 'front/ticket.php?itemtype=Ticket&sort=2&order=DESC&start=0&criteria[0][field]=5&criteria[0][searchtype]=equals&criteria[0][value]=' . $uid
             ])
         )->isTrue();
+
+        $this->boolean(
+            (bool)$bk->add([
+                'name'         => 'private',
+                'type'         => 1,
+                'itemtype'     => 'Ticket',
+                'users_id'     => $uid + 1,
+                'is_private'   => 1,
+                'entities_id'  => 0,
+                'is_recursive' => 1,
+                'url'          => 'front/ticket.php?itemtype=Ticket&sort=2&order=DESC&start=0&criteria[0][field]=5&criteria[0][searchtype]=equals&criteria[0][value]=' . $uid
+            ])
+        )->isTrue();
+        // With UPDATE 'config' right, we can see all bookmarks
+        $this->integer(count($bk->getMine()))->isEqualTo(3);
+        $_SESSION["glpiactiveprofile"]['config'] = $_SESSION["glpiactiveprofile"]['config'] & ~UPDATE;
         $this->integer(count($bk->getMine()))->isEqualTo(2);
 
         //add public saved searches read right for normal profile


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12690

SavedSearch_User relation class/table is only used to track the default searches for users and not which searches users have access to, so the condition in the JOIN clause doesn't make sense to me. Removing it fixes the visibility so users can only see their own private searches or, if they have the READ right, the public searches.