### PR TITLE
fix(template): fix hidden document field and remove it from predefine…

### DIFF
--- a/src/ITILTemplatePredefinedField.php
+++ b/src/ITILTemplatePredefinedField.php
@@ -226,6 +226,7 @@ abstract class ITILTemplatePredefinedField extends ITILTemplateField
         return [
             -2 => -2, // validation request
             52  => 52, // global_validation
+            142  => 142, // documents
         ];
     }
 

--- a/templates/components/itilobject/selfservice.html.twig
+++ b/templates/components/itilobject/selfservice.html.twig
@@ -238,7 +238,7 @@
                   __('Description'),
                   right_field_options|merge({
                      'enable_richtext': true,
-                     'enable_fileupload': true,
+                     'enable_fileupload': (itiltemplate.isHiddenField('_documents_id')) ? false : true,
                   })
                ) }}
             </div>

--- a/templates/components/itilobject/timeline/simple_form.html.twig
+++ b/templates/components/itilobject/timeline/simple_form.html.twig
@@ -88,6 +88,7 @@
             'enable_richtext': true,
             'enable_fileupload': true,
             'enable_mentions': true,
+            'enable_fileupload': (itiltemplate.isHiddenField('_documents_id')) ? false : true,
             'entities_id': item.isNewItem() ? entities_id : item.fields['entities_id'],
             'uploads': uploads,
             'add_field_class': 'col-12 itil-textarea-content',


### PR DESCRIPTION
Fix behavior for ```_documents_id``` fields from ```template```

- Fix hidden document field
- Remove it from predefined field



| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25353
