### PR TITLE
feat(rule): add action matching completename

### DIFF
--- a/src/RuleCommonITILObject.php
+++ b/src/RuleCommonITILObject.php
@@ -517,7 +517,7 @@ abstract class RuleCommonITILObject extends Rule
                                     break;
                                 }
                             }
-                        } elseif ($field == "itilcategories_id_by_completename") {
+                        } elseif ($field == "_itilcategories_id_by_completename") {
                             foreach ($regex_values as $regex_value) {
                                 // Search category by name
                                 $category = new ITILCategory();
@@ -722,10 +722,10 @@ abstract class RuleCommonITILObject extends Rule
         $actions['itilcategories_id']['table']                      = 'glpi_itilcategories';
         $actions['itilcategories_id']['force_actions']              = ['assign', 'regex_result'];
 
-        $actions['itilcategories_id_by_completename']['name']                 = sprintf(__('%1$s (%2$s)'), _n('Category', 'Categories', 1), __('by completename'));
-        $actions['itilcategories_id_by_completename']['type']                 = 'dropdown';
-        $actions['itilcategories_id_by_completename']['table']                = 'glpi_itilcategories';
-        $actions['itilcategories_id_by_completename']['force_actions']        = ['regex_result'];
+        $actions['_itilcategories_id_by_completename']['name']                 = sprintf(__('%1$s (%2$s)'), _n('Category', 'Categories', 1), __('by completename'));
+        $actions['_itilcategories_id_by_completename']['type']                 = 'dropdown';
+        $actions['_itilcategories_id_by_completename']['table']                = 'glpi_itilcategories';
+        $actions['_itilcategories_id_by_completename']['force_actions']        = ['regex_result'];
 
         $actions['_affect_itilcategory_by_code']['name']            = __('ITIL category from code');
         $actions['_affect_itilcategory_by_code']['type']            = 'text';

--- a/src/RuleCommonITILObject.php
+++ b/src/RuleCommonITILObject.php
@@ -468,7 +468,7 @@ abstract class RuleCommonITILObject extends Rule
                                     $output['_additional_groups_observers'][$group->getID()] = $group->getID();
                                 }
                             }
-                        }  elseif ($field == "_groups_id_observer_by_completename") {
+                        } elseif ($field == "_groups_id_observer_by_completename") {
                             foreach ($regex_values as $regex_value) {
                                 // Search group by name
                                 $group = new Group();

--- a/src/RuleCommonITILObject.php
+++ b/src/RuleCommonITILObject.php
@@ -412,6 +412,20 @@ abstract class RuleCommonITILObject extends Rule
                                     $output['_additional_groups_requesters'][$group->getID()] = $group->getID();
                                 }
                             }
+                        } elseif ($field == "_groups_id_requester_by_completename") {
+                            foreach ($regex_values as $regex_value) {
+                                // Search group by name
+                                $group = new Group();
+                                $result = $group->getFromDBByCrit([
+                                    "completename" => $regex_value,
+                                    "is_requester" => true
+                                ]);
+
+                                // Add groups found for each regex
+                                if ($result) {
+                                    $output['_additional_groups_requesters'][$group->getID()] = $group->getID();
+                                }
+                            }
                         } elseif ($field == "_groups_id_assign") {
                             foreach ($regex_values as $regex_value) {
                                 // Search group by name
@@ -426,12 +440,40 @@ abstract class RuleCommonITILObject extends Rule
                                     $output['_additional_groups_assigns'][$group->getID()] = $group->getID();
                                 }
                             }
+                        } elseif ($field == "_groups_id_assign_by_completename") {
+                            foreach ($regex_values as $regex_value) {
+                                // Search group by name
+                                $group = new Group();
+                                $result = $group->getFromDBByCrit([
+                                    "completename" => $regex_value,
+                                    "is_assign" => true
+                                ]);
+
+                                // Add groups found for each regex
+                                if ($result) {
+                                    $output['_additional_groups_assigns'][$group->getID()] = $group->getID();
+                                }
+                            }
                         } elseif ($field == "_groups_id_observer") {
                             foreach ($regex_values as $regex_value) {
                                 // Search group by name
                                 $group = new Group();
                                 $result = $group->getFromDBByCrit([
                                     "name" => $regex_value,
+                                    "is_watcher" => true
+                                ]);
+
+                                // Add groups found for each regex
+                                if ($result) {
+                                    $output['_additional_groups_observers'][$group->getID()] = $group->getID();
+                                }
+                            }
+                        }  elseif ($field == "_groups_id_observer_by_completename") {
+                            foreach ($regex_values as $regex_value) {
+                                // Search group by name
+                                $group = new Group();
+                                $result = $group->getFromDBByCrit([
+                                    "completename" => $regex_value,
                                     "is_watcher" => true
                                 ]);
 
@@ -467,6 +509,20 @@ abstract class RuleCommonITILObject extends Rule
                                 $category = new ITILCategory();
                                 $result = $category->getFromDBByCrit([
                                     "name" => $regex_value,
+                                ]);
+
+                                // Stop at the first valid category found
+                                if ($result) {
+                                    $output['itilcategories_id'] = $category->getID();
+                                    break;
+                                }
+                            }
+                        } elseif ($field == "itilcategories_id_by_completename") {
+                            foreach ($regex_values as $regex_value) {
+                                // Search category by name
+                                $category = new ITILCategory();
+                                $result = $category->getFromDBByCrit([
+                                    "completename" => $regex_value,
                                 ]);
 
                                 // Stop at the first valid category found
@@ -666,6 +722,11 @@ abstract class RuleCommonITILObject extends Rule
         $actions['itilcategories_id']['table']                      = 'glpi_itilcategories';
         $actions['itilcategories_id']['force_actions']              = ['assign', 'regex_result'];
 
+        $actions['itilcategories_id_by_completename']['name']                 = sprintf(__('%1$s (%2$s)'), _n('Category', 'Categories', 1), __('by completename'));
+        $actions['itilcategories_id_by_completename']['type']                 = 'dropdown';
+        $actions['itilcategories_id_by_completename']['table']                = 'glpi_itilcategories';
+        $actions['itilcategories_id_by_completename']['force_actions']        = ['regex_result'];
+
         $actions['_affect_itilcategory_by_code']['name']            = __('ITIL category from code');
         $actions['_affect_itilcategory_by_code']['type']            = 'text';
         $actions['_affect_itilcategory_by_code']['force_actions']   = ['regex_result'];
@@ -686,6 +747,14 @@ abstract class RuleCommonITILObject extends Rule
         $actions['_groups_id_requester']['permitseveral']           = ['append'];
         $actions['_groups_id_requester']['appendto']                = '_additional_groups_requesters';
 
+        $actions['_groups_id_requester_by_completename']['name']              = sprintf(__('%1$s (%2$s)'), _n('Requester group', 'Requester groups', 1), __('by completename'));
+        $actions['_groups_id_requester_by_completename']['type']              = 'dropdown';
+        $actions['_groups_id_requester_by_completename']['table']             = 'glpi_groups';
+        $actions['_groups_id_requester_by_completename']['condition']         = ['is_requester' => 1];
+        $actions['_groups_id_requester_by_completename']['force_actions']     = ['regex_result'];
+        $actions['_groups_id_requester_by_completename']['permitseveral']     = ['append'];
+        $actions['_groups_id_requester_by_completename']['appendto']          = '_additional_groups_requesters';
+
         $actions['_users_id_assign']['name']                        = __('Technician');
         $actions['_users_id_assign']['type']                        = 'dropdown_assign';
         $actions['_users_id_assign']['force_actions']                = ['assign', 'append'];
@@ -701,6 +770,14 @@ abstract class RuleCommonITILObject extends Rule
         $actions['_groups_id_assign']['force_actions']              = ['assign', 'append', 'regex_result'];
         $actions['_groups_id_assign']['permitseveral']              = ['append'];
         $actions['_groups_id_assign']['appendto']                   = '_additional_groups_assigns';
+
+        $actions['_groups_id_assign_by_completename']['table']                = 'glpi_groups';
+        $actions['_groups_id_assign_by_completename']['name']                 = sprintf(__('%1$s (%2$s)'), __('Technician group'), __('by completename'));
+        $actions['_groups_id_assign_by_completename']['type']                 = 'dropdown';
+        $actions['_groups_id_assign_by_completename']['condition']            = ['is_assign' => 1];
+        $actions['_groups_id_assign_by_completename']['force_actions']        = ['regex_result'];
+        $actions['_groups_id_assign_by_completename']['permitseveral']        = ['append'];
+        $actions['_groups_id_assign_by_completename']['appendto']             = '_additional_groups_assigns';
 
         $actions['_suppliers_id_assign']['table']                   = 'glpi_suppliers';
         $actions['_suppliers_id_assign']['name']                    = __('Assigned to a supplier');
@@ -726,6 +803,14 @@ abstract class RuleCommonITILObject extends Rule
         $actions['_groups_id_observer']['force_actions']            = ['assign', 'append', 'regex_result'];
         $actions['_groups_id_observer']['permitseveral']            = ['append'];
         $actions['_groups_id_observer']['appendto']                 = '_additional_groups_observers';
+
+        $actions['_groups_id_observer_by_completename']['table']              = 'glpi_groups';
+        $actions['_groups_id_observer_by_completename']['name']               = sprintf(__('%1$s (%2$s)'), _n('Watcher group', 'Watcher groups', 1), __('by completename'));
+        $actions['_groups_id_observer_by_completename']['type']               = 'dropdown';
+        $actions['_groups_id_observer_by_completename']['condition']          = ['is_watcher' => 1];
+        $actions['_groups_id_observer_by_completename']['force_actions']      = ['regex_result'];
+        $actions['_groups_id_observer_by_completename']['permitseveral']      = ['append'];
+        $actions['_groups_id_observer_by_completename']['appendto']           = '_additional_groups_observers';
 
         $actions['urgency']['name']                                 = __('Urgency');
         $actions['urgency']['type']                                 = 'dropdown_urgency';

--- a/src/RuleCriteria.php
+++ b/src/RuleCriteria.php
@@ -375,7 +375,11 @@ class RuleCriteria extends CommonDBChild
      **/
     public static function match(RuleCriteria &$criterion, $field, &$criterias_results, &$regex_result)
     {
-        $field = Sanitizer::decodeHtmlSpecialChars($field);
+        if (is_array($field)) {
+            $field = Sanitizer::decodeHtmlSpecialCharsRecursive($field);
+        } else {
+            $field = Sanitizer::decodeHtmlSpecialChars($field);
+        }
 
         $condition = $criterion->fields['condition'];
         $pattern   = $criterion->fields['pattern'];

--- a/src/RuleCriteria.php
+++ b/src/RuleCriteria.php
@@ -375,6 +375,7 @@ class RuleCriteria extends CommonDBChild
      **/
     public static function match(RuleCriteria &$criterion, $field, &$criterias_results, &$regex_result)
     {
+        $field = Sanitizer::decodeHtmlSpecialChars($field);
 
         $condition = $criterion->fields['condition'];
         $pattern   = $criterion->fields['pattern'];

--- a/src/RuleCriteria.php
+++ b/src/RuleCriteria.php
@@ -378,7 +378,7 @@ class RuleCriteria extends CommonDBChild
         if (is_array($field)) {
             $field = Sanitizer::decodeHtmlSpecialCharsRecursive($field);
         } else {
-            $field = Sanitizer::decodeHtmlSpecialChars($field);
+            $field = Sanitizer::decodeHtmlSpecialChars($field ?? '');
         }
 
         $condition = $criterion->fields['condition'];

--- a/tests/functionnal/Rule.php
+++ b/tests/functionnal/Rule.php
@@ -258,7 +258,7 @@ class Rule extends DbTestCase
         $this->integer($rule->maxActionsCount())->isIdenticalTo(1);
 
         $rule = new \RuleTicket();
-        $this->integer($rule->maxActionsCount())->isIdenticalTo(35);
+        $this->integer($rule->maxActionsCount())->isIdenticalTo(39);
 
         $rule = new \RuleDictionnarySoftware();
         $this->integer($rule->maxActionsCount())->isIdenticalTo(4);

--- a/tests/functionnal/RuleCommonITILObject.php
+++ b/tests/functionnal/RuleCommonITILObject.php
@@ -2164,9 +2164,9 @@ abstract class RuleCommonITILObject extends DbTestCase
             ],
             'action' => [
                 'action_type' => 'regex_result',
-                'field'       => 'itilcategories_id_by_completename',
+                'field'       => '_itilcategories_id_by_completename',
                 'field_specific' => function ($ticket) {
-                    // Can't read 'itilcategories_id_by_completename' from group field, need
+                    // Can't read '_itilcategories_id_by_completename' from group field, need
                     // to fetch it from the Ticket table
                     return $ticket->fields['itilcategories_id'];
                 },

--- a/tests/functionnal/RuleCommonITILObject.php
+++ b/tests/functionnal/RuleCommonITILObject.php
@@ -2144,6 +2144,34 @@ abstract class RuleCommonITILObject extends DbTestCase
      */
     protected function testActionProvider(): Generator
     {
+
+        // Test 'regex_result' action on the ticket category completename
+        $root_category = $this->createItem(ITILCategory::getType(), [
+            'name' => 'Category root'
+        ]);
+
+        // Test 'regex_result' action on the ticket category
+        $sub_root_category = $this->createItem(ITILCategory::getType(), [
+            'name' => 'Category sub',
+            'itilcategories_id' => $root_category->fields['id']
+        ]);
+
+        yield [
+            'criteria' => [
+                'condition' => Rule::REGEX_MATCH,
+                'field'     => 'name',
+                'pattern'   => '/(.*)/',
+            ],
+            'action' => [
+                'action_type' => 'regex_result',
+                'field'       => 'itilcategories_id_by_completename',
+                'value'       => '#0'
+            ],
+            'control_test_value' => 'Test_title_no_match',
+            'real_test_value'    => 'Category root > Category sub',
+            'expected_value'     => $sub_root_category->fields['id'],
+        ];
+
         // Test 'regex_result' action on the ticket category
         $category = $this->createItem(ITILCategory::getType(), [
             'name' => 'Category from regex'
@@ -2162,6 +2190,45 @@ abstract class RuleCommonITILObject extends DbTestCase
             'control_test_value' => 'Test_title_no_match',
             'real_test_value'    => 'Category from regex',
             'expected_value'     => $category->fields['id'],
+        ];
+
+        // Test 'regex_result' action on the ticket requester group by completename
+        $root_requester_group_completename = $this->createItem(Group::getType(), [
+            'name' => 'Requester group root'
+        ]);
+
+        $sub_requester_group_completename = $this->createItem(Group::getType(), [
+            'name' => 'Requester group sub',
+            'groups_id' => $root_requester_group_completename->fields['id'],
+        ]);
+
+        yield [
+            'criteria' => [
+                'condition' => Rule::REGEX_MATCH,
+                'field'     => 'name',
+                'pattern'   => '/(.*)/',
+            ],
+            'action' => [
+                'action_type'    => 'regex_result',
+                'field'          => '_groups_id_requester_by_completename',
+                'value'          => '#0',
+                'field_specific' => function ($ticket) {
+                    // Can't read '_groups_id_requester' from group field, need
+                    // to fetch it from the Group_Ticket table
+                    $groups = (new Group_Ticket())->find([
+                        'type' => CommonITILActor::REQUESTER,
+                        'tickets_id' => $ticket->fields['id'],
+                    ]);
+                    if (count($groups) == 1) {
+                        return array_pop($groups)['groups_id'];
+                    } else {
+                        return 0;
+                    }
+                }
+            ],
+            'control_test_value' => 'Test_title_no_match',
+            'real_test_value'    => 'Requester group root > Requester group sub',
+            'expected_value'     => $sub_requester_group_completename->fields['id'],
         ];
 
         // Test 'regex_result' action on the ticket requester group
@@ -2197,6 +2264,47 @@ abstract class RuleCommonITILObject extends DbTestCase
             'expected_value'     => $requester_group->fields['id'],
         ];
 
+
+        // Test 'regex_result' action on the ticket observer group by completename
+        $root_observer_group_completename = $this->createItem(Group::getType(), [
+            'name' => 'Observer group root'
+        ]);
+
+        $sub_observer_group_completename = $this->createItem(Group::getType(), [
+            'name' => 'Observer group sub',
+            'groups_id' => $root_observer_group_completename->fields['id'],
+        ]);
+
+        yield [
+            'criteria' => [
+                'condition' => Rule::REGEX_MATCH,
+                'field'     => 'name',
+                'pattern'   => '/(.*)/',
+            ],
+            'action' => [
+                'action_type'    => 'regex_result',
+                'field'          => '_groups_id_observer_by_completename',
+                'value'          => '#0',
+                'field_specific' => function ($ticket) {
+                    // Can't read '_groups_id_observer' from group field, need
+                    // to fetch it from the Group_Ticket table
+                    $groups = (new Group_Ticket())->find([
+                        'type' => CommonITILActor::OBSERVER,
+                        'tickets_id' => $ticket->fields['id'],
+                    ]);
+                    if (count($groups) == 1) {
+                        return array_pop($groups)['groups_id'];
+                    } else {
+                        return 0;
+                    }
+                }
+            ],
+            'control_test_value' => 'Test_title_no_match',
+            'real_test_value'    => 'Observer group root > Observer group sub',
+            'expected_value'     => $sub_observer_group_completename->fields['id'],
+        ];
+
+
         // Test 'regex_result' action on the ticket observer group
         $observer_group = $this->createItem(Group::getType(), [
             'name' => 'Observer group from regex'
@@ -2228,6 +2336,45 @@ abstract class RuleCommonITILObject extends DbTestCase
             'control_test_value' => 'Test_title_no_match',
             'real_test_value'    => 'Observer group from regex',
             'expected_value'     => $observer_group->fields['id'],
+        ];
+
+        // Test 'regex_result' action on the ticket observer group by completename
+        $root_assign_group_completename = $this->createItem(Group::getType(), [
+            'name' => 'Observer group root'
+        ]);
+
+        $sub_assign_group_completename = $this->createItem(Group::getType(), [
+            'name' => 'Observer group sub',
+            'groups_id' => $root_assign_group_completename->fields['id'],
+        ]);
+
+        yield [
+            'criteria' => [
+                'condition' => Rule::REGEX_MATCH,
+                'field'     => 'name',
+                'pattern'   => '/(.*)/',
+            ],
+            'action' => [
+                'action_type'    => 'regex_result',
+                'field'          => '_groups_id_assign_by_completename',
+                'value'          => '#0',
+                'field_specific' => function ($ticket) {
+                    // Can't read '_groups_id_assign' from group field, need
+                    // to fetch it from the Group_Ticket table
+                    $groups = (new Group_Ticket())->find([
+                        'type' => CommonITILActor::ASSIGN,
+                        'tickets_id' => $ticket->fields['id'],
+                    ]);
+                    if (count($groups) == 1) {
+                        return array_pop($groups)['groups_id'];
+                    } else {
+                        return 0;
+                    }
+                }
+            ],
+            'control_test_value' => 'Test_title_no_match',
+            'real_test_value'    => 'Observer group root > Observer group sub',
+            'expected_value'     => $sub_assign_group_completename->fields['id'],
         ];
 
         // Test 'regex_result' action on the ticket assigned group

--- a/tests/functionnal/RuleCommonITILObject.php
+++ b/tests/functionnal/RuleCommonITILObject.php
@@ -2345,11 +2345,11 @@ abstract class RuleCommonITILObject extends DbTestCase
 
         // Test 'regex_result' action on the ticket observer group by completename
         $root_assign_group_completename = $this->createItem(Group::getType(), [
-            'name' => 'Observer group root'
+            'name' => 'Assign group root'
         ]);
 
         $sub_assign_group_completename = $this->createItem(Group::getType(), [
-            'name' => 'Observer group sub',
+            'name' => 'Assign group sub',
             'groups_id' => $root_assign_group_completename->fields['id'],
         ]);
 
@@ -2378,7 +2378,7 @@ abstract class RuleCommonITILObject extends DbTestCase
                 }
             ],
             'control_test_value' => 'Test_title_no_match',
-            'real_test_value'    => 'Observer group root > Observer group sub',
+            'real_test_value'    => 'Assign group root > Assign group sub',
             'expected_value'     => $sub_assign_group_completename->fields['id'],
         ];
 

--- a/tests/functionnal/RuleCommonITILObject.php
+++ b/tests/functionnal/RuleCommonITILObject.php
@@ -2156,6 +2156,8 @@ abstract class RuleCommonITILObject extends DbTestCase
             'itilcategories_id' => $root_category->fields['id']
         ]);
 
+        $this->string($sub_root_category->fields['completename'])->isEqualTo("Category root > Category sub");
+
         yield [
             'criteria' => [
                 'condition' => Rule::REGEX_MATCH,
@@ -2206,6 +2208,8 @@ abstract class RuleCommonITILObject extends DbTestCase
             'name' => 'Requester group sub',
             'groups_id' => $root_requester_group_completename->fields['id'],
         ]);
+
+        $this->string($sub_requester_group_completename->fields['completename'])->isEqualTo("Requester group root > Requester group sub");
 
         yield [
             'criteria' => [
@@ -2280,6 +2284,8 @@ abstract class RuleCommonITILObject extends DbTestCase
             'groups_id' => $root_observer_group_completename->fields['id'],
         ]);
 
+        $this->string($sub_observer_group_completename->fields['completename'])->isEqualTo("Observer group root > Observer group sub");
+
         yield [
             'criteria' => [
                 'condition' => Rule::REGEX_MATCH,
@@ -2352,6 +2358,8 @@ abstract class RuleCommonITILObject extends DbTestCase
             'name' => 'Observer group sub',
             'groups_id' => $root_assign_group_completename->fields['id'],
         ]);
+
+        $this->string($sub_assign_group_completename->fields['completename'])->isEqualTo("Observer group root > Observer group sub");
 
         yield [
             'criteria' => [

--- a/tests/functionnal/RuleCommonITILObject.php
+++ b/tests/functionnal/RuleCommonITILObject.php
@@ -2165,6 +2165,11 @@ abstract class RuleCommonITILObject extends DbTestCase
             'action' => [
                 'action_type' => 'regex_result',
                 'field'       => 'itilcategories_id_by_completename',
+                'field_specific' => function ($ticket) {
+                    // Can't read 'itilcategories_id_by_completename' from group field, need
+                    // to fetch it from the Ticket table
+                    return $ticket->fields['itilcategories_id'];
+                },
                 'value'       => '#0'
             ],
             'control_test_value' => 'Test_title_no_match',

--- a/tests/functionnal/RuleCommonITILObject.php
+++ b/tests/functionnal/RuleCommonITILObject.php
@@ -2156,8 +2156,6 @@ abstract class RuleCommonITILObject extends DbTestCase
             'itilcategories_id' => $root_category->fields['id']
         ]);
 
-        $this->string($sub_root_category->fields['completename'])->isEqualTo("Category root > Category sub");
-
         yield [
             'criteria' => [
                 'condition' => Rule::REGEX_MATCH,
@@ -2208,8 +2206,6 @@ abstract class RuleCommonITILObject extends DbTestCase
             'name' => 'Requester group sub',
             'groups_id' => $root_requester_group_completename->fields['id'],
         ]);
-
-        $this->string($sub_requester_group_completename->fields['completename'])->isEqualTo("Requester group root > Requester group sub");
 
         yield [
             'criteria' => [
@@ -2284,8 +2280,6 @@ abstract class RuleCommonITILObject extends DbTestCase
             'groups_id' => $root_observer_group_completename->fields['id'],
         ]);
 
-        $this->string($sub_observer_group_completename->fields['completename'])->isEqualTo("Observer group root > Observer group sub");
-
         yield [
             'criteria' => [
                 'condition' => Rule::REGEX_MATCH,
@@ -2358,8 +2352,6 @@ abstract class RuleCommonITILObject extends DbTestCase
             'name' => 'Observer group sub',
             'groups_id' => $root_assign_group_completename->fields['id'],
         ]);
-
-        $this->string($sub_assign_group_completename->fields['completename'])->isEqualTo("Observer group root > Observer group sub");
 
         yield [
             'criteria' => [


### PR DESCRIPTION
Add action to match on ```completename``` for :

- ```category```
- ```group assign```
- ```group observer```
- ```group requester```


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23131
