### PR TITLE
more resilient query expression for user name

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -6192,7 +6192,7 @@ HTML;
         $first  = DBmysql::quoteName("$table.$first");
         $second = DBmysql::quoteName("$table.$second");
         $alias  = DBmysql::quoteName($alias);
-        $name   = DBmysql::quoteName(self::getNameField());
+        $name   = DBmysql::quoteName($table . '.' . self::getNameField());
 
         return new QueryExpression("IF(
             $first <> '' && $second <> '',


### PR DESCRIPTION
User::getFriendlyNameFields() may fail if used in a SQL query where the column **name** is used in other tables.

Other columns are qualified with table name, then **name** should be also properly qualified.




| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
