### PR TITLE
fix(timeline): restore the read_more button on long timeline items

### DIFF
--- a/css/includes/components/_richtext.scss
+++ b/css/includes/components/_richtext.scss
@@ -71,9 +71,9 @@ body.mce-content-body {
         max-height: 350px;
         position: relative;
         overflow: hidden;
-    
+
         .read_more {
-           background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, #f1f4e3 100%);
+            background: linear-gradient(to bottom, rgba(255, 255, 255, 0%) 0%, #f1f4e3 100%);
         }
     }
 }

--- a/css/includes/components/_richtext.scss
+++ b/css/includes/components/_richtext.scss
@@ -66,6 +66,16 @@ body.mce-content-body {
         content: "\ea99";
         padding-right: 4px;
     }
+
+    .long_text {
+        max-height: 350px;
+        position: relative;
+        overflow: hidden;
+    
+        .read_more {
+           background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, #f1f4e3 100%);
+        }
+    }
 }
 
 .user-mention,

--- a/src/RichText/RichText.php
+++ b/src/RichText/RichText.php
@@ -272,8 +272,11 @@ final class RichText
             'images_gallery' => false,
             'user_mentions'  => true,
             'images_lazy'    => true,
+            'text_maxsize'   => 2000,
         ];
         $p = array_replace($p, $params);
+
+        $content_size = strlen($content);
 
        // Sanitize content first (security and to decode HTML entities)
         $content = self::getSafeHtml($content);
@@ -288,6 +291,17 @@ final class RichText
 
         if ($p['images_gallery']) {
             $content = self::replaceImagesByGallery($content);
+        }
+
+        if ($content_size > $p['text_maxsize']) {
+            $content = <<<HTML
+<div class="long_text">$content
+    <p class='read_more'>
+        <span class='read_more_button'>...</span>
+    </p>
+</div>
+HTML;
+            $content .= HTML::scriptBlock('$(function() { read_more(); });');
         }
 
         return $content;


### PR DESCRIPTION
In 9.5, the long follow-ups were not displayed entirely by default, there was a "read_mode" button to display everything.

This PR restores this feature.

![image](https://user-images.githubusercontent.com/8530352/195053699-8ff40c12-96cd-42a2-bdc3-1173beb2d5d9.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25170
