### PR TITLE
fix infinite loop on massive actions

### DIFF
--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -570,7 +570,7 @@ class MassiveAction
      **/
     public function getRemainings()
     {
-        return $this->remainings;
+        return $this->remainings ?? [];
     }
 
 

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -116,7 +116,7 @@ class MassiveAction
      * Items remaining in current process.
      * @var array
      */
-    private $remainings = [];
+    private $remainings = null;
 
     /**
      * Fields to remove after reload.
@@ -403,7 +403,9 @@ class MassiveAction
 
        // Add process elements
         if ($stage == 'process') {
-            $this->remainings = $this->items;
+            if (!isset($this->remainings)) {
+                $this->remainings = $this->items;
+            }
 
             $this->fields_to_remove_when_reload = ['fields_to_remove_when_reload'];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25195

Regression from #10975 (https://github.com/glpi-project/glpi/pull/10975/files#diff-284b41ead4d268948c291846bcb61a98c51a0eebb76968e6d09a40b485909777L280) because the control:
```
if (!isset($this->remainings)) {
...
} 
```

has been removed.

For explanation, when a massive takes more time than `max_execution_time`, there is a mechanism to reload the page with an identifier to retrieve the current execution and continue to parse the items stored in `$remainings`.

Previously, as the property was not declared explicitly:

- it was not set at the first execution (before reloading)
- it was set after reloading (by https://github.com/glpi-project/glpi/blob/10.0.3/src/MassiveAction.php#L395)

As the `if (!isset($this->remainings)) {` has been removed and the property explicitly declared as an array.
we always fill `$remainings` by the full list of items, and so we have an infinite loop