### PR TITLE
Fix default locked_field rights

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -7769,10 +7769,45 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
                 'rights' => READ,
             ],
             [
+                'profiles_id' => self::PROFILE_SELF_SERVICE,
+                'name' => 'locked_field',
+                'rights' => self::RIGHT_NONE,
+            ],
+            [
+                'profiles_id' => self::PROFILE_OBSERVER,
+                'name' => 'locked_field',
+                'rights' => self::RIGHT_NONE,
+            ],
+            [
+                'profiles_id' => self::PROFILE_ADMIN,
+                'name' => 'locked_field',
+                'rights' => self::RIGHT_NONE,
+            ],
+            [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'locked_field',
                 'rights' => CREATE | PURGE,
-            ]
+            ],
+            [
+                'profiles_id' => self::PROFILE_HOTLINER,
+                'name' => 'locked_field',
+                'rights' => self::RIGHT_NONE,
+            ],
+            [
+                'profiles_id' => self::PROFILE_TECHNICIAN,
+                'name' => 'locked_field',
+                'rights' => self::RIGHT_NONE,
+            ],
+            [
+                'profiles_id' => self::PROFILE_SUPERVISOR,
+                'name' => 'locked_field',
+                'rights' => self::RIGHT_NONE,
+            ],
+            [
+                'profiles_id' => self::PROFILE_READ_ONLY,
+                'name' => 'locked_field',
+                'rights' => self::RIGHT_NONE,
+            ],
         ];
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

During update, `0` value is set on all profiles that are not matching required rights. Forcing `0` value on install makes fresh installed data consistent with updated data, and fixes main branch `Profile::testClone()` test.