### PR TITLE
fix height of dashboard charts in their cards

### DIFF
--- a/src/Dashboard/Widget.php
+++ b/src/Dashboard/Widget.php
@@ -593,7 +593,7 @@ HTML;
 
          {$palette_style}
       </style>
-      <div>
+      <div style="height: 100%">
          <div class="card g-chart {$class}"
             id="{$chart_id}">
             <div class="chart ct-chart">{$no_data_html}</div>
@@ -1094,7 +1094,7 @@ JAVASCRIPT;
       {$palette_style}
       </style>
 
-      <div>
+      <div style="height: 100%">
          <div class="card g-chart $class"
                id="{$chart_id}">
             <div class="chart ct-chart">$no_data_html</div>
@@ -1553,7 +1553,7 @@ JAVASCRIPT;
       {$palette_style}
       </style>
 
-      <div>
+      <div style="height: 100%">
           <div class="card g-chart $class"
                id="{$chart_id}">
              <div class="chart ct-chart"></div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

fix regression added in #12476

intermediate `<div>` doesn't have correct height.
To note: this (and the bug in the previous pr) is completely fixed by #12591 

![image](https://user-images.githubusercontent.com/418844/194888170-3c9e3284-2dcd-4881-bf31-ed5a57f76b2d.png)

