### PR TITLE
feat(inventory): move snmpcredentials_id to main form

### DIFF
--- a/src/NetworkEquipment.php
+++ b/src/NetworkEquipment.php
@@ -509,6 +509,8 @@ class NetworkEquipment extends CommonDBTM
 
         $tab = array_merge($tab, Socket::rawSearchOptionsToAdd(get_class($this)));
 
+        $tab = array_merge($tab, SNMPCredential::rawSearchOptionsToAdd(get_class($this)));
+
         return $tab;
     }
 

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -658,6 +658,8 @@ class Printer extends CommonDBTM
 
         $tab = array_merge($tab, Socket::rawSearchOptionsToAdd(get_class($this)));
 
+        $tab = array_merge($tab, SNMPCredential::rawSearchOptionsToAdd(get_class($this)));
+
         return $tab;
     }
 

--- a/src/SNMPCredential.php
+++ b/src/SNMPCredential.php
@@ -49,6 +49,36 @@ class SNMPCredential extends CommonDBTM
         return _n('SNMP credential', 'SNMP credentials', $nb);
     }
 
+    public static function rawSearchOptionsToAdd()
+    {
+        $tab = [];
+
+        $tab[] = [
+            'id'                => 'snmpcredential',
+            'name'              => SNMPCredential::getTypeName(0)
+        ];
+
+        $tab[] = [
+            'id'                => '106',
+            'table'             => 'glpi_snmpcredentials',
+            'field'             => 'name',
+            'name'              => __('Name'),
+            'datatype'          => 'dropdown',
+            'massiveaction'     => false,
+        ];
+
+        $tab[] = [
+            'id'                => '107',
+            'table'             => 'glpi_snmpcredentials',
+            'field'             => 'community',
+            'name'              => __('Community'),
+            'datatype'          => 'string',
+            'massiveaction'     => false,
+        ];
+
+        return $tab;
+    }
+
     public function rawSearchOptions()
     {
         $tab = parent::rawSearchOptions();

--- a/templates/components/form/inventory_info.html.twig
+++ b/templates/components/form/inventory_info.html.twig
@@ -148,10 +148,6 @@
    {% if item.isField('is_dynamic') and (item.getType() == 'NetworkEquipment' or item.getType() == 'Printer') %}
       <div class="card-body row">
          <div class="mb-3 col-12 col-sm-6">
-            <label class="form-label" >{{ __('SNMP Credential') }}</label>
-            <span>{{ get_item_link(item.getSNMPCredential()) }} </span>
-         </div>
-         <div class="mb-3 col-12 col-sm-6">
             <label class="form-label" >{{ __('Last inventory') }}</label>
             <span>{{ item.fields['last_inventory_update']|formatted_datetime }}</span>
          </div>

--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -444,6 +444,16 @@
                         {{ fields.textareaField('sysdescr', item.fields['sysdescr'], __('Sysdescr')) }}
                      {% endif %}
 
+                     {% if item.isField('snmpcredentials_id') %}
+                        {{ fields.dropdownField(
+                           'SNMPCredential',
+                           'snmpcredentials_id',
+                           item.fields['snmpcredentials_id'],
+                           'SNMPCredential'|itemtype_name,
+                           field_options
+                        ) }}
+                     {% endif %}
+
                      {% if item.isField('users_id') %}
                         {{ fields.dropdownField(
                            'User',


### PR DESCRIPTION
Move ```snmpcredentials_id``` dropdown to main form
Allow user to fill field when the object is created (or on update).
some users use this feature to no longer perform the network discovery task, but just the SNMP inventory on an IP range 
Compatible with ```locked_field```

Printer : 
![image](https://user-images.githubusercontent.com/7335054/193035854-75869f31-f21f-4698-8ea3-7e6bd4fe6e54.png)


NetworkEquipement : 
![image](https://user-images.githubusercontent.com/7335054/193035836-155d52cc-2f42-47cb-8af7-e75fd9caa1a1.png)




| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
