### PR TITLE
fix(ticket): rejectsolution raise 2 notifications

### DIFF
--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -241,8 +241,6 @@ class ITILFollowup extends CommonDBChild
             'date' => $this->fields['date'],
         ]);
 
-        $donotif = !isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"];
-
        // Check if stats should be computed after this change
         $no_stat = isset($this->input['_do_not_compute_takeintoaccount']);
 
@@ -254,6 +252,8 @@ class ITILFollowup extends CommonDBChild
         );
 
         $this->updateParentStatus($this->input['_job'], $this->input);
+
+        $donotif = !isset($this->input['_disablenotif']) && !isset($parentitem->input['_disablenotif']) && $CFG_GLPI["use_notifications"];
 
         if ($donotif) {
             $options = ['followup_id' => $this->fields["id"],

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1685,6 +1685,7 @@ class Ticket extends CommonITILObject
            // Read again ticket to be sure that all data are up to date
             $this->getFromDB($this->fields['id']);
             NotificationEvent::raiseEvent($mailtype, $this);
+            $this->input['_disablenotif'] = true;
         }
 
        // inquest created immediatly if delay = O


### PR DESCRIPTION
When a ticket was resolved, if its solution is rejected, it sent the rejection notification AND the follow-up notification.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25098
