### PR TITLE
Fix KB visibily when group restriction is set as 'no_entity_restriction'

### DIFF
--- a/src/CommonDBVisible.php
+++ b/src/CommonDBVisible.php
@@ -136,7 +136,7 @@ abstract class CommonDBVisible extends CommonDBTM
                 foreach ($data as $group) {
                     if (in_array($group['groups_id'], $_SESSION["glpigroups"])) {
                       // All the group
-                        if ($group['entities_id'] < 0) {
+                        if ($group['no_entity_restriction']) {
                              return true;
                         }
                       // Restrict to entities

--- a/src/CommonDBVisible.php
+++ b/src/CommonDBVisible.php
@@ -171,7 +171,7 @@ abstract class CommonDBVisible extends CommonDBTM
             if (isset($this->profiles[$_SESSION["glpiactiveprofile"]['id']])) {
                 foreach ($this->profiles[$_SESSION["glpiactiveprofile"]['id']] as $profile) {
                     // All the profile
-                    if ($profile['no_entity_restriction'] < 0) {
+                    if ($profile['no_entity_restriction']) {
                         return true;
                     }
                     // Restrict to entities

--- a/src/CommonDBVisible.php
+++ b/src/CommonDBVisible.php
@@ -171,7 +171,7 @@ abstract class CommonDBVisible extends CommonDBTM
             if (isset($this->profiles[$_SESSION["glpiactiveprofile"]['id']])) {
                 foreach ($this->profiles[$_SESSION["glpiactiveprofile"]['id']] as $profile) {
                     // All the profile
-                    if ($profile['entities_id'] < 0) {
+                    if ($profile['no_entity_restriction'] < 0) {
                         return true;
                     }
                     // Restrict to entities


### PR DESCRIPTION
`glpi_groups_knowbaseitems.entities_id` used to be set as `-1` to indicate no entities restrictions.
This behavior was modified to use `NULL` + an explicit `no_entity_restriction` field in GLPI 10 (unsigned keys restrictions).

See the relevant migration :

![image](https://user-images.githubusercontent.com/42734840/193842887-f2edb2b4-a720-476e-97a0-cbb36a857e56.png)


It seems this code was not updated accordingly.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25051
