### PR TITLE
fix(transfer): fix warning undefined array key

### DIFF
--- a/src/Transfer.php
+++ b/src/Transfer.php
@@ -3832,7 +3832,7 @@ class Transfer extends CommonDBTM
                     } else {
                         foreach ($iterator as $data) {
                           // Not a copy -> only update socket
-                            if ($data['sockets_id']) {
+                            if (isset($data['sockets_id']) && $data['sockets_id']) {
                                  $socket = new Socket();
                                 if ($socket->getFromDBByCrit(["networkports_id" => $data['id']])) {
                                     if ($socket->getID()) {


### PR DESCRIPTION
Prevent warning

```
[2022-10-04 10:54:57] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "sockets_id" in /home/DEV/GLPI/10.0-bugfixes/src/Transfer.php at line 3835
  Backtrace :
  src/Transfer.php:1220                              Transfer->transferNetworkLink()
  src/Transfer.php:265                               Transfer->transferItem()
```


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
