### PR TITLE
Support case-sensitive LIKE queries

### DIFF
--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -76,8 +76,10 @@ class DBmysqlIterator implements SeekableIterator, Countable
         '>=',
         '<>',
         'LIKE',
+        'LIKE BINARY',
         'REGEXP',
         'NOT LIKE',
+        'NOT LIKE BINARY',
         'NOT REGEX',
         '&',
         '|'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This would allow adding proper SQL mappings for the RSQL case-sensitive `=like=` filter added in the High-Level API.

https://github.com/glpi-project/glpi/blob/2ece3698fa2c015887ea4780b5a424b599aad56c/src/Api/HL/RSQLInput.php#L100-L112