### PR TITLE
fix(inventory): revert entities_id if auto transfer is not allowed

### DIFF
--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -703,12 +703,14 @@ abstract class MainAsset extends InventoryAsset
             if ($doTransfer > 0 && $transfer->getFromDB($doTransfer)) {
                 $item_to_transfer = [$this->itemtype => [$items_id => $items_id]];
                 $transfer->moveItems($item_to_transfer, $entities_id, $transfer->fields);
+                //and set new entity in session
+                $_SESSION['glpiactiveentities']        = [$entities_id];
+                $_SESSION['glpiactiveentities_string'] = $entities_id;
+                $_SESSION['glpiactive_entity']         = $entities_id;
+            } else {
+                //no transfert so revert to old entities_id
+                $val->entities_id = $this->item->fields['entities_id'];
             }
-
-            //and set new entity in session
-            $_SESSION['glpiactiveentities']        = [$entities_id];
-            $_SESSION['glpiactiveentities_string'] = $entities_id;
-            $_SESSION['glpiactive_entity']         = $entities_id;
         }
 
         if ($this->is_discovery === true && !$this->isNew()) {


### PR DESCRIPTION
When ```transfer_strategy``` does not allow the automatic transfer

the inventory does not put the old ```entities_id``` to ```item``` -> so the ```item``` changes entity.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25031
