### PR TITLE
Do not force plugin cron unregister on plugin clean

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1029,9 +1029,6 @@ class Plugin extends CommonDBTM
     {
 
         if ($this->getFromDB($ID)) {
-           // Clean crontask after "hard" remove
-            CronTask::Unregister($this->fields['directory']);
-
             $this->unload($this->fields['directory']);
             self::doHook(Hooks::POST_PLUGIN_CLEAN, $this->fields['directory']);
             $this->delete(['id' => $ID]);

--- a/src/Search.php
+++ b/src/Search.php
@@ -7356,7 +7356,7 @@ JAVASCRIPT;
                     if ($obj = getItemForItemtype($data[$ID][0]['name'])) {
                         return $obj->getTypeName();
                     }
-                    return "";
+                    return $data[$ID][0]['name'];
 
                 case "language":
                     if (isset($CFG_GLPI['languages'][$data[$ID][0]['name']])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Cleaning some removed plugins may take a really long time as `CronTask::unregister()` will indirectly remove each entry of related `CronTaskLog` in a separated SQL query (removal is done using `CommonDBTM::delete()`).

If a plugin has been removed without being uninstalled first, there are probably a lot of stale data in DB, so removing or not just those related to crontask would change that much the amount of stale data in the database.

I also updated rendering of `itemtypename` search option type to display the raw value when class is not found. It can happen whn some plugins are deactivated/deleted.