### PR TITLE
fix(lock): Display all lock available 

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -491,7 +491,7 @@ $CFG_GLPI['inventory_types'] = [
 
 $CFG_GLPI['inventory_lockable_objects'] = ['Computer_Item',  'Item_SoftwareLicense',
     'Item_SoftwareVersion', 'Item_Disk', 'ComputerVirtualMachine',
-    'NetworkPort', 'NetworkName', 'IPAddress'
+    'NetworkPort', 'NetworkName', 'IPAddress', 'Item_OperatingSystem'
 ];
 
 $CFG_GLPI["kb_types"]              = ['Budget', 'Change', 'Computer',

--- a/inc/define.php
+++ b/inc/define.php
@@ -490,8 +490,12 @@ $CFG_GLPI['inventory_types'] = [
 ];
 
 $CFG_GLPI['inventory_lockable_objects'] = ['Computer_Item',  'Item_SoftwareLicense',
-    'Item_SoftwareVersion', 'Item_Disk', 'ComputerVirtualMachine',
-    'NetworkPort', 'NetworkName', 'IPAddress', 'Item_OperatingSystem'
+    'Item_SoftwareVersion', 'Item_Disk', 'ComputerVirtualMachine','ComputerAntivirus',
+    'NetworkPort', 'NetworkName', 'IPAddress', 'Item_OperatingSystem', 'Item_DeviceBattery', 'Item_DeviceCase',
+    'Item_DeviceControl', 'Item_DeviceDrive', 'Item_DeviceFirmware', 'Item_DeviceGeneric', 'Item_DeviceGraphicCard',
+    'Item_DeviceHardDrive', 'Item_DeviceMemory', 'Item_DeviceMotherboard', 'Item_DeviceNetworkCard', 'Item_DevicePci',
+    'Item_DevicePowerSupply', 'Item_DeviceProcessor', 'Item_DeviceSensor', 'Item_DeviceSimcard', 'Item_DeviceSoundCard',
+    'DatabaseInstance', 'Item_RemoteManagement'
 ];
 
 $CFG_GLPI["kb_types"]              = ['Budget', 'Change', 'Computer',

--- a/src/CommonDBChild.php
+++ b/src/CommonDBChild.php
@@ -66,14 +66,16 @@ abstract class CommonDBChild extends CommonDBConnexity
      **/
     public static function getSQLCriteriaToSearchForItem($itemtype, $items_id)
     {
+        $table = static::getTable();
+
         $criteria = [
             'SELECT' => [
                 static::getIndexName(),
                 static::$items_id . ' AS items_id'
             ],
-            'FROM'   => static::getTable(),
+            'FROM'   => $table,
             'WHERE'  => [
-                static::$items_id  => $items_id
+                $table . '.' . static::$items_id  => $items_id
             ]
         ];
 
@@ -81,7 +83,7 @@ abstract class CommonDBChild extends CommonDBConnexity
         $request = false;
         if (preg_match('/^itemtype/', static::$itemtype)) {
             $criteria['SELECT'][] = static::$itemtype . ' AS itemtype';
-            $criteria['WHERE'][static::$itemtype] = $itemtype;
+            $criteria['WHERE'][$table . '.' . static::$itemtype] = $itemtype;
             $request = true;
         } else {
             $criteria['SELECT'][] = new \QueryExpression("'" . static::$itemtype . "' AS itemtype");

--- a/src/CommonDBRelation.php
+++ b/src/CommonDBRelation.php
@@ -99,6 +99,8 @@ abstract class CommonDBRelation extends CommonDBConnexity
     {
         global $DB;
 
+        $table = static::getTable();
+
         $conditions = [];
         $fields     = [
             static::getIndexName(),
@@ -108,13 +110,13 @@ abstract class CommonDBRelation extends CommonDBConnexity
 
        // Check item 1 type
         $where1 = [
-            static::$items_id_1  => $items_id
+            $table . '.' . static::$items_id_1  => $items_id
         ];
 
         $request = false;
         if (preg_match('/^itemtype/', static::$itemtype_1)) {
             $fields[] = static::$itemtype_1 . ' AS itemtype_1';
-            $where1[static::$itemtype_1] = $itemtype;
+            $where1[$table . '.' . static::$itemtype_1] = $itemtype;
             $request = true;
         } else {
             $fields[] = new \QueryExpression("'" . static::$itemtype_1 . "' AS itemtype_1");
@@ -137,12 +139,12 @@ abstract class CommonDBRelation extends CommonDBConnexity
 
        // Check item 2 type
         $where2 = [
-            static::$items_id_2 => $items_id
+            $table . '.' . static::$items_id_2 => $items_id
         ];
         $request = false;
         if (preg_match('/^itemtype/', static::$itemtype_2)) {
             $fields[] = static::$itemtype_2 . ' AS itemtype_2';
-            $where2[static::$itemtype_2] = $itemtype;
+            $where2[$table . '.' . static::$itemtype_2] = $itemtype;
             $request = true;
         } else {
             $fields[] = new \QueryExpression("'" . static::$itemtype_2 . "' AS itemtype_2");
@@ -166,7 +168,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
         if (count($conditions) != 0) {
             $criteria = [
                 'SELECT' => $fields,
-                'FROM'   => static::getTable(),
+                'FROM'   => $table,
                 'WHERE'  => ['OR' => $conditions]
             ];
             return $criteria;

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -90,6 +90,7 @@ class Lock extends CommonGLPI
             echo "</th>";
             echo "<th>" . $lockedfield->getTypeName() . "</th>";
             echo "<th>" . __('Itemtype') . "</th>";
+            echo "<th>" . __('Link') . "</th>";
             echo "<th>" . __('Last inventoried value')  . "</th></tr>";
 
             $subquery = [];
@@ -210,6 +211,11 @@ class Lock extends CommonGLPI
                 }
                 echo "<td class='left'>" . $field_label . "</td>";
                 echo "<td class='left'>" . $row['itemtype']::getTypeName() . "</td>";
+
+                //load object
+                $object = new $row['itemtype']();
+                $object->getFromDB($row['items_id']);
+                echo "<td class='left'>" . $object->getLink() . "</td>";
                 echo "<td class='left'>" . $row['value'] . "</td>";
                 echo "</tr>\n";
             }

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -112,7 +112,6 @@ class Lock extends CommonGLPI
             ]);
 
             //get locked field for other lockable object
-            //they are managed later
             foreach ($CFG_GLPI['inventory_lockable_objects'] as $lockable_itemtype) {
                 $lockable_object = new $lockable_itemtype();
                 $query  = [

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -85,10 +85,11 @@ class Lock extends CommonGLPI
             echo "<table class='tab_cadre_fixehov'>";
 
             echo "<tr>";
+            echo "<tr><th colspan='2'>" . __('Locked fields') . "</th></tr>";
             echo "<th width='10'>";
             Html::showCheckbox(['criterion' => ['tag_for_massive' => 'select_' . $lockedfield::getType()]]);
             echo "</th>";
-            echo "<th>" . $lockedfield->getTypeName() . "</th>";
+            echo "<th>" . _n('Field', 'Fields', Session::getPluralNumber())  . "</th>";
             echo "<th>" . __('Itemtype') . "</th>";
             echo "<th>" . _n('Link', 'Links', Session::getPluralNumber()) . "</th>";
             echo "<th>" . __('Last inventoried value')  . "</th></tr>";

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -177,14 +177,15 @@ class Lock extends CommonGLPI
             //get fields labels
             $search_options = Search::getOptions($itemtype);
             foreach ($search_options as $search_option) {
-                //exclude SO added by dropdown part (to get real name)
-                //ex : Manufacturer != Firmware : Manufacturer
-                if (isset($search_option['table']) && $search_option['table'] == getTableForItemType($itemtype)) {
-                    if (isset($search_option['linkfield'])) {
-                        $so_fields[$search_option['linkfield']] = $search_option['name'];
-                    } else if (isset($search_option['field'])) {
-                        $so_fields[$search_option['field']] = $search_option['name'];
-                    }
+                //get name from 'field' first and continue if found
+                if (isset($search_option['field'])) {
+                    $so_fields[$search_option['field']] = $search_option['name'];
+                    continue;
+                }
+                //else get name from 'linkfield' if not found from 'field'
+                if (isset($search_option['linkfield'])) {
+                    $so_fields[$search_option['linkfield']] = $search_option['name'];
+                    continue;
                 }
             }
 
@@ -221,21 +222,22 @@ class Lock extends CommonGLPI
                 $default_itemtype       = $row['itemtype'];
 
                 //get real type name from Item_Devices
-                // exemple : get 'Hard drives' instead of 'Hard drive items'
+                // ex: get 'Hard drives' instead of 'Hard drive items'
                 if (get_parent_class($row['itemtype']) == Item_Devices::class) {
                     $default_itemtype =  $row['itemtype']::$itemtype_2;
                     $default_items_id =  $row['itemtype']::$items_id_2;
                     $default_itemtype_label = $row['itemtype']::$itemtype_2::getTypeName();
                 //get real type name from CommonDBRelation
-                // exemple : get 'Operating System' instead of 'Item operating systems'
+                // ex: get 'Operating System' instead of 'Item operating systems'
                 } elseif (get_parent_class($row['itemtype']) == CommonDBRelation::class) {
                     $default_itemtype =  $row['itemtype']::$itemtype_1;
                     $default_items_id =  $row['itemtype']::$items_id_1;
                     $default_itemtype_label = $row['itemtype']::$itemtype_1::getTypeName();
                 }
 
-                // specific link for CommonDBRelation itemtype (get 'real' object name inside URL name)
-                // exemple : get 'Ubuntu 22.04.1 LTS' instead of 'Computer asus-desktop'
+                // specific link for CommonDBRelation itemtype (like Item_OperatingSystem)
+                // get 'real' object name inside URL name
+                // ex: get 'Ubuntu 22.04.1 LTS' instead of 'Computer asus-desktop'
                 if (is_a($row['itemtype'], CommonDBRelation::class, true)) {
                     $related_object = new $default_itemtype();
                     $related_object->getFromDB($object->fields[$default_items_id]);

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -140,18 +140,12 @@ class Lock extends CommonGLPI
                     ]
                 ];
 
-                if (
-                    is_a($lockable_itemtype, CommonDBConnexity::class, true)
-                    && (
-                        (property_exists($lockable_object, 'items_id') && $lockable_object::$items_id == "items_id")
-                        || (property_exists($lockable_object, 'items_id_1') && $lockable_object::$items_id_1 == "items_id")
-                        || (property_exists($lockable_object, 'items_id_2') && $lockable_object::$items_id_2 == "items_id")
-                    )
-                ) {
-                    $query['WHERE'][] = [
-                        getTableForItemType($lockable_itemtype) . '.itemtype' => $itemtype,
-                        getTableForItemType($lockable_itemtype) . '.items_id' => $ID
-                    ];
+                if ($lockable_object instanceof CommonDBConnexity) {
+                    $connexity_criteria = $lockable_itemtype::getSQLCriteriaToSearchForItem($itemtype, $ID);
+                    if ($connexity_criteria === null) {
+                        continue;
+                    }
+                    $query['WHERE'][] = $connexity_criteria['WHERE'];
                 } else {
                     if (
                         property_exists($lockable_object, 'items_id')
@@ -166,6 +160,7 @@ class Lock extends CommonGLPI
                         continue;
                     }
                 }
+
                 $subquery[] = new \QuerySubQuery($query);
             }
 

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -90,7 +90,7 @@ class Lock extends CommonGLPI
             echo "</th>";
             echo "<th>" . $lockedfield->getTypeName() . "</th>";
             echo "<th>" . __('Itemtype') . "</th>";
-            echo "<th>" . __('Link') . "</th>";
+            echo "<th>" . _n('Link', 'Links', Session::getPluralNumber()) . "</th>";
             echo "<th>" . __('Last inventoried value')  . "</th></tr>";
 
             $subquery = [];

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -215,7 +215,16 @@ class Lock extends CommonGLPI
                 //load object
                 $object = new $row['itemtype']();
                 $object->getFromDB($row['items_id']);
-                echo "<td class='left'>" . $object->getLink() . "</td>";
+
+                if (is_a($row['itemtype'], Item_Devices::class, true)) {
+                    $device_class = $object::$itemtype_2;
+                    $related_object = new $device_class();
+                    $related_object->getFromDB($object->fields[$object::$items_id_2]);
+                    echo "<td class='left'>" . $related_object->getLink() . "</td>";
+                } else {
+                    echo "<td class='left'>" . $object->getLink() . "</td>";
+                }
+
                 echo "<td class='left'>" . $row['value'] . "</td>";
                 echo "</tr>\n";
             }

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -220,7 +220,9 @@ class Lock extends CommonGLPI
                     $device_class = $object::$itemtype_2;
                     $related_object = new $device_class();
                     $related_object->getFromDB($object->fields[$object::$items_id_2]);
-                    echo "<td class='left'>" . $related_object->getLink() . "</td>";
+                    echo "<td class='left'>";
+                    echo "<a href='" . $object->getLinkURL() . "'" . $related_object->getName() . ">" . $related_object->getName() . "</a>";
+                    echo "</td>";
                 } else {
                     echo "<td class='left'>" . $object->getLink() . "</td>";
                 }

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -172,15 +172,14 @@ class Lock extends CommonGLPI
             //get fields labels
             $search_options = Search::getOptions($itemtype);
             foreach ($search_options as $search_option) {
-                //get name from 'field' first and continue if found
-                if (isset($search_option['field'])) {
-                    $so_fields[$search_option['field']] = $search_option['name'];
-                    continue;
-                }
-                //else get name from 'linkfield' if not found from 'field'
-                if (isset($search_option['linkfield'])) {
-                    $so_fields[$search_option['linkfield']] = $search_option['name'];
-                    continue;
+                //exclude SO added by dropdown part (to get real name)
+                //ex : Manufacturer != Firmware : Manufacturer
+                if (isset($search_option['table']) && $search_option['table'] == getTableForItemType($itemtype)) {
+                    if (isset($search_option['linkfield'])) {
+                        $so_fields[$search_option['linkfield']] = $search_option['name'];
+                    } else if (isset($search_option['field'])) {
+                        $so_fields[$search_option['field']] = $search_option['name'];
+                    }
                 }
             }
 

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -211,7 +211,13 @@ class Lock extends CommonGLPI
                     $field_label .= ' (' . __('Global') . ')';
                 }
                 echo "<td class='left'>" . $field_label . "</td>";
-                echo "<td class='left'>" . $row['itemtype']::getTypeName() . "</td>";
+
+                $itemtype_label = $row['itemtype']::getTypeName();
+                //get real type name from CommonDBRelation
+                if (is_a($row['itemtype'], CommonDBRelation::class, true)) {
+                    $itemtype_label = $row['itemtype']::$itemtype_1::getTypeName();
+                }
+                echo "<td class='left'>" . $itemtype_label . "</td>";
 
                 //load object
                 $object = new $row['itemtype']();

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -146,19 +146,6 @@ class Lock extends CommonGLPI
                         continue;
                     }
                     $query['WHERE'][] = $connexity_criteria['WHERE'];
-                } else {
-                    if (
-                        property_exists($lockable_object, 'items_id')
-                        && getForeignKeyFieldForItemType($itemtype) == $lockable_object::$items_id
-                    ) {
-                        $query['WHERE'][] = [getTableForItemType($lockable_itemtype) . '.' . $lockable_object::$items_id => $ID];
-                    } elseif (property_exists($lockable_object, 'items_id_1') && getForeignKeyFieldForItemType($itemtype) == $lockable_object::$items_id_1) {
-                        $query['WHERE'][] = [getTableForItemType($lockable_itemtype) . '.' . $lockable_object::$items_id_1 => $ID];
-                    } else {
-                        // ::$items_id != getForeignKeyFieldForItemType($itemtype)
-                        // ex: get ComputerVirtualMachine from NetworkEquipement
-                        continue;
-                    }
                 }
 
                 $subquery[] = new \QuerySubQuery($query);


### PR DESCRIPTION
Actually, GLPI displays only the locks of the current itemtype.

But some data are related to ```Ìtem_XXXX``` relationship who do not have  their own form (like Computer)
and GLPI allow user to update it directly from current itemtype

It is frustrating to see the lock in the ```OS``` tab but not in the ```Lock``` tab

Actually is see two relationship in this case :
- ```Item_OperatingSystem```
- ```Item_Disk```

So this PR :

- compute related ```lock``` (```Item_OperatingSystem``` and ```Item_Disk```) for current ```itemtype```
- display ```itemtype``` and ```value``` from ```glpi_lockedfield``` table
- add ```Item_OperatingSystem``` to ```$CFG_GLPI['inventory_lockable_objects']``` (missing)
- Fix ```Locked items```display (Software / license ```header``` / ```massiveAction``` display if  there is no deleted item)


Before 

![image](https://user-images.githubusercontent.com/7335054/191481263-96e19098-8650-47cf-88a2-00b58d1148da.png)


After
![image](https://user-images.githubusercontent.com/7335054/191481369-ef9b738b-61f1-48b7-ad1a-bf5cb8991f9d.png)

If ```Locked items``` part is empty
![image](https://user-images.githubusercontent.com/7335054/191481460-99ee4182-64eb-487d-ad6c-efd925bc3d8a.png)




| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
