### PR TITLE
feat(core): check is_deleted column if table have is_dynamic

### DIFF
--- a/src/System/Diagnostic/DatabaseSchemaConsistencyChecker.php
+++ b/src/System/Diagnostic/DatabaseSchemaConsistencyChecker.php
@@ -60,7 +60,7 @@ class DatabaseSchemaConsistencyChecker extends AbstractDatabaseChecker
                     }
                     break;
                 case 'is_dynamic':
-                    $exclude_table = ['glpi_useremails', 'glpi_profiles_users'];
+                    $exclude_table = ['glpi_useremails', 'glpi_profiles_users', 'glpi_groups_users'];
                     if (!in_array($table_name, $exclude_table)) {
                         if (!in_array('is_deleted', $columns)) {
                             $missing_columns[] = 'is_deleted';

--- a/src/System/Diagnostic/DatabaseSchemaConsistencyChecker.php
+++ b/src/System/Diagnostic/DatabaseSchemaConsistencyChecker.php
@@ -59,6 +59,14 @@ class DatabaseSchemaConsistencyChecker extends AbstractDatabaseChecker
                         $missing_columns[] = 'date_mod';
                     }
                     break;
+                case 'is_dynamic':
+                    $exclude_table = ['glpi_useremails', 'glpi_profiles_users'];
+                    if (!in_array($table_name, $exclude_table)) {
+                        if (!in_array('is_deleted', $columns)) {
+                            $missing_columns[] = 'is_deleted';
+                        }
+                    }
+                    break;
                 case 'date_mod':
                     if ($table_name === 'glpi_logs') {
                       // Logs cannot be modified and their date is stored on `date_mod`.


### PR DESCRIPTION
Checks the presence of the ```is_deleted``` column if the ```is_dynamic``` column is present

Exclude ```glpi_usermails``` and ```glpi_profiles_users``` tables

need : https://github.com/glpi-project/glpi/pull/12775


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
