### PR TITLE
more parameters for additional buttons in generic_form template

### DIFF
--- a/templates/components/form/buttons.html.twig
+++ b/templates/components/form/buttons.html.twig
@@ -135,7 +135,7 @@
 
          {% if canedit and params['addbuttons']|length > 0 %}
             {% for key, val in params['addbuttons'] %}
-               <button class="btn btn-outline-secondary me-2" type="{{ val.type|default('submit') }}" name="{{ key }}" value="1" title="{{ val.title|default('') }}" onclick="{{ val.onclick|default('') }}">
+               <button class="btn btn-outline-secondary me-2" type="{{ val.type ?? 'submit' }}" name="{{ key }}" value="1" title="{{ val.title ?? '' }}" onclick="{{ val.onclick ?? '' }}">
                   {% if val is iterable %}
                      {% if val.icon is defined %}
                         <i class="{{ val.icon }}"></i>

--- a/templates/components/form/buttons.html.twig
+++ b/templates/components/form/buttons.html.twig
@@ -135,7 +135,7 @@
 
          {% if canedit and params['addbuttons']|length > 0 %}
             {% for key, val in params['addbuttons'] %}
-               <button class="btn btn-outline-secondary me-2" type="submit" name="{{ key }}" value="1" title="{{ val.title|default('') }}">
+               <button class="btn btn-outline-secondary me-2" type="{{ val.type|default('submit') }}" name="{{ key }}" value="1" title="{{ val.title|default('') }}" onclick="{{ val.onclick|default('') }}">
                   {% if val is iterable %}
                      {% if val.icon is defined %}
                         <i class="{{ val.icon }}"></i>


### PR DESCRIPTION
- type may be submit (default) or button
- onclick attribute

TODO:

historical tab does not refresh when changing the count of items per page. It refreshes the tab of the item displayed under the modal.

Helps to improve UX in incoming tabs in modals of Formcreator. USed (for now) to show a "Apply" button which saves form data without closing the modal, and editing setings in several tabs without closing / reopening the question.

![image](https://user-images.githubusercontent.com/14139801/191840306-e60f7dcc-ea89-406a-88f9-3e24d4f6cfd4.png)

To satisfy this need, an additional button shall not be of type submit and shall trigger some JS code.

Example of this implementation

```php
      if (!$this->isNewItem()) {
         // Have an "apply" button if the item already exists in DB
         $options['addbuttons'] = [
            'apply' => [
               'type' => 'button',
               'text' => __('Apply', 'formcreator'),
               'onclick' => 'plugin_formcreator.editQuestion(this)',
            ],
         ];
      }
      $template = '@formcreator/field/undefinedfield.html.twig';
      if (!$this->loadField($this->fields['fieldtype'])) {
         TemplateRenderer::getInstance()->display($template, [
            'item' => $this,
            'params' => $options,
            'no_header' => true,
         ]);
         return true;
      }
```

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
