### PR TITLE
Move Is Empty search option to end of list

### DIFF
--- a/src/Search/SearchOption.php
+++ b/src/Search/SearchOption.php
@@ -411,7 +411,6 @@ final class SearchOption implements \ArrayAccess
             if (isset($actions['searchopt']['searchtype'])) {
                 // Reset search option
                 $actions = [
-                    'empty'       => __('is empty'),
                     'searchopt'   => $searchopt[$field_num]
                 ];
                 if (!is_array($actions['searchopt']['searchtype'])) {
@@ -453,6 +452,8 @@ final class SearchOption implements \ArrayAccess
                             break;
                     }
                 }
+                // Force is empty to be last
+                $actions['empty'] = __('is empty');
                 return $actions;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In all cases except when a search option has specific search types, the Is Empty option is last. In that one different case, it is first which makes it the default which may not be very intuitive. For example, Ticket title defaulting to is empty instead of contains.