### PR TITLE
fix(requesttype): fix request type not selected when more than one

### DIFF
--- a/ajax/itilfollowup.php
+++ b/ajax/itilfollowup.php
@@ -86,5 +86,33 @@ if (!$parent->getFromDB($parents_id)) {
 // Render template content using twig
 $template->fields['content'] = $template->getRenderedContent($parent);
 
+//load requesttypes name (use to create OPTION dom)
+//need when template is used and when GLPI preselected type if defined
+$template->fields['requesttypes_name'] = "";
+if ($template->fields['requesttypes_id']) {
+    $dbUtils = new DbUtils();
+    $entityRestrict = $dbUtils->getEntitiesRestrictCriteria(getTableForItemType(RequestType::getType()), "", $parent->fields['entities_id'], true, false);
+    if (count($entityRestrict)) {
+        $entityRestrict = [$entityRestrict];
+    }
+
+    $requesttype = new RequestType();
+    if (
+        $requesttype->getFromDBByCrit([
+            "id" => $template->fields['requesttypes_id'],
+        ] + $entityRestrict)
+    ) {
+        $template->fields['requesttypes_name'] = Dropdown::getDropdownName(
+            getTableForItemType(RequestType::getType()),
+            $template->fields['requesttypes_id'],
+            0,
+            true,
+            false,
+            //default value like "(id)" is the default behavior of GLPI when field 'name' is empty
+            "(" . $template->fields['requesttypes_id'] . ")"
+        );
+    }
+}
+
 // Return json response with the template fields
 echo json_encode($template->fields);

--- a/ajax/itilfollowup.php
+++ b/ajax/itilfollowup.php
@@ -90,11 +90,7 @@ $template->fields['content'] = $template->getRenderedContent($parent);
 //need when template is used and when GLPI preselected type if defined
 $template->fields['requesttypes_name'] = "";
 if ($template->fields['requesttypes_id']) {
-    $dbUtils = new DbUtils();
-    $entityRestrict = $dbUtils->getEntitiesRestrictCriteria(getTableForItemType(RequestType::getType()), "", $parent->fields['entities_id'], true, false);
-    if (count($entityRestrict)) {
-        $entityRestrict = [$entityRestrict];
-    }
+    $entityRestrict = getEntitiesRestrictCriteria(getTableForItemType(RequestType::getType()), "", $parent->fields['entities_id'], true);
 
     $requesttype = new RequestType();
     if (

--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -284,7 +284,11 @@
                   tasktinymce.setContent(data.content);
                }
                // set category
-               $("#dropdown_requesttypes_id{{ rand }}").trigger("setValue", requesttypes_id);
+               //need to create new DOM option, because SELECT is remotely-sourced (AJAX)
+               //see : https://select2.org/programmatic-control/add-select-clear-items#preselecting-options-in-an-remotely-sourced-ajax-select2
+               var newOption = new Option(data.requesttypes_name, requesttypes_id, true, true);
+               $("#dropdown_requesttypes_id{{ rand }}").append(newOption).trigger('change');
+
                // set is_private
                $("#is_private_{{ rand }}")
                   .prop("checked", data.is_private == "0"


### PR DESCRIPTION
If ```SELECT``` contain more than one ```options``` and if remotly sourced (AJAX)

When user choose a ```request template```, ```request type``` is not selected

Need to programmatically add new option with same ```id``` and ```text```


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 



| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
