### PR TITLE
Search notification by 'Allow response' field

### DIFF
--- a/src/Notification.php
+++ b/src/Notification.php
@@ -462,6 +462,14 @@ class Notification extends CommonDBTM
             'datatype'           => 'bool'
         ];
 
+        $tab[] = [
+            'id'                 => '87',
+            'table'              => $this->getTable(),
+            'field'              => 'allow_response',
+            'name'               => __('Allow response'),
+            'datatype'           => 'bool'
+         ];
+
         return $tab;
     }
 

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -468,7 +468,7 @@ class Notification extends CommonDBTM
             'field'              => 'allow_response',
             'name'               => __('Allow response'),
             'datatype'           => 'bool'
-         ];
+        ];
 
         return $tab;
     }


### PR DESCRIPTION
The 'Allow response' field was added in GLPI 9.5 but the relevant search option was missing.
Having this search option is useful as it allow to edit it through massive actions.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
