### PR TITLE
feat(inventory): Improved handleMacConnection

### DIFF
--- a/src/Inventory/Asset/NetworkPort.php
+++ b/src/Inventory/Asset/NetworkPort.php
@@ -173,6 +173,8 @@ class NetworkPort extends InventoryAsset
                 // LLDP provides ChassisId (sysmac) and PortID as one of: local number, mac, interface name
                 // We'll try to find the real mac and logical_number of the connection
                 if (property_exists($connection, 'sysmac')) {
+                    $field = null;
+                    $val = null;
                     if (property_exists($connection, 'ifnumber')) {
                         $field = 'logical_number';
                         $val = $connection->ifnumber;

--- a/src/Inventory/Asset/NetworkPort.php
+++ b/src/Inventory/Asset/NetworkPort.php
@@ -596,6 +596,9 @@ class NetworkPort extends InventoryAsset
      */
     public function rulepassed($items_id, $itemtype, $rules_id, $ports_id = [])
     {
+        if (!is_array($ports_id)) {
+           $ports_id = [$ports_id]; // Handle compatibility with previous signature.
+        }
         $netport = new \NetworkPort();
         if (empty($itemtype)) {
             $itemtype = 'Unmanaged';

--- a/src/Inventory/Asset/NetworkPort.php
+++ b/src/Inventory/Asset/NetworkPort.php
@@ -597,7 +597,7 @@ class NetworkPort extends InventoryAsset
     public function rulepassed($items_id, $itemtype, $rules_id, $ports_id = [])
     {
         if (!is_array($ports_id)) {
-           $ports_id = [$ports_id]; // Handle compatibility with previous signature.
+            $ports_id = [$ports_id]; // Handle compatibility with previous signature.
         }
         $netport = new \NetworkPort();
         if (empty($itemtype)) {

--- a/src/Inventory/Asset/NetworkPort.php
+++ b/src/Inventory/Asset/NetworkPort.php
@@ -184,7 +184,7 @@ class NetworkPort extends InventoryAsset
                 ) {
                     $field = 'logical_number';
                     if (!is_numeric($connection->ifnumber)) {
-                        $field = strstr($connection->ifnumber, ':') ? 'mac' : 'name';
+                        $field = substr_count($connection->ifnumber, ':') == 5 ? 'mac' : 'name';
                     }
                     $criteria = [
                         'SELECT'    => ['n1.logical_number', 'n1.mac'],

--- a/src/RuleImportAsset.php
+++ b/src/RuleImportAsset.php
@@ -538,9 +538,9 @@ class RuleImportAsset extends Rule
             $result_glpi = $DB->request($it_criteria);
 
             if (count($result_glpi)) {
+                $this->criterias_results['found_port'] = [];
                 foreach ($result_glpi as $data) {
                     $this->criterias_results['found_inventories'][$itemtype][] = $data['id'];
-                    $this->criterias_results['found_port'] = 0;
                     foreach ($data as $alias => $value) {
                         if (
                             strstr($alias, "portid")
@@ -548,7 +548,7 @@ class RuleImportAsset extends Rule
                             && is_numeric($value)
                             && $value > 0
                         ) {
-                            $this->criterias_results['found_port'] = $value;
+                            $this->criterias_results['found_port'][] = $value;
                         }
                     }
                 }

--- a/tests/functionnal/Glpi/Inventory/Assets/NetworkEquipment.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/NetworkEquipment.php
@@ -2085,7 +2085,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         // Import the switch into GLPI
         $converter = new \Glpi\Inventory\Converter();
         $data = json_decode($converter->convert($xml_source));
-        //$json = json_decode($data);
+
         $CFG_GLPI["is_contact_autoupdate"] = 0;
         $inventory = new \Glpi\Inventory\Inventory($data);
         $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default
@@ -2205,7 +2205,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         // Import the switch into GLPI
         $converter = new \Glpi\Inventory\Converter();
         $data = json_decode($converter->convert($xml_source));
-        //$json = json_decode($data);
+
         $CFG_GLPI["is_contact_autoupdate"] = 0;
         $inventory = new \Glpi\Inventory\Inventory($data);
         $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default
@@ -2321,7 +2321,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         // Import the switch into GLPI
         $converter = new \Glpi\Inventory\Converter();
         $data = json_decode($converter->convert($xml_source));
-        //$json = json_decode($data);
+
         $CFG_GLPI["is_contact_autoupdate"] = 0;
         $inventory = new \Glpi\Inventory\Inventory($data);
         $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default
@@ -2473,7 +2473,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         // Import the switch into GLPI
         $converter = new \Glpi\Inventory\Converter();
         $data = json_decode($converter->convert($xml_source));
-        //$json = json_decode($data);
+
         $CFG_GLPI["is_contact_autoupdate"] = 0;
         $inventory = new \Glpi\Inventory\Inventory($data);
         $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default

--- a/tests/functionnal/Glpi/Inventory/Assets/NetworkEquipment.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/NetworkEquipment.php
@@ -1992,4 +1992,501 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
           $first_np = array_pop($found_np);
           $this->string($first_np['sysdescr'])->isIdenticalTo("this a updated sysdescr");
     }
+
+    public function testSwitchMacConnection1()
+    {
+        $xml_source = '<?xml version="1.0" encoding="UTF-8" ?>
+<REQUEST>
+  <CONTENT>
+    <DEVICE>
+      <INFO>
+        <TYPE>NETWORKING</TYPE>
+        <MANUFACTURER>Hewlett-Packard</MANUFACTURER>
+        <MODEL>J9085A</MODEL>
+        <DESCRIPTION>ProCurve J9085A</DESCRIPTION>
+        <NAME>FR-SW01</NAME>
+        <LOCATION>BAT A - Niv 3</LOCATION>
+        <CONTACT>Admin</CONTACT>
+        <SERIAL>CN536H7J</SERIAL>
+        <FIRMWARE>R.10.06 R.11.60</FIRMWARE>
+        <UPTIME>8 days, 01:48:57.95</UPTIME>
+        <MAC>b4:39:d6:3a:7f:00</MAC>
+        <ID>0</ID>
+        <IPS>
+          <IP>192.168.1.56</IP>
+          <IP>192.168.10.56</IP>
+        </IPS>
+      </INFO>
+      <PORTS>
+        <PORT>
+          <CONNECTIONS>
+            <CONNECTION>
+              <MAC>bc:97:e1:5c:0e:90</MAC>
+            </CONNECTION>
+          </CONNECTIONS>
+          <IFDESCR>gi0/3</IFDESCR>
+          <IFNAME>gi0/3</IFNAME>
+          <IFNUMBER>3</IFNUMBER>
+          <IFSPEED>1000000000</IFSPEED>
+          <IFSTATUS>1</IFSTATUS>
+          <IFINTERNALSTATUS>1</IFINTERNALSTATUS>
+          <IFPORTDUPLEX>2</IFPORTDUPLEX>
+          <IFTYPE>6</IFTYPE>
+          <MAC>b4:39:d6:3b:22:bd</MAC>
+          <VLANS>
+            <VLAN>
+              <NAME>VLAN160</NAME>
+              <NUMBER>160</NUMBER>
+            </VLAN>
+          </VLANS>
+        </PORT>
+      </PORTS>
+    </DEVICE>
+    <MODULEVERSION>3.0</MODULEVERSION>
+    <PROCESSNUMBER>1</PROCESSNUMBER>
+  </CONTENT>
+  <DEVICEID>foo</DEVICEID>
+  <QUERY>SNMPQUERY</QUERY>
+</REQUEST>';
+
+        $computer                = new \Computer();
+        $networkPort             = new \NetworkPort();
+        $networkPort_NetworkPort = new \NetworkPort_NetworkPort();
+
+        // Create a computer
+        $computers_id = $computer->add([
+            'name'   => 'pc002',
+            'serial' => 'ggheb7ne7',
+            'entities_id' => 0
+        ]);
+        $this->integer($computers_id)->isGreaterThan(0);
+
+        // Add some computer ports
+        $ports_id = $networkPort->add([
+            'name'               => 'eth0',
+            'logical_number'     => '1',
+            'instantiation_type' => 'NetworkPortEthernet',
+            'items_id'           => $computers_id,
+            'itemtype'           => 'Computer',
+            'mac'                => 'bc:97:e1:5c:0e:90',
+        ]);
+        $this->integer($ports_id)->isGreaterThan(0);
+
+        $ports_id = $networkPort->add([
+            'name'               => 'eth1',
+            'logical_number'     => '1',
+            'instantiation_type' => 'NetworkPortEthernet',
+            'items_id'           => $computers_id,
+            'itemtype'           => 'Computer',
+            'mac'                => 'bc:97:e1:5c:0e:91',
+        ]);
+        $this->integer($ports_id)->isGreaterThan(0);
+
+        // Import the switch into GLPI
+        $converter = new \Glpi\Inventory\Converter();
+        $data = json_decode($converter->convert($xml_source));
+        //$json = json_decode($data);
+        $CFG_GLPI["is_contact_autoupdate"] = 0;
+        $inventory = new \Glpi\Inventory\Inventory($data);
+        $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default
+
+        $this->boolean($inventory->inError())->isFalse();
+        $this->array($inventory->getErrors())->isIdenticalTo([]);
+
+        // Verify that eth0 is the only port connected
+        $this->integer(countElementsInTable($networkPort_NetworkPort->getTable()))->isIdenticalTo(1);
+        $this->boolean($networkPort->getFromDBByCrit(['name' => 'eth0']));
+        $this->boolean($networkPort_NetworkPort->getFromDBForNetworkPort($networkPort->fields['id']))->isTrue();
+    }
+
+    public function testSwitchMacConnection2()
+    {
+        $xml_source = '<?xml version="1.0" encoding="UTF-8" ?>
+<REQUEST>
+  <CONTENT>
+    <DEVICE>
+      <INFO>
+        <TYPE>NETWORKING</TYPE>
+        <MANUFACTURER>Hewlett-Packard</MANUFACTURER>
+        <MODEL>J9085A</MODEL>
+        <DESCRIPTION>ProCurve J9085A</DESCRIPTION>
+        <NAME>FR-SW01</NAME>
+        <LOCATION>BAT A - Niv 3</LOCATION>
+        <CONTACT>Admin</CONTACT>
+        <SERIAL>CN536H7J</SERIAL>
+        <FIRMWARE>R.10.06 R.11.60</FIRMWARE>
+        <UPTIME>8 days, 01:48:57.95</UPTIME>
+        <MAC>b4:39:d6:3a:7f:00</MAC>
+        <ID>0</ID>
+        <IPS>
+          <IP>192.168.1.56</IP>
+          <IP>192.168.10.56</IP>
+        </IPS>
+      </INFO>
+      <PORTS>
+        <PORT>
+          <CONNECTIONS>
+            <CONNECTION>
+              <MAC>bc:97:e1:5c:0e:90</MAC>
+              <MAC>00:85:eb:f4:be:20</MAC>
+            </CONNECTION>
+          </CONNECTIONS>
+          <IFDESCR>gi0/3</IFDESCR>
+          <IFNAME>gi0/3</IFNAME>
+          <IFNUMBER>3</IFNUMBER>
+          <IFSPEED>1000000000</IFSPEED>
+          <IFSTATUS>1</IFSTATUS>
+          <IFINTERNALSTATUS>1</IFINTERNALSTATUS>
+          <IFPORTDUPLEX>2</IFPORTDUPLEX>
+          <IFTYPE>6</IFTYPE>
+          <MAC>b4:39:d6:3b:22:bd</MAC>
+          <VLANS>
+            <VLAN>
+              <NAME>VLAN160</NAME>
+              <NUMBER>160</NUMBER>
+            </VLAN>
+          </VLANS>
+        </PORT>
+      </PORTS>
+    </DEVICE>
+    <MODULEVERSION>3.0</MODULEVERSION>
+    <PROCESSNUMBER>1</PROCESSNUMBER>
+  </CONTENT>
+  <DEVICEID>foo</DEVICEID>
+  <QUERY>SNMPQUERY</QUERY>
+</REQUEST>';
+
+        $networkPort             = new \NetworkPort();
+        $unmanaged               = new \Unmanaged();
+        $networkPort_NetworkPort = new \NetworkPort_NetworkPort();
+
+        $computer = getItemByTypeName('Computer', '_test_pc01');
+        $computers_id = $computer->fields['id'];
+        $this->integer($computers_id)->isGreaterThan(0);
+
+        $printer = getItemByTypeName('Printer', '_test_printer_ent0');
+        $printers_id = $printer->fields['id'];
+        $this->integer($printers_id)->isGreaterThan(0);
+
+        // Add some ports
+        $ports_id = $networkPort->add([
+            'name'               => 'eth0',
+            'logical_number'     => '1',
+            'instantiation_type' => 'NetworkPortEthernet',
+            'items_id'           => $computer->fields['id'],
+            'itemtype'           => $computer->getTypeName(1),
+            'mac'                => 'bc:97:e1:5c:0e:90',
+        ]);
+        $this->integer($ports_id)->isGreaterThan(0);
+
+        $ports_id = $networkPort->add([
+            'name'               => 'eth1',
+            'logical_number'     => '1',
+            'instantiation_type' => 'NetworkPortEthernet',
+            'items_id'           => $computer->fields['id'],
+            'itemtype'           => $computer->getTypeName(1),
+            'mac'                => 'bc:97:e1:5c:0e:91',
+        ]);
+        $this->integer($ports_id)->isGreaterThan(0);
+
+        $ports_id = $networkPort->add([
+            'name'               => 'internal',
+            'logical_number'     => '1',
+            'instantiation_type' => 'NetworkPortEthernet',
+            'items_id'           => $printer->fields['id'],
+            'itemtype'           => $printer->getTypeName(1),
+            'mac'                => '00:85:eb:f4:be:20',
+        ]);
+        $this->integer($ports_id)->isGreaterThan(0);
+
+        // Make sure there are no hubs yet
+        $this->integer(countElementsInTable($unmanaged->getTable()))->isIdenticalTo(0);
+
+        // Import the switch into GLPI
+        $converter = new \Glpi\Inventory\Converter();
+        $data = json_decode($converter->convert($xml_source));
+        //$json = json_decode($data);
+        $CFG_GLPI["is_contact_autoupdate"] = 0;
+        $inventory = new \Glpi\Inventory\Inventory($data);
+        $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default
+
+        $this->boolean($inventory->inError())->isFalse();
+        $this->array($inventory->getErrors())->isIdenticalTo([]);
+
+        // Verify that gi0/3, eth0, internal ports are connected to a hub
+        $this->integer(countElementsInTable($unmanaged->getTable()))->isIdenticalTo(1);
+        $this->integer(countElementsInTable($networkPort_NetworkPort->getTable()))->isIdenticalTo(3);
+        foreach (['gi0/3', 'eth0', 'internal'] as $port_name) {
+            $this->boolean($networkPort->getFromDBByCrit(['name' => $port_name]));
+            $this->boolean($networkPort->isHubConnected($networkPort->fields['id']))->isTrue();
+        }
+    }
+
+    public function testSwitchMacConnection3()
+    {
+        $xml_source = '<?xml version="1.0" encoding="UTF-8" ?>
+<REQUEST>
+  <CONTENT>
+    <DEVICE>
+      <INFO>
+        <TYPE>NETWORKING</TYPE>
+        <MANUFACTURER>Hewlett-Packard</MANUFACTURER>
+        <MODEL>J9085A</MODEL>
+        <DESCRIPTION>ProCurve J9085A</DESCRIPTION>
+        <NAME>FR-SW01</NAME>
+        <LOCATION>BAT A - Niv 3</LOCATION>
+        <CONTACT>Admin</CONTACT>
+        <SERIAL>CN536H7J</SERIAL>
+        <FIRMWARE>R.10.06 R.11.60</FIRMWARE>
+        <UPTIME>8 days, 01:48:57.95</UPTIME>
+        <MAC>b4:39:d6:3a:7f:00</MAC>
+        <ID>0</ID>
+        <IPS>
+          <IP>192.168.1.56</IP>
+          <IP>192.168.10.56</IP>
+        </IPS>
+      </INFO>
+      <PORTS>
+        <PORT>
+          <CONNECTIONS>
+            <CONNECTION>
+              <MAC>bc:97:e1:5c:0e:90</MAC>
+            </CONNECTION>
+          </CONNECTIONS>
+          <IFDESCR>gi0/3</IFDESCR>
+          <IFNAME>gi0/3</IFNAME>
+          <IFNUMBER>3</IFNUMBER>
+          <IFSPEED>1000000000</IFSPEED>
+          <IFSTATUS>1</IFSTATUS>
+          <IFINTERNALSTATUS>1</IFINTERNALSTATUS>
+          <IFPORTDUPLEX>2</IFPORTDUPLEX>
+          <IFTYPE>6</IFTYPE>
+          <MAC>b4:39:d6:3b:22:bd</MAC>
+          <VLANS>
+            <VLAN>
+              <NAME>VLAN160</NAME>
+              <NUMBER>160</NUMBER>
+            </VLAN>
+          </VLANS>
+        </PORT>
+      </PORTS>
+    </DEVICE>
+    <MODULEVERSION>3.0</MODULEVERSION>
+    <PROCESSNUMBER>1</PROCESSNUMBER>
+  </CONTENT>
+  <DEVICEID>foo</DEVICEID>
+  <QUERY>SNMPQUERY</QUERY>
+</REQUEST>';
+
+        $networkPort             = new \NetworkPort();
+        $unmanaged               = new \Unmanaged();
+        $networkPort_NetworkPort = new \NetworkPort_NetworkPort();
+
+        $computer = getItemByTypeName('Computer', '_test_pc01');
+        $computers_id = $computer->fields['id'];
+        $this->integer($computers_id)->isGreaterThan(0);
+
+        // Add some ports
+        $ports_id = $networkPort->add([
+            'name'               => 'eth0',
+            'logical_number'     => '1',
+            'instantiation_type' => 'NetworkPortEthernet',
+            'items_id'           => $computer->fields['id'],
+            'itemtype'           => $computer->getTypeName(1),
+            'mac'                => 'bc:97:e1:5c:0e:90',
+        ]);
+        $this->integer($ports_id)->isGreaterThan(0);
+
+        $ports_id = $networkPort->add([
+            'name'               => 'eth1',
+            'logical_number'     => '1',
+            'instantiation_type' => 'NetworkPortEthernet',
+            'items_id'           => $computer->fields['id'],
+            'itemtype'           => $computer->getTypeName(1),
+            'mac'                => 'bc:97:e1:5c:0e:91',
+        ]);
+        $this->integer($ports_id)->isGreaterThan(0);
+
+        // add a virtual port (logical_number=0) with the same mac as eth0
+        $ports_id = $networkPort->add([
+            'name'               => 'eth0:srv',
+            'logical_number'     => '0',
+            'instantiation_type' => 'NetworkPortEthernet',
+            'items_id'           => $computer->fields['id'],
+            'itemtype'           => $computer->getTypeName(1),
+            'mac'                => 'bc:97:e1:5c:0e:90',
+        ]);
+        $this->integer($ports_id)->isGreaterThan(0);
+
+        // Import the switch into GLPI
+        $converter = new \Glpi\Inventory\Converter();
+        $data = json_decode($converter->convert($xml_source));
+        //$json = json_decode($data);
+        $CFG_GLPI["is_contact_autoupdate"] = 0;
+        $inventory = new \Glpi\Inventory\Inventory($data);
+        $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default
+
+        $this->boolean($inventory->inError())->isFalse();
+        $this->array($inventory->getErrors())->isIdenticalTo([]);
+
+        // Make sure there are no hubs
+        $this->integer(countElementsInTable($unmanaged->getTable()))->isIdenticalTo(0);
+
+        // Verify that eth0 is the only port connected
+        $this->integer(countElementsInTable($networkPort_NetworkPort->getTable()))->isIdenticalTo(1);
+        $this->boolean($networkPort->getFromDBByCrit(['name' => 'eth0']));
+        $this->boolean($networkPort_NetworkPort->getFromDBForNetworkPort($networkPort->fields['id']))->isTrue();
+    }
+
+    public function testSwitchMacConnection4()
+    {
+        $xml_source = '<?xml version="1.0" encoding="UTF-8" ?>
+<REQUEST>
+  <CONTENT>
+    <DEVICE>
+      <INFO>
+        <TYPE>NETWORKING</TYPE>
+        <MANUFACTURER>Hewlett-Packard</MANUFACTURER>
+        <MODEL>J9085A</MODEL>
+        <DESCRIPTION>ProCurve J9085A</DESCRIPTION>
+        <NAME>FR-SW01</NAME>
+        <LOCATION>BAT A - Niv 3</LOCATION>
+        <CONTACT>Admin</CONTACT>
+        <SERIAL>CN536H7J</SERIAL>
+        <FIRMWARE>R.10.06 R.11.60</FIRMWARE>
+        <UPTIME>8 days, 01:48:57.95</UPTIME>
+        <MAC>b4:39:d6:3a:7f:00</MAC>
+        <ID>0</ID>
+        <IPS>
+          <IP>192.168.1.56</IP>
+          <IP>192.168.10.56</IP>
+        </IPS>
+      </INFO>
+      <PORTS>
+        <PORT>
+          <CONNECTIONS>
+            <CONNECTION>
+              <MAC>bc:97:e1:5c:0e:90</MAC>
+              <MAC>fe:54:00:dd:1d:4f</MAC>
+              <MAC>fe:54:00:c0:97:8a</MAC>
+              <MAC>fe:54:00:ff:04:b5</MAC>
+            </CONNECTION>
+          </CONNECTIONS>
+          <IFDESCR>gi0/3</IFDESCR>
+          <IFNAME>gi0/3</IFNAME>
+          <IFNUMBER>3</IFNUMBER>
+          <IFSPEED>1000000000</IFSPEED>
+          <IFSTATUS>1</IFSTATUS>
+          <IFINTERNALSTATUS>1</IFINTERNALSTATUS>
+          <IFPORTDUPLEX>2</IFPORTDUPLEX>
+          <IFTYPE>6</IFTYPE>
+          <MAC>b4:39:d6:3b:22:bd</MAC>
+          <VLANS>
+            <VLAN>
+              <NAME>VLAN160</NAME>
+              <NUMBER>160</NUMBER>
+            </VLAN>
+          </VLANS>
+        </PORT>
+      </PORTS>
+    </DEVICE>
+    <MODULEVERSION>3.0</MODULEVERSION>
+    <PROCESSNUMBER>1</PROCESSNUMBER>
+  </CONTENT>
+  <DEVICEID>foo</DEVICEID>
+  <QUERY>SNMPQUERY</QUERY>
+</REQUEST>';
+
+        $networkPort             = new \NetworkPort();
+        $unmanaged               = new \Unmanaged();
+        $networkPort_NetworkPort = new \NetworkPort_NetworkPort();
+
+        $computer = getItemByTypeName('Computer', '_test_pc01');
+        $computers_id = $computer->fields['id'];
+        $this->integer($computers_id)->isGreaterThan(0);
+
+        // Add some ports
+        $ports_id = $networkPort->add([
+            'name'               => 'eth0',
+            'logical_number'     => '1',
+            'instantiation_type' => 'NetworkPortEthernet',
+            'items_id'           => $computer->fields['id'],
+            'itemtype'           => $computer->getTypeName(1),
+            'mac'                => 'bc:97:e1:5c:0e:90',
+        ]);
+        $this->integer($ports_id)->isGreaterThan(0);
+
+        $ports_id = $networkPort->add([
+            'name'               => 'eth1',
+            'logical_number'     => '1',
+            'instantiation_type' => 'NetworkPortEthernet',
+            'items_id'           => $computer->fields['id'],
+            'itemtype'           => $computer->getTypeName(1),
+            'mac'                => 'bc:97:e1:5c:0e:91',
+        ]);
+        $this->integer($ports_id)->isGreaterThan(0);
+
+        // add a virtual port (logical_number=0) with the same mac as eth0
+        $ports_id = $networkPort->add([
+            'name'               => 'ovs-bridge',
+            'logical_number'     => '0',
+            'instantiation_type' => 'NetworkPortEthernet',
+            'items_id'           => $computer->fields['id'],
+            'itemtype'           => $computer->getTypeName(1),
+            'mac'                => 'bc:97:e1:5c:0e:90',
+        ]);
+        $this->integer($ports_id)->isGreaterThan(0);
+
+        // add another virtual port
+        $ports_id = $networkPort->add([
+            'name'               => 'vnet13',
+            'logical_number'     => '0',
+            'instantiation_type' => 'NetworkPortEthernet',
+            'items_id'           => $computer->fields['id'],
+            'itemtype'           => $computer->getTypeName(1),
+            'mac'                => 'fe:54:00:dd:1d:4f',
+        ]);
+        $this->integer($ports_id)->isGreaterThan(0);
+
+        // add another virtual port
+        $ports_id = $networkPort->add([
+            'name'               => 'vnet15',
+            'logical_number'     => '0',
+            'instantiation_type' => 'NetworkPortEthernet',
+            'items_id'           => $computer->fields['id'],
+            'itemtype'           => $computer->getTypeName(1),
+            'mac'                => 'fe:54:00:c0:97:8a',
+        ]);
+        $this->integer($ports_id)->isGreaterThan(0);
+
+        // add another virtual port
+        $ports_id = $networkPort->add([
+            'name'               => 'vnet21',
+            'logical_number'     => '0',
+            'instantiation_type' => 'NetworkPortEthernet',
+            'items_id'           => $computer->fields['id'],
+            'itemtype'           => $computer->getTypeName(1),
+            'mac'                => 'fe:54:00:ff:04:b5',
+        ]);
+        $this->integer($ports_id)->isGreaterThan(0);
+
+        // Import the switch into GLPI
+        $converter = new \Glpi\Inventory\Converter();
+        $data = json_decode($converter->convert($xml_source));
+        //$json = json_decode($data);
+        $CFG_GLPI["is_contact_autoupdate"] = 0;
+        $inventory = new \Glpi\Inventory\Inventory($data);
+        $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default
+
+        $this->boolean($inventory->inError())->isFalse();
+        $this->array($inventory->getErrors())->isIdenticalTo([]);
+
+        // Make sure there are no hubs
+        $this->integer(countElementsInTable($unmanaged->getTable()))->isIdenticalTo(0);
+
+        // Verify that eth0 is the only port connected
+        $this->integer(countElementsInTable($networkPort_NetworkPort->getTable()))->isIdenticalTo(1);
+        $this->boolean($networkPort->getFromDBByCrit(['name' => 'eth0']));
+        $this->boolean($networkPort_NetworkPort->getFromDBForNetworkPort($networkPort->fields['id']))->isTrue();
+    }
 }

--- a/tests/functionnal/Glpi/Inventory/Assets/NetworkEquipment.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/NetworkEquipment.php
@@ -1450,7 +1450,8 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
             'instantiation_type' => 'NetworkPortEthernet',
             'items_id'           => $networkEquipments_id,
             'itemtype'           => 'NetworkEquipment',
-            'ifdescr'         => '20',
+            'ifdescr'            => '20',
+            'mac'                => '00:24:b5:bd:c8:02',
         ]);
         $this->integer($ports_id)->isGreaterThan(0);
 
@@ -1461,7 +1462,8 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
             'instantiation_type' => 'NetworkPortEthernet',
             'items_id'           => $networkEquipments_id,
             'itemtype'           => 'NetworkEquipment',
-            'ifdescr'         => '21',
+            'ifdescr'            => '21',
+            'mac'                => '00:24:b5:bd:c8:03',
         ]);
         $this->integer($ports_id)->isGreaterThan(0);
 
@@ -1472,7 +1474,8 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
             'instantiation_type' => 'NetworkPortEthernet',
             'items_id'           => $networkEquipments_id,
             'itemtype'           => 'NetworkEquipment',
-            'ifdescr'         => '22',
+            'ifdescr'            => '22',
+            'mac'                => '00:24:b5:bd:c8:04',
         ]);
         $this->integer($ports_id)->isGreaterThan(0);
 

--- a/tests/functionnal/Glpi/Inventory/Assets/NetworkEquipment.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/NetworkEquipment.php
@@ -2543,7 +2543,8 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
                          }
                       ]
                    }
-                }'],
+                }'
+            ],
             ['json_source' =>
                 '{
                   "content": {
@@ -2562,7 +2563,8 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
                          }
                       ]
                    }
-                }'],
+                }'
+            ],
             ['json_source' =>
                 '{
                   "content": {
@@ -2580,7 +2582,8 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
                          }
                       ]
                    }
-                }'],
+                }'
+            ],
         ];
     }
 
@@ -2605,4 +2608,4 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $this->boolean(property_exists($networkPort, 'logical_number'))->isTrue();
         $this->integer($networkPort->logical_number)->isEqualTo(1047);
     }
- }
+}

--- a/tests/functionnal/RuleImportAsset.php
+++ b/tests/functionnal/RuleImportAsset.php
@@ -926,7 +926,8 @@ class RuleImportAsset extends DbTestCase
         $this->string($rule->fields['name'])->isIdenticalTo('Global update (by ip+ifdescr not restricted port)');
         $this->integer($this->items_id)->isIdenticalTo($networkEquipments_id);
         $this->string($this->itemtype)->isIdenticalTo('NetworkEquipment');
-        $this->array($this->ports_id)->isEqualTo($a_portids);
+        $this->array($this->ports_id)->hasSize(count($a_portids));
+        $this->array($this->ports_id)->containsValues($a_portids);
     }
 
     /**

--- a/tests/functionnal/RuleImportAsset.php
+++ b/tests/functionnal/RuleImportAsset.php
@@ -905,20 +905,20 @@ class RuleImportAsset extends DbTestCase
         $a_portids[] = $ports_id;
 
         $ports_id = $networkPort->add([
-                'mac'                => '00:1a:6c:9a:fc:98',
-                'name'               => 'Fa0/2',
-                'logical_number'     => '10102',
-                'instantiation_type' => 'NetworkPortEthernet',
-                'items_id'           => $networkEquipments_id,
-                'itemtype'           => 'NetworkEquipment',
-                'ip'                 => '192.168.0.2',
-                '_create_children'   => 1,
-                'NetworkName_name'   => '',
-                'NetworkName_fqdns_id' => 0,
-                'NetworkName__ipaddresses' => [
-                    '-1' => '192.168.0.2'
-                ],
-                'ifdescr'         => 'FastEthernet0/2',
+            'mac'                => '00:1a:6c:9a:fc:98',
+            'name'               => 'Fa0/2',
+            'logical_number'     => '10102',
+            'instantiation_type' => 'NetworkPortEthernet',
+            'items_id'           => $networkEquipments_id,
+            'itemtype'           => 'NetworkEquipment',
+            'ip'                 => '192.168.0.2',
+            '_create_children'   => 1,
+            'NetworkName_name'   => '',
+            'NetworkName_fqdns_id' => 0,
+            'NetworkName__ipaddresses' => [
+                '-1' => '192.168.0.2'
+            ],
+            'ifdescr'         => 'FastEthernet0/2',
         ]);
         $this->integer($ports_id)->isGreaterThan(0);
         $a_portids[] = $ports_id;

--- a/tests/functionnal/RuleImportAsset.php
+++ b/tests/functionnal/RuleImportAsset.php
@@ -614,8 +614,7 @@ class RuleImportAsset extends DbTestCase
         $this->string($rule->fields['name'])->isIdenticalTo("Computer update (by ip)");
         $this->integer($this->items_id)->isIdenticalTo($computers_id);
         $this->string($this->itemtype)->isIdenticalTo('Computer');
-        $this->array($this->ports_id)->hasSize(1);
-        $this->integer(current($this->ports_id))->isIdenticalTo($ports_id);
+        $this->array($this->ports_id)->isEqualTo([$ports_id]);
     }
 
     /**

--- a/tests/functionnal/RuleImportAsset.php
+++ b/tests/functionnal/RuleImportAsset.php
@@ -53,15 +53,15 @@ class RuleImportAsset extends DbTestCase
         $this->items_id = null;
         $this->itemtype = null;
         $this->rules_id = null;
-        $this->ports_id = null;
+        $this->ports_id = [];
     }
 
-    public function rulepassed($items_id, $itemtype, $rules_id, $ports_id = 0)
+    public function rulepassed($items_id, $itemtype, $rules_id, $ports_id = [])
     {
         $this->items_id = (int)$items_id;
         $this->itemtype = $itemtype;
         $this->rules_id = (int)$rules_id;
-        $this->ports_id = (int)$ports_id;
+        $this->ports_id = (array)$ports_id;
     }
 
     protected function enableRule($name)
@@ -376,7 +376,8 @@ class RuleImportAsset extends DbTestCase
         $this->string($rule->fields['name'])->isIdenticalTo("Computer update (by mac)");
         $this->integer($this->items_id)->isIdenticalTo($computers_id);
         $this->string($this->itemtype)->isIdenticalTo('Computer');
-        $this->integer($this->ports_id)->isIdenticalTo($ports_id);
+        $this->array($this->ports_id)->hasSize(1);
+        $this->integer(current($this->ports_id))->isIdenticalTo($ports_id);
     }
 
     /**
@@ -505,7 +506,8 @@ class RuleImportAsset extends DbTestCase
         $this->string($rule->fields['name'])->isIdenticalTo("Computer update (by ip)");
         $this->integer($this->items_id)->isIdenticalTo($computers_id);
         $this->string($this->itemtype)->isIdenticalTo('Computer');
-        $this->integer($this->ports_id)->isIdenticalTo($ports_id);
+        $this->array($this->ports_id)->hasSize(1);
+        $this->integer(current($this->ports_id))->isIdenticalTo($ports_id);
     }
 
 
@@ -614,7 +616,8 @@ class RuleImportAsset extends DbTestCase
         $this->string($rule->fields['name'])->isIdenticalTo("Computer update (by ip)");
         $this->integer($this->items_id)->isIdenticalTo($computers_id);
         $this->string($this->itemtype)->isIdenticalTo('Computer');
-        $this->integer($this->ports_id)->isIdenticalTo($ports_id);
+        $this->array($this->ports_id)->hasSize(1);
+        $this->integer(current($this->ports_id))->isIdenticalTo($ports_id);
     }
 
     /**
@@ -714,7 +717,7 @@ class RuleImportAsset extends DbTestCase
         $this->string($rule->fields['name'])->isIdenticalTo("Global import (by mac+ifnumber)");
         $this->integer($this->items_id)->isIdenticalTo(0);
         $this->string($this->itemtype)->isIdenticalTo('Unmanaged'); //not handled yet...
-        $this->integer($this->ports_id)->isIdenticalTo(0);
+        $this->integer(count($this->ports_id))->isIdenticalTo(0);
     }
 
     /**
@@ -769,7 +772,8 @@ class RuleImportAsset extends DbTestCase
         $this->string($rule->fields['name'])->isIdenticalTo("Global update (by mac+ifnumber restricted port)");
         $this->integer($this->items_id)->isIdenticalTo($networkEquipments_id);
         $this->string($this->itemtype)->isIdenticalTo('NetworkEquipment');
-        $this->integer($this->ports_id)->isIdenticalTo($ports_id);
+        $this->array($this->ports_id)->hasSize(1);
+        $this->integer(current($this->ports_id))->isIdenticalTo($ports_id);
     }
 
    //Above commented tests are related to SNMP inventory
@@ -839,11 +843,12 @@ class RuleImportAsset extends DbTestCase
         $this->string($rule->fields['name'])->isIdenticalTo("Global update (by ip+ifdescr restricted port)");
         $this->integer($this->items_id)->isIdenticalTo($networkEquipments_id);
         $this->string($this->itemtype)->isIdenticalTo('NetworkEquipment');
-        $this->integer($this->ports_id)->isIdenticalTo($ports_id_1);
+        $this->array($this->ports_id)->hasSize(1);
+        $this->integer(current($this->ports_id))->isIdenticalTo($ports_id_1);
 
         $this->items_id = 0;
         $this->itemtype = "";
-        $this->ports_id = 0;
+        $this->ports_id = [];
         $input = [
             'ifdescr' => 'FastEthernet0/1',
             'ip'      => '192.168.0.2',
@@ -879,6 +884,7 @@ class RuleImportAsset extends DbTestCase
         ]);
         $this->integer($networkEquipments_id)->isGreaterThan(0);
 
+        $a_portids = [];
         $ports_id = $networkPort->add([
             'mac'                => '00:1a:6c:9a:fc:99',
             'name'               => 'Fa0/1',
@@ -896,9 +902,9 @@ class RuleImportAsset extends DbTestCase
             'ifdescr'         => 'FastEthernet0/1',
         ]);
         $this->integer($ports_id)->isGreaterThan(0);
+        $a_portids[] = $ports_id;
 
-        $this->integer(
-            $networkPort->add([
+        $ports_id = $networkPort->add([
                 'mac'                => '00:1a:6c:9a:fc:98',
                 'name'               => 'Fa0/2',
                 'logical_number'     => '10102',
@@ -913,8 +919,9 @@ class RuleImportAsset extends DbTestCase
                     '-1' => '192.168.0.2'
                 ],
                 'ifdescr'         => 'FastEthernet0/2',
-            ])
-        )->isGreaterThan(0);
+        ]);
+        $this->integer($ports_id)->isGreaterThan(0);
+        $a_portids[] = $ports_id;
 
         $data = $ruleCollection->processAllRules($input, [], ['class' => $this]);
 
@@ -924,7 +931,8 @@ class RuleImportAsset extends DbTestCase
         $this->string($rule->fields['name'])->isIdenticalTo('Global update (by ip+ifdescr not restricted port)');
         $this->integer($this->items_id)->isIdenticalTo($networkEquipments_id);
         $this->string($this->itemtype)->isIdenticalTo('NetworkEquipment');
-        $this->integer($this->ports_id)->isIdenticalTo($ports_id);
+        $this->array($this->ports_id)->hasSize(2);
+        $this->array(array_diff($this->ports_id, $a_portids))->hasSize(0);
     }
 
     /**
@@ -986,7 +994,8 @@ class RuleImportAsset extends DbTestCase
         $this->string($rule->fields['name'])->isIdenticalTo("Update only mac address (mac on switch port)");
         $this->integer($this->items_id)->isIdenticalTo($printers_id);
         $this->string($this->itemtype)->isIdenticalTo('Printer');
-        $this->integer($this->ports_id)->isIdenticalTo($ports_id_2);
+        $this->array($this->ports_id)->hasSize(1);
+        $this->integer(current($this->ports_id))->isIdenticalTo($ports_id_2);
     }
 
     public function testGetTitle()

--- a/tests/functionnal/RuleImportAsset.php
+++ b/tests/functionnal/RuleImportAsset.php
@@ -843,8 +843,7 @@ class RuleImportAsset extends DbTestCase
         $this->string($rule->fields['name'])->isIdenticalTo("Global update (by ip+ifdescr restricted port)");
         $this->integer($this->items_id)->isIdenticalTo($networkEquipments_id);
         $this->string($this->itemtype)->isIdenticalTo('NetworkEquipment');
-        $this->array($this->ports_id)->hasSize(1);
-        $this->integer(current($this->ports_id))->isIdenticalTo($ports_id_1);
+        $this->array($this->ports_id)->isEqualTo([$ports_id_1]);
 
         $this->items_id = 0;
         $this->itemtype = "";

--- a/tests/functionnal/RuleImportAsset.php
+++ b/tests/functionnal/RuleImportAsset.php
@@ -376,8 +376,7 @@ class RuleImportAsset extends DbTestCase
         $this->string($rule->fields['name'])->isIdenticalTo("Computer update (by mac)");
         $this->integer($this->items_id)->isIdenticalTo($computers_id);
         $this->string($this->itemtype)->isIdenticalTo('Computer');
-        $this->array($this->ports_id)->hasSize(1);
-        $this->integer(current($this->ports_id))->isIdenticalTo($ports_id);
+        $this->array($this->ports_id)->isEqualTo([$ports_id]);
     }
 
     /**

--- a/tests/functionnal/RuleImportAsset.php
+++ b/tests/functionnal/RuleImportAsset.php
@@ -994,8 +994,7 @@ class RuleImportAsset extends DbTestCase
         $this->string($rule->fields['name'])->isIdenticalTo("Update only mac address (mac on switch port)");
         $this->integer($this->items_id)->isIdenticalTo($printers_id);
         $this->string($this->itemtype)->isIdenticalTo('Printer');
-        $this->array($this->ports_id)->hasSize(1);
-        $this->integer(current($this->ports_id))->isIdenticalTo($ports_id_2);
+        $this->array($this->ports_id)->isEqualTo([$ports_id_2]);
     }
 
     public function testGetTitle()

--- a/tests/functionnal/RuleImportAsset.php
+++ b/tests/functionnal/RuleImportAsset.php
@@ -716,7 +716,7 @@ class RuleImportAsset extends DbTestCase
         $this->string($rule->fields['name'])->isIdenticalTo("Global import (by mac+ifnumber)");
         $this->integer($this->items_id)->isIdenticalTo(0);
         $this->string($this->itemtype)->isIdenticalTo('Unmanaged'); //not handled yet...
-        $this->integer(count($this->ports_id))->isIdenticalTo(0);
+        $this->array($this->ports_id)->isEmpty();
     }
 
     /**

--- a/tests/functionnal/RuleImportAsset.php
+++ b/tests/functionnal/RuleImportAsset.php
@@ -931,8 +931,7 @@ class RuleImportAsset extends DbTestCase
         $this->string($rule->fields['name'])->isIdenticalTo('Global update (by ip+ifdescr not restricted port)');
         $this->integer($this->items_id)->isIdenticalTo($networkEquipments_id);
         $this->string($this->itemtype)->isIdenticalTo('NetworkEquipment');
-        $this->array($this->ports_id)->hasSize(2);
-        $this->array(array_diff($this->ports_id, $a_portids))->hasSize(0);
+        $this->array($this->ports_id)->isEqualTo($a_portids);
     }
 
     /**

--- a/tests/functionnal/RuleImportAsset.php
+++ b/tests/functionnal/RuleImportAsset.php
@@ -506,8 +506,7 @@ class RuleImportAsset extends DbTestCase
         $this->string($rule->fields['name'])->isIdenticalTo("Computer update (by ip)");
         $this->integer($this->items_id)->isIdenticalTo($computers_id);
         $this->string($this->itemtype)->isIdenticalTo('Computer');
-        $this->array($this->ports_id)->hasSize(1);
-        $this->integer(current($this->ports_id))->isIdenticalTo($ports_id);
+        $this->array($this->ports_id)->isEqualTo([$ports_id]);
     }
 
 

--- a/tests/functionnal/RuleImportAsset.php
+++ b/tests/functionnal/RuleImportAsset.php
@@ -771,8 +771,7 @@ class RuleImportAsset extends DbTestCase
         $this->string($rule->fields['name'])->isIdenticalTo("Global update (by mac+ifnumber restricted port)");
         $this->integer($this->items_id)->isIdenticalTo($networkEquipments_id);
         $this->string($this->itemtype)->isIdenticalTo('NetworkEquipment');
-        $this->array($this->ports_id)->hasSize(1);
-        $this->integer(current($this->ports_id))->isIdenticalTo($ports_id);
+        $this->array($this->ports_id)->isEqualTo([$ports_id]);
     }
 
    //Above commented tests are related to SNMP inventory


### PR DESCRIPTION
The patch tries to pick the right NetworkPort to make a connection in the following cases:
1. A computer has several NetworkPorts having the same MAC, e.g. when alias interfaces exist
2. A computer has multiple MAC addresses on the same physical port (as seen from a network device), when the computer runs virtual machines, etc.

I had to modify rules handling because it didn't report all of the matching NetworkPorts, which lead to fixing handleLLDPConnection() as well.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | N/A
