### PR TITLE
feat(inventory): add dedicated right for RefusedEquipement

### DIFF
--- a/front/refusedequipment.php
+++ b/front/refusedequipment.php
@@ -35,7 +35,7 @@
 
 include('../inc/includes.php');
 
-Session::checkRight("config", READ);
+Session::checkRight("refusedequipment", READ);
 
 Html::header(RefusedEquipment::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "admin", "glpi\inventory\inventory", "refusedequipment");
 

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -7848,6 +7848,46 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
                 'name' => 'snmpcredential',
                 'rights' => self::RIGHT_NONE,
             ],
+            [
+                'profiles_id' => self::PROFILE_SELF_SERVICE,
+                'name' => 'refusedequipment',
+                'rights' => self::RIGHT_NONE,
+            ],
+            [
+                'profiles_id' => self::PROFILE_OBSERVER,
+                'name' => 'refusedequipment',
+                'rights' => self::RIGHT_NONE,
+            ],
+            [
+                'profiles_id' => self::PROFILE_ADMIN,
+                'name' => 'refusedequipment',
+                'rights' => self::RIGHT_NONE,
+            ],
+            [
+                'profiles_id' => self::PROFILE_SUPER_ADMIN,
+                'name' => 'refusedequipment',
+                'rights' => READ | UPDATE | PURGE,
+            ],
+            [
+                'profiles_id' => self::PROFILE_HOTLINER,
+                'name' => 'refusedequipment',
+                'rights' => self::RIGHT_NONE,
+            ],
+            [
+                'profiles_id' => self::PROFILE_TECHNICIAN,
+                'name' => 'refusedequipment',
+                'rights' => self::RIGHT_NONE,
+            ],
+            [
+                'profiles_id' => self::PROFILE_SUPERVISOR,
+                'name' => 'refusedequipment',
+                'rights' => self::RIGHT_NONE,
+            ],
+            [
+                'profiles_id' => self::PROFILE_READ_ONLY,
+                'name' => 'refusedequipment',
+                'rights' => self::RIGHT_NONE,
+            ],
         ];
 
 

--- a/install/migrations/update_10.0.3_to_10.0.4/inventory.php
+++ b/install/migrations/update_10.0.3_to_10.0.4/inventory.php
@@ -56,3 +56,6 @@ $migration->addField("glpi_agents", 'remote_addr', 'string');
 
 //new right value for snmpcredential (previously based on config UPDATE)
 $migration->addRight('snmpcredential', ALLSTANDARDRIGHT, ['config' => UPDATE]);
+
+//new right value for refusedequipment (previously based on config UPDATE)
+$migration->addRight('refusedequipment', READ | UPDATE | PURGE, ['config' => UPDATE]);

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -1806,6 +1806,17 @@ class Profile extends CommonDBTM
                 'itemtype'  => 'SNMPCredential',
                 'label'     => SNMPCredential::getTypeName(Session::getPluralNumber()),
                 'field'     => 'snmpcredential',
+            ], [
+                'itemtype'  => 'RefusedEquipment',
+                'label'     => RefusedEquipment::getTypeName(Session::getPluralNumber()),
+                'field'     => 'refusedequipment',
+                'rights'  => [
+                    READ  => __('Read'),
+                    UPDATE  => __('Update'),
+                    PURGE   => ['short' => __('Purge'),
+                        'long'  => _x('button', 'Delete permanently')
+                    ]
+                ],
             ]
         ];
         $matrix_options['title'] = __('Administration');

--- a/src/RefusedEquipment.php
+++ b/src/RefusedEquipment.php
@@ -44,7 +44,7 @@ class RefusedEquipment extends CommonDBTM
 
    // From CommonDBTM
     public $dohistory                   = true;
-    public static $rightname                   = 'config';
+    public static $rightname                   = 'refusedequipment';
 
     public static function getTypeName($nb = 0)
     {


### PR DESCRIPTION
Add dedicated right (```READ```, ```UPDATE```, ```PURGE```) for ```SNMPCredential``` 

Fix ```refusedquipment.form.php``` to handle ```update```

The ```showForm``` doesn't seem to prohibite the update, but is it really useful to allow the update ?


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

