### PR TITLE
fix(task): unplan task

### DIFF
--- a/front/commonitiltask.form.php
+++ b/front/commonitiltask.form.php
@@ -103,6 +103,20 @@ if (isset($_POST["add"])) {
     );
     $redirect = $itemtype::getFormURLWithID($task->getField($fk));
     $handled = true;
+} else if (isset($_POST["unplan"])) {
+    $task->check($_POST["id"], UPDATE);
+    $task->unplan($_POST);
+
+    Event::log(
+        $task->getField($fk),
+        strtolower($itemtype),
+        4,
+        "tracking",
+        //TRANS: %s is the user login
+        sprintf(__('%s updates a task'), $_SESSION["glpiname"])
+    );
+    $redirect = $itemtype::getFormURLWithID($task->getField($fk));
+    $handled = true;
 }
 
 if ($handled) {

--- a/front/commonitiltask.form.php
+++ b/front/commonitiltask.form.php
@@ -105,7 +105,7 @@ if (isset($_POST["add"])) {
     $handled = true;
 } else if (isset($_POST["unplan"])) {
     $task->check($_POST["id"], UPDATE);
-    $task->unplan($_POST);
+    $task->unplan();
 
     Event::log(
         $task->getField($fk),

--- a/front/commonitiltask.form.php
+++ b/front/commonitiltask.form.php
@@ -113,7 +113,7 @@ if (isset($_POST["add"])) {
         4,
         "tracking",
         //TRANS: %s is the user login
-        sprintf(__('%s updates a task'), $_SESSION["glpiname"])
+        sprintf(__('%s unplan a task'), $_SESSION["glpiname"])
     );
     $redirect = $itemtype::getFormURLWithID($task->getField($fk));
     $handled = true;

--- a/front/commonitiltask.form.php
+++ b/front/commonitiltask.form.php
@@ -113,7 +113,7 @@ if (isset($_POST["add"])) {
         4,
         "tracking",
         //TRANS: %s is the user login
-        sprintf(__('%s unplan a task'), $_SESSION["glpiname"])
+        sprintf(__('%s unplans a task'), $_SESSION["glpiname"])
     );
     $redirect = $itemtype::getFormURLWithID($task->getField($fk));
     $handled = true;

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -1832,9 +1832,9 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         return $input;
     }
 
-    public function unplan()
+    final public function unplan(): bool
     {
-        $this->update([
+        return $this->update([
             'id'         => $this->fields['id'],
             'begin'      => 'NULL',
             'end'        => 'NULL',

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -1831,4 +1831,20 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
 
         return $input;
     }
+
+    public function unplan()
+    {
+        global $DB;
+        $DB->update(
+            $this->getTable(),
+            [
+                'begin'      => null,
+                'end'        => null,
+                'actiontime' => 0,
+            ],
+            [
+                'id' => $this->fields['id'],
+            ]
+        );
+    }
 }

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -402,7 +402,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
                 $update_done = true;
 
                 if (in_array("actiontime", $this->updates)) {
-                    $item->updateActionTime($this->input[$item->getForeignKeyField()]);
+                    $item->updateActionTime($this->fields[$item->getForeignKeyField()]);
                 }
 
                // change ticket status (from splitted button)

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -1834,17 +1834,11 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
 
     public function unplan()
     {
-        global $DB;
-        $DB->update(
-            $this->getTable(),
-            [
-                'begin'      => null,
-                'end'        => null,
-                'actiontime' => 0,
-            ],
-            [
-                'id' => $this->fields['id'],
-            ]
-        );
+        $this->update([
+            'id'         => $this->fields['id'],
+            'begin'      => 'NULL',
+            'end'        => 'NULL',
+            'actiontime' => 0,
+        ]);
     }
 }

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -350,6 +350,7 @@
                      <script type="text/javascript">
                         function showPlanUpdate{{ rand }}(e) {
                            $('#plan{{ rand }}').hide();
+                           $('#unplan{{ rand }}').hide();
                            $('#viewplan{{ rand }}').load('{{ path('/ajax/planning.php') }}', {
                               action: "add_event_classic_form",
                               form: "followups", // Was followups for tasks before. Can't find where this is used.
@@ -369,8 +370,8 @@
                            <i class="fas fa-calendar"></i>
                            <span>{{ __('Plan this task') }}</span>
                         </button>
-                        {% if subitem.can(id, constant('UPDATE')) %}
-                           <button class="btn btn-outline-warning" type="submit" name="unplan"
+                        {% if subitem.can(id, constant('UPDATE')) and subitem.fields['begin'] %}
+                           <button id="unplan{{ rand }}" class="btn btn-outline-warning" type="submit" name="unplan"
                                  onclick="return confirm('{{ __('Confirm the deletion of planning?') }}');">
                               <i class="fas ti ti-calendar-off"></i>
                               <span>{{ __('Unplan') }}</span>

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -365,14 +365,15 @@
                         }
                      </script>
                      <div class="col-12">
-                        <button id="plan{{ rand }}" class="btn btn-outline-secondary mb-2 text-truncate" onclick="showPlanUpdate{{ rand }}()" type="button">
+                        <button id="plan{{ rand }}" class="btn btn-outline-secondary text-truncate" onclick="showPlanUpdate{{ rand }}()" type="button">
                            <i class="fas fa-calendar"></i>
                            <span>{{ __('Plan this task') }}</span>
                         </button>
                         {% if subitem.can(id, constant('UPDATE')) %}
-                           <button class="btn btn-outline-danger me-2" type="submit" name="unplan"
+                           <button class="btn btn-outline-warning" type="submit" name="unplan"
                                  onclick="return confirm('{{ __('Confirm the deletion of planning?') }}');">
-                              <i class="fas fa-trash-alt"></i>
+                              <i class="fas ti ti-calendar-off"></i>
+                              <span>{{ __('Unplan') }}</span>
                            </button>
                         {% endif %}
                         <div id="viewplan{{ rand }}"></div>

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -365,10 +365,16 @@
                         }
                      </script>
                      <div class="col-12">
-                        <button id="plan{{ rand }}" class="btn btn-outline-secondary d-block mb-2 text-truncate" onclick="showPlanUpdate{{ rand }}()" type="button">
+                        <button id="plan{{ rand }}" class="btn btn-outline-secondary mb-2 text-truncate" onclick="showPlanUpdate{{ rand }}()" type="button">
                            <i class="fas fa-calendar"></i>
                            <span>{{ __('Plan this task') }}</span>
                         </button>
+                        {% if subitem.can(id, constant('UPDATE')) %}
+                           <button class="btn btn-outline-danger me-2" type="submit" name="unplan"
+                                 onclick="return confirm('{{ __('Confirm the deletion of planning?') }}');">
+                              <i class="fas fa-trash-alt"></i>
+                           </button>
+                        {% endif %}
                         <div id="viewplan{{ rand }}"></div>
                      </div>
                   </div>


### PR DESCRIPTION
To remove the planning of a task, it was necessary to remove the whole task and recreate it without planning.

![image](https://user-images.githubusercontent.com/8530352/195816351-0c0e802a-050c-425e-82d2-53db603fc819.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25166
