### PR TITLE
Improve image pasting from MS Word

### DIFF
--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -443,15 +443,6 @@ if (typeof tinyMCE != 'undefined') {
             });
             $(editor.targetElm).val(fragment.html());
         });
-        editor.on('NodeChange', function(e) {
-            // Handle RTF image sources and remove the temporary "data-rtf-src" attribute.
-            if (e.element.tagName === 'IMG') {
-                if (e.element.hasAttribute('data-rtf-src')) {
-                    e.element.setAttribute('src', e.element.getAttribute('data-rtf-src'));
-                    e.element.removeAttribute('data-rtf-src');
-                }
-            }
-        });
     });
 }
 

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -346,13 +346,50 @@ var insertImageInTinyMCE = function(editor, image) {
  */
 if (typeof tinyMCE != 'undefined') {
     tinyMCE.PluginManager.add('glpi_upload_doc', function(editor) {
+        let last_paste_content = null;
+        const rtf_img_types = {
+            'pngblip': 'image/png',
+            'jpegblip': 'image/jpeg',
+        };
+        editor.on('paste', (e) => {
+            last_paste_content = e.clipboardData;
+        });
         editor.on('PastePreProcess', function(event) {
+            const base64_img_contents = [];
+            if (last_paste_content !== null && last_paste_content.types.includes('text/rtf')) {
+                // Extract all RTF images and remove line breaks
+                const rtf_content = last_paste_content.getData('text/rtf');
+                const rtf_content_no_line_break = rtf_content.replace(/(\r\n|\n|\r)/gm, "");
+                const hex_binary = rtf_content_no_line_break.matchAll(/\\(pngblip|jpegblip)([a-z0-9]*)}/g);
+
+                // For each match, convert to base64
+                for (const match of hex_binary) {
+                    const img_type = match[1];
+                    const hex = match[2];
+                    const hexToBase64 = function(hexstring) {
+                        return btoa(hexstring.match(/\w{2}/g).map(function(a) {
+                            return String.fromCharCode(parseInt(a, 16));
+                        }).join(""));
+                    };
+                    base64_img_contents.push({
+                        type: rtf_img_types[img_type],
+                        content: hexToBase64(hex)
+                    });
+                }
+            }
             // Trigger upload process for each pasted image
             var fragment = $('<div></div>');
             fragment.append(event.content);
             fragment.find('img').each(function() {
                 const image = $(this);
-                const src = image.attr('src');
+                let src = image.attr('src');
+                const file_pattern = '^file://';
+
+                if (src.match(file_pattern) !== null && base64_img_contents.length > 0) {
+                    const rtf_content = base64_img_contents.shift();
+                    src = `data:${rtf_content['type']};base64,` + rtf_content['content'];
+                    image.attr('src', src);
+                }
                 if (src.match(new RegExp('^(data|blob):')) !== null) {
                     const upload_id = Math.random().toString();
                     image.attr('data-upload_id', upload_id);
@@ -397,7 +434,7 @@ if (typeof tinyMCE != 'undefined') {
             // regex that are not correctly handling huge strings (see #8044).
             var fragment = $('<div></div>');
             fragment.append($(editor.targetElm).val());
-            fragment.find('img').each(function() {
+            fragment.find('img').each(function () {
                 const image = $(this);
                 const upload_id = image.attr('data-upload_id');
                 if (upload_id !== undefined) {
@@ -405,6 +442,15 @@ if (typeof tinyMCE != 'undefined') {
                 }
             });
             $(editor.targetElm).val(fragment.html());
+        });
+        editor.on('NodeChange', function(e) {
+            // Handle RTF image sources and remove the temporary "data-rtf-src" attribute.
+            if (e.element.tagName === 'IMG') {
+                if (e.element.hasAttribute('data-rtf-src')) {
+                    e.element.setAttribute('src', e.element.getAttribute('data-rtf-src'));
+                    e.element.removeAttribute('data-rtf-src');
+                }
+            }
         });
     });
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12849

When pasting an image from MS Word or LibreOffice Writer, the images were being inserted with one of two formats for their source attributes (Seemed random which it was):
1. A `file://` URI pointing to the image in a temporary directory
2. A `blob:` URI that seemed to point to a broken image

Local file access is not allowed in at least Chrome and Firefox for security reasons. However, the raw clipboard data has 3 different data sources (plain text, HTML, and RTF). TinyMCE only uses HTML or plain text but the RTF source has the binary image contents in hexadecimal. We can extract that data and replace the broken image sources.

I don't know if this fix would cause issues with other copy-paste cases that worked previously but I've not found any issues yet.
There is still an error printed in the browser console as it tries to initially access the local file. I haven't found a way to replace the `src` value earlier to prevent that error.