### PR TITLE
Fix < and > search operators

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -3526,9 +3526,7 @@ JAVASCRIPT;
                 case "number":
                 case "decimal":
                 case "timestamp":
-                    $search  = ["/\&lt;/","/\&gt;/"];
-                    $replace = ["<",">"];
-                    $val     = preg_replace($search, $replace, $val);
+                    $val = Sanitizer::decodeHtmlSpecialChars($val); // Decode "<" and ">" operators
                     if (preg_match("/([<>])([=]*)[[:space:]]*([0-9]+)/", $val, $regs)) {
                         if ($NOT) {
                             if ($regs[1] == '<') {
@@ -4824,9 +4822,7 @@ JAVASCRIPT;
                            $SEARCH ) ";
 
             case "glpi_ipaddresses.name":
-                $search  = ["/\&lt;/","/\&gt;/"];
-                $replace = ["<",">"];
-                $val     = preg_replace($search, $replace, $val);
+                $val = Sanitizer::decodeHtmlSpecialChars($val); // Decode "<" and ">" operators
                 if (preg_match("/^\s*([<>])([=]*)[[:space:]]*([0-9\.]+)/", $val, $regs)) {
                     if ($nott) {
                         if ($regs[1] == '<') {
@@ -5073,9 +5069,7 @@ JAVASCRIPT;
                     if (in_array($searchtype, ['equals', 'notequals'])) {
                         return " $link ($date_computation " . $SEARCH . ') ';
                     }
-                    $search  = ["/\&lt;/","/\&gt;/"];
-                    $replace = ["<",">"];
-                    $val     = preg_replace($search, $replace, $val);
+                    $val = Sanitizer::decodeHtmlSpecialChars($val); // Decode "<" and ">" operators
                     if (preg_match("/^\s*([<>=]+)(.*)/", $val, $regs)) {
                         if (is_numeric($regs[2])) {
                             return $link . " $date_computation " . $regs[1] . "
@@ -5131,9 +5125,7 @@ JAVASCRIPT;
                 case "timestamp":
                 case "progressbar":
                     $decimal_contains = $searchopt[$ID]["datatype"] === 'decimal' && $searchtype === 'contains';
-                    $search  = ["/\&lt;/", "/\&gt;/"];
-                    $replace = ["<", ">"];
-                    $val     = preg_replace($search, $replace, $val);
+                    $val = Sanitizer::decodeHtmlSpecialChars($val); // Decode "<" and ">" operators
 
                     if (preg_match("/([<>])([=]*)[[:space:]]*([0-9]+)/", $val, $regs)) {
                         if (in_array($searchtype, ["notequals", "notcontains"])) {

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -39,6 +39,7 @@ use CommonDBTM;
 use CommonITILActor;
 use DBConnection;
 use DbTestCase;
+use Glpi\Toolbox\Sanitizer;
 use Ticket;
 
 /* Test for inc/search.class.php */
@@ -1393,11 +1394,12 @@ class Search extends DbTestCase
 
     private function cleanSQL($sql)
     {
-        $sql = str_replace("\r\n", ' ', $sql);
-        $sql = str_replace("\n", ' ', $sql);
-        while (strpos($sql, '  ') !== false) {
-            $sql = str_replace('  ', ' ', $sql);
-        }
+        // Clean whitespaces
+        $sql = preg_replace('/\s+/', ' ', $sql);
+
+        // Remove whitespaces around parenthesis
+        $sql = preg_replace('/\(\s+/', '(', $sql);
+        $sql = preg_replace('/\s+\)/', ')', $sql);
 
         $sql = trim($sql);
 
@@ -1686,7 +1688,7 @@ class Search extends DbTestCase
                 'searchtype' => 'equals',
                 'val' => '5',
                 'meta' => false,
-                'expected' => "   (`glpi_users_users_id_supervisor`.`id` = '5')",
+                'expected' => "(`glpi_users_users_id_supervisor`.`id` = '5')",
             ],
             [
                 'link' => ' AND ',
@@ -1696,7 +1698,7 @@ class Search extends DbTestCase
                 'searchtype' => 'equals',
                 'val' => '2',
                 'meta' => false,
-                'expected' => "  AND  (`glpi_users_users_id_tech`.`id` = '2') ",
+                'expected' => "AND (`glpi_users_users_id_tech`.`id` = '2')",
             ],
             [
                 'link' => ' AND ',
@@ -1706,7 +1708,7 @@ class Search extends DbTestCase
                 'searchtype' => 'contains',
                 'val' => '70',
                 'meta' => false,
-                'expected' => "  AND  (`glpi_monitors`.`size`  LIKE '%70.%'  )",
+                'expected' => "AND (`glpi_monitors`.`size` LIKE '%70.%')",
             ],
             [
                 'link' => ' AND ',
@@ -1716,7 +1718,7 @@ class Search extends DbTestCase
                 'searchtype' => 'contains',
                 'val' => '70.5',
                 'meta' => false,
-                'expected' => "  AND  (`glpi_monitors`.`size`  LIKE '%70.5%'  )",
+                'expected' => "AND (`glpi_monitors`.`size` LIKE '%70.5%')",
             ],
             [
                 'link' => ' AND ',
@@ -1726,8 +1728,68 @@ class Search extends DbTestCase
                 'searchtype' => 'contains',
                 'val' => '70.5%',
                 'meta' => false,
-                'expected' => "  AND  (`glpi_monitors`.`size`  LIKE '%70.5%'  )",
-            ]
+                'expected' => "AND (`glpi_monitors`.`size` LIKE '%70.5%')",
+            ],
+            [
+                'link' => ' AND ',
+                'nott' => 0,
+                'itemtype' => \Computer::class,
+                'ID' => 121, // Search ID 121 (date_creation field)
+                'searchtype' => 'contains',
+                'val' => Sanitizer::sanitize('>2022-10-25'),
+                'meta' => false,
+                'expected' => "AND CONVERT(`glpi_computers`.`date_creation` USING utf8mb4) > '2022-10-25'",
+            ],
+            [
+                'link' => ' AND ',
+                'nott' => 0,
+                'itemtype' => \Computer::class,
+                'ID' => 121, // Search ID 121 (date_creation field)
+                'searchtype' => 'contains',
+                'val' => Sanitizer::sanitize('<2022-10-25'),
+                'meta' => false,
+                'expected' => "AND CONVERT(`glpi_computers`.`date_creation` USING utf8mb4) < '2022-10-25'",
+            ],
+            [
+                'link' => ' AND ',
+                'nott' => 0,
+                'itemtype' => \Computer::class,
+                'ID' => 151, // Search ID 151 (Item_Disk freesize field)
+                'searchtype' => 'contains',
+                'val' => Sanitizer::sanitize('>100'),
+                'meta' => false,
+                'expected' => "AND (`glpi_items_disks`.`freesize` > 100)",
+            ],
+            [
+                'link' => ' AND ',
+                'nott' => 0,
+                'itemtype' => \Computer::class,
+                'ID' => 151, // Search ID 151 (Item_Disk freesize field)
+                'searchtype' => 'contains',
+                'val' => Sanitizer::sanitize('<10000'),
+                'meta' => false,
+                'expected' => "AND (`glpi_items_disks`.`freesize` < 10000)",
+            ],
+            [
+                'link' => ' AND ',
+                'nott' => 0,
+                'itemtype' => \NetworkName::class,
+                'ID' => 13, // Search ID 13 (IPAddress name field)
+                'searchtype' => 'contains',
+                'val' => Sanitizer::sanitize('< 192.168.1.10'),
+                'meta' => false,
+                'expected' => "AND (INET_ATON(`glpi_ipaddresses`.`name`) < INET_ATON('192.168.1.10'))",
+            ],
+            [
+                'link' => ' AND ',
+                'nott' => 0,
+                'itemtype' => \NetworkName::class,
+                'ID' => 13, // Search ID 13 (IPAddress name field)
+                'searchtype' => 'contains',
+                'val' => Sanitizer::sanitize('> 192.168.1.10'),
+                'meta' => false,
+                'expected' => "AND (INET_ATON(`glpi_ipaddresses`.`name`) > INET_ATON('192.168.1.10'))",
+            ],
         ];
     }
 
@@ -1737,7 +1799,7 @@ class Search extends DbTestCase
     public function testAddWhere($link, $nott, $itemtype, $ID, $searchtype, $val, $meta, $expected)
     {
         $output = \Search::addWhere($link, $nott, $itemtype, $ID, $searchtype, $val, $meta);
-        $this->string($output)->isEqualTo($expected);
+        $this->string($this->cleanSQL($output))->isEqualTo($expected);
 
         if ($meta) {
             return; // Do not know how to run search on meta here


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13044

Sanitizer uses different entites for `<` and `>` since GLPI 10.0.