### PR TITLE
Fix reservation planning display

### DIFF
--- a/js/reservations.js
+++ b/js/reservations.js
@@ -171,6 +171,9 @@ var Reservations = function() {
                     element.find(".fc-title, .fc-list-item-title")
                         .append("&nbsp;<i class='"+extProps.icon+"' title='"+icon_alt+"'></i>");
                 }
+                
+                var reservation_content =  extProps.comment + (extProps.comment ?  " - " : "") + extProps.username;
+                element.find(".fc-content, .fc-list-item-title").append("&nbsp;"+reservation_content);
 
                 // detect ideal position
                 var qtip_position = {
@@ -188,7 +191,7 @@ var Reservations = function() {
 
                 element.qtip({
                     position: qtip_position,
-                    content: extProps.comment,
+                    content: reservation_content,
                     style: {
                         classes: 'qtip-shadow qtip-bootstrap'
                     },

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -554,10 +554,8 @@ JAVASCRIPT;
                 'resourceId'  => $data['itemtype'] . "-" . $data['items_id'],
                 'start'       => $data['begin'],
                 'end'         => $data['end'],
-                'comment'     => $data['comment'] .
-                             $canedit_admin || $my_item
-                              ? "\n" . sprintf(__("Reserved by %s"), $username)
-                              : "",
+                'comment'     => $data['comment'],
+                'username'    => ($canedit_admin || $my_item) ? $username : "",
                 'title'       => $params['reservationitems_id'] ? "" : $name,
                 'icon'        => $item->getIcon(),
                 'description' => $item->getTypeName(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12424

This PR fixes a bug that prevented users with read right to see the comment of a reservation as a tooltip. I also took this opportunity to directly display the comment and username on the calendar and list views
