### PR TITLE
fix(ticket): unreadable table when many columns

### DIFF
--- a/css/includes/components/_richtext.scss
+++ b/css/includes/components/_richtext.scss
@@ -61,6 +61,10 @@ body.mce-content-body {
         max-width: 100%;
     }
 
+    table {
+        word-break: normal;
+    }
+
     a[target="_blank"]::before {
         font-family: tabler-icons;
         content: "\ea99";


### PR DESCRIPTION
When there was a table with many columns, the words in the cells were cut off, which was not readable.

Before:
![image](https://user-images.githubusercontent.com/8530352/196975008-b47ddc11-23c3-4a7c-99c7-946fb4021860.png)


After:
![image](https://user-images.githubusercontent.com/8530352/196974710-845b80a4-751a-4e21-8cff-f1b12e7b16f2.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25297
