### PR TITLE
fix(ticket): FAQ link too small

### DIFF
--- a/css/legacy/includes/_styles.scss
+++ b/css/legacy/includes/_styles.scss
@@ -646,8 +646,6 @@
       position: relative;
       display: inline-block;
       width: max-content;
-      top: 50%;
-      transform: translateY(-50%);
 
       .display_faq_chkbox {
          display: none;

--- a/css/legacy/includes/_styles.scss
+++ b/css/legacy/includes/_styles.scss
@@ -645,6 +645,9 @@
    .faqadd_block {
       position: relative;
       display: inline-block;
+      width: max-content;
+      top: 50%;
+      transform: translateY(-50%);
 
       .display_faq_chkbox {
          display: none;

--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -936,8 +936,7 @@ abstract class CommonDropdown extends CommonDBTM
                 $kbitem->getFromDB(reset($found_kbitem)['id']);
                 $ret .= "<div class='faqadd_block'>";
                 $ret .= "<label for='display_faq_chkbox$rand'>";
-                $ret .= "<img src='" . $CFG_GLPI["root_doc"] . "/pics/faqadd.png' class='middle pointer'
-                      alt=\"$title\" title=\"$title\">";
+                $ret .= "<i class='ti ti-zoom-question'></i>";
                 $ret .= "</label>";
                 $ret .= "<input type='checkbox'  class='display_faq_chkbox' id='display_faq_chkbox$rand'>";
                 $ret .= "<div class='faqadd_entries'>";

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -1528,8 +1528,7 @@ class CommonGLPI implements CommonGLPIInterface
             $kbitem->getFromDB(reset($found_kbitem)['id']);
             $ret .= "<div class='faqadd_block'>";
             $ret .= "<label for='display_faq_chkbox$rand'>";
-            $ret .= "<img src='" . $CFG_GLPI["root_doc"] . "/pics/faqadd.png' class='middle pointer'
-                    alt=\"$title\" title=\"$title\">";
+            $ret .= "<i class='ti ti-zoom-question'></i>";
             $ret .= "</label>";
             $ret .= "<input type='checkbox'  class='display_faq_chkbox' id='display_faq_chkbox$rand'>";
             $ret .= "<div class='faqadd_entries' style='position:relative;'>";

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -366,30 +366,32 @@ class Dropdown
                 $item->isField('knowbaseitemcategories_id') && Session::haveRightsOr('knowbase', [READ, KnowbaseItem::READFAQ])
                 && method_exists($item, 'getLinks')
             ) {
-                $paramskblinks = [
-                    'value'       => '__VALUE__',
-                    'itemtype'    => $itemtype,
-                    '_idor_token' => Session::getNewIDORToken($itemtype),
-                    'withlink'    => $kblink_id,
-                ];
-                $kb_link_icon = '<div>';
-                $kb_link_icon .= Ajax::updateItemOnSelectEvent(
-                    $field_id,
-                    $kblink_id,
-                    $CFG_GLPI["root_doc"] . "/ajax/kblink.php",
-                    $paramskblinks,
-                    false
-                );
                 // With the self-service profile, $item (whose itemtype = ITILCategory) is empty,
                 //  as the profile does not have rights to ITILCategory to initialise it before.
                 if ($item->isNewItem()) {
                     $item->getFromDB($params['value']);
                 }
-                $kb_link_icon .= "<span id='$kblink_id'>";
-                $kb_link_icon .= $item->getLinks();
-                $kb_link_icon .= "</span>";
-                $kb_link_icon .= '</div>';
-                $icon_array[] = $kb_link_icon;
+                if ($itemlinks = $item->getLinks()) {
+                    $paramskblinks = [
+                        'value'       => '__VALUE__',
+                        'itemtype'    => $itemtype,
+                        '_idor_token' => Session::getNewIDORToken($itemtype),
+                        'withlink'    => $kblink_id,
+                    ];
+                    $kb_link_icon = '<div class="btn btn-outline-secondary">';
+                    $kb_link_icon .= Ajax::updateItemOnSelectEvent(
+                        $field_id,
+                        $kblink_id,
+                        $CFG_GLPI["root_doc"] . "/ajax/kblink.php",
+                        $paramskblinks,
+                        false
+                    );
+                    $kb_link_icon .= "<span id='$kblink_id'>";
+                    $kb_link_icon .= $itemlinks;
+                    $kb_link_icon .= "</span>";
+                    $kb_link_icon .= '</div>';
+                    $icon_array[] = $kb_link_icon;
+                }
             }
         }
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -386,7 +386,7 @@ class Dropdown
                     $item->getFromDB($params['value']);
                 }
                 $kb_link_icon .= "<span id='$kblink_id'>";
-                $kb_link_icon .= '&nbsp;' . $item->getLinks();
+                $kb_link_icon .= $item->getLinks();
                 $kb_link_icon .= "</span>";
                 $kb_link_icon .= '</div>';
                 $icon_array[] = $kb_link_icon;

--- a/src/Item_Ticket.php
+++ b/src/Item_Ticket.php
@@ -351,7 +351,7 @@ class Item_Ticket extends CommonItilObject_Item
                     $result .= " <i class='fas fa-times-circle pointer' onclick=\"itemAction" . $params['rand'] . "('delete', '$itemtype', '$items_id');\"></i>";
                 }
                 if ($params['kblink']) {
-                    $result .= ' ' . $item->getKBLinks();
+                    $result .= $item->getKBLinks();
                 }
                 $result .= "</div>";
             } else {

--- a/src/Item_Ticket.php
+++ b/src/Item_Ticket.php
@@ -351,7 +351,7 @@ class Item_Ticket extends CommonItilObject_Item
                     $result .= " <i class='fas fa-times-circle pointer' onclick=\"itemAction" . $params['rand'] . "('delete', '$itemtype', '$items_id');\"></i>";
                 }
                 if ($params['kblink']) {
-                    $result .= $item->getKBLinks();
+                    $result .= ' ' . $item->getKBLinks();
                 }
                 $result .= "</div>";
             } else {


### PR DESCRIPTION
When the category is very large, the link to the FAQ was reduced and became almost invisible:

Before:

![image](https://user-images.githubusercontent.com/8530352/193763988-d02077d0-4fa5-4a60-8d12-8ed0900940d6.png)

After:

![image](https://user-images.githubusercontent.com/8530352/193769327-9d663d77-cd00-4e84-b27e-b54ec98238e8.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25091
