### PR TITLE
Make isUnique check for state accent insensitive

### DIFF
--- a/src/State.php
+++ b/src/State.php
@@ -556,6 +556,12 @@ class State extends CommonTreeDropdown
             return true;
         }
 
+        // Apply collate
+        if (isset($where['name'])) {
+            $collate = $DB->use_utf8mb4 ? "utf8mb4_bin" : "utf8_bin";
+            $where['name'] = new QueryExpression($DB->quoteValue(addslashes($where['name'])) . " COLLATE $collate");
+        }
+
         $query = [
             'FROM'   => $this->getTable(),
             'COUNT'  => 'cpt',

--- a/tests/functionnal/State.php
+++ b/tests/functionnal/State.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2022 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use DbTestCase;
+use Generator;
+
+class State extends DbTestCase
+{
+    protected function testIsUniqueProvider(): Generator
+    {
+        // Insert test data
+        $this->createItems("State", [
+            ['name' => "Test"],
+            ['name' => "Tést 2"],
+            ['name' => "abcdefg"],
+        ]);
+
+        yield [
+            'input'  => ['name' => 'Test'],
+            'expected' => false,
+        ];
+
+        yield [
+            'input'  => ['name' => "Test'"],
+            'expected' => true,
+        ];
+
+        yield [
+            'input'  => ['name' => "Tést"],
+            'expected' => true,
+        ];
+
+        yield [
+            'input'  => ['name' => "Test 2"],
+            'expected' => true,
+        ];
+
+        yield [
+            'input'  => ['name' => "Tést 2"],
+            'expected' => false,
+        ];
+    }
+
+    /**
+     * @dataprovider testIsUniqueProvider
+     */
+    public function testIsUnique(array $input, bool $expected)
+    {
+        $state = new \State();
+        $this->boolean($state->isUnique($input))->isEqualTo($expected);
+    }
+}


### PR DESCRIPTION
Trying to rename a state (`front/state.form.php`) named `TEST` to `TÉST` will throw an error.
This is because we search for existing values using a standard SQL query, which is accent insensitive:

```sql
SELECT * FROM `glpi_states` WHERE `name` = 'TÉST' 
```
```
+----+------+
| id | name |
+----+------+
|  1 | TEST |
+----+------+
1 row in set (0.00 sec)
```

We must specify the collation to avoid this issue:
```sql
SELECT id, name FROM `glpi_states` WHERE `name` = 'TÉST' collate utf8mb4_bin;
```
```
Empty set (0.00 sec)
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25023
