### PR TITLE
fix(inventory): add missing infor to rule from discovery

### DIFF
--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -64,6 +64,7 @@ abstract class MainAsset extends InventoryAsset
         'hardware'     => null,
         'bios'         => null,
         'users'        => null,
+        'network_device' => null,
         '\Glpi\Inventory\Asset\NetworkCard' => null
     ];
     /** @var mixed */
@@ -428,6 +429,31 @@ abstract class MainAsset extends InventoryAsset
 
         if (!isset($input['name'])) {
             $input['name'] = '';
+        }
+
+        //from discovery put extra data to rule input
+        if ($this->is_discovery && isset($this->extra_data['network_device'])) {
+            if (property_exists($this->extra_data['network_device'], 'ips')) {
+                foreach ($this->extra_data['network_device']->ips as $ip) {
+                    if ($ip != '127.0.0.1' && $ip != '::1') {
+                        $input['ip'][] = $ip;
+                    }
+                }
+            }
+
+            if (
+                property_exists($this->extra_data['network_device'], 'mac')
+                && !empty($this->extra_data['network_device']->mac)
+            ) {
+                $input['mac'][] = $this->extra_data['network_device']->mac;
+            }
+
+            if (
+                property_exists($this->extra_data['network_device'], 'name')
+                && !empty($this->extra_data['network_device']->name)
+            ) {
+                $input['name'] = $this->extra_data['network_device']->name;
+            }
         }
 
         if (isset($this->extra_data['\Glpi\Inventory\Asset\NetworkCard'])) {


### PR DESCRIPTION
I don't know if it the right place to do this and if we want to change but, from discovery 

- MAC
- IPs
- name

are never passed to ```RuleImportAsset``` engine, because they are placed from different XML node

```
<?xml version="1.0" encoding="UTF-8" ?>
<REQUEST>
  <CONTENT>
    <DEVICE>
      <DNSHOSTNAME>192.168.1.20</DNSHOSTNAME>
      <ENTITY>0</ENTITY>
      <IP>192.168.1.20</IP>
      <MAC>4c:cc:6a:02:13:a9</MAC>
      <NETBIOSNAME>DESKTOP-A3J16LF</NETBIOSNAME>
      <WORKGROUP>WORKGROUP</WORKGROUP>
    </DEVICE>
    <MODULEVERSION>5.1</MODULEVERSION>
    <PROCESSNUMBER>8</PROCESSNUMBER>
  </CONTENT>
  <DEVICEID>stanislas-asus-desktop-2022-09-20-16-43-09</DEVICEID>
  <QUERY>NETDISCOVERY</QUERY>
</REQUEST>
```

and handle differently by ```inventory_format```

```php
stdClass Object
  (
      [content] => stdClass Object
          (
              [hardware] => stdClass Object
                  (
                      [workgroup] => WORKGROUP
                  )
  
              [versionclient] => 5.1
              [network_device] => stdClass Object
                  (
                      [type] => Computer
                      [mac] => 4c:cc:6a:02:13:a9
                      [name] => DESKTOP-A3J16LF
                      [ips] => Array
                          (
                              [0] => 192.168.1.20
                          )
  
                  )
  
          )
  
      [deviceid] => stanislas-asus-desktop-2022-09-20-16-43-09
      [action] => netdiscovery
      [jobid] => 9
      [itemtype] => Computer
  )
```


It is therefore impossible to use the rules that check MAC / IP already existing into GLPI


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
