### PR TITLE
fix(lockedfield): add missing monitor itemtype

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -495,7 +495,7 @@ $CFG_GLPI['inventory_lockable_objects'] = ['Computer_Item',  'Item_SoftwareLicen
     'Item_DeviceControl', 'Item_DeviceDrive', 'Item_DeviceFirmware', 'Item_DeviceGeneric', 'Item_DeviceGraphicCard',
     'Item_DeviceHardDrive', 'Item_DeviceMemory', 'Item_DeviceMotherboard', 'Item_DeviceNetworkCard', 'Item_DevicePci',
     'Item_DevicePowerSupply', 'Item_DeviceProcessor', 'Item_DeviceSensor', 'Item_DeviceSimcard', 'Item_DeviceSoundCard',
-    'DatabaseInstance', 'Item_RemoteManagement'
+    'DatabaseInstance', 'Item_RemoteManagement','Monitor'
 ];
 
 $CFG_GLPI["kb_types"]              = ['Budget', 'Change', 'Computer',


### PR DESCRIPTION
Add ```Monitor``` to ```$CFG_GLPI['inventory_lockable_objects']```

Usefull to add global lock

![image](https://user-images.githubusercontent.com/7335054/195777863-2c979b43-fb27-474b-9c0e-e91fd9c4ed22.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
