### PR TITLE
Fix storing dashboard cards with long IDs

### DIFF
--- a/install/migrations/update_10.0.3_to_10.0.4/dashboard.php
+++ b/install/migrations/update_10.0.3_to_10.0.4/dashboard.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2022 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+$migration->changeField('glpi_dashboards_items', 'card_id', 'card_id', 'varchar(255) NOT NULL');
+$migration->changeField('glpi_dashboards_items', 'gridstack_id', 'gridstack_id', 'varchar(255) NOT NULL');

--- a/install/mysql/glpi-10.0.4-empty.sql
+++ b/install/mysql/glpi-10.0.4-empty.sql
@@ -1633,8 +1633,8 @@ DROP TABLE IF EXISTS `glpi_dashboards_items`;
 CREATE TABLE `glpi_dashboards_items` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `dashboards_dashboards_id` int unsigned NOT NULL,
-  `gridstack_id` varchar(100) NOT NULL,
-  `card_id` varchar(100) NOT NULL,
+  `gridstack_id` varchar(255) NOT NULL,
+  `card_id` varchar(255) NOT NULL,
   `x` int DEFAULT NULL,
   `y` int DEFAULT NULL,
   `width` int DEFAULT NULL,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://forum.glpi-project.org/viewtopic.php?id=285002

Some classes from plugins may have very long names especially if they are relational classes like "PluginGenericobjectVideoprojecteur_PluginGenericobjectVideoprojecteurModel". The card ID and gridstack ID fields for dashboard items are limited to 100 characters which is not enough for these cases.

This PR raises the character limit to 255 characters.