### PR TITLE
Fix escaping issue with preg_quote calls

### DIFF
--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -310,7 +310,7 @@ final class DbUtils
         global $GLPI_CACHE;
 
         // If a class exists for this itemtype, just return the declared class name.
-        $matches = preg_grep('/^' . preg_quote($itemtype) . '$/i', get_declared_classes());
+        $matches = preg_grep('/^' . preg_quote($itemtype, '/') . '$/i', get_declared_classes());
         if (count($matches) === 1) {
             return current($matches);
         }
@@ -325,12 +325,12 @@ final class DbUtils
            // indeed, we must be able to separate plugin name (directory) from class name (file)
            // so pattern must be the one provided by getItemTypeForTable: PluginDirectorynameClassname
             $context = strtolower($plugin_matches['plugin']);
-        } else if (preg_match('/^' . preg_quote(NS_PLUG) . '(?<plugin>[a-z]+)\\\/i', $itemtype, $plugin_matches)) {
+        } else if (preg_match('/^' . preg_quote(NS_PLUG, '/') . '(?<plugin>[a-z]+)\\\/i', $itemtype, $plugin_matches)) {
             $context = strtolower($plugin_matches['plugin']);
         }
 
         $namespace      = $context === 'glpi-core' ? NS_GLPI : NS_PLUG . ucfirst($context) . '\\';
-        $uses_namespace = preg_match('/^(' . preg_quote($namespace) . ')/i', $itemtype);
+        $uses_namespace = preg_match('/^(' . preg_quote($namespace, '/') . ')/i', $itemtype);
 
         $expected_lc_path = str_ireplace(
             [$namespace, '\\'],

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -1476,7 +1476,7 @@ class Migration
             foreach ($fkey_column_array as $fkey_column) {
                 $fkey_table   = $fkey_column['TABLE_NAME'];
                 $fkey_oldname = $fkey_column['COLUMN_NAME'];
-                $fkey_newname = preg_replace('/^' . preg_quote($old_fkey) . '/', $new_fkey, $fkey_oldname);
+                $fkey_newname = preg_replace('/^' . preg_quote($old_fkey, '/') . '/', $new_fkey, $fkey_oldname);
                 if ($DB->fieldExists($fkey_table, $fkey_newname)) {
                     throw new \RuntimeException(
                         sprintf(
@@ -1500,7 +1500,7 @@ class Migration
             foreach ($fkey_column_array as $fkey_column) {
                 $fkey_table   = $fkey_column['TABLE_NAME'];
                 $fkey_oldname = $fkey_column['COLUMN_NAME'];
-                $fkey_newname = preg_replace('/^' . preg_quote($old_fkey) . '/', $new_fkey, $fkey_oldname);
+                $fkey_newname = preg_replace('/^' . preg_quote($old_fkey, '/') . '/', $new_fkey, $fkey_oldname);
 
                 if ($fkey_table == $old_table) {
                   // Special case, foreign key is inside renamed table, use new name


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Ref: https://forum.glpi-project.org/viewtopic.php?id=285200

User reported getting the following warning when viewing the Planning Recall notification recipients tab:
```
PHP Warning (2): preg_grep(): Unknown modifier '$' in /var/www/glpi/src/DbUtils.php at line 313
Uncaught Exception TypeError: count(): Argument #1 ($value) must be of type Countable|array, bool given in /var/www/glpi/src/DbUtils.php at line 314
```

I was able to recreate the issue and the fix seems to be passing the delimiter parameter to the `preg_quote` calls in `DBUtils`. The fixes in the `Migration` class are not for this specific issue but should still have the delimiter set just in case (my IDE doesn't like it missing either).
