### PR TITLE
Handle empty rights matrix

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -5905,7 +5905,8 @@ HTML;
             $number_columns += 1;
         }
 
-       // count checked
+        // count checked
+        $nb_cb_per_col = [];
         foreach ($columns as $col_name => $column) {
             $nb_cb_per_col[$col_name] = [
                 'total'   => 0,
@@ -5913,6 +5914,7 @@ HTML;
             ];
         }
 
+        $nb_cb_per_row = [];
         foreach ($rows as $row_name => $row) {
             if ((!is_string($row)) && (!is_array($row))) {
                 continue;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

If a plugin calls `Profile::displayRightsChoiceMatrix()` with an empty matrix, it will produce warnings as some variables are declared only inside `foreach` loops.
See #12875.