### PR TITLE
CommonITIL: restrict location dropdown to correct entity

### DIFF
--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -212,7 +212,9 @@
                   item.fields['locations_id'],
                   'Location'|itemtype_name,
                   field_options|merge({
-                     'hide_if_no_elements': true
+                     'hide_if_no_elements': true,
+                     'entity': item.fields['entities_id'],
+                     'entity_sons': true
                   })
                ) }}
             {% endif %}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -109,7 +109,7 @@ function loadDataset()
    // Unit test data definition
     $data = [
       // bump this version to force reload of the full dataset, when content change
-        '_version' => '4.8',
+        '_version' => '4.9',
 
       // Type => array of entries
         'Entity' => [
@@ -366,7 +366,12 @@ function loadDataset()
             [
                 'name'         => '_location02',
                 'comment'      => 'Comment for location _sublocation02'
-            ]
+            ],
+            [
+                'name'         => '_location01_subentity',
+                'entities_id'  => '_test_root_entity',
+                'comment'      => 'Comment for location _location01_subentity'
+            ],
         ], Socket::class => [
             [
                 'name'         => '_socket01',


### PR DESCRIPTION
Given the 3 following entities;

![image](https://user-images.githubusercontent.com/42734840/201622379-00222e00-b1e9-4dfe-96af-a77d13413672.png)

The location dropdown does not restrict the values correctly:

![image](https://user-images.githubusercontent.com/42734840/201622573-2236addf-4279-41c2-9afb-3b46d7b4cfee.png)

After fix:

![image](https://user-images.githubusercontent.com/42734840/201622261-f473340b-cea5-4c20-8114-06e753e6a602.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25523
