### PR TITLE
Do not limit number of tickets linked to a contract

### DIFF
--- a/src/Ticket_Contract.php
+++ b/src/Ticket_Contract.php
@@ -116,9 +116,10 @@ class Ticket_Contract extends CommonDBRelation
             echo "<tr class='tab_bg_2'><td class='right'>";
             echo "<input type='hidden' name='$item_a_fkey' value='$ID'>";
             $linked_itemtype::dropdown([
-                'used'        => $used,
-                'displaywith' => ['id'],
-                'entity'      => $item->fields['entities_id'],
+                'used'         => $used,
+                'displaywith'  => ['id'],
+                'entity'       => $item->fields['entities_id'],
+                'nochecklimit' => true,
             ]);
             echo "</td><td class='center'>";
             echo "<input type='submit' name='add' value=\"" . _sx('button', 'Add') . "\" class='btn btn-primary'>";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12632

As far as I understand, purpose of link between contract and ticket, introduced in #8947, is to be able to track tickets that have been processed under a given contract. The max number of items related to a contract should not, IMHO, have any impact on the number of tickets that can be created for this contract.

For instance, if my contract is limited to 15 assets (i.e. computers), users of these assets should be able to create as many tickets as they have problems with these assets.
