### PR TITLE
Fix warning on document send buffer cleaning

### DIFF
--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -697,7 +697,9 @@ class Toolbox
             ob_end_clean();
         }
         // 2. Clean any buffered output in remaining level (output_buffering="on" case).
-        ob_clean();
+        if (ob_get_level() > 0) {
+            ob_clean();
+        }
 
         // Now send the file with header() magic
         header("Last-Modified: " . gmdate("D, d M Y H:i:s", $lastModified) . " GMT");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Follows #12802 .

If there is nothing in buffer, and if `output_buffering="off"`, a warning was trigerred (`PHP Notice (8): ob_clean(): failed to delete buffer. No buffer to delete in /var/www/glpi/src/Toolbox.php at line 700`).

