### PR TITLE
Fix broken new lines cleaning on TinyMCE

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -3972,7 +3972,7 @@ JS;
                      });
                   }
 
-                  editor.on('SaveContent', function (contentEvent) {
+                  editor.on('PostProcess', function (contentEvent) {
                      contentEvent.content = contentEvent.content.replace(/\\r?\\n/g, '');
                   });
                   editor.on('Change', function (e) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13202 #13205

As explained in #13202, upgrade to TinyMCE 5.x have broken new lines cleaning process between GLPI 9.5.9 and GLPI 9.5.11. Problem is that different add/strip slashes operations made in ticket creation/update process and in rules processing result in `rn` and `n` tokens in place of these new lines.
