### PR TITLE
fix(inventory): check if link need to be updated are added (prevent d…

### DIFF
--- a/src/Inventory/Asset/Device.php
+++ b/src/Inventory/Asset/Device.php
@@ -110,14 +110,15 @@ abstract class Device extends InventoryAsset
                     'itemtype'           => $this->item->getType(),
                     'items_id'           => $this->item->fields['id'],
                 ]);
-                $itemdevice_data = $input_data + $this->handleInput($val, $itemdevice);
 
                 //check if link between device and asset exist
                 if ($itemdevice->getFromDBByCrit($input_data)) {
+                    $itemdevice_data = $input_data + $this->handleInput($val, $itemdevice);
                     $itemdevice_data['id'] = $itemdevice->fields['id'];
                     $itemdevice->update($itemdevice_data, true, []);
                     unset($existing[$device_id]);
                 } else {
+                    $itemdevice_data = $input_data + $this->handleInput($val, $itemdevice);
                     $itemdevice->add($itemdevice_data, [], false);
                     $this->itemdeviceAdded($itemdevice, $val);
                     unset($existing[$device_id]);
@@ -126,14 +127,14 @@ abstract class Device extends InventoryAsset
 
             foreach ($existing as $deviceid => $data) {
                 //first, remove items
-                if ($data['is_dynamic'] == 1) {
+                //if ($data['is_dynamic'] == 1) {
                     $DB->delete(
                         $itemdevice->getTable(),
                         [
                             $fk => $deviceid
                         ]
                     );
-                }
+                //}
             }
         }
     }

--- a/src/Inventory/Asset/Device.php
+++ b/src/Inventory/Asset/Device.php
@@ -102,14 +102,26 @@ abstract class Device extends InventoryAsset
                 }
 
                 //create device or get existing device ID
-                $device_id = $device->import(\Toolbox::addslashes_deep($this->handleInput($val, $device)) + ['with_history' => false]);
+                $input_device = \Toolbox::addslashes_deep($this->handleInput($val, $device)) + ['with_history' => false];
+                $device_id = $device->import($input_device);
 
                 //prepare data
                 $input_data = \Toolbox::addslashes_deep([
                     $fk                  => $device_id,
                     'itemtype'           => $this->item->getType(),
                     'items_id'           => $this->item->fields['id'],
+                    'is_dynamic'         => 1,
                 ]);
+
+                //add serial if available (usefull for memories)
+                if (property_exists($val, "serial")) {
+                    $input_data['serial'] = $val->serial;
+                }
+
+                //add serial if available (usefull for memories)
+                if (property_exists($val, "otherserial")) {
+                    $input_data['otherserial'] = $val->otherserial;
+                }
 
                 //check if link between device and asset exist
                 if ($itemdevice->getFromDBByCrit($input_data)) {
@@ -127,14 +139,14 @@ abstract class Device extends InventoryAsset
 
             foreach ($existing as $deviceid => $data) {
                 //first, remove items
-                //if ($data['is_dynamic'] == 1) {
+                if ($data['is_dynamic'] == 1) {
                     $DB->delete(
                         $itemdevice->getTable(),
                         [
                             $fk => $deviceid
                         ]
                     );
-                //}
+                }
             }
         }
     }

--- a/src/Inventory/Asset/Device.php
+++ b/src/Inventory/Asset/Device.php
@@ -88,7 +88,6 @@ abstract class Device extends InventoryAsset
             $fk              = getForeignKeyFieldForTable($devicetable);
 
             $existing = $this->getExisting($itemdevicetable, $fk);
-            $deleted_items = [];
 
             foreach ($value as $val) {
                 if (!isset($val->designation) || $val->designation == '') {

--- a/src/Inventory/Asset/Device.php
+++ b/src/Inventory/Asset/Device.php
@@ -124,10 +124,6 @@ abstract class Device extends InventoryAsset
                     }
                 }
 
-                var_dump($input_data_for_check);
-                var_dump($val);
-
-
                 //check if link between device and asset exist
                 if (!$itemdevice->getFromDBByCrit($input_data_for_check)) {
                     $input_item_device['is_dynamic'] = 1;

--- a/tests/functionnal/Glpi/Inventory/Assets/Device.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Device.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2022 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Inventory\Asset;
+
+include_once __DIR__ . '/../../../../abstracts/AbstractInventoryAsset.php';
+
+/* Test for inc/inventory/asset/memory.class.php */
+
+class Device extends AbstractInventoryAsset
+{
+    protected function assetProvider(): array
+    {
+        return [];
+    }
+
+
+    public function testInventoryUpdate()
+    {
+        global $DB;
+        $device_mem = new \DeviceMemory();
+        $item_mem = new \Item_DeviceMemory();
+        $info_com = new \Infocom();
+
+        $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<REQUEST>
+  <CONTENT>
+    <MEMORIES>
+      <CAPACITY>8192</CAPACITY>
+      <CAPTION>Bottom-Slot 1(left)</CAPTION>
+      <DESCRIPTION>SODIMM</DESCRIPTION>
+      <MANUFACTURER>Samsung</MANUFACTURER>
+      <MEMORYCORRECTION>None</MEMORYCORRECTION>
+      <NUMSLOTS>1</NUMSLOTS>
+      <SERIALNUMBER>97842456</SERIALNUMBER>
+      <SPEED>2133</SPEED>
+      <TYPE>DDR4</TYPE>
+    </MEMORIES>
+    <MEMORIES>
+      <CAPACITY>8192</CAPACITY>
+      <CAPTION>Bottom-Slot 2(right)</CAPTION>
+      <DESCRIPTION>SODIMM</DESCRIPTION>
+      <MANUFACTURER>Samsung</MANUFACTURER>
+      <MEMORYCORRECTION>None</MEMORYCORRECTION>
+      <NUMSLOTS>1</NUMSLOTS>
+      <SERIALNUMBER>97842457</SERIALNUMBER>
+      <SPEED>2133</SPEED>
+      <TYPE>DDR4</TYPE>
+    </MEMORIES>
+    <HARDWARE>
+      <NAME>pc002</NAME>
+    </HARDWARE>
+    <BIOS>
+      <SSN>ggheb7ne7</SSN>
+    </BIOS>
+    <VERSIONCLIENT>FusionInventory-Agent_v2.3.19</VERSIONCLIENT>
+  </CONTENT>
+  <DEVICEID>test-pc002</DEVICEID>
+  <QUERY>INVENTORY</QUERY>
+</REQUEST>";
+
+
+        $this->doInventory($xml_source, true);
+
+        //check created agent
+        $agents = $DB->request(['FROM' => \Agent::getTable()]);
+        $this->integer(count($agents))->isIdenticalTo(1);
+        $agent = $agents->current();
+        $computers_id = $agent['items_id'];
+        $this->integer($computers_id)->isGreaterThan(0);
+        $computer = new \Computer();
+        $computer->getFromDB($computers_id);
+
+
+        //memories present from the inventory source are dynamic
+        $memories = $item_mem->find(['itemtype' => 'Computer', 'items_id' => $computers_id, 'is_dynamic' => 1]);
+
+        $this->integer(count($memories))->isIdenticalTo(2);
+
+        $data_to_check = [];
+
+        $infocom_buy_date = '2020-10-21';
+        $infocom_value = '300';
+        foreach ($memories as $result) {
+            $item_device_memory_id = $result['id'];
+            $input = [
+                "items_id" => $item_device_memory_id,
+                "itemtype" => \Item_DeviceMemory::class,
+                "entities_id" => $computer->fields['entities_id'],
+                "buy_date" => $infocom_buy_date,
+                "value" => $infocom_value
+            ];
+            //create infocom
+            $id = $info_com->add($input);
+            $this->integer($id)->isGreaterThan(0);
+            $input['id'] = $id;
+            $data_to_check[] = $input;
+        }
+
+        //redo an inventory
+        $this->doInventory($xml_source, true);
+
+       //memory present in the inventory source is still dynamic
+        $memories = $item_mem->find(['itemtype' =>  \Computer::class, 'items_id' => $computers_id, 'is_dynamic' => 1]);
+        $this->integer(count($memories))->isIdenticalTo(2);
+
+        //check item_device_memory is the same from frist step
+        foreach ($data_to_check as $data_value) {
+          $memories = $item_mem->find(['id' => $data_value['items_id'], "itemtype" => \Computer::class, 'is_dynamic' => 1]);
+          $this->integer(count($memories))->isIdenticalTo(1);
+        }
+
+        //check infocom is still exist
+        foreach ($data_to_check as $data_value) {
+          $info_coms = $info_com->find(['id' => $data_value['id'], "buy_date" => $infocom_buy_date, "value" => $infocom_value]);
+          $this->integer(count($info_coms))->isIdenticalTo(1);
+        }
+
+    }
+}


### PR DESCRIPTION
At each inventory, GLPI delete all links (and ```infocom``` too) between asset and device (```item_devicexxxx```)

Check if link need to be updated are added (prevent bulk deletion)

Best regards

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12852
