### PR TITLE
Improve dashboard performances (replication)

### DIFF
--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -1107,9 +1107,7 @@ HTML;
         global $CFG_GLPI;
 
        // anonymous fct for adding relevant filters to cards
-        $add_filters_fct = static function ($itemtable) {
-            $DB = DBConnection::getReadConnection();
-
+        $add_filters_fct = static function ($itemtable, $DB) {
             $add_filters = [];
             if ($DB->fieldExists($itemtable, "ititlcategories_id")) {
                   $add_filters[] = "itilcategory";
@@ -1138,6 +1136,7 @@ HTML;
         if ($cards === null || $force) {
             $cards = [];
             $menu_itemtypes = $this->getMenuItemtypes();
+            $DB_read = DBConnection::getReadConnection();
 
             foreach ($menu_itemtypes as $firstlvl => $itemtypes) {
                 foreach ($itemtypes as $itemtype) {
@@ -1151,7 +1150,7 @@ HTML;
                         'filters'    => array_merge([
                             'dates',
                             'dates_mod',
-                        ], $add_filters_fct($itemtype::getTable()))
+                        ], $add_filters_fct($itemtype::getTable(), $DB_read))
                     ];
                 }
             }
@@ -1173,7 +1172,7 @@ HTML;
                     'filters'    => array_merge([
                         'dates',
                         'dates_mod',
-                    ], $add_filters_fct($itemtype::getTable()))
+                    ], $add_filters_fct($itemtype::getTable(), $DB_read))
                 ];
 
                 $clean_itemtype = str_replace('\\', '_', $itemtype);
@@ -1186,7 +1185,7 @@ HTML;
                     'filters'    => array_merge([
                         'dates',
                         'dates_mod',
-                    ], $add_filters_fct($itemtype::getTable()))
+                    ], $add_filters_fct($itemtype::getTable(), $DB_read))
                 ];
             }
 
@@ -1201,7 +1200,7 @@ HTML;
                     'filters'    => array_merge([
                         'dates',
                         'dates_mod',
-                    ], $add_filters_fct($itemtype::getTable()))
+                    ], $add_filters_fct($itemtype::getTable(), $DB_read))
                 ];
             }
 
@@ -1238,7 +1237,7 @@ HTML;
                         'filters'    => array_merge([
                             'dates',
                             'dates_mod',
-                        ], $add_filters_fct($itemtype::getTable()))
+                        ], $add_filters_fct($itemtype::getTable(), $DB_read))
                     ];
                 }
             }


### PR DESCRIPTION
I've noticed that the `Dashboard\Grid\getAllDasboardCards` function was taking 4+ seconds of execution time on a production server.
The problems seem to come from calling `DBConnection::getReadConnection()` in `$add_filters_fct`, which is being executed in multiple double foreach loops.

This cause a lot of extra SQL requests if you are using replication :

![image](https://user-images.githubusercontent.com/42734840/195356289-c915618e-9942-4c41-92d5-d2acbf060d29.png)

Moving the variable outside the function allow to reduce the 4s of execution time to nearly 0s.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25025
