### PR TITLE
fix(ticket): notifications not send

### DIFF
--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -253,7 +253,7 @@ class ITILFollowup extends CommonDBChild
 
         $this->updateParentStatus($this->input['_job'], $this->input);
 
-        $donotif = !isset($this->input['_disablenotif']) && !isset($parentitem->input['_disablenotif']) && $CFG_GLPI["use_notifications"];
+        $donotif = !isset($this->input['_disablenotif']) && !isset($parentitem->fields['_disablenotif']) && $CFG_GLPI["use_notifications"];
 
         if ($donotif) {
             $options = ['followup_id' => $this->fields["id"],

--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -253,7 +253,7 @@ class ITILFollowup extends CommonDBChild
 
         $this->updateParentStatus($this->input['_job'], $this->input);
 
-        $donotif = !isset($this->input['_disablenotif']) && !isset($parentitem->fields['_disablenotif']) && $CFG_GLPI["use_notifications"];
+        $donotif = !isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"];
 
         if ($donotif) {
             $options = ['followup_id' => $this->fields["id"],

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1685,7 +1685,6 @@ class Ticket extends CommonITILObject
            // Read again ticket to be sure that all data are up to date
             $this->getFromDB($this->fields['id']);
             NotificationEvent::raiseEvent($mailtype, $this);
-            $this->fields['_disablenotif'] = true;
         }
 
        // inquest created immediatly if delay = O

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1685,7 +1685,7 @@ class Ticket extends CommonITILObject
            // Read again ticket to be sure that all data are up to date
             $this->getFromDB($this->fields['id']);
             NotificationEvent::raiseEvent($mailtype, $this);
-            $this->input['_disablenotif'] = true;
+            $this->fields['_disablenotif'] = true;
         }
 
        // inquest created immediatly if delay = O


### PR DESCRIPTION
Follow-up notifications were not always generated.
For example, when the ticket is already pending and a follow-up is added, it did not generate a notification.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25494

#13043 