### PR TITLE
CommonITIL: add 'Entity' meta search criteria

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -4292,7 +4292,7 @@ abstract class CommonITILObject extends CommonDBTM
             case 'time_to_own':
                 return 'IF(' . $DB->quoteName($table . '.' . $type) . ' IS NOT NULL
             AND ' . $DB->quoteName($table . '.status') . ' <> ' . self::WAITING . '
-            AND ((' . $DB->quoteName($table . '.takeintoaccountdate') . ' IS NOT NULL AND 
+            AND ((' . $DB->quoteName($table . '.takeintoaccountdate') . ' IS NOT NULL AND
                  ' . $DB->quoteName($table . '.takeintoaccountdate') . ' > ' . $DB->quoteName($table . '.' . $type) . ')
                  OR (' . $DB->quoteName($table . '.takeintoaccountdate') . ' IS NULL AND
                  ' . $DB->quoteName($table . '.takeintoaccount_delay_stat') . '
@@ -4873,8 +4873,10 @@ abstract class CommonITILObject extends CommonDBTM
 
     /**
      * Get all available types to which an ITIL object can be assigned
+     *
+     * @param array $extra Extra items to add (must be done here to be properly sorted)
      **/
-    public static function getAllTypesForHelpdesk()
+    public static function getAllTypesForHelpdesk(array $extra = [])
     {
         global $PLUGIN_HOOKS, $CFG_GLPI;
 
@@ -4904,6 +4906,16 @@ abstract class CommonITILObject extends CommonDBTM
                 }
             }
         }
+
+        // Add specified extra types
+        foreach ($extra as $itemtype) {
+            if (!is_a($itemtype, CommonDBTM::class, true)) {
+                // Skip invalid vaues
+                continue;
+            }
+            $types[$itemtype::getType()] = $itemtype::getTypeName(1);
+        }
+
         asort($types); // core type first... asort could be better ?
 
        // Drop not available plugins

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -4873,10 +4873,8 @@ abstract class CommonITILObject extends CommonDBTM
 
     /**
      * Get all available types to which an ITIL object can be assigned
-     *
-     * @param array $extra Extra items to add (must be done here to be properly sorted)
      **/
-    public static function getAllTypesForHelpdesk(array $extra = [])
+    public static function getAllTypesForHelpdesk()
     {
         global $PLUGIN_HOOKS, $CFG_GLPI;
 
@@ -4906,16 +4904,6 @@ abstract class CommonITILObject extends CommonDBTM
                 }
             }
         }
-
-        // Add specified extra types
-        foreach ($extra as $itemtype) {
-            if (!is_a($itemtype, CommonDBTM::class, true)) {
-                // Skip invalid vaues
-                continue;
-            }
-            $types[$itemtype::getType()] = $itemtype::getTypeName(1);
-        }
-
         asort($types); // core type first... asort could be better ?
 
        // Drop not available plugins

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -4292,7 +4292,7 @@ abstract class CommonITILObject extends CommonDBTM
             case 'time_to_own':
                 return 'IF(' . $DB->quoteName($table . '.' . $type) . ' IS NOT NULL
             AND ' . $DB->quoteName($table . '.status') . ' <> ' . self::WAITING . '
-            AND ((' . $DB->quoteName($table . '.takeintoaccountdate') . ' IS NOT NULL AND
+            AND ((' . $DB->quoteName($table . '.takeintoaccountdate') . ' IS NOT NULL AND 
                  ' . $DB->quoteName($table . '.takeintoaccountdate') . ' > ' . $DB->quoteName($table . '.' . $type) . ')
                  OR (' . $DB->quoteName($table . '.takeintoaccountdate') . ' IS NULL AND
                  ' . $DB->quoteName($table . '.takeintoaccount_delay_stat') . '

--- a/src/Search.php
+++ b/src/Search.php
@@ -2327,8 +2327,8 @@ class Search
                 continue;
             }
             if ($key === 'ticket_types' && $item instanceof CommonITILObject) {
-               // Linked are filtered by CommonITILObject::getAllTypesForHelpdesk()
-                $linked = array_merge($linked, array_keys($item::getAllTypesForHelpdesk()));
+                // Linked are filtered by CommonITILObject::getAllTypesForHelpdesk()
+                $linked = array_merge($linked, array_keys($item::getAllTypesForHelpdesk([Entity::class])));
                 continue;
             }
 

--- a/src/Search.php
+++ b/src/Search.php
@@ -2328,7 +2328,7 @@ class Search
             }
             if ($key === 'ticket_types' && $item instanceof CommonITILObject) {
                 // Linked are filtered by CommonITILObject::getAllTypesForHelpdesk()
-                $linked = array_merge($linked, array_keys($item::getAllTypesForHelpdesk([Entity::class])));
+                $linked = array_merge($linked, array_keys($item::getAllTypesForHelpdesk()));
                 continue;
             }
 
@@ -2336,11 +2336,16 @@ class Search
                 if ($itemtype === $config_itemtype::getType()) {
                    // List is related to source itemtype, all types of list are so linked
                     $linked = array_merge($linked, $values);
-                } else if (in_array($itemtype, $values)) {
+                } elseif (in_array($itemtype, $values)) {
                    // Source itemtype is inside list, type corresponding to list is so linked
                     $linked[] = $config_itemtype::getType();
                 }
             }
+        }
+
+        // Add entity meta is needed
+        if ($item->isField('entities_id') && !($item instanceof Entity)) {
+            $linked[] = Entity::getType();
         }
 
         return array_unique($linked);

--- a/src/Search.php
+++ b/src/Search.php
@@ -2343,7 +2343,7 @@ class Search
             }
         }
 
-        // Add entity meta is needed
+        // Add entity meta if needed
         if ($item->isField('entities_id') && !($item instanceof Entity)) {
             $linked[] = Entity::getType();
         }


### PR DESCRIPTION
Add entities as a new meta criteria for CommonITIL items:

![image](https://user-images.githubusercontent.com/42734840/196356539-fe2adab5-9535-4d45-8fbb-bec841238ba1.png)

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25017
