### PR TITLE
feat(inventory): add dedicated right for Agent

### DIFF
--- a/front/agent.form.php
+++ b/front/agent.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRight("config", READ);
+Session::checkRight("agent", READ);
 
 if (!isset($_GET["id"])) {
     $_GET["id"] = "";

--- a/front/agent.php
+++ b/front/agent.php
@@ -35,7 +35,7 @@
 
 include('../inc/includes.php');
 
-Session::checkRight("config", READ);
+Session::checkRight("agent", READ);
 
 Html::header(Agent::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "admin", "glpi\inventory\inventory", "agent");
 

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -7906,7 +7906,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'agent',
-                'rights' => ALLSTANDARDRIGHT,
+                'rights' => READ | UPDATE | PURGE,
             ],
             [
                 'profiles_id' => self::PROFILE_HOTLINER,

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -7888,6 +7888,46 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
                 'name' => 'refusedequipment',
                 'rights' => self::RIGHT_NONE,
             ],
+            [
+                'profiles_id' => self::PROFILE_SELF_SERVICE,
+                'name' => 'agent',
+                'rights' => self::RIGHT_NONE,
+            ],
+            [
+                'profiles_id' => self::PROFILE_OBSERVER,
+                'name' => 'agent',
+                'rights' => self::RIGHT_NONE,
+            ],
+            [
+                'profiles_id' => self::PROFILE_ADMIN,
+                'name' => 'agent',
+                'rights' => self::RIGHT_NONE,
+            ],
+            [
+                'profiles_id' => self::PROFILE_SUPER_ADMIN,
+                'name' => 'agent',
+                'rights' => ALLSTANDARDRIGHT,
+            ],
+            [
+                'profiles_id' => self::PROFILE_HOTLINER,
+                'name' => 'agent',
+                'rights' => self::RIGHT_NONE,
+            ],
+            [
+                'profiles_id' => self::PROFILE_TECHNICIAN,
+                'name' => 'agent',
+                'rights' => self::RIGHT_NONE,
+            ],
+            [
+                'profiles_id' => self::PROFILE_SUPERVISOR,
+                'name' => 'agent',
+                'rights' => self::RIGHT_NONE,
+            ],
+            [
+                'profiles_id' => self::PROFILE_READ_ONLY,
+                'name' => 'agent',
+                'rights' => self::RIGHT_NONE,
+            ]
         ];
 
 

--- a/install/migrations/update_10.0.3_to_10.0.4/inventory.php
+++ b/install/migrations/update_10.0.3_to_10.0.4/inventory.php
@@ -61,4 +61,4 @@ $migration->addRight('snmpcredential', ALLSTANDARDRIGHT, ['config' => UPDATE]);
 $migration->addRight('refusedequipment', READ | UPDATE | PURGE, ['config' => UPDATE]);
 
 //new right value for agent (previously based on config UPDATE)
-$migration->addRight('agent', ALLSTANDARDRIGHT, ['config' => UPDATE]);
+$migration->addRight('agent', READ | UPDATE | PURGE, ['config' => UPDATE]);

--- a/install/migrations/update_10.0.3_to_10.0.4/inventory.php
+++ b/install/migrations/update_10.0.3_to_10.0.4/inventory.php
@@ -59,3 +59,6 @@ $migration->addRight('snmpcredential', ALLSTANDARDRIGHT, ['config' => UPDATE]);
 
 //new right value for refusedequipment (previously based on config UPDATE)
 $migration->addRight('refusedequipment', READ | UPDATE | PURGE, ['config' => UPDATE]);
+
+//new right value for agent (previously based on config UPDATE)
+$migration->addRight('agent', ALLSTANDARDRIGHT, ['config' => UPDATE]);

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -63,7 +63,7 @@ class Agent extends CommonDBTM
     public $dohistory = true;
 
     /** @var string */
-    public static $rightname = 'computer';
+    public static $rightname = 'agent';
    //static $rightname = 'inventory';
 
     private static $found_adress = false;

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -1817,6 +1817,10 @@ class Profile extends CommonDBTM
                         'long'  => _x('button', 'Delete permanently')
                     ]
                 ],
+            ], [
+                'itemtype'  => 'Agent',
+                'label'     => Agent::getTypeName(Session::getPluralNumber()),
+                'field'     => 'agent',
             ]
         ];
         $matrix_options['title'] = __('Administration');

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -1821,6 +1821,13 @@ class Profile extends CommonDBTM
                 'itemtype'  => 'Agent',
                 'label'     => Agent::getTypeName(Session::getPluralNumber()),
                 'field'     => 'agent',
+                'rights'  => [
+                    READ    => __('Read'),
+                    UPDATE  => __('Update'),
+                    PURGE   => ['short' => __('Purge'),
+                        'long'  => _x('button', 'Delete permanently')
+                    ]
+                ],
             ]
         ];
         $matrix_options['title'] = __('Administration');


### PR DESCRIPTION
Add dedicated right (```ALLSTANDARDRIGHT```) for ```Agent``` 
Except ```CREATE```

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
