### PR TITLE
Fix session related warnings on plugin activation from cli

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -902,6 +902,7 @@ class Plugin extends CommonDBTM
                 if (
                     isset($PLUGIN_HOOKS[Hooks::CHANGE_PROFILE][$this->fields['directory']])
                     && is_callable($PLUGIN_HOOKS[Hooks::CHANGE_PROFILE][$this->fields['directory']])
+                    && isset($_SESSION['glpiactiveprofile'])
                 ) {
                     call_user_func($PLUGIN_HOOKS[Hooks::CHANGE_PROFILE][$this->fields['directory']]);
                 }


### PR DESCRIPTION
As discussed with @cedric-anne and @orthagh, we want to avoid calling the `CHANGE_PROFILE` hook on plugin activation if there is no active session.

Before : 
![image](https://user-images.githubusercontent.com/42734840/192281056-a848b32f-e565-4eb0-b4b4-6a7e595c1b81.png)

After :
![image](https://user-images.githubusercontent.com/42734840/192281522-23765999-b500-4283-9388-93286e1e546c.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
