### PR TITLE
feat(planning): display event origin

### DIFF
--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -1401,6 +1401,9 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         $html .= "<div class='event-description rich_text_container'>" . $content . "</div>";
         $html .= $recall;
 
+        $parent->getFromDB($val[$parent->getForeignKeyField()]);
+        $html .= $parent->getLink(['icon' => true, 'forceid' => true]) . "<br>";
+        $html .= "<span>" . Entity::badgeCompletenameFromID($parent->getEntityID()) . "</span><br>";
         return $html;
     }
 

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -4070,4 +4070,11 @@ class Entity extends CommonTreeDropdown
          implode('<i class="fas fa-caret-right mx-1"></i>', $split) .
         "</span>";
     }
+
+    public static function badgeCompletenameFromID(int $entity_id): string
+    {
+        $entity = new self();
+        $entity->getFromDB($entity_id);
+        return self::badgeCompletename($entity->fields['completename']);
+    }
 }

--- a/src/Features/PlanningEvent.php
+++ b/src/Features/PlanningEvent.php
@@ -708,6 +708,11 @@ trait PlanningEvent
                 ]
             );
         }
+
+        $parent = getItemForItemtype($val['itemtype']);
+        $parent->getFromDB($val[$parent->getForeignKeyField()]);
+        $html .= $parent->getLink(['icon' => true, 'forceid' => true]) . "<br>";
+        $html .= "<span>" . Entity::badgeCompletenameFromID($parent->getEntityID()) . "</span><br>";
         return $html;
     }
 

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -1891,6 +1891,11 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
        // $val['content'] has already been sanitized and decoded by self::populatePlanning()
         $content = $val['content'];
         $html .= "<div class='event-description rich_text_container'>" . $content . "</div>";
+
+        $parent = getItemForItemtype($val['itemtype']);
+        $parent->getFromDB($val[$parent->getForeignKeyField()]);
+        $html .= $parent->getLink(['icon' => true, 'forceid' => true]) . "<br>";
+        $html .= "<span>" . Entity::badgeCompletenameFromID($parent->getEntityID()) . "</span><br>";
         return $html;
     }
 

--- a/src/Reminder.php
+++ b/src/Reminder.php
@@ -854,6 +854,11 @@ class Reminder extends CommonDBVisible implements
                 ]
             );
         }
+
+        $parent = getItemForItemtype($val['itemtype']);
+        $parent->getFromDB($val[$parent->getForeignKeyField()]);
+        $html .= $parent->getLink(['icon' => true, 'forceid' => true]) . "<br>";
+        $html .= "<span>" . Entity::badgeCompletenameFromID($parent->getEntityID()) . "</span><br>";
         return $html;
     }
 


### PR DESCRIPTION
Display in the tooltip of an event its origin: entity + ticket (or other) with its ID.

Example:
![image](https://user-images.githubusercontent.com/8530352/197966540-7b623ef2-0307-47aa-9b22-3ca32fbdf28f.png)


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25061
