### PR TITLE
fix(inventory): convert datetime to date for os installation date

### DIFF
--- a/src/Inventory/Asset/OperatingSystem.php
+++ b/src/Inventory/Asset/OperatingSystem.php
@@ -79,7 +79,7 @@ class OperatingSystem extends InventoryAsset
         }
 
         if (property_exists($val, 'install_date')) {
-            $val->install_date = $val->install_date;
+            $val->install_date = date('Y-m-d', strtotime($val->install_date));
         }
 
         if (


### PR DESCRIPTION
Prevent SQL error (for new asset manually / dynamically imported)

```sql
Note:  Data truncated for column 'install_date' at row 1
```

Convert ```datetime``` to ```date```


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
