### PR TITLE
Fix LDAP filter Sanitizer in ldap_get_user_groups

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -1999,7 +1999,8 @@ class User extends CommonDBTM
 
        //Only retrive cn and member attributes from groups
         $attrs = ['dn'];
-
+        
+        $group_condition = Sanitizer::unsanitize($group_condition);
         if (!$use_dn) {
             $filter = "(& $group_condition (|($group_member_field=$user_dn)
                                           ($group_member_field=$login_field=$user_dn)))";
@@ -2008,7 +2009,6 @@ class User extends CommonDBTM
         }
 
        //Perform the search
-        $filter = Sanitizer::unsanitize($filter);
         $sr     = ldap_search($ds, $ldap_base_dn, $filter, $attrs);
 
        //Get the result of the search as an array

--- a/src/User.php
+++ b/src/User.php
@@ -1999,7 +1999,7 @@ class User extends CommonDBTM
 
        //Only retrive cn and member attributes from groups
         $attrs = ['dn'];
-        
+
         $group_condition = Sanitizer::unsanitize($group_condition);
         if (!$use_dn) {
             $filter = "(& $group_condition (|($group_member_field=$user_dn)


### PR DESCRIPTION
Sanitizer::unsanitize($filter) is not handled properly as it contains "& " at the begin of string and isHtmlEncoded in that case returns false so Sanitizer::unsanitize() does nothing. Either above lines should be written as ``$filter = "(&#38; `` or as proposed just group_condition should be unsanitized as propsoed in PR only this field probably could contain sanitized characters (I believe)...


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | NA
