### PR TITLE
Fix display of OS tab delete button

### DIFF
--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -209,7 +209,10 @@ class Item_OperatingSystem extends CommonDBRelation
                 $instance->fields['install_date']   = $item->fields['install_date'] ?? '';
                 $instance->fields['entities_id']    = $item->fields['entities_id'];
             }
-            $instance->showForm($id, ['canedit' => $canedit]);
+            $instance->showForm($id, [
+                'canedit' => $canedit,
+                'candel'  => $canedit
+            ]);
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Ref https://forum.glpi-project.org/viewtopic.php?id=285282

The delete button was showing in the OS tab of an item even if the user didn't have permission to update that item.