### PR TITLE
Fix entity restriction in Add Appliance massive action

### DIFF
--- a/src/Appliance.php
+++ b/src/Appliance.php
@@ -459,9 +459,7 @@ class Appliance extends CommonDBTM
 
         switch ($ma->getAction()) {
             case 'add_item':
-                Appliance::dropdown([
-                    'entity'  => $_POST['entity_restrict'] ?? 0
-                ]);
+                Appliance::dropdown();
                 echo Html::submit(_x('button', 'Post'), ['name' => 'massiveaction']);
                 return true;
             break;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12766

There is no `$_POST['entity_restrict'] ` sent. Removing the option will make the dropdown filtered on currently active entities.