### PR TITLE
Remove return by reference for getOptionsByItemtype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ The present file will list all changes made to the project; according to the
 - `Ticket_Ticket::getLinkedTicketsTo()`
 - `Ticket_Ticket::manageLinkedTicketsOnSolved()`
 - `Toolbox::seems_utf8()`
+- `Search::getOptions()` no longer returns a reference
 
 #### Removed
 - Usage of `csrf_compliant` plugins hook.

--- a/ajax/dropdownMassiveActionField.php
+++ b/ajax/dropdownMassiveActionField.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Search\SearchOption;
+
 include('../inc/includes.php');
 
 header("Content-Type: text/html; charset=UTF-8");
@@ -64,7 +66,7 @@ if (
     isset($_POST["itemtype"])
     && isset($_POST["id_field"]) && $_POST["id_field"]
 ) {
-    $search = Search::getOptions($_POST["itemtype"]);
+    $search = SearchOption::getOptionsForItemtype($_POST["itemtype"]);
     if (!isset($search[$_POST["id_field"]])) {
         exit();
     }

--- a/install/migrations/update_0.90.x_to_9.1.0.php
+++ b/install/migrations/update_0.90.x_to_9.1.0.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Search\SearchOption;
+
 /**
  * Update from 0.90.5 to 9.1
  *
@@ -541,7 +543,7 @@ function update090xto910()
     if (!isset($CFG_GLPI["use_rich_text"])) {
         $CFG_GLPI["use_rich_text"] = false;
     }
-    $searchOption = Search::getOptions('Ticket');
+    $searchOption = SearchOption::getOptionsForItemtype('Ticket');
     $item_num     = 0;
     $itemtype_num = 0;
     foreach ($searchOption as $num => $option) {

--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -50,6 +50,7 @@ use Config;
 use Contract;
 use Document;
 use Dropdown;
+use Glpi\Search\SearchOption;
 use Glpi\Toolbox\Sanitizer;
 use Html;
 use Infocom;
@@ -1397,7 +1398,7 @@ abstract class API
             $itemtype = $this->handleDepreciation($itemtype);
         }
 
-        $soptions = Search::getOptions($itemtype);
+        $soptions = SearchOption::getOptionsForItemtype($itemtype);
 
         if (isset($params['raw'])) {
             return $soptions;

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -39,6 +39,7 @@ use Glpi\Features\CacheableListInterface;
 use Glpi\Plugin\Hooks;
 use Glpi\RichText\RichText;
 use Glpi\RichText\UserMention;
+use Glpi\Search\SearchOption;
 use Glpi\Toolbox\Sanitizer;
 
 /**
@@ -4110,7 +4111,7 @@ class CommonDBTM extends CommonGLPI
     {
 
         if (!$this->searchopt) {
-            $this->searchopt = Search::getOptions($this->getType());
+            $this->searchopt = SearchOption::getOptionsForItemtype(static::getType());
         }
 
         return $this->searchopt;

--- a/src/Dashboard/Provider.php
+++ b/src/Dashboard/Provider.php
@@ -44,6 +44,7 @@ use CommonTreeDropdown;
 use CommonDevice;
 use Config;
 use DBConnection;
+use Glpi\Search\SearchOption;
 use Group;
 use Group_Ticket;
 use ITILCategory;
@@ -1624,7 +1625,7 @@ class Provider
 
     private static function getSearchOptionID(string $table, string $name, string $tableToSearch): int
     {
-        $data = Search::getOptions(getItemTypeForTable($table), true);
+        $data = SearchOption::getOptionsForItemtype(getItemTypeForTable($table), true);
         $sort = [];
         foreach ($data as $ref => $opt) {
             if (isset($opt['field'])) {

--- a/src/DisplayPreference.php
+++ b/src/DisplayPreference.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Search\SearchOption;
+
 class DisplayPreference extends CommonDBTM
 {
    // From CommonGLPI
@@ -176,7 +178,7 @@ class DisplayPreference extends CommonDBTM
             }
         } else {
            // No items in the global config
-            $searchopt = Search::getOptions($input["itemtype"]);
+            $searchopt = SearchOption::getOptionsForItemtype($input["itemtype"]);
             if (count($searchopt) > 1) {
                 $done = false;
 

--- a/src/DropdownTranslation.php
+++ b/src/DropdownTranslation.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Search\SearchOption;
+
 /**
  * DropdownTranslation Class
  *
@@ -560,7 +562,8 @@ class DropdownTranslation extends CommonDBChild
         global $DB;
 
         $options = [];
-        foreach (Search::getOptions(get_class($item)) as $id => $field) {
+        $opts = SearchOption::getOptionsForItemtype(get_class($item));
+        foreach ($opts as $id => $field) {
            //Can only translate name, and fields whose datatype is text or string
             if (
                 isset($field['field'])

--- a/src/ITILTemplate.php
+++ b/src/ITILTemplate.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Search\SearchOption;
 
 /**
  * ITIL Template class
@@ -351,7 +352,7 @@ abstract class ITILTemplate extends CommonDropdown
     {
 
         $itiltype = static::getITILObjectClass();
-        $searchOption = Search::getOptions($itiltype);
+        $searchOption = SearchOption::getOptionsForItemtype($itiltype);
         $tab          = $this->getAllowedFields($withtypeandcategory, $with_items_id);
         foreach (array_keys($tab) as $ID) {
             switch ($ID) {

--- a/src/ITILTemplatePredefinedField.php
+++ b/src/ITILTemplatePredefinedField.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Search\SearchOption;
+
 /**
  * ITILTemplatePredefinedField Class
  *
@@ -256,7 +258,7 @@ abstract class ITILTemplatePredefinedField extends ITILTemplateField
         $fields        = array_diff_key($fields, self::getExcludedFields());
 
         $itil_class    = static::$itiltype;
-        $searchOption  = Search::getOptions($itil_class);
+        $searchOption  = SearchOption::getOptionsForItemtype($itil_class);
         $itil_object   = new $itil_class();
         $rand          = mt_rand();
 

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\Plugin\Hooks;
+use Glpi\Search\SearchOption;
 
 /**
  * This class manages locks
@@ -157,7 +158,7 @@ class Lock extends CommonGLPI
             ]);
 
             //get fields labels
-            $search_options = Search::getOptions($itemtype);
+            $search_options = SearchOption::getOptionsForItemtype($itemtype);
             foreach ($search_options as $search_option) {
                 //exclude SO added by dropdown part (to get real name)
                 //ex : Manufacturer != Firmware : Manufacturer

--- a/src/Lockedfield.php
+++ b/src/Lockedfield.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Search\SearchOption;
 
 /**
  *  Locked fields for inventory
@@ -325,7 +326,7 @@ class Lockedfield extends CommonDBTM
         $itemtypes = $CFG_GLPI['inventory_types'] + $CFG_GLPI['inventory_lockable_objects'];
 
         foreach ($itemtypes as $itemtype) {
-            $search_options = Search::getOptions($itemtype);
+            $search_options = SearchOption::getOptionsForItemtype($itemtype);
             $fields = $std_fields;
             $fields[] = strtolower($itemtype) . 'models_id'; //model relation field
             $fields[] = strtolower($itemtype) . 'types_id'; //type relation field

--- a/src/Log.php
+++ b/src/Log.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Search\SearchOption;
 use Glpi\Toolbox\Sanitizer;
 
 /**
@@ -126,7 +127,7 @@ class Log extends CommonDBTM
         }
        // needed to have  $SEARCHOPTION
         list($real_type, $real_id) = $item->getLogTypeID();
-        $searchopt                 = Search::getOptions($real_type);
+        $searchopt                 = SearchOption::getOptionsForItemtype($real_type);
         if (!is_array($searchopt)) {
             return false;
         }
@@ -356,7 +357,7 @@ class Log extends CommonDBTM
         $items_id  = $item->getField('id');
         $itemtable = $item->getTable();
 
-        $SEARCHOPTION = Search::getOptions($itemtype);
+        $SEARCHOPTION = SearchOption::getOptionsForItemtype($itemtype);
 
         $query = [
             'FROM'   => self::getTable(),
@@ -952,7 +953,8 @@ class Log extends CommonDBTM
                 }
             } else {
                // It's not an internal device
-                foreach (Search::getOptions($itemtype) as $search_opt_key => $search_opt_val) {
+                $opts = SearchOption::getOptionsForItemtype($itemtype);
+                foreach ($opts as $search_opt_key => $search_opt_val) {
                     if ($search_opt_key == $data["id_search_option"]) {
                         $key = 'id_search_option::' . $data['id_search_option'] . ';';
                         $value = $search_opt_val["name"];

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\Features\Clonable;
+use Glpi\Search\SearchOption;
 use Glpi\Toolbox\Sanitizer;
 
 /**
@@ -1147,7 +1148,7 @@ class MassiveAction
                         $so_item->checkGlobal(UPDATE);
                     }
 
-                    $itemtype_search_options = Search::getOptions($so_itemtype);
+                    $itemtype_search_options = SearchOption::getOptionsForItemtype($so_itemtype);
                     if (!isset($itemtype_search_options[$so_index])) {
                         exit();
                     }

--- a/src/Search.php
+++ b/src/Search.php
@@ -769,7 +769,8 @@ class Search
      **/
     public static function &getOptions($itemtype, $withplugins = true)
     {
-        return SearchOption::getOptionsForItemtype($itemtype, $withplugins);
+        $optionsForItemtype = SearchOption::getOptionsForItemtype($itemtype, $withplugins);
+        return $optionsForItemtype;
     }
 
     /**

--- a/src/Search.php
+++ b/src/Search.php
@@ -765,12 +765,11 @@ class Search
      * @param string  $itemtype     Item type
      * @param boolean $withplugins  Get search options from plugins (true by default)
      *
-     * @return array The reference to the array of search options for the given item type
+     * @return array The array of search options for the given item type
      **/
-    public static function &getOptions($itemtype, $withplugins = true)
+    public static function getOptions($itemtype, $withplugins = true)
     {
-        $optionsForItemtype = SearchOption::getOptionsForItemtype($itemtype, $withplugins);
-        return $optionsForItemtype;
+        return SearchOption::getOptionsForItemtype($itemtype, $withplugins);
     }
 
     /**

--- a/src/Search/Output/ExportSearchOutput.php
+++ b/src/Search/Output/ExportSearchOutput.php
@@ -57,7 +57,7 @@ abstract class ExportSearchOutput extends AbstractSearchOutput
     public static function displayConfigItem($itemtype, $ID, $data = [])
     {
 
-        $searchopt  = &SearchOption::getOptionsForItemtype($itemtype);
+        $searchopt  = SearchOption::getOptionsForItemtype($itemtype);
 
         $table      = $searchopt[$ID]["table"];
         $field      = $searchopt[$ID]["field"];

--- a/src/Search/Output/PDFSearchOutput.php
+++ b/src/Search/Output/PDFSearchOutput.php
@@ -69,9 +69,9 @@ abstract class PDFSearchOutput extends ExportSearchOutput
 
             foreach ($data['search']['criteria'] as $criteria) {
                 if (isset($criteria['itemtype'])) {
-                    $searchopt = &SearchOption::getOptionsForItemtype($criteria['itemtype']);
+                    $searchopt = SearchOption::getOptionsForItemtype($criteria['itemtype']);
                 } else {
-                    $searchopt = &SearchOption::getOptionsForItemtype($data['itemtype']);
+                    $searchopt = SearchOption::getOptionsForItemtype($data['itemtype']);
                 }
                 $titlecontain = '';
 
@@ -219,7 +219,7 @@ abstract class PDFSearchOutput extends ExportSearchOutput
         ) {
             $metanames = [];
             foreach ($data['search']['metacriteria'] as $metacriteria) {
-                $searchopt = &SearchOption::getOptionsForItemtype($metacriteria['itemtype']);
+                $searchopt = SearchOption::getOptionsForItemtype($metacriteria['itemtype']);
                 if (!isset($metanames[$metacriteria['itemtype']])) {
                     if ($metaitem = getItemForItemtype($metacriteria['itemtype'])) {
                         $metanames[$metacriteria['itemtype']] = $metaitem->getTypeName();

--- a/src/Search/Provider/SQLProvider.php
+++ b/src/Search/Provider/SQLProvider.php
@@ -137,7 +137,7 @@ final class SQLProvider implements SearchProviderInterface
     {
         global $DB, $CFG_GLPI;
 
-        $searchopt   = &SearchOption::getOptionsForItemtype($itemtype);
+        $searchopt   = SearchOption::getOptionsForItemtype($itemtype);
         $table       = $searchopt[$ID]["table"];
         $field       = $searchopt[$ID]["field"];
         $addtable    = "";
@@ -578,7 +578,7 @@ final class SQLProvider implements SearchProviderInterface
                 $condition = '';
                 if (!Session::haveRight("ticket", \Ticket::READALL)) {
                     $searchopt
-                        = &SearchOption::getOptionsForItemtype($itemtype);
+                        = SearchOption::getOptionsForItemtype($itemtype);
                     $requester_table
                         = '`glpi_tickets_users_' .
                         self::computeComplexJoinID($searchopt[4]['joinparams']['beforejoin']
@@ -671,7 +671,7 @@ final class SQLProvider implements SearchProviderInterface
                 // Same structure in addDefaultJoin
                 $condition = '';
                 if (!Session::haveRight("$right", $itemtype::READALL)) {
-                    $searchopt       = &SearchOption::getOptionsForItemtype($itemtype);
+                    $searchopt       = SearchOption::getOptionsForItemtype($itemtype);
                     if (Session::haveRight("$right", $itemtype::READMY)) {
                         $requester_table      = '`glpi_' . $table . '_users_' .
                             self::computeComplexJoinID($searchopt[4]['joinparams']
@@ -835,7 +835,7 @@ final class SQLProvider implements SearchProviderInterface
 
         global $DB;
 
-        $searchopt = &SearchOption::getOptionsForItemtype($itemtype);
+        $searchopt = SearchOption::getOptionsForItemtype($itemtype);
         if (!isset($searchopt[$ID]['table'])) {
             return false;
         }
@@ -1623,7 +1623,7 @@ final class SQLProvider implements SearchProviderInterface
             case 'Ticket':
                 // Same structure in addDefaultWhere
                 if (!Session::haveRight("ticket", \Ticket::READALL)) {
-                    $searchopt = &SearchOption::getOptionsForItemtype($itemtype);
+                    $searchopt = SearchOption::getOptionsForItemtype($itemtype);
 
                     // show mine : requester
                     $out .= self::addLeftJoin(
@@ -1757,7 +1757,7 @@ final class SQLProvider implements SearchProviderInterface
                 // Same structure in addDefaultWhere
                 $out = '';
                 if (!Session::haveRight("$right", $itemtype::READALL)) {
-                    $searchopt = &SearchOption::getOptionsForItemtype($itemtype);
+                    $searchopt = SearchOption::getOptionsForItemtype($itemtype);
 
                     if (Session::haveRight("$right", $itemtype::READMY)) {
                         // show mine : requester
@@ -2536,7 +2536,7 @@ final class SQLProvider implements SearchProviderInterface
 
         global $DB;
 
-        $searchopt  = &SearchOption::getOptionsForItemtype($itemtype);
+        $searchopt  = SearchOption::getOptionsForItemtype($itemtype);
         if (!isset($searchopt[$ID]['table'])) {
             return false;
         }
@@ -2702,7 +2702,7 @@ final class SQLProvider implements SearchProviderInterface
         }
 
         $orderby_criteria = [];
-        $searchopt = &SearchOption::getOptionsForItemtype($itemtype);
+        $searchopt = SearchOption::getOptionsForItemtype($itemtype);
 
         foreach ($sort_fields as $sort_field) {
             $ID = $sort_field['searchopt_id'];
@@ -2873,7 +2873,7 @@ final class SQLProvider implements SearchProviderInterface
         $data['sql']['count']  = [];
         $data['sql']['search'] = '';
 
-        $searchopt        = &SearchOption::getOptionsForItemtype($data['itemtype']);
+        $searchopt        = SearchOption::getOptionsForItemtype($data['itemtype']);
 
         $blacklist_tables = [];
         $orig_table = SearchEngine::getOrigTableName($data['itemtype']);
@@ -3334,7 +3334,7 @@ final class SQLProvider implements SearchProviderInterface
             ) {
                 $itemtype = $criterion['itemtype'];
                 $meta = true;
-                $meta_searchopt = &SearchOption::getOptionsForItemtype($itemtype);
+                $meta_searchopt = SearchOption::getOptionsForItemtype($itemtype);
             } else {
                 // Not a meta, use the same search option everywhere
                 $meta_searchopt = $searchopt;
@@ -3543,7 +3543,7 @@ final class SQLProvider implements SearchProviderInterface
             }
 
             $m_itemtype = $criterion['itemtype'];
-            $metaopt = &SearchOption::getOptionsForItemtype($m_itemtype);
+            $metaopt = SearchOption::getOptionsForItemtype($m_itemtype);
             $sopt    = $metaopt[$criterion['field']];
 
             //add toview for meta criterion
@@ -3670,7 +3670,7 @@ final class SQLProvider implements SearchProviderInterface
             // Get columns
             $data['data']['cols'] = [];
 
-            $searchopt = &SearchOption::getOptionsForItemtype($data['itemtype']);
+            $searchopt = SearchOption::getOptionsForItemtype($data['itemtype']);
 
             foreach ($data['toview'] as $opt_id) {
                 $data['data']['cols'][] = [
@@ -3684,7 +3684,7 @@ final class SQLProvider implements SearchProviderInterface
 
             // manage toview column for criteria with meta flag
             foreach ($data['meta_toview'] as $m_itemtype => $toview) {
-                $searchopt = &SearchOption::getOptionsForItemtype($m_itemtype);
+                $searchopt = SearchOption::getOptionsForItemtype($m_itemtype);
                 foreach ($toview as $opt_id) {
                     $data['data']['cols'][] = [
                         'itemtype'  => $m_itemtype,
@@ -3706,7 +3706,7 @@ final class SQLProvider implements SearchProviderInterface
                         && isset($metacriteria['value']) && (strlen($metacriteria['value']) > 0)
                     ) {
                         if (!isset($already_printed[$metacriteria['itemtype'] . $metacriteria['field']])) {
-                            $searchopt = &SearchOption::getOptionsForItemtype($metacriteria['itemtype']);
+                            $searchopt = SearchOption::getOptionsForItemtype($metacriteria['itemtype']);
 
                             $data['data']['cols'][] = [
                                 'itemtype'  => $metacriteria['itemtype'],
@@ -4003,7 +4003,7 @@ final class SQLProvider implements SearchProviderInterface
     ) {
         global $CFG_GLPI;
 
-        $searchopt = &SearchOption::getOptionsForItemtype($itemtype);
+        $searchopt = SearchOption::getOptionsForItemtype($itemtype);
         if (
             isset($CFG_GLPI["union_search_type"][$itemtype])
             && ($CFG_GLPI["union_search_type"][$itemtype] == $searchopt[$ID]["table"])
@@ -4018,7 +4018,7 @@ final class SQLProvider implements SearchProviderInterface
 
             // Search option may not exists in subtype
             // This is the case for "Inventory number" for a Software listed from ReservationItem search
-            $subtype_so = &SearchOption::getOptionsForItemtype($data["TYPE"]);
+            $subtype_so = SearchOption::getOptionsForItemtype($data["TYPE"]);
             if (!array_key_exists($ID, $subtype_so)) {
                 return '';
             }

--- a/src/Search/SearchOption.php
+++ b/src/Search/SearchOption.php
@@ -110,7 +110,7 @@ final class SearchOption implements \ArrayAccess
      *
      * @return array The reference to the array of search options for the given item type
      **/
-    public static function &getOptionsForItemtype($itemtype, $withplugins = true): array
+    public static function getOptionsForItemtype($itemtype, $withplugins = true): array
     {
         global $CFG_GLPI;
         $item = null;
@@ -396,7 +396,7 @@ final class SearchOption implements \ArrayAccess
     public static function getActionsFor($itemtype, $field_num)
     {
 
-        $searchopt = &self::getOptionsForItemtype($itemtype);
+        $searchopt = self::getOptionsForItemtype($itemtype);
         $actions   = [
             'contains'    => __('contains'),
             'notcontains' => __('not contains'),
@@ -578,7 +578,7 @@ final class SearchOption implements \ArrayAccess
     {
 
         $table = $itemtype::getTable();
-        $opts  = &self::getOptionsForItemtype($itemtype);
+        $opts  = self::getOptionsForItemtype($itemtype);
 
         foreach ($opts as $num => $opt) {
             if (
@@ -606,7 +606,7 @@ final class SearchOption implements \ArrayAccess
     {
         global $CFG_GLPI;
 
-        $options = &self::getOptionsForItemtype($itemtype, $withplugins);
+        $options = self::getOptionsForItemtype($itemtype, $withplugins);
         $todel   = [];
 
         if (

--- a/tools/getsearchoptions.php
+++ b/tools/getsearchoptions.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Search\SearchOption;
+
 define('DO_NOT_CHECK_HTTP_REFERER', 1);
 
 // Ensure current directory when run from crontab
@@ -70,7 +72,7 @@ if (isset($_GET['lang'])) {
     Session::loadLanguage($_GET['lang']);
 }
 
-$opts = &Search::getOptions($_GET['type']);
+$opts = SearchOption::getOptionsForItemtype($_GET['type']);
 $sort = [];
 $group = 'N/A';
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | - 

This also replaces calls to `Search::getOptions` with new `SearchOption::getOptionsByItemtype`.