### PR TITLE
HTML encoding fix tool

### DIFF
--- a/src/Console/Database/FixHtmlEncodingCommand.php
+++ b/src/Console/Database/FixHtmlEncodingCommand.php
@@ -157,6 +157,7 @@ class FixHtmlEncodingCommand extends AbstractCommand
             }
         }
 
+        $failed_items = [];
         foreach ($item_ids as $item_id) {
             $item = new $itemtype();
             $item->getFromDB($item_id);
@@ -171,12 +172,22 @@ class FixHtmlEncodingCommand extends AbstractCommand
                 ['id' => $item->fields['id']],
             );
             if (!$success) {
+                $failed_items[] = $item_id;
+            }
+        }
+
+        if (count($failed_items) > 0) {
+            $this->output->writeln(
+                '<error>' . sprintf(__('Unable to update %s items'), count($failed_items)) . '</error>',
+                OutputInterface::VERBOSITY_QUIET
+            );
+            foreach ($failed_items as $item_id) {
                 $this->output->writeln(
-                    '<error>' . sprintf(__('Unable to update item %s'), $item_id) . '</error>',
+                    '<error>' . sprintf(__('Itemtype %s ID %s'), $itemtype, $item_id) . '</error>',
                     OutputInterface::VERBOSITY_QUIET
                 );
-                return self::ERROR_UPDATE_FAILED;
             }
+            return self::ERROR_UPDATE_FAILED;
         }
 
         return 0;

--- a/src/Console/Database/FixHtmlEncodingCommand.php
+++ b/src/Console/Database/FixHtmlEncodingCommand.php
@@ -193,7 +193,7 @@ class FixHtmlEncodingCommand extends AbstractCommand
     }
 
     /**
-     * Remove double encoding og HTML tags
+     * Remove double encoding of HTML tags
      * character < is encoded &#38;lt; but should  be encoded &#60;
      * character > is encoded &#38;gt; but should  be encoded &#62;
      *

--- a/src/Console/Database/FixHtmlEncodingCommand.php
+++ b/src/Console/Database/FixHtmlEncodingCommand.php
@@ -194,8 +194,8 @@ class FixHtmlEncodingCommand extends AbstractCommand
 
     /**
      * Remove double encoding of HTML tags
-     * character < is encoded &#38;lt; but should  be encoded &#60;
-     * character > is encoded &#38;gt; but should  be encoded &#62;
+     * character < is encoded &#38;lt; but should be encoded &#60;
+     * character > is encoded &#38;gt; but should be encoded &#62;
      *
      * Does not take into account the content of < and > pair
      *

--- a/src/Console/Database/FixHtmlEncodingCommand.php
+++ b/src/Console/Database/FixHtmlEncodingCommand.php
@@ -168,6 +168,7 @@ class FixHtmlEncodingCommand extends AbstractCommand
             return self::ERROR_UPDATE_FAILED;
         }
 
+        $output->writeln('<info>' . __('HTML encoding has been fixed.') . '</info>');
         return 0;
     }
 

--- a/src/Console/Database/FixHtmlEncodingCommand.php
+++ b/src/Console/Database/FixHtmlEncodingCommand.php
@@ -84,7 +84,7 @@ class FixHtmlEncodingCommand extends AbstractCommand
 
         $this->setName('glpi:database:fix_html_encoding');
         $this->setAliases(['db:fix_html']);
-        $this->setDescription(__('Fix Html encoding in database.'));
+        $this->setDescription(__('Fix HTML encoding in database.'));
 
         $this->addOption(
             'itemtype',

--- a/src/Console/Database/FixHtmlEncodingCommand.php
+++ b/src/Console/Database/FixHtmlEncodingCommand.php
@@ -104,7 +104,7 @@ class FixHtmlEncodingCommand extends AbstractCommand
             'dump',
             null,
             InputOption::VALUE_OPTIONAL,
-            __('Field of the item to fix')
+            __('Path of file containing dump of existing values.')
         );
 
         $this->addUsage('--itemtype=ITILFollowup --id=42 --field=content [--dump=file_path.sql]');

--- a/src/Console/Database/FixHtmlEncodingCommand.php
+++ b/src/Console/Database/FixHtmlEncodingCommand.php
@@ -218,7 +218,7 @@ class FixHtmlEncodingCommand extends AbstractCommand
                 );
             } else {
                 $this->output->writeln(
-                    '<comment>' . sprintf(__('Failed to write rollback SQL queries file %s'), $dump_file_name) . '</comment>',
+                    '<comment>' . sprintf(__('Failed to write rollback SQL queries file %s.'), $dump_file_name) . '</comment>',
                     OutputInterface::VERBOSITY_QUIET
                 );
             }

--- a/src/Console/Database/FixHtmlEncodingCommand.php
+++ b/src/Console/Database/FixHtmlEncodingCommand.php
@@ -77,7 +77,7 @@ class FixHtmlEncodingCommand extends AbstractCommand
 
         $this->setName('glpi:database:fix_html_encoding');
         $this->setAliases(['db:fix_html']);
-        $this->setDescription(__('Enable timezones usage.'));
+        $this->setDescription(__('Fix Html encoding in database.'));
 
         $this->addOption(
             'itemtype',
@@ -109,7 +109,7 @@ class FixHtmlEncodingCommand extends AbstractCommand
             . PHP_EOL
         );
 
-        $this->addUsage('--field name --field content');
+        $this->addUsage('--itemtype=ITILFollowup --id=42 --field=content');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -122,7 +122,6 @@ class FixHtmlEncodingCommand extends AbstractCommand
                 '<error>' . sprintf(__('Itemtype %s not found'), $itemtype) . '</error>',
                 OutputInterface::VERBOSITY_QUIET
             );
-            $this->outputSessionBufferedMessages([WARNING, ERROR]);
             return self::ERROR_ITEMTYPE_NOT_FOUND;
         }
 
@@ -134,7 +133,6 @@ class FixHtmlEncodingCommand extends AbstractCommand
                 '<error>' . sprintf(__('Item id not specified')) . '</error>',
                 OutputInterface::VERBOSITY_QUIET
             );
-            $this->outputSessionBufferedMessages([WARNING, ERROR]);
             return self::ERROR_ITEM_ID_NOT_FOUND;
         }
         foreach ($item_ids as $item_id) {
@@ -144,7 +142,6 @@ class FixHtmlEncodingCommand extends AbstractCommand
                     '<error>' . sprintf(__('Item id %s not found'), $item_id) . '</error>',
                     OutputInterface::VERBOSITY_QUIET
                 );
-                $this->outputSessionBufferedMessages([WARNING, ERROR]);
                 return self::ERROR_ITEM_ID_NOT_FOUND;
             }
         }
@@ -157,7 +154,6 @@ class FixHtmlEncodingCommand extends AbstractCommand
                 '<error>' . sprintf(__('Field not specified')) . '</error>',
                 OutputInterface::VERBOSITY_QUIET
             );
-            $this->outputSessionBufferedMessages([WARNING, ERROR]);
             return self::ERROR_ITEM_ID_NOT_FOUND;
         }
         foreach ($fields as $field) {
@@ -166,7 +162,6 @@ class FixHtmlEncodingCommand extends AbstractCommand
                     '<error>' . sprintf(__('Field %s not found'), $field) . '</error>',
                     OutputInterface::VERBOSITY_QUIET
                 );
-                $this->outputSessionBufferedMessages([WARNING, ERROR]);
                 return self::ERROR_FIELD_NOT_FOUND;
             }
         }

--- a/src/Console/Database/FixHtmlEncodingCommand.php
+++ b/src/Console/Database/FixHtmlEncodingCommand.php
@@ -44,7 +44,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class FixHtmlEncodingCommand extends AbstractCommand
 {
     /**
-     * Error code returned when a specified iteltype does not exists
+     * Error code returned when a specified itemtype does not exists
      *
      * @var integer
      */
@@ -84,9 +84,6 @@ class FixHtmlEncodingCommand extends AbstractCommand
             null,
             InputOption::VALUE_REQUIRED,
             __('Itemtype to fix')
-            . PHP_EOL
-            . __('"--itemtype ITILFollowup" will fix an item of type ITILFollowup')
-            . PHP_EOL
         );
 
         $this->addOption(
@@ -94,9 +91,6 @@ class FixHtmlEncodingCommand extends AbstractCommand
             null,
             InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
             __('Id of the item to fix')
-            . PHP_EOL
-            . __('"--id 42 will fix the item with id 42')
-            . PHP_EOL
         );
 
         $this->addOption(
@@ -104,9 +98,6 @@ class FixHtmlEncodingCommand extends AbstractCommand
             null,
             InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
             __('Field of the item to fix')
-            . PHP_EOL
-            . __('"--field content" will fix the field "content"')
-            . PHP_EOL
         );
 
         $this->addUsage('--itemtype=ITILFollowup --id=42 --field=content');
@@ -148,13 +139,13 @@ class FixHtmlEncodingCommand extends AbstractCommand
 
         $fields = $input->getOption('field');
 
-        // Checl all fields exist
+        // Check all fields exist
         if (count($fields) < 1) {
             $this->output->writeln(
                 '<error>' . sprintf(__('Field not specified')) . '</error>',
                 OutputInterface::VERBOSITY_QUIET
             );
-            return self::ERROR_ITEM_ID_NOT_FOUND;
+            return self::ERROR_FIELD_NOT_FOUND;
         }
         foreach ($fields as $field) {
             if (!$DB->fieldExists($itemtype::getTable(), $field)) {
@@ -184,7 +175,6 @@ class FixHtmlEncodingCommand extends AbstractCommand
                     '<error>' . sprintf(__('Unable to update item %s'), $item_id) . '</error>',
                     OutputInterface::VERBOSITY_QUIET
                 );
-                $this->outputSessionBufferedMessages([WARNING]);
                 return self::ERROR_UPDATE_FAILED;
             }
         }

--- a/src/Console/Database/FixHtmlEncodingCommand.php
+++ b/src/Console/Database/FixHtmlEncodingCommand.php
@@ -1,0 +1,223 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2022 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Console\Database;
+
+use CommonDBTM;
+use Glpi\Console\AbstractCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class FixHtmlEncodingCommand extends AbstractCommand
+{
+    /**
+     * Error code returned when a specified iteltype does not exists
+     *
+     * @var integer
+     */
+    const ERROR_ITEMTYPE_NOT_FOUND = 1;
+
+    /**
+     * Error code returned when at least one item id is not found
+     *
+     * @var integer
+     */
+    const ERROR_ITEM_ID_NOT_FOUND = 2;
+
+    /**
+     * Error code returned when at least one field is not found
+     *
+     * @var integer
+     */
+    const ERROR_FIELD_NOT_FOUND = 3;
+
+    /**
+     * Error code returned when update of an item failed
+     *
+     * @var integer
+     */
+    const ERROR_UPDATE_FAILED = 4;
+
+    protected function configure()
+    {
+        parent::configure();
+
+        $this->setName('glpi:database:fix_html_encoding');
+        $this->setAliases(['db:fix_html']);
+        $this->setDescription(__('Enable timezones usage.'));
+
+        $this->addOption(
+            'itemtype',
+            null,
+            InputOption::VALUE_REQUIRED,
+            __('Itemtype to fix')
+            . PHP_EOL
+            . __('"--itemtype ITILFollowup" will fix an item of type ITILFollowup')
+            . PHP_EOL
+        );
+
+        $this->addOption(
+            'id',
+            null,
+            InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
+            __('Id of the item to fix')
+            . PHP_EOL
+            . __('"--id 42 will fix the item with id 42')
+            . PHP_EOL
+        );
+
+        $this->addOption(
+            'field',
+            null,
+            InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
+            __('Field of the item to fix')
+            . PHP_EOL
+            . __('"--field content" will fix the field "content"')
+            . PHP_EOL
+        );
+
+        $this->addUsage('--field name --field content');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        global $DB;
+
+        $itemtype = $input->getOption('itemtype');
+        if (empty($itemtype) || !class_exists($itemtype) || !is_a($itemtype, CommonDBTM::class, true)) {
+            $this->output->writeln(
+                '<error>' . sprintf(__('Itemtype %s not found'), $itemtype) . '</error>',
+                OutputInterface::VERBOSITY_QUIET
+            );
+            $this->outputSessionBufferedMessages([WARNING, ERROR]);
+            return self::ERROR_ITEMTYPE_NOT_FOUND;
+        }
+
+        $item_ids = $input->getOption('id');
+
+        // Check all items exists
+        if (count($item_ids) < 1) {
+            $this->output->writeln(
+                '<error>' . sprintf(__('Item id not specified')) . '</error>',
+                OutputInterface::VERBOSITY_QUIET
+            );
+            $this->outputSessionBufferedMessages([WARNING, ERROR]);
+            return self::ERROR_ITEM_ID_NOT_FOUND;
+        }
+        foreach ($item_ids as $item_id) {
+            $item = new $itemtype();
+            if (!$item->getFromDB($item_id)) {
+                $this->output->writeln(
+                    '<error>' . sprintf(__('Item id %s not found'), $item_id) . '</error>',
+                    OutputInterface::VERBOSITY_QUIET
+                );
+                $this->outputSessionBufferedMessages([WARNING, ERROR]);
+                return self::ERROR_ITEM_ID_NOT_FOUND;
+            }
+        }
+
+        $fields = $input->getOption('field');
+
+        // Checl all fields exist
+        if (count($fields) < 1) {
+            $this->output->writeln(
+                '<error>' . sprintf(__('Field not specified')) . '</error>',
+                OutputInterface::VERBOSITY_QUIET
+            );
+            $this->outputSessionBufferedMessages([WARNING, ERROR]);
+            return self::ERROR_ITEM_ID_NOT_FOUND;
+        }
+        foreach ($fields as $field) {
+            if (!$DB->fieldExists($itemtype::getTable(), $field)) {
+                $this->output->writeln(
+                    '<error>' . sprintf(__('Field %s not found'), $field) . '</error>',
+                    OutputInterface::VERBOSITY_QUIET
+                );
+                $this->outputSessionBufferedMessages([WARNING, ERROR]);
+                return self::ERROR_FIELD_NOT_FOUND;
+            }
+        }
+
+        foreach ($item_ids as $item_id) {
+            $item = new $itemtype();
+            $item->getFromDB($item_id);
+            $update = [];
+            foreach ($fields as $field) {
+                $update[$field] = $this->doubleEncoding($item->fields[$field]);
+                $update[$field] = $DB->escape($update[$field]);
+            }
+            $success = $DB->update(
+                $itemtype::getTable(),
+                $update,
+                ['id' => $item->fields['id']],
+            );
+            if (!$success) {
+                $this->output->writeln(
+                    '<error>' . sprintf(__('Unable to update item %s'), $item_id) . '</error>',
+                    OutputInterface::VERBOSITY_QUIET
+                );
+                $this->outputSessionBufferedMessages([WARNING]);
+                return self::ERROR_UPDATE_FAILED;
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * Remove double encoding og HTML tags
+     * character < is encoded &#38;lt; but should  be encoded &#60;
+     * character > is encoded &#38;gt; but should  be encoded &#62;
+     *
+     * Does not take into account the content of < and > pair
+     *
+     * @param string $input
+     * @return string
+     */
+    private function doubleEncoding($input): string
+    {
+        // Prepare the double encoding fix of HTML tag
+        $pattern = [
+            '/&#38;lt;/', // Opening tag
+            '/&#38;gt;/', // closing tag
+        ];
+        $replace = [
+            '&#60;',
+            '&#62;',
+        ];
+        return preg_replace($pattern, $replace, $input);
+    }
+}

--- a/src/Console/Database/FixHtmlEncodingCommand.php
+++ b/src/Console/Database/FixHtmlEncodingCommand.php
@@ -182,7 +182,7 @@ class FixHtmlEncodingCommand extends AbstractCommand
                     $itemtype::getTable(),
                     $object_state,
                     ['id' => $item_id],
-                ) . PHP_EOL . PHP_EOL;
+                ) . ';' . PHP_EOL;
             }
 
             // update the item

--- a/src/Console/Database/FixHtmlEncodingCommand.php
+++ b/src/Console/Database/FixHtmlEncodingCommand.php
@@ -121,14 +121,14 @@ class FixHtmlEncodingCommand extends AbstractCommand
     {
         global $DB;
 
-        $this->checkArguments($input);
+        $this->checkArguments();
 
         $itemtype = $input->getOption('itemtype');
         $item_ids = $input->getOption('id');
         $fields = $input->getOption('field');
 
         if ($input->getOption('dump')) {
-            $this->dumpObjects($input);
+            $this->dumpObjects();
         }
 
         $failed_items = [];
@@ -174,15 +174,14 @@ class FixHtmlEncodingCommand extends AbstractCommand
     /**
      * Check that the arguments are correct
      *
-     * @param InputInterface $input
      * @return void
      */
-    private function checkArguments(InputInterface $input)
+    private function checkArguments()
     {
         global $DB;
 
         // Check itemtype exists
-        $itemtype = $input->getOption('itemtype');
+        $itemtype = $this->input->getOption('itemtype');
         if (empty($itemtype) || !class_exists($itemtype) || !is_a($itemtype, CommonDBTM::class, true)) {
             throw new \Glpi\Console\Exception\EarlyExitException(
                 '<error>' . sprintf(__('Itemtype %s not found'), $itemtype) . '</error>',
@@ -191,7 +190,7 @@ class FixHtmlEncodingCommand extends AbstractCommand
         }
 
         // Check all items exists
-        $item_ids = $input->getOption('id');
+        $item_ids = $this->input->getOption('id');
         if (count($item_ids) < 1) {
             throw new \Glpi\Console\Exception\EarlyExitException(
                 '<error>' . sprintf(__('Item id not specified')) . '</error>',
@@ -209,7 +208,7 @@ class FixHtmlEncodingCommand extends AbstractCommand
         }
 
         // Check all fields exist
-        $fields = $input->getOption('field');
+        $fields = $this->input->getOption('field');
         if (count($fields) < 1) {
             throw new \Glpi\Console\Exception\EarlyExitException(
                 '<error>' . sprintf(__('Field not specified')) . '</error>',
@@ -229,16 +228,15 @@ class FixHtmlEncodingCommand extends AbstractCommand
     /**
      * Dump items
      *
-     * @param InputInterface $input
      * @return void
      */
-    private function dumpObjects(InputInterface $input)
+    private function dumpObjects()
     {
         global $DB;
 
-        $itemtype = $input->getOption('itemtype');
-        $item_ids = $input->getOption('id');
-        $fields = $input->getOption('field');
+        $itemtype = $this->input->getOption('itemtype');
+        $item_ids = $this->input->getOption('id');
+        $fields = $this->input->getOption('field');
 
         $dump_content = '';
 
@@ -262,7 +260,7 @@ class FixHtmlEncodingCommand extends AbstractCommand
         }
 
         // Save the rollback SQL queries dump
-        $dump_file_name = $input->getOption('dump');
+        $dump_file_name = $this->input->getOption('dump');
         if (@file_put_contents($dump_file_name, $dump_content) == strlen($dump_content)) {
             $this->output->writeln(
                 '<comment>' . sprintf(__('File %s contains SQL queries that can be used to rollback command.'), $dump_file_name) . '</comment>',


### PR DESCRIPTION
CLI tool to fix data having bad HTML encoding in database. 

Currently fixes double encoded items 

internal ref 24943


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal: 24943
