### PR TITLE
fix(notification template translation): images not uploaded

### DIFF
--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -465,7 +465,7 @@ class Document_Item extends CommonDBRelation
                     } else if ($item instanceof Item_Devices) {
                         $linkname = $data["itemtype"];
                     } else {
-                        $linkname = $data["name"];
+                        $linkname = $data["name"] ?? $data["id"];
                     }
                     if (
                         $_SESSION["glpiis_ids_visible"]

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -465,7 +465,7 @@ class Document_Item extends CommonDBRelation
                     } else if ($item instanceof Item_Devices) {
                         $linkname = $data["itemtype"];
                     } else {
-                        $linkname = $data["name"] ?? $data["id"];
+                        $linkname = $data[$item::getNameField()];
                     }
                     if (
                         $_SESSION["glpiis_ids_visible"]

--- a/src/NotificationTemplateTranslation.php
+++ b/src/NotificationTemplateTranslation.php
@@ -53,6 +53,10 @@ class NotificationTemplateTranslation extends CommonDBChild
         return _n('Template translation', 'Template translations', $nb);
     }
 
+    public static function getNameField()
+    {
+        return 'id';
+    }
 
     /**
      * @since 0.84
@@ -296,6 +300,32 @@ class NotificationTemplateTranslation extends CommonDBChild
     public function prepareInputForUpdate($input)
     {
         return parent::prepareInputForUpdate(self::cleanContentHtml($input));
+    }
+
+
+    public function post_addItem($history = 1)
+    {
+        // Handle rich-text images and uploaded documents
+        $this->input = $this->addFiles($this->input, [
+            'force_update' => true,
+            'name' => 'content_html',
+            'content_field' => 'content_html'
+        ]);
+
+        parent::post_addItem($history);
+    }
+
+
+    public function post_updateItem($history = 1)
+    {
+        // Handle rich-text images and uploaded documents
+        $this->input = $this->addFiles($this->input, [
+            'force_update' => true,
+            'name' => 'content_html',
+            'content_field' => 'content_html'
+        ]);
+
+        parent::post_updateItem($history);
     }
 
 


### PR DESCRIPTION
In notification template translation, we can insert images in rich text, but images were not uploaded.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25497
