### PR TITLE
Update can*Item checks to count with recursive items

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -2419,7 +2419,7 @@ class CommonDBTM extends CommonGLPI
             $infocom = new Infocom();
 
             if ($infocom->getFromDBforDevice($this->getType(), $this->fields['id'])) {
-                return $infocom->canPurge(true);
+                return $infocom->canPurge();
             }
         }
         return true;

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -2372,7 +2372,7 @@ class CommonDBTM extends CommonGLPI
     public function canUpdateItem()
     {
 
-        if (!$this->checkEntity()) {
+        if (!$this->checkEntity(true)) {
             return false;
         }
         return true;
@@ -2391,7 +2391,7 @@ class CommonDBTM extends CommonGLPI
     public function canDeleteItem()
     {
 
-        if (!$this->checkEntity()) {
+        if (!$this->checkEntity(true)) {
             return false;
         }
         return true;
@@ -2410,7 +2410,7 @@ class CommonDBTM extends CommonGLPI
     public function canPurgeItem()
     {
 
-        if (!$this->checkEntity()) {
+        if (!$this->checkEntity(true)) {
             return false;
         }
 
@@ -2419,7 +2419,7 @@ class CommonDBTM extends CommonGLPI
             $infocom = new Infocom();
 
             if ($infocom->getFromDBforDevice($this->getType(), $this->fields['id'])) {
-                return $infocom->canPurge();
+                return $infocom->canPurge(true);
             }
         }
         return true;

--- a/tests/functionnal/CommonDBTM.php
+++ b/tests/functionnal/CommonDBTM.php
@@ -497,12 +497,12 @@ class CommonDBTM extends DbTestCase
         $this->boolean($printer->can($id[0], READ))->isTrue("Fail can read Printer 1");
         $this->boolean($printer->can($id[1], READ))->isTrue("Fail can read Printer 2");
         $this->boolean($printer->can($id[2], READ))->isFalse("Fail can't read Printer 3");
-        $this->boolean($printer->can($id[3], READ))->isFalse("Fail can't read Printer 1");
+        $this->boolean($printer->can($id[3], READ))->isFalse("Fail can't read Printer 4");
 
         $this->boolean($printer->canEdit($id[0]))->isTrue("Fail can write Printer 1");
         $this->boolean($printer->canEdit($id[1]))->isTrue("Fail can write Printer 2");
-        $this->boolean($printer->canEdit($id[2]))->isFalse("Fail can't write Printer 1");
-        $this->boolean($printer->canEdit($id[3]))->isFalse("Fail can't write Printer 1");
+        $this->boolean($printer->canEdit($id[2]))->isFalse("Fail can't write Printer 3");
+        $this->boolean($printer->canEdit($id[3]))->isFalse("Fail can't write Printer 4");
 
        // See only in child entity 1 + parent if recursive
         $this->boolean(\Session::changeActiveEntities($ent1))->isTrue();
@@ -513,9 +513,9 @@ class CommonDBTM extends DbTestCase
         $this->boolean($printer->can($id[3], READ))->isFalse("Fail can't read Printer 4");
 
         $this->boolean($printer->canEdit($id[0]))->isFalse("Fail can't write Printer 1");
-        $this->boolean($printer->canEdit($id[1]))->isFalse("Fail can't write Printer 2");
-        $this->boolean($printer->canEdit($id[2]))->isTrue("Fail can write Printer 2");
-        $this->boolean($printer->canEdit($id[3]))->isFalse("Fail can't write Printer 2");
+        $this->boolean($printer->canEdit($id[1]))->isTrue("Fail can write Printer 2");
+        $this->boolean($printer->canEdit($id[2]))->isTrue("Fail can write Printer 3");
+        $this->boolean($printer->canEdit($id[3]))->isFalse("Fail can't write Printer 4");
 
        // See only in child entity 2 + parent if recursive
         $this->boolean(\Session::changeActiveEntities($ent2))->isTrue();
@@ -526,7 +526,7 @@ class CommonDBTM extends DbTestCase
         $this->boolean($printer->can($id[3], READ))->isTrue("Fail can read Printer 4");
 
         $this->boolean($printer->canEdit($id[0]))->isFalse("Fail can't write Printer 1");
-        $this->boolean($printer->canEdit($id[1]))->isFalse("Fail can't write Printer 2");
+        $this->boolean($printer->canEdit($id[1]))->isTrue("Fail can write Printer 2");
         $this->boolean($printer->canEdit($id[2]))->isFalse("Fail can't write Printer 3");
         $this->boolean($printer->canEdit($id[3]))->isTrue("Fail can write Printer 4");
     }

--- a/tests/functionnal/Notification_NotificationTemplate.php
+++ b/tests/functionnal/Notification_NotificationTemplate.php
@@ -99,7 +99,11 @@ class Notification_NotificationTemplate extends DbTestCase
             function () use ($notif) {
                 \Notification_NotificationTemplate::showForNotification($notif);
             }
-        )->isIdenticalTo("<div class='center'><table class='tab_cadre_fixehov'><tr><th>ID</th><th>Template</th><th>Mode</th></tr><tr class='tab_bg_2'><td><a  href='/glpi/front/notification_notificationtemplate.form.php?id=1'  title=\"1\">1</a></td><td><a  href='/glpi/front/notificationtemplate.form.php?id=6'  title=\"Alert Tickets not closed\">Alert Tickets not closed</a></td><td>Email</td></tr><tr><th>ID</th><th>Template</th><th>Mode</th></tr></table></div>");
+        )->isIdenticalTo(<<<HTML
+<div class='center firstbloc'><a class='btn btn-primary' href='/glpi/front/notification_notificationtemplate.form.php?notifications_id=1&amp;withtemplate=0'>Add a template</a></div>
+<div class='center'><table class='tab_cadre_fixehov'><tr><th>ID</th><th>Template</th><th>Mode</th></tr><tr class='tab_bg_2'><td><a  href='/glpi/front/notification_notificationtemplate.form.php?id=1'  title="1">1</a></td><td><a  href='/glpi/front/notificationtemplate.form.php?id=6'  title="Alert Tickets not closed">Alert Tickets not closed</a></td><td>Email</td></tr><tr><th>ID</th><th>Template</th><th>Mode</th></tr></table></div>
+HTML
+            );
     }
 
     public function testGetName()


### PR DESCRIPTION
Update canPurgeItem() canUpdateItem() canDeleteItem() to call $this->checkEntity(true) by default, so count with recursive objects entity by default.

This is to allow recursive ITIL Objects to work (Changes, Problems), so all these rights are checked for active entity not on items entity, if item is recursive. 

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | NA
