### PR TITLE
fix(planning): fix import external planning by decoding url

### DIFF
--- a/front/planning.form.php
+++ b/front/planning.form.php
@@ -54,6 +54,10 @@ if ($_REQUEST["action"] == "send_add_group_form") {
 }
 
 if ($_REQUEST["action"] == "send_add_external_form") {
+    if(isset($_REQUEST['url'])) {
+       $_REQUEST['url'] =  html_entity_decode($_REQUEST['url']); 
+    }
+
     Planning::sendAddExternalForm($_REQUEST);
 }
 


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
--> 
Hello, 

When I try to import an external planning, I noticed that that the ampersand is wrongly encoded.
In my database I see `&#38;` instead of `&`.

I added a decode function to transform the ampersand.
Another solution would be to fix the url in the javascript before sending it to the backend.

Thanks 

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   |  yes
| Fixed tickets | N/A
