### PR TITLE
Fix ISO-8859-1 document filename conversion

### DIFF
--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -712,7 +712,7 @@ class Toolbox
         }
         header(
             "Content-disposition:$attachment filename=\"" .
-            addslashes(iconv('UTF-8', 'ISO-8859-1', $filename)) .
+            addslashes(mb_convert_encoding($filename, 'ISO-8859-1', 'UTF-8')) .
             "\"; filename*=utf-8''" .
             rawurlencode($filename)
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13022

It seems that ``mb_convert_encoding`` handles more chars than ``iconv``.