### PR TITLE
Fix CalDAV object deletion handling

### DIFF
--- a/src/CalDAV/Backend/Calendar.php
+++ b/src/CalDAV/Backend/Calendar.php
@@ -248,7 +248,11 @@ class Calendar extends AbstractBackend
             throw new \Sabre\DAV\Exception\NotFound(sprintf('Object "%s" not found', $objectPath));
         }
 
-        if (!$item->deleteFromDB()) {
+        if (!$item->can($item->fields['id'], PURGE)) {
+            throw new \Sabre\DAV\Exception\Forbidden();
+        }
+
+        if (!$item->delete(['id' => $item->fields['id']], 1)) {
             throw new \Sabre\DAV\Exception('Error during object deletion');
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12753

1. `PURGE` right was not checked before deleting the item.
2. The `CommonDBTM::deleteFromDB()` method was used. I do not remember if it was intentional, but I think it would be better to use the `CommonDBTM::delete()` method instead.