### PR TITLE
feat(inventory): add dedicated right for SNMP Credential

### DIFF
--- a/front/snmpcredential.form.php
+++ b/front/snmpcredential.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRight("config", READ);
+Session::checkRight("snmpcredential", READ);
 
 if (!isset($_GET["id"])) {
     $_GET["id"] = "";

--- a/front/snmpcredential.php
+++ b/front/snmpcredential.php
@@ -35,7 +35,7 @@
 
 include('../inc/includes.php');
 
-Session::checkRight("config", READ);
+Session::checkRight("snmpcredential", READ);
 
 Html::header(SNMPCredential::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "admin", "glpi\inventory\inventory", "snmpcredential");
 

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -7808,6 +7808,45 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'locked_field',
                 'rights' => self::RIGHT_NONE,
+            ],            [
+                'profiles_id' => self::PROFILE_SELF_SERVICE,
+                'name' => 'snmpcredential',
+                'rights' => self::RIGHT_NONE,
+            ],
+            [
+                'profiles_id' => self::PROFILE_OBSERVER,
+                'name' => 'snmpcredential',
+                'rights' => self::RIGHT_NONE,
+            ],
+            [
+                'profiles_id' => self::PROFILE_ADMIN,
+                'name' => 'snmpcredential',
+                'rights' => self::RIGHT_NONE,
+            ],
+            [
+                'profiles_id' => self::PROFILE_SUPER_ADMIN,
+                'name' => 'snmpcredential',
+                'rights' => ALLSTANDARDRIGHT,
+            ],
+            [
+                'profiles_id' => self::PROFILE_HOTLINER,
+                'name' => 'snmpcredential',
+                'rights' => self::RIGHT_NONE,
+            ],
+            [
+                'profiles_id' => self::PROFILE_TECHNICIAN,
+                'name' => 'snmpcredential',
+                'rights' => self::RIGHT_NONE,
+            ],
+            [
+                'profiles_id' => self::PROFILE_SUPERVISOR,
+                'name' => 'snmpcredential',
+                'rights' => self::RIGHT_NONE,
+            ],
+            [
+                'profiles_id' => self::PROFILE_READ_ONLY,
+                'name' => 'snmpcredential',
+                'rights' => self::RIGHT_NONE,
             ],
         ];
 

--- a/install/migrations/update_10.0.3_to_10.0.4/inventory.php
+++ b/install/migrations/update_10.0.3_to_10.0.4/inventory.php
@@ -53,3 +53,6 @@ $migration->addField("glpi_items_operatingsystems", 'install_date', 'date');
 
 //add remote_addr
 $migration->addField("glpi_agents", 'remote_addr', 'string');
+
+//new right value for snmpcredential (previously based on config UPDATE)
+$migration->addRight('snmpcredential', ALLSTANDARDRIGHT, ['config' => UPDATE]);

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -1802,6 +1802,10 @@ class Profile extends CommonDBTM
                 'itemtype'  => 'Log',
                 'label'     => Log::getTypeName(Session::getPluralNumber()),
                 'field'     => 'logs'
+            ], [
+                'itemtype'  => 'SNMPCredential',
+                'label'     => SNMPCredential::getTypeName(Session::getPluralNumber()),
+                'field'     => 'snmpcredential',
             ]
         ];
         $matrix_options['title'] = __('Administration');

--- a/src/SNMPCredential.php
+++ b/src/SNMPCredential.php
@@ -42,7 +42,7 @@ class SNMPCredential extends CommonDBTM
 {
    // From CommonDBTM
     public $dohistory                   = true;
-    public static $rightname = 'computer';
+    public static $rightname = 'snmpcredential';
 
     public static function getTypeName($nb = 0)
     {


### PR DESCRIPTION
Add dedicated right (```ALLSTANDARDRIGHT```) for ```SNMPCredential``` 

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
