### PR TITLE
fix(inventory): do not purge dynamic item, lock it

### DIFF
--- a/front/computervirtualmachine.form.php
+++ b/front/computervirtualmachine.form.php
@@ -47,11 +47,11 @@ if (!isset($_GET["computers_id"])) {
     $_GET["computers_id"] = "";
 }
 
-$disk = new ComputerVirtualMachine();
+$computer_vm = new ComputerVirtualMachine();
 if (isset($_POST["add"])) {
-    $disk->check(-1, CREATE, $_POST);
+    $computer_vm->check(-1, CREATE, $_POST);
 
-    if ($disk->add($_POST)) {
+    if ($computer_vm->add($_POST)) {
         Event::log(
             $_POST['computers_id'],
             "computers",
@@ -61,16 +61,30 @@ if (isset($_POST["add"])) {
             sprintf(__('%s adds a virtual machine'), $_SESSION["glpiname"])
         );
         if ($_SESSION['glpibackcreated']) {
-            Html::redirect($disk->getLinkURL());
+            Html::redirect($computer_vm->getLinkURL());
         }
     }
     Html::back();
-} else if (isset($_POST["purge"])) {
-    $disk->check($_POST["id"], PURGE);
+}  else if (isset($_POST["delete"])) {
+    $computer_vm->check($_POST["id"], DELETE);
+    $computer_vm->delete($_POST);
 
-    if ($disk->delete($_POST, 1)) {
+    Event::log(
+        $_POST["id"],
+        "computers",
+        4,
+        "inventory",
+        //TRANS: %s is the user login
+        sprintf(__('%s deletes an item'), $_SESSION["glpiname"])
+    );
+    Html::redirect(Toolbox::getItemTypeFormURL('Computer') . '?id=' . $computer_vm->fields['computers_id'] .
+                  ($computer->fields['is_template'] ? "&withtemplate=1" : ""));
+} else if (isset($_POST["purge"])) {
+    $computer_vm->check($_POST["id"], PURGE);
+
+    if ($computer_vm->delete($_POST, 1)) {
         Event::log(
-            $disk->fields['computers_id'],
+            $computer_vm->fields['computers_id'],
             "computers",
             4,
             "inventory",
@@ -79,15 +93,15 @@ if (isset($_POST["add"])) {
         );
     }
     $computer = new Computer();
-    $computer->getFromDB($disk->fields['computers_id']);
-    Html::redirect(Toolbox::getItemTypeFormURL('Computer') . '?id=' . $disk->fields['computers_id'] .
+    $computer->getFromDB($computer_vm->fields['computers_id']);
+    Html::redirect(Toolbox::getItemTypeFormURL('Computer') . '?id=' . $computer_vm->fields['computers_id'] .
                   ($computer->fields['is_template'] ? "&withtemplate=1" : ""));
 } else if (isset($_POST["update"])) {
-    $disk->check($_POST["id"], UPDATE);
+    $computer_vm->check($_POST["id"], UPDATE);
 
-    if ($disk->update($_POST)) {
+    if ($computer_vm->update($_POST)) {
         Event::log(
-            $disk->fields['computers_id'],
+            $computer_vm->fields['computers_id'],
             "computers",
             4,
             "inventory",

--- a/front/computervirtualmachine.form.php
+++ b/front/computervirtualmachine.form.php
@@ -65,7 +65,7 @@ if (isset($_POST["add"])) {
         }
     }
     Html::back();
-}  else if (isset($_POST["delete"])) {
+} else if (isset($_POST["delete"])) {
     $computer_vm->check($_POST["id"], DELETE);
     $computer_vm->delete($_POST);
 

--- a/front/item_disk.form.php
+++ b/front/item_disk.form.php
@@ -67,6 +67,19 @@ if (isset($_POST["add"])) {
         }
     }
     Html::back();
+} else if (isset($_POST["delete"])) {
+    $disk->check($_POST["id"], DELETE);
+    $disk->delete($_POST);
+
+    Event::log(
+        $_POST["id"],
+        $_POST['itemtype'],
+        4,
+        "inventory",
+        //TRANS: %s is the user login
+        sprintf(__('%s deletes an item'), $_SESSION["glpiname"])
+    );
+    $disk->redirectToList();
 } else if (isset($_POST["purge"])) {
     $disk->check($_POST["id"], PURGE);
 

--- a/front/networkname.form.php
+++ b/front/networkname.form.php
@@ -56,6 +56,22 @@ if (isset($_POST["add"])) {
         }
     }
     Html::back();
+}  else if (isset($_POST["delete"])) {
+    $nn->check($_POST["id"], DELETE);
+    $nn->delete($_POST);
+
+    Event::log(
+        $_POST["id"],
+        $_POST['itemtype'],
+        4,
+        "inventory",
+        //TRANS: %s is the user login
+        sprintf(__('%s deletes an item'), $_SESSION["glpiname"])
+    );
+    if ($_SESSION['glpibackcreated']) {
+        Html::redirect($nn->getLinkURL());
+    }
+    Html::back();
 } else if (isset($_POST["purge"])) {
     $nn->check($_POST['id'], PURGE);
     $nn->delete($_POST, 1);

--- a/front/networkname.form.php
+++ b/front/networkname.form.php
@@ -56,7 +56,7 @@ if (isset($_POST["add"])) {
         }
     }
     Html::back();
-}  else if (isset($_POST["delete"])) {
+} else if (isset($_POST["delete"])) {
     $nn->check($_POST["id"], DELETE);
     $nn->delete($_POST);
 

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -771,6 +771,7 @@ class CommonDBTM extends CommonGLPI
     {
         global $DB;
 
+
         if (
             ($force == 1)
             || !$this->maybeDeleted()

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -771,7 +771,6 @@ class CommonDBTM extends CommonGLPI
     {
         global $DB;
 
-
         if (
             ($force == 1)
             || !$this->maybeDeleted()

--- a/src/ComputerVirtualMachine.php
+++ b/src/ComputerVirtualMachine.php
@@ -58,11 +58,6 @@ class ComputerVirtualMachine extends CommonDBChild
         return __('Virtualization');
     }
 
-    /**
-     * @see CommonDBTM::useDeletedToLockIfDynamic()
-     *
-     * @since 0.84
-     **/
     public function useDeletedToLockIfDynamic()
     {
         return false;

--- a/src/ComputerVirtualMachine.php
+++ b/src/ComputerVirtualMachine.php
@@ -58,6 +58,15 @@ class ComputerVirtualMachine extends CommonDBChild
         return __('Virtualization');
     }
 
+    /**
+     * @see CommonDBTM::useDeletedToLockIfDynamic()
+     *
+     * @since 0.84
+     **/
+    public function useDeletedToLockIfDynamic()
+    {
+        return false;
+    }
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {

--- a/src/Item_Disk.php
+++ b/src/Item_Disk.php
@@ -63,6 +63,17 @@ class Item_Disk extends CommonDBChild
     }
 
 
+    /**
+     * @see CommonDBTM::useDeletedToLockIfDynamic()
+     *
+     * @since 0.84
+     **/
+    public function useDeletedToLockIfDynamic()
+    {
+        return false;
+    }
+
+
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
 

--- a/src/Item_Disk.php
+++ b/src/Item_Disk.php
@@ -63,11 +63,6 @@ class Item_Disk extends CommonDBChild
     }
 
 
-    /**
-     * @see CommonDBTM::useDeletedToLockIfDynamic()
-     *
-     * @since 0.84
-     **/
     public function useDeletedToLockIfDynamic()
     {
         return false;

--- a/src/Item_SoftwareVersion.php
+++ b/src/Item_SoftwareVersion.php
@@ -48,10 +48,6 @@ class Item_SoftwareVersion extends CommonDBRelation
     public static $log_history_2_add    = Log::HISTORY_INSTALL_SOFTWARE;
     public static $log_history_2_delete = Log::HISTORY_UNINSTALL_SOFTWARE;
 
-    public function useDeletedToLockIfDynamic()
-    {
-        return false;
-    }
 
     public static function getTypeName($nb = 0)
     {

--- a/src/NetworkName.php
+++ b/src/NetworkName.php
@@ -69,6 +69,16 @@ class NetworkName extends FQDNLabel
         return _n('Network name', 'Network names', $nb);
     }
 
+    /**
+     * @see CommonDBTM::useDeletedToLockIfDynamic()
+     *
+     * @since 0.84
+     **/
+    public function useDeletedToLockIfDynamic()
+    {
+        return false;
+    }
+
 
     public function defineTabs($options = [])
     {

--- a/src/NetworkName.php
+++ b/src/NetworkName.php
@@ -69,11 +69,6 @@ class NetworkName extends FQDNLabel
         return _n('Network name', 'Network names', $nb);
     }
 
-    /**
-     * @see CommonDBTM::useDeletedToLockIfDynamic()
-     *
-     * @since 0.84
-     **/
     public function useDeletedToLockIfDynamic()
     {
         return false;

--- a/tests/functionnal/Item_Disk.php
+++ b/tests/functionnal/Item_Disk.php
@@ -116,6 +116,7 @@ class Item_Disk extends DbTestCase
                 'id'  => $id
             ])
         )->isTrue();
-        $this->boolean($obj->getFromDB($id))->isFalse();
+        $this->boolean($obj->getFromDB($id))->istrue(); //it's always in DB but with is_deleted = 1
+        $this->boolean($obj->fields['is_deleted'])->isTrue();
     }
 }

--- a/tests/functionnal/Item_Disk.php
+++ b/tests/functionnal/Item_Disk.php
@@ -117,6 +117,6 @@ class Item_Disk extends DbTestCase
             ])
         )->isTrue();
         $this->boolean($obj->getFromDB($id))->istrue(); //it's always in DB but with is_deleted = 1
-        $this->boolean($obj->fields['is_deleted'])->isTrue();
+        $this->integer($obj->fields['is_deleted'])->isIdenticalTo(1);
     }
 }


### PR DESCRIPTION
Fix ```purge``` / ```delete``` behavior from ```dynamic``` items. 

### For item with dedicated form (ex : ```Item_Disk```)
Ensure that this function is used :
```php
    public function useDeletedToLockIfDynamic()
    {
        return false;
    }
``` 
and be sure that ```item.form.php``` handle ```deleted``` action.

### For item without dedicated form (deleted from massive action) (ex : ```Item_SoftwareVersion```)
 Ensure that this function is NOT used (this use case is handled by ```MassiveAction``` logic) :
```php
    public function useDeletedToLockIfDynamic()
    {
        return false;
    }
``` 


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
