### PR TITLE
Improve dashboards performances

### DIFF
--- a/inc/based_config.php
+++ b/inc/based_config.php
@@ -103,7 +103,7 @@ include_once(GLPI_ROOT . "/inc/autoload.function.php");
         'GLPI_DISABLE_ONLY_FULL_GROUP_BY_SQL_MODE' => '1', // '1' to disable ONLY_FULL_GROUP_BY 'sql_mode'
 
       // Other constants
-        'GLPI_AJAX_DASHBOARD'         => '1',
+        'GLPI_AJAX_DASHBOARD'         => '1', // 1 for "multi ajax mode" 0 for "single ajax mode" (see Glpi\Dashboard\Grid::getCards)
         'GLPI_CALDAV_IMPORT_STATE'    => 0, // external events created from a caldav client will take this state by default (0 = Planning::INFO)
         'GLPI_DEMO_MODE'              => '0',
         'GLPI_CENTRAL_WARNINGS'       => '1', // display (1), or not (0), warnings on GLPI Central page


### PR DESCRIPTION
I've been notified that dashboard performances are not great on heavy GLPI databases and I'm looking for potential solutions.

Here are the potential fixes I've found so far:
- [x] Remove duplicated AJAX request
- [x] Restore browser cache
- [x] Split AJAX requests

1\) Duplicated AJAX request

I've found that `getCardsAjax` was being called twice when loading/refreshing a dashboard
![image](https://user-images.githubusercontent.com/42734840/195635273-e6b142ed-5f03-4398-a13c-5782ed2294db.png)
![image](https://user-images.githubusercontent.com/42734840/195635347-676e242f-9146-471c-a5a3-fde34ebe0851.png)

2\) Restore browser cache

Browser cache has been broken since #9370 as `POST` request can't be cached.
At that time, I'd propose to revert to a `GET` request (#9548) but it wasn't possible due to the request size and no solution was found at the time

Is it possible to find a solution for this now ?

I've heard of a new `QUERY` request type that allow cached content of unlimited size but I couldn't find anything regarding browser support (it is quite recent) so it probably isn't usable yet.

The obvious solution would be to lighten the request and get it under the `GET` limit.
The current request content looks like this:
![image](https://user-images.githubusercontent.com/42734840/195636384-9f46e5b8-d854-4732-a2ea-2e675a57cea6.png)
It seems to me that it contains mainly data that is already known to the back-end in case of a dashboard refresh (widget color, grid stack ids, ...).
![image](https://user-images.githubusercontent.com/42734840/195641727-16951ebd-a2ad-46a8-a5d7-53965b882dde.png)
I've also noted that the `c_cache_key` data seems to be unused as I can only find the code that set the value:
![image](https://user-images.githubusercontent.com/42734840/195636861-695a2db9-4fa2-4c6d-9caa-e64ac758cbc8.png)

I may be missing some information but it seems to me that a full dashboard refresh should only send the dashboard ID and the current filters to the backend.
Doing so would reduce the query size drastically.
The other information may be needed for some other actions (editing a card ? I'm not sure) but not for the load/refresh action.

3\) Split AJAX requests

In the first iteration of the dashboards every card had its own AJAX request.
This implementation was changed because it would trigger too many request for some servers and it seems now that we are now using a single request for all the cards.

This is problematic because if you have a very slow card (due to a complex SQL query or a heavy database) then nothing is displayed in the meantime.

Maybe some cards should be flagged as "slow" (store the last 10 executions time then do an average) and be run in their own AJAX request in this case.

This mean you would have a "main" AJAX request with all the quick data and a few specific requests for the slow loading dashboards.

---

What are you thoughts about it @orthagh @cedric-anne @trasher @cconard96 ?
Specifically:
- is my assumption for 2 correct and that we could keep the request payload super light as none of these data are really needed ?
- is 3 doable ? am I correct to assume all dashboard are always loaded by a single ajax query at this moment ?
- any other potential solutions I'm missing ? 

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25025
