### PR TITLE
Update PHP version override in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
     "config": {
         "optimize-autoloader": true,
         "platform": {
-            "php": "8.0.0"
+            "php": "8.0.99"
         },
         "sort-packages": true
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b5e70544cecf72276f5a6a113041425b",
+    "content-hash": "687e421f9cfb015f06a2397a83995831",
     "packages": [
         {
             "name": "blueimp/jquery-file-upload",
@@ -6157,7 +6157,7 @@
         "ext-xml": "*"
     },
     "platform-overrides": {
-        "php": "8.0.0"
+        "php": "8.0.99"
     },
     "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Forcing PHP `8.0.0` in composer platform overrides prevent dependabot to propose some new versions of our dependencies. For instance, `symfony` 6.x requires PHP `>= 8.0.2` (see https://github.com/symfony/symfony/pull/41282).

Forcing version to `8.0.99` will permit to still ensure that composer checks requirement against a `8.0.x` version.