### PR TITLE
set requester's supervisor as approbator on ticket creation

### DIFF
--- a/ajax/dropdownValidator.php
+++ b/ajax/dropdownValidator.php
@@ -81,9 +81,18 @@ if (isset($_POST["validatortype"])) {
 
     switch (strtolower($_POST['validatortype'])) {
         case 'user':
-            $itilObjectType = $validation_class::$itemtype;
-            $itilObject = $itilObjectType::getById($_POST['parents_id']);
-            $requester_users = $itilObject->getUsers(CommonITILActor::REQUESTER);
+            if ($_POST['parents_id'] != "") {
+                // Existing ticket
+                $itilObjectType = $validation_class::$itemtype;
+                $itilObject = $itilObjectType::getById($_POST['parents_id']);
+                $requester_users = $itilObject->getUsers(CommonITILActor::REQUESTER);
+            } else {
+                // New ticket
+                $requester_users = [];
+                foreach ($_POST['users_id_requester'] as $requester) {
+                    $requester_users[] = ['users_id' => $requester];
+                };
+            }
             $added_supervisors = [];
             foreach ($requester_users as $requester) {
                 $requester = User::getById($requester['users_id']);

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -1721,24 +1721,28 @@ abstract class CommonITILValidation extends CommonDBChild
         }
 
         $params = [
-            'prefix'            => null,
-            'id'                => 0,
-            'parents_id'        => null,
-            'entity'            => $_SESSION['glpiactive_entity'],
-            'right'             => static::$itemtype == 'Ticket' ? ['validate_request', 'validate_incident'] : 'validate',
-            'groups_id'         => 0,
-            'itemtype_target'   => '',
-            'items_id_target'   => 0,
-            'display'           => true,
-            'disabled'          => false,
-            'width'             => '100%',
-            'required'          => false,
-            'rand'              => mt_rand(),
+            'prefix'             => null,
+            'id'                 => 0,
+            'parents_id'         => null,
+            'entity'             => $_SESSION['glpiactive_entity'],
+            'right'              => static::$itemtype == 'Ticket' ? ['validate_request', 'validate_incident'] : 'validate',
+            'groups_id'          => 0,
+            'itemtype_target'    => '',
+            'items_id_target'    => 0,
+            'users_id_requester' => [],
+            'display'            => true,
+            'disabled'           => false,
+            'width'              => '100%',
+            'required'           => false,
+            'rand'               => mt_rand(),
         ];
         $params['applyto'] = 'show_validator_field' . $params['rand'];
 
         foreach ($options as $key => $val) {
             $params[$key] = $val;
+        }
+        if (!is_array($params['users_id_requester'])) {
+            $params['users_id_requester'] = [$params['users_id_requester']];
         }
 
         $params['validation_class'] = static::class;

--- a/templates/components/itilobject/fields/global_validation.html.twig
+++ b/templates/components/itilobject/fields/global_validation.html.twig
@@ -66,6 +66,7 @@
                'itemtype_target': params['_validation_targets'][0]['itemtype_target'] ?? '',
                'items_id_target': params['_validation_targets'][0]['items_id_target'] ?? '',
                'groups_id': params['_validation_targets'][0]['groups_id'] ?? '',
+               'users_id_requester': params['_users_id_requester'] ?? '',
                'right': validation_right,
                'display': false,
                'disabled': (not canupdate),


### PR DESCRIPTION
Extends #12504 

This PR allows the requester to create a validation request based on already defined requesters in the form.

Adding / removing requesters triggers a full page refresh, then the approbators dropdown is always up to date with requesters list.

Also fix a PHP warning


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 23396
