### PR TITLE
Ensure CFG_GLPI is reset after each test

### DIFF
--- a/tests/GLPITestCase.php
+++ b/tests/GLPITestCase.php
@@ -44,6 +44,7 @@ class GLPITestCase extends atoum
 {
     private $int;
     private $str;
+
     protected $has_failed = false;
 
     /**
@@ -56,8 +57,18 @@ class GLPITestCase extends atoum
      */
     private $sql_log_handler;
 
+    /**
+     * Configuration backup.
+     * @var array
+     */
+    private $cfg_backup;
+
     public function beforeTestMethod($method)
     {
+        // Backup config (to restore it after test).
+        global $CFG_GLPI;
+        $this->cfg_backup = $CFG_GLPI;
+
         // Ensure cache is clear
         global $GLPI_CACHE;
         $GLPI_CACHE->clear();
@@ -81,7 +92,7 @@ class GLPITestCase extends atoum
         // Reset session and configuration.
         // It have to be done before calling asserters, as asserters may stop method execution.
         $this->resetSession();
-        $CFG_GLPI = [];
+        $CFG_GLPI = $this->cfg_backup;
 
         // Ensure there is no unexpected session messages
         if (!$this->has_failed) {

--- a/tests/LDAP/AuthLdap.php
+++ b/tests/LDAP/AuthLdap.php
@@ -68,8 +68,6 @@ class AuthLDAP extends DbTestCase
 
     public function afterTestMethod($method)
     {
-        unset($_SESSION['ldap_import']);
-
        //make sure bootstrapped ldap is not active and is default
         $this->boolean(
             $this->ldap->update([
@@ -1517,7 +1515,6 @@ class AuthLDAP extends DbTestCase
          ->hasSize(2)
          ->integer['action']->isIdenticalTo(\AuthLDAP::USER_DELETED_LDAP)
          ->variable['id']->isEqualTo($uid);
-        $CFG_GLPI['user_deleted_ldap'] = 0;
 
        //check that user no longer exists
         $this->boolean($user->getFromDB($uid))->isTrue();
@@ -1584,11 +1581,9 @@ class AuthLDAP extends DbTestCase
             )
         )->isTrue();
 
-        $user_deleted_ldap_original = $CFG_GLPI['user_deleted_ldap'] ?? 0;
        //put deleted LDAP users in trashbin
         $CFG_GLPI['user_deleted_ldap'] = 1;
         $synchro = $ldap->forceOneUserSynchronization($user);
-        $CFG_GLPI['user_deleted_ldap'] = $user_deleted_ldap_original;
         $this->array($synchro)
          ->hasSize(2)
          ->integer['action']->isIdenticalTo(\AuthLDAP::USER_DELETED_LDAP)
@@ -1617,10 +1612,8 @@ class AuthLDAP extends DbTestCase
             )
         )->isTrue();
 
-        $user_restored_ldap_original = $CFG_GLPI['user_restored_ldap'] ?? 0;
         $CFG_GLPI['user_restored_ldap'] = 1;
         $synchro = $ldap->forceOneUserSynchronization($user);
-        $CFG_GLPI['user_restored_ldap'] = $user_restored_ldap_original;
         $this->array($synchro)
          ->hasSize(2)
          ->integer['action']->isIdenticalTo(\AuthLDAP::USER_RESTORED_LDAP)
@@ -1663,11 +1656,6 @@ class AuthLDAP extends DbTestCase
         $auth = new \Auth();
         $this->boolean($auth->login("", ""))->isTrue();
         $this->string($_SESSION['glpiname'])->isEqualTo('brazil6');
-
-       //reset config
-        \Config::setConfigurationValues('core', [
-            'ssovariables_id' => $config_values['ssovariables_id']
-        ]);
     }
 
     public function testSyncLongDN()

--- a/tests/functionnal/Agent.php
+++ b/tests/functionnal/Agent.php
@@ -245,7 +245,6 @@ class Agent extends DbTestCase
 
         $CFG_GLPI["is_contact_autoupdate"] = 0;
         $inventory = new \Glpi\Inventory\Inventory($json);
-        $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {

--- a/tests/functionnal/Auth.php
+++ b/tests/functionnal/Auth.php
@@ -164,12 +164,10 @@ class Auth extends DbTestCase
         $this->integer($user_id)->isGreaterThan(0);
         $this->boolean($user->update(['id' => $user_id, 'password_last_update' => $last_update]))->isTrue();
 
-        $cfg_backup = $CFG_GLPI;
         $CFG_GLPI['password_expiration_delay'] = $exp_delay;
         $CFG_GLPI['password_expiration_lock_delay'] = $lock_delay;
         $auth = new \Auth();
         $is_logged = $auth->login($username, 'test', true);
-        $CFG_GLPI = $cfg_backup;
 
         $this->boolean($is_logged)->isEqualTo(!$expected_lock);
         $this->boolean($user->getFromDB($user->fields['id']))->isTrue();

--- a/tests/functionnal/CommonDBTM.php
+++ b/tests/functionnal/CommonDBTM.php
@@ -189,11 +189,10 @@ class CommonDBTM extends DbTestCase
         $this->array($comp->fields)->isEmpty();
 
         $this->boolean($comp->getEmpty())->isTrue();
-        $this->array($comp->fields)->integer['entities_id']->isEqualTo(0);
+        $this->array($comp->fields)->string['entities_id']->isEqualTo(''); // No default 'entities_id' if session is not initialized
 
         $_SESSION["glpiactive_entity"] = 12;
         $this->boolean($comp->getEmpty())->isTrue();
-        unset($_SESSION['glpiactive_entity']);
         $this->array($comp->fields)
          ->integer['entities_id']->isIdenticalTo(12);
     }
@@ -856,7 +855,6 @@ class CommonDBTM extends DbTestCase
     {
         $computer = new \Computer();
         $ent0 = getItemByTypeName('Entity', '_test_root_entity', true);
-        $bkp_current = $_SESSION['glpi_currenttime'];
         $_SESSION['glpi_currenttime'] = '2000-01-01 00:00:00';
 
        //test with date set
@@ -892,15 +890,12 @@ class CommonDBTM extends DbTestCase
         $this->string($computer->fields['date_creation'])->isEqualTo('2000-01-01 00:00:00');
         $this->string($computer->fields['date_mod'])->isEqualTo('2000-01-01 00:00:00');
         $this->string($computer->fields['name'])->isIdenticalTo("Computer01 '");
-
-        $_SESSION['glpi_currenttime'] = $bkp_current;
     }
 
     public function testUpdate()
     {
         $computer = new \Computer();
         $ent0 = getItemByTypeName('Entity', '_test_root_entity', true);
-        $bkp_current = $_SESSION['glpi_currenttime'];
         $_SESSION['glpi_currenttime'] = '2000-01-01 00:00:00';
 
        //test with date set
@@ -1086,10 +1081,8 @@ class CommonDBTM extends DbTestCase
         $this->integer($relation_item_2_id)->isGreaterThan(0);
         $this->boolean($relation_item->getFromDB($relation_item_2_id))->isTrue();
 
-        $cfg_backup = $CFG_GLPI;
         $CFG_GLPI[$config_name] = [$computer->getType()];
         $computer->delete(['id' => $computer_1_id], true);
-        $CFG_GLPI = $cfg_backup;
 
        // Relation with deleted item has been cleaned
         $this->boolean($relation_item->getFromDB($relation_item_1_id))->isFalse();
@@ -1158,9 +1151,6 @@ class CommonDBTM extends DbTestCase
 
         $res = \CommonDBTM::checkTemplateEntity($data, $parent_id, $parent_itemtype);
         $this->array($res)->isEqualTo($expected);
-
-       // Reset session
-        unset($_SESSION['glpiactiveentities']);
     }
 
     public function testGetById()

--- a/tests/functionnal/Computer.php
+++ b/tests/functionnal/Computer.php
@@ -75,7 +75,6 @@ class Computer extends DbTestCase
     public function testUpdate()
     {
         global $CFG_GLPI;
-        $saveconf = $CFG_GLPI;
 
         $computer = $this->getNewComputer();
         $printer  = $this->getNewPrinter();
@@ -158,9 +157,7 @@ class Computer extends DbTestCase
             $this->variable($printer->getField($k))->isEqualTo($in[$k]);
         }
 
-       // Restore configuration
         $computer = $this->getNewComputer();
-        $CFG_GLPI = $saveconf;
 
        //update devices
         $cpu = new \DeviceProcessor();
@@ -237,9 +234,6 @@ class Computer extends DbTestCase
            // Check the printer and test propagation DOES NOT occurs
             $this->variable($link->getField($k))->isEqualTo($in[$k]);
         }
-
-       // Restore configuration
-        $CFG_GLPI = $saveconf;
     }
 
     /**
@@ -252,7 +246,6 @@ class Computer extends DbTestCase
         global $CFG_GLPI;
 
         $computer = $this->getNewComputer();
-        $saveconf = $CFG_GLPI;
 
         $CFG_GLPI['is_contact_autoupdate']  = 1;
         $CFG_GLPI['is_user_autoupdate']     = 1;
@@ -332,9 +325,6 @@ class Computer extends DbTestCase
            // Check the printer and test propagation occurs
             $this->variable($link->getField($k))->isEqualTo($v);
         }
-
-       // Restore configuration
-        $CFG_GLPI = $saveconf;
     }
 
     public function testGetFromIter()
@@ -537,10 +527,8 @@ class Computer extends DbTestCase
         // clone!
         $computer = new \Computer(); //$computer->fields contents is already escaped!
         $this->boolean($computer->getFromDB($id))->isTrue();
-        $infocom_auto_create_original = $CFG_GLPI["infocom_auto_create"] ?? 0;
         $CFG_GLPI["infocom_auto_create"] = 1;
         $added = $computer->clone();
-        $CFG_GLPI["infocom_auto_create"] = $infocom_auto_create_original;
         $this->integer((int)$added)->isGreaterThan(0);
         $this->integer($added)->isNotEqualTo($computer->fields['id']);
 
@@ -678,7 +666,6 @@ class Computer extends DbTestCase
             [$cid]
         );
         $transfer->moveItems(['Computer' => [$cid]], $entities_id, [$cid, 'keep_software' => 1]);
-        unset($_SESSION['glpitransfer_list']);
 
         $this->boolean($computer->getFromDB($cid))->isTrue();
         $this->integer((int)$computer->fields['entities_id'])->isidenticalTo($entities_id);

--- a/tests/functionnal/Config.php
+++ b/tests/functionnal/Config.php
@@ -204,8 +204,6 @@ class Config extends DbTestCase
 
         $CFG_GLPI['password_min_length'] = strlen('mypass');
         $this->boolean(\Config::validatePassword('mypass'))->isFalse();
-        $CFG_GLPI['password_min_length'] = 8; //reset
-
         $this->hasSessionMessages(ERROR, $expected);
 
         $expected = [
@@ -217,7 +215,6 @@ class Config extends DbTestCase
 
         $CFG_GLPI['password_need_number'] = 0;
         $this->boolean(\Config::validatePassword('mypassword'))->isFalse();
-        $CFG_GLPI['password_need_number'] = 1; //reset
         $this->hasSessionMessages(ERROR, $expected);
 
         $expected = [
@@ -228,7 +225,6 @@ class Config extends DbTestCase
 
         $CFG_GLPI['password_need_caps'] = 0;
         $this->boolean(\Config::validatePassword('my1password'))->isFalse();
-        $CFG_GLPI['password_need_caps'] = 1; //reset
         $this->hasSessionMessages(ERROR, $expected);
 
         $this->boolean(\Config::validatePassword('my1paSsw@rd'))->isTrue();
@@ -236,7 +232,6 @@ class Config extends DbTestCase
 
         $CFG_GLPI['password_need_symbol'] = 0;
         $this->boolean(\Config::validatePassword('my1paSsword'))->isTrue();
-        $CFG_GLPI['password_need_symbol'] = 1; //reset
         $this->hasNoSessionMessage(ERROR);
     }
 
@@ -709,7 +704,6 @@ class Config extends DbTestCase
        // check that activation of password expiration reset `password_last_update` to current date
        // for all local users but not for external users
        // and activate passwordexpiration crontask
-        $current_time = $_SESSION['glpi_currenttime'];
         $update_datetime = date('Y-m-d H:i:s', strtotime('-15 days')); // arbitrary date
         $_SESSION['glpi_currenttime'] = $update_datetime;
         $conf->update(
@@ -718,7 +712,6 @@ class Config extends DbTestCase
                 'password_expiration_delay' => 30
             ]
         );
-        $_SESSION['glpi_currenttime'] = $current_time;
         $values = \Config::getConfigurationValues('core');
         $this->array($values)->hasKey('password_expiration_delay');
         $this->integer((int)$values['password_expiration_delay'])->isIdenticalTo(30);
@@ -739,7 +732,6 @@ class Config extends DbTestCase
 
        // check that changing password expiration delay does not reset `password_last_update` to current date
        // if password expiration was already active
-        $current_time = $_SESSION['glpi_currenttime'];
         $new_update_datetime = date('Y-m-d H:i:s', strtotime('-5 days')); // arbitrary date
         $_SESSION['glpi_currenttime'] = $new_update_datetime;
         $conf->update(
@@ -748,7 +740,6 @@ class Config extends DbTestCase
                 'password_expiration_delay' => 45
             ]
         );
-        $_SESSION['glpi_currenttime'] = $current_time;
         $values = \Config::getConfigurationValues('core');
         $this->array($values)->hasKey('password_expiration_delay');
         $this->integer((int)$values['password_expiration_delay'])->isIdenticalTo(45);
@@ -863,8 +854,6 @@ class Config extends DbTestCase
         ];
         $infocom_types = array_diff($infocom_types, $excluded_types);
 
-        $infocom_auto_create_original = $CFG_GLPI["infocom_auto_create"] ?? 0;
-
         $infocom = new \Infocom();
         foreach ($infocom_types as $asset_type) {
             $CFG_GLPI['auto_create_infocoms'] = 1;
@@ -876,7 +865,6 @@ class Config extends DbTestCase
                 'itemtype'              => 'Computer', // Random item type for testing Item_DeviceSimcard
                 'devicesimcards_id'     => 1, // Random ID for testing Item_DeviceSimcard
             ]);
-            $CFG_GLPI['auto_create_infocoms'] = $infocom_auto_create_original;
             // Verify an Infocom object exists for the newly created asset
             $infocom_exists = $infocom->getFromDBforDevice($asset_type, $asset_id);
             $this->boolean($infocom_exists)->isTrue();
@@ -890,7 +878,6 @@ class Config extends DbTestCase
                 'itemtype'              => 'Computer', // Random item type for testing Item_DeviceSimcard
                 'devicesimcards_id'     => 1, // Random ID for testing Item_DeviceSimcard
             ]);
-            $CFG_GLPI['auto_create_infocoms'] = $infocom_auto_create_original;
             $infocom_exists = $infocom->getFromDBforDevice($asset_type, $asset_id2);
             $this->boolean($infocom_exists)->isFalse();
         }

--- a/tests/functionnal/Domain.php
+++ b/tests/functionnal/Domain.php
@@ -168,7 +168,6 @@ class Domain extends DbTestCase
             [$domains_id]
         );
         $transfer->moveItems(['Domain' => [$domains_id]], $entities_id, [$domains_id]);
-        unset($_SESSION['glpitransfer_list']);
 
         $this->boolean($domain->getFromDB($domains_id))->isTrue();
         $this->integer((int)$domain->fields['entities_id'])->isidenticalTo($entities_id);

--- a/tests/functionnal/Dropdown.php
+++ b/tests/functionnal/Dropdown.php
@@ -786,13 +786,9 @@ class Dropdown extends DbTestCase
     {
         $this->login();
 
-        $bkp_params = [];
        //set session params if any
         if (count($session_params)) {
             foreach ($session_params as $param => $value) {
-                if (isset($_SESSION[$param])) {
-                    $bkp_params[$param] = $_SESSION[$param];
-                }
                 $_SESSION[$param] = $value;
             }
         }
@@ -800,17 +796,6 @@ class Dropdown extends DbTestCase
         $params['_idor_token'] = $this->generateIdor($params);
 
         $result = \Dropdown::getDropdownValue($params, false);
-
-       //reset session params before executing test
-        if (count($session_params)) {
-            foreach ($session_params as $param => $value) {
-                if (isset($bkp_params[$param])) {
-                    $_SESSION[$param] = $bkp_params[$param];
-                } else {
-                    unset($_SESSION[$param]);
-                }
-            }
-        }
 
         $this->array($result)->isIdenticalTo($expected);
     }
@@ -953,13 +938,9 @@ class Dropdown extends DbTestCase
     {
         $this->login();
 
-        $bkp_params = [];
        //set session params if any
         if (count($session_params)) {
             foreach ($session_params as $param => $value) {
-                if (isset($_SESSION[$param])) {
-                    $bkp_params[$param] = $_SESSION[$param];
-                }
                 $_SESSION[$param] = $value;
             }
         }
@@ -967,17 +948,6 @@ class Dropdown extends DbTestCase
         $params['_idor_token'] = $this->generateIdor($params);
 
         $result = \Dropdown::getDropdownConnect($params, false);
-
-       //reset session params before executing test
-        if (count($session_params)) {
-            foreach ($session_params as $param => $value) {
-                if (isset($bkp_params[$param])) {
-                    $_SESSION[$param] = $bkp_params[$param];
-                } else {
-                    unset($_SESSION[$param]);
-                }
-            }
-        }
 
         $this->array($result)->isIdenticalTo($expected);
     }
@@ -1131,10 +1101,8 @@ class Dropdown extends DbTestCase
     public function testGetDropdownNumber($params, $expected)
     {
         global $CFG_GLPI;
-        $orig_max = $CFG_GLPI['dropdown_max'];
         $CFG_GLPI['dropdown_max'] = 10;
         $result = \Dropdown::getDropdownNumber($params, false);
-        $CFG_GLPI['dropdown_max'] = $orig_max;
         $this->array($result)->isIdenticalTo($expected);
     }
 

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -848,8 +848,7 @@ class Entity extends DbTestCase
         ]);
         $this->integer($solutions_id)->isGreaterThan(0);
 
-       // Save and replace session data
-        $old_interface = $_SESSION['glpiactiveprofile']['interface'];
+       // Replace session data
         $_SESSION['glpiactiveprofile']['interface'] = $interface;
 
        // Case 1: removed (test values recovered from CommonITILObject::showUsersAssociated())
@@ -915,9 +914,6 @@ class Entity extends DbTestCase
                 );
             }
         }
-
-       // Reset session
-        $_SESSION['glpiactiveprofile']['interface'] = $old_interface;
     }
 
     public function testDefaultContractConfig()

--- a/tests/functionnal/Glpi/Inventory/Assets/NetworkEquipment.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/NetworkEquipment.php
@@ -379,7 +379,6 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $data = json_decode($converter->convert($xml_source));
         $CFG_GLPI["is_contact_autoupdate"] = 0;
         $inventory = new \Glpi\Inventory\Inventory($data);
-        $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
@@ -462,7 +461,6 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $data = json_decode($converter->convert($xml_source));
         $CFG_GLPI["is_contact_autoupdate"] = 0;
         $inventory = new \Glpi\Inventory\Inventory($data);
-        $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
@@ -526,7 +524,6 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $data = json_decode($converter->convert($xml_source));
         $CFG_GLPI["is_contact_autoupdate"] = 0;
         $inventory = new \Glpi\Inventory\Inventory($data);
-        $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
@@ -642,7 +639,6 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $data = json_decode($converter->convert($xml_source));
         $CFG_GLPI["is_contact_autoupdate"] = 0;
         $inventory = new \Glpi\Inventory\Inventory($data);
-        $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
@@ -743,7 +739,6 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $data = json_decode($converter->convert($xml_source));
         $CFG_GLPI["is_contact_autoupdate"] = 0;
         $inventory = new \Glpi\Inventory\Inventory($data);
-        $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
@@ -848,7 +843,6 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $data = json_decode($converter->convert($xml_source));
         $CFG_GLPI["is_contact_autoupdate"] = 0;
         $inventory = new \Glpi\Inventory\Inventory($data);
-        $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
@@ -940,7 +934,6 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $data = json_decode($converter->convert($xml_source));
         $CFG_GLPI["is_contact_autoupdate"] = 0;
         $inventory = new \Glpi\Inventory\Inventory($data);
-        $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
@@ -1059,7 +1052,6 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $data = json_decode($converter->convert($xml_source));
         $CFG_GLPI["is_contact_autoupdate"] = 0;
         $inventory = new \Glpi\Inventory\Inventory($data);
-        $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
@@ -1202,7 +1194,6 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $data = json_decode($converter->convert($xml_source));
         $CFG_GLPI["is_contact_autoupdate"] = 0;
         $inventory = new \Glpi\Inventory\Inventory($data);
-        $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
@@ -1347,7 +1338,6 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $data = json_decode($converter->convert($xml_source));
         $CFG_GLPI["is_contact_autoupdate"] = 0;
         $inventory = new \Glpi\Inventory\Inventory($data);
-        $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
@@ -1481,7 +1471,6 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $data = json_decode($converter->convert($xml_source));
         $CFG_GLPI["is_contact_autoupdate"] = 0;
         $inventory = new \Glpi\Inventory\Inventory($data);
-        $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
@@ -1609,7 +1598,6 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $data = json_decode($converter->convert($xml_source));
         $CFG_GLPI["is_contact_autoupdate"] = 0;
         $inventory = new \Glpi\Inventory\Inventory($data);
-        $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
@@ -1737,7 +1725,6 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $data = json_decode($converter->convert($xml_source));
         $CFG_GLPI["is_contact_autoupdate"] = 0;
         $inventory = new \Glpi\Inventory\Inventory($data);
-        $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default
 
         $this->boolean($inventory->inError())->isFalse();
         $this->array($inventory->getErrors())->isIdenticalTo([]);
@@ -1872,7 +1859,6 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         //$json = json_decode($data);
         $CFG_GLPI["is_contact_autoupdate"] = 0;
         $inventory = new \Glpi\Inventory\Inventory($data);
-        $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default
 
         $this->boolean($inventory->inError())->isFalse();
         $this->array($inventory->getErrors())->isIdenticalTo([]);

--- a/tests/functionnal/IPAddress.php
+++ b/tests/functionnal/IPAddress.php
@@ -160,7 +160,6 @@ class IPAddress extends DbTestCase
             "1..3.4",
         ];
 
-        unset($_SESSION['glpicronuserrunning']);
         foreach ($IPV4ShouldNotWork as $name) {
             $ipAdress = new \IPAddress();
             $id = $ipAdress->add([
@@ -174,8 +173,7 @@ class IPAddress extends DbTestCase
                 "Invalid IP address: " . $name,
             ];
 
-            $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo($expectedSession);
-            $_SESSION['MESSAGE_AFTER_REDIRECT'] = [];
+            $this->hasSessionMessages(ERROR, ["Invalid IP address: " . $name]);
         }
     }
 
@@ -275,7 +273,6 @@ class IPAddress extends DbTestCase
             "12345::6:7:8" //more than 4 digit
         ];
 
-        unset($_SESSION['glpicronuserrunning']);
         foreach ($IPV6ShouldNotWork as $name) {
             $ipAdress = new \IPAddress();
             $id = $ipAdress->add([
@@ -289,8 +286,7 @@ class IPAddress extends DbTestCase
                 "Invalid IP address: " . $name,
             ];
 
-            $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo($expectedSession);
-            $_SESSION['MESSAGE_AFTER_REDIRECT'] = [];
+            $this->hasSessionMessages(ERROR, ["Invalid IP address: " . $name]);
         }
     }
 }

--- a/tests/functionnal/ITILFollowup.php
+++ b/tests/functionnal/ITILFollowup.php
@@ -229,10 +229,6 @@ class ITILFollowup extends DbTestCase
         $this->login();
 
         $ticket = new \Ticket();
-        $oldConf = [
-            'glpiset_default_tech'      => $_SESSION['glpiset_default_tech'],
-            'glpiset_default_requester' => $_SESSION['glpiset_default_requester'],
-        ];
 
         $_SESSION['glpiset_default_tech'] = 0;
         $_SESSION['glpiset_default_requester'] = 0;
@@ -271,10 +267,6 @@ class ITILFollowup extends DbTestCase
         $this->boolean($ticket->getFromDB($ticketID))->isTrue();
         $this->integer((int) $ticket->fields['takeintoaccount_delay_stat'])->isEqualTo(0);
         $this->variable($ticket->fields['takeintoaccountdate'])->isEqualTo(null);
-
-       // Reset conf
-        $_SESSION['glpiset_default_tech']      = $oldConf['glpiset_default_tech'];
-        $_SESSION['glpiset_default_requester'] = $oldConf['glpiset_default_requester'];
     }
 
     protected function testIsFromSupportAgentProvider()
@@ -333,7 +325,6 @@ class ITILFollowup extends DbTestCase
         global $CFG_GLPI, $DB;
 
        // Disable notifications
-        $old_conf = $CFG_GLPI['use_notifications'];
         $CFG_GLPI['use_notifications'] = false;
 
         $this->login();
@@ -386,9 +377,6 @@ class ITILFollowup extends DbTestCase
        // Execute test
         $result = $fup->isFromSupportAgent();
         $this->boolean($result)->isEqualTo($expected);
-
-       // Reset conf
-        $CFG_GLPI['use_notifications'] = $old_conf;
     }
 
     public function testScreenshotConvertedIntoDocument()

--- a/tests/functionnal/Impact.php
+++ b/tests/functionnal/Impact.php
@@ -140,20 +140,17 @@ class Impact extends \DbTestCase
 
     public function testGetTabNameForItem_tabCountDisabled()
     {
-        $old_session = $_SESSION['glpishow_count_on_tabs'];
         $_SESSION['glpishow_count_on_tabs'] = false;
 
         $impact = new \Impact();
         $computer = new Computer();
         $tab_name = $impact->getTabNameForItem($computer);
-        $_SESSION['glpishow_count_on_tabs'] = $old_session;
 
         $this->string($tab_name)->isEqualTo("Impact analysis");
     }
 
     public function testGetTabNameForItem_enabledAsset()
     {
-        $old_session = $_SESSION['glpishow_count_on_tabs'];
         $_SESSION['glpishow_count_on_tabs'] = true;
 
         $impact = new \Impact();
@@ -167,14 +164,12 @@ class Impact extends \DbTestCase
         $this->addDbEdge($computer1, $computer2);
         $this->addDbEdge($computer2, $computer3);
         $tab_name = $impact->getTabNameForItem($computer2);
-        $_SESSION['glpishow_count_on_tabs'] = $old_session;
 
         $this->string($tab_name)->isEqualTo("Impact analysis <span class='badge'>2</span>");
     }
 
     public function testGetTabNameForItem_ITILObject()
     {
-        $old_session = $_SESSION['glpishow_count_on_tabs'];
         $_SESSION['glpishow_count_on_tabs'] = true;
 
         $impact = new \Impact();
@@ -203,7 +198,6 @@ class Impact extends \DbTestCase
         $ticket->getFromDB($ticket_id);
 
         $tab_name = $impact->getTabNameForItem($ticket);
-        $_SESSION['glpishow_count_on_tabs'] = $old_session;
 
         $this->string($tab_name)->isEqualTo("Impact analysis");
     }

--- a/tests/functionnal/Knowbase.php
+++ b/tests/functionnal/Knowbase.php
@@ -274,19 +274,13 @@ class Knowbase extends DbTestCase
 
        // Check that tree contains root only (FAQ is not public) for anonymous user
        // Force session reset
-        $session_bck = $_SESSION;
         $this->resetSession();
         $tree_with_no_public_faq = \Knowbase::getTreeCategoryList();
 
        // Check that tree contains root + category branch containing FAQ item (FAQ is public) for anonymous user
         global $CFG_GLPI;
-        $use_public_faq_bck = $CFG_GLPI['use_public_faq'];
         $CFG_GLPI['use_public_faq'] = 1;
         $tree_with_public_faq = \Knowbase::getTreeCategoryList();
-
-       // Put back globals
-        $_SESSION = $session_bck;
-        $CFG_GLPI['use_public_faq'] = $use_public_faq_bck;
 
         $this->array($tree_with_no_public_faq)->isEqualTo([$expected_root_cat]);
         $this->array($tree_with_public_faq)->isEqualTo(

--- a/tests/functionnal/KnowbaseItem_Item.php
+++ b/tests/functionnal/KnowbaseItem_Item.php
@@ -186,9 +186,6 @@ class KnowbaseItem_Item extends DbTestCase
         $ticket3 = getItemByTypeName(\Ticket::getType(), '_ticket03');
         $kbs = \KnowbaseItem_Item::getItems($ticket3);
         $this->array($kbs)->hasSize(0);
-
-        $_SESSION['glpishowallentities'] = 1;
-        unset($_SESSION['glpiactiveentities']);
     }
 
     public function testGetTabNameForItem()

--- a/tests/functionnal/MassiveAction.php
+++ b/tests/functionnal/MassiveAction.php
@@ -214,7 +214,6 @@ class MassiveAction extends DbTestCase
     ) {
         $base_comment = "test comment";
         $amendment = "test amendment";
-        $old_session = $_SESSION['glpiactiveentities'] ?? [];
 
        // Set rights if needed
         if ($has_right) {
@@ -266,8 +265,6 @@ class MassiveAction extends DbTestCase
             ->string($item->fields['comment'])
             ->isIdenticalTo("$base_comment\n\n$amendment");
         }
-
-        $_SESSION['glpiactiveentities'] = $old_session;
     }
 
     protected function addNoteProvider()
@@ -296,7 +293,6 @@ class MassiveAction extends DbTestCase
 
        // Init vars
         $new_note_content = "Test add note";
-        $old_session = $_SESSION['glpiactiveprofile'][$item::$rightname] ?? 0;
         $note_search = [
             'items_id' => $item->fields['id'],
             'itemtype' => $item->getType(),
@@ -339,8 +335,6 @@ class MassiveAction extends DbTestCase
             $new_count = countElementsInTable(Notepad::getTable(), $note_search);
             $this->integer($new_count)->isIdenticalTo($count_notes + 1);
         }
-
-        $_SESSION['glpiactiveprofile'][$item::$rightname] = $old_session;
     }
 
     protected function linkToProblemProvider()
@@ -388,7 +382,6 @@ class MassiveAction extends DbTestCase
         bool $has_right
     ) {
        // Set up session rights
-        $old_session = $_SESSION['glpiactiveprofile'][Problem::$rightname] ?? 0;
         if ($has_right) {
             $_SESSION['glpiactiveprofile'][Problem::$rightname] = UPDATE;
         }
@@ -426,9 +419,6 @@ class MassiveAction extends DbTestCase
             $expected_ko,
             Ticket::class
         );
-
-       // Reset rights
-        $_SESSION['glpiactiveprofile'][Problem::$rightname] = $old_session;
     }
 
     protected function resolveTicketsProvider()
@@ -488,7 +478,6 @@ class MassiveAction extends DbTestCase
         $this->login(); // must be logged as ITILSolution uses Session::getLoginUserID()
 
        // Set up session rights
-        $old_session = $_SESSION['glpiactiveprofile'][Ticket::$rightname] ?? 0;
         if ($has_right) {
             $_SESSION['glpiactiveprofile'][Ticket::$rightname] = UPDATE;
         } else {
@@ -519,9 +508,6 @@ class MassiveAction extends DbTestCase
             $expected_ko,
             Ticket::class
         );
-
-       // Reset rights
-        $_SESSION['glpiactiveprofile'][Ticket::$rightname] = $old_session;
     }
 
     protected function addContractProvider()

--- a/tests/functionnal/MassiveAction.php
+++ b/tests/functionnal/MassiveAction.php
@@ -214,6 +214,7 @@ class MassiveAction extends DbTestCase
     ) {
         $base_comment = "test comment";
         $amendment = "test amendment";
+        $old_session = $_SESSION['glpiactiveentities'] ?? [];
 
        // Set rights if needed
         if ($has_right) {
@@ -265,6 +266,8 @@ class MassiveAction extends DbTestCase
             ->string($item->fields['comment'])
             ->isIdenticalTo("$base_comment\n\n$amendment");
         }
+
+        $_SESSION['glpiactiveentities'] = $old_session;
     }
 
     protected function addNoteProvider()

--- a/tests/functionnal/NotificationAjax.php
+++ b/tests/functionnal/NotificationAjax.php
@@ -136,8 +136,5 @@ class NotificationAjax extends DbTestCase
         $this->array($notifs)->hasSize(1);
         $this->string($notifs[0]['url'])
          ->isIdenticalTo($computer->getFormURLWithID($computer->fields['id'], false));
-
-       //reset
-        $CFG_GLPI['notifications_ajax'] = 0;
     }
 }

--- a/tests/functionnal/NotificationAjaxSetting.php
+++ b/tests/functionnal/NotificationAjaxSetting.php
@@ -110,8 +110,5 @@ class NotificationAjaxSetting extends DbTestCase
                 $instance->showFormConfig();
             }
         )->notContains('Notifications are disabled.');
-
-       //rest to defaults
-        $CFG_GLPI['notifications_ajax'] = 0;
     }
 }

--- a/tests/functionnal/NotificationEventAjax.php
+++ b/tests/functionnal/NotificationEventAjax.php
@@ -220,9 +220,5 @@ TEXT,
             'mode' => 'ajax'
         ];
         $this->array($data)->isIdenticalTo($expected);
-
-       //reset
-        $CFG_GLPI['use_notifications'] = 0;
-        $CFG_GLPI['notifications_ajax'] = 0;
     }
 }

--- a/tests/functionnal/NotificationMailingSetting.php
+++ b/tests/functionnal/NotificationMailingSetting.php
@@ -111,8 +111,5 @@ class NotificationMailingSetting extends DbTestCase
                 $instance->showFormConfig();
             }
         )->notContains('Notifications are disabled.');
-
-       //rest to defaults
-        $CFG_GLPI['notifications_mailing'] = 0;
     }
 }

--- a/tests/functionnal/NotificationSettingConfig.php
+++ b/tests/functionnal/NotificationSettingConfig.php
@@ -134,10 +134,5 @@ class NotificationSettingConfig extends DbTestCase
          ->contains('Notification templates')
          ->contains('Browser followups configuration')
          ->contains('Email followups configuration');
-
-       //reset
-        $CFG_GLPI['use_notifications'] = 0;
-        $CFG_GLPI['notifications_mailing'] = 0;
-        $CFG_GLPI['notifications_ajax'] = 0;
     }
 }

--- a/tests/functionnal/NotificationTargetTicket.php
+++ b/tests/functionnal/NotificationTargetTicket.php
@@ -141,9 +141,6 @@ class NotificationTargetTicket extends DbTestCase
         ];
 
         $this->array($ret['tasks'])->isIdenticalTo($expected);
-
-       // switch back to default language
-        $_SESSION["glpilanguage"] = \Session::loadLanguage('en_GB');
     }
 
 

--- a/tests/functionnal/NotificationTargetUser.php
+++ b/tests/functionnal/NotificationTargetUser.php
@@ -107,14 +107,13 @@ class NotificationTargetUser extends DbTestCase
         $user = new \mock\User();
         $this->calling($user)->getPasswordExpirationTime = $expiration_time;
 
-        $cfg_backup = $CFG_GLPI;
-        $CFG_GLPI['password_expiration_lock_delay'] = $lock_delay;$target = new \NotificationTargetUser(
+        $CFG_GLPI['password_expiration_lock_delay'] = $lock_delay;
+        $target = new \NotificationTargetUser(
             getItemByTypeName('Entity', '_test_root_entity', true),
             'passwordexpires',
             $user
         );
         $target->addDataForTemplate('passwordexpires');
-        $CFG_GLPI = $cfg_backup;
 
         $this->checkTemplateData($target->data, $expected);
     }

--- a/tests/functionnal/Notification_NotificationTemplate.php
+++ b/tests/functionnal/Notification_NotificationTemplate.php
@@ -234,6 +234,5 @@ class Notification_NotificationTemplate extends DbTestCase
         $this->boolean(\Notification_NotificationTemplate::hasActiveMode())->isFalse();
         $CFG_GLPI['notifications_ajax'] = 1;
         $this->boolean(\Notification_NotificationTemplate::hasActiveMode())->isTrue();
-        $CFG_GLPI['notifications_ajax'] = 0;
     }
 }

--- a/tests/functionnal/Planning.php
+++ b/tests/functionnal/Planning.php
@@ -80,8 +80,6 @@ class Planning extends \DbTestCase
 
         $this->login();
 
-        $session_backup = $_SESSION['glpi_plannings'];
-
         \Planning::initSessionForCurrentUser();
 
        // Expected results
@@ -161,8 +159,6 @@ class Planning extends \DbTestCase
                 'end'   => '2019-11-30 23:59:59',
             ]
         );
-
-        $_SESSION['glpi_plannings'] = $session_backup;
 
         foreach ($expected_events_keys as $list_var => $events_keys) {
             $events_list = $$list_var;

--- a/tests/functionnal/Reminder.php
+++ b/tests/functionnal/Reminder.php
@@ -60,10 +60,8 @@ class Reminder extends DbTestCase
                             AND (`glpi_profiles_reminders`.`no_entity_restriction` = '1'))
                                   OR  (`glpi_entities_reminders`.`entities_id` IN ('0', '1', '2', '3')))"));
 
-        $bkp_groups = $_SESSION['glpigroups'];
         $_SESSION['glpigroups'] = [42, 1337];
         $str = \Reminder::addVisibilityRestrict();
-        $_SESSION['glpigroups'] = $bkp_groups;
         $this->string(trim(preg_replace('/\s+/', ' ', $str)))
          ->isIdenticalTo(preg_replace('/\s+/', ' ', "(`glpi_reminders`.`users_id` = '4'  OR `glpi_reminders_users`.`users_id` = '4'  OR (`glpi_groups_reminders`.`groups_id`
                                  IN ('42', '1337')

--- a/tests/functionnal/ReminderTranslation.php
+++ b/tests/functionnal/ReminderTranslation.php
@@ -76,10 +76,8 @@ class ReminderTranslation extends DbTestCase
         $this->integer((int)$nb)->isIdenticalTo(2);
 
        // second, test what we retrieve
-        $current_lang = $_SESSION['glpilanguage'];
         $_SESSION['glpilanguage'] = 'fr_FR';
         $text = \ReminderTranslation::getTranslatedValue($reminder1, "text");
-        $_SESSION['glpilanguage'] = $current_lang;
         $this->string($text)->isIdenticalTo($text_fr);
     }
 

--- a/tests/functionnal/SLM.php
+++ b/tests/functionnal/SLM.php
@@ -631,8 +631,6 @@ class SLM extends DbTestCase
     {
         $this->login();
 
-        $currenttime_bak = $_SESSION['glpi_currenttime'];
-
        // Create SLM with TTR/TTO OLA/SLA
         $slm = new \SLM();
         $slm_id = $slm->add(
@@ -759,7 +757,6 @@ class SLM extends DbTestCase
                 'date_mod'    => date('Y-m-d H:i:s', strtotime($ticket->fields['date']) + 1),
             ]
         );
-        $_SESSION['glpi_currenttime'] = $currenttime_bak;
 
         $this->boolean($updated)->isTrue();
 

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -63,7 +63,6 @@ class Search extends DbTestCase
         }
 
        // force session in debug mode (to store & retrieve sql errors)
-        $glpi_use_mode             = $_SESSION['glpi_use_mode'];
         $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
 
        // don't compute last request from session
@@ -79,9 +78,6 @@ class Search extends DbTestCase
             $data['last_errors'] = implode(', ', $DEBUG_SQL['errors']);
             unset($DEBUG_SQL['errors']);
         }
-
-       // restore glpi mode to previous
-        $_SESSION['glpi_use_mode'] = $glpi_use_mode;
 
        // do not store this search from session
         \Search::resetSaveSearch();
@@ -1586,10 +1582,6 @@ class Search extends DbTestCase
         $data = $this->doSearch('State', $search_params);
 
         $this->integer($data['data']['totalcount'])->isIdenticalTo(1);
-
-        $conf->setConfigurationValues('core', ['translate_dropdowns' => 0]);
-        $CFG_GLPI['translate_dropdowns'] = 0;
-        unset($_SESSION['glpi_dropdowntranslations']);
     }
 
     public function dataInfocomOptions()

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -2133,11 +2133,8 @@ class Ticket extends DbTestCase
            ->isEqualto(\CommonITILObject::INCOMING);
 
        // drop UPDATE right to TU_USER and redo "associate myself"
-        $saverights = $_SESSION['glpiactiveprofile'];
         $_SESSION['glpiactiveprofile']['ticket'] -= \UPDATE;
         $this->integer((int) $ticket_user->add($input_ticket_user))->isGreaterThan(0);
-       // restore rights
-        $_SESSION['glpiactiveprofile'] = $saverights;
        //check ticket creation
         $this->boolean($ticket_user->getFromDB($ticket_user->getId()))->isTrue();
 
@@ -2168,8 +2165,6 @@ class Ticket extends DbTestCase
                                                + \Ticket::READGROUP
                                                + \Ticket::OWN; // OWN right must allow self-assign
         $this->integer((int) $ticket_user->add($input_ticket_user))->isGreaterThan(0);
-       // restore rights
-        $_SESSION['glpiactiveprofile'] = $saverights;
        //check ticket creation
         $this->boolean($ticket_user->getFromDB($ticket_user->getId()))->isTrue();
 

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -3463,12 +3463,10 @@ class Ticket extends DbTestCase
         $ticket = new \Ticket();
         $this->boolean($ticket->getFromDB($ticket_id))->isTrue();
 
-        $session_backup = $_SESSION['glpiactiveprofile'];
         foreach ($rights as $rightname => $rightvalue) {
             $_SESSION['glpiactiveprofile'][$rightname] = $rightvalue;
         }
         $crit = $ticket->getAssociatedDocumentsCriteria($bypass_rights);
-        $_SESSION['glpiactiveprofile'] = $session_backup;
 
         $it = new \DBmysqlIterator(null);
         $it->execute('glpi_tickets', $crit);

--- a/tests/functionnal/TicketTask.php
+++ b/tests/functionnal/TicketTask.php
@@ -264,7 +264,6 @@ class TicketTask extends DbTestCase
             function () {
                 $_SESSION['glpidisplay_count_on_home'] = 2;
                 \TicketTask::showCentralList(0, 'todo', false);
-                unset($_SESSION['glpidisplay_count_on_home']);
             }
         )
          ->contains("Ticket tasks to do <span class='primary-bg primary-fg count'>2 on 4</span>")

--- a/tests/functionnal/Toolbox.php
+++ b/tests/functionnal/Toolbox.php
@@ -664,18 +664,10 @@ class Toolbox extends DbTestCase
         $expected_url   = str_replace('{docid}', $doc_id, $expected_url);
         $expected_result = '<a href="' . $expected_url . '" target="_blank" ><img alt="' . $img_tag . '" width="10" src="' . $expected_url . '" /></a>';
 
-       // Save old config
         global $CFG_GLPI;
-        $old_url_base = $CFG_GLPI['url_base'];
 
-       // Get result
         $CFG_GLPI['url_base'] = $url_base;
         $result = \Toolbox::convertTagToImage($content_text, $item, [$doc_id => ['tag' => $img_tag]]);
-
-       // Restore config
-        $CFG_GLPI['url_base'] = $old_url_base;
-
-       // Validate result
         $this->string($result)->isEqualTo($expected_result);
     }
 

--- a/tests/functionnal/Transfer.php
+++ b/tests/functionnal/Transfer.php
@@ -165,7 +165,6 @@ class Transfer extends DbTestCase
                 [$id]
             );
             $transfer->moveItems([$itemtype => [$id]], $dentity, [$id]);
-            unset($_SESSION['glpitransfer_list']);
 
             $this->boolean($obj->getFromDB($id))->isTrue();
             $this->integer((int)$obj->fields['entities_id'])->isidenticalTo($dentity, "Transfer has failed on $itemtype");
@@ -239,7 +238,6 @@ class Transfer extends DbTestCase
             [$did]
         );
         $transfer->moveItems(['Domain' => [$did]], $dentity, [$did]);
-        unset($_SESSION['glpitransfer_list']);
 
         $this->boolean($domain->getFromDB($did))->isTrue();
         $this->integer((int)$domain->fields['entities_id'])->isidenticalTo($dentity);

--- a/tests/functionnal/Unmanaged.php
+++ b/tests/functionnal/Unmanaged.php
@@ -113,7 +113,6 @@ Compiled Fri 26-Mar-10 09:14 by prod_rel_team</DESCRIPTION>
         $data = json_decode($converter->convert($net_xml_source));
         $CFG_GLPI["is_contact_autoupdate"] = 0;
         $inventory = new \Glpi\Inventory\Inventory($data);
-        $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
@@ -161,7 +160,6 @@ Compiled Fri 26-Mar-10 09:14 by prod_rel_team</DESCRIPTION>
 
         $CFG_GLPI["is_contact_autoupdate"] = 0;
         $inventory = new \Glpi\Inventory\Inventory($source);
-        $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {

--- a/tests/functionnal/User.php
+++ b/tests/functionnal/User.php
@@ -852,15 +852,12 @@ class User extends \DbTestCase
         $this->boolean($user->update(['id' => $user_id, 'password_last_update' => $last_update]))->isTrue();
         $this->boolean($user->getFromDB($user->fields['id']))->isTrue();
 
-        $cfg_backup = $CFG_GLPI;
         $CFG_GLPI['password_expiration_delay'] = $expiration_delay;
         $CFG_GLPI['password_expiration_notice'] = $expiration_notice;
 
         $expiration_time = $user->getPasswordExpirationTime();
         $should_change_password = $user->shouldChangePassword();
         $has_password_expire = $user->hasPasswordExpired();
-
-        $CFG_GLPI = $cfg_backup;
 
         $this->variable($expiration_time)->isEqualTo($expected_expiration_time);
         $this->boolean($should_change_password)->isEqualTo($expected_should_change_password);
@@ -988,14 +985,12 @@ class User extends \DbTestCase
         $this->boolean($crontask->getFromDBbyName(\User::getType(), 'passwordexpiration'))->isTrue();
         $crontask->fields['param'] = $cron_limit;
 
-        $cfg_backup = $CFG_GLPI;
         $CFG_GLPI['password_expiration_delay'] = $expiration_delay;
         $CFG_GLPI['password_expiration_notice'] = $notice_delay;
         $CFG_GLPI['password_expiration_lock_delay'] = $lock_delay;
         $CFG_GLPI['use_notifications']  = true;
         $CFG_GLPI['notifications_ajax'] = 1;
         $result = \User::cronPasswordExpiration($crontask);
-        $CFG_GLPI = $cfg_backup;
 
         $this->integer($result)->isEqualTo($expected_result);
         $this->integer(

--- a/tests/units/Glpi/Application/ErrorHandler.php
+++ b/tests/units/Glpi/Application/ErrorHandler.php
@@ -144,7 +144,6 @@ class ErrorHandler extends \GLPITestCase
         $logger = $this->newMockInstance('Monolog\\Logger', null, null, ['test-logger', [$handler]]);
 
        // Force session in debug mode (to get debug output)
-        $previous_use_mode         = $_SESSION['glpi_use_mode'];
         $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
 
         $this->newTestedInstance($logger);
@@ -152,17 +151,12 @@ class ErrorHandler extends \GLPITestCase
         $this->testedInstance->register();
 
        // Assert that nothing is logged when using '@' operator
-        $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
         @$error_call();
-        $_SESSION['glpi_use_mode'] = $previous_use_mode;
         $this->integer(count($handler->getRecords()))->isEqualTo(0);
         $this->output->isEmpty();
 
        // Assert that error handler acts as expected when not using '@' operator
-        $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
         $error_call();
-        $_SESSION['glpi_use_mode'] = $previous_use_mode;
-
         $this->integer(count($handler->getRecords()))->isEqualTo(1);
         $this->boolean($handler->hasRecordThatMatches($expected_msg_pattern, $expected_log_level));
 
@@ -273,24 +267,19 @@ class ErrorHandler extends \GLPITestCase
         $logger = $this->newMockInstance('Monolog\\Logger', null, null, ['test-logger', [$handler]]);
 
        // Force session in debug mode (to get debug output)
-        $previous_use_mode         = $_SESSION['glpi_use_mode'];
         $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
 
         $this->newTestedInstance($logger);
         $this->testedInstance->setForwardToInternalHandler(false);
 
        // Assert that nothing is logged when using '@' operator
-        $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
         @$this->testedInstance->handleError($error_code, 'err_msg', __FILE__, __LINE__);
-        $_SESSION['glpi_use_mode'] = $previous_use_mode;
         $this->integer(count($handler->getRecords()))->isEqualTo(0);
         $this->output->isEmpty();
 
        // Assert that error handler acts as expected when not using '@' operator
        // Fatal error are not logged by function, but other errors should be
-        $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
         $this->testedInstance->handleError($error_code, 'err_msg', __FILE__, __LINE__);
-        $_SESSION['glpi_use_mode'] = $previous_use_mode;
 
         if ($is_fatal_error) {
            // If error is a Fatal error, message logging should be delegated to
@@ -303,9 +292,7 @@ class ErrorHandler extends \GLPITestCase
                 'file'    => __FILE__,
                 'line'    => __LINE__,
             ];
-            $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
             $this->testedInstance->handleFatalError();
-            $_SESSION['glpi_use_mode'] = $previous_use_mode;
         }
 
         $this->integer(count($handler->getRecords()))->isEqualTo(1);
@@ -329,35 +316,25 @@ class ErrorHandler extends \GLPITestCase
          . '/';
 
        // Force session in debug mode (to get debug output)
-        $previous_use_mode         = $_SESSION['glpi_use_mode'];
         $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
         $this->newTestedInstance($logger);
 
        // Assert that exception handler logs exception and output error when quiet parameter is not set
-        $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
         $this->testedInstance->handleException($exception);
-        $_SESSION['glpi_use_mode'] = $previous_use_mode;
-
         $this->integer(count($handler->getRecords()))->isEqualTo(1);
         $this->boolean($handler->hasRecordThatMatches($expected_msg_pattern, LogLevel::CRITICAL));
         $this->output->matches($expected_msg_pattern);
         $handler->reset(); // Remove records
 
        // Assert that exception handler logs exception and DO NOT output error when parameter mode is set to true
-        $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
         $this->testedInstance->handleException($exception, true);
-        $_SESSION['glpi_use_mode'] = $previous_use_mode;
-
         $this->integer(count($handler->getRecords()))->isEqualTo(1);
         $this->boolean($handler->hasRecordThatMatches($expected_msg_pattern, LogLevel::CRITICAL));
         $this->output->isEmpty();
         $handler->reset(); // Remove records
 
        // Assert that exception handler logs exception and output error when parameter mode is set to false
-        $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
         $this->testedInstance->handleException($exception, false);
-        $_SESSION['glpi_use_mode'] = $previous_use_mode;
-
         $this->integer(count($handler->getRecords()))->isEqualTo(1);
         $this->boolean($handler->hasRecordThatMatches($expected_msg_pattern, LogLevel::CRITICAL));
         $this->output->matches($expected_msg_pattern);

--- a/tests/units/Html.php
+++ b/tests/units/Html.php
@@ -589,9 +589,7 @@ class Html extends \GLPITestCase
     public function testManageRefreshPage()
     {
        //no session refresh, no args => no timer
-        if (isset($_SESSION['glpirefresh_views'])) {
-            unset($_SESSION['glpirefresh_views']);
-        }
+        unset($_SESSION['glpirefresh_views']);
 
         $base_script = \Html::scriptBlock("window.setInterval(function() {
                ##CALLBACK##


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I made some tests and it seems that it is not even required, as every test is executed in a distinct sub-process, but at least this will be done globally, instead of having to do it manually in each test.