### PR TITLE
fix(ticket): fill auto-assign when no tech defined (only for tech) from API

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -321,6 +321,7 @@ abstract class CommonITILObject extends CommonDBTM
                     'items_id'          => $user['users_id'],
                     'itemtype'          => 'User',
                     'text'              => $name,
+                    'type'              => $actortype, //required by CommonITILActor::post_addItem:415'
                     'title'             => $name,
                     'use_notification'  => $user['use_notification'],
                     'alternative_email' => $user['alternative_email'],
@@ -336,6 +337,7 @@ abstract class CommonITILObject extends CommonDBTM
                         'items_id' => $group['groups_id'],
                         'itemtype' => 'Group',
                         'text'     => $group_obj->getName(),
+                        'type'     => $actortype, //required by CommonITILActor::post_addItem:415'
                         'title'    => $group_obj->getRawCompleteName(),
                     ];
                 }
@@ -350,6 +352,7 @@ abstract class CommonITILObject extends CommonDBTM
                     'itemtype'          => 'Supplier',
                     'text'              => $name,
                     'title'             => $name,
+                    'type'              => $actortype, //required by CommonITILActor::post_addItem:415'
                     'use_notification'  => $supplier['use_notification'],
                     'alternative_email' => $supplier['alternative_email'],
                 ];

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -220,6 +220,7 @@ abstract class CommonITILObject extends CommonDBTM
                             'items_id'          => $users_id,
                             'itemtype'          => 'User',
                             'text'              => $name,
+                            'type'              => $actortype, //required by CommonITILActor::post_addItem:415
                             'title'             => $name,
                             'use_notification'  => $email === '' ? false : $default_use_notif,
                             'alternative_email' => $email,
@@ -234,6 +235,7 @@ abstract class CommonITILObject extends CommonDBTM
                         $actors[] = [
                             'items_id' => $group_obj->fields['id'],
                             'itemtype' => 'Group',
+                            'type'     => $actortype, //required by CommonITILActor::post_addItem:415
                             'text'     => $group_obj->getName(),
                             'title'    => $group_obj->getRawCompleteName(),
                         ];
@@ -248,6 +250,7 @@ abstract class CommonITILObject extends CommonDBTM
                             'items_id'          => $supplier_obj->fields['id'],
                             'itemtype'          => 'Supplier',
                             'text'              => $supplier_obj->fields['name'],
+                            'type'              => $actortype, //required by CommonITILActor::post_addItem:415'
                             'title'             => $supplier_obj->fields['name'],
                             'use_notification'  => $supplier_obj->fields['email'] === '' ? false : $default_use_notif,
                             'alternative_email' => $supplier_obj->fields['email'],
@@ -288,6 +291,7 @@ abstract class CommonITILObject extends CommonDBTM
 
                             $actors[] = $existing_actor + [
                                 'text'  => $name,
+                                'type'  => $actortype, //required by CommonITILActor::post_addItem:415
                                 'title' => $completename,
                             ];
                         } elseif (
@@ -298,6 +302,7 @@ abstract class CommonITILObject extends CommonDBTM
                             // direct mail actor
                             $actors[] = $existing_actor + [
                                 'text'  => $existing_actor['alternative_email'],
+                                'type'  => $actortype, //required by CommonITILActor::post_addItem:415'
                                 'title' => $existing_actor['alternative_email'],
                             ];
                         }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1819,6 +1819,18 @@ class Ticket extends CommonITILObject
             }
         }
 
+        // fill auto-assign when no tech defined (only for tech)
+        if (
+            !isset($input['_auto_import'])
+            && isset($_SESSION['glpiset_default_tech']) && $_SESSION['glpiset_default_tech']
+            && Session::getCurrentInterface() == 'central'
+            && (!isset($input['_users_id_assign']) || $input['_users_id_assign'] == 0)
+            && Session::haveRight("ticket", Ticket::OWN)
+        ) {
+            $input['_users_id_assign'] = Session::getLoginUserID();
+        }
+
+
         $cat_id = $input['itilcategories_id'] ?? 0;
         if ($cat_id) {
             $input['itilcategories_id_code'] = ITILCategory::getById($cat_id)->fields['code'];

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1819,18 +1819,6 @@ class Ticket extends CommonITILObject
             }
         }
 
-        // fill auto-assign when no tech defined (only for tech)
-        if (
-            !isset($input['_auto_import'])
-            && isset($_SESSION['glpiset_default_tech']) && $_SESSION['glpiset_default_tech']
-            && Session::getCurrentInterface() == 'central'
-            && (!isset($input['_users_id_assign']) || $input['_users_id_assign'] == 0)
-            && Session::haveRight("ticket", Ticket::OWN)
-        ) {
-            $input['_users_id_assign'] = Session::getLoginUserID();
-        }
-
-
         $cat_id = $input['itilcategories_id'] ?? 0;
         if ($cat_id) {
             $input['itilcategories_id_code'] = ITILCategory::getById($cat_id)->fields['code'];


### PR DESCRIPTION
Re-implementation of a feature removed in GLPI 10

Fill auto-assign when no tech defined (usefull from API)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25351
