### PR TITLE
fix(networkport): fix delete / purge behavior

### DIFF
--- a/front/networkport.form.php
+++ b/front/networkport.form.php
@@ -117,6 +117,22 @@ if (isset($_POST["add"])) {
         Html::redirect($item->getFormURLWithID($np->fields['items_id']));
     }
     Html::redirect($CFG_GLPI["root_doc"] . "/front/central.php");
+} else if (isset($_POST["delete"])) {
+    $np->check($_POST['id'], DELETE);
+    $np->delete($_POST, 0);
+    Event::log(
+        $_POST['id'],
+        "networkport",
+        5,
+        "inventory",
+        //TRANS: %s is the user login
+        sprintf(__('%s deletes an item'), $_SESSION["glpiname"])
+    );
+
+    if ($item = getItemForItemtype($np->fields['itemtype'])) {
+        Html::redirect($item->getFormURLWithID($np->fields['items_id']));
+    }
+    Html::redirect($CFG_GLPI["root_doc"] . "/front/central.php");
 } else if (isset($_POST["update"])) {
     $np->check($_POST['id'], UPDATE);
 

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -98,6 +98,11 @@ class NetworkPort extends CommonDBChild
         return $value;
     }
 
+    public function useDeletedToLockIfDynamic()
+    {
+        return false;
+    }
+
     public function __set(string $property, $value)
     {
         switch ($property) {


### PR DESCRIPTION
Fix ```NetworkPort``` ```delete``` / ```purge```.

Use ```delete``` step because of ```is_deleted``` database column instead of directly ```purged```

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12971
