### PR TITLE
fix(inventory): prevent php warning when check unicity add event on uplicate

### DIFF
--- a/src/Inventory/Inventory.php
+++ b/src/Inventory/Inventory.php
@@ -251,6 +251,10 @@ class Inventory
             $_SESSION['glpiinventoryuserrunning'] = 'inventory';
         }
 
+        if (!isset($_SESSION['glpiname'])) {
+            $_SESSION['glpiname'] = $_SESSION['glpiinventoryuserrunning'];
+        }
+
         try {
             //bench
             $main_start = microtime(true);


### PR DESCRIPTION
Prevent this warning when ```checkUnicity``` try to add ```Event``` from inventory session without (```$_SESSION["glpiname"]```)

```shell
[2022-11-04 14:42:56] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "glpiname" in /home/stanislas/TECLIB/DEV/GLPI/10.0-bugfixes/src/CommonDBTM.php at line 4522
  Backtrace :
  src/CommonDBTM.php:1601                            CommonDBTM->checkUnicity()
  src/Inventory/Asset/MainAsset.php:779              CommonDBTM->update()
  src/RuleImportAsset.php:950                        Glpi\Inventory\Asset\MainAsset->rulepassed()
  src/Rule.php:1510                                  RuleImportAsset->executeActions()
  src/RuleCollection.php:1591                        Rule->process()
  src/Inventory/Asset/MainAsset.php:564              RuleCollection->processAllRules()
  src/Inventory/Inventory.php:702                    Glpi\Inventory\Asset\MainAsset->handle()
  src/Inventory/Inventory.php:337                    Glpi\Inventory\Inventory->handleItem()
  src/Inventory/Request.php:360                      Glpi\Inventory\Inventory->doInventory()
  src/Inventory/Request.php:90                       Glpi\Inventory\Request->inventory()
  src/Agent/Communication/AbstractRequest.php:305    Glpi\Inventory\Request->handleAction()
  src/Agent/Communication/AbstractRequest.php:242    Glpi\Agent\Communication\AbstractRequest->handleXMLRequest()
  front/inventory.php:92                             Glpi\Agent\Communication\AbstractRequest->handleRequest()
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
