### PR TITLE
PHP router to expose only public directory

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -44,11 +44,7 @@ $glpi_root  = realpath(dirname(__FILE__, 2));
 // `$_SERVER['SCRIPT_NAME']` corresponds to the script path relative to server document root.
 // -> if server document root is `/public`, then `$_SERVER['SCRIPT_NAME']` will be equal to `/index.php`
 // -> if script is located into a `/glpi-alias` alias directory, then `$_SERVER['SCRIPT_NAME']` will be equal to `/glpi-alias/index.php`
-$uri_prefix = preg_replace(
-    '/\/index.php$/',
-    '',
-    str_replace('\\', '/', $_SERVER['SCRIPT_NAME'])
-);
+$uri_prefix = rtrim(str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME'])), '/');
 // Get URI path relative to GLPI (i.e. without alias directory prefix).
 $path       = preg_replace(
     '/^' . preg_quote($uri_prefix, '/') . '/',

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * GLPI web router.
+ *
+ * This router is used to be able to expose only the `/public` directory on the webserver.
+ */
+
+$glpi_root  = realpath(dirname(__FILE__, 2));
+
+// `$_SERVER['SCRIPT_NAME']` corresponds to the script path relative to server document root.
+// -> if server document root is `/public`, then `$_SERVER['SCRIPT_NAME']` will be equal to `/index.php`
+// -> if script is located into a `/glpi-alias` alias directory, then `$_SERVER['SCRIPT_NAME']` will be equal to `/glpi-alias/index.php`
+$uri_prefix = preg_replace(
+    '/\/index.php$/',
+    '',
+    str_replace('\\', '/', $_SERVER['SCRIPT_NAME'])
+);
+// Get URI path relative to GLPI (i.e. without alias directory prefix).
+$path       = preg_replace(
+    '/^' . preg_quote($uri_prefix, '/') . '/',
+    '',
+    parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH)
+);
+
+require $glpi_root . '/src/Http/ProxyRouter.php';
+
+$proxy = new \Glpi\Http\ProxyRouter($glpi_root, $path);
+
+if ($proxy->isTargetAPhpScript() && $proxy->isPathAllowed()) {
+    $target_file = $proxy->getTargetFile();
+
+    // Ensure `getcwd()` and inclusion path is based on requested file FS location.
+    chdir(dirname($target_file));
+
+    // Redefine some $_SERVER variables to have same values whenever scripts are called directly
+    // or through current router.
+    $target_path = $uri_prefix . $proxy->getTargetPath();
+    $_SERVER['PHP_SELF']        = $target_path;
+    $_SERVER['SCRIPT_NAME']     = $target_path;
+    $_SERVER['SCRIPT_FILENAME'] = $target_file;
+
+    // Execute target script.
+    require($target_file);
+    exit();
+}
+
+$proxy->proxify();

--- a/public/index.php
+++ b/public/index.php
@@ -60,9 +60,7 @@ require $glpi_root . '/src/Http/ProxyRouter.php';
 
 $proxy = new \Glpi\Http\ProxyRouter($glpi_root, $path);
 
-if ($proxy->isTargetAPhpScript() && $proxy->isPathAllowed()) {
-    $target_file = $proxy->getTargetFile();
-
+if ($proxy->isTargetAPhpScript() && $proxy->isPathAllowed() && ($target_file = $proxy->getTargetFile()) !== null) {
     // Ensure `getcwd()` and inclusion path is based on requested file FS location.
     chdir(dirname($target_file));
 

--- a/public/index.php
+++ b/public/index.php
@@ -68,10 +68,12 @@ if ($proxy->isTargetAPhpScript() && $proxy->isPathAllowed()) {
 
     // Redefine some $_SERVER variables to have same values whenever scripts are called directly
     // or through current router.
-    $target_path = $uri_prefix . $proxy->getTargetPath();
+    $target_path     = $uri_prefix . $proxy->getTargetPath();
+    $target_pathinfo = $proxy->getTargetPathInfo();
+    $_SERVER['PATH_INFO']       = $target_pathinfo;
     $_SERVER['PHP_SELF']        = $target_path;
-    $_SERVER['SCRIPT_NAME']     = $target_path;
     $_SERVER['SCRIPT_FILENAME'] = $target_file;
+    $_SERVER['SCRIPT_NAME']     = $target_path;
 
     // Execute target script.
     require($target_file);

--- a/src/Central.php
+++ b/src/Central.php
@@ -36,6 +36,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Event;
 use Glpi\Plugin\Hooks;
+use Glpi\System\Requirement\SafeDocumentRoot;
 
 /**
  * Central class
@@ -514,6 +515,11 @@ class Central extends CommonGLPI
                 . ' '
                 . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:unsigned_keys');
             }
+        }
+
+        $safe_doc_root_requirement = new SafeDocumentRoot();
+        if (!$safe_doc_root_requirement->isValidated()) {
+            $messages['warnings'] = array_merge($messages['warnings'], $safe_doc_root_requirement->getValidationMessages());
         }
 
         if ($DB->isSlave() && !$DB->first_connection) {

--- a/src/Console/System/CheckRequirementsCommand.php
+++ b/src/Console/System/CheckRequirementsCommand.php
@@ -73,24 +73,22 @@ class CheckRequirementsCommand extends AbstractCommand
        /* @var \Glpi\System\Requirement\RequirementInterface $requirement */
         foreach ($core_requirements as $requirement) {
             if ($requirement->isOutOfContext()) {
-                continue; // skip requirement if not relevant
-            }
-
-            if ($requirement->isValidated()) {
+                $status = sprintf('<%s>[%s]</> ', 'fg=white;bg=yellow', __('SKIPPED'));
+            } elseif ($requirement->isValidated()) {
                 $status = sprintf('<%s>[%s]</>', 'fg=black;bg=green', __('OK'));
             } else {
                 $status = $requirement->isOptional()
-                ? sprintf('<%s>[%s]</> ', 'fg=white;bg=yellow', __('INFO'))
-                : sprintf('<%s>[%s]</> ', 'fg=white;bg=red', __('ERROR'));
+                    ? sprintf('<%s>[%s]</> ', 'fg=white;bg=yellow', __('INFO'))
+                    : sprintf('<%s>[%s]</> ', 'fg=white;bg=red', __('ERROR'));
             }
 
             $badge = $requirement->isOptional()
-            ? sprintf('<%s>[%s]</> ', 'fg=black;bg=bright-blue', mb_strtoupper(__('Suggested')))
-            : sprintf('<%s>[%s]</> ', 'fg=black;bg=bright-yellow', mb_strtoupper(__('Required')));
+                ? sprintf('<%s>[%s]</> ', 'fg=black;bg=bright-blue', mb_strtoupper(__('Suggested')))
+                : sprintf('<%s>[%s]</> ', 'fg=black;bg=bright-yellow', mb_strtoupper(__('Required')));
             $title = $badge . '<options=bold>' . $requirement->getTitle() . '</>';
             if (!empty($description = $requirement->getDescription())) {
-               // wordwrap to to keep table width acceptable
-                $wrapped = wordwrap($description, 70, '-----');
+                // wordwrap to keep table width acceptable
+                $wrapped = wordwrap($description, 50, '-----');
                 $lines = explode('-----', $wrapped);
                 foreach ($lines as $line) {
                     $title .= "\n\e[2m\e[3m" . $line . "\e[0m";

--- a/src/Http/ProxyRouter.php
+++ b/src/Http/ProxyRouter.php
@@ -186,6 +186,8 @@ final class ProxyRouter
             '\.(eot|otf|ttf|woff2?)$',
             // JSON files in plugins (except `composer.json`, `package.json` and `package-lock.json` located on root)
             '^\/(marketplace|plugins)\/[^\/]+\/(?!composer\.json|package\.json|package-lock\.json).+\.json$',
+            // favicon
+            '(^|\/)favicon\.ico$',
         ];
         if (preg_match('/(' . implode('|', $allowed_path_pattern) . ')/i', $this->path) === 1) {
             return true;

--- a/src/Http/ProxyRouter.php
+++ b/src/Http/ProxyRouter.php
@@ -1,0 +1,292 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Http;
+
+/**
+ * @since 10.0.7
+ */
+final class ProxyRouter
+{
+    /**
+     * GLPI root directory.
+     * @var string
+     */
+    private string $root_dir;
+
+    /**
+     * Target path.
+     * @var string
+     */
+    private string $path;
+
+    public function __construct(string $root_dir, string $path)
+    {
+        $this->root_dir = $root_dir;
+        $this->path     = $this->normalizePath($path);
+    }
+
+    /**
+     * Normalize URI path into a path relative to GLPI web root.
+     *
+     * @param string $path
+     * @return string
+     */
+    private function normalizePath(string $path): string
+    {
+        // Clean trailing `/`.
+        $path = rtrim($path, '/');
+
+        // If URI matches a directory path, consider `index.php` is the requested script.
+        if (is_dir($this->root_dir . $path) && is_file($this->root_dir . $path . '/index.php')) {
+            $path .= '/index.php';
+        }
+
+        return $path;
+    }
+
+    /**
+     * Return target path.
+     *
+     * @return string
+     */
+    public function getTargetPath(): string
+    {
+        return $this->path;
+    }
+
+    /**
+     * Return target file.
+     *
+     * @return string|null
+     */
+    public function getTargetFile(): ?string
+    {
+        $target_file = $this->root_dir . $this->path;
+        return is_file($target_file) ? $target_file : null;
+    }
+
+    /**
+     * Determine whether the requested path is allowed.
+     *
+     * @param string $file_relative_path
+     * @return bool
+     */
+    public function isPathAllowed(): bool
+    {
+        // Check global exclusion patterns.
+        $excluded_path_patterns = [
+            // hidden file or `.`/`..` path traversal component
+            '\/\.',
+            // config files
+            '^\/config\/',
+            // data files
+            '^\/files\/',
+            // tests files (should anyway not be present in dist)
+            '^\/tests\/',
+            // old-styles CLI tools (should anyway not be present in dist)
+            '^\/tools\/',
+            // `node_modules` and `vendor`, in GLPI root directory or in any plugin root directory
+            '^(\/(marketplace|plugins)\/[^\/]+)?\/(node_modules|vendor)\/',
+        ];
+        if (preg_match('/(' . implode('|', $excluded_path_patterns) . ')/i', $this->path) === 1) {
+            return false;
+        }
+
+        // Check rules related to PHP files.
+        // Check extension on path even if file not exists, to be able to send a 403 error even if file not exists.
+        if ($this->isTargetAPhpScript()) {
+            $glpi_path_patterns = [
+                // `/ajax/` scripts
+                'ajax\/',
+                // `/front/` scripts
+                'front\/',
+                // install/update scripts
+                'install\/(install|update)\.php$',
+                // endpoints located on root directory
+                '(apirest|apixmlrpc|caldav|index|status)\.php',
+            ];
+
+            $plugins_path_patterns = [
+                // `/ajax/` scripts
+                'ajax\/',
+                // `/front/` scripts
+                'front\/',
+                // `/public/` scripts
+                'public\/',
+                // Any `index.php` script
+                '(.+\/)?index\.php',
+                // PHP scripts located in root directory, except `setup.php` and `hook.php`
+                '(?!setup\.php|hook\.php)[^\/]+\.php',
+                // dynamic CSS and JS files
+                '.+\.(css|js)\.php',
+                // `reports` plugin specific URLs (used by many plugins)
+                'report\/',
+            ];
+
+            $allowed_path_pattern = '/^'
+                . '('
+                . sprintf('\/(%s)', implode('|', $glpi_path_patterns))
+                . '|'
+                . sprintf('\/(marketplace|plugins)\/[^\/]+\/(%s)', implode('|', $plugins_path_patterns))
+                . ')'
+                . '/';
+            return preg_match($allowed_path_pattern, $this->path) === 1;
+        }
+
+        // Check rules related to non-PHP files.
+        $allowed_path_pattern = [
+            // files in `/public` directories
+            '^(\/(marketplace|plugins)\/[^\/]+)?\/public\/',
+            // static pages
+            '\.html?$',
+            // JS/CSS files
+            '\.(js|css)$',
+            // JS/CSS files sourcemaps used in dev env (it is to the publisher responsibility to remove them in dist packages)
+            '\.(js|css)\.map$',
+            // images
+            '\.(gif|jpe?g|png|svg)$',
+            // audios
+            '\.(mp3|ogg|wav)$',
+            // videos
+            '\.(mp4|ogm|ogv|webm)$',
+            // webfonts
+            '\.(eot|otf|ttf|woff2?)$',
+            // JSON files in plugins (except `composer.json`, `package.json` and `package-lock.json` located on root)
+            '^\/(marketplace|plugins)\/[^\/]+\/(?!composer\.json|package\.json|package-lock\.json).+\.json$',
+        ];
+        if (preg_match('/(' . implode('|', $allowed_path_pattern) . ')/i', $this->path) === 1) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Check whether target is a PHP script.
+     *
+     * @return bool
+     */
+    public function isTargetAPhpScript(): bool
+    {
+        // Check extension on path directly to be able to recognize that target is supposed to be a PHP
+        // script even if it not exists. This is usefull to send most appropriate response code (i.e. 403 VS 404).
+        if (preg_match('/^php\d*$/', pathinfo($this->path, PATHINFO_EXTENSION)) === 1) {
+            return true;
+        }
+
+        // Check mime type of target file
+        $target_file = $this->getTargetFile();
+
+        if ($target_file === null) {
+            return false;
+        }
+
+        $mime = mime_content_type($target_file);
+
+        return preg_match('/^(application|text)\/(x-)?php$/', $mime) === 1;
+    }
+
+    /**
+     * Serve the requested file.
+     *
+     * @return void
+     */
+    public function proxify(): void
+    {
+        if ($this->isPathAllowed() === false) {
+            http_response_code(403);
+            return;
+        }
+
+        if ($this->isTargetAPhpScript()) {
+            // PHP specific case.
+            // Requested file has to be included in global scope so is done in `/public/index.php` script.
+            // Anyway, this check has to be kept to ensure that PHP scripts are not served as static files.
+            http_response_code(500); // 500 error as this is a bug if such case happen
+            return;
+        }
+
+        $target_file = $this->getTargetFile();
+
+        if ($target_file === null) {
+            http_response_code(404);
+            return;
+        }
+
+        $extension = pathinfo($target_file, PATHINFO_EXTENSION);
+
+        // Serve static files if web server is not configured to do it directly.
+        $etag = md5_file($target_file);
+        $last_modified = filemtime($target_file);
+        $mime = null;
+        switch ($extension) {
+            case 'css':
+                $mime = 'text/css';
+                break;
+            case 'js':
+                $mime = 'application/javascript';
+                break;
+            default:
+                $mime = mime_content_type($target_file);
+
+                if ($mime === false) {
+                    $mime = 'application/octet-stream';
+                }
+                break;
+        }
+
+        // HTTP_IF_NONE_MATCH takes precedence over HTTP_IF_MODIFIED_SINCE.
+        // see http://tools.ietf.org/html/rfc7232#section-3.3
+        $is_not_modified = trim($_SERVER['HTTP_IF_NONE_MATCH'] ?? '') === $etag
+            || @strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE'] ?? '') >= $last_modified;
+
+        http_response_code($is_not_modified ? 304 : 200);
+        header(sprintf('Last-Modified: %s GMT', gmdate('D, d M Y H:i:s', $last_modified)));
+        header(sprintf('Etag: %s', $etag));
+        header_remove('Pragma');
+        header('Cache-Control: public, max-age=2592000, must-revalidate'); // 30 days cache
+        header(sprintf('Content-Disposition: attachment; filename="%s"', basename($target_file)));
+        header(sprintf('Content-type: %s', $mime));
+
+        if ($is_not_modified) {
+            // Do not send contents if not modified.
+            return;
+        }
+
+        header(sprintf('Content-Length: %s', filesize($target_file)));
+        readfile($target_file);
+    }
+}

--- a/src/Http/ProxyRouter.php
+++ b/src/Http/ProxyRouter.php
@@ -252,18 +252,18 @@ final class ProxyRouter
             return;
         }
 
+        $target_file = $this->getTargetFile();
+
+        if ($target_file === null) {
+            http_response_code(404);
+            return;
+        }
+
         if ($this->isTargetAPhpScript()) {
             // PHP specific case.
             // Requested file has to be included in global scope so is done in `/public/index.php` script.
             // Anyway, this check has to be kept to ensure that PHP scripts are not served as static files.
             http_response_code(500); // 500 error as this is a bug if such case happen
-            return;
-        }
-
-        $target_file = $this->getTargetFile();
-
-        if ($target_file === null) {
-            http_response_code(404);
             return;
         }
 

--- a/src/System/Requirement/DataDirectoriesProtectedPath.php
+++ b/src/System/Requirement/DataDirectoriesProtectedPath.php
@@ -55,11 +55,11 @@ final class DataDirectoriesProtectedPath extends AbstractRequirement
     private $var_root_constant;
 
     /**
-     * Web root directory.
+     * GLPI root directory.
      *
      * @var string
      */
-    private $web_root_directory;
+    private $glpi_root_directory;
 
     /**
      * @param array $directories_constants  Constants defining directories to check.
@@ -69,7 +69,7 @@ final class DataDirectoriesProtectedPath extends AbstractRequirement
     public function __construct(
         array $directories_constants,
         string $var_root_constant = 'GLPI_VAR_DIR',
-        string $web_root_directory = GLPI_ROOT
+        string $glpi_root_directory = GLPI_ROOT
     ) {
         $this->title = __('Safe path for data directories');
         $this->description = __('GLPI data directories should be placed outside web root directory. It can be achieved by redefining corresponding constants. See installation documentation for more details.');
@@ -77,12 +77,12 @@ final class DataDirectoriesProtectedPath extends AbstractRequirement
 
         $this->directories_constants = $directories_constants;
         $this->var_root_constant     = $var_root_constant;
-        $this->web_root_directory    = $web_root_directory;
+        $this->glpi_root_directory   = $glpi_root_directory;
     }
 
     protected function check()
     {
-        $web_root_directory = realpath($this->web_root_directory);
+        $glpi_root_directory = realpath($this->glpi_root_directory);
 
         $missing_directories = [];
         $unsafe_directories  = [];
@@ -90,7 +90,7 @@ final class DataDirectoriesProtectedPath extends AbstractRequirement
         $var_root_directory = constant($this->var_root_constant);
         if (!is_dir($var_root_directory)) {
             $missing_directories[$this->var_root_constant] = $var_root_directory;
-        } elseif (str_starts_with(realpath($var_root_directory), $web_root_directory)) {
+        } elseif (str_starts_with(realpath($var_root_directory), $glpi_root_directory)) {
             $unsafe_directories[$this->var_root_constant] = $var_root_directory;
         }
 
@@ -110,7 +110,7 @@ final class DataDirectoriesProtectedPath extends AbstractRequirement
                 continue;
             }
 
-            if (str_starts_with(realpath($directory_path), $web_root_directory)) {
+            if (str_starts_with(realpath($directory_path), $glpi_root_directory)) {
                 $unsafe_directories[$directory_constant] = $directory_path;
             }
         }
@@ -129,13 +129,16 @@ final class DataDirectoriesProtectedPath extends AbstractRequirement
             if (count($unsafe_directories) > 0) {
                 $this->validation_messages[] = sprintf(
                     __('The following directories should be placed outside "%s":'),
-                    $web_root_directory
+                    $glpi_root_directory
                 );
                 foreach ($unsafe_directories as $constant => $path) {
                     $this->validation_messages[] = sprintf('‣ "%s" ("%s")', $path, $constant);
                 }
             }
-            $this->validation_messages[] = __('You can ignore this suggestion if you are certain that these directories are not accessible through your web server.');
+            $this->validation_messages[] = sprintf(
+                __('You can ignore this suggestion if your web server root directory is "%s".'),
+                sprintf('%s/public', $glpi_root_directory)
+            );
         }
     }
 }

--- a/src/System/Requirement/SafeDocumentRoot.php
+++ b/src/System/Requirement/SafeDocumentRoot.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\System\Requirement;
+
+/**
+ * @since 10.0.7
+ */
+final class SafeDocumentRoot extends AbstractRequirement
+{
+    public function __construct()
+    {
+        $this->title = __('Safe configuration of web root directory');
+        $this->description = sprintf(
+            __('Web server root directory should be `%s` to ensure non-public files cannot be accessed.'),
+            sprintf('%s/public', realpath(GLPI_ROOT))
+        );
+        $this->optional = true;
+    }
+
+    protected function check()
+    {
+        if (isCommandLine()) {
+            $this->out_of_context = true;
+            $this->validated = false;
+            $this->validation_messages[] = __('Checking web server root directory configuration cannot be done on CLI context.');
+            return;
+        }
+
+        $initial_script = get_included_files()[0] ?? '';
+        if (realpath($initial_script) === realpath(sprintf('%s/public/index.php', GLPI_ROOT))) {
+            // Configuration is safe if install/update script is accessed through `public/index.php` router script.
+            $this->validated = true;
+            $this->validation_messages[] = __('Web server root directory configuration seems safe.');
+        } else {
+            $this->validated = false;
+            $this->validation_messages[] = __('Web server root directory configuration is not safe as it permits access to non-public files. See installation documentation for more details.');
+        }
+    }
+}

--- a/src/System/RequirementsManager.php
+++ b/src/System/RequirementsManager.php
@@ -49,6 +49,7 @@ use Glpi\System\Requirement\LogsWriteAccess;
 use Glpi\System\Requirement\MemoryLimit;
 use Glpi\System\Requirement\MysqliMysqlnd;
 use Glpi\System\Requirement\PhpVersion;
+use Glpi\System\Requirement\SafeDocumentRoot;
 use Glpi\System\Requirement\SeLinux;
 use Glpi\System\Requirement\SessionsConfiguration;
 use Glpi\System\Requirement\SessionsSecurityConfiguration;
@@ -132,12 +133,15 @@ class RequirementsManager
             )
         );
 
-        $requirements[] = new DataDirectoriesProtectedPath(Variables::getDataDirectoriesConstants());
-
         $requirements[] = new SeLinux();
 
-       // Below requirements are optionals
+        // Below requirements are optionals
 
+        $safe_doc_root_requirement = new SafeDocumentRoot();
+        $requirements[] = $safe_doc_root_requirement;
+        if (!$safe_doc_root_requirement->isValidated()) {
+            $requirements[] = new DataDirectoriesProtectedPath(Variables::getDataDirectoriesConstants());
+        }
         $requirements[] = new SessionsSecurityConfiguration();
         $requirements[] = new IntegerSize();
         $requirements[] = new Extension(

--- a/tests/units/Glpi/Http/ProxyRouter.php
+++ b/tests/units/Glpi/Http/ProxyRouter.php
@@ -46,13 +46,13 @@ class ProxyRouter extends \GLPITestCase
             null,
             [
                 'ajax'  => [
-                    'thereisnoindex.php' => '',
+                    'thereisnoindex.php' => '<php echo(1);',
                 ],
                 'front' => [
-                    'index.php' => '',
+                    'index.php' => '<php echo(1);',
                 ],
                 'js' => [
-                    'common.js' => '',
+                    'common.js' => 'console.log("ok");',
                 ],
                 'marketplace' => [
                     'mystaleplugin' => [
@@ -66,7 +66,8 @@ class ProxyRouter extends \GLPITestCase
                         ],
                     ],
                 ],
-                'apirest.php' => '',
+                'apirest.php' => '<php echo(1);',
+                'index.php' => '<php echo(1);',
             ]
         );
 
@@ -430,6 +431,13 @@ class ProxyRouter extends \GLPITestCase
                 yield [
                     'path'      => $path,
                     'http_code' => 403,
+                    'body'      => '',
+                ];
+            } elseif (file_exists(vfsStream::url('glpi' . $path)) === false) {
+                // Non existing files should result in 404 error
+                yield [
+                    'path'      => $path,
+                    'http_code' => 404,
                     'body'      => '',
                 ];
             } elseif (preg_match('/\.php$/', $path) === 1) {

--- a/tests/units/Glpi/Http/ProxyRouter.php
+++ b/tests/units/Glpi/Http/ProxyRouter.php
@@ -1,0 +1,588 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Http;
+
+use org\bovigo\vfs\vfsStream;
+
+class ProxyRouter extends \GLPITestCase
+{
+    protected function targetProvider(): iterable
+    {
+        vfsStream::setup(
+            'glpi',
+            null,
+            [
+                'ajax'  => [
+                    'thereisnoindex.php' => '',
+                ],
+                'front' => [
+                    'index.php' => '',
+                ],
+                'js' => [
+                    'common.js' => '',
+                ],
+                'marketplace' => [
+                    'mystaleplugin' => [
+                        'front' => [
+                            'page.php5' => '<?php //a PHP5 script',
+                        ],
+                    ],
+                    'mimehack' => [
+                        'css' => [
+                            'style.css' => '<?php //a PHP script hidden in a CSS file',
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        // Path to an existing directory that does not have a `index.php` script.
+        yield [
+            'path'          => '/ajax',
+            'target_path'   => '/ajax',
+            'target_file'   => null,
+            'is_php_script' => false,
+        ];
+
+        // Path to an invalid PHP script.
+        yield [
+            'path'          => '/is/not/valid.php',
+            'target_path'   => '/is/not/valid.php',
+            'target_file'   => null,
+            'is_php_script' => true,
+        ];
+
+        // Path to a `index.php` script.
+        yield [
+            'path'          => '/front/index.php',
+            'target_path'   => '/front/index.php',
+            'target_file'   => vfsStream::url('glpi/front/index.php'),
+            'is_php_script' => true,
+        ];
+
+        // Path to an existing directory that have a `index.php` script.
+        yield [
+            'path'          => '/front',
+            'target_path'   => '/front/index.php',
+            'target_file'   => vfsStream::url('glpi/front/index.php'),
+            'is_php_script' => true,
+        ];
+
+        // Path to a JS file
+        yield [
+            'path'          => '/js/common.js',
+            'target_path'   => '/js/common.js',
+            'target_file'   => vfsStream::url('glpi/js/common.js'),
+            'is_php_script' => false,
+        ];
+
+        // Path to a `.php5` script.
+        yield [
+            'path'          => '/marketplace/mystaleplugin/front/page.php5',
+            'target_path'   => '/marketplace/mystaleplugin/front/page.php5',
+            'target_file'   => vfsStream::url('glpi/marketplace/mystaleplugin/front/page.php5'),
+            'is_php_script' => true,
+        ];
+
+        // Path to a PHP script hidden in a CSS file
+        yield [
+            'path'          => '/marketplace/mimehack/css/style.css',
+            'target_path'   => '/marketplace/mimehack/css/style.css',
+            'target_file'   => vfsStream::url('glpi/marketplace/mimehack/css/style.css'),
+            'is_php_script' => true,
+        ];
+    }
+
+    /**
+     * @dataProvider targetProvider
+     */
+    public function testTarget(
+        string $path,
+        string $target_path,
+        ?string $target_file,
+        bool $is_php_script
+    ) {
+        $this->newTestedInstance(vfsStream::url('glpi'), $path);
+        $this->string($this->testedInstance->getTargetPath())->isEqualTo($target_path, $path);
+        $this->variable($this->testedInstance->getTargetFile())->isEqualTo($target_file, $path);
+        $this->boolean($this->testedInstance->isTargetAPhpScript())->isEqualTo($is_php_script, $path);
+    }
+
+    protected function pathProvider(): iterable
+    {
+        $allowed_glpi_php_paths = [
+            '/ajax/script.php',
+            '/front/page.php',
+            '/install/install.php',
+            '/install/update.php',
+            '/apirest.php',
+            '/apixmlrpc.php',
+            '/caldav.php',
+            '/index.php',
+            '/status.php',
+        ];
+        $disallowed_glpi_php_paths = [
+            '/.atoum.php',
+            '/ajax-script.php',
+            '/bin/console',
+            '/config/config_db.php',
+            '/files/PHP/1c/db5d8ce30068f6259d1b926165619386c58f1e.PHP',
+            '/front-page.php',
+            '/front/.hidden.php',
+            '/inc/includes.php',
+            '/install/index.php',
+            '/install/install.old.php',
+            '/install/migrations/update_9.5.x_to_10.0.0.php',
+            '/node_modules/flatted/php/flatted.php',
+            '/src/Computer.php',
+            '/tests/bootstrap.php',
+            '/tools/psr4.php',
+            '/vendor/htmlawed/htmlawed/htmLawed.php',
+        ];
+        $allowed_glpi_static_paths = [
+            '/css/lib/fontsource/inter/files/inter-latin-100-normal.woff2',
+            '/css/lib/tabler/icons-webfont/fonts/tabler-icons.eot',
+            '/css/lib/tabler/icons-webfont/fonts/tabler-icons.ttf',
+            '/css/lib/tabler/icons-webfont/fonts/tabler-icons.woff',
+            '/css/lib/xxx/style.css',
+            '/css/lib/xxx/webfont.otf',
+            '/js/common.js',
+            '/pics/expand.gif',
+            '/pics/image.jpeg',
+            '/pics/icones/ai-dist.png',
+            '/pics/20/schema.svg',
+            '/public/anyfile.ext',
+            '/public/subdir/data.json',
+            '/sound/sound_a.mp3',
+            '/sound/sound_a.ogg',
+            '/sound/sound_a.wav',
+            '/videos/demo.mp4',
+            '/videos/demo.ogm',
+            '/videos/demo.ogv',
+            '/videos/demo.webm',
+        ];
+        $disallowed_glpi_static_paths = [
+            '/.htaccess',
+            '/.tx/config',
+            '/config/glpicrypt.key',
+            '/css/palettes/auror.scss',
+            '/files/_log/php-errors.log',
+            '/install/mysql/.htaccess',
+            '/install/mysql/glpi-empty.sql',
+            '/locales/en_GB.po',
+            '/locales/en_GB.mo',
+            '/locales/glpi.pot',
+            '/node_modules/.bin/webpack-cli',
+            '/node_modules/rrule/dist/esm/demo/demo.js',
+            '/pics/charts/sources.md',
+            '/resources/Rules/RuleAsset.xml',
+            '/templates/pages/login.html.twig',
+            '/tests/fixtures/uploads/bar.png',
+            '/tests/run_tests.sh',
+            '/tools/psr12.sh',
+        ];
+        foreach (array_merge($allowed_glpi_php_paths, $allowed_glpi_static_paths) as $path) {
+            yield [
+                'path'            => $path,
+                'is_path_allowed' => true,
+            ];
+        }
+        foreach (array_merge($disallowed_glpi_php_paths, $disallowed_glpi_static_paths) as $path) {
+            yield [
+                'path'            => $path,
+                'is_path_allowed' => false,
+            ];
+        }
+
+        $allowed_plugins_php_paths = [
+            '/ajax/script.php',
+            '/ajax/subdir/messages.php',
+            '/css/styles.css.php',
+            '/css/palette/test.css.php',
+            '/front/page.php',
+            '/front/subdir/form.php',
+            '/index.php',
+            '/js/scripts.js.php',
+            '/path/to/any/index.php',
+            '/path/to/any/file.css.php',
+            '/path/to/any/file.js.php',
+            '/public/api.php',
+            '/report/mycustomreport.php',
+            '/report/metrics/metrics.php',
+            '/root_script.php',
+        ];
+        $disallowed_plugins_php_paths = [
+            '/.atoum.php',
+            '/hook.php',
+            '/inc/config.class.php',
+            '/install/install.php',
+            '/install/update_2.5_3.0.php',
+            '/lib/php-saml/settings_example.php',
+            '/scripts/cli_install.php',
+            '/setup.php',
+            '/tools/dump.php',
+            '/vendor/autoload.php',
+            '/vendor/fpdf/fpdf/src/Fpdf/Fpdf.php',
+        ];
+        $allowed_plugins_static_paths = [
+            '/css/lib/fontsource/inter/files/inter-latin-100-normal.woff2',
+            '/css/lib/tabler/icons-webfont/fonts/tabler-icons.eot',
+            '/css/lib/tabler/icons-webfont/fonts/tabler-icons.ttf',
+            '/css/lib/tabler/icons-webfont/fonts/tabler-icons.woff',
+            '/css/lib/xxx/webfont.otf',
+            '/css/dev.css.map',
+            '/css/base.css',
+            '/documentation/index.htm',
+            '/js/common.js',
+            '/pics/expand.gif',
+            '/pics/image.jpeg',
+            '/pics/icones/ai-dist.png',
+            '/pics/20/schema.svg',
+            '/public/anyfile.ext',
+            '/public/subdir/data.json',
+            '/readme/api/v1.html',
+            '/sound/sound_a.mp3',
+            '/sound/sound_a.ogg',
+            '/sound/sound_a.wav',
+            '/videos/demo.mp4',
+            '/videos/demo.ogm',
+            '/videos/demo.ogv',
+            '/videos/demo.webm',
+        ];
+        $disallowed_plugins_static_paths = [
+            '/.gitignore',
+            '/.htaccess',
+            '/.tx/config',
+            '/changelog.txt',
+            '/css/styles.scss',
+            '/docker-compose.yml',
+            '/files/templates/holidays_template.txt',
+            '/locales/en_GB.po',
+            '/locales/en_GB.mo',
+            '/locales/myplugin.pot',
+            '/myplugin.xml',
+            '/node_modules/.bin/webpack-cli',
+            '/node_modules/rrule/dist/esm/demo/demo.js',
+            '/package.json',
+            '/package-lock.json',
+            '/patch/fix-pear-image-barcode.patch',
+            '/README.md',
+            '/sql/update-1.2.0.sql',
+            '/templates/.htaccess',
+            '/templates/config.html.twig',
+            '/templates/type.class.tpl',
+            '/tools/extract_template.sh',
+            '/tools/update_mo.pl',
+            '/vendor/mpdf/qrcode/tests/reference/LOREM-IPSUM-2019-L.html',
+            '/vendor/tecnickcom/tcpdf/examples/images/img.png',
+            '/yarn.lock',
+        ];
+        foreach (['/marketplace/anyname', '/plugins/myplugin'] as $plugin_basepath) {
+            foreach (array_merge($allowed_plugins_php_paths, $allowed_plugins_static_paths) as $path) {
+                yield [
+                    'path'            => $plugin_basepath . $path,
+                    'is_path_allowed' => true,
+                ];
+            }
+            foreach (array_merge($disallowed_plugins_php_paths, $disallowed_plugins_static_paths) as $path) {
+                yield [
+                    'path'            => $plugin_basepath . $path,
+                    'is_path_allowed' => false,
+                ];
+            }
+        }
+    }
+
+    /**
+     * @dataProvider pathProvider
+     */
+    public function testIsPathAllowed(
+        string $path,
+        bool $is_path_allowed
+    ) {
+        vfsStream::setup('glpi', null, []);
+
+        $this->newTestedInstance(vfsStream::url('glpi'), $path);
+        $this->boolean($this->testedInstance->isPathAllowed())->isEqualTo($is_path_allowed, $path);
+    }
+
+    protected function proxifyProvider(): iterable
+    {
+        $structure = [
+            'index.php' => '<php echo(1);',
+            'css' => [
+                'test.css' => 'body { color:blue; }',
+            ],
+            'docs' => [
+                'index.html' => '<html><head><title>Home</head><body>...</body>',
+            ],
+            'js' => [
+                'scripts.js' => 'console.log("ok");',
+            ],
+            'media' => [
+                // https://commons.wikimedia.org/wiki/File:Blank.gif
+                'Blank.gif' => hex2bin(
+                    '47494638396101000100800000ffffff00000021f90400000000002c00000000010001000002024401003b'
+                ),
+                // https://commons.wikimedia.org/wiki/File:Blank.JPG
+                'Blank.jpeg' => hex2bin(
+                    'ffd8ffe000104a46494600010101006000600000ffdb004300080606070605080707070909080a0c140d0c0b0b0c191213'
+                    . '0f141d1a1f1e1d1a1c1c20242e2720222c231c1c2837292c30313434341f27393d38323c2e333432ffdb004301090909'
+                    . '0c0b0c180d0d1832211c2132323232323232323232323232323232323232323232323232323232323232323232323232'
+                    . '32323232323232323232323232ffc00011080001000103012200021101031101ffc4001f000001050101010101010000'
+                    . '0000000000000102030405060708090a0bffc400b5100002010303020403050504040000017d01020300041105122131'
+                    . '410613516107227114328191a1082342b1c11552d1f02433627282090a161718191a25262728292a3435363738393a43'
+                    . '4445464748494a535455565758595a636465666768696a737475767778797a838485868788898a92939495969798999a'
+                    . 'a2a3a4a5a6a7a8a9aab2b3b4b5b6b7b8b9bac2c3c4c5c6c7c8c9cad2d3d4d5d6d7d8d9dae1e2e3e4e5e6e7e8e9eaf1f2'
+                    . 'f3f4f5f6f7f8f9faffc4001f0100030101010101010101010000000000000102030405060708090a0bffc400b5110002'
+                    . '0102040403040705040400010277000102031104052131061241510761711322328108144291a1b1c109233352f01562'
+                    . '72d10a162434e125f11718191a262728292a35363738393a434445464748494a535455565758595a636465666768696a'
+                    . '737475767778797a82838485868788898a92939495969798999aa2a3a4a5a6a7a8a9aab2b3b4b5b6b7b8b9bac2c3c4c5'
+                    . 'c6c7c8c9cad2d3d4d5d6d7d8d9dae2e3e4e5e6e7e8e9eaf2f3f4f5f6f7f8f9faffda000c03010002110311003f00f7fa'
+                    . '28a2803fffd9'
+                ),
+                // https://commons.wikimedia.org/wiki/File:Empty.png
+                'Empty.png' => hex2bin(
+                    '89504e470d0a1a0a0000000d49484452000002c00000018c0103000000ee93862600000003504c5445ffffffa7c41bc800'
+                    . '00000174524e530040e6d8660000003949444154785eedc03101000000c220fba7b6c60e581800000000000000000000'
+                    . '0000000000000000000000000000000000000000000000c00189ac000180fa9d590000000049454e44ae426082'
+                ),
+                // https://commons.wikimedia.org/wiki/File:Sq_blank.svg
+                'Sq_blank.svg' => '<?xml version="1.0"?>'
+                    . '<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">'
+                    . '<path fill="none" stroke="#999" stroke-width="2" d="M1,1V199H199V1z"/>'
+                    . '</svg>',
+            ],
+            'plugins' => [
+                'myplugin' => [
+                    'public' => [
+                        'resources.json' => '["a","b","c"]',
+                    ],
+                ],
+            ],
+            'public' => [
+                'fonts' => [
+                    // see https://en.wikipedia.org/wiki/List_of_file_signatures
+                    'myfont.woff2' => hex2bin('774F4632'),
+                ],
+            ],
+        ];
+
+        vfsStream::setup('glpi', null, $structure);
+
+        foreach ($this->pathProvider() as $path_specs) {
+            $path = $path_specs['path'];
+            $is_path_allowed = $path_specs['is_path_allowed'];
+            if ($is_path_allowed === false) {
+                // Unauthorized path should result in 403 error
+                yield [
+                    'path'      => $path,
+                    'http_code' => 403,
+                    'body'      => '',
+                ];
+            } elseif (preg_match('/\.php$/', $path) === 1) {
+                // PHP scripts should not be proxified
+                yield [
+                    'path'      => $path,
+                    'http_code' => 500,
+                    'body'      => '',
+                ];
+            }
+        }
+
+        // HTML file
+        yield [
+            'path'      => '/docs/index.html',
+            'http_code' => 200,
+            'body'      => $structure['docs']['index.html'],
+            'headers'   => [
+                'Etag: b745c5b25a44dff8d077fdfa738c1db7',
+                'Cache-Control: public, max-age=2592000, must-revalidate',
+                'Content-Disposition: attachment; filename="index.html"',
+                'Content-type: text/html',
+                'Content-Length: 46'
+            ],
+        ];
+
+        // CSS file
+        yield [
+            'path'      => '/css/test.css',
+            'http_code' => 200,
+            'body'      => $structure['css']['test.css'],
+            'headers'   => [
+                'Etag: 3b6bc56f81f3a3f94e38e1bb2ac392a2',
+                'Cache-Control: public, max-age=2592000, must-revalidate',
+                'Content-Disposition: attachment; filename="test.css"',
+                'Content-type: text/css',
+                'Content-Length: 20'
+            ],
+        ];
+
+        // JS file
+        yield [
+            'path'      => '/js/scripts.js',
+            'http_code' => 200,
+            'body'      => $structure['js']['scripts.js'],
+            'headers'   => [
+                'Etag: 3d7266fa7f019a62fdf08b68ff8279aa',
+                'Cache-Control: public, max-age=2592000, must-revalidate',
+                'Content-Disposition: attachment; filename="scripts.js"',
+                'Content-type: application/javascript',
+                'Content-Length: 18'
+            ],
+        ];
+
+        // GIF file
+        yield [
+            'path'      => '/media/Blank.gif',
+            'http_code' => 200,
+            'body'      => $structure['media']['Blank.gif'],
+            'headers'   => [
+                'Etag: b4491705564909da7f9eaf749dbbfbb1',
+                'Cache-Control: public, max-age=2592000, must-revalidate',
+                'Content-Disposition: attachment; filename="Blank.gif"',
+                'Content-type: image/gif',
+                'Content-Length: 43'
+            ],
+        ];
+
+        // JPG file
+        yield [
+            'path'      => '/media/Blank.jpeg',
+            'http_code' => 200,
+            'body'      => $structure['media']['Blank.jpeg'],
+            'headers'   => [
+                'Etag: d68e763c825dc0e388929ae1b375ce18',
+                'Cache-Control: public, max-age=2592000, must-revalidate',
+                'Content-Disposition: attachment; filename="Blank.jpeg"',
+                'Content-type: image/jpeg',
+                'Content-Length: 631'
+            ],
+        ];
+
+        // PNG file
+        yield [
+            'path'      => '/media/Empty.png',
+            'http_code' => 200,
+            'body'      => $structure['media']['Empty.png'],
+            'headers'   => [
+                'Etag: c9477b1f1820f9acfb93eebb2e6679c2',
+                'Cache-Control: public, max-age=2592000, must-revalidate',
+                'Content-Disposition: attachment; filename="Empty.png"',
+                'Content-type: image/png',
+                'Content-Length: 142'
+            ],
+        ];
+
+        // SVG file
+        yield [
+            'path'      => '/media/Sq_blank.svg',
+            'http_code' => 200,
+            'body'      => $structure['media']['Sq_blank.svg'],
+            'headers'   => [
+                'Etag: 634ea49fe1aac547655c289003d0e83b',
+                'Cache-Control: public, max-age=2592000, must-revalidate',
+                'Content-Disposition: attachment; filename="Sq_blank.svg"',
+                'Content-type: image/svg+xml',
+                'Content-Length: 162'
+            ],
+        ];
+
+        // JSON file
+        yield [
+            'path'      => '/plugins/myplugin/public/resources.json',
+            'http_code' => 200,
+            'body'      => $structure['plugins']['myplugin']['public']['resources.json'],
+            'headers'   => [
+                'Etag: c29a5747d698b2f95cdfd5ed6502f19d',
+                'Cache-Control: public, max-age=2592000, must-revalidate',
+                'Content-Disposition: attachment; filename="resources.json"',
+                'Content-type: application/json',
+                'Content-Length: 13'
+            ],
+        ];
+
+        // WOFF2 file
+        yield [
+            'path'      => '/public/fonts/myfont.woff2',
+            'http_code' => 200,
+            'body'      => $structure['public']['fonts']['myfont.woff2'],
+            'headers'   => [
+                'Etag: a27fb479f580fd2628de4df27ba45137',
+                'Cache-Control: public, max-age=2592000, must-revalidate',
+                'Content-Disposition: attachment; filename="myfont.woff2"',
+                'Content-type: font/woff2',
+                'Content-Length: 4'
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider proxifyProvider
+     */
+    public function testProxify(
+        string $path,
+        int $http_code,
+        string $body,
+        array $headers = []
+    ) {
+        $this->newTestedInstance(vfsStream::url('glpi'), $path);
+
+        if ($http_code === 200) {
+            // Force `filemtime` result to be able to have a stable test for `Last-Modified` result.
+            $filemtime = time() - 3600;
+            $this->function->filemtime = $filemtime;
+            $headers[] = sprintf('Last-Modified: %s GMT', gmdate('D, d M Y H:i:s', $filemtime));
+        }
+
+        $added_headers = [];
+        $this->function->header = function ($value) use (&$added_headers) {
+            $added_headers[] = $value;
+        };
+
+        $this->output(
+            function () {
+                $this->testedInstance->proxify();
+            }
+        )->isEqualTo($body, $path);
+
+        $this->integer(http_response_code())->isEqualTo($http_code, $path);
+
+        $not_found_headers = array_diff($headers, $added_headers);
+        $unexpected_headers = array_diff($added_headers, $headers);
+        $this->array($not_found_headers)->isEmpty($path . ': ' . json_encode($unexpected_headers));
+    }
+}

--- a/tests/units/Glpi/Http/ProxyRouter.php
+++ b/tests/units/Glpi/Http/ProxyRouter.php
@@ -66,63 +66,80 @@ class ProxyRouter extends \GLPITestCase
                         ],
                     ],
                 ],
+                'apirest.php' => '',
             ]
         );
 
         // Path to an existing directory that does not have a `index.php` script.
         yield [
-            'path'          => '/ajax',
-            'target_path'   => '/ajax',
-            'target_file'   => null,
-            'is_php_script' => false,
+            'path'            => '/ajax',
+            'target_path'     => '/ajax',
+            'target_pathinfo' => null,
+            'target_file'     => null,
+            'is_php_script'   => false,
         ];
 
         // Path to an invalid PHP script.
         yield [
-            'path'          => '/is/not/valid.php',
-            'target_path'   => '/is/not/valid.php',
-            'target_file'   => null,
-            'is_php_script' => true,
+            'path'            => '/is/not/valid.php',
+            'target_path'     => '/is/not/valid.php',
+            'target_pathinfo' => null,
+            'target_file'     => null,
+            'is_php_script'   => true,
         ];
 
         // Path to a `index.php` script.
         yield [
-            'path'          => '/front/index.php',
-            'target_path'   => '/front/index.php',
-            'target_file'   => vfsStream::url('glpi/front/index.php'),
-            'is_php_script' => true,
+            'path'            => '/front/index.php',
+            'target_path'     => '/front/index.php',
+            'target_pathinfo' => null,
+            'target_file'     => vfsStream::url('glpi/front/index.php'),
+            'is_php_script'   => true,
+        ];
+
+        // Path to an existing file, but containing an extra PathInfo
+        yield [
+            'path'            => '/apirest.php/initSession/',
+            'target_path'     => '/apirest.php',
+            'target_pathinfo' => '/initSession/',
+            'target_file'     => vfsStream::url('glpi/apirest.php'),
+            'is_php_script'   => true,
         ];
 
         // Path to an existing directory that have a `index.php` script.
         yield [
-            'path'          => '/front',
-            'target_path'   => '/front/index.php',
-            'target_file'   => vfsStream::url('glpi/front/index.php'),
-            'is_php_script' => true,
+            'path'            => '/front',
+            'target_path'     => '/front/index.php',
+            'target_pathinfo' => null,
+            'target_file'     => vfsStream::url('glpi/front/index.php'),
+            'is_php_script'   => true,
         ];
 
         // Path to a JS file
         yield [
-            'path'          => '/js/common.js',
-            'target_path'   => '/js/common.js',
-            'target_file'   => vfsStream::url('glpi/js/common.js'),
-            'is_php_script' => false,
+            'path'            => '/js/common.js',
+            'target_path'     => '/js/common.js',
+            'target_pathinfo' => null,
+            'target_file'     => vfsStream::url('glpi/js/common.js'),
+            'is_php_script'   => false,
         ];
 
         // Path to a `.php5` script.
         yield [
-            'path'          => '/marketplace/mystaleplugin/front/page.php5',
-            'target_path'   => '/marketplace/mystaleplugin/front/page.php5',
-            'target_file'   => vfsStream::url('glpi/marketplace/mystaleplugin/front/page.php5'),
-            'is_php_script' => true,
+            'path'            => '/marketplace/mystaleplugin/front/page.php5',
+            'target_path'     => '/marketplace/mystaleplugin/front/page.php5',
+            'target_pathinfo' => null,
+            'target_file'     => vfsStream::url('glpi/marketplace/mystaleplugin/front/page.php5'),
+            'is_php_script'   => true,
         ];
 
         // Path to a PHP script hidden in a CSS file
         yield [
-            'path'          => '/marketplace/mimehack/css/style.css',
-            'target_path'   => '/marketplace/mimehack/css/style.css',
-            'target_file'   => vfsStream::url('glpi/marketplace/mimehack/css/style.css'),
-            'is_php_script' => true,
+            'path'            => '/marketplace/mimehack/css/style.css',
+            'target_path'     => '/marketplace/mimehack/css/style.css',
+            'target_pathinfo' => null,
+            'target_file'     => vfsStream::url('glpi/marketplace/mimehack/css/style.css'),
+            'is_php_script'   => true,
         ];
     }
 
@@ -132,11 +149,13 @@ class ProxyRouter extends \GLPITestCase
     public function testTarget(
         string $path,
         string $target_path,
+        ?string $target_pathinfo,
         ?string $target_file,
         bool $is_php_script
     ) {
         $this->newTestedInstance(vfsStream::url('glpi'), $path);
         $this->string($this->testedInstance->getTargetPath())->isEqualTo($target_path, $path);
+        $this->variable($this->testedInstance->getTargetPathInfo())->isEqualTo($target_pathinfo, $path);
         $this->variable($this->testedInstance->getTargetFile())->isEqualTo($target_file, $path);
         $this->boolean($this->testedInstance->isTargetAPhpScript())->isEqualTo($is_php_script, $path);
     }

--- a/tests/units/Glpi/System/Requirement/DataDirectoriesProtectedPath.php
+++ b/tests/units/Glpi/System/Requirement/DataDirectoriesProtectedPath.php
@@ -96,7 +96,7 @@ class DataDirectoriesProtectedPath extends \GLPITestCase
                  sprintf('‣ "%s" ("%s")', $unsecure_var_root_path, $unsecure_var_root_constant),
                  // $unsecure_dir_constant1 and $unsecure_dir_constant2 are ignored as they are nested in var root
                  sprintf('‣ "%s/config" ("%s")', $root_path, $unsecure_dir_constant3),
-                 'You can ignore this suggestion if you are certain that these directories are not accessible through your web server.',
+                 sprintf('You can ignore this suggestion if your web server root directory is "%s/public".', $root_path),
              ]
          );
     }
@@ -127,13 +127,14 @@ class DataDirectoriesProtectedPath extends \GLPITestCase
                  sprintf('‣ "%s/files/_cache" ("%s")', $root_path, $unsecure_dir_constant1),
                  sprintf('‣ "%s/files/_log" ("%s")', $root_path, $unsecure_dir_constant2),
                  sprintf('‣ "%s/config" ("%s")', $root_path, $unsecure_dir_constant3),
-                 'You can ignore this suggestion if you are certain that these directories are not accessible through your web server.',
+                 sprintf('You can ignore this suggestion if your web server root directory is "%s/public".', $root_path),
              ]
          );
     }
 
     public function testCheckOnMissingDirs()
     {
+        $root_path = realpath(GLPI_ROOT);
         $tmp_dir = sys_get_temp_dir();
 
         $secure_var_root_constant = sprintf('GLPI_TEST_%08x', rand());
@@ -154,7 +155,7 @@ class DataDirectoriesProtectedPath extends \GLPITestCase
                  'The following directories do not exist and cannot be tested:',
                  sprintf('‣ "/this/dir/not/exists" ("%s")', $missing_dir_constant1),
                  sprintf('‣ "%s/not/exists" ("%s")', $tmp_dir, $missing_dir_constant2),
-                 'You can ignore this suggestion if you are certain that these directories are not accessible through your web server.',
+                 sprintf('You can ignore this suggestion if your web server root directory is "%s/public".', $root_path),
              ]
          );
     }
@@ -174,7 +175,7 @@ class DataDirectoriesProtectedPath extends \GLPITestCase
              [
                  sprintf('The following directories should be placed outside "%s":', $root_path),
                  sprintf('‣ "%s" ("%s")', $root_path, $unsecure_var_root_constant),
-                 'You can ignore this suggestion if you are certain that these directories are not accessible through your web server.',
+                 sprintf('You can ignore this suggestion if your web server root directory is "%s/public".', $root_path),
              ]
          );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Remaining work to do:
- [x] Test it works as expected when GLPI is served under a subdir (e.g. `http://domain.tld/glpi/`).
- [x] Add a requirement to suggest to set `/public` as root directory.
- [x] Filter static files access.
- [x] Produce complete `nginx` and `apache` configuration examples.
- [x] Add a warning on central page when router is not used.