### PR TITLE
Fix database relations handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The present file will list all changes made to the project; according to the
 #### Added
 
 #### Changes
+- Itemtype that can be linked to a disk are now declared in `$CFG_GLPI['disk_types']`.
 
 #### Deprecated
 - `Glpi\Inventory\Conf::importFile()`

--- a/inc/define.php
+++ b/inc/define.php
@@ -519,6 +519,8 @@ $CFG_GLPI['operatingsystem_types'] = ['Computer', 'Monitor', 'NetworkEquipment',
 
 $CFG_GLPI['software_types']      = $CFG_GLPI['operatingsystem_types'];
 
+$CFG_GLPI['disk_types'] = ['Computer', 'NetworkEquipment', 'Phone', 'Printer'];
+
 $CFG_GLPI['kanban_types']        = ['Project'];
 
 $CFG_GLPI['domain_types']        = ['Computer', 'Monitor', 'NetworkEquipment', 'Peripheral',

--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -477,7 +477,6 @@ $RELATION = [
     'glpi_domains'    => [
         '_glpi_domainrecords' => 'domains_id',
         '_glpi_domains_items' => 'domains_id',
-        'glpi_unmanageds'     => 'domains_id',
     ],
 
     'glpi_domaintypes' => [
@@ -718,29 +717,32 @@ $RELATION = [
             'groups_id',
         ],
         'glpi_planningexternalevents' => 'groups_id',
-        'glpi_phones'                => [
+        'glpi_phones'                 => [
             'groups_id_tech',
             'groups_id',
         ],
-        'glpi_printers'              => [
+        'glpi_printers'               => [
             'groups_id_tech',
             'groups_id',
         ],
-        'glpi_problemtasks'          => 'groups_id_tech',
-        'glpi_projects'              => 'groups_id',
-        'glpi_racks'                 => 'groups_id_tech',
-        'glpi_softwarelicenses'      => [
+        'glpi_problemtasks'           => 'groups_id_tech',
+        'glpi_projects'               => 'groups_id',
+        'glpi_racks'                  => 'groups_id_tech',
+        'glpi_softwarelicenses'       => [
             'groups_id_tech',
             'groups_id',
         ],
-        'glpi_softwares'             => [
+        'glpi_softwares'              => [
             'groups_id_tech',
             'groups_id',
         ],
-        'glpi_tasktemplates'         => 'groups_id_tech',
-        'glpi_tickettasks'           => 'groups_id_tech',
-        'glpi_unmanageds'            => 'groups_id',
-        'glpi_users'                 => 'groups_id',
+        'glpi_tasktemplates'          => 'groups_id_tech',
+        'glpi_tickettasks'            => 'groups_id_tech',
+        'glpi_unmanageds'             => [
+            'groups_id_tech',
+            'groups_id',
+        ],
+        'glpi_users'                  => 'groups_id',
     ],
 
     'glpi_holidays' => [
@@ -848,6 +850,7 @@ $RELATION = [
         'glpi_cartridgeitems'            => 'locations_id',
         'glpi_certificates'              => 'locations_id',
         'glpi_computers'                 => 'locations_id',
+        'glpi_contracts'                 => 'locations_id',
         'glpi_consumableitems'           => 'locations_id',
         'glpi_databaseinstances'         => 'locations_id',
         'glpi_datacenters'               => 'locations_id',
@@ -1574,7 +1577,10 @@ $RELATION = [
             'users_id',
             'users_id_validate',
         ],
-        'glpi_unmanageds'               => 'users_id',
+        'glpi_unmanageds'               => [
+            'users_id_tech',
+            'users_id',
+        ],
         '_glpi_useremails'              => 'users_id',
         'glpi_users'                    => 'users_id_supervisor',
     ],

--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -1694,6 +1694,7 @@ foreach ($CFG_GLPI['planning_types'] as $planning_itemtype) {
 }
 
 $specifically_managed_types = [
+    Agent::class, // FIXME Agent should be a CommonDBChild with $mustBeAttached=true
     Consumable::class, // Consumables are handled manually to redefine `date_out` to `null`
     Item_Cluster::class, // FIXME $mustBeAttached_1 and $mustBeAttached_2 should probably be set to true
     Item_Enclosure::class, // FIXME $mustBeAttached_1 and $mustBeAttached_2 should probably be set to true

--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -1650,6 +1650,13 @@ $define_mapping_entry = static function (string $source_table, string $target_ta
 
 // Add polymorphic relations based on configuration.
 global $CFG_GLPI;
+$specifically_managed_types = [
+    Agent::class, // FIXME Agent should be a CommonDBChild with $mustBeAttached=true
+    Consumable::class, // Consumables are handled manually to redefine `date_out` to `null`
+    Item_Cluster::class, // FIXME $mustBeAttached_1 and $mustBeAttached_2 should probably be set to true
+    Item_Enclosure::class, // FIXME $mustBeAttached_1 and $mustBeAttached_2 should probably be set to true
+    Item_Rack::class, // FIXME $mustBeAttached_1 and $mustBeAttached_2 should probably be set to true
+];
 $polymorphic_types_mapping = [
     Agent::class                   => $CFG_GLPI['agent_types'],
     Appliance_Item::class          => $CFG_GLPI['appliance_types'],
@@ -1685,6 +1692,7 @@ foreach ($CFG_GLPI['itemdevices'] as $itemdevice_itemtype) {
         $source_itemtypes = $CFG_GLPI['itemdevices_types'];
     }
     $polymorphic_types_mapping[$itemdevice_itemtype] = $source_itemtypes;
+    $specifically_managed_types[] = $itemdevice_itemtype; // Item_Devices is handled manually to take care of `keep_devices` option
 }
 $polymorphic_types_mapping[\VObject::class] = [];
 foreach ($CFG_GLPI['planning_types'] as $planning_itemtype) {
@@ -1692,14 +1700,6 @@ foreach ($CFG_GLPI['planning_types'] as $planning_itemtype) {
         $polymorphic_types_mapping[\VObject::class][] = $planning_itemtype;
     }
 }
-
-$specifically_managed_types = [
-    Agent::class, // FIXME Agent should be a CommonDBChild with $mustBeAttached=true
-    Consumable::class, // Consumables are handled manually to redefine `date_out` to `null`
-    Item_Cluster::class, // FIXME $mustBeAttached_1 and $mustBeAttached_2 should probably be set to true
-    Item_Enclosure::class, // FIXME $mustBeAttached_1 and $mustBeAttached_2 should probably be set to true
-    Item_Rack::class, // FIXME $mustBeAttached_1 and $mustBeAttached_2 should probably be set to true
-];
 
 foreach ($polymorphic_types_mapping as $target_itemtype => $source_itemtypes) {
     foreach ($source_itemtypes as $source_itemtype) {

--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -1694,6 +1694,7 @@ foreach ($CFG_GLPI['planning_types'] as $planning_itemtype) {
 }
 
 $specifically_managed_types = [
+    Consumable::class, // Consumables are handled manually to redefine `date_out` to `null`
     Item_Cluster::class, // FIXME $mustBeAttached_1 and $mustBeAttached_2 should probably be set to true
     Item_Enclosure::class, // FIXME $mustBeAttached_1 and $mustBeAttached_2 should probably be set to true
     Item_Rack::class, // FIXME $mustBeAttached_1 and $mustBeAttached_2 should probably be set to true

--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -71,8 +71,6 @@ use Glpi\Socket;
  *
  * /!\ Table's names are in alphabetic order - Please respect it
  *
- * /!\ "_virtual_device" mapping is a special mapping used on CommonDBTM::CanUnrecurs().
- *
  * @var array $RELATION
  */
 $RELATION = [
@@ -1609,29 +1607,6 @@ $RELATION = [
 
     'glpi_wifinetworks' => [
         'glpi_networkportwifis' => 'wifinetworks_id',
-    ],
-
-    '_virtual_device' => [
-        'glpi_appliances_items' => [
-            'items_id',
-            'itemtype'
-        ],
-        'glpi_contracts_items'  => [
-            'items_id',
-            'itemtype',
-        ],
-        'glpi_databaseinstances' => [
-            'items_id',
-            'itemtype'
-        ],
-        'glpi_documents_items'  => [
-            'items_id',
-            'itemtype',
-        ],
-        'glpi_infocoms'         => [
-            'items_id',
-            'itemtype',
-        ],
     ],
 
 ];

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1019,6 +1019,14 @@ class CommonDBTM extends CommonGLPI
     {
         global $CFG_GLPI, $DB;
 
+        if (in_array($this->getType(), $CFG_GLPI['itemdevices_types'])) {
+            Item_Devices::cleanItemDeviceDBOnItemDelete(
+                $this->getType(),
+                $this->getID(),
+                !empty($this->input['keep_devices'])
+            );
+        }
+
         if (in_array($this->getType(), $CFG_GLPI['networkport_types'])) {
             // Manage networkportmigration if exists
             if ($DB->tableExists('glpi_networkportmigrations')) {

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -39,6 +39,7 @@ use Glpi\Features\CacheableListInterface;
 use Glpi\Plugin\Hooks;
 use Glpi\RichText\RichText;
 use Glpi\RichText\UserMention;
+use Glpi\Socket;
 use Glpi\Toolbox\Sanitizer;
 
 /**
@@ -849,73 +850,88 @@ class CommonDBTM extends CommonGLPI
 
 
     /**
-     * Clean data in the tables which have linked the deleted item
-     * Clear 1/N Relation
+     * Detach items related to current item.
+     * Related items will be either:
+     * - attached to replacement item having ID specified in `_replace_by` input;
+     * - detached from the item (foreign key field will be set to empty).
+     *
+     * @FIXME Method should be renamed to reflect its precise role (e.g. `detachRelatedItems()`).
      *
      * @return void
      **/
     public function cleanRelationData()
     {
-        global $DB, $CFG_GLPI;
+        global $DB;
 
         $RELATION = getDbRelations();
         if (isset($RELATION[$this->getTable()])) {
-            $newval = (isset($this->input['_replace_by']) ? $this->input['_replace_by'] : 0);
+            $newval = (isset($this->input['_replace_by']) ? (int)$this->input['_replace_by'] : 0);
 
-            foreach ($RELATION[$this->getTable()] as $tablename => $field) {
-                if ($tablename[0] != '_') {
-                    $itemtype = getItemTypeForTable($tablename);
-
-                   // Code factorization : we transform the singleton to an array
-                    if (!is_array($field)) {
-                        $field = [$field];
-                    }
-
-                    foreach ($field as $f) {
-                        $result = $DB->request(
-                            [
-                                'FROM'  => $tablename,
-                                'WHERE' => [$f => $this->getID()],
-                            ]
-                        );
-                        foreach ($result as $data) {
-                             // Be carefull : we must use getIndexName because self::update rely on that !
-                            if ($object = getItemForItemtype($itemtype)) {
-                                $idName = $object->getIndexName();
-                          // And we must ensure that the index name is not the same as the field
-                          // we try to modify. Otherwise we will loose this element because all
-                          // will be set to $newval ...
-                                if ($idName != $f) {
-                                      $object->update([$idName          => $data[$idName],
-                                          $f               => $newval,
-                                          '_disablenotif'  => true
-                                      ]); // Disable notifs
-                                }
-                            }
-                        }
-                    }
+            foreach ($RELATION[$this->getTable()] as $tablename => $fields) {
+                if ($tablename[0] == '_') {
+                    // Relation in tables prefixed by `_` are manualy handled.
+                    continue;
                 }
-            }
-        }
 
-       // Clean ticket open against the item
-        if (in_array($this->getType(), $CFG_GLPI["ticket_types"])) {
-            $job         = new Ticket();
-            $itemsticket = new Item_Ticket();
+                $itemtype = getItemTypeForTable($tablename);
+                if (!is_a($itemtype, CommonDBTM::class, true)) {
+                    trigger_error(
+                        sprintf('Unable to update relations between %s and %s tables.', $this->getTable(), $tablename),
+                        E_USER_WARNING
+                    );
+                    continue;
+                }
 
-            $iterator = $DB->request([
-                'FROM'   => 'glpi_items_tickets',
-                'WHERE'  => [
-                    'items_id'  => $this->getID(),
-                    'itemtype'  => $this->getType()
-                ]
-            ]);
+                $id_field = $itemtype::getIndexName();
 
-            foreach ($iterator as $data) {
-                $cnt = countElementsInTable('glpi_items_tickets', ['tickets_id' => $data['tickets_id']]);
-                $itemsticket->delete(["id" => $data["id"]]);
-                if ($cnt == 1 && !$CFG_GLPI["keep_tickets_on_delete"]) {
-                    $job->delete(["id" => $data["tickets_id"]]);
+                foreach ($fields as $field) {
+                    if (is_array($field)) {
+                        // Relation based on 'itemtype'/'items_id' (polymorphic relationship)
+                        if ($this instanceof IPAddress && in_array('mainitemtype', $field) && in_array('mainitems_id', $field)) {
+                            // glpi_ipaddresses relationship that does not respect naming conventions
+                            $itemtype_field = 'mainitemtype';
+                            $items_id_field = 'mainitems_id';
+                        } else {
+                            $itemtype_matches = preg_grep('/^itemtype/', $field);
+                            $items_id_matches = preg_grep('/^items_id/', $field);
+                            $itemtype_field = reset($itemtype_matches);
+                            $items_id_field = reset($items_id_matches);
+                        }
+                        $criteria = [
+                            $itemtype_field => $this->getType(),
+                            $items_id_field => $this->getID(),
+                        ];
+                        $update = [
+                            $items_id_field => $newval,
+                        ];
+                        if ($newval === 0) {
+                            $update[$itemtype_field] = 'NULL';
+                        }
+                    } else {
+                        // Relation based on single foreign key
+                        $criteria = [
+                            $field => $this->getID(),
+                        ];
+                        $update = [
+                            $field => $newval,
+                        ];
+                    }
+
+                    $result = $DB->request(
+                        [
+                            'FROM'  => $tablename,
+                            'WHERE' => $criteria,
+                        ]
+                    );
+                    foreach ($result as $data) {
+                        $item = new $itemtype();
+                        $item->update(
+                            [
+                                $id_field       => $data[$id_field],
+                                '_disablenotif' => true,
+                            ] + $update
+                        );
+                    }
                 }
             }
         }
@@ -993,53 +1009,22 @@ class CommonDBTM extends CommonGLPI
 
 
     /**
-     * Clean the data in the relation tables for the deleted item
-     * Clear N/N Relation
+     * Purge items related to current item.
+     *
+     * @FIXME Method should be renamed to reflect its precise role (e.g. `purgeRelatedItems()`).
      *
      * @return void
-     **/
+     */
     public function cleanRelationTable()
     {
         global $CFG_GLPI, $DB;
 
-       // If this type have INFOCOM, clean one associated to purged item
-        if (Infocom::canApplyOn($this)) {
-            $infocom = new Infocom();
-
-            if ($infocom->getFromDBforDevice($this->getType(), $this->fields['id'])) {
-                $infocom->delete(['id' => $infocom->fields['id']]);
-            }
-        }
-
-       // If this type have NETPORT, clean one associated to purged item
         if (in_array($this->getType(), $CFG_GLPI['networkport_types'])) {
-           // If we don't use delete, then cleanDBonPurge() is not call and the NetworkPorts are not
-           // clean properly
-            $networkPortObject = new NetworkPort();
-            $networkPortObject->cleanDBonItemDelete($this->getType(), $this->getID());
-           // Manage networkportmigration if exists
+            // Manage networkportmigration if exists
             if ($DB->tableExists('glpi_networkportmigrations')) {
                 $networkPortMigObject = new NetworkPortMigration();
                 $networkPortMigObject->cleanDBonItemDelete($this->getType(), $this->getID());
             }
-        }
-
-       // If this type is RESERVABLE clean one associated to purged item
-        if (in_array($this->getType(), $CFG_GLPI['reservation_types'])) {
-            $rr = new ReservationItem();
-            $rr->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-        }
-
-       // If this type have CONTRACT, clean one associated to purged item
-        if (in_array($this->getType(), $CFG_GLPI['contract_types'])) {
-            $ci = new Contract_Item();
-            $ci->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-        }
-
-       // If this type have DOCUMENT, clean one associated to purged item
-        if (Document::canApplyOn($this)) {
-            $di = new Document_Item();
-            $di->cleanDBonItemDelete($this->getType(), $this->fields['id']);
         }
 
        // If this type have NOTEPAD, clean one associated to purged item
@@ -1048,78 +1033,70 @@ class CommonDBTM extends CommonGLPI
             $note->cleanDBonItemDelete($this->getType(), $this->fields['id']);
         }
 
-       // Delete relations with KB
-        if (in_array($this->getType(), $CFG_GLPI['kb_types'])) {
-            $kbitem_item = new KnowbaseItem_Item();
-            $kbitem_item->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-        }
-
         if (in_array($this->getType(), $CFG_GLPI['ticket_types'])) {
-           //delete relation beetween item and changes/problems
-            $this->deleteChildrenAndRelationsFromDb(
-                [
-                    Change_Item::class,
-                    Item_Problem::class,
+            // Clean ticket open against the item
+            $job         = new Ticket();
+            $itemsticket = new Item_Ticket();
+
+            $iterator = $DB->request([
+                'FROM'   => 'glpi_items_tickets',
+                'WHERE'  => [
+                    'items_id'  => $this->getID(),
+                    'itemtype'  => $this->getType()
                 ]
-            );
-        }
-
-        if (in_array($this->getType(), $CFG_GLPI['rackable_types'])) {
-           //delete relation beetween rackable type and its rack
-            $item_rack = new Item_Rack();
-            $item_rack->deleteByCriteria(
-                [
-                    'itemtype' => $this->getType(),
-                    'items_id' => $this->fields['id']
-                ]
-            );
-
-            $item_enclosure = new Item_Enclosure();
-            $item_enclosure->deleteByCriteria(
-                [
-                    'itemtype' => $this->getType(),
-                    'items_id' => $this->fields['id']
-                ]
-            );
-        }
-
-        if (in_array($this->getType(), $CFG_GLPI['cluster_types'])) {
-           //delete relation beetween clusterable elements type and their cluster
-            $this->deleteChildrenAndRelationsFromDb(
-                [
-                    Item_Cluster::class,
-                ]
-            );
-        }
-
-        if (in_array($this->getType(), $CFG_GLPI['operatingsystem_types'])) {
-            $this->deleteChildrenAndRelationsFromDb([
-                Item_OperatingSystem::class
             ]);
-        }
 
-        if (in_array($this->getType(), $CFG_GLPI['software_types'])) {
-            $this->deleteChildrenAndRelationsFromDb([
-                Item_SoftwareVersion::class
-            ]);
-        }
-
-        if (in_array($this->getType(), $CFG_GLPI['kanban_types'])) {
-            $this->deleteChildrenAndRelationsFromDb([
-                Item_Kanban::class
-            ]);
-        }
-
-        if (in_array($this->getType(), $CFG_GLPI['domain_types'])) {
-            $this->deleteChildrenAndRelationsFromDb([
-                Domain_Item::class
-            ]);
+            foreach ($iterator as $data) {
+                $cnt = countElementsInTable('glpi_items_tickets', ['tickets_id' => $data['tickets_id']]);
+                $itemsticket->delete(["id" => $data["id"]]);
+                if ($cnt == 1 && !$CFG_GLPI["keep_tickets_on_delete"]) {
+                    $job->delete(["id" => $data["tickets_id"]]);
+                }
+            }
         }
 
         $lockedfield = new Lockedfield();
         if ($lockedfield->isHandled($this)) {
             $lockedfield->itemDeleted();
         }
+
+        // Delete relation items and child items from DB
+        $polymorphic_types_mapping = [
+            Appliance_Item::class          => $CFG_GLPI['appliance_types'],
+            Appliance_Item_Relation::class => $CFG_GLPI['appliance_relation_types'],
+            Certificate_Item::class        => $CFG_GLPI['certificate_types'],
+            Change_Item::class             => $CFG_GLPI['ticket_types'],
+            Computer_Item::class           => $CFG_GLPI['directconnect_types'],
+            Consumable::class              => $CFG_GLPI['consumables_types'],
+            Contract_Item::class           => $CFG_GLPI['contract_types'],
+            Document_Item::class           => \Document::getItemtypesThatCanHave(),
+            Domain_Item::class             => $CFG_GLPI['domain_types'],
+            Infocom::class                 => \Infocom::getItemtypesThatCanHave(),
+            Item_Cluster::class            => $CFG_GLPI['cluster_types'],
+            Item_Disk::class               => $CFG_GLPI['disk_types'],
+            Item_Enclosure::class          => $CFG_GLPI['rackable_types'],
+            Item_Kanban::class             => $CFG_GLPI['kanban_types'],
+            Item_OperatingSystem::class    => $CFG_GLPI['operatingsystem_types'],
+            Item_Problem::class            => $CFG_GLPI['ticket_types'],
+            Item_Project::class            => $CFG_GLPI['project_asset_types'],
+            Item_Rack::class               => $CFG_GLPI['rackable_types'],
+            Item_SoftwareLicense::class    => $CFG_GLPI['software_types'],
+            Item_SoftwareVersion::class    => $CFG_GLPI['software_types'],
+            // specific case, see above Item_Ticket::class             => $CFG_GLPI['ticket_types'],
+            KnowbaseItem_Item::class       => $CFG_GLPI['kb_types'],
+            NetworkPort::class             => $CFG_GLPI['networkport_types'],
+            ReservationItem::class         => $CFG_GLPI['reservation_types'],
+            Socket::class                   => $CFG_GLPI['socket_types'],
+            VObject::class                 => $CFG_GLPI['planning_types'],
+        ];
+
+        $to_delete = [];
+        foreach ($polymorphic_types_mapping as $target_itemtype => $source_itemtypes) {
+            if (in_array($this->getType(), $source_itemtypes)) {
+                $to_delete[] = $target_itemtype;
+            }
+        }
+        $this->deleteChildrenAndRelationsFromDb($to_delete);
     }
 
 

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1019,6 +1019,12 @@ class CommonDBTM extends CommonGLPI
     {
         global $CFG_GLPI, $DB;
 
+        if (in_array($this->getType(), $CFG_GLPI['agent_types'])) {
+           // Agent does not extends CommonDBConnexity
+            $agent = new Agent();
+            $agent->deleteByCriteria(['itemtype' => $this->getType(), 'items_id' => $this->getID()]);
+        }
+
         if (in_array($this->getType(), $CFG_GLPI['itemdevices_types'])) {
             Item_Devices::cleanItemDeviceDBOnItemDelete(
                 $this->getType(),

--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -567,6 +567,10 @@ abstract class CommonDropdown extends CommonDBTM
                 }
             }
 
+            if (count($or_criteria) === 0) {
+                return false;
+            }
+
             $row = $DB->request([
                 'FROM'   => $tablename,
                 'COUNT'  => 'cpt',

--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -520,44 +520,63 @@ abstract class CommonDropdown extends CommonDBTM
     }
 
 
-    /** Check if the dropdown $ID is used into item tables
+    /**
+     * Check if the dropdown $ID is used into item tables
      *
      * @return boolean : is the value used ?
-     **/
+     */
     public function isUsed()
     {
         global $DB;
 
-        $ID = $this->fields['id'];
-
         $RELATION = getDbRelations();
-        if (isset($RELATION[$this->getTable()])) {
-            foreach ($RELATION[$this->getTable()] as $tablename => $field) {
-                if ($tablename[0] != '_') {
-                    if (!is_array($field)) {
-                        $row = $DB->request([
-                            'FROM'   => $tablename,
-                            'COUNT'  => 'cpt',
-                            'WHERE'  => [$field => $ID]
-                        ])->current();
-                        if ($row['cpt'] > 0) {
-                             return true;
-                        }
+
+        if (!array_key_exists($this->getTable(), $RELATION)) {
+            return false;
+        }
+
+        foreach ($RELATION[$this->getTable()] as $tablename => $fields) {
+            if ($tablename[0] == '_') {
+                continue; // Ignore relations prefxed by `_`
+            }
+
+            $or_criteria = [];
+
+            foreach ($fields as $field) {
+                if (is_array($field)) {
+                    // Relation based on 'itemtype'/'items_id' (polymorphic relationship)
+                    if ($this instanceof IPAddress && in_array('mainitemtype', $field) && in_array('mainitems_id', $field)) {
+                        // glpi_ipaddresses relationship that does not respect naming conventions
+                        $itemtype_field = 'mainitemtype';
+                        $items_id_field = 'mainitems_id';
                     } else {
-                        foreach ($field as $f) {
-                             $row = $DB->request([
-                                 'FROM'   => $tablename,
-                                 'COUNT'  => 'cpt',
-                                 'WHERE'  => [$f => $ID]
-                             ])->current();
-                            if ($row['cpt'] > 0) {
-                                return true;
-                            }
-                        }
+                        $itemtype_matches = preg_grep('/^itemtype/', $field);
+                        $items_id_matches = preg_grep('/^items_id/', $field);
+                        $itemtype_field = reset($itemtype_matches);
+                        $items_id_field = reset($items_id_matches);
                     }
+                    $or_criteria[] = [
+                        $itemtype_field => $this->getType(),
+                        $items_id_field => $this->getID(),
+                    ];
+                } else {
+                    // Relation based on single foreign key
+                    $or_criteria[] = [
+                        $field => $this->getID(),
+                    ];
                 }
             }
+
+            $row = $DB->request([
+                'FROM'   => $tablename,
+                'COUNT'  => 'cpt',
+                'WHERE'  => ['OR' => $or_criteria]
+            ])->current();
+            if ($row['cpt'] > 0) {
+                 return true;
+            }
         }
+
         return false;
     }
 

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -680,7 +680,6 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         $this->deleteChildrenAndRelationsFromDb(
             [
                 PlanningRecall::class,
-                VObject::class,
             ]
         );
     }

--- a/src/Computer.php
+++ b/src/Computer.php
@@ -308,14 +308,9 @@ class Computer extends CommonDBTM
 
         $this->deleteChildrenAndRelationsFromDb(
             [
-                Certificate_Item::class,
                 Computer_Item::class,
-                Item_SoftwareLicense::class,
-                Item_SoftwareVersion::class,
                 ComputerAntivirus::class,
                 ComputerVirtualMachine::class,
-                Item_Disk::class,
-                Item_Project::class,
             ]
         );
 

--- a/src/Computer.php
+++ b/src/Computer.php
@@ -313,12 +313,6 @@ class Computer extends CommonDBTM
                 ComputerVirtualMachine::class,
             ]
         );
-
-        Item_Devices::cleanItemDeviceDBOnItemDelete(
-            $this->getType(),
-            $this->fields['id'],
-            (!empty($this->input['keep_devices']))
-        );
     }
 
 

--- a/src/Consumable.php
+++ b/src/Consumable.php
@@ -83,17 +83,6 @@ class Consumable extends CommonDBChild
     }
 
 
-    public function cleanDBonPurge()
-    {
-
-        $this->deleteChildrenAndRelationsFromDb(
-            [
-                Infocom::class,
-            ]
-        );
-    }
-
-
     public function prepareInputForAdd($input)
     {
 

--- a/src/Dashboard/Item.php
+++ b/src/Dashboard/Item.php
@@ -41,6 +41,7 @@ class Item extends \CommonDBChild
     public static $items_id = 'dashboards_dashboards_id';
 
    // prevent bad getFromDB when bootstraping tests suite
+   // FIXME Should be true
     public static $mustBeAttached = false;
 
     /**

--- a/src/Dashboard/Right.php
+++ b/src/Dashboard/Right.php
@@ -41,6 +41,7 @@ class Right extends \CommonDBChild
     public static $items_id = 'dashboards_dashboards_id';
 
    // prevent bad getFromDB when bootstraping tests suite
+   // FIXME Should be true
     public static $mustBeAttached = false;
 
     /**

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -2008,13 +2008,6 @@ final class DbUtils
 
         $normalized_relations = [];
         foreach ($RELATION as $source_table => $table_relations) {
-            if ($source_table === '_virtual_device') {
-                // '_virtual_device' special case, not normalized for now.
-                // FIXME Add some checks on it
-                $normalized_relations['_virtual_device'] = $table_relations;
-                continue;
-            }
-
             $source_itemtype = getItemTypeForTable($source_table);
             if (!is_a($source_itemtype, CommonDBTM::class, true)) {
                 trigger_error(

--- a/src/ImageFormat.php
+++ b/src/ImageFormat.php
@@ -47,4 +47,11 @@ class ImageFormat extends CommonDropdown
     {
         return "far fa-file-image";
     }
+
+    public function cleanDBonPurge()
+    {
+        $this->deleteChildrenAndRelationsFromDb([
+            Item_DeviceCamera_ImageFormat::class,
+        ]);
+    }
 }

--- a/src/ImageResolution.php
+++ b/src/ImageResolution.php
@@ -41,4 +41,11 @@ class ImageResolution extends CommonDropdown
     {
         return _nx('image', 'Resolution', 'Resolutions', $nb);
     }
+
+    public function cleanDBonPurge()
+    {
+        $this->deleteChildrenAndRelationsFromDb([
+            Item_DeviceCamera_ImageResolution::class,
+        ]);
+    }
 }

--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -100,10 +100,11 @@ class Infocom extends CommonDBChild
     {
         global $CFG_GLPI;
 
-        return array_merge(
+        $types = array_merge(
             $CFG_GLPI['infocom_types'],
             Item_Devices::getDeviceTypes()
         );
+        return array_unique($types);
     }
 
 

--- a/src/Item_Cluster.php
+++ b/src/Item_Cluster.php
@@ -40,8 +40,8 @@ class Item_Cluster extends CommonDBRelation
     public static $itemtype_2 = 'itemtype';
     public static $items_id_2 = 'items_id';
     public static $checkItem_1_Rights = self::DONT_CHECK_ITEM_RIGHTS;
-    public static $mustBeAttached_1      = false;
-    public static $mustBeAttached_2      = false;
+    public static $mustBeAttached_1 = false; // FIXME It make no sense for a cluster item to not be attached to a Cluster.
+    public static $mustBeAttached_2 = false; // FIXME It make no sense for a cluster item to not be attached to an Item.
 
     public static function getTypeName($nb = 0)
     {

--- a/src/Item_DeviceCamera.php
+++ b/src/Item_DeviceCamera.php
@@ -52,4 +52,12 @@ class Item_DeviceCamera extends Item_Devices
     {
         return [];
     }
+
+    public function cleanDBonPurge()
+    {
+        $this->deleteChildrenAndRelationsFromDb([
+            Item_DeviceCamera_ImageFormat::class,
+            Item_DeviceCamera_ImageResolution::class,
+        ]);
+    }
 }

--- a/src/Item_Enclosure.php
+++ b/src/Item_Enclosure.php
@@ -40,8 +40,8 @@ class Item_Enclosure extends CommonDBRelation
     public static $itemtype_2 = 'itemtype';
     public static $items_id_2 = 'items_id';
     public static $checkItem_1_Rights = self::DONT_CHECK_ITEM_RIGHTS;
-    public static $mustBeAttached_1      = false;
-    public static $mustBeAttached_2      = false;
+    public static $mustBeAttached_1 = false; // FIXME It make no sense for an enclosure item to not be attached to an Enclosure.
+    public static $mustBeAttached_2 = false; // FIXME It make no sense for an enclosure item to not be attached to an Item.
 
     public static function getTypeName($nb = 0)
     {

--- a/src/Item_Rack.php
+++ b/src/Item_Rack.php
@@ -40,8 +40,8 @@ class Item_Rack extends CommonDBRelation
     public static $itemtype_2 = 'itemtype';
     public static $items_id_2 = 'items_id';
     public static $checkItem_2_Rights = self::DONT_CHECK_ITEM_RIGHTS;
-    public static $mustBeAttached_1      = false;
-    public static $mustBeAttached_2      = false;
+    public static $mustBeAttached_1 = false; // FIXME It make no sense for a rack item to not be attached to a Rack.
+    public static $mustBeAttached_2 = false; // FIXME It make no sense for a rack item to not be attached to an Item.
 
     public static function getTypeName($nb = 0)
     {

--- a/src/KnowbaseItemCategory.php
+++ b/src/KnowbaseItemCategory.php
@@ -62,4 +62,13 @@ class KnowbaseItemCategory extends CommonTreeDropdown
     {
         return KnowbaseItem::getIcon();
     }
+
+    public function cleanDBonPurge()
+    {
+        $this->deleteChildrenAndRelationsFromDb(
+            [
+                KnowbaseItem_KnowbaseItemCategory::class
+            ]
+        );
+    }
 }

--- a/src/Monitor.php
+++ b/src/Monitor.php
@@ -134,16 +134,6 @@ class Monitor extends CommonDBTM
     }
 
 
-    public function cleanDBonPurge()
-    {
-        Item_Devices::cleanItemDeviceDBOnItemDelete(
-            $this->getType(),
-            $this->fields['id'],
-            (!empty($this->input['keep_devices']))
-        );
-    }
-
-
     /**
      * Print the monitor form
      *

--- a/src/Monitor.php
+++ b/src/Monitor.php
@@ -136,14 +136,6 @@ class Monitor extends CommonDBTM
 
     public function cleanDBonPurge()
     {
-
-        $this->deleteChildrenAndRelationsFromDb(
-            [
-                Computer_Item::class,
-                Item_Project::class,
-            ]
-        );
-
         Item_Devices::cleanItemDeviceDBOnItemDelete(
             $this->getType(),
             $this->fields['id'],

--- a/src/NetworkEquipment.php
+++ b/src/NetworkEquipment.php
@@ -97,21 +97,6 @@ class NetworkEquipment extends CommonDBTM
 
 
     /**
-     * @since 0.84
-     *
-     * @see CommonDBTM::cleanDBonPurge()
-     **/
-    public function cleanDBonPurge()
-    {
-        Item_Devices::cleanItemDeviceDBOnItemDelete(
-            $this->getType(),
-            $this->fields['id'],
-            (!empty($this->input['keep_devices']))
-        );
-    }
-
-
-    /**
      * @see CommonDBTM::useDeletedToLockIfDynamic()
      *
      * @since 0.84

--- a/src/NetworkEquipment.php
+++ b/src/NetworkEquipment.php
@@ -103,14 +103,6 @@ class NetworkEquipment extends CommonDBTM
      **/
     public function cleanDBonPurge()
     {
-
-        $this->deleteChildrenAndRelationsFromDb(
-            [
-                Certificate_Item::class,
-                Item_Project::class,
-            ]
-        );
-
         Item_Devices::cleanItemDeviceDBOnItemDelete(
             $this->getType(),
             $this->fields['id'],

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -540,6 +540,14 @@ class NetworkPort extends CommonDBChild
                 NetworkName::class,
                 NetworkPort_NetworkPort::class,
                 NetworkPort_Vlan::class,
+                NetworkPortAggregate::class,
+                NetworkPortAlias::class,
+                NetworkPortDialup::class,
+                NetworkPortEthernet::class,
+                NetworkPortFiberchannel::class,
+                NetworkPortLocal::class,
+                NetworkPortMetrics::class,
+                NetworkPortWifi::class,
             ]
         );
     }

--- a/src/NetworkPortConnectionLog.php
+++ b/src/NetworkPortConnectionLog.php
@@ -35,6 +35,9 @@
 
 /**
  * Store ports connections log
+ *
+ * FIXME This class should inherit from CommonDBRelation, as it is linked
+ * to both 'networkports_id_source' and 'networkports_id_destination'
  */
 class NetworkPortConnectionLog extends CommonDBChild
 {

--- a/src/OperatingSystem.php
+++ b/src/OperatingSystem.php
@@ -43,4 +43,13 @@ class OperatingSystem extends CommonDropdown
     {
         return _n('Operating system', 'Operating systems', $nb);
     }
+
+    public function cleanDBonPurge()
+    {
+        $this->deleteChildrenAndRelationsFromDb(
+            [
+                Item_OperatingSystem::class
+            ]
+        );
+    }
 }

--- a/src/PendingReason.php
+++ b/src/PendingReason.php
@@ -286,4 +286,13 @@ class PendingReason extends CommonDropdown
 
         return parent::getSpecificValueToSelect($field, $name, $values, $options);
     }
+
+    public function cleanDBonPurge()
+    {
+        $this->deleteChildrenAndRelationsFromDb(
+            [
+                PendingReason_Item::class,
+            ]
+        );
+    }
 }

--- a/src/Peripheral.php
+++ b/src/Peripheral.php
@@ -137,15 +137,6 @@ class Peripheral extends CommonDBTM
 
     public function cleanDBonPurge()
     {
-
-        $this->deleteChildrenAndRelationsFromDb(
-            [
-                Certificate_Item::class,
-                Computer_Item::class,
-                Item_Project::class,
-            ]
-        );
-
         Item_Devices::cleanItemDeviceDBOnItemDelete(
             $this->getType(),
             $this->fields['id'],

--- a/src/Peripheral.php
+++ b/src/Peripheral.php
@@ -135,16 +135,6 @@ class Peripheral extends CommonDBTM
     }
 
 
-    public function cleanDBonPurge()
-    {
-        Item_Devices::cleanItemDeviceDBOnItemDelete(
-            $this->getType(),
-            $this->fields['id'],
-            (!empty($this->input['keep_devices']))
-        );
-    }
-
-
     /**
      * Return the linked items (in computers_items)
      *

--- a/src/Phone.php
+++ b/src/Phone.php
@@ -138,14 +138,6 @@ class Phone extends CommonDBTM
 
     public function cleanDBonPurge()
     {
-
-        $this->deleteChildrenAndRelationsFromDb(
-            [
-                Computer_Item::class,
-                Item_Project::class,
-            ]
-        );
-
         Item_Devices::cleanItemDeviceDBOnItemDelete(
             $this->getType(),
             $this->fields['id'],

--- a/src/Phone.php
+++ b/src/Phone.php
@@ -136,16 +136,6 @@ class Phone extends CommonDBTM
     }
 
 
-    public function cleanDBonPurge()
-    {
-        Item_Devices::cleanItemDeviceDBOnItemDelete(
-            $this->getType(),
-            $this->fields['id'],
-            (!empty($this->input['keep_devices']))
-        );
-    }
-
-
     /**
      * Print the phone form
      *

--- a/src/PlanningExternalEvent.php
+++ b/src/PlanningExternalEvent.php
@@ -389,16 +389,6 @@ JAVASCRIPT;
         return $values;
     }
 
-    public function cleanDBonPurge()
-    {
-
-        $this->deleteChildrenAndRelationsFromDb(
-            [
-                VObject::class,
-            ]
-        );
-    }
-
     public static function getGroupItemsAsVCalendars($groups_id)
     {
 

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -263,10 +263,8 @@ class Printer extends CommonDBTM
 
         $this->deleteChildrenAndRelationsFromDb(
             [
-                Certificate_Item::class,
-                Computer_Item::class,
-                Item_Project::class,
-                Printer_CartridgeInfo::class
+                Printer_CartridgeInfo::class,
+                PrinterLog::class,
             ]
         );
 

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -267,12 +267,6 @@ class Printer extends CommonDBTM
                 PrinterLog::class,
             ]
         );
-
-        Item_Devices::cleanItemDeviceDBOnItemDelete(
-            $this->getType(),
-            $this->fields['id'],
-            (!empty($this->input['keep_devices']))
-        );
     }
 
 

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -165,7 +165,6 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
             [
                 ProjectTask_Ticket::class,
                 ProjectTaskTeam::class,
-                VObject::class,
                 ProjectTaskLink::class,
             ]
         );

--- a/src/Reminder.php
+++ b/src/Reminder.php
@@ -175,7 +175,6 @@ class Reminder extends CommonDBVisible implements
                 PlanningRecall::class,
                 Profile_Reminder::class,
                 Reminder_User::class,
-                VObject::class,
                 ReminderTranslation::class,
             ]
         );

--- a/src/Software.php
+++ b/src/Software.php
@@ -176,7 +176,6 @@ class Software extends CommonDBTM
 
         $this->deleteChildrenAndRelationsFromDb(
             [
-                Item_Project::class,
                 SoftwareVersion::class,
             ]
         );

--- a/src/SoftwareLicense.php
+++ b/src/SoftwareLicense.php
@@ -192,7 +192,6 @@ class SoftwareLicense extends CommonTreeDropdown
 
         $this->deleteChildrenAndRelationsFromDb(
             [
-                Certificate_Item::class,
                 Item_SoftwareLicense::class,
             ]
         );

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1017,6 +1017,7 @@ class Ticket extends CommonITILObject
                 Problem_Ticket::class,
                 ProjectTask_Ticket::class,
                 TicketCost::class,
+                Ticket_Contract::class,
                 Ticket_Ticket::class,
                 TicketValidation::class,
             ]

--- a/src/Unmanaged.php
+++ b/src/Unmanaged.php
@@ -187,16 +187,6 @@ class Unmanaged extends CommonDBTM
         return $tab;
     }
 
-    public function cleanDBonPurge()
-    {
-
-        $this->deleteChildrenAndRelationsFromDb(
-            [
-                NetworkPort::class
-            ]
-        );
-    }
-
     public static function getIcon()
     {
         return "ti ti-question-mark";

--- a/src/User.php
+++ b/src/User.php
@@ -34,6 +34,8 @@
  */
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Dashboard\Dashboard;
+use Glpi\Dashboard\Filter;
 use Glpi\Exception\ForgetPasswordException;
 use Glpi\Plugin\Hooks;
 use Glpi\Toolbox\Sanitizer;
@@ -393,6 +395,8 @@ class User extends CommonDBTM
        // Reminder does not extends CommonDBConnexity
         $r = new Reminder();
         $r->deleteByCriteria(['users_id' => $this->fields['id']]);
+        $reminder_translation = new ReminderTranslation();
+        $reminder_translation->deleteByCriteria(['users_id' => $this->fields['id']]);
 
        // Delete private bookmark
         $ss = new SavedSearch();
@@ -430,9 +434,9 @@ class User extends CommonDBTM
 
         $this->deleteChildrenAndRelationsFromDb(
             [
-                Certificate_Item::class,
                 Change_User::class,
                 Group_User::class,
+                Item_Kanban::class,
                 KnowbaseItem_User::class,
                 Problem_User::class,
                 Profile_User::class,
@@ -450,6 +454,12 @@ class User extends CommonDBTM
             // DisplayPreference does not extends CommonDBConnexity
             $dp = new DisplayPreference();
             $dp->deleteByCriteria(['users_id' => $this->fields['id']]);
+
+            // Delete private dashboards and private dashboard filters
+            $dashboard = new Dashboard();
+            $dashboard->deleteByCriteria(['users_id' => $this->fields['id']]);
+            $dashboard_filters = new Filter();
+            $dashboard_filters->deleteByCriteria(['users_id' => $this->fields['id']]);
         }
 
         $this->dropPictureFiles($this->fields['picture']);

--- a/tests/functionnal/CommonDBTM.php
+++ b/tests/functionnal/CommonDBTM.php
@@ -1097,6 +1097,90 @@ class CommonDBTM extends DbTestCase
         $this->boolean($relation_item->getFromDB($relation_item_2_id))->isTrue();
     }
 
+    public function testCleanRelationDataForPolymorphicRelations()
+    {
+        $this->login();
+
+        $entity_id     = getItemByTypeName(\Entity::class, '_test_root_entity', true);
+        $computer_1    = getItemByTypeName(\Computer::class, '_test_pc01');
+        $computer_id_1 = $computer_1->getID();
+        $computer_2    = getItemByTypeName(\Computer::class, '_test_pc02');
+        $computer_id_2 = $computer_2->getID();
+        $phone         = getItemByTypeName(\Phone::class, '_test_phone_1');
+        $phone_id      = $phone->getID();
+
+        $device_battery_1 = $this->createItem(
+            \DeviceBattery::class,
+            [
+                'designation'         => 'Battery 1',
+                'entities_id'         => $entity_id,
+            ]
+        );
+        $device_battery_1_id = $device_battery_1->getID();
+        $device_battery_2 = $this->createItem(
+            \DeviceBattery::class,
+            [
+                'designation'         => 'Battery 2',
+                'entities_id'         => $entity_id,
+            ]
+        );
+        $device_battery_2_id = $device_battery_2->getID();
+
+        // Attach both softwares to items
+        $items = [
+            [
+                'itemtype' => \Computer::class,
+                'items_id' => $computer_id_1,
+            ],
+            [
+                'itemtype' => \Computer::class,
+                'items_id' => $computer_id_2,
+            ],
+            [
+                'itemtype' => \Phone::class,
+                'items_id' => $phone_id,
+            ],
+        ];
+        foreach ($items as $item) {
+            foreach ([$device_battery_1_id, $device_battery_2_id] as $device_battery_id) {
+                $this->createItem(
+                    \Item_DeviceBattery::class,
+                    $item + [
+                        'devicebatteries_id' => $device_battery_id,
+                        'entities_id'        => $entity_id,
+                    ]
+                );
+            }
+        }
+
+        // Check that only created relations exists
+        $this->integer(
+            countElementsInTable(\Item_DeviceBattery::getTable(), ['itemtype' => \Computer::class, 'items_id' => $computer_id_1])
+        )->isEqualTo(2);
+        $this->integer(
+            countElementsInTable(\Item_DeviceBattery::getTable(), ['itemtype' => \Computer::class, 'items_id' => $computer_id_2])
+        )->isEqualTo(2);
+        $this->integer(
+            countElementsInTable(\Item_DeviceBattery::getTable(), ['itemtype' => \Phone::class, 'items_id' => $phone_id])
+        )->isEqualTo(2);
+
+        $computer_1->cleanRelationData();
+
+        // Check that only relations to computer were cleaned
+        $this->integer(
+            countElementsInTable(\Item_DeviceBattery::getTable(), ['itemtype' => \Computer::class, 'items_id' => $computer_id_1])
+        )->isEqualTo(0);
+        $this->integer(
+            countElementsInTable(\Item_DeviceBattery::getTable(), ['itemtype' => null, 'items_id' => 0])
+        )->isEqualTo(2);
+        $this->integer(
+            countElementsInTable(\Item_DeviceBattery::getTable(), ['itemtype' => \Computer::class, 'items_id' => $computer_id_2])
+        )->isEqualTo(2);
+        $this->integer(
+            countElementsInTable(\Item_DeviceBattery::getTable(), ['itemtype' => \Phone::class, 'items_id' => $phone_id])
+        )->isEqualTo(2);
+    }
+
 
     protected function testCheckTemplateEntityProvider()
     {

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -1054,13 +1054,9 @@ class DbUtils extends DbTestCase
 
         $mapping = $this->testedInstance->getDbRelations();
 
-        // Check that '_virtual_device' is declared
-        $this->array($mapping)->hasKey('_virtual_device');
-        $this->array($mapping['_virtual_device']);
-
         // Check that target fields exists in database
         foreach ($mapping as $source_table => $relations) {
-            $this->boolean($source_table === '_virtual_device' || $DB->tableExists($source_table))
+            $this->boolean($DB->tableExists($source_table))
                 ->isTrue(sprintf('Invalid table "%s" in relation mapping.', $source_table));
 
             foreach ($relations as $target_table_key => $target_fields) {
@@ -1085,13 +1081,10 @@ class DbUtils extends DbTestCase
                         $fields_to_check = array_merge($fields_to_check, $target_field);
                     } else {
                         // Ensure polymorphic relations are correctly declared in an array with both fields names.
-                        if ($source_table !== '_virtual_device') {
-                            // FIXME '_virtual_device' should respect same format
-                            $msg = sprintf('Invalid table field "%s.%s" in "%s" mapping.', $target_table, $target_field, $source_table);
-                            $this->string($target_field)
-                                ->notMatches('/^itemtype/', $msg)
-                                ->notMatches('/^items_id/', $msg);
-                        }
+                        $msg = sprintf('Invalid table field "%s.%s" in "%s" mapping.', $target_table, $target_field, $source_table);
+                        $this->string($target_field)
+                            ->notMatches('/^itemtype/', $msg)
+                            ->notMatches('/^items_id/', $msg);
 
                         $fields_to_check[] = $target_field;
                     }

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -1048,50 +1048,231 @@ class DbUtils extends DbTestCase
      */
     public function testRelationsValidity()
     {
-
         global $DB;
 
-        $this
-         ->if($this->newTestedInstance)
-         ->then
-         ->array($mapping = $this->testedInstance->getDbRelations())
-         ->hasKey('_virtual_device');
+        $this->newTestedInstance();
 
-        $virtual_mapping = $mapping['_virtual_device'];
-        unset($mapping['_virtual_device']);
+        $mapping = $this->testedInstance->getDbRelations();
 
-        foreach ($mapping as $tablename => $relations) {
-            $this->boolean($DB->tableExists($tablename))
-            ->isTrue(sprintf('Invalid table "%s" in relation mapping.', $tablename));
+        // Check that '_virtual_device' is declared
+        $this->array($mapping)->hasKey('_virtual_device');
+        $this->array($mapping['_virtual_device']);
 
-            foreach ($relations as $relation_tablename => $fields) {
-                if (strpos($relation_tablename, '_') === 0) {
-                    $relation_tablename = substr($relation_tablename, 1);
+        // Check that target fields exists in database
+        foreach ($mapping as $source_table => $relations) {
+            $this->boolean($source_table === '_virtual_device' || $DB->tableExists($source_table))
+                ->isTrue(sprintf('Invalid table "%s" in relation mapping.', $source_table));
+
+            foreach ($relations as $target_table_key => $target_fields) {
+                $target_table = preg_replace('/^_/', '', $target_table_key);
+
+                $this->boolean($DB->tableExists($target_table))
+                    ->isTrue(sprintf('Invalid table "%s" in "%s" mapping.', $target_table, $source_table));
+
+                $this->array($target_fields);
+
+                $fields_to_check = [];
+                foreach ($target_fields as $target_field) {
+                    if (is_array($target_field)) {
+                        // Polymorphic relation
+                        $this->array($target_field)->size->isEqualTo(2); // has only `itemtype*` and `items_id*` fields
+                        if ($target_table === 'glpi_ipaddresses') {
+                            $this->array($target_field)->containsValues(['mainitemtype', 'mainitems_id']);
+                        } else {
+                            $this->integer(count(preg_grep('/^itemtype/', $target_field)))->isEqualTo(1);
+                            $this->integer(count(preg_grep('/^items_id/', $target_field)))->isEqualTo(1);
+                        }
+                        $fields_to_check = array_merge($fields_to_check, $target_field);
+                    } else {
+                        // Ensure polymorphic relations are correctly declared in an array with both fields names.
+                        if ($source_table !== '_virtual_device') {
+                            // FIXME '_virtual_device' should respect same format
+                            $msg = sprintf('Invalid table field "%s.%s" in "%s" mapping.', $target_table, $target_field, $source_table);
+                            $this->string($target_field)
+                                ->notMatches('/^itemtype/', $msg)
+                                ->notMatches('/^items_id/', $msg);
+                        }
+
+                        $fields_to_check[] = $target_field;
+                    }
                 }
-
-                $this->boolean($DB->tableExists($relation_tablename))
-                ->isTrue(sprintf('Invalid table "%s" in relation mapping.', $relation_tablename));
-
-                if (!is_array($fields)) {
-                    $fields = [$fields];
-                }
-
-                foreach ($fields as $field) {
-                    $this->boolean($DB->fieldExists($relation_tablename, $field))
-                    ->isTrue(sprintf('Invalid table field "%s.%s" in relation mapping.', $relation_tablename, $field));
+                foreach ($fields_to_check as $field_to_check) {
+                    $this->boolean($DB->fieldExists($target_table, $field_to_check))
+                        ->isTrue(sprintf('Invalid table field "%s.%s" in "%s" mapping.', $target_table, $field_to_check, $source_table));
                 }
             }
         }
 
-        foreach ($virtual_mapping as $tablename => $fields) {
-            $this->boolean($DB->tableExists($tablename))
-            ->isTrue(sprintf('Invalid table "%s" in _virtual_device mapping.', $tablename));
+        // Check for duplicated relations declaration
+        $already_known_relations = [];
+        $duplicated_relations    = [];
+        $mixed_relations         = [];
+        foreach ($mapping as $source_table => $relations) {
+            foreach ($relations as $target_table_key => $target_fields) {
+                $is_table_key_prefixed = str_starts_with($target_table_key, '_');
 
-            foreach ($fields as $field) {
-                $this->boolean($DB->fieldExists($tablename, $field))
-                ->isTrue(sprintf('Invalid table field "%s.%s" in _virtual_device mapping.', $tablename, $field));
+                $unprefixed_table_key = $is_table_key_prefixed ? preg_replace('/^_/', '', $target_table_key) : $target_table_key;
+                $prefixed_table_key   = $is_table_key_prefixed ? $target_table_key : '_' . $target_table_key;
+
+                foreach ($target_fields as $target_field) {
+                    $relation            = sprintf('‣ "%s" > "%s" > %s', $source_table, $target_table_key, json_encode($target_field));
+                    $unprefixed_relation = sprintf('‣ "%s" > "%s" > %s', $source_table, $unprefixed_table_key, json_encode($target_field));
+                    $prefixed_relation   = sprintf('‣ "%s" > "%s" > %s', $source_table, $prefixed_table_key, json_encode($target_field));
+
+                    if (in_array($relation, $already_known_relations)) {
+                        $duplicated_relations[] = $relation;
+                    } elseif (
+                        ($is_table_key_prefixed && in_array($unprefixed_relation, $already_known_relations))
+                        || (!$is_table_key_prefixed && in_array($prefixed_relation, $already_known_relations))
+                    ) {
+                        $mixed_relations[] = $relation;
+                    }
+
+                    $already_known_relations[] = $relation;
+                }
             }
         }
+
+        // Check that relations are all declared (and correctly declared)
+        $expected_mapping = [];
+
+        // Compute expected relations based on foreign keys in tables
+        foreach ($DB->listTables() as $table_specs) {
+            $target_table = $table_specs['TABLE_NAME'];
+            $target_itemtype = getItemTypeForTable($target_table);
+            if (!is_a($target_itemtype, \CommonDBTM::class, true)) {
+                continue;
+            }
+
+            foreach ($DB->listFields($target_table) as $field_specs) {
+                $target_field = $field_specs['Field'];
+                if (!isForeignKeyField($target_field) || preg_match('/^int([ (].+)*$/', $field_specs['Type']) !== 1) {
+                    continue;
+                }
+
+                $source_itemtype = getItemtypeForForeignKeyField($target_field);
+                if (!is_a($source_itemtype, \CommonDBTM::class, true)) {
+                    continue;
+                }
+                $source_table = $source_itemtype::getTable();
+
+                $target_table_key_prefix = '';
+                if (
+                    (
+                        is_a($target_itemtype, \CommonDBChild::class, true)
+                        && $target_itemtype::$itemtype === $source_itemtype
+                        && $target_itemtype::$items_id === $target_field
+                        && $target_itemtype::$mustBeAttached === true
+                    )
+                    || (
+                        is_a($target_itemtype, \CommonDBRelation::class, true)
+                        && (
+                            (
+                                $target_itemtype::$itemtype_1 === $source_itemtype
+                                && $target_itemtype::$items_id_1 === $target_field
+                                && $target_itemtype::$mustBeAttached_1 === true
+                            )
+                            || (
+                                $target_itemtype::$itemtype_2 === $source_itemtype
+                                && $target_itemtype::$items_id_2 === $target_field
+                                && $target_itemtype::$mustBeAttached_2 === true
+                            )
+                        )
+                    )
+                ) {
+                    // If item must be attached, target table key has to be prefixed by "_"
+                    // to be ignored by `CommonDBTM::cleanRelationData()`. Indeed, without usage of this prefix,
+                    // related item will be preserved with its foreign key defined to 0, making it an unwanted orphaned item.
+                    $target_table_key_prefix = '_';
+                } elseif ($target_itemtype::getIndexName() === $target_field) {
+                    // Automatic update will not be possible due to the way automatic update is done in `CommonDBTM::cleanRelationData()`.
+                    $target_table_key_prefix = '_';
+                }
+                $target_table_key = $target_table_key_prefix . $target_table;
+
+                if (!array_key_exists($source_table, $expected_mapping)) {
+                    $expected_mapping[$source_table] = [];
+                }
+                if (!array_key_exists($target_table_key, $expected_mapping[$source_table])) {
+                    $expected_mapping[$source_table][$target_table_key] = [];
+                }
+
+                $expected_mapping[$source_table][$target_table_key][] = $target_field;
+            }
+        }
+
+        // FIXME Try to automatize computation of expected polymorphic relations mapping (not sure it is possible).
+
+        // Check for missing relation
+        $missing_relations = [];
+        $forbiddenly_prefixed_relations = [];
+        foreach ($expected_mapping as $expected_source_table => $expected_relations) {
+            foreach ($expected_relations as $expected_target_table_key => $expected_target_fields) {
+                foreach ($expected_target_fields as $expected_target_field) {
+                    $is_expected_key_prefixed = str_starts_with($expected_target_table_key, '_');
+
+                    $unprefixed_table_key = $is_expected_key_prefixed ? preg_replace('/^_/', '', $expected_target_table_key) : $expected_target_table_key;
+                    $prefixed_table_key   = $is_expected_key_prefixed ? $expected_target_table_key : '_' . $expected_target_table_key;
+
+                    $is_declared_without_prefix = isset($mapping[$expected_source_table][$unprefixed_table_key])
+                        && in_array($expected_target_field, $mapping[$expected_source_table][$unprefixed_table_key]);
+                    $is_declared_with_prefix    = isset($mapping[$expected_source_table][$prefixed_table_key])
+                        && in_array($expected_target_field, $mapping[$expected_source_table][$prefixed_table_key]);
+
+                    if ($is_declared_without_prefix && $is_expected_key_prefixed) {
+                        // If "_" prefix is present in expected mapping, it means that computation
+                        // states that relation has to be handled specifically.
+                        // In this case, having this declaration without "_" prefix in result mapping is forbidden.
+                        $forbiddenly_prefixed_relations[] = sprintf(
+                            '‣ "%s" > "%s" > %s',
+                            $expected_source_table,
+                            $unprefixed_table_key,
+                            json_encode($expected_target_field)
+                        );
+                    } elseif (!$is_declared_without_prefix && !$is_declared_with_prefix) {
+                        $missing_relations[] = sprintf(
+                            '‣ "%s" > "%s" > %s',
+                            $expected_source_table,
+                            $expected_target_table_key,
+                            json_encode($expected_target_field)
+                        );
+                    }
+                }
+            }
+        }
+
+        sort($forbiddenly_prefixed_relations);
+        sort($missing_relations);
+        sort($duplicated_relations);
+        sort($mixed_relations);
+
+        $msg = PHP_EOL;
+        if (!empty($forbiddenly_prefixed_relations)) {
+            $msg .= 'Following relations are declared without "_" prefix but should not:'
+                . PHP_EOL
+                . implode(PHP_EOL, $forbiddenly_prefixed_relations)
+                . PHP_EOL;
+        }
+        if (!empty($missing_relations)) {
+            $msg .= 'Following relations are missing:'
+                . PHP_EOL
+                . implode(PHP_EOL, $missing_relations)
+                . PHP_EOL;
+        }
+        if (!empty($duplicated_relations)) {
+            $msg .= 'Following relations are duplicated:'
+                . PHP_EOL
+                . implode(PHP_EOL, $duplicated_relations)
+                . PHP_EOL;
+        }
+        if (!empty($mixed_relations)) {
+            $msg .= 'Following relations are mixed (declared twice with and without "_" prefix):'
+                . PHP_EOL
+                . implode(PHP_EOL, $mixed_relations)
+                . PHP_EOL;
+        }
+        $this->boolean(empty($forbiddenly_prefixed_relations) && empty($missing_relations) && empty($duplicated_relations) && empty($mixed_relations))
+            ->isTrue($msg);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yeso
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`CommonDBTM::cleanRelationData()`, `CommonDBTM::canUnrecurs()` and `Dropdown::isUsed()` have an incorrect handling of `itemtype`/`items_id` relations.

For instance, I figured out that when an item is purged, every element linked to an item having same ID as purged item, regardless its itemtype, will be detached. It means that if a battery item is linked to both computer 1 and phone 1, it will be detached from both assets when any of them is purged.
See https://github.com/glpi-project/glpi/blob/5dce9c6dc3bd713ec6f622238f3e925d40f6d277/src/CommonDBTM.php#L875-L880

I also figured out that some declarations added in #13015 should have been prefixed by a `_`, as relation is deleted in `cleanDBOnPurge`.

Then, I noticed that many relations were not declared in mapping.

TODO:

- [x] Fix handling of polymorphic relations in `CommonDBTM::cleanRelationData()`.
- [x] Fix handling of polymorphic relations in `CommonDBTM::canUnrecurs()`.
- [x] Fix handling of polymorphic relations in `Dropdown::isUsed()`.
- [x] Add tests to detect missing/misdeclared/duplicated relations.
- [x] Automatize polymorphic relations declaration logic.
- [ ] Automatize handling of relations to `Alert`.
- [ ] Automatize handling of relations to `PlanningRecall`.
- [ ] Automatize handling of relations to `ProjectTeam`.
- [ ] Automatize handling of relations to `ProjectTaskTeam`.
- [ ] Automatize handling of relations to `NetworkName`.
- [x] Automatize calls to `Item_Devices::cleanItemDeviceDBOnItemDelete()`.
