### PR TITLE
Events: search by itemtype

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -528,15 +528,21 @@ class Event extends CommonDBTM
      */
     public static function getUsedItemtypes(): array
     {
+        global $DB;
+
         // These values are not itemtypes
         $blacklist = array_keys(self::logArray()[0]);
 
-        $events = new self();
-        $data = $events->find([
-            'NOT' => ['type' => $blacklist]
+        $data = $DB->request([
+            'SELECT'   => ['type'],
+            'DISTINCT' => 'true',
+            'FROM'     => self::getTable(),
+            'WHERE'    => [
+                'NOT' => ['type' => $blacklist]
+            ]
         ]);
 
-        return array_column($data, 'type');
+        return array_column(iterator_to_array($data), 'type');
     }
 
     public static function getSpecificValueToSelect($field, $name = '', $values = '', array $options = [])

--- a/src/Event.php
+++ b/src/Event.php
@@ -492,6 +492,53 @@ class Event extends CommonDBTM
         return $tab;
     }
 
+    /**
+     * Get the possibles values for the 'Source' search option, which target
+     * the `type` column in glpi_events.
+     * Possibles values are :
+     * - Some specials types (see self::logArray)
+     * - Used itemtypes
+     *
+     * @return array
+     */
+    public static function getTypeValuesForDropdown(): array
+    {
+        // Get specials types
+        $specials = self::logArray()[0];
+
+        // Get itemtypes and build their display names
+        $itemtypes = [];
+        foreach (self::getUsedItemtypes() as $value) {
+            $itemtype = self::getItemtypeFromType($value);
+            $itemtypes[$value] = $itemtype::getTypeName(1);
+        }
+
+        return [
+            __('Special') => $specials,
+            __('Items') => $itemtypes,
+        ];
+    }
+
+    /**
+     * Get all itemtypes referenced in the `type` columns of glpi_events
+     * Note that these values are not real itemtypes but strings like "users".
+     * You need to call self::getItemtypeFromType() to get a valid GLPI itemtype
+     *
+     * @return array
+     */
+    public static function getUsedItemtypes(): array
+    {
+        // These values are not itemtypes
+        $blacklist = array_keys(self::logArray()[0]);
+
+        $events = new self();
+        $data = $events->find([
+            'NOT' => ['type' => $blacklist]
+        ]);
+
+        return array_column($data, 'type');
+    }
+
     public static function getSpecificValueToSelect($field, $name = '', $values = '', array $options = [])
     {
         if ($field === 'service') {
@@ -509,7 +556,7 @@ class Event extends CommonDBTM
             if (empty($value)) {
                 $value = 0;
             }
-            return \Dropdown::showFromArray($name, self::logArray()[0], [
+            return \Dropdown::showFromArray($name, self::getTypeValuesForDropdown(), [
                 'value' => $value,
                 'display' => false,
                 'display_emptychoice' => true

--- a/src/Event.php
+++ b/src/Event.php
@@ -501,7 +501,7 @@ class Event extends CommonDBTM
      *
      * @return array
      */
-    public static function getTypeValuesForDropdown(): array
+    private static function getTypeValuesForDropdown(): array
     {
         // Get specials types
         $specials = self::logArray()[0];
@@ -526,7 +526,7 @@ class Event extends CommonDBTM
      *
      * @return array
      */
-    public static function getUsedItemtypes(): array
+    private static function getUsedItemtypes(): array
     {
         global $DB;
 


### PR DESCRIPTION
Some itemtypes are not searchable on the events log page:

![image](https://user-images.githubusercontent.com/42734840/192458991-e98c747d-673f-4d98-b02a-5c5395bed862.png)

Fixed by adding used itemtypes to the 'Source' search option.
Previous values are moved to a "Special" dropdown group, while itemtpes are in the new `Item` dropdown group:

![image](https://user-images.githubusercontent.com/42734840/192458606-cdcfdf23-8e0d-44d3-b611-b66481b1e08e.png)
![image](https://user-images.githubusercontent.com/42734840/192458643-5ed9d5b6-5166-4bbb-a4ec-da132ee51972.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25021
