### PR TITLE
Do not try loading mini ticket dashboard for simplified interface

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -161,6 +161,7 @@ class Search
 
         if (
             $itemtype == "Ticket"
+            && Session::getCurrentInterface() === 'central'
             && $default = Glpi\Dashboard\Grid::getDefaultDashboardForMenu('mini_ticket', true)
         ) {
             $dashboard = new Glpi\Dashboard\Grid($default, 33, 2);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12994

Simplified interface profiles don't usually have access to dashboards, but the mini ticket dashboard still tries to load. Even though it seems to fail, the loading animations and other initial elements seem to stay present.