### PR TITLE
fix namespaced tab not correctly set as active

### DIFF
--- a/inc/includes.php
+++ b/inc/includes.php
@@ -132,7 +132,7 @@ if (isset($_REQUEST['forcetab'])) {
 }
 // Manage tabs
 if (isset($_REQUEST['glpi_tab']) && isset($_REQUEST['itemtype'])) {
-    Session::setActiveTab($_REQUEST['itemtype'], $_REQUEST['glpi_tab']);
+    Session::setActiveTab($_UREQUEST['itemtype'], $_UREQUEST['glpi_tab']);
 }
 // Override list-limit if choosen
 if (isset($_REQUEST['glpilist_limit'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Found while discuting with @mary-Clb about plugin development tutorial, set active tab doesn't work correctly with namespaced tabs.
Not sure it's the good way, but i don't have time today to check for a better solution.

