### PR TITLE
fix(search): column name with metacriteria

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -1521,14 +1521,15 @@ class Search
 
            // manage toview column for criteria with meta flag
             foreach ($data['meta_toview'] as $m_itemtype => $toview) {
-                $searchopt = self::getOptions($m_itemtype);
+                $m_searchopt = self::getOptions($m_itemtype);
                 foreach ($toview as $opt_id) {
                     $data['data']['cols'][] = [
                         'itemtype'  => $m_itemtype,
                         'id'        => $opt_id,
-                        'name'      => $searchopt[$opt_id]["name"],
+                        'name'      => $m_searchopt[$opt_id]["name"],
                         'meta'      => 1,
-                        'searchopt' => $searchopt[$opt_id],
+                        'searchopt' => $m_searchopt[$opt_id],
+                        'groupname' => $m_itemtype,
                     ];
                 }
             }
@@ -1543,14 +1544,15 @@ class Search
                         && isset($metacriteria['value']) && (strlen($metacriteria['value']) > 0)
                     ) {
                         if (!isset($already_printed[$metacriteria['itemtype'] . $metacriteria['field']])) {
-                            $searchopt = self::getOptions($metacriteria['itemtype']);
+                            $m_searchopt = self::getOptions($metacriteria['itemtype']);
 
                             $data['data']['cols'][] = [
                                 'itemtype'  => $metacriteria['itemtype'],
                                 'id'        => $metacriteria['field'],
-                                'name'      => $searchopt[$metacriteria['field']]["name"],
+                                'name'      => $m_searchopt[$metacriteria['field']]["name"],
                                 'meta'      => 1,
-                                'searchopt' => $searchopt[$metacriteria['field']]
+                                'searchopt' => $m_searchopt[$metacriteria['field']],
+                                'groupname' => $metacriteria['itemtype'],
                             ];
 
                             $already_printed[$metacriteria['itemtype'] . $metacriteria['field']] = 1;
@@ -1580,6 +1582,7 @@ class Search
                     if (
                         key($searchopt) !== null
                         && key($searchopt) !== "common"
+                        && !isset($data['data']['cols'][$num]['groupname'])
                     ) {
                         $data['data']['cols'][$num]['groupname'] = current($searchopt);
                     }


### PR DESCRIPTION
When using metacriteria in a search, the title of some columns was wrong. _The data was OK_

Before:
![image](https://user-images.githubusercontent.com/8530352/198529854-2ba95df4-61b2-4ed8-b39d-fb3b7ec4f515.png)

After:
![image](https://user-images.githubusercontent.com/8530352/198529672-b8321bd0-0e9f-4520-93c8-d6a56914b2ba.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25240
