### PR TITLE
fix(timeline content): enlarge to avoid truncating the date

### DIFF
--- a/css/includes/components/itilobject/_timeline.scss
+++ b/css/includes/components/itilobject/_timeline.scss
@@ -99,7 +99,7 @@
     .timeline-content {
         position: relative;
         border-top-left-radius: 0;
-        max-width: 700px;
+        max-width: 820px;
         min-width: 100%;
         word-break: break-word;
 


### PR DESCRIPTION
The current limit of 700px systematically truncates the date when scheduling a task.

![image](https://user-images.githubusercontent.com/8530352/191740394-62dae69a-064c-42dc-976d-89c19fa48945.png)

By increasing this max, it allows to see the hours and minutes.

![image](https://user-images.githubusercontent.com/8530352/191740235-ae34bb9c-46e6-469e-8a83-e249b1c5ec79.png)

https://github.com/glpi-project/glpi/commit/b76e5b8c7f047cf197579c2f0db7402cc9da23a2

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
