### PR TITLE
Do not block session with inventory request

### DIFF
--- a/ajax/agent.php
+++ b/ajax/agent.php
@@ -51,6 +51,7 @@ if (isset($_POST['action']) && isset($_POST['id'])) {
     }
     $answer = [];
 
+    session_write_close();
     switch ($_POST['action']) {
         case Agent::ACTION_INVENTORY:
             $answer = $agent->requestInventory();


### PR DESCRIPTION
Waiting for inventory response can block your session for a long time, especially if you are on a server with a proxy where each request will wait until the max timeout before failing.

Would this change be OK ?
I don't see any code that would impact the session after this line.

| Q             | A
| ------------- | ---
| Bug fix?      | yes/
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
