### PR TITLE
fix(Notification Template Translation): list url 404

### DIFF
--- a/front/notificationtemplatetranslation.form.php
+++ b/front/notificationtemplatetranslation.form.php
@@ -45,6 +45,10 @@ if (!isset($_GET["id"])) {
 
 $language = new NotificationTemplateTranslation();
 
+$template = new NotificationTemplate();
+$template->getFromDB($_GET["notificationtemplates_id"]);
+$_SESSION['glpilisturl'][NotificationTemplateTranslation::getType()] = $template->getLinkURL();
+
 if (isset($_POST["add"])) {
     $language->check(-1, CREATE, $_POST);
     $newID = $language->add($_POST);


### PR DESCRIPTION
In the translations of the notification templates. the link refers to: ".../front/notificationtemplateetranslation.php" (which does not exist) instead of ".../front/notificationtemplate.form.php?id=xx"

![image](https://user-images.githubusercontent.com/8530352/191964741-6c918d05-24f2-4602-8c03-3ee805ddb34b.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24997
