### PR TITLE
small dashboard issues

### DIFF
--- a/css/standalone/dashboard.scss
+++ b/css/standalone/dashboard.scss
@@ -86,10 +86,9 @@ $break_tablet: 1400px;
     &.mini {
         padding-top: 0;
         margin: 0 auto;
-        margin-bottom: -10px;
+        margin-bottom: -45px !important;
         z-index: 1;
         box-sizing: content-box;
-        height: 100px;
 
         & + .search_page {
             z-index: 2;
@@ -101,7 +100,6 @@ $break_tablet: 1400px;
 
         .grid-guide {
             top: 0;
-            bottom: 0 !important;
         }
 
         .main-icon {

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1043,7 +1043,7 @@ var Dashboard = {
 
     generateCss: function() {
         var dash_width    = Math.floor(this.element.width());
-        var cell_length   = dash_width / this.cols;
+        var cell_length   = (dash_width - 1) / this.cols;
         var cell_height   = cell_length;
         var cell_fullsize = (dash_width / this.cols);
         var width_percent = 100 / this.cols;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Replace #12880 and #12532

fixes:

- [x] zoom issues on mini-dashboard
- [x] `cell-add` block wrongly wrapping one index too early
- [x] bottom spacing due to to hidden gridstack block
