### PR TITLE
Fix translated complatename encoding in PDF export

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -7437,7 +7437,7 @@ HTML;
                         if (isset($data[$ID][$k]['trans']) && !empty($data[$ID][$k]['trans'])) {
                             $out .= $data[$ID][$k]['trans'];
                         } elseif (isset($data[$ID][$k]['trans_completename']) && !empty($data[$ID][$k]['trans_completename'])) {
-                            $out .= $data[$ID][$k]['trans_completename'];
+                            $out .= CommonTreeDropdown::sanitizeSeparatorInCompletename($data[$ID][$k]['trans_completename']);
                         } else {
                             $value = $data[$ID][$k]['name'];
                             $out .= $so['field'] === 'completename'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

Follows #12879 .

If any element of the tree contains a special char (`&`, `>` or `<`), encoding in PDF export will be broken, as the value will contain both encoded special char and non-encoded separator, and so export logic will not handle it properly.
![image](https://user-images.githubusercontent.com/33253653/194536613-eca229d7-6001-450a-8107-ceb2d90404ac.png)
