### PR TITLE
Fix warning during user visibility definition

### DIFF
--- a/front/knowbaseitem.form.php
+++ b/front/knowbaseitem.form.php
@@ -101,7 +101,7 @@ if (isset($_POST["add"])) {
         isset($_POST["_type"]) && !empty($_POST["_type"])
         && isset($_POST["knowbaseitems_id"]) && $_POST["knowbaseitems_id"]
     ) {
-        if ($_POST['entities_id'] == -1) {
+        if (array_key_exists('entities_id', $_POST) && $_POST['entities_id'] == -1) {
             // "No restriction" value selected
             $_POST['entities_id'] = 'NULL';
             $_POST['no_entity_restriction'] = 1;

--- a/front/reminder.form.php
+++ b/front/reminder.form.php
@@ -93,7 +93,7 @@ if (isset($_POST["add"])) {
         isset($_POST["_type"]) && !empty($_POST["_type"])
         && isset($_POST["reminders_id"]) && $_POST["reminders_id"]
     ) {
-        if ($_POST['entities_id'] == -1) {
+        if (array_key_exists('entities_id', $_POST) && $_POST['entities_id'] == -1) {
             // "No restriction" value selected
             $_POST['entities_id'] = 'NULL';
             $_POST['no_entity_restriction'] = 1;

--- a/front/rssfeed.form.php
+++ b/front/rssfeed.form.php
@@ -93,7 +93,7 @@ if (isset($_POST["add"])) {
         isset($_POST["_type"]) && !empty($_POST["_type"])
         && isset($_POST["rssfeeds_id"]) && $_POST["rssfeeds_id"]
     ) {
-        if ($_POST['entities_id'] == -1) {
+        if (array_key_exists('entities_id', $_POST) && $_POST['entities_id'] == -1) {
             // "No restriction" value selected
             $_POST['entities_id'] = 'NULL';
             $_POST['no_entity_restriction'] = 1;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12765

`entities_id` is not present in form data when adding a user in KB, Reminder or RSS targets.