### PR TITLE
Migrate transifex config for new client

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[GLPI.glpipot10]
+[o:glpi:p:GLPI:r:glpipot10]
 file_filter = locales/<lang>.po
 source_file = locales/glpi.pot
 source_lang = en_GB


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

After November 30, old Transifex Python client will no longer work as Transifex API 2.0 and 2.5 will not be available anymore.

To install the new client, remove the previously installed client, then run ``cd /usr/local/bin/ && curl --silent --location https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash``.

I just run the `tx migrate` command to get the config file updated, then tested to push/pull to confirm it works.