### PR TITLE
Fix RedirectList from CommonDBChild class

### DIFF
--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -979,7 +979,7 @@ class CommonGLPI implements CommonGLPIInterface
             $glpilisturl   = & $_SESSION['glpilisturl'][$this->getType()];
             if ($this instanceof CommonDBChild) {
                 $parent = $this->getItem(true, false);
-                $glpilisturl = $parent::getFormURL(true)."?id=".$parent->fields['id'];
+                $glpilisturl = $parent::getFormURL(true) . "?id=" . $parent->fields['id'];
             }
             if (empty($glpilisturl)) {
                 $glpilisturl = $this->getSearchURL();

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -977,7 +977,10 @@ class CommonGLPI implements CommonGLPIInterface
             $glpilistitems = & $_SESSION['glpilistitems'][$this->getType()];
             $glpilisttitle = & $_SESSION['glpilisttitle'][$this->getType()];
             $glpilisturl   = & $_SESSION['glpilisturl'][$this->getType()];
-
+            if ($this instanceof CommonDBChild) {
+                $parent = $this->getItem(true, false);
+                $glpilisturl = $parent::getFormURL(true)."?id=".$parent->fields['id'];
+            }
             if (empty($glpilisturl)) {
                 $glpilisturl = $this->getSearchURL();
             }

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -979,7 +979,7 @@ class CommonGLPI implements CommonGLPIInterface
             $glpilisturl   = & $_SESSION['glpilisturl'][$this->getType()];
             if ($this instanceof CommonDBChild) {
                 $parent = $this->getItem(true, false);
-                $glpilisturl = $parent::getFormURL(true) . "?id=" . $parent->fields['id'];
+                $glpilisturl = $parent::getFormURLWithID($parent->fields['id'], true);
             }
             if (empty($glpilisturl)) {
                 $glpilisturl = $this->getSearchURL();


### PR DESCRIPTION
Fix RedirectList from CommonDBChild class

When use 
![image](https://user-images.githubusercontent.com/13178158/200633947-45fcf202-9269-4592-89d4-52b06521f196.png)
 from 
CommonDBChild class, we are redirected to non existant pages

Examples : /front/computerantivirus.php, /front/item_disk.php & from pplugins too

Other problem (not fixed here) - from front/apiclient.form.php?id=1
-> try to redirect to http://localhost/glpi/front/apiclient.php?sort%5B0%5D=0&order%5B0%5D=ASC&criteria%5B0%5D%5Bfield%5D=view&criteria%5B0%5D%5Blink%5D=contains&criteria%5B0%5D%5Bvalue%5D=

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
