### PR TITLE
Fix port error metric graph

### DIFF
--- a/src/NetworkPortMetrics.php
+++ b/src/NetworkPortMetrics.php
@@ -158,7 +158,7 @@ class NetworkPortMetrics extends CommonDBChild
             unset($errors_metrics['ifinbytes'], $errors_metrics['ifoutbytes']);
             foreach ($errors_metrics as $key => $value) {
                 $errors_series[$key]['name'] = $this->getLabelFor($key);
-                $errors_series[$key]['data'][] = round($value / 1024 / 1024, 0); //convert bytes to megabytes
+                $errors_series[$key]['data'][] = $value;
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13092

Port error metric should not be treated like a number of bytes, it is the number of packets with errors.