### PR TITLE
fix(right): check PURGE instead of DELETE

### DIFF
--- a/src/Planning.php
+++ b/src/Planning.php
@@ -662,7 +662,7 @@ class Planning extends CommonGLPI
                 'resources'    => self::getTimelineResources(),
                 'now'          => date("Y-m-d H:i:s"),
                 'can_create'   => PlanningExternalEvent::canCreate(),
-                'can_delete'   => PlanningExternalEvent::canDelete(),
+                'can_delete'   => PlanningExternalEvent::canPurge(),
             ];
         } else {
            // short view (on Central page)


### PR DESCRIPTION
check ```PURGE``` instead of ```DELETE``` to allow users to ```delete``` external event
Because ```PlanningExternalEvent``` cannot be deleted (no ```is_deleted``` fields in database)

```sql
mysql> explain glpi_planningexternalevents;
+-----------------------------------+--------------+------+-----+---------+----------------+
| Field                             | Type         | Null | Key | Default | Extra          |
+-----------------------------------+--------------+------+-----+---------+----------------+
| id                                | int unsigned | NO   | PRI | NULL    | auto_increment |
| uuid                              | varchar(255) | YES  | UNI | NULL    |                |
| planningexternaleventtemplates_id | int unsigned | NO   | MUL | 0       |                |
| entities_id                       | int unsigned | NO   | MUL | 0       |                |
| is_recursive                      | tinyint      | NO   | MUL | 1       |                |
| date                              | timestamp    | YES  | MUL | NULL    |                |
| users_id                          | int unsigned | NO   | MUL | 0       |                |
| users_id_guests                   | text         | YES  |     | NULL    |                |
| groups_id                         | int unsigned | NO   | MUL | 0       |                |
| name                              | varchar(255) | YES  | MUL | NULL    |                |
| text                              | text         | YES  |     | NULL    |                |
| begin                             | timestamp    | YES  | MUL | NULL    |                |
| end                               | timestamp    | YES  | MUL | NULL    |                |
| rrule                             | text         | YES  |     | NULL    |                |
| state                             | int          | NO   | MUL | 0       |                |
| planningeventcategories_id        | int unsigned | NO   | MUL | 0       |                |
| background                        | tinyint      | NO   |     | 0       |                |
| date_mod                          | timestamp    | YES  | MUL | NULL    |                |
| date_creation                     | timestamp    | YES  | MUL | NULL    |                |
+-----------------------------------+--------------+------+-----+---------+----------------+
```
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25314
