### PR TITLE
Make unsigned keys migration errored result more clear

### DIFF
--- a/src/Console/Migration/UnsignedKeysCommand.php
+++ b/src/Console/Migration/UnsignedKeysCommand.php
@@ -265,7 +265,7 @@ class UnsignedKeysCommand extends AbstractCommand
                 }
                 $message .= "\n";
                 $message .= sprintf(
-                    '<comment>' . __('Some errors were related to following plugins: %s.') . '</comment>',
+                    '<comment>' . __('Some errors are related to following plugins: %s.') . '</comment>',
                     implode(', ', $plugins_names)
                 );
                 $message .= "\n";

--- a/src/Console/Migration/UnsignedKeysCommand.php
+++ b/src/Console/Migration/UnsignedKeysCommand.php
@@ -265,9 +265,11 @@ class UnsignedKeysCommand extends AbstractCommand
                 }
                 $message .= "\n";
                 $message .= sprintf(
-                    '<comment>' . __('You should try to update following plugins to their latest version and run the command again: %s.') . '</comment>',
+                    '<comment>' . __('Some errors were related to following plugins: %s.') . '</comment>',
                     implode(', ', $plugins_names)
                 );
+                $message .= "\n";
+                $message .= '<comment>' . __('You should try to update these plugins to their latest version and run the command again.') . '</comment>';
             }
             throw new \Glpi\Console\Exception\EarlyExitException(
                 $message,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Error message in `glpi:migration:unsigned_keys` command is not clear. Some people are asking us what they are supposed to do, meaning they do not understand what the message is advicing for (see !25184). 