### PR TITLE
fix(group): error when there are already many users

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -3883,7 +3883,15 @@ JAVASCRIPT;
         $used = [];
 
         if (isset($post['used'])) {
-            $used = $post['used'];
+            if (isset($post['used_counter'])) {
+                $used = $post['used'];
+            } else {
+                $gusers = Group_User::getGroupUsers($post['group_id']);
+                $used = [];
+                foreach ($gusers as $user) {
+                    $used[$user['id']] = $user['id'];
+                }
+            }
         }
 
         if (!isset($post['value'])) {

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -3883,9 +3883,8 @@ JAVASCRIPT;
         $used = [];
 
         if (isset($post['used'])) {
-            if (isset($post['used_counter'])) {
-                $used = $post['used'];
-            } else {
+            $used = $post['used'];
+            if (!isset($post['used_counter']) && isset($post['group_id'])) {
                 $gusers = Group_User::getGroupUsers($post['group_id']);
                 $used = [];
                 foreach ($gusers as $user) {

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -3884,13 +3884,11 @@ JAVASCRIPT;
 
         if (isset($post['used'])) {
             $used = $post['used'];
-            if (!isset($post['used_counter']) && isset($post['group_id'])) {
-                $gusers = Group_User::getGroupUsers($post['group_id']);
-                $used = [];
-                foreach ($gusers as $user) {
-                    $used[$user['id']] = $user['id'];
-                }
-            }
+        }
+
+        $condition = [];
+        if (isset($post['condition'])) {
+            $condition = $_SESSION['glpicondition'][$post['condition']];
         }
 
         if (!isset($post['value'])) {
@@ -3921,7 +3919,8 @@ JAVASCRIPT;
             $start,
             (int)$post['page_limit'],
             $inactive_deleted,
-            $with_no_right
+            $with_no_right,
+            $condition,
         );
 
         $users = [];

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -338,7 +338,8 @@ class Group_User extends CommonDBRelation
             User::dropdown(['right'  => "all",
                 'entity' => $entityrestrict,
                 'with_no_right' => true,
-                'used'   => $used_ids
+                'used'   => $used_ids,
+                'group_id' => $group->fields['id'],
             ]);
 
             echo "</td><td>" . _n('Manager', 'Managers', 1) . "</td><td>";

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -338,8 +338,7 @@ class Group_User extends CommonDBRelation
             User::dropdown(['right'  => "all",
                 'entity' => $entityrestrict,
                 'with_no_right' => true,
-                'used'   => $used_ids,
-                'group_id' => $group->fields['id'],
+                'condition' => Dropdown::addNewCondition(['NOT' => ['glpi_users.id' => $used_ids]]),
             ]);
 
             echo "</td><td>" . _n('Manager', 'Managers', 1) . "</td><td>";

--- a/src/User.php
+++ b/src/User.php
@@ -4396,6 +4396,7 @@ HTML;
             'hide_if_no_elements' => false,
             'readonly'            => false,
             'multiple'            => false,
+            'group_id'            => 0,
         ];
 
         if (is_array($options) && count($options)) {
@@ -4477,7 +4478,6 @@ HTML;
             'placeholder'         => $p['placeholder'],
             'right'               => $p['right'],
             'on_change'           => $p['on_change'],
-            'used'                => $p['used'],
             'inactive_deleted'    => $p['inactive_deleted'],
             'with_no_right'       => $p['with_no_right'],
             'entity_restrict'     => ($entity_restrict = (is_array($p['entity']) ? json_encode(array_values($p['entity'])) : $p['entity'])),
@@ -4488,6 +4488,9 @@ HTML;
                 'right'           => $p['right'],
                 'entity_restrict' => $entity_restrict,
             ]),
+            'group_id'            => $p['group_id'],
+            'used'                => $p['used'],
+            'used_counter'        => count($p['used']),
         ];
 
         if ($p['multiple']) {

--- a/src/User.php
+++ b/src/User.php
@@ -3960,7 +3960,8 @@ HTML;
         $start = 0,
         $limit = -1,
         $inactive_deleted = 0,
-        $with_no_right = 0
+        $with_no_right = 0,
+        array $condition = []
     ) {
         global $DB;
 
@@ -4220,6 +4221,10 @@ HTML;
             ];
         }
 
+        if (count($condition)) {
+            $WHERE[] = [$condition];
+        }
+
         // remove helpdesk user
         $config = Config::getConfigurationValues('core');
         $WHERE[] = [
@@ -4396,7 +4401,7 @@ HTML;
             'hide_if_no_elements' => false,
             'readonly'            => false,
             'multiple'            => false,
-            'group_id'            => 0,
+            'condition'           => [],
         ];
 
         if (is_array($options) && count($options)) {
@@ -4478,6 +4483,7 @@ HTML;
             'placeholder'         => $p['placeholder'],
             'right'               => $p['right'],
             'on_change'           => $p['on_change'],
+            'used'                => $p['used'],
             'inactive_deleted'    => $p['inactive_deleted'],
             'with_no_right'       => $p['with_no_right'],
             'entity_restrict'     => ($entity_restrict = (is_array($p['entity']) ? json_encode(array_values($p['entity'])) : $p['entity'])),
@@ -4488,9 +4494,7 @@ HTML;
                 'right'           => $p['right'],
                 'entity_restrict' => $entity_restrict,
             ]),
-            'group_id'            => $p['group_id'],
-            'used'                => $p['used'],
-            'used_counter'        => count($p['used']),
+            'condition'           => $p['condition'],
         ];
 
         if ($p['multiple']) {


### PR DESCRIPTION
When a group already has many users (around 1000), the add dropdown was in error, which blocked the addition of other users.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25185
