### PR TITLE
fix(taskcategorie): fix task type not selected when more than one

### DIFF
--- a/ajax/task.php
+++ b/ajax/task.php
@@ -86,5 +86,34 @@ if (!$parent->getFromDB($parents_id)) {
 // Render template content using twig
 $template->fields['content'] = $template->getRenderedContent($parent);
 
+//load taskcategorie name (use to create OPTION dom)
+//need when template is used and when GLPI preselected type if defined
+$template->fields['taskcategories_name'] = "";
+if ($template->fields['taskcategories_id']) {
+    $dbUtils = new DbUtils();
+    $entityRestrict = $dbUtils->getEntitiesRestrictCriteria(getTableForItemType(TaskCategory::getType()), "", $parent->fields['entities_id'], true, false);
+    if (count($entityRestrict)) {
+        $entityRestrict = [$entityRestrict];
+    }
+
+    $taskcategory = new TaskCategory();
+    if (
+        $taskcategory->getFromDBByCrit([
+            "id" => $template->fields['taskcategories_id'],
+        ] + $entityRestrict)
+    ) {
+        $template->fields['taskcategories_name'] = Dropdown::getDropdownName(
+            getTableForItemType(TaskCategory::getType()),
+            $template->fields['taskcategories_id'],
+            0,
+            true,
+            false,
+            //default value like "(id)" is the default behavior of GLPI when field 'name' is empty
+            "(" . $template->fields['taskcategories_id'] . ")"
+        );
+    }
+}
+
+
 // Return json response with the template fields
 echo json_encode($template->fields);

--- a/ajax/task.php
+++ b/ajax/task.php
@@ -90,11 +90,7 @@ $template->fields['content'] = $template->getRenderedContent($parent);
 //need when template is used and when GLPI preselected type if defined
 $template->fields['taskcategories_name'] = "";
 if ($template->fields['taskcategories_id']) {
-    $dbUtils = new DbUtils();
-    $entityRestrict = $dbUtils->getEntitiesRestrictCriteria(getTableForItemType(TaskCategory::getType()), "", $parent->fields['entities_id'], true, false);
-    if (count($entityRestrict)) {
-        $entityRestrict = [$entityRestrict];
-    }
+    $entityRestrict = getEntitiesRestrictCriteria(getTableForItemType(TaskCategory::getType()), "", $parent->fields['entities_id'], true);
 
     $taskcategory = new TaskCategory();
     if (

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -456,7 +456,11 @@
                     const taskcategories_id = isNaN(parseInt(data.taskcategories_id))
                         ? 0
                         : parseInt(data.taskcategories_id);
-                    $("#dropdown_taskcategories_id{{ rand }}").trigger("setValue", taskcategories_id);
+
+                     //need to create new DOM option, because SELECT is remotely-sourced (AJAX)
+                     //see : https://select2.org/programmatic-control/add-select-clear-items#preselecting-options-in-an-remotely-sourced-ajax-select2
+                     var newOption = new Option(data.taskcategories_name, taskcategories_id, true, true);
+                     $("#dropdown_taskcategories_id{{ rand }}").append(newOption).trigger('change');
                 }
 
                 if (data.is_private !== undefined) {


### PR DESCRIPTION
If ```SELECT``` contain more than one ```options``` and if remotly sourced (AJAX)

When user choose a ```task template```, ```task type``` is not selected

Need to programmatically add new option with same ```id``` and ```text```


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
