### PR TITLE
fix(document): check availability

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5439,7 +5439,7 @@ class CommonDBTM extends CommonGLPI
             }
 
            // Check for duplicate and availability (e.g. file deleted in _files)
-            if ($doc->getDuplicateOf($entities_id, $filename) && $doc->checkAvailability($filename)) {
+            if ($doc->getDuplicateOf($entities_id, $filename)) {
                 $docID = $doc->fields["id"];
                // File already exist, we replace the tag by the existing one
                 if (
@@ -5453,6 +5453,14 @@ class CommonDBTM extends CommonGLPI
                         $input[$options['content_field']]
                     );
                     $docadded[$docID]['tag'] = $doc->fields["tag"];
+                }
+                if (!$doc->checkAvailability($filename)) {
+                    $doc->update([
+                        'id'                      => $docID,
+                        '_only_if_upload_succeed' => 1,
+                        '_filename'               => [$file],
+                        'current_filepath'        => $filename,
+                    ]);
                 }
             } else {
                 if ($this->getType() == 'Ticket') {

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5438,8 +5438,8 @@ class CommonDBTM extends CommonGLPI
                 $is_recursive = $input['_job']->fields['is_recursive'];
             }
 
-           // Check for duplicate
-            if ($doc->getDuplicateOf($entities_id, $filename)) {
+           // Check for duplicate and availability (e.g. file deleted in _files)
+            if ($doc->getDuplicateOf($entities_id, $filename) && $doc->checkAvailability($filename)) {
                 $docID = $doc->fields["id"];
                // File already exist, we replace the tag by the existing one
                 if (

--- a/src/Document.php
+++ b/src/Document.php
@@ -1893,4 +1893,26 @@ class Document extends CommonDBTM
 
         return true;
     }
+
+
+    /**
+     * It checks if a file exists and is readable
+     *
+     * @param string filename The name of the file to check.
+     *
+     * @return boolean
+     */
+    public function checkAvailability(string $filename): bool
+    {
+        $file = GLPI_DOC_DIR . '/' . $filename;
+        if (!file_exists($file)) {
+            return false;
+        }
+
+        if (!is_readable($file)) {
+            return false;
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
When an ITILObject was created by inserting an image that was already in use, but whose corresponding file had been deleted, the image was not reimported, because it was only checked if the document was already present in the database, but not if the file was available.

This PR checks the accessibility of the file to reimport it if it is missing.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24661
