### PR TITLE
feat(cartridge): better display

### DIFF
--- a/src/Printer_CartridgeInfo.php
+++ b/src/Printer_CartridgeInfo.php
@@ -120,7 +120,7 @@ class Printer_CartridgeInfo extends CommonDBChild
                         </div>
 
                     </div>
-                HTML;
+HTML;
             } else {
                 $out = $value;
             }

--- a/src/Printer_CartridgeInfo.php
+++ b/src/Printer_CartridgeInfo.php
@@ -83,14 +83,6 @@ class Printer_CartridgeInfo extends CommonDBChild
             $bar_color = $matches[1] ?? 'green';
             $text_color = ($bar_color == "black") ? 'white' : 'black';
 
-            $pics_info = '';
-            if ($value < 50) {
-                $pics_info = "<i class='orange ti ti-alert-triangle' ></i>";
-            }
-            if ($value < 25) {
-                $pics_info = "<i class='red ti ti-alert-circle'></i>";
-            }
-
             echo "<tr>";
             echo sprintf("<td>%s</td>", $tags[$property]['name'] ?? $property);
 
@@ -110,8 +102,7 @@ class Printer_CartridgeInfo extends CommonDBChild
                     'percent_text'      => $value,
                     'background-color'  => $bar_color,
                     'text-color'        => $text_color,
-                    'text'              => '',
-                    'pics_info'         => $pics_info
+                    'text'              => ''
                 ];
 
 
@@ -129,9 +120,6 @@ class Printer_CartridgeInfo extends CommonDBChild
                         </div>
 
                     </div>
-                    <span class='text-nowrap'>
-                    {$progressbar_data['pics_info']}
-                    </span>
                 HTML;
             } else {
                 $out = $value;

--- a/src/Printer_CartridgeInfo.php
+++ b/src/Printer_CartridgeInfo.php
@@ -76,13 +76,21 @@ class Printer_CartridgeInfo extends CommonDBChild
         $tags = $asset->knownTags();
 
         foreach ($info as $row) {
-            $property = $row['property'];
+            $property   = $row['property'];
+            $value      = $row['value'];
 
             preg_match("/^toner(\w+.*$)/", $property, $matches);
             $bar_color = $matches[1] ?? 'green';
             $text_color = ($bar_color == "black") ? 'white' : 'black';
 
-            $value = $row['value'];
+            $pics_info = '';
+            if ($value < 50) {
+                $pics_info = "<i class='orange ti ti-alert-triangle' ></i>";
+            }
+            if ($value < 25) {
+                $pics_info = "<i class='red ti ti-alert-circle'></i>";
+            }
+
             echo "<tr>";
             echo sprintf("<td>%s</td>", $tags[$property]['name'] ?? $property);
 
@@ -102,16 +110,29 @@ class Printer_CartridgeInfo extends CommonDBChild
                     'percent_text'      => $value,
                     'background-color'  => $bar_color,
                     'text-color'        => $text_color,
-                    'text'              => ''
+                    'text'              => '',
+                    'pics_info'         => $pics_info
                 ];
 
-                $out = "{$progressbar_data['text']}<div class='center' style='background-color: #ffffff; width: 100%;
-                     border: 1px solid #9BA563; position: relative;' >";
-                $out .= "<div style='position:absolute; color: {$progressbar_data['text-color']};'>";
-                $out .= "&nbsp;{$progressbar_data['percent_text']}%</div>";
-                $out .= "<div class='center' style='background-color: {$progressbar_data['background-color']};
-                     width: {$progressbar_data['percent']}%; height: 20px' ></div>";
-                $out .= "</div>";
+
+                $out = <<<HTML
+                    <span class='text-nowrap'>
+                    {$progressbar_data['text']}
+                    </span>
+                    <div class="progress" style="height: 16px">
+                        <div class="progress-bar progress-bar-striped" role="progressbar"
+                            style="width: {$progressbar_data['percent']}%; background-color:
+                            {$progressbar_data['background-color']}; color: {$progressbar_data['text-color']};"
+                            aria-valuenow="{$progressbar_data['percent']}"
+                            aria-valuemin="0" aria-valuemax="100">
+                            {$progressbar_data['percent_text']}%
+                        </div>
+
+                    </div>
+                    <span class='text-nowrap'>
+                    {$progressbar_data['pics_info']}
+                    </span>
+                HTML;
             } else {
                 $out = $value;
             }

--- a/src/Printer_CartridgeInfo.php
+++ b/src/Printer_CartridgeInfo.php
@@ -77,6 +77,11 @@ class Printer_CartridgeInfo extends CommonDBChild
 
         foreach ($info as $row) {
             $property = $row['property'];
+
+            preg_match("/^toner(\w+.*$)/", $property, $matches);
+            $bar_color = $matches[1] ?? 'green';
+            $text_color = ($bar_color == "black") ? 'white' : 'black';
+
             $value = $row['value'];
             echo "<tr>";
             echo sprintf("<td>%s</td>", $tags[$property]['name'] ?? $property);
@@ -92,19 +97,20 @@ class Printer_CartridgeInfo extends CommonDBChild
             }
 
             if (is_numeric($value)) {
-                $bar_color = 'green';
                 $progressbar_data = [
-                    'percent'      => $value,
-                    'percent_text' => $value,
-                    'color'        => $bar_color,
-                    'text'         => ''
+                    'percent'           => $value,
+                    'percent_text'      => $value,
+                    'background-color'  => $bar_color,
+                    'text-color'        => $text_color,
+                    'text'              => ''
                 ];
 
                 $out = "{$progressbar_data['text']}<div class='center' style='background-color: #ffffff; width: 100%;
                      border: 1px solid #9BA563; position: relative;' >";
-                $out .= "<div style='position:absolute;'>&nbsp;{$progressbar_data['percent_text']}%</div>";
-                $out .= "<div class='center' style='background-color: {$progressbar_data['color']};
-                     width: {$progressbar_data['percent']}%; height: 12px' ></div>";
+                $out .= "<div style='position:absolute; color: {$progressbar_data['text-color']};'>";
+                $out .= "&nbsp;{$progressbar_data['percent_text']}%</div>";
+                $out .= "<div class='center' style='background-color: {$progressbar_data['background-color']};
+                     width: {$progressbar_data['percent']}%; height: 20px' ></div>";
                 $out .= "</div>";
             } else {
                 $out = $value;


### PR DESCRIPTION
Before : 
![image](https://user-images.githubusercontent.com/7335054/192732696-fb9ee634-a4fb-4e7e-8b50-74d1d7ced565.png)

After : 
![image](https://user-images.githubusercontent.com/7335054/192732715-90991012-356a-4b88-b36d-4748e5468d84.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
