### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,24 +7,44 @@ updates:
     schedule:
       interval: "weekly"
 
-  # Strategy for npm dependencies on main branch.
+
+  # Update development dependencies on current release branch (10.0/bugfixes).
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "monthly"
     allow:
-      - dependency-type: "direct"
+      - dependency-type: "development"
     open-pull-requests-limit: 100
-    target-branch: "main"
-    versioning-strategy: "lockfile-only"
-
-  # Strategy for composer dependencies on main branch.
+    target-branch: "10.0/bugfixes"
+    versioning-strategy: "increase"
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
       interval: "monthly"
     allow:
-      - dependency-type: "direct"
+      - dependency-type: "development"
+    open-pull-requests-limit: 100
+    target-branch: "10.0/bugfixes"
+    versioning-strategy: "increase"
+
+
+  # Update production dependencies on future release branch (main).
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-type: "production"
     open-pull-requests-limit: 100
     target-branch: "main"
-    versioning-strategy: "lockfile-only"
+    versioning-strategy: "increase"
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-type: "production"
+    open-pull-requests-limit: 100
+    target-branch: "main"
+    versioning-strategy: "increase"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. On current release branch (`10.0/bugfixes`), keep development dependencies up-to-date and allow major version increase.
This will reduce the risk to have outdated dependencies that may prevent to execute the release script on a recent machine (cf #13042).

2. On future release branch (`main`), keep production dependencies up-to-date and allow major version increase.
As we allow us to introduce BC-breaks inside intermediate releases, we should probably switch to new production dependencies major versions as soon as they are available.