### PR TITLE
Remove notification deduplication logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The present file will list all changes made to the project; according to the
 - `Symfony` libraries have been upgraded to version 6.0.
 - `users_id_validate` field in `CommonITILValidation` will now have a `0` value until someone approves or refuses the validation.
   Approval targets (who the approval is for) is now indicated by `itemtype_target` and `items_id_target` fields.
+- Notifications are not deduplicated anymore.
 - Notifications with `Approver` recipient have had this recipient replaced with the new `Approval target` recipient to maintain previous behavior as much as possible.
   The previous recipient option still exists if needed. This replacement will only happen once during the upgrade.
 - `GLPIMailer` mailer class does not extends anymore `PHPMailer\PHPMailer\PHPMailer`.
@@ -81,6 +82,7 @@ The present file will list all changes made to the project; according to the
 
 #### Removed
 - Usage of `csrf_compliant` plugins hook.
+- `CommonDBTM::$deduplicate_queued_notifications` property.
 - `Glpi\Dashboard\Widget::getCssGradientPalette()`
 - `Search::computeTitle()`
 - `Search::csv_clean()`

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -169,15 +169,6 @@ class CommonDBTM extends CommonGLPI
     protected $usenotepad = false;
 
     /**
-     * Flag to determine whether or not queued notifications should be deduplicated.
-     * Deduplication is done when a new notification is raised.
-     * Any existing notification for same object, event and recipient is dropped to be replaced by the new one.
-     *
-     * @var boolean
-     */
-    public $deduplicate_queued_notifications = true;
-
-    /**
      * Computed/forced values of classes tables.
      * @var string[]
      */

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -64,8 +64,6 @@ abstract class CommonITILObject extends CommonDBTM
    /// Use user entity to select entity of the object
     protected $userentity_oncreate = false;
 
-    public $deduplicate_queued_notifications = false;
-
     protected static $showTitleInNavigationHeader = true;
 
     const MATRIX_FIELD         = '';

--- a/src/QueuedNotification.php
+++ b/src/QueuedNotification.php
@@ -168,33 +168,6 @@ class QueuedNotification extends CommonDBTM
             $input['items_id'] = 0;
         }
 
-       // Drop existing mails in queue for the same event and item  and recipient
-        $item = isset($input['itemtype']) ? getItemForItemtype($input['itemtype']) : false;
-        if (
-            $item instanceof CommonDBTM && $item->deduplicate_queued_notifications
-            && isset($input['entities_id']) && ($input['entities_id'] >= 0)
-            && isset($input['items_id']) && ($input['items_id'] >= 0)
-            && isset($input['notificationtemplates_id']) && !empty($input['notificationtemplates_id'])
-            && isset($input['recipient'])
-        ) {
-            $criteria = [
-                'FROM'   => $this->getTable(),
-                'WHERE'  => [
-                    'is_deleted'   => 0,
-                    'itemtype'     => $input['itemtype'],
-                    'items_id'     => $input['items_id'],
-                    'entities_id'  => $input['entities_id'],
-                    'notificationtemplates_id' => $input['notificationtemplates_id'],
-                    'recipient'                => $input['recipient']
-
-                ]
-            ];
-            $iterator = $DB->request($criteria);
-            foreach ($iterator as $data) {
-                $this->delete(['id' => $data['id']], 1);
-            }
-        }
-
         return $input;
     }
 

--- a/tests/functionnal/QueuedNotification.php
+++ b/tests/functionnal/QueuedNotification.php
@@ -41,7 +41,7 @@ use Project;
 
 class QueuedNotification extends DbTestCase
 {
-    public function testAddNotificationWithDeduplication()
+    public function testAddProjectNotification()
     {
         $queued_notification = new \QueuedNotification();
 
@@ -55,7 +55,7 @@ class QueuedNotification extends DbTestCase
         $project_id_2 = $project->add(['name' => 'Test project 2', 'entities_id' => $root_entity_id]);
         $this->integer($project_id_2)->isGreaterThan(0);
 
-       // First notification
+        // First notification
         $queued_id_1 = $queued_notification->add(
             [
                 'itemtype'                 => 'Project',
@@ -72,7 +72,7 @@ class QueuedNotification extends DbTestCase
         $this->integer($queued_id_1)->isGreaterThan(0);
         $this->boolean($queued_notification->getFromDB($queued_id_1))->isTrue();
 
-       // Notification with same item and recipient, should trigger previous notification deletion
+        // Notification with same item and recipient, should not trigger previous notification deletion
         $queued_id_2 = $queued_notification->add(
             [
                 'itemtype'                 => 'Project',
@@ -88,10 +88,10 @@ class QueuedNotification extends DbTestCase
         );
         $this->integer($queued_id_2)->isGreaterThan(0);
         $this->boolean($queued_notification->getFromDB($queued_id_2))->isTrue();
-       // Previous notifications have been removed
-        $this->boolean($queued_notification->getFromDB($queued_id_1))->isFalse();
+        // Previous notifications have not been removed
+        $this->boolean($queued_notification->getFromDB($queued_id_1))->isTrue();
 
-       // Notification with different recipient, should not trigger previous notification deletion
+        // Notification with different recipient, should not trigger previous notification deletion
         $queued_id_3 = $queued_notification->add(
             [
                 'itemtype'                 => 'Project',
@@ -107,10 +107,11 @@ class QueuedNotification extends DbTestCase
         );
         $this->integer($queued_id_2)->isGreaterThan(0);
         $this->boolean($queued_notification->getFromDB($queued_id_3))->isTrue();
-       // Previous notifications have not been removed
+        // Previous notifications have not been removed
         $this->boolean($queued_notification->getFromDB($queued_id_2))->isTrue();
+        $this->boolean($queued_notification->getFromDB($queued_id_1))->isTrue();
 
-       // Notification with different item, should not trigger previous notification deletion
+        // Notification with different item, should not trigger previous notification deletion
         $this->integer($project_id_1)->isGreaterThan(0);
         $queued_id_4 = $queued_notification->add(
             [
@@ -127,12 +128,13 @@ class QueuedNotification extends DbTestCase
         );
         $this->integer($queued_id_2)->isGreaterThan(0);
         $this->boolean($queued_notification->getFromDB($queued_id_4))->isTrue();
-       // Previous notifications have not been removed
+        // Previous notifications have not been removed
         $this->boolean($queued_notification->getFromDB($queued_id_3))->isTrue();
         $this->boolean($queued_notification->getFromDB($queued_id_2))->isTrue();
+        $this->boolean($queued_notification->getFromDB($queued_id_1))->isTrue();
     }
 
-    public function testAddNotificationWithoutDeduplication()
+    public function testAddTicketNotification()
     {
         $queued_notification = new \QueuedNotification();
 
@@ -146,7 +148,7 @@ class QueuedNotification extends DbTestCase
         $ticket_id_2 = $ticket->add(['name' => 'Test ticket 2', 'entities_id' => $root_entity_id]);
         $this->integer($ticket_id_2)->isGreaterThan(0);
 
-       // First notification
+        // First notification
         $queued_id_1 = $queued_notification->add(
             [
                 'itemtype'                 => 'Ticket',
@@ -163,7 +165,7 @@ class QueuedNotification extends DbTestCase
         $this->integer($queued_id_1)->isGreaterThan(0);
         $this->boolean($queued_notification->getFromDB($queued_id_1))->isTrue();
 
-       // Notification with same item and recipient, should trigger previous notification deletion
+        // Notification with same item and recipient, should not trigger previous notification deletion
         $queued_id_2 = $queued_notification->add(
             [
                 'itemtype'                 => 'Ticket',
@@ -179,10 +181,10 @@ class QueuedNotification extends DbTestCase
         );
         $this->integer($queued_id_2)->isGreaterThan(0);
         $this->boolean($queued_notification->getFromDB($queued_id_2))->isTrue();
-       // Previous notifications have not been removed
+        // Previous notifications have not been removed
         $this->boolean($queued_notification->getFromDB($queued_id_1))->isTrue();
 
-       // Notification with different recipient, should not trigger previous notification deletion
+        // Notification with different recipient, should not trigger previous notification deletion
         $queued_id_3 = $queued_notification->add(
             [
                 'itemtype'                 => 'Ticket',
@@ -198,11 +200,11 @@ class QueuedNotification extends DbTestCase
         );
         $this->integer($queued_id_2)->isGreaterThan(0);
         $this->boolean($queued_notification->getFromDB($queued_id_3))->isTrue();
-       // Previous notifications have not been removed
+        // Previous notifications have not been removed
         $this->boolean($queued_notification->getFromDB($queued_id_2))->isTrue();
         $this->boolean($queued_notification->getFromDB($queued_id_1))->isTrue();
 
-       // Notification with different item, should not trigger previous notification deletion
+        // Notification with different item, should not trigger previous notification deletion
         $this->integer($ticket_id_1)->isGreaterThan(0);
         $queued_id_4 = $queued_notification->add(
             [
@@ -219,7 +221,7 @@ class QueuedNotification extends DbTestCase
         );
         $this->integer($queued_id_2)->isGreaterThan(0);
         $this->boolean($queued_notification->getFromDB($queued_id_4))->isTrue();
-       // Previous notifications have not been removed
+        // Previous notifications have not been removed
         $this->boolean($queued_notification->getFromDB($queued_id_3))->isTrue();
         $this->boolean($queued_notification->getFromDB($queued_id_2))->isTrue();
         $this->boolean($queued_notification->getFromDB($queued_id_1))->isTrue();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Every queued notification has probably a distinct content, even when it is related to same item/action/recipient than another queued notification. Deduplication logic could can lead to the loss of important information, and this is the reason it has been disabled a long time ago on Ticket items.
For the same reason, I think that notification deduplication logic should disabled on all items.