### PR TITLE
Restore saved search visiblity from 10.0.2

### DIFF
--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -807,7 +807,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
                 'itemtype',
                 'name'
             ]
-        ] + self::getVisibilityCriteria();
+        ] + self::getVisibilityCriteriaForMine();
 
         if ($itemtype != null) {
             if (!$inverse) {
@@ -1315,22 +1315,9 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
         return $sql;
     }
 
-    /**
-     * Return visibility joins to add to DBIterator parameters
-     *
-     * @since 9.4
-     *
-     * @param boolean $forceall force all joins (false by default)
-     *
-     * @return array
-     */
-    public static function getVisibilityCriteria(bool $forceall = false): array
+    private static function getVisibilityCriteriaForMine(): array
     {
         $criteria = ['WHERE' => []];
-        if (Session::haveRight('config', UPDATE)) {
-            return $criteria;
-        }
-
         $restrict = [
             self::getTable() . '.is_private' => 1,
             self::getTable() . '.users_id'    => Session::getLoginUserID()
@@ -1347,6 +1334,24 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
 
         $criteria['WHERE'] = $restrict;
         return $criteria;
+    }
+
+    /**
+     * Return visibility joins to add to DBIterator parameters
+     *
+     * @since 9.4
+     *
+     * @param boolean $forceall force all joins (false by default)
+     *
+     * @return array
+     */
+    public static function getVisibilityCriteria(bool $forceall = false): array
+    {
+        if (Session::haveRight('config', UPDATE)) {
+            return ['WHERE' => []];
+        }
+
+        return self::getVisibilityCriteriaForMine();
     }
 
 

--- a/tests/functionnal/SavedSearch.php
+++ b/tests/functionnal/SavedSearch.php
@@ -41,6 +41,16 @@ use DbTestCase;
 
 class SavedSearch extends DbTestCase
 {
+    public function testGetVisibilityCriteria()
+    {
+        $this->login();
+        $this->setEntity('_test_root_entity', true);
+
+        // No restrictions when having the config UPDATE right
+        $this->array(\SavedSearch::getVisibilityCriteria())->isEqualTo(['WHERE' => []]);
+        $_SESSION["glpiactiveprofile"]['config'] = $_SESSION["glpiactiveprofile"]['config'] & ~UPDATE;
+        $this->array(\SavedSearch::getVisibilityCriteria()['WHERE'])->isNotEmpty();
+    }
     public function testAddVisibilityRestrict()
     {
        //first, as a super-admin
@@ -128,8 +138,8 @@ class SavedSearch extends DbTestCase
                 'url'          => 'front/ticket.php?itemtype=Ticket&sort=2&order=DESC&start=0&criteria[0][field]=5&criteria[0][searchtype]=equals&criteria[0][value]=' . $uid
             ])
         )->isTrue();
-        // With UPDATE 'config' right, we can see all bookmarks
-        $this->integer(count($bk->getMine()))->isEqualTo(3);
+        // With UPDATE 'config' right, we still shouldn't see other user's private searches
+        $this->integer(count($bk->getMine()))->isEqualTo(2);
         $_SESSION["glpiactiveprofile"]['config'] = $_SESSION["glpiactiveprofile"]['config'] & ~UPDATE;
         $this->integer(count($bk->getMine()))->isEqualTo(2);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12756

The last fix (post-10.0.3) had fixed the issue of seeing other user's private searches in the list but only if the user didn't have the "config" UPDATE permission. This PR should only show public searches and your own private searches in the flyout list. If you have the "config" UPDATE permission, you can still see all the searches in the "Manage saved searches" search list.