### PR TITLE
Fix planned task edition

### DIFF
--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -350,7 +350,6 @@
                      <script type="text/javascript">
                         function showPlanUpdate{{ rand }}(e) {
                            $('#plan{{ rand }}').hide();
-                           $('#unplan{{ rand }}').hide();
                            $('#viewplan{{ rand }}').load('{{ path('/ajax/planning.php') }}', {
                               action: "add_event_classic_form",
                               form: "followups", // Was followups for tasks before. Can't find where this is used.
@@ -362,19 +361,25 @@
                               parent_itemtype: "{{ item.type }}",
                               parent_items_id: {{ item.fields['id'] }},
                               parent_fk_field: "{{ item.getForeignKeyField() }}",
+                              begin: "{{ subitem.fields['begin'] }}",
+                              end: "{{ subitem.fields['end'] }}",
                            });
                         }
                      </script>
                      <div class="col-12">
-                        <button id="plan{{ rand }}" class="btn btn-outline-secondary text-truncate" onclick="showPlanUpdate{{ rand }}()" type="button">
-                           <i class="fas fa-calendar"></i>
-                           <span>{{ __('Plan this task') }}</span>
-                        </button>
                         {% if subitem.can(id, constant('UPDATE')) and subitem.fields['begin'] %}
+                           <script type="text/javascript">
+                              showPlanUpdate{{ rand }}();
+                           </script>
                            <button id="unplan{{ rand }}" class="btn btn-outline-warning" type="submit" name="unplan"
                                  onclick="return confirm('{{ __('Confirm the deletion of planning?') }}');">
                               <i class="fas ti ti-calendar-off"></i>
                               <span>{{ __('Unplan') }}</span>
+                           </button>
+                        {% else %}
+                           <button id="plan{{ rand }}" class="btn btn-outline-secondary text-truncate" onclick="showPlanUpdate{{ rand }}()" type="button">
+                              <i class="fas fa-calendar"></i>
+                              <span>{{ __('Plan this task') }}</span>
                            </button>
                         {% endif %}
                         <div id="viewplan{{ rand }}"></div>


### PR DESCRIPTION
Given the following task (note the planning information at the bottom):

![image](https://user-images.githubusercontent.com/42734840/200283996-56629191-3933-4935-b990-59f46bd5af15.png)

Going into edition, planning information are hidden:

![image](https://user-images.githubusercontent.com/42734840/200284164-3a49e11a-1cc2-4f5b-854d-19ac11bf2ccf.png)

After clicking the "Plan this task" button, 2 out of 3 values are incorrect:

![image](https://user-images.githubusercontent.com/42734840/200284283-24aee393-98d8-4063-ae71-afbb75528c7b.png)

Fix: the date are shown directly in edition (no need to reclick the "Plan this task" button) and the correct values are displayed:

![image](https://user-images.githubusercontent.com/42734840/200285032-f66e675e-11d8-47e5-874d-cece0a5be44c.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25423
