### PR TITLE
API: fix update input and warnings

### DIFF
--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -1981,7 +1981,7 @@ abstract class API
                         }
 
                      //update item
-                        $object = Sanitizer::sanitize((array)$object);
+                        $object = Sanitizer::sanitize($this->inputObjectToArray($object));
                         $update_return = $item->update($object);
                         if ($update_return === false) {
                              $failed++;
@@ -1991,7 +1991,6 @@ abstract class API
                         ];
                     }
                 }
-
                // attach fileupload answer
                 if (
                     isset($params['upload_result'])
@@ -2366,7 +2365,7 @@ abstract class API
        // get sql errors
         if (
             count($all_messages) <= 0
-            && $DEBUG_SQL['errors'] !== null
+            && ($DEBUG_SQL['errors'] ?? null) !== null
         ) {
             $all_messages = $DEBUG_SQL['errors'];
         }

--- a/tests/web/APIRest.php
+++ b/tests/web/APIRest.php
@@ -1319,4 +1319,58 @@ class APIRest extends APIBaseClass
         ], 200);
         $this->string($data['comment'])->isEqualTo("<>");
     }
+
+    public function test_ActorUpdate()
+    {
+        $headers = ['Session-Token' => $this->session_token];
+        $rand = mt_rand();
+
+        // Group user for our tests
+        $groups_id = getItemByTypeName("Group", "_test_group_1", true);
+
+        // Create ticket
+        $input = [
+            'input' => [
+                'name' => "test_ActorUpdate_Ticket_$rand",
+                'content' => 'content'
+            ]
+        ];
+        $data = $this->query("/Ticket", [
+            'headers' => $headers,
+            'verb'    => "POST",
+            'json'    => $input,
+        ], 201);
+        $this->integer($data['id'])->isGreaterThan(0);
+        $tickets_id = $data['id'];
+
+        // Add group
+        var_dump($tickets_id);
+        $input = [
+            'input' => [
+                '_actors' => [
+                    'assign' => [
+                        [
+                            'itemtype' => "Group",
+                            'items_id' => $groups_id,
+                            'use_notification' => 1,
+                        ]
+                    ]
+                ]
+            ]
+        ];
+        $this->query("/Ticket/$tickets_id/", [
+            'headers' => $headers,
+            'verb'    => "PUT",
+            'json'    => $input,
+        ], 200);
+
+        // Check assigned groups
+        $data = $this->query("/Ticket/$tickets_id/Group_Ticket", [
+            'headers' => $headers,
+            'verb'    => "GET",
+        ], 200);
+
+        $this->integer($data[0]['tickets_id'])->isEqualTo($tickets_id);
+        $this->integer($data[0]['groups_id'])->isEqualTo($groups_id);
+    }
 }

--- a/tests/web/APIRest.php
+++ b/tests/web/APIRest.php
@@ -1325,7 +1325,7 @@ class APIRest extends APIBaseClass
         $headers = ['Session-Token' => $this->session_token];
         $rand = mt_rand();
 
-        // Group user for our tests
+        // Group used for our tests
         $groups_id = getItemByTypeName("Group", "_test_group_1", true);
 
         // Create ticket
@@ -1344,7 +1344,6 @@ class APIRest extends APIBaseClass
         $tickets_id = $data['id'];
 
         // Add group
-        var_dump($tickets_id);
         $input = [
             'input' => [
                 '_actors' => [


### PR DESCRIPTION
I've noticed this API call (adding a group to a ticket) was failing: 

![image](https://user-images.githubusercontent.com/42734840/191462347-ac4c6fdb-32c4-421a-a988-fc6ad9e13f4f.png)

It failed because the content of  `_actors` wasn't converted properly from stdobject to array.

![image](https://user-images.githubusercontent.com/42734840/191462605-985474ee-3ac4-46c0-b0d7-d2464e056dd1.png)

Fix seems to be calling the `inputObjectToArray` instead of simply casting to array (like it's already done for the `createItem` process).
![image](https://user-images.githubusercontent.com/42734840/191463223-ccf31c51-dbc8-42f2-8f7a-dc204c642c8f.png)
![image](https://user-images.githubusercontent.com/42734840/191463299-6bad2141-fc44-4b4c-b932-d5ef10880932.png)

Not sure why our json is decoded as an object and then converted to an array later.
Maybe it would be simpler to decode it directly as an array ?   
If so it should probably be done in another PR (main) to be safe.

Second fix was regarding this warning:
```
[2022-09-21 10:11:06] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "errors" in /home/aclai/localhost/glpi/10.0-bugfixes/src/Api/API.php at line 2369
  Backtrace :
  src/Api/API.php:1990                               Glpi\Api\API->getGlpiLastMessage()
  src/Api/APIRest.php:326                            Glpi\Api\API->updateItems()
  apirest.php:58                                     Glpi\Api\APIRest->call()
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
