### PR TITLE
fix itemtype migration

### DIFF
--- a/src/Migration.php
+++ b/src/Migration.php
@@ -1430,11 +1430,11 @@ class Migration
 
         $this->displayMessage(sprintf(__('Renaming "%s" itemtype to "%s"...'), $old_itemtype, $new_itemtype));
 
-        if ($update_structure) {
-            $old_table = getTableForItemType($old_itemtype);
-            $new_table = getTableForItemType($new_itemtype);
-            $old_fkey  = getForeignKeyFieldForItemType($old_itemtype);
-            $new_fkey  = getForeignKeyFieldForItemType($new_itemtype);
+        $old_table = getTableForItemType($old_itemtype);
+        $new_table = getTableForItemType($new_itemtype);
+        if ($old_table !== $new_table && $update_structure) {
+            $old_fkey  = getForeignKeyFieldForTable($old_table);
+            $new_fkey  = getForeignKeyFieldForTable($new_table);
 
            // Check prerequisites
             if (!$DB->tableExists($old_table)) {

--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -1038,6 +1038,33 @@ class Migration extends \GLPITestCase
             "UPDATE `glpi_stuffs` SET `itemtype_source` = 'NewName' WHERE `itemtype_source` = 'SomeOldType'",
             "UPDATE `glpi_stuffs` SET `itemtype_dest` = 'NewName' WHERE `itemtype_dest` = 'SomeOldType'",
         ]);
+
+        // Test renaming when old class and new class have the same table name
+        $this->queries = [];
+
+        $this->output(
+            function () {
+                $this->migration->renameItemtype('PluginFooThing', 'GlpiPlugin\\Foo\\Thing');
+                $this->migration->executeMigration();
+            }
+        )->isIdenticalTo(
+            implode(
+                '',
+                [
+                    'Renaming "PluginFooThing" itemtype to "GlpiPlugin\\Foo\\Thing"...',
+                    'Renaming "PluginFooThing" itemtype to "GlpiPlugin\\Foo\\Thing" in all tables...',
+                    'Task completed.',
+                ]
+            )
+        );
+
+        $this->array($this->queries)->isIdenticalTo([
+            "UPDATE `glpi_computers` SET `itemtype` = 'GlpiPlugin\\Foo\\Thing' WHERE `itemtype` = 'PluginFooThing'",
+            "UPDATE `glpi_users` SET `itemtype` = 'GlpiPlugin\\Foo\\Thing' WHERE `itemtype` = 'PluginFooThing'",
+            "UPDATE `glpi_stuffs` SET `itemtype_source` = 'GlpiPlugin\\Foo\\Thing' WHERE `itemtype_source` = 'PluginFooThing'",
+            "UPDATE `glpi_stuffs` SET `itemtype_dest` = 'GlpiPlugin\\Foo\\Thing' WHERE `itemtype_dest` = 'PluginFooThing'",
+        ]);
+
     }
 
     public function testChangeSearchOption()

--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -1064,7 +1064,6 @@ class Migration extends \GLPITestCase
             "UPDATE `glpi_stuffs` SET `itemtype_source` = 'GlpiPlugin\\Foo\\Thing' WHERE `itemtype_source` = 'PluginFooThing'",
             "UPDATE `glpi_stuffs` SET `itemtype_dest` = 'GlpiPlugin\\Foo\\Thing' WHERE `itemtype_dest` = 'PluginFooThing'",
         ]);
-
     }
 
     public function testChangeSearchOption()


### PR DESCRIPTION
if an itemtype moves to a namespace, the table name does not change but the migration class fails in such case

From a internal discussion with @cedric-anne 

Solves a migration issue found in develop branch of Formcreator

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
