### PR TITLE
Events: search by itemtype 2

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -511,10 +511,11 @@ class Event extends CommonDBTM
         $itemtypes = [];
         foreach (self::getUsedItemtypes() as $value) {
             $itemtype = self::getItemtypeFromType($value);
-            if ($itemtype) {
+            if (is_a($itemtype, CommonGLPI::class, true)) {
                 $itemtypes[$value] = $itemtype::getTypeName(1);
             } else {
                 trigger_error("Unsupported type: $value", E_USER_WARNING);
+                $itemtypes[$value] = $value
             }
         }
 

--- a/src/Event.php
+++ b/src/Event.php
@@ -44,6 +44,7 @@ use Document;
 use Glpi\Application\View\TemplateRenderer;
 use Html;
 use Infocom;
+use ITILSolution;
 use Session;
 use Toolbox;
 
@@ -510,7 +511,11 @@ class Event extends CommonDBTM
         $itemtypes = [];
         foreach (self::getUsedItemtypes() as $value) {
             $itemtype = self::getItemtypeFromType($value);
-            $itemtypes[$value] = $itemtype::getTypeName(1);
+            if ($itemtype) {
+                $itemtypes[$value] = $itemtype::getTypeName(1);
+            } else {
+                trigger_error("Unsupported type: $value", E_USER_WARNING);
+            }
         }
 
         return [
@@ -648,6 +653,10 @@ class Event extends CommonDBTM
         if (is_a($fallback_type, CommonGLPI::class, true)) {
             $mapping[$type] = $fallback_type;
             return $fallback_type;
+        }
+
+        if ($type == 'solution') {
+            return ITILSolution::class;
         }
 
         return null;

--- a/src/Event.php
+++ b/src/Event.php
@@ -515,7 +515,7 @@ class Event extends CommonDBTM
                 $itemtypes[$value] = $itemtype::getTypeName(1);
             } else {
                 trigger_error("Unsupported type: $value", E_USER_WARNING);
-                $itemtypes[$value] = $value
+                $itemtypes[$value] = $value;
             }
         }
 


### PR DESCRIPTION
Fix for #12770 :
* Avoid failure if no itemtype is found by `getItemtypeFromType()`
* Trigger warning on unsupported itemtype
* Add support for "solution"


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
