### PR TITLE
feat: human search order

### DIFF
--- a/src/Search/Provider/SQLProvider.php
+++ b/src/Search/Provider/SQLProvider.php
@@ -2803,6 +2803,11 @@ final class SQLProvider implements SearchProviderInterface
                     case "glpi_ipaddresses.name":
                         $criterion = "INET6_ATON(`$table$addtable`.`$field`) $order";
                         break;
+                    case "glpi_computers.name":
+                    case "glpi_networkequipments.name":
+                        $_field = "`$table$addtable`.`$field`";
+                        $criterion = "SOUNDEX($_field),LENGTH($_field),$_field $order";
+                        break;
                 }
             }
 

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -2032,12 +2032,12 @@ class Search extends DbTestCase
         $this->login();
         $this->setEntity('_test_root_entity', true);
 
-        $data = $this->doSearch('SearchTest\\Computer', $search_params);
+        $data = $this->doSearch('SearchTest\\Monitor', $search_params);
 
         $this->string($data['sql']['search'])
-         ->contains("`glpi_computers`.`name` AS `ITEM_SearchTest\Computer_1`")
-         ->contains("`glpi_computers`.`id` AS `ITEM_SearchTest\Computer_1_id`")
-         ->contains("ORDER BY `ITEM_SearchTest\Computer_1` ASC");
+         ->contains("`glpi_monitors`.`name` AS `ITEM_SearchTest\Monitor_1`")
+         ->contains("`glpi_monitors`.`id` AS `ITEM_SearchTest\Monitor_1_id`")
+         ->contains("ORDER BY `ITEM_SearchTest\Monitor_1` ASC");
     }
 
     public function testGroupParamAfterMeta()
@@ -2138,6 +2138,15 @@ class Search extends DbTestCase
 
     protected function testNamesOutputProvider(): array
     {
+        $computer = new \Computer();
+        foreach (['_test_pc1', '_test_pc101', '_test_p100', '_test_p1000'] as $name) {
+            $computer->add([
+                'name'         => $name,
+                'entities_id'  => 0,
+                'is_recursive' => 1,
+            ]);
+        }
+
         return [
             [
                 'params' => [
@@ -2166,7 +2175,9 @@ class Search extends DbTestCase
                     'as_map'       => 0,
                 ],
                 'expected' => [
-                    '_test_pc_with_encoded_comment',
+                    '_test_p100',
+                    '_test_p1000',
+                    '_test_pc1',
                     '_test_pc01',
                     '_test_pc02',
                     '_test_pc03',
@@ -2175,6 +2186,8 @@ class Search extends DbTestCase
                     '_test_pc13',
                     '_test_pc21',
                     '_test_pc22',
+                    '_test_pc101',
+                    '_test_pc_with_encoded_comment',
                 ]
             ],
         ];
@@ -2369,11 +2382,11 @@ class DupSearchOpt extends \CommonDBTM
 namespace SearchTest;
 
 // @codingStandardsIgnoreStart
-class Computer extends \Computer
+class Monitor extends \Monitor
 {
     // @codingStandardsIgnoreEnd
     public static function getTable($classname = null)
     {
-        return 'glpi_computers';
+        return 'glpi_monitors';
     }
 }


### PR DESCRIPTION
Human sort order for computers and network equipment.
Simple order by name:

```
p100
p1000
pc01
pc02
pc03
pc1
pc101
pc11
pc12
pc13
pc21
pc22
```
Human sort order:

```
p100
p1000
pc1
pc01
pc02
pc03
pc11
pc12
pc13
pc21
pc22
pc101
```



| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
