### PR TITLE
Prevent duplicates "GLPI Native Inventory" auto update systems

### DIFF
--- a/src/AutoUpdateSystem.php
+++ b/src/AutoUpdateSystem.php
@@ -35,6 +35,8 @@
 
 class AutoUpdateSystem extends CommonDropdown
 {
+    public const NATIVE_INVENTORY = "GLPI Native Inventory";
+
     public static function getTypeName($nb = 0)
     {
         return _n('Update Source', 'Update Sources', $nb);

--- a/src/Features/Inventoriable.php
+++ b/src/Features/Inventoriable.php
@@ -36,6 +36,7 @@
 namespace Glpi\Features;
 
 use Agent;
+use AutoUpdateSystem;
 use CommonDBTM;
 use Computer;
 use Computer_Item;
@@ -75,7 +76,7 @@ trait Inventoriable
 
         if ($this->isField('autoupdatesystems_id')) {
             $source = new \AutoUpdateSystem();
-            $source->getFromDBByCrit(['name' => 'GLPI Native Inventory']);
+            $source->getFromDBByCrit(['name' => AutoUpdateSystem::NATIVE_INVENTORY]);
 
             if (
                 !$this->isDynamic()

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -37,6 +37,7 @@
 namespace Glpi\Inventory\Asset;
 
 use Auth;
+use AutoUpdateSystem;
 use Blacklist;
 use CommonDBTM;
 use Dropdown;
@@ -128,7 +129,7 @@ abstract class MainAsset extends InventoryAsset
             $val = new \stdClass();
 
             //set update system
-            $val->autoupdatesystems_id = $entry->content->autoupdatesystems_id ?? 'GLPI Native Inventory';
+            $val->autoupdatesystems_id = $entry->content->autoupdatesystems_id ?? AutoUpdateSystem::NATIVE_INVENTORY;
             $val->last_inventory_update = $_SESSION["glpi_currenttime"];
 
             if (isset($this->extra_data['hardware'])) {
@@ -589,11 +590,19 @@ abstract class MainAsset extends InventoryAsset
         }
 
         if (!is_numeric($input['autoupdatesystems_id'])) {
-            $input['autoupdatesystems_id'] = Dropdown::importExternal(
-                getItemtypeForForeignKeyField('autoupdatesystems_id'),
-                addslashes($input['autoupdatesystems_id']),
-                $input['entities_id']
-            );
+            $system_name = addslashes($input['autoupdatesystems_id']);
+            $auto_update_system = new AutoUpdateSystem();
+            if ($auto_update_system->getFromDBByCrit(['name' => $system_name])) {
+                // Load from DB
+                $input['autoupdatesystems_id'] = $auto_update_system->getID();
+            } else {
+                // Import
+                $input['autoupdatesystems_id'] = Dropdown::importExternal(
+                    getItemtypeForForeignKeyField('autoupdatesystems_id'),
+                    $system_name,
+                    $input['entities_id']
+                );
+            }
         }
         $refused_input['autoupdatesystems_id'] = $input['autoupdatesystems_id'];
 

--- a/src/Inventory/Asset/VirtualMachine.php
+++ b/src/Inventory/Asset/VirtualMachine.php
@@ -36,6 +36,7 @@
 
 namespace Glpi\Inventory\Asset;
 
+use AutoUpdateSystem;
 use Computer;
 use ComputerVirtualMachine;
 use Glpi\Inventory\Conf;
@@ -90,7 +91,7 @@ class VirtualMachine extends InventoryAsset
             }
 
             if (!property_exists($vm_val, 'autoupdatesystems_id')) {
-                $vm_val->autoupdatesystems_id = 'GLPI Native Inventory';
+                $vm_val->autoupdatesystems_id = AutoUpdateSystem::NATIVE_INVENTORY;
             }
 
             // Hack for BSD jails


### PR DESCRIPTION
I've found some duplicated auto update systems:
 
![image](https://user-images.githubusercontent.com/42734840/193816280-d1bb76b1-7141-485b-ae31-5af7e30d1645.png)

Not sure how it happens, so I'm adding a simple check to ensure we don't create a system that already exists.
I've also added a constant for "GLPI Native Inventory".

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25096
