### PR TITLE
fix(core): prevent double saveInput

### DIFF
--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -870,7 +870,7 @@ class CommonGLPI implements CommonGLPIInterface
             }
             if ($this instanceof CommonITILObject && $this->isNewItem()) {
                 $this->input = $cleaned_options;
-                $this->saveInput();
+                //$this->saveInput();
                // $extraparamhtml can be too long in case of ticket with content
                // (passed in GET in ajax request)
                 unset($cleaned_options['content']);

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -854,6 +854,10 @@ class CommonGLPI implements CommonGLPIInterface
             }
         }
 
+        if ($this instanceof CommonITILObject && $this->isNewItem()) {
+            $this->restoreInputAndDefaults($ID, $options, null);
+        }
+
         $target         = $_SERVER['PHP_SELF'];
         $extraparamhtml = "";
         $withtemplate   = "";
@@ -870,7 +874,7 @@ class CommonGLPI implements CommonGLPIInterface
             }
             if ($this instanceof CommonITILObject && $this->isNewItem()) {
                 $this->input = $cleaned_options;
-                //$this->saveInput();
+                $this->saveInput();
                // $extraparamhtml can be too long in case of ticket with content
                // (passed in GET in ajax request)
                 unset($cleaned_options['content']);

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -863,7 +863,8 @@ class CommonGLPI implements CommonGLPIInterface
         }
 
         // if form is reloaded (example from a change on type field in a ITIL Object)
-        if (isset($options['reload_form'])) {
+        if (isset($options['reload_form'])
+            && $this instanceof CommonDBTM) {
             $this->input = $options;
             $this->saveInput();
         }

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -854,39 +854,21 @@ class CommonGLPI implements CommonGLPIInterface
             }
         }
 
-        if ($this instanceof CommonITILObject && $this->isNewItem()) {
-            $this->restoreInputAndDefaults($ID, $options, null);
-        }
-
         $target         = $_SERVER['PHP_SELF'];
-        $extraparamhtml = "";
         $withtemplate   = "";
         if (is_array($options) && count($options)) {
             if (isset($options['withtemplate'])) {
-                $withtemplate = $options['withtemplate'];
+               $withtemplate = $options['withtemplate'];
             }
-            $cleaned_options = $options;
-            if (isset($cleaned_options['id'])) {
-                unset($cleaned_options['id']);
-            }
-            if (isset($cleaned_options['stock_image'])) {
-                unset($cleaned_options['stock_image']);
-            }
-            if ($this instanceof CommonITILObject && $this->isNewItem()) {
-                $this->input = $cleaned_options;
-                $this->saveInput();
-               // $extraparamhtml can be too long in case of ticket with content
-               // (passed in GET in ajax request)
-                unset($cleaned_options['content']);
-            }
-
-            // prevent double sanitize, because the includes.php sanitize all data
-            $cleaned_options = Sanitizer::unsanitize($cleaned_options);
-
-            $extraparamhtml = "&amp;" . Toolbox::append_params($cleaned_options, '&amp;');
         }
 
-        $onglets     = $this->defineAllTabs($options);
+        // if form is reloaded (example from a change on type field in a ITIL Object)
+        if (isset($options['reload_form'])) {
+            $this->input = $options;
+            $this->saveInput();
+        }
+
+        $onglets = $this->defineAllTabs($options);
         $display_all = true;
         if (isset($onglets['no_all_tab'])) {
             $display_all = false;
@@ -898,10 +880,15 @@ class CommonGLPI implements CommonGLPIInterface
             $tabs    = [];
 
             foreach ($onglets as $key => $val) {
-                $tabs[$key] = ['title'  => $val,
+                $tabs[$key] = [
+                    'title'  => $val,
                     'url'    => $tabpage,
-                    'params' => "_target=$target&amp;_itemtype=" . $this->getType() .
-                                            "&amp;_glpi_tab=$key&amp;id=$ID$extraparamhtml"
+                    'params' => http_build_query([
+                        '_target'   => $target,
+                        '_itemtype' => $this->getType(),
+                        '_glpi_tab' => $key,
+                        'id'        => $ID,
+                    ])
                 ];
             }
 
@@ -911,10 +898,15 @@ class CommonGLPI implements CommonGLPIInterface
                 && empty($withtemplate)
                 && (count($tabs) > 1)
             ) {
-                $tabs[-1] = ['title'  => __('All'),
+                $tabs[-1] = [
+                    'title'  => __('All'),
                     'url'    => $tabpage,
-                    'params' => "_target=$target&amp;_itemtype=" . $this->getType() .
-                                          "&amp;_glpi_tab=-1&amp;id=$ID$extraparamhtml"
+                    'params' => http_build_query([
+                        '_target'   => $target,
+                        '_itemtype' => $this->getType(),
+                        '_glpi_tab' => -1,
+                        'id'        => $ID,
+                    ])
                 ];
             }
 

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -863,8 +863,7 @@ class CommonGLPI implements CommonGLPIInterface
         }
 
         // if form is reloaded (example from a change on type field in a ITIL Object)
-        if (isset($options['reload_form'])
-            && $this instanceof CommonDBTM) {
+        if (isset($options['reload_form']) && $this instanceof CommonDBTM) {
             $this->input = $options;
             $this->saveInput();
         }

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -858,7 +858,7 @@ class CommonGLPI implements CommonGLPIInterface
         $withtemplate   = "";
         if (is_array($options) && count($options)) {
             if (isset($options['withtemplate'])) {
-               $withtemplate = $options['withtemplate'];
+                $withtemplate = $options['withtemplate'];
             }
         }
 

--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -47,7 +47,7 @@
 
 {% set onchange = '' %}
 {% if item.isNewItem() %}
-   {% set onchange = 'this.form.submit();' %}
+   {% set onchange = 'reloadForm(this.form);' %}
 {% endif %}
 
 {% if not is_actor_hidden %}

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -70,7 +70,7 @@
                      _n('Entity', 'Entities', 1),
                      field_options|merge({
                         'entity': userentities,
-                        'on_change': 'this.form.submit()',
+                        'on_change': 'reloadForm(this.form)',
                      })
                   ) }}
                {% else %}
@@ -141,7 +141,7 @@
                   'display': false
                }|merge(field_options) %}
                {% if item.isNewItem() %}
-                  {% set type_params = type_params|merge({'on_change': 'this.form.submit()',}) %}
+                  {% set type_params = type_params|merge({'on_change': 'reloadForm(this.form)',}) %}
                {% else %}
                   {% set type_params = type_params|merge({'on_change': 'reloadCategory()',}) %}
                {% endif %}
@@ -159,7 +159,7 @@
             }) %}
             {% if item.isNewItem() %}
                {% set cat_params = cat_params|merge({
-                  'on_change': 'this.form.submit()',
+                  'on_change': 'reloadForm(this.form)',
                }) %}
             {% endif %}
             {% if not item.isNewItem() and itiltemplate.isMandatoryField('itilcategories_id') and item.fields['itilcategories_id'] > 0 %}
@@ -469,5 +469,12 @@ var reloadCategory = function() {
             'value': {{ item.fields['itilcategories_id'] }},
         }
     );
+};
+
+var reloadForm = function(form) {
+    // append an hidden input to identify the action of reloading the form
+    $(form).append('<input type="hidden" name="reload_form" value="1" /> ');
+    form.submit();
+    return true;
 };
 </script>

--- a/templates/components/itilobject/selfservice.html.twig
+++ b/templates/components/itilobject/selfservice.html.twig
@@ -129,14 +129,14 @@
                      'value': params['type'],
                      'width': '100%',
                      'display': false,
-                     'on_change': 'this.form.submit()',
+                     'on_change': 'reloadForm(this.form)',
                   }|merge(right_field_options)),
                   _n('Type', 'Types', 1),
                   right_field_options
                ) }}
 
                {% set cat_params = right_field_options|merge({
-                  'on_change': 'this.form.submit()',
+                  'on_change': 'reloadForm(this.form)',
                }) %}
                {% set condition = {
                   'is_helpdeskvisible': 1
@@ -281,4 +281,11 @@ $(function () {
 
     saveActorsToDom();
 });
+
+var reloadForm = function(form) {
+    // append an hidden input to identify the action of reloading the form
+    $(form).append('<input type="hidden" name="reload_form" value="1" /> ');
+    form.submit();
+    return true;
+};
 </script>


### PR DESCRIPTION
restore input (in the case where a mandatory field is not filled in, for example) is broken.
```input``` is always empty when the page reloads.

It appears that ```saveInput()``` is called two times : 

- ```prepareInputForAdd($input)```  (seems legitimate)
- ```showTabsContent($options = [])``` from ```CommonGLPI``` 

From  ```CommonGLPI``` step,  ```$options``` saved by ```saveInput()```is always set like this 

```
Array
  (
      [id] => 0
  )
```

:warning:  This change does not fix the problem with images that are not restored.

I dont know how to deal with it 

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
