### PR TITLE
fix(ticket): readability of FAQ articles

### DIFF
--- a/css/legacy/includes/_styles.scss
+++ b/css/legacy/includes/_styles.scss
@@ -700,13 +700,17 @@
    }
 
    .faqadd_block_content {
-      overflow-x: hidden;
-      overflow-y: auto;
+      overflow: auto;
       position: absolute;
       top: 40px;
       bottom: 0;
       left: 0;
       right: 0;
+   }
+
+   .faqadd_entries,
+   .faqadd_entries:hover {
+      color: initial;
    }
 
    .faqadd_entries {


### PR DESCRIPTION
The FAQ articles linked to a category were difficult to read, because the content was cut off (no scrollbar) and when hovering over the content the text became white on white.

After _(the scrollbars are present, but not visible in the screenshot)_:

![image](https://user-images.githubusercontent.com/8530352/196715967-c108fb58-08b4-4efd-91ba-00dc28c0f212.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25091
