### PR TITLE
fix(lockedfield): load right locked field siwtch itemtype

### DIFF
--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -188,7 +188,14 @@ abstract class InventoryAsset
         //load locked field for current itemtype
         $itemtype = $this->getItemtype();
         $lockedfield = new Lockedfield();
-        $locks = $lockedfield->getLockedNames($itemtype, $this->item->fields['id'] ?? 0);
+
+        $items_id = 0;
+        //compare current itemtype et mainasset itemtype to be sure
+        //to get related lock
+        if (get_class($this->item) == $itemtype) {
+            $items_id = $this->item->fields['id'];
+        }
+        $locks = $lockedfield->getLockedNames($itemtype, $items_id);
 
         $data = $this->data;
         foreach ($data as &$value) {

--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -193,7 +193,7 @@ abstract class InventoryAsset
         //compare current itemtype et mainasset itemtype to be sure
         //to get related lock
         if (get_class($this->item) == $itemtype) {
-            $items_id = $this->item->fields[static::getIndexName()] ?? 0;
+            $items_id = $this->item->fields['id'] ?? 0;
         }
         $locks = $lockedfield->getLockedNames($itemtype, $items_id);
 

--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -193,7 +193,7 @@ abstract class InventoryAsset
         //compare current itemtype et mainasset itemtype to be sure
         //to get related lock
         if (get_class($this->item) == $itemtype) {
-            $items_id = $this->item->$this->fields[static::getIndexName()] ?? 0;
+            $items_id = $this->item->fields[static::getIndexName()] ?? 0;
         }
         $locks = $lockedfield->getLockedNames($itemtype, $items_id);
 

--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -193,7 +193,7 @@ abstract class InventoryAsset
         //compare current itemtype et mainasset itemtype to be sure
         //to get related lock
         if (get_class($this->item) == $itemtype) {
-            $items_id = $this->item->fields['id'];
+            $items_id = $this->item->$this->fields[static::getIndexName()] ?? 0;
         }
         $locks = $lockedfield->getLockedNames($itemtype, $items_id);
 


### PR DESCRIPTION
Actually native inventory try to load ```locked field``` for current handled item (```Computer``` or ```Peripheral``` or other)

But ```items_id``` is always the main asset ```ID```.

in certain circumstances some SQL error appears
```shell
 SQL: UPDATE `glpi_peripherals` SET `manufacturers_id` = 'Realtek Semiconductor Corp.' WHERE `id` = '13886'
  Error: Incorrect integer value: 'Realtek Semiconductor Corp.' for column `sicoval`.`glpi_peripherals`.`manufacturers_id` at row 1
```
Circumstance in my case : 

- A ```Computer``` with ```ID``` = 3297
- A ```Peripheral``` in trash bin with  ```ID``` = 3297 (and with``` manufacturers_id``` as ```locked field```)

the right ```Peripheral``` attached to ```Computer``` thrown SQL error because GLPI try to load ```locked field``` from "Peripheral" and ID 3297, and as it finds some it does not manage the value as expected et try (later) to ```add``` / ```update``` with unmanage value



So at this place ```handleLinks()```, it's impossible to get ```lockedfield``` for ```links``` because we don't have its ```ID```

It doesn't matter because on ```add``` or ```update``` GLPI also takes into account ```locked fields``` to avoid loading manually placed values



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25503
