### PR TITLE
Twig computer antivirus

### DIFF
--- a/src/ComputerAntivirus.php
+++ b/src/ComputerAntivirus.php
@@ -232,7 +232,7 @@ class ComputerAntivirus extends CommonDBChild
         return $tab;
     }
 
-        /**
+    /**
      * Display form for antivirus
      *
      * @param integer $ID      id of the antivirus
@@ -263,88 +263,6 @@ class ComputerAntivirus extends CommonDBChild
             'computer'                => $comp,
             'params'                    => $options,
         ]);
-
-        return true;
-    }
-
-    /**
-     * Display form for antivirus
-     *
-     * @param integer $ID      id of the antivirus
-     * @param array   $options
-     *
-     * @return boolean TRUE if form is ok
-     **/
-    public function showFormV1($ID, array $options = [])
-    {
-
-        echo "toto";
-
-        if (!Session::haveRight("computer", READ)) {
-            return false;
-        }
-
-        $comp = new Computer();
-        if ($ID > 0) {
-            $this->check($ID, READ);
-            $comp->getFromDB($this->fields['computers_id']);
-        } else {
-            $this->check(-1, CREATE, $options);
-            $comp->getFromDB($options['computers_id']);
-        }
-
-        $this->showFormHeader($options);
-
-        if ($this->isNewID($ID)) {
-            echo "<input type='hidden' name='computers_id' value='" . $options['computers_id'] . "'>";
-        }
-
-        echo "<tr class='tab_bg_1'>";
-        echo "<td>" . Computer::getTypeName(1) . "</td>";
-        echo "<td>" . $comp->getLink() . "</td>";
-        $this->autoinventoryInformation();
-        echo "</tr>\n";
-
-        echo "<tr class='tab_bg_1'>";
-        echo "<td>" . __('Name') . "</td>";
-        echo "<td>";
-        echo Html::input('name', ['value' => $this->fields['name']]);
-        echo "</td>";
-        echo "<td>" . __('Active') . "</td>";
-        echo "<td>";
-        Dropdown::showYesNo('is_active', $this->fields['is_active']);
-        echo "</td></tr>";
-
-        echo "<tr class='tab_bg_1'>";
-        echo "<td>" . Manufacturer::getTypeName(1) . "</td>";
-        echo "<td>";
-        Dropdown::show('Manufacturer', ['value' => $this->fields["manufacturers_id"]]);
-        echo "</td>";
-        echo "<td>" . __('Up to date') . "</td>";
-        echo "<td>";
-        Dropdown::showYesNo('is_uptodate', $this->fields['is_uptodate']);
-        echo "</td></tr>";
-
-        echo "<tr class='tab_bg_1'>";
-        echo "<td>" . __('Antivirus version') . "</td>";
-        echo "<td>";
-        echo Html::input('antivirus_version', ['value' => $this->fields['antivirus_version']]);
-        echo "</td>";
-        echo "<td>" . __('Signature database version') . "</td>";
-        echo "<td>";
-        echo Html::input('signature_version', ['value' => $this->fields['signature_version']]);
-        echo "</td></tr>";
-
-        echo "<tr class='tab_bg_1'>";
-        echo "<td>" . __('Expiration date') . "</td>";
-        echo "<td>";
-        Html::showDateField("date_expiration", ['value' => $this->fields['date_expiration']]);
-        echo "</td>";
-        echo "<td colspan='2'></td>";
-        echo "</tr>";
-
-        $options['canedit'] = Session::haveRight("computer", UPDATE);
-        $this->showFormButtons($options);
 
         return true;
     }

--- a/templates/components/form/computerantivirus.html.twig
+++ b/templates/components/form/computerantivirus.html.twig
@@ -44,7 +44,7 @@
    {{ fields.htmlField(
       'computers_id',
       computer.getLink(),
-      __('Computer'),
+      computer.getTypeName(1),
       field_options|merge(params)
    ) }}
 

--- a/templates/components/form/computerantivirus.html.twig
+++ b/templates/components/form/computerantivirus.html.twig
@@ -1,0 +1,72 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2022 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% extends "generic_show_form.html.twig" %}
+{% import 'components/form/fields_macros.html.twig' as fields %}
+{% set params  = params ?? [] %}
+{% set no_header = true %}
+{% set no_inventory_footer = true %}
+
+{% block more_fields %}
+
+    <input type="hidden" name="computers_id" value="{{ item.fields['computers_id'] }}">
+
+   {{ fields.htmlField(
+      'computers_id',
+      computer.getLink(),
+      __('Computer'),
+      field_options|merge(params)
+   ) }}
+
+   {{ fields.dropdownYesNo(
+      'is_uptodate',
+      item.fields['is_uptodate'],
+      __('Up to date'),
+      field_options
+   ) }}
+
+   {{ fields.textField(
+      'antivirus_version',
+      item.fields['antivirus_version'],
+      __('Antivirus version'),
+      field_options|merge(params)
+   ) }}
+
+   {{ fields.textField(
+      'signature_version',
+      item.fields['signature_version'],
+      __('Signature database version'),
+      field_options|merge(params)
+   ) }}
+
+{% endblock %}

--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -335,12 +335,12 @@
                            {{ fields.dateField('date_expiration', item.fields['date_expiration'], __('Expiration date'), {
                               'helper': __('Empty for infinite'),
                               'checkIsExpired': true
-                           }) }}
+                           }|merge(field_options)) }}
                         {% else %}
                            {{ fields.datetimeField('date_expiration', item.fields['date_expiration'], __('Expiration date'), {
                               'helper': __('Empty for infinite'),
                               'checkIsExpired': true
-                           }) }}
+                           }|merge(field_options)) }}
                         {% endif %}
                      {% endif %}
 

--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -331,7 +331,7 @@
                      {% endif %}
 
                      {% if item.isField('date_expiration') %}
-                        {% if item_type == 'Certificate' %}
+                        {% if item_type == 'Certificate' or item_type == 'ComputerAntivirus' %}
                            {{ fields.dateField('date_expiration', item.fields['date_expiration'], __('Expiration date'), {
                               'helper': __('Empty for infinite'),
                               'checkIsExpired': true


### PR DESCRIPTION
Use twig for ```ComputerAntivirus``` (usefull for locked field)
I take this opportunity to : 
- add the "Lock" tab
- fix ```expiration_date``` to ```NULL``` if empty
- propage ```field_options``` for ```twig``` ```date_field``` (usefull for locked field icon / toolti)

Before : 
![image](https://user-images.githubusercontent.com/7335054/191689225-3a28a090-2306-4801-8e47-1b65d670f076.png)

After : 
![image](https://user-images.githubusercontent.com/7335054/191689239-748b6f91-0b4c-4fb0-849e-58d56e3a2ec1.png)

Need https://github.com/glpi-project/glpi/pull/12722 for ```is_dynamic``` generic field


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
