### PR TITLE
Fix FAQ/KB

### DIFF
--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -572,22 +572,66 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
     {
         global $CFG_GLPI;
 
-        $is_public_faq_context = !Session::getLoginUserID() && $CFG_GLPI["use_public_faq"];
-        $has_session_groups = isset($_SESSION["glpigroups"]) && count($_SESSION["glpigroups"]);
-        $has_active_profile = isset($_SESSION["glpiactiveprofile"])
-         && isset($_SESSION["glpiactiveprofile"]['id']);
-        $has_active_entity = isset($_SESSION["glpiactiveentities"])
-         && count($_SESSION["glpiactiveentities"]);
+        // Build common JOIN clause
+        $criteria = [
+            'LEFT JOIN' => self::getVisibilityCriteriaCommonJoin($forceall),
+        ];
 
-        $where = [];
-        $join = [
-            'glpi_knowbaseitems_users' => [
+        // Handle anonymous users
+        if (!Session::getLoginUserID()) {
+            if ($CFG_GLPI["use_public_faq"]) {
+                // Public FAQ is enabled; show FAQ
+                $criteria['WHERE'] = self::getVisibilityCriteriaFAQ();
+                return $criteria;
+            } else {
+                // Public FAQ is disabled; show nothing
+                $criteria['WHERE'] = [0];
+                return $criteria;
+            }
+        }
+
+        // Handle logged in users
+        if (Session::getCurrentInterface() == "helpdesk") {
+            // Show FAQ for helpdesk user
+            $criteria['WHERE'] = self::getVisibilityCriteriaFAQ();
+            return $criteria;
+        } else {
+            // Show knowledge base for central users
+            $criteria['WHERE'] = self::getVisibilityCriteriaKB();
+            return $criteria;
+        }
+    }
+
+    /**
+     * Common JOIN clause used by getVisibilityCriteria* methods
+     *
+     * @param bool $forceall Force all join ?
+     *
+     * @return array LEFT JOIN clause
+     */
+    private static function getVisibilityCriteriaCommonJoin(bool $forceall = false)
+    {
+        global $CFG_GLPI;
+
+        $join = [];
+
+        // Context checks - avoid doing unnecessary join if possible
+        $is_public_faq_context = !Session::getLoginUserID() && $CFG_GLPI["use_public_faq"];
+        $has_session_groups = count(($_SESSION["glpigroups"] ?? []));
+        $has_active_profile = isset($_SESSION["glpiactiveprofile"]['id']);
+        $has_active_entity = count(($_SESSION["glpiactiveentities"] ?? []));
+
+        // Add user restriction data
+        if ($forceall || Session::getLoginUserID()) {
+            $join['glpi_knowbaseitems_users'] = [
                 'ON' => [
                     'glpi_knowbaseitems_users' => 'knowbaseitems_id',
                     'glpi_knowbaseitems'       => 'id'
                 ]
-            ]
-        ];
+            ];
+        }
+
+        // Add group restriction data
         if ($forceall || $has_session_groups) {
             $join['glpi_groups_knowbaseitems'] = [
                 'ON' => [
@@ -596,6 +640,8 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
                 ]
             ];
         }
+
+        // Add profile restriction data
         if ($forceall || $has_active_profile) {
             $join['glpi_knowbaseitems_profiles'] = [
                 'ON' => [
@@ -604,6 +650,8 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
                 ]
             ];
         }
+
+        // Add entity restriction data
         if ($forceall || $has_active_entity || $is_public_faq_context) {
             $join['glpi_entities_knowbaseitems'] = [
                 'ON' => [
@@ -613,81 +661,157 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
             ];
         }
 
+        return $join;
+    }
+
+    /**
+     * Get visibility criteria for articles displayed in the FAQ (seen by
+     * helpdesk and anonymous users)
+     * This mean any KB article tagged as 'is_faq' should be displayed
+     *
+     * @return array WHERE clause
+     */
+    private static function getVisibilityCriteriaFAQ(): array
+    {
+        $where = ['is_faq' => 1];
+
+        // Specific case for anonymous users + multi entities
+        if (!Session::getLoginUserID() && Session::isMultiEntitiesMode()) {
+            $where[Entity_KnowbaseItem::getTableField('entities_id')] = 0;
+            $where[Entity_KnowbaseItem::getTableField('is_recursive')] = 1;
+        }
+
+        return $where;
+    }
+
+    /**
+     * Get visibility criteria for articles displayed in the knowledge base
+     * (seen by central users)
+     * This mean any KB article with valid visibility criteria for the current
+     * user should be displayed
+     *
+     * @return array WHERE clause
+     */
+    private static function getVisibilityCriteriaKB(): array
+    {
+        // Special case for KB Admins
         if (Session::haveRight(self::$rightname, self::KNOWBASEADMIN)) {
-            return [
-                'LEFT JOIN' => $join,
-                'WHERE' => [],
+            // See all articles
+            return [1];
+        }
+
+        // Prepare criteria, which will use an OR statement (the user can read
+        // the article if any of the user/group/profile/entity criteria are
+        // validated)
+        $where = ['OR' => []];
+
+        // Special case: the user may be the article's author
+        $user = Session::getLoginUserID();
+        $author_check = [self::getTableField('users_id') => $user];
+        $where['OR'][] = $author_check;
+
+        // Filter on users
+        $where['OR'][] = self::getVisibilityCriteriaKB_User();
+
+        // Filter on groups (if the current user have any)
+        $groups = $_SESSION["glpigroups"] ?? [];
+        if (count($groups)) {
+            $where['OR'][] = self::getVisibilityCriteriaKB_Group();
+        }
+
+        // Filter on profiles
+        $where['OR'][] = self::getVisibilityCriteriaKB_Profile();
+
+        // Filter on entities
+        $where['OR'][] = self::getVisibilityCriteriaKB_Entity();
+
+        return $where;
+    }
+
+    /**
+     * Get criteria used to filter knowledge base articles on users
+     *
+     * @return array
+     */
+    private static function getVisibilityCriteriaKB_User(): array
+    {
+        $user = Session::getLoginUserID();
+        return [
+            KnowbaseItem_User::getTableField('users_id') => $user,
+        ];
+    }
+
+    /**
+     * Get criteria used to filter knowledge base articles on groups
+     *
+     * @return array
+     */
+    private static function getVisibilityCriteriaKB_Group(): array
+    {
+        $groups = $_SESSION["glpigroups"] ?? [-1];
+        $entity_restriction = getEntitiesRestrictCriteria(
+            Group_KnowbaseItem::getTable(),
+            '',
+            '',
+            true,
+            true
+        );
+
+        return [
+            Group_KnowbaseItem::getTableField('groups_id') => $groups,
+            'OR' => [
+                Group_KnowbaseItem::getTableField('no_entity_restriction') => 1,
+            ] + $entity_restriction,
+        ];
+    }
+
+    /**
+     * Get criteria used to filter knowledge base articles on profiles
+     *
+     * @return array
+     */
+    private static function getVisibilityCriteriaKB_Profile(): array
+    {
+        $profile = $_SESSION["glpiactiveprofile"]['id'] ?? -1;
+        $entity_restriction = getEntitiesRestrictCriteria(
+            KnowbaseItem_Profile::getTable(),
+            '',
+            '',
+            true,
+            true
+        );
+
+        return [
+            KnowbaseItem_Profile::getTableField('profiles_id') => $profile,
+            'OR' => [
+                KnowbaseItem_Profile::getTableField('no_entity_restriction') => 1,
+            ] + $entity_restriction,
+        ];
+    }
+
+    /**
+     * Get criteria used to filter knowledge base articles on entity
+     *
+     * @return array
+     */
+    private static function getVisibilityCriteriaKB_Entity(): array
+    {
+        $entity_restriction = getEntitiesRestrictCriteria(
+            Entity_KnowbaseItem::getTable(),
+            '',
+            '',
+            true,
+            true
+        );
+
+        // All entities
+        if (!count($entity_restriction)) {
+            $entity_restriction = [
+                Entity_KnowbaseItem::getTableField('entities_id') => null
             ];
         }
 
-       // Users
-        if (Session::getLoginUserID()) {
-            $where['OR'] = [
-                'glpi_knowbaseitems.users_id'       => Session::getLoginUserID(),
-                'glpi_knowbaseitems_users.users_id' => Session::getLoginUserID(),
-                'glpi_knowbaseitems.is_faq'         => 1,
-            ];
-        } else if ($is_public_faq_context) {
-            $where = [
-                "glpi_knowbaseitems.is_faq" => 1,
-            ];
-            if (Session::isMultiEntitiesMode()) {
-                $where += [
-                    "glpi_entities_knowbaseitems.entities_id" => 0,
-                    "glpi_entities_knowbaseitems.is_recursive" => 1,
-                ];
-            }
-        } else {
-            $where = [
-                0
-            ];
-        }
-       // Groups
-        if ($forceall || $has_session_groups) {
-            if (Session::getLoginUserID()) {
-                $restrict = getEntitiesRestrictCriteria('glpi_groups_knowbaseitems', '', '', true, true);
-                $where['OR'][] = [
-                    'glpi_groups_knowbaseitems.groups_id' => count($_SESSION["glpigroups"])
-                                                         ? $_SESSION["glpigroups"]
-                                                         : [-1],
-                    'OR' => [
-                        'glpi_groups_knowbaseitems.no_entity_restriction' => 1,
-                    ] + $restrict
-                ];
-            }
-        }
-
-       // Profiles
-        if ($forceall || $has_active_profile) {
-            if (Session::getLoginUserID()) {
-                $where['OR'][] = [
-                    'glpi_knowbaseitems_profiles.profiles_id' => $_SESSION["glpiactiveprofile"]['id'],
-                    'OR' => [
-                        'glpi_knowbaseitems_profiles.no_entity_restriction' => 1,
-                        getEntitiesRestrictCriteria('glpi_knowbaseitems_profiles', '', '', true, true)
-                    ]
-                ];
-            }
-        }
-
-       // Entities
-        if ($forceall || $has_active_entity) {
-            if (Session::getLoginUserID()) {
-                $restrict = getEntitiesRestrictCriteria('glpi_entities_knowbaseitems', '', '', true, true);
-                if (count($restrict)) {
-                    $where['OR'] = $where['OR'] + $restrict;
-                } else {
-                    $where['glpi_entities_knowbaseitems.entities_id'] = null;
-                }
-            }
-        }
-
-        $criteria = ['LEFT JOIN' => $join];
-        if (count($where)) {
-            $criteria['WHERE'] = $where;
-        }
-
-        return $criteria;
+        return $entity_restriction;
     }
 
     public function prepareInputForAdd($input)

--- a/tests/functionnal/KnowbaseItem.php
+++ b/tests/functionnal/KnowbaseItem.php
@@ -821,6 +821,11 @@ HTML
 
         $data = $DB->request($criteria);
         $result = array_column(iterator_to_array($data), "name");
+
+        // We need to sort data before comparing or the tests will fails on mariaDB
+        sort($articles);
+        sort($result);
+
         $this->array($result)->isEqualTo($articles);
     }
 }

--- a/tests/functionnal/KnowbaseItem.php
+++ b/tests/functionnal/KnowbaseItem.php
@@ -36,6 +36,7 @@
 namespace test\units;
 
 use DbTestCase;
+use Generator;
 use Glpi\Toolbox\Sanitizer;
 
 /* Test for inc/knowbaseitem.class.php */
@@ -507,5 +508,319 @@ HTML
             $category_ids[] = $row['knowbaseitemcategories_id'];
         }
         $this->array($category_ids)->containsValues([$kb_cat_id1, $kb_cat_id2]);
+    }
+
+    protected function testGetVisibilityCriteriaProvider(): Generator
+    {
+        yield from $this->testGetVisibilityCriteriaProvider_FAQ();
+        yield from $this->testGetVisibilityCriteriaProvider_KB();
+    }
+
+    protected function testGetVisibilityCriteriaProvider_FAQ(): Generator
+    {
+        global $DB, $CFG_GLPI;
+
+        // Removing existing data
+        $DB->delete(\KnowbaseItem::getTable(), [1]);
+        $this->integer(countElementsInTable(\KnowbaseItem::getTable()))->isEqualTo(0);
+
+        // Create set of test subjects
+        $glpi_user = getItemByTypeName("User", "glpi", true);
+        $this->createItems("KnowbaseItem", [
+            [
+                'name'     => 'FAQ 1',
+                'answer'   => 'FAQ 1',
+                'is_faq'   => true,
+                'users_id' => $glpi_user,
+            ],
+            [
+                'name'     => 'FAQ 2',
+                'answer'   => 'FAQ 2',
+                'is_faq'   => true,
+                'users_id' => $glpi_user,
+            ],
+            [
+                'name'     => 'FAQ 3',
+                'answer'   => 'FAQ 3',
+                'is_faq'   => false, // Not really a FAQ article
+                'users_id' => $glpi_user,
+            ]
+        ]);
+
+        // Set entity for FAQ 2
+        $faq_2 = getItemByTypeName("KnowbaseItem", "FAQ 2", true);
+        $this->createItem("Entity_KnowbaseItem", [
+            'knowbaseitems_id' => $faq_2,
+            'entities_id'      => 0,
+            'is_recursive'     => 1,
+        ]);
+
+        // First FAQ test case: public FAQ disabled
+        $CFG_GLPI['use_public_faq'] = false;
+        yield ['articles' => []];
+
+        // Second FAQ test case: public FAQ enabled + multi entities
+        if (!isset($_SESSION['glpi_multientitiesmode'])) {
+            $_SESSION['glpi_multientitiesmode'] = 1;
+        }
+        $this->integer($_SESSION['glpi_multientitiesmode'])->isEqualTo(1);
+        $CFG_GLPI['use_public_faq'] = true;
+        yield ['articles' => ['FAQ 2']];
+
+        // Third FAQ test case: public FAQ enabled + single entity
+        $_SESSION['glpi_multientitiesmode'] = 0;
+        yield ['articles' => ['FAQ 1', 'FAQ 2']];
+
+        // Revert session / config
+        $_SESSION['glpi_multientitiesmode'] = 1;
+        $CFG_GLPI['use_public_faq'] = false;
+    }
+
+    protected function testGetVisibilityCriteriaProvider_KB(): Generator
+    {
+        // Create set of test subjects
+        $glpi_user = getItemByTypeName("User", "glpi", true);
+        $tech_user = getItemByTypeName("User", "tech", true);
+        $this->createItems("KnowbaseItem", [
+            [
+                'name'     => 'KB 1',
+                'answer'   => 'KB 1',
+                'is_faq'   => false,
+                'users_id' => $glpi_user,
+            ],
+            [
+                'name'     => 'KB 2',
+                'answer'   => 'KB 2',
+                'is_faq'   => false,
+                'users_id' => $tech_user, // Specific author (our test user)
+            ],
+            [
+                'name'     => 'KB 3',
+                'answer'   => 'KB 3',
+                'is_faq'   => false,
+                'users_id' => $glpi_user,
+            ],
+            [
+                'name'     => 'KB 4',
+                'answer'   => 'KB 4',
+                'is_faq'   => false,
+                'users_id' => $glpi_user,
+            ],
+            [
+                'name'     => 'KB 5',
+                'answer'   => 'KB 5',
+                'is_faq'   => false,
+                'users_id' => $glpi_user,
+            ],
+            [
+                'name'     => 'KB 6',
+                'answer'   => 'KB 6',
+                'is_faq'   => false,
+                'users_id' => $glpi_user,
+            ],
+            [
+                'name'     => 'KB 7',
+                'answer'   => 'KB 7',
+                'is_faq'   => false,
+                'users_id' => $glpi_user,
+            ],
+            [
+                'name'     => 'KB 8',
+                'answer'   => 'KB 8',
+                'is_faq'   => false,
+                'users_id' => $glpi_user,
+            ],
+            [
+                'name'     => 'KB 9',
+                'answer'   => 'KB 9',
+                'is_faq'   => false,
+                'users_id' => $glpi_user,
+            ],
+            [
+                'name'     => 'KB 10',
+                'answer'   => 'KB 10',
+                'is_faq'   => false,
+                'users_id' => $glpi_user,
+            ],
+            [
+                'name'     => 'KB 11',
+                'answer'   => 'KB 11',
+                'is_faq'   => false,
+                'users_id' => $glpi_user,
+            ],
+            [
+                'name'     => 'KB 12',
+                'answer'   => 'KB 12',
+                'is_faq'   => false,
+                'users_id' => $glpi_user,
+            ],
+            [
+                'name'     => 'KB 13',
+                'answer'   => 'KB 13',
+                'is_faq'   => false,
+                'users_id' => $glpi_user,
+            ],
+        ]);
+
+        // First three KB article will be visible only for a given user
+        $kb_1 = getItemByTypeName("KnowbaseItem", "KB 1", true);
+        $kb_2 = getItemByTypeName("KnowbaseItem", "KB 2", true);
+        $kb_3 = getItemByTypeName("KnowbaseItem", "KB 3", true);
+        $normal_user = getItemByTypeName("User", "normal", true);
+        $this->createItems("KnowbaseItem_User", [
+            [
+                'knowbaseitems_id' => $kb_1,
+                'users_id' => $normal_user,
+            ],
+            [
+                'knowbaseitems_id' => $kb_2,
+                'users_id' => $normal_user,
+            ],
+            [
+                'knowbaseitems_id' => $kb_3,
+                'users_id' => $tech_user, // Allowed for our test user
+            ],
+        ]);
+
+        // Add group restrictions for articles 4 to 7
+        $kb_4 = getItemByTypeName("KnowbaseItem", "KB 4", true);
+        $kb_5 = getItemByTypeName("KnowbaseItem", "KB 5", true);
+        $kb_6 = getItemByTypeName("KnowbaseItem", "KB 6", true);
+        $kb_7 = getItemByTypeName("KnowbaseItem", "KB 7", true);
+        $group_a = $this->createItem("Group", [
+            "name" => "Group KB A",
+            'is_recursive' => 1,
+        ])->fields['id'];
+        $group_b = $this->createItem("Group", [
+            "name" => "Group KB A",
+            'is_recursive' => 1,
+        ])->fields['id'];
+        $this->createItem("Group_User", ['users_id' => $tech_user, 'groups_id' => $group_a]);
+        $this->createItems("Group_KnowbaseItem", [
+            [
+                'knowbaseitems_id' => $kb_4,
+                'groups_id' => $group_a, // Our test user is part of this group
+                'entities_id' => 0,
+                'is_recursive' => 1,
+                'no_entity_restriction' => false,
+            ],
+            [
+                'knowbaseitems_id' => $kb_5,
+                'groups_id' => $group_b,
+                'entities_id' => 0,
+                'is_recursive' => 1,
+                'no_entity_restriction' => false,
+            ],
+            [
+                'knowbaseitems_id' => $kb_6,
+                'groups_id' => $group_a, // Our test user is part of this group
+                'entities_id' => 0,
+                'is_recursive' => 0,
+                'no_entity_restriction' => false,
+            ],
+            [
+                'knowbaseitems_id' => $kb_7,
+                'groups_id' => $group_a, // Our test user is part of this group
+                'entities_id' => 0,
+                'is_recursive' => 0,
+                'no_entity_restriction' => true,
+            ],
+        ]);
+
+        // Add profiles restrictions for article 8 to 11
+        $kb_8 = getItemByTypeName("KnowbaseItem", "KB 8", true);
+        $kb_9 = getItemByTypeName("KnowbaseItem", "KB 9", true);
+        $kb_10 = getItemByTypeName("KnowbaseItem", "KB 10", true);
+        $kb_11 = getItemByTypeName("KnowbaseItem", "KB 11", true);
+        $this->createItems("KnowbaseItem_Profile", [
+            [
+                'knowbaseitems_id' => $kb_8,
+                'profiles_id' => getItemByTypeName("Profile", "Technician", true), // our test user have this profile
+                'entities_id' => 0,
+                'is_recursive' => 1,
+                'no_entity_restriction' => false,
+            ],
+            [
+                'knowbaseitems_id' => $kb_9,
+                'profiles_id' => getItemByTypeName("Profile", "Technician", true), // our test user have this profile
+                'entities_id' => 0,
+                'is_recursive' => 0,
+                'no_entity_restriction' => false,
+            ],
+            [
+                'knowbaseitems_id' => $kb_10,
+                'profiles_id' => getItemByTypeName("Profile", "Technician", true), // our test user have this profile
+                'entities_id' => 0,
+                'is_recursive' => 0,
+                'no_entity_restriction' => true,
+            ],
+            [
+                'knowbaseitems_id' => $kb_11,
+                'profiles_id' => getItemByTypeName("Profile", "Hotliner", true),
+                'entities_id' => 0,
+                'is_recursive' => 1,
+                'no_entity_restriction' => false,
+            ],
+        ]);
+
+        // Add entity restriction for articles 12 and 13
+        $kb_12 = getItemByTypeName("KnowbaseItem", "KB 12", true);
+        $kb_13 = getItemByTypeName("KnowbaseItem", "KB 13", true);
+        $this->createItems("Entity_KnowbaseItem", [
+            [
+                'knowbaseitems_id' => $kb_12,
+                'entities_id' => 0,
+                'is_recursive' => 1,
+            ],
+            [
+                'knowbaseitems_id' => $kb_13,
+                'entities_id' => 0,
+                'is_recursive' => 0,
+            ],
+        ]);
+
+        // Check articles visible for "tech" user
+        $this->login('tech', 'tech');
+        yield [
+            'articles' => [
+                'FAQ 2', 'KB 2', 'KB 3', 'KB 4', 'KB 6', 'KB 7', 'KB 8', 'KB 9',
+                'KB 10', 'KB 12', 'KB 13',
+            ]
+        ];
+
+        // Switch entities
+        $this->setEntity("_test_child_1", true);
+        yield [
+            'articles' => [
+                'FAQ 2', 'KB 2', 'KB 3', 'KB 4', 'KB 7', 'KB 8', 'KB 10', 'KB 12'
+            ]
+        ];
+
+        // Last test, admin should see all articles
+        $this->login('glpi', 'glpi');
+        yield [
+            'articles' => [
+                'FAQ 1', 'FAQ 2', 'FAQ 3', 'KB 1', 'KB 2', 'KB 3', 'KB 4',
+                'KB 5', 'KB 6', 'KB 7', 'KB 8', 'KB 9', 'KB 10', 'KB 11',
+                'KB 12', 'KB 13',
+            ]
+        ];
+    }
+
+    /**
+     * @dataprovider testGetVisibilityCriteriaProvider
+     */
+    public function testGetVisibilityCriteria(array $articles)
+    {
+        global $DB;
+
+        $criteria = array_merge(\KnowbaseItem::getVisibilityCriteria(false), [
+            'SELECT' => 'name',
+            'FROM'   => \KnowbaseItem::getTable()
+        ]);
+
+        $data = $DB->request($criteria);
+        $result = array_column(iterator_to_array($data), "name");
+        $this->array($result)->isEqualTo($articles);
     }
 }

--- a/tests/functionnal/KnowbaseItem.php
+++ b/tests/functionnal/KnowbaseItem.php
@@ -560,10 +560,7 @@ HTML
         yield ['articles' => []];
 
         // Second FAQ test case: public FAQ enabled + multi entities
-        if (!isset($_SESSION['glpi_multientitiesmode'])) {
-            $_SESSION['glpi_multientitiesmode'] = 1;
-        }
-        $this->integer($_SESSION['glpi_multientitiesmode'])->isEqualTo(1);
+        $_SESSION['glpi_multientitiesmode'] = 1;
         $CFG_GLPI['use_public_faq'] = true;
         yield ['articles' => ['FAQ 2']];
 
@@ -692,7 +689,7 @@ HTML
             'is_recursive' => 1,
         ])->fields['id'];
         $group_b = $this->createItem("Group", [
-            "name" => "Group KB A",
+            "name" => "Group KB B",
             'is_recursive' => 1,
         ])->fields['id'];
         $this->createItem("Group_User", ['users_id' => $tech_user, 'groups_id' => $group_a]);

--- a/tests/functionnal/KnowbaseItem.php
+++ b/tests/functionnal/KnowbaseItem.php
@@ -36,7 +36,6 @@
 namespace test\units;
 
 use DbTestCase;
-use Generator;
 use Glpi\Toolbox\Sanitizer;
 
 /* Test for inc/knowbaseitem.class.php */
@@ -510,13 +509,13 @@ HTML
         $this->array($category_ids)->containsValues([$kb_cat_id1, $kb_cat_id2]);
     }
 
-    protected function testGetVisibilityCriteriaProvider(): Generator
+    protected function testGetVisibilityCriteriaProvider(): iterable
     {
         yield from $this->testGetVisibilityCriteriaProvider_FAQ();
         yield from $this->testGetVisibilityCriteriaProvider_KB();
     }
 
-    protected function testGetVisibilityCriteriaProvider_FAQ(): Generator
+    protected function testGetVisibilityCriteriaProvider_FAQ(): iterable
     {
         global $DB, $CFG_GLPI;
 
@@ -573,7 +572,7 @@ HTML
         $CFG_GLPI['use_public_faq'] = false;
     }
 
-    protected function testGetVisibilityCriteriaProvider_KB(): Generator
+    protected function testGetVisibilityCriteriaProvider_KB(): iterable
     {
         // Create set of test subjects
         $glpi_user = getItemByTypeName("User", "glpi", true);


### PR DESCRIPTION
The FAQ / KB view does not seem to work properly.
You can see on the following images that the category tree indicate that some articles should be visible, however when you click on the category you find out that there is no valid articles:

![image](https://user-images.githubusercontent.com/42734840/194832747-5af16703-092c-4197-bbc6-1bc4c045195a.png)
![image](https://user-images.githubusercontent.com/42734840/194832808-57d760f9-dc70-47d1-ab2a-b7d7b569fd7c.png)
![image](https://user-images.githubusercontent.com/42734840/194832851-6731abc2-6b9c-4b43-b4f2-ab439184edb7.png)

The code handling this list was hard to read because it was handling two different cases (FAQ and KB) at the same time.

I've: 
* Split and moved the code around to have proper KB / FAQ "code paths" which are easier to read and understand.
* Added a great number of tests which should handle every possible KB configuration.

Regarding the specific error in the images above, I think the `is_faq => 1` condition was not properly applied for self-service users (it was thrown in an `OR` clause with other criteria that should only be used for the KB side, not the FAQ).
The new code handle it correctly as it separate KB and FAQ more cleanly, thus only applying the correct condition.

More details on the FAQ / KB expected restrictions can be found here : https://glpi-user-documentation.readthedocs.io/fr/latest/modules/tools/knowledgebase.html
> Only public FAQ items are visible to users of simplified interface. 
FAQ items are public to everyone (within their entity) that has access to read FAQs.
The additional visibility restrictions will have no affect in this case

> Other elements are visible only to technicians via standard interface

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25026
