### PR TITLE
Add Opening Date to Common BR Criteria

### DIFF
--- a/src/RuleCommonITILObject.php
+++ b/src/RuleCommonITILObject.php
@@ -519,6 +519,11 @@ abstract class RuleCommonITILObject extends Rule
         $criterias['date_mod']['name']                        = __('Last update');
         $criterias['date_mod']['linkfield']                   = 'date_mod';
 
+        $criterias['date']['table']                           = $itil_table;
+        $criterias['date']['field']                           = 'date';
+        $criterias['date']['name']                            = __('Opening date');
+        $criterias['date']['linkfield']                       = 'date';
+
         $criterias['itilcategories_id']['table']              = 'glpi_itilcategories';
         $criterias['itilcategories_id']['field']              = 'name';
         $criterias['itilcategories_id']['name']               = _n('Category', 'Categories', 1) . " - " . __('Name');


### PR DESCRIPTION
Add date field (Opening Date) to the rule BR criteria matching (I could imagine using this for simple round-robin assignment based on seconds)

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | NA
