### PR TITLE
fix(notification): fix img size when height is null

### DIFF
--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -284,24 +284,17 @@ class NotificationEventMailing extends NotificationEventAbstract
                                 $initial_width = $img_infos[0];
                                 $initial_height = $img_infos[1];
 
-                                if ($custom_width && $custom_height) {
-                                    //compute height if need
-                                    if ($custom_width && is_null($custom_height)) {
-                                        $custom_height = $initial_height * $custom_width / $initial_width;
-                                    }
-
+                                if ($custom_width !== null && $custom_height === null) {
+                                    //compute height if needed
+                                    $custom_height = $initial_height * $custom_width / $initial_width;
+                                } elseif ($custom_height !== null && $custom_width === null) {
                                     //compute width if needed
-                                    if ($custom_height && is_null($custom_width)) {
-                                        $custom_width = $initial_width * $custom_height / $initial_height;
-                                    }
-
+                                    $custom_width = $initial_width * $custom_height / $initial_height;
+                                } elseif ($custom_height === null && $custom_width === null) {
                                     //if both are null keep initial size
-                                    if (is_null($custom_height) && is_null($custom_width)) {
-                                        $custom_width = $initial_width;
-                                        $custom_height = $initial_height;
-                                    }
+                                    $custom_width = $initial_width;
+                                    $custom_height = $initial_height;
                                 }
-
 
                                 $image_path = Document::getImage(
                                     GLPI_DOC_DIR . "/" . $doc->fields['filepath'],

--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -284,7 +284,7 @@ class NotificationEventMailing extends NotificationEventAbstract
                                 $initial_width = $img_infos[0];
                                 $initial_height = $img_infos[1];
 
-                                //computer height if need
+                                //compute height if need
                                 if ($custom_width && is_null($custom_height)) {
                                     $custom_height = $initial_height * $custom_width / $initial_width;
                                 }

--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -284,21 +284,24 @@ class NotificationEventMailing extends NotificationEventAbstract
                                 $initial_width = $img_infos[0];
                                 $initial_height = $img_infos[1];
 
-                                //compute height if need
-                                if ($custom_width && is_null($custom_height)) {
-                                    $custom_height = $initial_height * $custom_width / $initial_width;
+                                if ($custom_width && $custom_height) {
+                                    //compute height if need
+                                    if ($custom_width && is_null($custom_height)) {
+                                        $custom_height = $initial_height * $custom_width / $initial_width;
+                                    }
+
+                                    //compute width if needed
+                                    if ($custom_height && is_null($custom_width)) {
+                                        $custom_width = $initial_width * $custom_height / $initial_height;
+                                    }
+
+                                    //if both are null keep initial size
+                                    if (is_null($custom_height) && is_null($custom_width)) {
+                                        $custom_width = $initial_width;
+                                        $custom_height = $initial_height;
+                                    }
                                 }
 
-                                //compute width if needed
-                                if ($custom_height && is_null($custom_width)) {
-                                    $custom_width = $initial_width * $custom_height / $initial_height;
-                                }
-
-                                //if both are null keep initial size
-                                if (is_null($custom_height) && is_null($custom_width)) {
-                                    $custom_width = $initial_width;
-                                    $custom_height = $initial_height;
-                                }
 
                                 $image_path = Document::getImage(
                                     GLPI_DOC_DIR . "/" . $doc->fields['filepath'],

--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -284,11 +284,13 @@ class NotificationEventMailing extends NotificationEventAbstract
                                 $initial_width = $img_infos[0];
                                 $initial_height = $img_infos[1];
 
-                                if($custom_width && is_null($custom_height)){
+                                //computer height if need
+                                if ($custom_width && is_null($custom_height)) {
                                     $custom_height = $initial_height * $custom_width / $initial_width;
                                 }
 
-                                if($custom_height && is_null($custom_width)){
+                                //compute width if needed
+                                if ($custom_height && is_null($custom_width)) {
                                     $custom_width = $initial_width * $custom_height / $initial_height;
                                 }
 

--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -294,6 +294,12 @@ class NotificationEventMailing extends NotificationEventAbstract
                                     $custom_width = $initial_width * $custom_height / $initial_height;
                                 }
 
+                                //if both are null keep initial size
+                                if (is_null($custom_height) && is_null($custom_width)) {
+                                    $custom_width = $initial_width;
+                                    $custom_height = $initial_height;
+                                }
+
                                 $image_path = Document::getImage(
                                     GLPI_DOC_DIR . "/" . $doc->fields['filepath'],
                                     'mail',

--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -271,20 +271,32 @@ class NotificationEventMailing extends NotificationEventAbstract
                                 $doc->getFromDB($docID);
 
                                 //find width
-                                $width = null;
+                                $custom_width = null;
                                 if (preg_match("/width=[\"|'](\d+)(\.\d+)?[\"|']/", $matches[0][$pos], $wmatches)) {
-                                    $width = intval($wmatches[1]);
+                                    $custom_width = intval($wmatches[1]);
                                 }
-                                $height = null;
+                                $custom_height = null;
                                 if (preg_match("/height=[\"|'](\d+)(\.\d+)?[\"|']/", $matches[0][$pos], $hmatches)) {
-                                    $height = intval($hmatches[1]);
+                                    $custom_height = intval($hmatches[1]);
+                                }
+
+                                $img_infos  = getimagesize(GLPI_DOC_DIR . "/" . $doc->fields['filepath']);
+                                $initial_width = $img_infos[0];
+                                $initial_height = $img_infos[1];
+
+                                if($custom_width && is_null($custom_height)){
+                                    $custom_height = $initial_height * $custom_width / $initial_width;
+                                }
+
+                                if($custom_height && is_null($custom_width)){
+                                    $custom_width = $initial_width * $custom_height / $initial_height;
                                 }
 
                                 $image_path = Document::getImage(
                                     GLPI_DOC_DIR . "/" . $doc->fields['filepath'],
                                     'mail',
-                                    $width,
-                                    $height
+                                    $custom_width,
+                                    $custom_height
                                 );
                                 if (
                                     $mmail->AddEmbeddedImage(


### PR DESCRIPTION
If ```height``` is not defined from ```img``` 

images are distorted in notifications

Try to compute ```height``` or ```width``` if need.



| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24988 (seel last follow up)
