### PR TITLE
fix(search): translation in search result

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -7438,6 +7438,8 @@ HTML;
                             $out .= $data[$ID][$k]['trans'];
                         } elseif (isset($data[$ID][$k]['trans_completename']) && !empty($data[$ID][$k]['trans_completename'])) {
                             $out .= CommonTreeDropdown::sanitizeSeparatorInCompletename($data[$ID][$k]['trans_completename']);
+                        } elseif (isset($data[$ID][$k]['trans_name']) && !empty($data[$ID][$k]['trans_name'])) {
+                            $out .= $data[$ID][$k]['trans_name'];
                         } else {
                             $value = $data[$ID][$k]['name'];
                             $out .= $so['field'] === 'completename'


### PR DESCRIPTION
"Type" fields were not translated in the search results, although a translation existed.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25100
