### PR TITLE
fix(inventory): default value if value not exist in inventory

### DIFF
--- a/src/Inventory/Asset/Processor.php
+++ b/src/Inventory/Asset/Processor.php
@@ -59,7 +59,10 @@ class Processor extends Device
             }
             if (property_exists($val, 'frequency')) {
                 $val->frequency_default = $val->frequency;
-                $val->frequence = $val->frequency;
+                $val->frequency = $val->frequency;
+            } else {
+                $val->frequency_default = 0;
+                $val->frequency = 0;
             }
             if (property_exists($val, 'type')) {
                 $val->designation = $val->type;

--- a/src/Inventory/Asset/Processor.php
+++ b/src/Inventory/Asset/Processor.php
@@ -59,7 +59,7 @@ class Processor extends Device
             }
             if (property_exists($val, 'frequency')) {
                 $val->frequency_default = $val->frequency;
-                $val->frequency = $val->frequency;
+                $val->frequence = $val->frequency;
             } else {
                 $val->frequency_default = 0;
                 $val->frequency = 0;

--- a/src/Inventory/Asset/Processor.php
+++ b/src/Inventory/Asset/Processor.php
@@ -63,6 +63,7 @@ class Processor extends Device
             } else {
                 $val->frequency_default = 0;
                 $val->frequency = 0;
+                $val->frequence = 0;
             }
             if (property_exists($val, 'type')) {
                 $val->designation = $val->type;

--- a/tests/functionnal/Glpi/Inventory/Assets/Processor.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Processor.php
@@ -93,7 +93,7 @@ class Processor extends AbstractInventoryAsset
 <DEVICEID>glpixps.teclib.infra-2018-10-03-08-42-36</DEVICEID>
 <QUERY>INVENTORY</QUERY>
 </REQUEST>",
-                'expected'  => '{"arch": "i386", "core": 2, "external_clock": 100, "familyname": "Core i5", "familynumber": "6", "internalid": "E3 06 04 00 FF FB EB BF", "manufacturer": "Intel", "model": "78", "name": "Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz", "serial": "To Be Filled By O.E.M.", "stepping": 3, "thread": 4, "frequency": 2300, "manufacturers_id": "Intel", "designation": "Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz", "nbcores": 2, "nbthreads": 4, "frequency_default": 0, "frequency": 0, "is_dynamic": 1}'
+                'expected'  => '{"arch": "i386", "core": 2, "external_clock": 100, "familyname": "Core i5", "familynumber": "6", "internalid": "E3 06 04 00 FF FB EB BF", "manufacturer": "Intel", "model": "78", "name": "Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz", "serial": "To Be Filled By O.E.M.", "stepping": 3, "thread": 4, "frequency": 2300, "manufacturers_id": "Intel", "designation": "Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz", "nbcores": 2, "nbthreads": 4, "frequency_default": 0, "frequency": 0, "frequence": 0, "is_dynamic": 1}'
             ]
         ];
     }

--- a/tests/functionnal/Glpi/Inventory/Assets/Processor.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Processor.php
@@ -69,6 +69,31 @@ class Processor extends AbstractInventoryAsset
   <QUERY>INVENTORY</QUERY>
   </REQUEST>",
                 'expected'  => '{"arch": "i386", "core": 2, "external_clock": 100, "familyname": "Core i5", "familynumber": "6", "internalid": "E3 06 04 00 FF FB EB BF", "manufacturer": "Intel", "model": "78", "name": "Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz", "serial": "To Be Filled By O.E.M.", "speed": 2300, "stepping": 3, "thread": 4, "frequency": 2300, "manufacturers_id": "Intel", "designation": "Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz", "nbcores": 2, "nbthreads": 4, "frequency_default": 2300, "frequency": 2300, "is_dynamic": 1}'
+            ],
+            [
+                'xml' => "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<REQUEST>
+<CONTENT>
+  <CPUS>
+    <ARCH>i386</ARCH>
+    <CORE>2</CORE>
+    <EXTERNAL_CLOCK>100</EXTERNAL_CLOCK>
+    <FAMILYNAME>Core i5</FAMILYNAME>
+    <FAMILYNUMBER>6</FAMILYNUMBER>
+    <ID>E3 06 04 00 FF FB EB BF</ID>
+    <MANUFACTURER>Intel</MANUFACTURER>
+    <MODEL>78</MODEL>
+    <NAME>Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz</NAME>
+    <SERIAL>To Be Filled By O.E.M.</SERIAL>
+    <STEPPING>3</STEPPING>
+    <THREAD>4</THREAD>
+  </CPUS>
+  <VERSIONCLIENT>FusionInventory-Inventory_v2.4.1-2.fc28</VERSIONCLIENT>
+</CONTENT>
+<DEVICEID>glpixps.teclib.infra-2018-10-03-08-42-36</DEVICEID>
+<QUERY>INVENTORY</QUERY>
+</REQUEST>",
+                'expected'  => '{"arch": "i386", "core": 2, "external_clock": 100, "familyname": "Core i5", "familynumber": "6", "internalid": "E3 06 04 00 FF FB EB BF", "manufacturer": "Intel", "model": "78", "name": "Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz", "serial": "To Be Filled By O.E.M.", "stepping": 3, "thread": 4, "frequency": 2300, "manufacturers_id": "Intel", "designation": "Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz", "nbcores": 2, "nbthreads": 4, "frequency_default": 0, "frequency": 0, "is_dynamic": 1}'
             ]
         ];
     }

--- a/tests/functionnal/Glpi/Inventory/Assets/Processor.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Processor.php
@@ -68,7 +68,7 @@ class Processor extends AbstractInventoryAsset
   <DEVICEID>glpixps.teclib.infra-2018-10-03-08-42-36</DEVICEID>
   <QUERY>INVENTORY</QUERY>
   </REQUEST>",
-                'expected'  => '{"arch": "i386", "core": 2, "external_clock": 100, "familyname": "Core i5", "familynumber": "6", "internalid": "E3 06 04 00 FF FB EB BF", "manufacturer": "Intel", "model": "78", "name": "Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz", "serial": "To Be Filled By O.E.M.", "speed": 2300, "stepping": 3, "thread": 4, "frequency": 2300, "manufacturers_id": "Intel", "designation": "Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz", "nbcores": 2, "nbthreads": 4, "frequency_default": 2300, "frequency": 2300, "is_dynamic": 1}'
+                'expected'  => '{"arch": "i386", "core": 2, "external_clock": 100, "familyname": "Core i5", "familynumber": "6", "internalid": "E3 06 04 00 FF FB EB BF", "manufacturer": "Intel", "model": "78", "name": "Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz", "serial": "To Be Filled By O.E.M.", "speed": 2300, "stepping": 3, "thread": 4, "frequency": 2300, "manufacturers_id": "Intel", "designation": "Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz", "nbcores": 2, "nbthreads": 4, "frequency_default": 2300, "frequence": 2300, "is_dynamic": 1}'
             ],
             [
                 'xml' => "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>

--- a/tests/functionnal/Glpi/Inventory/Assets/Processor.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Processor.php
@@ -68,7 +68,7 @@ class Processor extends AbstractInventoryAsset
   <DEVICEID>glpixps.teclib.infra-2018-10-03-08-42-36</DEVICEID>
   <QUERY>INVENTORY</QUERY>
   </REQUEST>",
-                'expected'  => '{"arch": "i386", "core": 2, "external_clock": 100, "familyname": "Core i5", "familynumber": "6", "internalid": "E3 06 04 00 FF FB EB BF", "manufacturer": "Intel", "model": "78", "name": "Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz", "serial": "To Be Filled By O.E.M.", "speed": 2300, "stepping": 3, "thread": 4, "frequency": 2300, "manufacturers_id": "Intel", "designation": "Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz", "nbcores": 2, "nbthreads": 4, "frequency_default": 2300, "frequence": 2300, "is_dynamic": 1}'
+                'expected'  => '{"arch": "i386", "core": 2, "external_clock": 100, "familyname": "Core i5", "familynumber": "6", "internalid": "E3 06 04 00 FF FB EB BF", "manufacturer": "Intel", "model": "78", "name": "Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz", "serial": "To Be Filled By O.E.M.", "speed": 2300, "stepping": 3, "thread": 4, "frequency": 2300, "manufacturers_id": "Intel", "designation": "Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz", "nbcores": 2, "nbthreads": 4, "frequency_default": 2300, "frequency": 2300, "is_dynamic": 1}'
             ]
         ];
     }


### PR DESCRIPTION
Prevent PHP warning
```shell
[2022-11-04 12:10:33] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "frequency" in /home/stanislas/TECLIB/DEV/GLPI/10.0-bugfixes/src/Inventory/Asset/Device.php at line 145
  Backtrace :
  src/Inventory/Asset/MainAsset.php:862              Glpi\Inventory\Asset\Device->handle()
  src/Inventory/Asset/MainAsset.php:782              Glpi\Inventory\Asset\MainAsset->handleAssets()
  src/RuleImportAsset.php:950                        Glpi\Inventory\Asset\MainAsset->rulepassed()
  src/Rule.php:1510                                  RuleImportAsset->executeActions()
  src/RuleCollection.php:1591                        Rule->process()
  src/Inventory/Asset/MainAsset.php:564              RuleCollection->processAllRules()
  src/Inventory/Inventory.php:702                    Glpi\Inventory\Asset\MainAsset->handle()
  src/Inventory/Inventory.php:337                    Glpi\Inventory\Inventory->handleItem()
  src/Inventory/Request.php:360                      Glpi\Inventory\Inventory->doInventory()
  src/Inventory/Request.php:90                       Glpi\Inventory\Request->inventory()
  src/Agent/Communication/AbstractRequest.php:305    Glpi\Inventory\Request->handleAction()
  src/Agent/Communication/AbstractRequest.php:242    Glpi\Agent\Communication\AbstractRequest->handleXMLRequest()
  front/inventory.php:92                             Glpi\Agent\Communication\AbstractRequest->handleRequest()
```

When inventory file not provide (not mandatory) information
Example ```CPUS``` without ```speed``` (glpi ```frequency```)

```xml
    <CPUS>
      <ARCH>i386</ARCH>
      <CORE>1</CORE>
      <FAMILYNAME>Other</FAMILYNAME>
      <FAMILYNUMBER>6</FAMILYNUMBER>
      <ID>63 06 00 00 FD FB 8B 07</ID>
      <MANUFACTURER>Intel</MANUFACTURER>
      <MODEL>6</MODEL>
      <NAME>QEMU Virtual CPU version 2.4.0</NAME>
      <STEPPING>3</STEPPING>
      <THREAD>1</THREAD>
    </CPUS>
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
