### PR TITLE
feat(inventory): manage computer last boot

### DIFF
--- a/install/migrations/update_10.0.3_to_10.0.4/computer.php
+++ b/install/migrations/update_10.0.3_to_10.0.4/computer.php
@@ -38,4 +38,4 @@
  * @var Migration $migration
  */
 
-$migration->addField(getTableForItemType(Computer::class), 'last_boot', 'datetime');
+$migration->addField('glpi_computers', 'last_boot', 'datetime');

--- a/install/migrations/update_10.0.3_to_10.0.4/computer.php
+++ b/install/migrations/update_10.0.3_to_10.0.4/computer.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2022 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+$migration->addField(getTableForItemType(Computer::class), 'last_boot', 'datetime');

--- a/install/mysql/glpi-10.0.4-empty.sql
+++ b/install/mysql/glpi-10.0.4-empty.sql
@@ -983,6 +983,7 @@ CREATE TABLE `glpi_computers` (
   `date_creation` timestamp NULL DEFAULT NULL,
   `is_recursive` tinyint NOT NULL DEFAULT '0',
   `last_inventory_update` timestamp NULL DEFAULT NULL,
+  `last_boot` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `date_mod` (`date_mod`),
   KEY `name` (`name`),

--- a/src/Computer.php
+++ b/src/Computer.php
@@ -451,6 +451,14 @@ class Computer extends CommonDBTM
         ];
 
         $tab[] = [
+            'id'                 => '10',
+            'table'              => $this->getTable(),
+            'field'              => 'last_boot',
+            'name'               => __('Last boot'),
+            'datatype'           => 'datetime',
+        ];
+
+        $tab[] = [
             'id'                 => '16',
             'table'              => $this->getTable(),
             'field'              => 'comment',

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -132,6 +132,17 @@ abstract class MainAsset extends InventoryAsset
             $val->autoupdatesystems_id = $entry->content->autoupdatesystems_id ?? AutoUpdateSystem::NATIVE_INVENTORY;
             $val->last_inventory_update = $_SESSION["glpi_currenttime"];
 
+            //try to get "last_boot" only available from "operatingsystem->boot_time" node
+            if (
+                $this->raw_data instanceof stdClass
+                && property_exists($this->raw_data, 'content')
+                && property_exists($this->raw_data->content, 'operatingsystem')
+                && property_exists($this->raw_data->content->operatingsystem, 'boot_time')
+            ) {
+                $val->last_boot = $entry->content->operatingsystem->boot_time;
+            }
+
+
             if (isset($this->extra_data['hardware'])) {
                 $this->prepareForHardware($val);
             }
@@ -761,14 +772,6 @@ abstract class MainAsset extends InventoryAsset
         }
 
         $input = $this->handleInput($val, $this->item);
-
-        //try to get "last_boot" only available from "operatingsystem->boot_time" node
-        if (
-            property_exists($this->raw_data->content, 'operatingsystem')
-            && property_exists($this->raw_data->content->operatingsystem, 'boot_time')
-        ) {
-            $input['last_boot'] = $this->raw_data->content->operatingsystem->boot_time;
-        }
         $this->item->update(Toolbox::addslashes_deep($input));
 
         if (!($this->item instanceof RefusedEquipment)) {

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -762,7 +762,7 @@ abstract class MainAsset extends InventoryAsset
 
         $input = $this->handleInput($val, $this->item);
 
-        //try to get loast boot only available from operatingsystem node
+        //try to get "last_boot" only available from "operatingsystem->boot_time" node
         if (property_exists($this->raw_data->content, 'operatingsystem')) {
             if (property_exists($this->raw_data->content->operatingsystem, 'boot_time')) {
                 $input['last_boot'] = $this->raw_data->content->operatingsystem->boot_time;

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -763,10 +763,11 @@ abstract class MainAsset extends InventoryAsset
         $input = $this->handleInput($val, $this->item);
 
         //try to get "last_boot" only available from "operatingsystem->boot_time" node
-        if (property_exists($this->raw_data->content, 'operatingsystem')) {
-            if (property_exists($this->raw_data->content->operatingsystem, 'boot_time')) {
-                $input['last_boot'] = $this->raw_data->content->operatingsystem->boot_time;
-            }
+        if (
+            property_exists($this->raw_data->content, 'operatingsystem')
+            && property_exists($this->raw_data->content->operatingsystem, 'boot_time')
+        ) {
+            $input['last_boot'] = $this->raw_data->content->operatingsystem->boot_time;
         }
         $this->item->update(Toolbox::addslashes_deep($input));
 

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -142,7 +142,6 @@ abstract class MainAsset extends InventoryAsset
                 $val->last_boot = $entry->content->operatingsystem->boot_time;
             }
 
-
             if (isset($this->extra_data['hardware'])) {
                 $this->prepareForHardware($val);
             }

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -761,6 +761,13 @@ abstract class MainAsset extends InventoryAsset
         }
 
         $input = $this->handleInput($val, $this->item);
+
+        //try to get loast boot only available from operatingsystem node
+        if (property_exists($this->raw_data->content, 'operatingsystem')) {
+            if (property_exists($this->raw_data->content->operatingsystem, 'boot_time')) {
+                $input['last_boot'] = $this->raw_data->content->operatingsystem->boot_time;
+            }
+        }
         $this->item->update(Toolbox::addslashes_deep($input));
 
         if (!($this->item instanceof RefusedEquipment)) {

--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -645,6 +645,11 @@
                         {{ fields.field('is_dynamic', is_dynamic_value, __('Automatic Inventory')) }}
                      {% endif %}
 
+                     {# display last_boot data only if item is dynamic and have field #}
+                     {% if item.isField('last_boot') and item.isField('is_dynamic') and item.fields['is_dynamic'] %}
+                        {{ fields.htmlField('last_boot', item.fields['last_boot'], __('Last boot')) }}
+                     {% endif %}
+
                      {% block more_fields %}
                      {% endblock %}
                   {% endblock %}

--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -647,7 +647,7 @@
 
                      {# display last_boot data only if item is dynamic and have field #}
                      {% if item.isField('last_boot') and item.isField('is_dynamic') and item.fields['is_dynamic'] %}
-                        {{ fields.htmlField('last_boot', item.fields['last_boot'], __('Last boot')) }}
+                        {{ fields.htmlField('last_boot', item.fields['last_boot']|formatted_datetime(true), __('Last boot')) }}
                      {% endif %}
 
                      {% block more_fields %}

--- a/tests/functionnal/Glpi/Inventory/Assets/Computer.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Computer.php
@@ -403,7 +403,7 @@ class Computer extends AbstractInventoryAsset
         $computer = new \Computer();
         $this->boolean($computer->getFromDB($computers_id))->isTrue();
 
-        //check serial came from "MSN" node.
+        //check last_boot came from "operatingsystem->boot_time" node.
         $this->string($computer->fields['last_boot'])->isIdenticalTo('2020-06-09 07:58:08');
     }
 }

--- a/tests/functionnal/Glpi/Inventory/Assets/Computer.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Computer.php
@@ -379,4 +379,31 @@ class Computer extends AbstractInventoryAsset
         //check serial came from "MSN" node.
         $this->string($computer->fields['serial'])->isIdenticalTo('640HP72');
     }
+
+    public function testLastBoot()
+    {
+        global $DB;
+        $json_str = file_get_contents(self::INV_FIXTURES . 'computer_1.json');
+        $json = json_decode($json_str);
+
+        $this->doInventory($json);
+
+        //check created agent
+        $agents = $DB->request(['FROM' => \Agent::getTable()]);
+        $this->integer(count($agents))->isIdenticalTo(1);
+        $agent = $agents->current();
+        $this->array($agent)
+            ->string['deviceid']->isIdenticalTo('glpixps-2018-07-09-09-07-13')
+            ->string['itemtype']->isIdenticalTo('Computer');
+
+        //check created computer
+        $computers_id = $agent['items_id'];
+
+        $this->integer($computers_id)->isGreaterThan(0);
+        $computer = new \Computer();
+        $this->boolean($computer->getFromDB($computers_id))->isTrue();
+
+        //check serial came from "MSN" node.
+        $this->string($computer->fields['last_boot'])->isIdenticalTo('2020-06-09 07:58:08');
+    }
 }

--- a/tests/functionnal/Glpi/Inventory/Inventory.php
+++ b/tests/functionnal/Glpi/Inventory/Inventory.php
@@ -95,6 +95,7 @@ class Inventory extends InventoryTestCase
             'date_creation' => $computer->fields['date_creation'],
             'is_recursive' => 0,
             'last_inventory_update' => $computer->fields['last_inventory_update'],
+            'last_boot' => '2020-06-09 07:58:08',
         ];
         $this->array($computer->fields)->isIdenticalTo($expected);
 
@@ -1272,6 +1273,7 @@ class Inventory extends InventoryTestCase
             'date_creation' => $computer->fields['date_creation'],
             'is_recursive' => 0,
             'last_inventory_update' => $computer->fields['last_inventory_update'],
+            'last_boot' => "2017-02-20 08:11:53",
         ];
         $this->array($computer->fields)->isIdenticalTo($expected);
 
@@ -1484,6 +1486,7 @@ class Inventory extends InventoryTestCase
             'date_creation' => $computer->fields['date_creation'],
             'is_recursive' => 0,
             'last_inventory_update' => $computer->fields['last_inventory_update'],
+            'last_boot' => "2017-02-20 08:11:53",
         ];
         $this->array($computer->fields)->isIdenticalTo($expected);
 
@@ -1643,6 +1646,7 @@ class Inventory extends InventoryTestCase
             'date_creation' => $computer->fields['date_creation'],
             'is_recursive' => 0,
             'last_inventory_update' => $computer->fields['last_inventory_update'],
+            'last_boot' => "2017-06-08 07:06:47",
         ];
         $this->array($computer->fields)->isIdenticalTo($expected);
 
@@ -1757,10 +1761,10 @@ class Inventory extends InventoryTestCase
             'OFFSET' => $nblogsnow,
         ]);
 
-        $this->integer(count($logs))->isIdenticalTo(4443);
+        $this->integer(count($logs))->isIdenticalTo(4444);
 
         $expected_types_count = [
-            0 => 3, //Agent version, disks usage
+            0 => 4, //Agent version, disks usage
             \Log::HISTORY_ADD_RELATION => 1, //new IPNetwork/IPAddress
             \Log::HISTORY_DEL_RELATION => 2,//monitor-computer relation
             \Log::HISTORY_ADD_SUBITEM => 3243,//network port/name, ip address, VMs, Software


### PR DESCRIPTION
Get ```last_boot``` date from ```operatingsystem``` available in the ```boot_time``` node

```json
"operatingsystem": {
            "arch": "x86_64",
            "boot_time": "2020-06-09 07:58:08",
            "fqdn": "glpixps",
            "full_name": "Fedora 31 (Workstation Edition)",
            "hostid": "a8c07601",
            "kernel_name": "linux",
            "kernel_version": "5.6.15-200.fc31.x86_64",
            "name": "Fedora",
            "timezone": {
                "name": "CEST",
                "offset": "+0200"
            },
            "version": "31 (Workstation Edition)"
        }
```

```xml
<OPERATINGSYSTEM>
      <ARCH>64-bit</ARCH>
      <BOOT_TIME>2019-09-26 11:24:17</BOOT_TIME>
      <DNS_DOMAIN>glpi-dev</DNS_DOMAIN>
      <FQDN>mkjghkghkj.glpi-project.dev</FQDN>
      <FULL_NAME>Fedora 31 (Workstation Edition)</FULL_NAME>
      <INSTALL_DATE>2015-07-02 11:57:03</INSTALL_DATE>
      <KERNEL_NAME>MSWin32</KERNEL_NAME>
      <KERNEL_VERSION>6.3.9600</KERNEL_VERSION>
      <NAME>Windows</NAME>
      <SERVICE_PACK/>  <TIMEZONE>
        <NAME>Europe/Paris</NAME>
        <OFFSET>+0200</OFFSET>
      </TIMEZONE>
    </OPERATINGSYSTEM>
```


![image](https://user-images.githubusercontent.com/7335054/194356105-b882068e-9f1a-4126-8d54-0adcf0d32ac3.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | [#233](https://github.com/glpi-project/glpi-inventory-plugin/issues/233)
