### PR TITLE
feat(inventory): add dedicated right for locked field

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -7768,6 +7768,11 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
                 'name' => 'recurrentchange',
                 'rights' => READ,
             ],
+            [
+                'profiles_id' => self::PROFILE_SUPER_ADMIN,
+                'name' => 'locked_field',
+                'rights' => CREATE | PURGE,
+            ]
         ];
 
 

--- a/install/migrations/update_10.0.3_to_10.0.4/inventory.php
+++ b/install/migrations/update_10.0.3_to_10.0.4/inventory.php
@@ -44,3 +44,6 @@ foreach ($tables as $table) {
     $migration->addField($table, 'is_deleted', 'bool', ['value' => 0, 'after' => 'is_dynamic']);
     $migration->addKey($table, "is_deleted");
 }
+
+//new right value for locked_field (previously based on config UPDATE)
+$migration->addRight('locked_field', CREATE | PURGE, ['config' => UPDATE]);

--- a/src/Lockedfield.php
+++ b/src/Lockedfield.php
@@ -249,11 +249,6 @@ class Lockedfield extends CommonDBTM
         return ['update', 'clone'];
     }
 
-    public static function canPurge()
-    {
-        return Session::haveRight(static::$rightname, PURGE);
-    }
-
     public function prepareInputForAdd($input)
     {
         return $this->prepareInput($input);
@@ -288,13 +283,6 @@ class Lockedfield extends CommonDBTM
         return true;
     }
 
-    public static function canCreate()
-    {
-        if (static::$rightname) {
-            return Session::haveRight(static::$rightname, CREATE);
-        }
-        return false;
-    }
 
     /**
      * List of itemtypes/fields that can be locked globally

--- a/src/Lockedfield.php
+++ b/src/Lockedfield.php
@@ -46,7 +46,7 @@ class Lockedfield extends CommonDBTM
    // From CommonDBTM
     public $dohistory                   = false;
 
-    public static $rightname                   = 'config';
+    public static $rightname                   = 'locked_field';
 
     public static function getTypeName($nb = 0)
     {
@@ -251,7 +251,7 @@ class Lockedfield extends CommonDBTM
 
     public static function canPurge()
     {
-        return Session::haveRight(static::$rightname, UPDATE);
+        return Session::haveRight(static::$rightname, PURGE);
     }
 
     public function prepareInputForAdd($input)
@@ -291,7 +291,7 @@ class Lockedfield extends CommonDBTM
     public static function canCreate()
     {
         if (static::$rightname) {
-            return Session::haveRight(static::$rightname, UPDATE);
+            return Session::haveRight(static::$rightname, CREATE);
         }
         return false;
     }

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -1789,6 +1789,14 @@ class Profile extends CommonDBTM
                 'label'     => __('Inventory'),
                 'field'     => 'inventory'
             ], [
+                'itemtype'  => 'LockedField',
+                'label'     => Lockedfield::getTypeName(Session::getPluralNumber()),
+                'field'     => 'locked_field',
+                'rights'  => [
+                    CREATE  => __('Create'),
+                    PURGE  => __('Purge')
+                ],
+            ], [
                 'itemtype'  => 'Log',
                 'label'     => Log::getTypeName(Session::getPluralNumber()),
                 'field'     => 'logs'

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -1794,7 +1794,9 @@ class Profile extends CommonDBTM
                 'field'     => 'locked_field',
                 'rights'  => [
                     CREATE  => __('Create'),
-                    PURGE  => __('Purge')
+                    PURGE   => ['short' => __('Purge'),
+                        'long'  => _x('button', 'Delete permanently')
+                    ]
                 ],
             ], [
                 'itemtype'  => 'Log',


### PR DESCRIPTION
 Add dedicated right for locked field (only ```CREATE``` (for global lock) and ```PURGE``` are needed)

![image](https://user-images.githubusercontent.com/7335054/192748473-3dcf1724-d184-49c8-9258-7da2b4b922c6.png)


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
