### PR TITLE
requester should be able to reopen

### DIFF
--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -230,7 +230,7 @@
                                  <input type="checkbox" name="pending" value="1" class="form-check-input"
                                        id="enable-pending-reasons-{{ rand }}"
                                        role="button"
-                                       {{ item.fields['status'] == constant('CommonITILObject::WAITING') ? 'checked' : '' }}
+                                       {{ item.fields['status'] == constant('CommonITILObject::WAITING') and not add_reopen ? 'checked' : '' }}
                                        data-bs-toggle="collapse" data-bs-target="#pending-reasons-setup-{{ rand }}" />
                               </label>
                            </span>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
!24785

Regression in #12684 (part of forcing waiting checkbox to true if ticket.status = WAITING). Fortunately not yet published in a release.
If needRopen() = true, we should not check the waiting checkbox
