### PR TITLE
fix(core): insertId return 0

### DIFF
--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -583,6 +583,9 @@ class DBmysql
         $insert_id = $this->dbh->insert_id;
 
         if ($insert_id === 0) {
+            // See https://www.php.net/manual/en/mysqli.insert-id.php
+            // `$this->dbh->insert_id` will return 0 value if `INSERT` statement did not change the `AUTO_INCREMENT` value.
+            // We have to retrieve it manually via `LAST_INSERT_ID()`.
             $insert_id = $this->dbh->query('SELECT LAST_INSERT_ID()')->fetch_row()[0];
         }
         return $insert_id;

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -580,7 +580,12 @@ class DBmysql
      */
     public function insertId()
     {
-        return $this->dbh->insert_id;
+        $insert_id = $this->dbh->insert_id;
+
+        if ($insert_id === 0) {
+            $insert_id = $this->dbh->query('SELECT LAST_INSERT_ID()')->fetch_row()[0];
+        }
+        return $insert_id;
     }
 
     /**


### PR DESCRIPTION
Sometimes, the `insertId` function returned 0 even though the record had been added to the database.

_Case with the `alert` plugin, whose ID column is in AUTO_INCREMENT (as it should be)._

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25385
