### PR TITLE
fix(lockedfield): fix display add btn

### DIFF
--- a/src/Inventory/Inventory.php
+++ b/src/Inventory/Inventory.php
@@ -494,7 +494,7 @@ class Inventory
             ];
         }
 
-        if (Session::haveRight(Lockedfield::$rightname, READ)) {
+        if (Session::haveRight(Lockedfield::$rightname, CREATE)) {
             $menu['options']['lockedfield'] = [
                 'icon'  => Lockedfield::getIcon(),
                 'title' => Lockedfield::getTypeName(Session::getPluralNumber()),


### PR DESCRIPTION
Check ```CREATE``` instead of ```READ```

```CREATE``` was introduced by the following PR https://github.com/glpi-project/glpi/pull/12792

![image](https://user-images.githubusercontent.com/7335054/195778239-121b5c35-a589-4d59-9547-b61ac95da792.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
