### PR TITLE
Fix missing Database Instance Category dropdown option

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -1137,7 +1137,8 @@ class Dropdown
                 __('Management') => [
                     'DocumentCategory' => null,
                     'DocumentType' => null,
-                    'BusinessCriticity' => null
+                    'BusinessCriticity' => null,
+                    'DatabaseInstanceCategory' => null,
                 ],
 
                 __('Tools') => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Database Instance Category dropdown option was not showing in the Dropdowns page and if you went directly to the search page using the "i" icon next to the field in a Database Instance form, it would not have the correct breadcrumbs so adding was blocked from there.