### PR TITLE
Fix logout session destroy

### DIFF
--- a/front/logout.php
+++ b/front/logout.php
@@ -39,17 +39,12 @@
 
 include('../inc/includes.php');
 
-//@session_start();
-
-Session::destroy();
-
-//Remove cookie to allow new login
-Auth::setRememberMeCookie('');
 
 if (
     $CFG_GLPI["ssovariables_id"] > 0
     && strlen($CFG_GLPI['ssologout_url']) > 0
 ) {
+    Session::logOut();
     Html::redirect($CFG_GLPI["ssologout_url"]);
 }
 
@@ -67,6 +62,7 @@ if (
         false
     );
     phpCAS::setServerLogoutURL(strval($CFG_GLPI["cas_logout"]));
+    Session::logOut();
     phpCAS::logout();
 }
 
@@ -87,6 +83,8 @@ if (isset($_SESSION["noAUTO"]) || isset($_GET['noAUTO'])) {
     }
     $toADD .= "noAUTO=1";
 }
+
+Session::logOut();
 
 // Redirect to the login-page
 Html::redirect($CFG_GLPI["root_doc"] . "/index.php" . $toADD);

--- a/front/logout.php
+++ b/front/logout.php
@@ -44,7 +44,7 @@ if (
     $CFG_GLPI["ssovariables_id"] > 0
     && strlen($CFG_GLPI['ssologout_url']) > 0
 ) {
-    Session::logOut();
+    Session::cleanOnLogout();
     Html::redirect($CFG_GLPI["ssologout_url"]);
 }
 
@@ -62,7 +62,6 @@ if (
         false
     );
     phpCAS::setServerLogoutURL(strval($CFG_GLPI["cas_logout"]));
-    Session::logOut();
     phpCAS::logout();
 }
 
@@ -84,7 +83,7 @@ if (isset($_SESSION["noAUTO"]) || isset($_GET['noAUTO'])) {
     $toADD .= "noAUTO=1";
 }
 
-Session::logOut();
+Session::cleanOnLogout();
 
 // Redirect to the login-page
 Html::redirect($CFG_GLPI["root_doc"] . "/index.php" . $toADD);

--- a/src/Session.php
+++ b/src/Session.php
@@ -1853,4 +1853,20 @@ class Session
         $_SESSION['glpiactiveentities']        = $entities;
         $_SESSION['glpiactiveentities_string'] = "'" . implode("', '", $entities) . "'";
     }
+
+     /**
+     * clean what needs to be cleaned on logout
+     *
+     * @since 10.0.4
+     *
+     * @return int
+     */
+    public static function logOut()
+    {
+        //@session_start();
+        Session::destroy();
+
+        //Remove cookie to allow new login
+        Auth::setRememberMeCookie('');
+    }
 }

--- a/src/Session.php
+++ b/src/Session.php
@@ -1863,7 +1863,6 @@ class Session
      */
     public static function cleanOnLogout()
     {
-        //@session_start();
         Session::destroy();
 
         //Remove cookie to allow new login

--- a/src/Session.php
+++ b/src/Session.php
@@ -1859,12 +1859,11 @@ class Session
      *
      * @since 10.0.4
      *
-     * @return int
+     * @return void
      */
     public static function cleanOnLogout()
     {
         Session::destroy();
-
         //Remove cookie to allow new login
         Auth::setRememberMeCookie('');
     }

--- a/src/Session.php
+++ b/src/Session.php
@@ -1861,7 +1861,7 @@ class Session
      *
      * @return int
      */
-    public static function logOut()
+    public static function cleanOnLogout()
     {
         //@session_start();
         Session::destroy();


### PR DESCRIPTION
Previous version of ```front/logout.php``` destroy ```$_SESSION``` on top of page.
In this context ```CAS::logout``` can work (need to check some variables from  ```$_SESSION```




| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Maybe fix #12874
