### PR TITLE
Remove invalid gendered language

### DIFF
--- a/src/Planning.php
+++ b/src/Planning.php
@@ -1280,7 +1280,7 @@ class Planning extends CommonGLPI
             echo "<div class='center'>";
             echo "<a href='" . $params['url'] . "' class='btn btn-outline-secondary'>" .
                 "<i class='ti ti-eye'></i>" .
-                "<span>" . __("View this item in his context") . "</span>" .
+                "<span>" . __("View this item in its context") . "</span>" .
             "</a>";
             echo "</div>";
             echo "<hr>";

--- a/src/User.php
+++ b/src/User.php
@@ -5489,7 +5489,7 @@ HTML;
         // Check that the configuration allow this user to change his password
         if ($this->fields["authtype"] !== Auth::DB_GLPI && Auth::useAuthExt()) {
             trigger_error(
-                __("The authentication method configuration doesn't allow the user '$email' to change his password."),
+                __("The authentication method configuration doesn't allow the user '$email' to change their password."),
                 E_USER_WARNING
             );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

English is not a gendered language, so defaulting to using "his" when referring to an object or unknown person is not valid.