### PR TITLE
Fix database integrity check on plugins

### DIFF
--- a/src/Console/Database/CheckSchemaIntegrityCommand.php
+++ b/src/Console/Database/CheckSchemaIntegrityCommand.php
@@ -169,8 +169,11 @@ class CheckSchemaIntegrityCommand extends AbstractCommand
         }
 
         if (!$checker->canCheckIntegrity($installed_version, $context)) {
+            $message = $plugin_key === null
+                ? sprintf(__('Checking database integrity of version "%s" is not supported.'), $installed_version)
+                : sprintf(__('Checking database integrity of plugin "%s" is not supported.'), $plugin_key);
             throw new \Glpi\Console\Exception\EarlyExitException(
-                '<error>' . sprintf(__('Checking database integrity of version "%s" is not supported.'), $installed_version) . '</error>',
+                '<error>' . $message . '</error>',
                 self::ERROR_UNSUPPORTED_VERSION
             );
         }

--- a/src/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
+++ b/src/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
@@ -717,14 +717,15 @@ class DatabaseSchemaIntegrityChecker
             $schema_path = sprintf('%s/install/mysql/glpi-%s-empty.sql', GLPI_ROOT, $schema_version_clean);
         } elseif (preg_match('/^plugin:(?<plugin_key>\w+)$/', $context) === 1) {
             $plugin_key = str_replace('plugin:', '', $context);
+            Plugin::load($plugin_key); // Load setup file, to be able to check schema even on inactive plugins
             $function_name = sprintf('plugin_%s_getSchemaPath', $plugin_key);
-            if (!Plugin::isPluginActive($plugin_key) || !function_exists($function_name)) {
+            if (!function_exists($function_name)) {
                 return null;
             }
             $schema_path = $function_name($schema_version);
         }
 
-        return !empty($schema_version) && file_exists($schema_path)
+        return !empty($schema_path) && file_exists($schema_path)
             ? $schema_path
             : null;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Message was not correct (was `Checking database integrity of version "" is not supported.` and will now be `Checking database integrity of plugin "formcreator" is not supported.`.
2. A wong variable usage was breaking the feature for plugins (fixed by: `!empty($schema_version)` -> `!empty($schema_path)`).
3. Now it will be possible to run the command even on inactive plugins. Plugin is responsible to know which version of schema is actually installed.