### PR TITLE
fix(contract): fix input check

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1827,7 +1827,7 @@ class Ticket extends CommonITILObject
 
         // Set default contract if not specified
         if (
-            (!isset($input['_contracts_id']) || (int)$input['_contracts_id'] !== 0)
+            (!isset($input['_contracts_id']) || (int)$input['_contracts_id'] == 0)
             && (!isset($input['_skip_default_contract']) || $input['_skip_default_contract'] === false)
         ) {
             $input['_contracts_id'] = Entity::getDefaultContract($this->input['entities_id'] ?? 0);

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1825,9 +1825,9 @@ class Ticket extends CommonITILObject
             $input['itilcategories_id_code'] = ITILCategory::getById($cat_id)->fields['code'];
         }
 
-       // Set default contract if not specified
+        // Set default contract if not specified
         if (
-            !isset($input['_contracts_id']) &&
+            !empty($input['_contracts_id']) &&
             (!isset($input['_skip_default_contract']) || $input['_skip_default_contract'] === false)
         ) {
             $input['_contracts_id'] = Entity::getDefaultContract($this->input['entities_id'] ?? 0);

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1827,7 +1827,7 @@ class Ticket extends CommonITILObject
 
         // Set default contract if not specified
         if (
-            (!isset($input['_contracts_id']) || empty($input['_contracts_id']))
+            (!isset($input['_contracts_id']) || (int)$input['_contracts_id'] !== 0)
             && (!isset($input['_skip_default_contract']) || $input['_skip_default_contract'] === false)
         ) {
             $input['_contracts_id'] = Entity::getDefaultContract($this->input['entities_id'] ?? 0);

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1827,8 +1827,8 @@ class Ticket extends CommonITILObject
 
         // Set default contract if not specified
         if (
-            !empty($input['_contracts_id']) &&
-            (!isset($input['_skip_default_contract']) || $input['_skip_default_contract'] === false)
+            (!isset($input['_contracts_id']) || empty($input['_contracts_id']))
+            && (!isset($input['_skip_default_contract']) || $input['_skip_default_contract'] === false)
         ) {
             $input['_contracts_id'] = Entity::getDefaultContract($this->input['entities_id'] ?? 0);
         }


### PR DESCRIPTION
Fix input check.

```!isset($input['_contracts_id'])```  return always ```false``` because ```$input['_contracts_id']``` alays exist with ```0``` value




| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25407
