### PR TITLE
fix(ticket): pending reason lost status

### DIFF
--- a/src/Features/ParentStatus.php
+++ b/src/Features/ParentStatus.php
@@ -84,7 +84,7 @@ trait ParentStatus
        // Set parent status to pending
         if ($input['pending'] ?? 0) {
             $input['_status'] = CommonITILObject::WAITING;
-        } elseif ($parentitem->fields["status"] == CommonITILObject::WAITING) {
+        } elseif (!isset($input['_no_reopen']) && $parentitem->fields["status"] == CommonITILObject::WAITING) {
             $input["_reopen"] = true;
         }
 

--- a/src/PendingReasonCron.php
+++ b/src/PendingReasonCron.php
@@ -161,6 +161,7 @@ class PendingReasonCron extends CommonDBTM
                     'is_private' => $fup_template->fields['is_private'],
                     'requesttypes_id' => $fup_template->fields['requesttypes_id'],
                     'timeline_position' => CommonITILObject::TIMELINE_RIGHT,
+                    'pending' => 1,
                 ]);
                 $task->addVolume(1);
             } else if ($resolve && $now > $resolve) {

--- a/src/PendingReasonCron.php
+++ b/src/PendingReasonCron.php
@@ -161,7 +161,7 @@ class PendingReasonCron extends CommonDBTM
                     'is_private' => $fup_template->fields['is_private'],
                     'requesttypes_id' => $fup_template->fields['requesttypes_id'],
                     'timeline_position' => CommonITILObject::TIMELINE_RIGHT,
-                    'pending' => 1,
+                    '_no_reopen' => 1,
                 ]);
                 $task->addVolume(1);
             } else if ($resolve && $now > $resolve) {


### PR DESCRIPTION
When pending reason create the first follow-up, pending status was lost and other follow-ups were not sent.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25499
