### PR TITLE
fix(cartridge_info): fix and refactor code

### DIFF
--- a/src/Printer_CartridgeInfo.php
+++ b/src/Printer_CartridgeInfo.php
@@ -207,41 +207,23 @@ class Printer_CartridgeInfo extends CommonDBChild
             $search_option_id = $printer->getSearchOptionIDByField('field', $field);
             $raw_search_opt_values = $options['raw_data']['Printer_' . $search_option_id];
 
-            $get_percent_remaining = static function ($color, $field, $raw_search_opt_values) {
-                $max_field = "toner{$color}max";
-                $used_field = "toner{$color}used";
-                $remaining_field = "toner{$color}remaining";
+            $get_percent_remaining = static function ($color, $raw_search_opt_values) {
+                $used_field = "toner{$color}";
 
                 if ($raw_search_opt_values !== null) {
                     unset($raw_search_opt_values['count']);
-                    // Get the max and used values (stored in property key and value key of elements)
-                    $max_value = null;
-                    $used_value = null;
-                    $remaining_value = null;
                     foreach ($raw_search_opt_values as $raw_search_opt_value) {
-                        if ($raw_search_opt_value['property'] === $max_field) {
-                            $max_value = $raw_search_opt_value['value'];
-                        } elseif ($raw_search_opt_value['property'] === $used_field) {
-                            $used_value = $raw_search_opt_value['value'];
-                        } elseif ($raw_search_opt_value['property'] === $remaining_field) {
-                            $remaining_value = $raw_search_opt_value['value'];
+                        if ($raw_search_opt_value['property'] === $used_field) {
+                            return $raw_search_opt_value['value'];
                         }
-                    }
-                    // If max is not set or 0, we cannot display anything
-                    if ($max_value !== null && (int)$max_value > 0) {
-                        // If remaining is not set, we can calculate it from used
-                        if ($remaining_value === null && $used_value !== null) {
-                            $remaining_value = $max_value - $used_value;
-                        }
-                        return round(($remaining_value / $max_value) * 100);
                     }
                 }
                 return null;
             };
 
-            $percent_remaining = $get_percent_remaining($color, $field, $raw_search_opt_values);
+            $percent_remaining = $get_percent_remaining($color, $raw_search_opt_values);
             if ($percent_remaining === null && array_key_exists($color, $color_aliases)) {
-                $percent_remaining = $get_percent_remaining($color_aliases[$color], $field, $raw_search_opt_values);
+                $percent_remaining = $get_percent_remaining($color_aliases[$color], $raw_search_opt_values);
             }
 
             if ($percent_remaining !== null) {


### PR DESCRIPTION
Fix Cartridge Info ```searchoption```

I don't known why, but this method try to deals with some ```key``` that not exist

- ```$remaining_field = "toner{$color}remaining";```
- ```$max_field = "toner{$color}max";```
- ```$used_field = "toner{$color}used";```

```glpi_printers_cartridgeinfos``` contain only the current level of cartridge (```value``` column)

```sql
+----+-------------+--------------+-------+---------------------+---------------------+
| id | printers_id | property     | value | date_mod            | date_creation       |
+----+-------------+--------------+-------+---------------------+---------------------+
|  2 |           2 | fuserkit     | 22    | 2022-10-14 10:29:30 | 2022-10-14 10:29:30 |
|  3 |           2 | tonerblack   | 52    | 2022-10-14 10:29:30 | 2022-10-14 10:29:30 |
|  4 |           2 | tonercyan    | 56    | 2022-10-14 10:29:30 | 2022-10-14 10:29:30 |
|  5 |           2 | tonermagenta | 34    | 2022-10-14 10:29:30 | 2022-10-14 10:29:30 |
|  6 |           2 | toneryellow  | 97    | 2022-10-14 10:29:30 | 2022-10-14 10:29:30 |
|  7 |           2 | transferkit  | 71    | 2022-10-14 10:29:30 | 2022-10-14 10:29:30 |
+----+-------------+--------------+-------+---------------------+---------------------+
```


Before :
![image](https://user-images.githubusercontent.com/7335054/195808236-3578c593-079d-49f0-8f16-5ac4612f36e2.png)


After : 
![image](https://user-images.githubusercontent.com/7335054/195808120-aef70e80-346d-42f1-be78-95045aa8a09a.png)




You can try with this inventory file -> [7223.zip](https://github.com/glpi-project/glpi/files/9784309/7223.zip)


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 25030
