### PR TITLE
Add itemtype and item to sockets table

### DIFF
--- a/src/Socket.php
+++ b/src/Socket.php
@@ -803,7 +803,7 @@ class Socket extends CommonDBChild
             if (
                 $cable->fields['itemtype_endpoint_a'] === $item->getType() &&
                     $cable->fields['items_id_endpoint_a'] === $item->getID()
-                ) {
+            ) {
                     $itemtype = $cable->fields['itemtype_endpoint_b'];
                     $itemId = $cable->fields['items_id_endpoint_b'];
             } else {

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -805,16 +805,14 @@ class Socket extends CommonDBChild
                     $cable->fields['items_id_endpoint_a'] === $item->getID()
             ) {
                     $itemtype = $cable->fields['itemtype_endpoint_b'];
-                    $itemId = $cable->fields['items_id_endpoint_b'];
+                    $item_id = $cable->fields['items_id_endpoint_b'];
             } else {
                 $itemtype = $cable->fields['itemtype_endpoint_a'];
                 $itemId = $cable->fields['items_id_endpoint_a'];
             }
 
-
-            if ($itemId !== 0) {
-                $endpoint = new $itemtype();
-                $endpoint->getFromDB($itemId);
+            $endpoint = getItemForItemtype($itemtype);
+            if ($endpoint !== false && $item_id !== 0 && $endpoint->getFromDB($item_id)) {
                 echo "<td>" . $endpoint->getType() . "</td>";
                 echo "<td><a href='" . $endpoint->getLinkURL() . "'>" . $endpoint->getName() . "</a></td>";
             } else {

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -745,6 +745,8 @@ class Socket extends CommonDBChild
         $header_end .= "<th>" . __('Wiring side') . "</th>";
         $header_end .= "<th>" .  _n('Network port', 'Network ports', Session::getPluralNumber()) . "</th>";
         $header_end .= "<th>" .  Cable::getTypeName(0) . "</th>";
+        $header_end .= "<th>" .  __('Itemtype') . "</th>";
+        $header_end .= "<th>" .  __('Item') . "</th>";
         $header_end .= "</tr>\n";
         echo $header_begin . $header_top . $header_end;
 
@@ -795,6 +797,28 @@ class Socket extends CommonDBChild
             ) {
                 echo "<td><a href='" . $cable->getLinkURL() . "'>" . $cable->getName() . "</a></td>";
             } else {
+                echo "<td></td>";
+            }
+
+            if (
+                $cable->fields['itemtype_endpoint_a'] === $item->getType() &&
+                    $cable->fields['items_id_endpoint_a'] === $item->getID()
+                ) {
+                    $itemtype = $cable->fields['itemtype_endpoint_b'];
+                    $itemId = $cable->fields['items_id_endpoint_b'];
+            } else {
+                $itemtype = $cable->fields['itemtype_endpoint_a'];
+                $itemId = $cable->fields['items_id_endpoint_a'];
+            }
+
+
+            if ($itemId !== 0) {
+                $endpoint = new $itemtype();
+                $endpoint->getFromDB($itemId);
+                echo "<td>" . $endpoint->getType() . "</td>";
+                echo "<td><a href='" . $endpoint->getLinkURL() . "'>" . $endpoint->getName() . "</a></td>";
+            } else {
+                echo "<td></td>";
                 echo "<td></td>";
             }
 

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -746,7 +746,7 @@ class Socket extends CommonDBChild
         $header_end .= "<th>" .  _n('Network port', 'Network ports', Session::getPluralNumber()) . "</th>";
         $header_end .= "<th>" .  Cable::getTypeName(0) . "</th>";
         $header_end .= "<th>" .  __('Itemtype') . "</th>";
-        $header_end .= "<th>" .  __('Item') . "</th>";
+        $header_end .= "<th>" .  __('Item', 'Items') . "</th>";
         $header_end .= "</tr>\n";
         echo $header_begin . $header_top . $header_end;
 

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -746,7 +746,7 @@ class Socket extends CommonDBChild
         $header_end .= "<th>" .  _n('Network port', 'Network ports', Session::getPluralNumber()) . "</th>";
         $header_end .= "<th>" .  Cable::getTypeName(0) . "</th>";
         $header_end .= "<th>" .  __('Itemtype') . "</th>";
-        $header_end .= "<th>" .  __('Item', 'Items') . "</th>";
+        $header_end .= "<th>" .  __('Item Name') . "</th>";
         $header_end .= "</tr>\n";
         echo $header_begin . $header_top . $header_end;
 

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -801,14 +801,14 @@ class Socket extends CommonDBChild
             }
 
             if (
-                $cable->fields['itemtype_endpoint_a'] === $item->getType() &&
-                    $cable->fields['items_id_endpoint_a'] === $item->getID()
+                $cable->fields['itemtype_endpoint_a'] === $item->getType()
+                && $cable->fields['items_id_endpoint_a'] === $item->getID()
             ) {
-                    $itemtype = $cable->fields['itemtype_endpoint_b'];
-                    $item_id = $cable->fields['items_id_endpoint_b'];
+                $itemtype = $cable->fields['itemtype_endpoint_b'];
+                $item_id = $cable->fields['items_id_endpoint_b'];
             } else {
                 $itemtype = $cable->fields['itemtype_endpoint_a'];
-                $itemId = $cable->fields['items_id_endpoint_a'];
+                $item_id = $cable->fields['items_id_endpoint_a'];
             }
 
             $endpoint = getItemForItemtype($itemtype);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13214

Adds the item type and item of a socket to the socket table of an item, which is defined via the cable.
