### PR TITLE
fix(inventory): fix rule software category rule

### DIFF
--- a/src/Inventory/Asset/Software.php
+++ b/src/Inventory/Asset/Software.php
@@ -695,7 +695,7 @@ class Software extends InventoryAsset
 
                 //if the rule engine returns a different category
                 if ($soft_input['softwarecategories_id'] != $db_soft_input['softwarecategories_id']) {
-                    $software->update( \Toolbox::addslashes_deep([
+                    $software->update(\Toolbox::addslashes_deep([
                         'id' => $skey
                     ] + $soft_input));
                 }

--- a/src/Inventory/Asset/Software.php
+++ b/src/Inventory/Asset/Software.php
@@ -688,6 +688,17 @@ class Software extends InventoryAsset
                     \Log::HISTORY_CREATE_ITEM
                 );
                 $this->softwares[$skey] = $softwares_id;
+            } else {
+                //handle Category Rules if needed
+                $soft_input = $db_soft_input = $this->cleanInputToPrepare((array)$val, $soft_fields);
+                $software->handleCategoryRules($soft_input);
+
+                //if the rule engine returns a different category
+                if ($soft_input['softwarecategories_id'] != $db_soft_input['softwarecategories_id']) {
+                    $software->update( \Toolbox::addslashes_deep([
+                        'id' => $skey
+                    ] + $soft_input));
+                }
             }
         }
 

--- a/src/Software.php
+++ b/src/Software.php
@@ -1160,20 +1160,15 @@ class Software extends CommonDBTM
     public function handleCategoryRules(array &$input)
     {
        //If category was not set by user (when manually adding a user)
-        if (!isset($input["softwarecategories_id"]) || !$input["softwarecategories_id"]) {
-            $softcatrule = new RuleSoftwareCategoryCollection();
-            $result      = $softcatrule->processAllRules(null, null, Toolbox::stripslashes_deep($input));
+        $softcatrule = new RuleSoftwareCategoryCollection();
+        $result      = $softcatrule->processAllRules(null, null, Toolbox::stripslashes_deep($input));
 
-            if (!empty($result) && !isset($result['_ignore_import'])) {
-                if (isset($result["softwarecategories_id"])) {
-                    $input["softwarecategories_id"] = $result["softwarecategories_id"];
-                } else if (isset($result["_import_category"]) && isset($input['_system_category'])) {
-                    $softCat = new SoftwareCategory();
-                    $input["softwarecategories_id"] = $softCat->importExternal($input["_system_category"]);
-                }
-            }
-            if (!isset($input["softwarecategories_id"])) {
-                $input["softwarecategories_id"] = 0;
+        if (!empty($result) && !isset($result['_ignore_import'])) {
+            if (isset($result["softwarecategories_id"])) {
+                $input["softwarecategories_id"] = $result["softwarecategories_id"];
+            } else if (isset($result["_import_category"]) && isset($input['_system_category'])) {
+                $softCat = new SoftwareCategory();
+                $input["softwarecategories_id"] = $softCat->importExternal($input["_system_category"]);
             }
         }
     }


### PR DESCRIPTION
Fix rule software category rule

- Use of the rule engine even if the category exists (from inventory file)
- If the rule engine does not match any rules, do not put ```0``` in ```$input["softwarecategories_id"]```
- Allow category change when updating the software


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12933
