### PR TITLE
Fix notification error when supplier is added to ticket

### DIFF
--- a/src/NotificationTargetCommonITILObject.php
+++ b/src/NotificationTargetCommonITILObject.php
@@ -1159,10 +1159,10 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                     $users[] = $user_tmp->getName();
 
                     // Legacy authors data
-                    $author = self::getActorData($user_tmp, CommonITILActor::REQUESTER, 'author');
-                    $author['##author.title##'] = $author['##author.usertitle##'];
-                    $author['##author.category##'] = $author['##author.usercategory##'];
-                    $data['authors'][] = $author;
+                    $actor_data = self::getActorData($user_tmp, CommonITILActor::REQUESTER, 'author');
+                    $actor_data['##author.title##'] = $actor_data['##author.usertitle##'];
+                    $actor_data['##author.category##'] = $actor_data['##author.usercategory##'];
+                    $data['authors'][] = $actor_data;
 
                     $data['actors'][]  = self::getActorData($user_tmp, CommonITILActor::REQUESTER, 'actor');
                 } else {
@@ -1185,9 +1185,9 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                     $suppliers[] = $supplier->getName();
 
                     // Legacy suppliers data
-                    $supplier = self::getActorData($supplier, CommonITILActor::ASSIGN, 'supplier');
-                    $supplier['##supplier.type##'] = $supplier['##supplier.suppliertype##'];
-                    $data['suppliers'][] = $supplier;
+                    $actor_data = self::getActorData($supplier, CommonITILActor::ASSIGN, 'supplier');
+                    $actor_data['##supplier.type##'] = $actor_data['##supplier.suppliertype##'];
+                    $data['suppliers'][] = $actor_data;
 
                     $data['actors'][]    = self::getActorData($supplier, CommonITILActor::ASSIGN, 'actor');
                 }
@@ -1225,9 +1225,9 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                         $users[$uid] = $user_tmp->getName();
                     }
 
-                    $actor = self::getActorData($user_tmp, CommonITILActor::ASSIGN, 'actor');
-                    $actor['##actor.name##'] = $users[$uid]; // Use anonymized name
-                    $data['actors'][] = $actor;
+                    $actor_data = self::getActorData($user_tmp, CommonITILActor::ASSIGN, 'actor');
+                    $actor_data['##actor.name##'] = $users[$uid]; // Use anonymized name
+                    $data['actors'][] = $actor_data;
                 }
             }
             $data["##$objettype.assigntousers##"] = implode(', ', $users);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12727

`$supplier` variable, containing a `Supplier` instance, was erased by an `array`.
I renamed variables to prevent this kind of issues.