### PR TITLE
Ignore KEY comments during database integrity checks

### DIFF
--- a/src/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
+++ b/src/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
@@ -514,6 +514,8 @@ class DatabaseSchemaIntegrityChecker
 
         // Normalize indexes definitions
         $indexes_replacements = [
+            // Remove comments
+            '/ COMMENT \'.+\'/i' => '',
             // Always use `KEY` word
             '/INDEX\s*(`\w+`)/' => 'KEY $1',
             // Add `KEY` word when missing from UNIQUE/FULLTEXT

--- a/tests/units/Glpi/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
+++ b/tests/units/Glpi/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
@@ -148,7 +148,8 @@ CREATE TABLE `table_{$table_increment}` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
   `is_valid` tinyint(4) NOT NULL COMMENT 'is object valid ?',
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `is_valid` (`is_valid`) COMMENT 'this is a key'
 ) ENGINE=InnoDB COMMENT='some comment with an escaped \' backquote' AUTO_INCREMENT=15
 SQL,
                 'normalized_sql' => <<<SQL
@@ -156,7 +157,8 @@ CREATE TABLE `table_{$table_increment}` (
   `id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
   `is_valid` tinyint NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `is_valid` (`is_valid`)
 ) ENGINE=InnoDB
 SQL,
                 'effective_sql'  => <<<SQL
@@ -164,7 +166,8 @@ CREATE TABLE `table_{$table_increment}` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL COMMENT 'name of the object',
   `is_valid` tinyint(4) NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `is_valid` (`is_valid`)
 ) ENGINE=InnoDB AUTO_INCREMENT=15
 SQL,
                 'differences'    => null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Even if it is not usual, it may happens that a coment is added on a table index. In this case, comment should be ignored during integrity checks, to prevent following kind of result:
```
Le schéma diffère pour la table "glpi_notifications_notificationtemplates".
--- Schéma de base de données attendu
+++ Schéma de base de données actuel
@@ @@
   `notificationtemplates_id` int NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`notifications_id`,`mode`,`notificationtemplates_id`),
-  KEY `mode` (`mode`),
+  KEY `mode` (`mode`) COMMENT 'See Notification_NotificationTemplate::MODE_* constants',
   KEY `notificationtemplates_id` (`notificationtemplates_id`)
 )
```