### PR TITLE
fix(dashboard): session expiration

### DIFF
--- a/src/Dashboard/Dashboard.php
+++ b/src/Dashboard/Dashboard.php
@@ -478,10 +478,10 @@ class Dashboard extends \CommonDBTM
 
        // check specific rights
         if (
-            count(array_intersect($rights['entities_id'], $_SESSION['glpiactiveentities']))
-            || in_array($_SESSION["glpiactiveprofile"]['id'], $rights['profiles_id'])
-            || in_array($_SESSION['glpiID'], $rights['users_id'])
-            || count(array_intersect($rights['groups_id'], $_SESSION['glpigroups']))
+            count(array_intersect($rights['entities_id'], $_SESSION['glpiactiveentities'] ?? []))
+            || in_array($_SESSION["glpiactiveprofile"]['id'] ?? null, $rights['profiles_id'])
+            || in_array($_SESSION['glpiID'] ?? null, $rights['users_id'])
+            || count(array_intersect($rights['groups_id'], $_SESSION['glpigroups'] ?? []))
         ) {
             return true;
         }

--- a/src/Dashboard/Dashboard.php
+++ b/src/Dashboard/Dashboard.php
@@ -476,12 +476,16 @@ class Dashboard extends \CommonDBTM
         ];
         $rights = array_merge_recursive($default_rights, $rights);
 
+        if (!Session::getLoginUserID()) {
+            return false;
+        }
+
        // check specific rights
         if (
-            count(array_intersect($rights['entities_id'], $_SESSION['glpiactiveentities'] ?? []))
-            || in_array($_SESSION["glpiactiveprofile"]['id'] ?? null, $rights['profiles_id'])
-            || in_array($_SESSION['glpiID'] ?? null, $rights['users_id'])
-            || count(array_intersect($rights['groups_id'], $_SESSION['glpigroups'] ?? []))
+            count(array_intersect($rights['entities_id'], $_SESSION['glpiactiveentities']))
+            || in_array($_SESSION["glpiactiveprofile"]['id'], $rights['profiles_id'])
+            || in_array($_SESSION['glpiID'], $rights['users_id'])
+            || count(array_intersect($rights['groups_id'], $_SESSION['glpigroups']))
         ) {
             return true;
         }


### PR DESCRIPTION
When a user remained displayed on the dashboards and $_SESSION expired, each card added this message in `php-errors.log`:

```
glpiphplog.CRITICAL :   *** Uncaught Exception TypeError : array_intersect() : Argument #2 must be of type array, null given in .../src/Dashboard/Dashboard.php at line 481
  Backtrace :
  src/Dashboard/Dashboard.php:481 array_intersect()
  src/Dashboard/Dashboard.php:155 Glpi\Dashboard\Dashboard::checkRights()
  src/Dashboard/Dashboard.php:391 GlpiDashboard\Dashboard->canViewCurrent()
  src/Dashboard/Grid.php:109 Glpi\Dashboard\Dashboard::getAll()
  src/Dashboard/Grid.php:1547 Glpi\Dashboard\Grid::loadAllDashboards()
  src/Html.php:1412 Glpi\Dashboard\Grid::getDefaultDashboardForMenu()
  src/Html.php:1520 Html::getMenuInfos()
  src/Html.php:1779 Html::generateMenuSession()
  marketplace/glpiinventory/index.php:51 Html::header()
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25108
