### PR TITLE
fix(monitor): add missing UUID searh option

### DIFF
--- a/src/Monitor.php
+++ b/src/Monitor.php
@@ -290,6 +290,14 @@ class Monitor extends CommonDBTM
         ];
 
         $tab[] = [
+            'id'                 => '10',
+            'table'              => $this->getTable(),
+            'field'              => 'uuid',
+            'name'               => __('UUID'),
+            'datatype'           => 'string',
+        ];
+
+        $tab[] = [
             'id'                 => '70',
             'table'              => 'glpi_users',
             'field'              => 'name',


### PR DESCRIPTION
add missing ```UUID``` searh option for ```Monitor```


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25059
