### PR TITLE
fix(RuleLocation): correctly handle regex case

### DIFF
--- a/src/RuleLocation.php
+++ b/src/RuleLocation.php
@@ -65,7 +65,7 @@ class RuleLocation extends Rule
                                     $action->fields["value"],
                                     $regex_result
                                 );
-                                $compute_entities_id = $input['entities_id'] ?? -1;
+                                $compute_entities_id = $input['entities_id'] ?? 0;
                                 $location = new Location();
                                 $output['locations_id'] = $location->importExternal($regexvalue, $compute_entities_id);
                             }

--- a/src/RuleLocation.php
+++ b/src/RuleLocation.php
@@ -50,6 +50,32 @@ class RuleLocation extends Rule
         return 2;
     }
 
+    public function executeActions($output, $params, array $input = [])
+    {
+        if (count($this->actions)) {
+            foreach ($this->actions as $action) {
+                switch ($action->fields["action_type"]) {
+                    case "assign":
+                        $output[$action->fields["field"]] = $action->fields["value"];
+                        break;
+                    case 'regex_result':
+                        if ($action->fields["field"] == "locations_id") {
+                            foreach ($this->regex_results as $regex_result) {
+                                $regexvalue          = RuleAction::getRegexResultById(
+                                    $action->fields["value"],
+                                    $regex_result
+                                );
+                                $compute_entities_id = $input['entities_id'] ?? -1;
+                                $location = new Location();
+                                $output['locations_id'] = $location->importExternal($regexvalue, $compute_entities_id);
+                            }
+                        }
+                        break;
+                }
+            }
+        }
+        return $output;
+    }
 
     public function getCriterias()
     {

--- a/src/RuleLocation.php
+++ b/src/RuleLocation.php
@@ -52,26 +52,24 @@ class RuleLocation extends Rule
 
     public function executeActions($output, $params, array $input = [])
     {
-        if (count($this->actions)) {
-            foreach ($this->actions as $action) {
-                switch ($action->fields["action_type"]) {
-                    case "assign":
-                        $output[$action->fields["field"]] = $action->fields["value"];
-                        break;
-                    case 'regex_result':
-                        if ($action->fields["field"] == "locations_id") {
-                            foreach ($this->regex_results as $regex_result) {
-                                $regexvalue          = RuleAction::getRegexResultById(
-                                    $action->fields["value"],
-                                    $regex_result
-                                );
-                                $compute_entities_id = $input['entities_id'] ?? 0;
-                                $location = new Location();
-                                $output['locations_id'] = $location->importExternal($regexvalue, $compute_entities_id);
-                            }
+        foreach ($this->actions as $action) {
+            switch ($action->fields["action_type"]) {
+                case "assign":
+                    $output[$action->fields["field"]] = $action->fields["value"];
+                    break;
+                case 'regex_result':
+                    if ($action->fields["field"] == "locations_id") {
+                        foreach ($this->regex_results as $regex_result) {
+                            $regexvalue          = RuleAction::getRegexResultById(
+                                $action->fields["value"],
+                                $regex_result
+                            );
+                            $compute_entities_id = $input['entities_id'] ?? 0;
+                            $location = new Location();
+                            $output['locations_id'] = $location->importExternal($regexvalue, $compute_entities_id);
                         }
-                        break;
-                }
+                    }
+                    break;
             }
         }
         return $output;

--- a/tests/functionnal/RuleLocation.php
+++ b/tests/functionnal/RuleLocation.php
@@ -108,6 +108,74 @@ class RuleLocation extends DbTestCase
         $this->array($location_data)->isEqualTo($expected);
     }
 
+    public function testActionRegex()
+    {
+        $this->login();
+
+        $location = new \Location();
+        $locations_id = $location->add([
+            'name' => 'Location 1',
+        ]);
+        $this->integer($locations_id)->isGreaterThan(0);
+
+        $rule = new \Rule();
+        $input = [
+            'is_active' => 1,
+            'name'      => 'location rule 1',
+            'match'     => 'AND',
+            'sub_type'  => 'RuleLocation',
+            'ranking'   => 1
+        ];
+        $rules_id = $rule->add($input);
+        $this->integer($rules_id)->isGreaterThan(0);
+
+        $rulecriteria = new \RuleCriteria();
+        $input = [
+            'rules_id'  => $rules_id,
+            'criteria'  => "tag",
+            'pattern'   => " /(.*)/",
+            'condition' => \RuleImportEntity::REGEX_MATCH
+        ];
+        $this->integer($rulecriteria->add($input))->isGreaterThan(0);
+
+        $ruleaction = new \RuleAction();
+        $input = [
+            'rules_id'    => $rules_id,
+            'action_type' => 'regex_result',
+            'field'       => 'locations_id',
+            'value'       => '#0'
+        ];
+        $this->integer($ruleaction->add($input))->isGreaterThan(0);
+
+        //test with existing location
+        $input = [
+            'tag' => 'Location 1',
+        ];
+
+        $ruleLocation = new \RuleLocationCollection();
+        $ruleLocation->getCollectionPart();
+        $location_data = $ruleLocation->processAllRules($input, []);
+
+        $expected = [
+            'locations_id' => $locations_id,
+            '_ruleid'      => $rules_id
+        ];
+        $this->array($location_data)->isEqualTo($expected);
+
+        //test with non existing location
+        $input = [
+            'tag' => 'testtag2',
+        ];
+        $location_data = $ruleLocation->processAllRules($input, []);
+
+
+        $this->array($location_data)->hasKey('locations_id');
+        $this->integer((integer) $location_data['locations_id'])->isGreaterThan(0);
+        $this->integer((integer) $location_data['locations_id'])->isNotEqualTo($locations_id);
+        $this->array($location_data)->hasKey('_ruleid');
+        $this->integer((integer) $location_data['_ruleid'])->isGreaterThan(0);
+    }
+
 
     public function testIPCIDR()
     {

--- a/tests/functionnal/RuleLocation.php
+++ b/tests/functionnal/RuleLocation.php
@@ -170,10 +170,10 @@ class RuleLocation extends DbTestCase
 
 
         $this->array($location_data)->hasKey('locations_id');
-        $this->integer((integer) $location_data['locations_id'])->isGreaterThan(0);
-        $this->integer((integer) $location_data['locations_id'])->isNotEqualTo($locations_id);
+        $this->integer((int)$location_data['locations_id'])->isGreaterThan(0);
+        $this->integer((int)$location_data['locations_id'])->isNotEqualTo($locations_id);
         $this->array($location_data)->hasKey('_ruleid');
-        $this->integer((integer) $location_data['_ruleid'])->isGreaterThan(0);
+        $this->integer((int)$location_data['_ruleid'])->isGreaterThan(0);
     }
 
 


### PR DESCRIPTION
Correctly handle ```regex_result``` case from ```RuleLocation```

Prevent SQL error 

```
[2022-11-16 10:20:01] glpisqllog.ERROR: DBmysql::query() in /home/stanislas/DEV/GLPI/10.0-bugfixes/src/DBmysql.php line 370
  *** MySQL query error:
  SQL: UPDATE `glpi_computers` SET `locations_id` = 'sub' WHERE `id` = '2'
  Error: Incorrect integer value: 'sub' for column `10bugfixes_ruless`.`glpi_computers`.`locations_id` at row 1
  Backtrace :
  src/DBmysql.php:1439                               
  src/CommonDBTM.php:675                             DBmysql->update()
  src/CommonDBTM.php:1678                            CommonDBTM->updateInDB()
  src/Inventory/Asset/MainAsset.php:781              CommonDBTM->update()
  src/RuleImportAsset.php:950                        Glpi\Inventory\Asset\MainAsset->rulepassed()
  src/Rule.php:1522                                  RuleImportAsset->executeActions()
  src/RuleCollection.php:1591                        Rule->process()
  src/Inventory/Asset/MainAsset.php:566              RuleCollection->processAllRules()
  src/Inventory/Inventory.php:706                    Glpi\Inventory\Asset\MainAsset->handle()
  src/Inventory/Inventory.php:341                    Glpi\Inventory\Inventory->handleItem()
  src/Inventory/Request.php:360                      Glpi\Inventory\Inventory->doInventory()
  src/Inventory/Request.php:90                       Glpi\Inventory\Request->inventory()
  src/Agent/Communication/AbstractRequest.php:332    Glpi\Inventory\Request->handleAction()
  src/Agent/Communication/AbstractRequest.php:244    Glpi\Agent\Communication\AbstractRequest->handleJSONRequest()
  front/inventory.php:92                             Glpi\Agent\Communication\AbstractRequest->handleRequest()

```


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
