### PR TITLE
Rollback CommonDBTM::generateLinkContents() signature change

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5354,9 +5354,12 @@ class CommonDBTM extends CommonGLPI
      * @param bool          $safe_url   indicates whether URL should be sanitized or not
      *
      * @return array of link contents (may have several when item have several IP / MAC cases)
+     *
+     * @FIXME Uncomment $safe_url parameter declaration in GLPI 10.1.
      */
-    public static function generateLinkContents($link, CommonDBTM $item, bool $safe_url = true)
+    public static function generateLinkContents($link, CommonDBTM $item/*, bool $safe_url = true*/)
     {
+        $safe_url = func_num_args() === 3 ? func_get_arg(2) : true;
         return Link::generateLinkContents($link, $item, $safe_url);
     }
 

--- a/src/Domain.php
+++ b/src/Domain.php
@@ -727,8 +727,13 @@ class Domain extends CommonDBTM
         return $types;
     }
 
-    public static function generateLinkContents($link, CommonDBTM $item, bool $safe_url = true)
+    /**
+     * @FIXME Uncomment $safe_url parameter declaration in GLPI 10.1.
+     */
+    public static function generateLinkContents($link, CommonDBTM $item/*, bool $safe_url = true*/)
     {
+        $safe_url = func_num_args() === 3 ? func_get_arg(2) : true;
+
         if (strstr($link, "[DOMAIN]")) {
             $link = str_replace("[DOMAIN]", $item->getName(), $link);
             if ($safe_url) {

--- a/src/Link.php
+++ b/src/Link.php
@@ -268,9 +268,13 @@ class Link extends CommonDBTM
      * @param bool          $safe_url   indicates whether URL should be sanitized or not
      *
      * @return array of link contents (may have several when item have several IP / MAC cases)
+     *
+     * @FIXME Uncomment $safe_url parameter declaration in GLPI 10.1.
      */
-    public static function generateLinkContents($link, CommonDBTM $item, bool $safe_url = true)
+    public static function generateLinkContents($link, CommonDBTM $item/*, bool $safe_url = true*/)
     {
+        $safe_url = func_num_args() === 3 ? func_get_arg(2) : true;
+
         global $DB, $CFG_GLPI;
 
        // Replace [FIELD:<field name>]

--- a/tests/functionnal/Link.php
+++ b/tests/functionnal/Link.php
@@ -182,5 +182,11 @@ TEXT,
         $this->newTestedInstance();
         $this->array($this->testedInstance->generateLinkContents($link, $item, $safe_url))
             ->isEqualTo($expected);
+
+        // Validates that default values is true
+        if ($safe_url) {
+            $this->array($this->testedInstance->generateLinkContents($link, $item))
+                ->isEqualTo($expected);
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Signature change was introducing a BC-break resulting in a fatal error on some plugins, e.g.
```
PHP Compile Error (64): Declaration of PluginOcsinventoryngTeamviewer::generateLinkContents($link, CommonDBTM $item) must be compatible with CommonDBTM::generateLinkContents($link, CommonDBTM $item, bool $safe_url = true) in /var/www/glpi/marketplace/ocsinventoryng/inc/teamviewer.class.php at line 326
```