### PR TITLE
feat(inventory): add new option to not change asset states

### DIFF
--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -645,12 +645,12 @@ abstract class MainAsset extends InventoryAsset
         $entities_id = $this->entities_id;
         $val->is_dynamic = 1;
         $val->entities_id = $entities_id;
-
-        if ($items_id != 0 && $this->states_id_default != '-1') {
-            $val->states_id = $this->states_id_default ?? 0;
+        $default_states_id = $this->states_id_default ?? 0;
+        if ($items_id != 0 && $default_states_id != '-1') {
+            $val->states_id = $default_states_id;
         } elseif ($items_id == 0) {
             //if create mode default states_id can't be '-1' put 0 if needed
-            $val->states_id = $this->states_id_default > 0 ? $this->states_id_default : 0;
+            $val->states_id = $default_states_id > 0 ? $default_states_id : 0;
         }
 
         // append data from RuleImportEntity

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -645,7 +645,10 @@ abstract class MainAsset extends InventoryAsset
         $entities_id = $this->entities_id;
         $val->is_dynamic = 1;
         $val->entities_id = $entities_id;
-        $val->states_id = $this->states_id_default ?? 0;
+
+        if ($this->states_id_default ?? 0 != '-1') {
+            $val->states_id = $this->states_id_default ?? 0;
+        }
 
         // append data from RuleImportEntity
         foreach ($this->ruleentity_data as $attribute => $value) {

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -646,7 +646,9 @@ abstract class MainAsset extends InventoryAsset
         $val->is_dynamic = 1;
         $val->entities_id = $entities_id;
 
-        if ($this->states_id_default != '-1') {
+        if ($items_id != 0 && $this->states_id_default != '-1') {
+            $val->states_id = $this->states_id_default ?? 0;
+        } elseif ($items_id == 0) {
             $val->states_id = $this->states_id_default ?? 0;
         }
 

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -646,7 +646,7 @@ abstract class MainAsset extends InventoryAsset
         $val->is_dynamic = 1;
         $val->entities_id = $entities_id;
 
-        if ($this->states_id_default ?? 0 != '-1') {
+        if ($this->states_id_default != '-1') {
             $val->states_id = $this->states_id_default ?? 0;
         }
 
@@ -691,6 +691,8 @@ abstract class MainAsset extends InventoryAsset
             $this->agent->fields['items_id'] = $items_id;
             $this->agent->fields['entities_id'] = $entities_id;
         }
+
+
 
         //check for any old agent to remove
         $agent = new \Agent();

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -695,8 +695,6 @@ abstract class MainAsset extends InventoryAsset
             $this->agent->fields['entities_id'] = $entities_id;
         }
 
-
-
         //check for any old agent to remove
         $agent = new \Agent();
         $agent->deleteByCriteria([

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -649,7 +649,8 @@ abstract class MainAsset extends InventoryAsset
         if ($items_id != 0 && $this->states_id_default != '-1') {
             $val->states_id = $this->states_id_default ?? 0;
         } elseif ($items_id == 0) {
-            $val->states_id = $this->states_id_default ?? 0;
+            //if create mode default states_id can't be '-1' put 0 if needed
+            $val->states_id = $this->states_id_default > 0 ? $this->states_id_default : 0;
         }
 
         // append data from RuleImportEntity

--- a/src/Inventory/Conf.php
+++ b/src/Inventory/Conf.php
@@ -120,7 +120,7 @@ class Conf extends CommonGLPI
         'component_control'              => 1,
         'component_battery'              => 1,
         'component_simcard'              => 1,
-        'states_id_default'              => 0,
+        'states_id_default'              => -1,
         'location'                       => 0,
         'group'                          => 0,
         'vm_type'                        => 0,
@@ -456,6 +456,7 @@ class Conf extends CommonGLPI
                 'name'   => 'states_id_default',
                 'id'     => 'states_id_default',
                 'value'  => $config['states_id_default'],
+                'toadd'  => ['-1' => __('Do not change')],
                 'rand' => $rand
             ]
         );

--- a/src/Inventory/Conf.php
+++ b/src/Inventory/Conf.php
@@ -451,7 +451,6 @@ class Conf extends CommonGLPI
         echo "</td>";
         echo "<td>";
 
-        var_dump($config['states_id_default']);
         \Dropdown::show(
             'State',
             [

--- a/src/Inventory/Conf.php
+++ b/src/Inventory/Conf.php
@@ -450,6 +450,8 @@ class Conf extends CommonGLPI
         echo "</label>";
         echo "</td>";
         echo "<td>";
+
+        var_dump($config['states_id_default']);
         \Dropdown::show(
             'State',
             [

--- a/src/Inventory/Conf.php
+++ b/src/Inventory/Conf.php
@@ -120,7 +120,7 @@ class Conf extends CommonGLPI
         'component_control'              => 1,
         'component_battery'              => 1,
         'component_simcard'              => 1,
-        'states_id_default'              => -1,
+        'states_id_default'              => 0,
         'location'                       => 0,
         'group'                          => 0,
         'vm_type'                        => 0,

--- a/tests/functionnal/Glpi/Inventory/Assets/Computer.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Computer.php
@@ -568,6 +568,5 @@ class Computer extends AbstractInventoryAsset
         //load printer
         $computer->getFromDB($computers_id);
         $this->integer($computer->fields['states_id'])->isEqualTo($state_1_id);
-
     }
 }

--- a/tests/functionnal/Glpi/Inventory/Assets/Computer.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Computer.php
@@ -406,4 +406,96 @@ class Computer extends AbstractInventoryAsset
         //check last_boot came from "operatingsystem->boot_time" node.
         $this->string($computer->fields['last_boot'])->isIdenticalTo('2020-06-09 07:58:08');
     }
+
+    public function testInventoryChangeStatusOrNot()
+    {
+        //create states
+        $state = new \State();
+        $state_1_id = $state->add(
+            [
+                'name'      => 'Manual state',
+                'states_id' => 0,
+                "entities_id" => 0,
+                'is_visible_computer' => 1
+            ]
+        );
+        $this->integer($state_1_id)->isGreaterThan(0);
+
+        $state_2_id = $state->add(
+            [
+                'name'      => 'Inventory state',
+                'states_id' => 0,
+                "entities_id" => 0,
+                'is_visible_computer' => 1
+            ]
+        );
+        $this->integer($state_2_id)->isGreaterThan(0);
+
+        //create computer manually with specific states before do an automatic inventory
+        $computer = new \Computer();
+        $computer->add(
+            [
+                "name" => "glpixps",
+                "serial" => "640HP72",
+                "states_id" => $state_1_id,
+                "entities_id" => 0
+            ]
+        );
+
+
+        $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+        <REQUEST>
+        <CONTENT>
+          <HARDWARE>
+            <NAME>glpixps</NAME>
+            <UUID>25C1BB60-5BCB-11D9-B18F-5404A6A534C4</UUID>
+          </HARDWARE>
+          <BIOS>
+            <MSN>640HP72</MSN>
+          </BIOS>
+          <VERSIONCLIENT>FusionInventory-Inventory_v2.4.1-2.fc28</VERSIONCLIENT>
+        </CONTENT>
+        <DEVICEID>glpixps.teclib.infra-2018-10-03-08-42-36</DEVICEID>
+        <QUERY>INVENTORY</QUERY>
+        </REQUEST>";
+
+        //per default, do not change states_id
+        $this->login();
+        $conf = new \Glpi\Inventory\Conf();
+        $this->boolean(
+            $conf->saveConf([
+                'states_id_default' => '-1'
+            ])
+        )->isTrue();
+        $this->logout();
+
+        $inventory = $this->doInventory($xml_source, true);
+
+        $computers_id = $inventory->getItem()->fields['id'];
+        $this->integer($computers_id)->isGreaterThan(0);
+
+        //load printer
+        $computer->getFromDB($computers_id);
+        $this->integer($computer->fields['states_id'])->isEqualTo($state_1_id);
+
+        //restore default configuration
+        $this->login();
+        $this->boolean(
+            $conf->saveConf([
+                'states_id_default' => $state_2_id
+            ])
+        )->isTrue();
+        $this->logOut();
+
+        //inventory again
+        $this->doInventory($xml_source, true);
+
+        $computers_id = $inventory->getItem()->fields['id'];
+        $this->integer($computers_id)->isGreaterThan(0);
+
+        //load printer
+        $computer->getFromDB($computers_id);
+        $this->integer($computer->fields['states_id'])->isEqualTo($state_2_id);
+
+    }
 }

--- a/tests/functionnal/Glpi/Inventory/Assets/Computer.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Computer.php
@@ -496,7 +496,6 @@ class Computer extends AbstractInventoryAsset
         //load printer
         $computer->getFromDB($computers_id);
         $this->integer($computer->fields['states_id'])->isEqualTo($state_2_id);
-
     }
 
     public function testInventoryChangeStatusOrNotFromAutomaticInventory()


### PR DESCRIPTION
Add new option to avoid the change of ```states_id``` (when is set manually before inventory)

![image](https://user-images.githubusercontent.com/7335054/198541567-6fca056a-e4a4-4991-8bbc-be65da0b217d.png)



| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
