### PR TITLE
Fix signature_text

### DIFF
--- a/src/NotificationTemplate.php
+++ b/src/NotificationTemplate.php
@@ -294,7 +294,6 @@ class NotificationTemplate extends CommonDBTM
                //If no html content, then send only in text
                 if (!empty($template_datas['content_html'])) {
                     $signature_html = RichText::getSafeHtml($this->signature);
-                    $signature_text = RichText::getTextFromHtml($this->signature, false, false);
 
                     $template_datas['content_html'] = self::process(
                         $template_datas['content_html'],
@@ -324,6 +323,7 @@ class NotificationTemplate extends CommonDBTM
                      "\n</body></html>";
                 }
 
+                $signature_text = RichText::getTextFromHtml($this->signature, false, false);
                 $lang['content_text'] = (!empty($add_header) ? $add_header . "\n\n" : '')
                 . self::process($template_datas['content_text'], self::getDataForPlainText($data))
                 . "\n\n-- \n" . $signature_text


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

If a notification template has no html content it will generate the following error in the logs.

glpiphplog.WARNING:   *** PHP Warning (2): Undefined variable $signature_text in src/NotificationTemplate.php at line 325