### PR TITLE
Improve browse view performance

### DIFF
--- a/src/Features/TreeBrowse.php
+++ b/src/Features/TreeBrowse.php
@@ -188,6 +188,8 @@ JAVASCRIPT;
         $raw_select = $data['sql']['raw']['SELECT'];
         $replacement_select = 'SELECT DISTINCT ' . $itemtype::getTableField('id');
         $sql = preg_replace('/^' . preg_quote($raw_select, '/') . '/', $replacement_select, $sql, 1);
+        // Remove GROUP BY and ORDER BY clauses
+        $sql = str_replace(array($data['sql']['raw']['GROUPBY'], $data['sql']['raw']['ORDER']), '', $sql);
 
         $id_criteria = new QueryExpression($itemtype::getTableField('id') . ' IN ( SELECT * FROM (' . $sql . ') AS id_criteria )');
 

--- a/src/Search.php
+++ b/src/Search.php
@@ -691,6 +691,7 @@ class Search
 
         $data['sql']['count']  = [];
         $data['sql']['search'] = '';
+        $data['sql']['raw']    = [];
 
         $searchopt        = self::getOptions($data['itemtype']);
 
@@ -1105,7 +1106,7 @@ class Search
                         $tmpquery = str_replace("`glpi_softwares`.`serial`", "''", $tmpquery);
                         $tmpquery = str_replace("`glpi_softwares`.`otherserial`", "''", $tmpquery);
                     }
-                     $QUERY .= $tmpquery;
+                    $QUERY .= $tmpquery;
                 }
             }
             if (empty($QUERY)) {
@@ -1115,6 +1116,15 @@ class Search
             $QUERY .= str_replace($CFG_GLPI["union_search_type"][$data['itemtype']] . ".", "", $ORDER) .
                    $LIMIT;
         } else {
+            $data['sql']['raw'] = [
+                'SELECT' => $SELECT,
+                'FROM' => $FROM,
+                'WHERE' => $WHERE,
+                'GROUPBY' => $GROUPBY,
+                'HAVING' => $HAVING,
+                'ORDER' => $ORDER,
+                'LIMIT' => $LIMIT
+            ];
             $QUERY = $SELECT .
                   $FROM .
                   $WHERE .


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12779

Instead of using a copy of the current search query to get all IDs that would be returned in the results (all pages), and then using another query with those IDs in an IN condition to create the category counters, this PR combines them together into a single query. This seems to remove or reduce the chance of reaching the MySQL `range_optimizer_max_mem_size` (MariaDB doesn't have such a limit) and seems to improve overall query time as well regardless of the DBMS.

This required keeping track of the individual parts of a constructed query from the search engine so it would be easy to replace/remove parts. This is expected to just be a temporary solution until the search engine uses the array/iterator format for its built query.