### PR TITLE
reduce widgets list to display better vertically

### DIFF
--- a/css/standalone/dashboard.scss
+++ b/css/standalone/dashboard.scss
@@ -1252,6 +1252,8 @@ $break_tablet: 1400px;
 .widgettype_field {
     .widget-list {
         max-width: 400px;
+        display: flex;
+        flex-wrap: wrap;
     }
 
     input[type="radio"].widget-select {
@@ -1266,6 +1268,7 @@ $break_tablet: 1400px;
             display: none;
             text-align: center;
             font-weight: bold;
+            width: 30%;
 
             &:hover {
                 background: rgba($color: #000, $alpha: 10%);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

While fixing #12884 this afternoon, i noticed the widget icons were very big and a scroll was needed to display the palette selection.

So i suggest to reduce a little the list of widgets icons:

**Before:**
![image](https://user-images.githubusercontent.com/418844/202209509-d17044fd-d047-4655-9000-3a908d6f654e.png)


**After:**
![image](https://user-images.githubusercontent.com/418844/202209363-fdf0c522-0616-4601-92c5-de69f5766024.png)

