### PR TITLE
Fix array value handling in GLPI constants display

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -2070,7 +2070,7 @@ class Config extends CommonDBTM
         echo "<tr class='tab_bg_1'><td><pre class='section-content'>\n&nbsp;\n";
         foreach (get_defined_constants() as $constant_name => $constant_value) {
             if (preg_match('/^GLPI_/', $constant_name)) {
-                echo $constant_name . ': ' . $constant_value . "\n";
+                echo $constant_name . ': ' . json_encode($constant_value, JSON_UNESCAPED_SLASHES) . "\n";
             }
         }
         echo "\n</pre></td></tr>";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Using `json_decode` permit to have a better handling of array and boolean values, and to know the exact value of each constant.

```diff
- GLPI_IDOR_EXPIRES: 7200
+ GLPI_IDOR_EXPIRES: "7200"
- GLPI_ALLOW_IFRAME_IN_RICH_TEXT: 
+ GLPI_ALLOW_IFRAME_IN_RICH_TEXT: false
- GLPI_SERVERSIDE_URL_ALLOWLIST: Array
+ GLPI_SERVERSIDE_URL_ALLOWLIST: ["/^(https?|feed):\\/\\/[^@:]+(\\/.*)?$/"]
- GLPI_INSTALL_MODE: GIT
+ GLPI_INSTALL_MODE: "GIT"
- GLPI_MARKETPLACE_ALLOW_OVERRIDE: 1
+ GLPI_MARKETPLACE_ALLOW_OVERRIDE: true
- GLPI_USER_AGENT_EXTRA_COMMENTS: 
+ GLPI_USER_AGENT_EXTRA_COMMENTS: ""
```