### PR TITLE
feat(inventory): allow instantiation_type update

### DIFF
--- a/src/Inventory/Asset/InventoryNetworkPort.php
+++ b/src/Inventory/Asset/InventoryNetworkPort.php
@@ -396,22 +396,19 @@ trait InventoryNetworkPort
                     continue;
                 }
 
-                //check for logical number change
-                $update_input = [
-                    "id" => $keydb
-                ];
                 if (property_exists($data, 'logical_number') && $data->logical_number != $db_lnumber) {
-                    $update_input['logical_number'] = $data->logical_number;
+                    $networkport->update(
+                        [
+                            'id'              => $keydb,
+                            'logical_number'  => $data->logical_number
+                        ]
+                    );
                 }
 
-                //check for instantiation_type number change
+                //check for instantiation_type switch for NetworkPort
                 if (property_exists($data, 'instantiation_type') && $data->instantiation_type != $db_instantiation_type) {
-                    $update_input['instantiation_type'] = $data->instantiation_type;
-                }
-
-                //update if needed
-                if (count($update_input) > 1) {
-                    $networkport->update($update_input);
+                    $networkport->getFromDB($keydb);
+                    $networkport->switchInstantiationType($data->instantiation_type);
                 }
 
                //handle instantiation type

--- a/src/Inventory/Asset/InventoryNetworkPort.php
+++ b/src/Inventory/Asset/InventoryNetworkPort.php
@@ -404,17 +404,15 @@ trait InventoryNetworkPort
                     $update_input['logical_number'] = $data->logical_number;
                 }
 
-                //check for logical number change
+                //check for instantiation_type number change
                 if (property_exists($data, 'instantiation_type') && $data->instantiation_type != $db_instantiation_type) {
                     $update_input['instantiation_type'] = $data->instantiation_type;
-
                 }
 
                 //update if needed
                 if (count($update_input) > 1) {
                     $networkport->update($update_input);
                 }
-
 
                //handle instantiation type
                 if (property_exists($data, 'instantiation_type')) {


### PR DESCRIPTION
It appears that the agent does not always report the type of networkport from inventory file

```json
         {
            "description": "Intel(R) Ethernet Connection (13) I219-V",
            "mac": "A0:29:19:37:5D:C1",
            "pciid": "8086:15FC:0A20:1028",
            "pnpdeviceid": "PCI\\VEN_8086&DEV_15FC&SUBSYS_0A201028&REV_20\\3&11583659&0&FE",
            "status": "down",
            "type": "ethernet", //missing node
            "virtualdev": false
         },
```
So GLPI adds a ```NetworkPort``` with ```instantiation_type``` to ```null``` (hard to do better without information :disappointed: )

But if the agent improves and finds a way to report this information, GLPI does not update the ```NetworkPort```.

It adds a new one because the  ```instantiation_type ``` is one of reconciliation keys.

I propose to remove ```instantiation_type ``` from reconciliation keys to allow GLPI to update ```NetworkPort``` rather than create new one.


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
