### PR TITLE
Fix illegal SCSS syntax

### DIFF
--- a/css/includes/components/_select2.scss
+++ b/css/includes/components/_select2.scss
@@ -55,22 +55,6 @@
             }
         }
 
-        .select2-container--focus& {
-            border-color: $input-focus-border-color;
-            box-shadow: $input-focus-box-shadow;
-        }
-
-        .select2-container--disabled& {
-            background-color: $input-disabled-bg;
-            border-color: $input-border-color;
-            box-shadow: none;
-            cursor: not-allowed;
-
-            .select2-selection__rendered {
-                color: $text-muted;
-            }
-        }
-
         &.select2-selection--single {
             @include font-size($input-font-size);
 
@@ -191,6 +175,22 @@
                     }
                 }
             }
+        }
+    }
+
+    &.select2-container--focus .select2-selection {
+        border-color: $input-focus-border-color;
+        box-shadow: $input-focus-box-shadow;
+    }
+
+    &.select2-container--disabled .select2-selection {
+        background-color: $input-disabled-bg;
+        border-color: $input-border-color;
+        box-shadow: none;
+        cursor: not-allowed;
+
+        .select2-selection__rendered {
+            color: $text-muted;
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fix syntax that is illegal according to SCSS documentation.
See https://sass-lang.com/documentation/style-rules/parent-selector
![image](https://user-images.githubusercontent.com/33253653/196612938-6dab65df-62af-4100-aa16-cc6fff9e9818.png)
