### PR TITLE
Fix canViewItem() for recursive Changes

### DIFF
--- a/src/Change.php
+++ b/src/Change.php
@@ -104,7 +104,7 @@ class Change extends CommonITILObject
     public function canViewItem()
     {
 
-        if (!Session::haveAccessToEntity($this->getEntityID())) {
+        if (!$this->checkEntity(true)) {
             return false;
         }
         return (Session::haveRight(self::$rightname, self::READALL)


### PR DESCRIPTION
Update to use checkEntity(true)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | NA
