### PR TITLE
fix colors when an input is in disabled state

### DIFF
--- a/css/includes/components/_select2.scss
+++ b/css/includes/components/_select2.scss
@@ -65,6 +65,10 @@
             border-color: $input-border-color;
             box-shadow: none;
             cursor: not-allowed;
+
+            .select2-selection__rendered {
+                color: $text-muted;
+            }
         }
 
         &.select2-selection--single {

--- a/css/palettes/_defaults.scss
+++ b/css/palettes/_defaults.scss
@@ -35,6 +35,7 @@ $primary: #fec95c;
 $secondary: #606f91;
 $fg-secondary: #f4f6fa;
 $input-bg: rgb(253, 253, 253) !default;
+$input-disabled-bg: #f1f5f9;
 $link-color: #3a5693;
 $mainmenu_bg: #2f3f64;
 $mainmenu_fg: #f4f6fa;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Inputs requires a little more contrast and select2 missed text-muted color

Before:
![image](https://user-images.githubusercontent.com/418844/194498062-af9884bd-09f4-4311-b0eb-0e7dd5a5d9fd.png)


After:
![image](https://user-images.githubusercontent.com/418844/194497868-b3a5e853-2c49-4b77-b0f8-d7cacc1d5d20.png)

