### PR TITLE
feat(lockedfield): prevent locked field from auto update users_id / g…

### DIFF
--- a/src/Computer.php
+++ b/src/Computer.php
@@ -195,6 +195,11 @@ class Computer extends CommonDBTM
         }
 
         if (count($changes)) {
+            //propage is_dynamic value if needed to prevent locked fields
+            if (isset($input['is_dynamic'])) {
+                $changes['is_dynamic'] = $input['is_dynamic'];
+            }
+
             $update_done = false;
 
            // Propagates the changes to linked items

--- a/tests/functionnal/Glpi/Inventory/Assets/Computer.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Computer.php
@@ -192,6 +192,162 @@ class Computer extends AbstractInventoryAsset
         $this->object($result[0])->isEqualTo(json_decode($asset));
     }
 
+
+    public function testAutoUpdate()
+    {
+        global $DB, $CFG_GLPI;
+        $item_monitor = new \Computer_Item();
+
+        $xml =  "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<REQUEST>
+  <CONTENT>
+    <HARDWARE>
+      <NAME>glpixps</NAME>
+      <UUID>25C1BB60-5BCB-11D9-B18F-5404A6A534C4</UUID>
+      <LASTLOGGEDUSER>glpi</LASTLOGGEDUSER>
+    </HARDWARE>
+    <BIOS>
+      <ASSETTAG>SER1234</ASSETTAG>
+      <BDATE>06/02/2016</BDATE>
+      <BMANUFACTURER>Dell Inc.</BMANUFACTURER>
+      <BVERSION>1.4.3</BVERSION>
+      <MMANUFACTURER>Dell Inc.</MMANUFACTURER>
+      <MMODEL>07TYC2</MMODEL>
+      <MSN>/640HP72/CN129636460078/</MSN>
+      <SKUNUMBER>0704</SKUNUMBER>
+      <SMANUFACTURER>Dell Inc.</SMANUFACTURER>
+      <SMODEL>XPS 13 9350</SMODEL>
+      <SSN>640HP72</SSN>
+    </BIOS>
+    <MONITORS>
+          <BASE64>AP///////wBNEEkUAAAAACAZAQSlHRF4Dt5Qo1RMmSYPUFQAAAABAQEBAQEBAQEBAQEBAQEBGjaAoHA4H0AwIDUAJqUQAAAYAAAAEAAAAAAAAAAAAAAAAAAAAAAA/gBESkNQNoBMUTEzM00xAAAAAAACQQMoABIAAAsBCiAgAGY=</BASE64>
+          <CAPTION>DJCP6</CAPTION>
+          <DESCRIPTION>32/2015</DESCRIPTION>
+          <MANUFACTURER>Sharp Corporation</MANUFACTURER>
+          <SERIAL>AFGHHDR0</SERIAL>
+        </MONITORS>
+    <VERSIONCLIENT>FusionInventory-Inventory_v2.4.1-2.fc28</VERSIONCLIENT>
+  </CONTENT>
+  <DEVICEID>glpixps.teclib.infra-2018-10-03-08-42-36</DEVICEID>
+  <QUERY>INVENTORY</QUERY>
+</REQUEST>";
+
+        $converter = new \Glpi\Inventory\Converter();
+        $data = $converter->convert($xml);
+        $json = json_decode($data);
+
+        $this->doInventory($json);
+
+        //check created agent
+        $agents = $DB->request(['FROM' => \Agent::getTable()]);
+        $this->integer(count($agents))->isIdenticalTo(1);
+        $agent = $agents->current();
+        $this->array($agent)
+            ->string['deviceid']->isIdenticalTo('glpixps.teclib.infra-2018-10-03-08-42-36')
+            ->string['itemtype']->isIdenticalTo('Computer');
+
+        //check created computer
+        $computers_id = $agent['items_id'];
+
+        $this->integer($computers_id)->isGreaterThan(0);
+        $computer = new \Computer();
+        $this->boolean($computer->getFromDB($computers_id))->isTrue();
+
+        $this->integer($computer->fields['users_id'])->isGreaterThan(0);
+
+        //one dynamic monitor linked
+        $monitors = $item_monitor->find(['itemtype' => 'Monitor', 'computers_id' => $computers_id, 'is_dynamic' => 1]);
+        $this->integer(count($monitors))->isIdenticalTo(1);
+
+        //load monitor
+        $monitor = new \Monitor();
+        $this->boolean($monitor->getFromDB(reset($monitors)['items_id']))->isTrue();
+        //check same users
+        $this->integer($monitor->fields['users_id'])->isIdenticalTo($computer->fields['users_id']);
+
+        //Enable option to propagate users_id on update to connected element
+        $CFG_GLPI['is_user_autoupdate']     = 1;
+
+        //change user from XML file
+        $xml =  "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+        <REQUEST>
+          <CONTENT>
+            <HARDWARE>
+              <NAME>glpixps</NAME>
+              <UUID>25C1BB60-5BCB-11D9-B18F-5404A6A534C4</UUID>
+              <LASTLOGGEDUSER>tech</LASTLOGGEDUSER>
+            </HARDWARE>
+            <BIOS>
+              <ASSETTAG>SER1234</ASSETTAG>
+              <BDATE>06/02/2016</BDATE>
+              <BMANUFACTURER>Dell Inc.</BMANUFACTURER>
+              <BVERSION>1.4.3</BVERSION>
+              <MMANUFACTURER>Dell Inc.</MMANUFACTURER>
+              <MMODEL>07TYC2</MMODEL>
+              <MSN>/640HP72/CN129636460078/</MSN>
+              <SKUNUMBER>0704</SKUNUMBER>
+              <SMANUFACTURER>Dell Inc.</SMANUFACTURER>
+              <SMODEL>XPS 13 9350</SMODEL>
+              <SSN>640HP72</SSN>
+            </BIOS>
+            <MONITORS>
+                  <BASE64>AP///////wBNEEkUAAAAACAZAQSlHRF4Dt5Qo1RMmSYPUFQAAAABAQEBAQEBAQEBAQEBAQEBGjaAoHA4H0AwIDUAJqUQAAAYAAAAEAAAAAAAAAAAAAAAAAAAAAAA/gBESkNQNoBMUTEzM00xAAAAAAACQQMoABIAAAsBCiAgAGY=</BASE64>
+                  <CAPTION>DJCP6</CAPTION>
+                  <DESCRIPTION>32/2015</DESCRIPTION>
+                  <MANUFACTURER>Sharp Corporation</MANUFACTURER>
+                  <SERIAL>AFGHHDR0</SERIAL>
+                </MONITORS>
+            <VERSIONCLIENT>FusionInventory-Inventory_v2.4.1-2.fc28</VERSIONCLIENT>
+          </CONTENT>
+          <DEVICEID>glpixps.teclib.infra-2018-10-03-08-42-36</DEVICEID>
+          <QUERY>INVENTORY</QUERY>
+        </REQUEST>";
+
+        $converter = new \Glpi\Inventory\Converter();
+        $data = $converter->convert($xml);
+        $json = json_decode($data);
+
+        $this->doInventory($json);
+
+        //check agent
+        $agents = $DB->request(['FROM' => \Agent::getTable()]);
+        $this->integer(count($agents))->isIdenticalTo(1);
+        $agent = $agents->current();
+        $this->array($agent)
+            ->string['deviceid']->isIdenticalTo('glpixps.teclib.infra-2018-10-03-08-42-36')
+            ->string['itemtype']->isIdenticalTo('Computer');
+
+        //check computer
+        $computers_id = $agent['items_id'];
+
+        $this->integer($computers_id)->isGreaterThan(0);
+        $computer = new \Computer();
+        $this->boolean($computer->getFromDB($computers_id))->isTrue();
+
+        $this->integer($computer->fields['users_id'])->isGreaterThan(0);
+
+        //one dynamic monitor linked
+        $monitors = $item_monitor->find(['itemtype' => 'Monitor', 'computers_id' => $computers_id, 'is_dynamic' => 1]);
+        $this->integer(count($monitors))->isIdenticalTo(1);
+
+        //load monitor
+        $monitor = new \Monitor();
+        $monitor_id = reset($monitors)['items_id'];
+        $this->boolean($monitor->getFromDB($monitor_id))->isTrue();
+        //check same users
+        $this->integer($monitor->fields['users_id'])->isIdenticalTo($computer->fields['users_id']);
+
+
+        $locked_field = new \Lockedfield();
+        //no lock from computer
+        $locks = $locked_field->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
+        $this->integer(count($locks))->isIdenticalTo(0);
+
+        //no lock from computer
+        $locks = $locked_field->find(['itemtype' => 'Monitor', 'items_id' => $monitor_id]);
+        $this->integer(count($locks))->isIdenticalTo(0);
+    }
+
     public function testHandle()
     {
         $json_str = file_get_contents(self::INV_FIXTURES . 'computer_1.json');

--- a/tests/functionnal/Glpi/Inventory/Assets/Computer.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Computer.php
@@ -193,7 +193,7 @@ class Computer extends AbstractInventoryAsset
     }
 
 
-    public function testAutoUpdate()
+    public function testAutoUpdateWithoutLockedField()
     {
         global $DB, $CFG_GLPI;
         $item_monitor = new \Computer_Item();


### PR DESCRIPTION
When this options are enabled to copy value to connected item on update. 

![image](https://user-images.githubusercontent.com/7335054/202208080-5a7b2bf7-8d81-4218-aa32-1fcbe7a64848.png)

From inventory context, GLPI add some ```locked field```

this PR prevent this



| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
