### PR TITLE
Enhance progress bars on migration commands

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3427,16 +3427,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.15",
+            "version": "v5.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "ea59bb0edfaf9f28d18d8791410ee0355f317669"
+                "reference": "8e9b9c8dfb33af6057c94e1b44846bee700dc5ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/ea59bb0edfaf9f28d18d8791410ee0355f317669",
-                "reference": "ea59bb0edfaf9f28d18d8791410ee0355f317669",
+                "url": "https://api.github.com/repos/symfony/console/zipball/8e9b9c8dfb33af6057c94e1b44846bee700dc5ef",
+                "reference": "8e9b9c8dfb33af6057c94e1b44846bee700dc5ef",
                 "shasum": ""
             },
             "require": {
@@ -3506,7 +3506,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.15"
+                "source": "https://github.com/symfony/console/tree/v5.4.16"
             },
             "funding": [
                 {
@@ -3522,7 +3522,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-26T21:41:52+00:00"
+            "time": "2022-11-25T14:09:27+00:00"
         },
         {
             "name": "symfony/css-selector",

--- a/src/Console/AbstractCommand.php
+++ b/src/Console/AbstractCommand.php
@@ -76,6 +76,13 @@ abstract class AbstractCommand extends Command implements GlpiCommandInterface
      */
     protected $requires_db_up_to_date = true;
 
+    /**
+     * Current progress bar.
+     *
+     * @var ProgressBar
+     */
+    protected $progress_bar;
+
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
 
@@ -250,5 +257,94 @@ abstract class AbstractCommand extends Command implements GlpiCommandInterface
                 0 // Success code
             );
         }
+    }
+
+    /**
+     * Tell user that execution time can be long.
+     *
+     * @return void
+     */
+    protected function warnAboutExecutionTime(): void
+    {
+        $this->output->writeln(
+            '<comment>' . __('Command execution may take a long time and should not be interrupted.') . '</comment>',
+            OutputInterface::VERBOSITY_QUIET
+        );
+    }
+
+    /**
+     * Iterate on given iterable and display a progress bar (unless on quiet mode).
+     * Progress bar message can be customized.
+     *
+     * @param iterable $iterable
+     * @param callable $message_callback
+     *
+     * @return iterable
+     */
+    final protected function iterate(iterable $iterable, ?callable $message_callback = null): iterable
+    {
+        // Redefine formats
+        $formats = [
+            ProgressBar::FORMAT_NORMAL,
+            ProgressBar::FORMAT_NORMAL . '_nomax',
+            ProgressBar::FORMAT_VERBOSE,
+            ProgressBar::FORMAT_VERBOSE . '_nomax',
+            ProgressBar::FORMAT_VERY_VERBOSE,
+            ProgressBar::FORMAT_VERY_VERBOSE . '_nomax',
+            ProgressBar::FORMAT_DEBUG,
+            ProgressBar::FORMAT_DEBUG . '_nomax',
+        ];
+        $original_formats_definitions = [];
+        if (is_callable($message_callback)) {
+            foreach ($formats as $format) {
+                $original_formats_definitions[$format] = ProgressBar::getFormatDefinition($format);
+                // Put message directly in progress bar template
+                ProgressBar::setFormatDefinition(
+                    $format,
+                    $original_formats_definitions[$format] . PHP_EOL . ' <comment>%message%</comment>' . PHP_EOL
+                );
+            }
+        }
+
+        // Init progress bar
+        $this->progress_bar = new ProgressBar($this->output);
+        $this->progress_bar->setMessage(''); // Empty message on iteration start
+        $this->progress_bar->start(is_countable($iterable) ? \count($iterable) : 0);
+
+        // Iterate on items
+        foreach ($iterable as $key => $value) {
+            if (is_callable($message_callback)) {
+                $this->progress_bar->setMessage($message_callback($value));
+                $this->progress_bar->display();
+            }
+
+            yield $key => $value;
+
+            $this->progress_bar->advance();
+        }
+
+        // Finish progress bar
+        $this->progress_bar->setMessage(''); // Remove last message
+        $this->progress_bar->finish();
+        $this->progress_bar = null;
+
+        // Restore formats
+        if (is_callable($message_callback)) {
+            foreach ($formats as $format) {
+                ProgressBar::setFormatDefinition($format, $original_formats_definitions[$format]);
+            }
+        }
+    }
+
+    /**
+     * Output a message.
+     * This method handles displaying of messages in the middle of progress bar iteration.
+     *
+     * @param string $message
+     * @param int $verbosity
+     */
+    final protected function outputMessage(string $message, int $verbosity = OutputInterface::VERBOSITY_NORMAL): void
+    {
+        $this->writelnOutputWithProgressBar($message, $this->progress_bar, $verbosity);
     }
 }

--- a/src/Console/Migration/TimestampsCommand.php
+++ b/src/Console/Migration/TimestampsCommand.php
@@ -38,7 +38,6 @@ namespace Glpi\Console\Migration;
 use DBConnection;
 use Glpi\Console\AbstractCommand;
 use Glpi\System\Requirement\DbTimezones;
-use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -85,11 +84,20 @@ class TimestampsCommand extends AbstractCommand
         if ($tbl_iterator->count() === 0) {
             $output->writeln('<info>' . __('No migration needed.') . '</info>');
         } else {
+            $this->warnAboutExecutionTime();
             $this->askForConfirmation();
 
-            $progress_bar = new ProgressBar($output);
+            $tables = [];
+            foreach ($tbl_iterator as $table_data) {
+                $tables[] = $table_data['TABLE_NAME'];
+            }
+            sort($tables);
 
-            foreach ($progress_bar->iterate($tbl_iterator) as $table) {
+            $progress_message = function (string $table) {
+                return sprintf(__('Migrating table "%s"...'), $table);
+            };
+
+            foreach ($this->iterate($tables, $progress_message) as $table) {
                 $tablealter = ''; // init by default
 
                // get accurate info from information_schema to perform correct alter
@@ -104,7 +112,7 @@ class TimestampsCommand extends AbstractCommand
                     'FROM'   => 'information_schema.columns',
                     'WHERE'  => [
                         'table_schema' => $this->db->dbdefault,
-                        'table_name'   => $table['TABLE_NAME'],
+                        'table_name'   => $table,
                         'data_type'    => 'datetime'
                     ]
                 ]);
@@ -119,7 +127,7 @@ class TimestampsCommand extends AbstractCommand
 
                     // Fix invalid zero dates
                     $this->db->update(
-                        $table['TABLE_NAME'],
+                        $table,
                         [
                             $column['COLUMN_NAME'] => $nullable ? null : '1970-01-01 00:00:01'
                         ],
@@ -172,31 +180,23 @@ class TimestampsCommand extends AbstractCommand
                 $tablealter =  rtrim($tablealter, ",");
 
                // apply alter to table
-                $query = "ALTER TABLE " . $this->db->quoteName($table['TABLE_NAME']) . " " . $tablealter . ";\n";
-                $this->writelnOutputWithProgressBar(
-                    '<comment>' . sprintf(__('Running %s'), $query) . '</comment>',
-                    $progress_bar,
-                    OutputInterface::VERBOSITY_VERBOSE
-                );
+                $query = "ALTER TABLE " . $this->db->quoteName($table) . " " . $tablealter . ";\n";
 
                 $result = $this->db->query($query);
                 if (false === $result) {
-                     $message = sprintf(
-                         __('Update of `%s` failed with message "(%s) %s".'),
-                         $table['TABLE_NAME'],
-                         $this->db->errno(),
-                         $this->db->error()
-                     );
-                     $this->writelnOutputWithProgressBar(
-                         '<error>' . $message . '</error>',
-                         $progress_bar,
-                         OutputInterface::VERBOSITY_QUIET
-                     );
-                     $errors = true;
+                    $message = sprintf(
+                        __('Migration of table "%s" failed with message "(%s) %s".'),
+                        $table,
+                        $this->db->errno(),
+                        $this->db->error()
+                    );
+                    $this->outputMessage(
+                        '<error>' . $message . '</error>',
+                        OutputInterface::VERBOSITY_QUIET
+                    );
+                    $errors = true;
                 }
             }
-
-            $this->output->write(PHP_EOL);
         }
 
         $properties_to_update = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Add a message to warn about migration execution time.
2. Always display currently migrated table/column next to progress bar. User will so be able to see more information about migration progress without having to use the `verbose` mode. Thus, only errors remains in command output, so it is easier to find valuable information in command output, even in verbose mode (see second image).

![Capture vidéo du 05-12-2022 14 50 00](https://user-images.githubusercontent.com/33253653/205663763-d3c699f3-953f-4c1e-afa6-0f9b5b7a94aa.gif)

![image](https://user-images.githubusercontent.com/33253653/205663709-f0d3fa86-21a6-45f4-bb79-d0ce51977db8.png)

