### PR TITLE
CommonITIL: fix restore input on failed submission

### DIFF
--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -854,6 +854,27 @@ class CommonGLPI implements CommonGLPIInterface
             }
         }
 
+        // In GLPI 9.5 $options was empty when reloading a ticket after a
+        // failed submition due to mising mandatory fields
+        // In GLPI 10.0, $options contains a single `id => 0` content for the
+        // same action
+        // This means the `count($options)` check below is true
+        //   -> which trigger input saving
+        //   -> which mean that the user submtted data is overriden.
+        // We must empty `$options['id']` in this specific case to avoid losing
+        // user submitted data
+        // TODO - This is a temporary solution - the backend should be improved
+        // to be more rebust and differenciate form reload on data change
+        // (category, requester, ...) and failed submission in a better way that
+        // checking whether or not $options is empty.
+        // See:
+        //  - https://github.com/glpi-project/glpi/pull/12929
+        //  - https://github.com/glpi-project/glpi/pull/13101
+        //  - https://github.com/glpi-project/glpi/commit/1d27bf14d4527f748876dcd556f2b995a0bf7684
+        if (isset($options['id']) && $this->isNewID($options['id'])) {
+            unset($options['id']);
+        }
+
         $target         = $_SERVER['PHP_SELF'];
         $extraparamhtml = "";
         $withtemplate   = "";

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -860,7 +860,7 @@ class CommonGLPI implements CommonGLPIInterface
         // same action
         // This means the `count($options)` check below is true
         //   -> which trigger input saving
-        //   -> which mean that the user submtted data is overriden.
+        //   -> which mean that the user submitted data is overridden.
         // We must empty `$options['id']` in this specific case to avoid losing
         // user submitted data
         // TODO - This is a temporary solution - the backend should be improved

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -854,41 +854,29 @@ class CommonGLPI implements CommonGLPIInterface
             }
         }
 
-        // In GLPI 9.5 $options was empty when reloading a ticket after a
-        // failed submition due to mising mandatory fields
-        // In GLPI 10.0, $options contains a single `id => 0` content for the
-        // same action
-        // This means the `count($options)` check below is true
-        //   -> which trigger input saving
-        //   -> which mean that the user submitted data is overridden.
-        // We must empty `$options['id']` in this specific case to avoid losing
-        // user submitted data
-        // TODO - This is a temporary solution - the backend should be improved
-        // to be more rebust and differenciate form reload on data change
-        // (category, requester, ...) and failed submission in a better way that
-        // checking whether or not $options is empty.
-        // See:
-        //  - https://github.com/glpi-project/glpi/pull/12929
-        //  - https://github.com/glpi-project/glpi/pull/13101
-        //  - https://github.com/glpi-project/glpi/commit/1d27bf14d4527f748876dcd556f2b995a0bf7684
-        if (isset($options['id']) && $this->isNewID($options['id'])) {
-            unset($options['id']);
+        $cleaned_options = $options;
+        if (isset($cleaned_options['id'])) {
+            unset($cleaned_options['id']);
+        }
+        if (isset($cleaned_options['stock_image'])) {
+            unset($cleaned_options['stock_image']);
         }
 
         $target         = $_SERVER['PHP_SELF'];
         $extraparamhtml = "";
         $withtemplate   = "";
-        if (is_array($options) && count($options)) {
+
+        // TODO - There should be a better option than checking whether or not
+        // $options is empty.
+        // See:
+        //  - https://github.com/glpi-project/glpi/pull/12929
+        //  - https://github.com/glpi-project/glpi/pull/13101
+        //  - https://github.com/glpi-project/glpi/commit/1d27bf14d4527f748876dcd556f2b995a0bf7684
+        if (is_array($cleaned_options) && count($cleaned_options)) {
             if (isset($options['withtemplate'])) {
                 $withtemplate = $options['withtemplate'];
             }
-            $cleaned_options = $options;
-            if (isset($cleaned_options['id'])) {
-                unset($cleaned_options['id']);
-            }
-            if (isset($cleaned_options['stock_image'])) {
-                unset($cleaned_options['stock_image']);
-            }
+
             if ($this instanceof CommonITILObject && $this->isNewItem()) {
                 $this->input = $cleaned_options;
                 $this->saveInput();

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -855,12 +855,7 @@ class CommonGLPI implements CommonGLPIInterface
         }
 
         $cleaned_options = $options;
-        if (isset($cleaned_options['id'])) {
-            unset($cleaned_options['id']);
-        }
-        if (isset($cleaned_options['stock_image'])) {
-            unset($cleaned_options['stock_image']);
-        }
+        unset($cleaned_options['id'], $cleaned_options['stock_image']);
 
         $target         = $_SERVER['PHP_SELF'];
         $extraparamhtml = "";


### PR DESCRIPTION
When a ticket submission fails (e.g. missing mandatory fields), the user submitted data is lost (ticket title, description, ...).

![image](https://user-images.githubusercontent.com/42734840/201681217-ceb3fc80-10ca-483a-a82f-64473db9bc53.png)

I've found that this is due to a code change from GLPI 9.5 to GLPI 10.0.
The ticket form may be reloaded from different actions:
- Failed submission (missing mandatory fields)
- Important data change (entity, category, requester, ...)

The backend handle the saved input differently for these two cases and thus must be able to differentiate them.
To do this, it rely on `$options`:
- Failed submission -> `$option` will be empty
- Data change -> `$options` will contain the form data written by the user

With this in mind, the backend only need to check if  `$option` is empty to do the right decision.

This was broken in GLPI 10 because `$options` is no longer empty in case of a failed submission:
```
[2022-11-14 14:19:21] glpiphplog.DEBUG: CommonGLPI::showTabsContent() in /home/aclai/localhost/glpi/10.0-bugfixes/src/CommonGLPI.php line 846
Array
  (
      [id] => 0
  )
``` 

To fix this, I've emptied `$options['id']` in this specific case.

![image](https://user-images.githubusercontent.com/42734840/201681091-8b9c0db5-d780-4186-ac78-377ce516bdf3.png)


Obviously  relying on an empty `$options` is not reliable.
A better fix would be to rework the backend to not longer "guess" which action was taken but rather get a specific instruction from the front.

I've seen that a first attempt was done here but was later reverted: #12929 
Maybe something to add to GLPI 10.1 roadmap if it's not already done ?


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25540
