### PR TITLE
fix(timeline ticket): display source of followup

### DIFF
--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -53,6 +53,13 @@
          </div>
 
          <div class="timeline-badges">
+            {% if entry_i['requesttypes_id'] %}
+               <span class="badge bg-blue-lt" title="{{ __('Source of followup') }}">
+                  <i class="fas fa-inbox me-1"></i>
+                  {{ get_item_name('RequestType', entry_i['requesttypes_id']) }}
+               </span>
+            {% endif %}
+
             {% if entry_i['sourceitems_id'] %}
                <span class="badge bg-blue-lt">
                   <i class="fas fa-code-branch me-1"></i>


### PR DESCRIPTION
Since 10.0, the 'source of followup' was no longer displayed directly in the followup, you had to edit it to see its value.

![image](https://user-images.githubusercontent.com/8530352/193591547-e10fe225-cd44-495b-bd92-dcf50d80ee03.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25076
