### PR TITLE
Autoclose issues by adding a label

### DIFF
--- a/.github/label-commenter-config.yml
+++ b/.github/label-commenter-config.yml
@@ -1,0 +1,25 @@
+labels:
+  - name: "invalid"
+    labeled:
+      issue:
+        body: |
+            This issue has been closed because you did not provide the requested information.
+        action: "close"
+  - name: "support"
+    labeled:
+      issue:
+        body: |
+            This issue has been closed as we only track bugs here.
+            
+            You can get community support on [forums](https://forum.glpi-project.org/) or you can consider [taking a subscription](https://glpi-project.org/subscriptions/) to get professional support.
+            You can also [contact GLPI editor team](https://portal.glpi-network.com/contact-us) directly.
+        action: close
+  - name: "feature suggestion"
+    labeled:
+      issue:
+        body: |
+            This issue has been closed as we only track bugs here.
+            
+            You can open a topic to discuss with community about this enhancement on [suggestion website](https://glpi.userecho.com/).
+            You can also [contact GLPI editor team](https://portal.glpi-network.com/contact-us) directly if you are willing to sponsor this feature.
+        action: close

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -1,0 +1,21 @@
+name: "Label commenter"
+
+on:
+  issues:
+    types:
+      - "labeled"
+      - "unlabeled"
+
+permissions:
+  contents: "read"
+  issues: "write"
+
+jobs:
+  comment:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v3"
+
+      - name: "Label commenter"
+        uses: "peaceiris/actions-label-commenter@v1"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

We often waste valuable time unsuccessfully investigating issues because we do not have all the information requested. Automatically closing this kind of issues by just adding a `invalid` label mays seems a bit rude, but I am pretty sure it will be more efficient than politely asking for missing information. Also, the requester not providing the requested information is already disrespectful, so closing their ticket is probably a good way to reframe it.

I also added autoclose action when `support` and `feature suggestion` labels are added.