### PR TITLE
Fix locked field from transfer

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1754,7 +1754,12 @@ class CommonDBTM extends CommonGLPI
      */
     protected function cleanLockeds()
     {
-        if ($this->isDynamic() && (in_array('is_dynamic', $this->updates) || isset($this->input['is_dynamic']) && $this->input['is_dynamic'] == true)) {
+        if (
+            !isset($this->input['_transfer']) //do not managed lock from transfer
+            && $this->isDynamic()
+            && (in_array('is_dynamic', $this->updates) || isset($this->input['is_dynamic'])
+            && $this->input['is_dynamic'] == true)
+        ) {
             $lockedfield = new Lockedfield();
             $locks = $lockedfield->getLockedNames($this->getType(), $this->fields['id']);
             foreach ($locks as $lock) {
@@ -1781,7 +1786,11 @@ class CommonDBTM extends CommonGLPI
         global $DB;
 
         $lockedfield = new Lockedfield();
-        if ($lockedfield->isHandled($this) && (!isset($this->input['is_dynamic']) || $this->input['is_dynamic'] == false)) {
+        if (
+            !isset($this->input['_transfer']) //do not managed lock from transfer
+            && $lockedfield->isHandled($this)
+            && (!isset($this->input['is_dynamic']) || $this->input['is_dynamic'] == false)
+        ) {
             $fields = array_values($this->updates);
             $idx = array_search('date_mod', $fields);
             if ($idx !== false) {

--- a/tests/functionnal/Glpi/Inventory/Assets/Computer.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Computer.php
@@ -811,4 +811,50 @@ class Computer extends AbstractInventoryAsset
         $computer->getFromDB($computers_id);
         $this->integer($computer->fields['entities_id'])->isEqualTo(1);
     }
+
+    public function testTransferWithoutLockedField()
+    {
+        $computer = new \Computer();
+        $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+        <REQUEST>
+        <CONTENT>
+          <HARDWARE>
+            <NAME>glpixps</NAME>
+            <UUID>25C1BB60-5BCB-11D9-B18F-5404A6A534C4</UUID>
+          </HARDWARE>
+          <BIOS>
+            <MSN>640HP72</MSN>
+          </BIOS>
+          <VERSIONCLIENT>FusionInventory-Inventory_v2.4.1-2.fc28</VERSIONCLIENT>
+        </CONTENT>
+        <DEVICEID>glpixps.teclib.infra-2018-10-03-08-42-36</DEVICEID>
+        <QUERY>INVENTORY</QUERY>
+        </REQUEST>";
+
+        $inventory = $this->doInventory($xml_source, true);
+
+        $computers_id = $inventory->getItem()->fields['id'];
+        $this->integer($computers_id)->isGreaterThan(0);
+        //load computer
+        $this->boolean($computer->getFromDB($computers_id))->isTrue();
+        //test entities_id
+        $this->integer($computer->fields['entities_id'])->isEqualTo(0);
+
+        //transer to another entity
+        $doTransfer = \Entity::getUsedConfig('transfers_strategy', $computer->fields['entities_id'], 'transfers_id', 0);
+        $transfer = new \Transfer();
+        $transfer->getFromDB($doTransfer);
+
+        $item_to_transfer = ["Computer" => [$computers_id => $computers_id]];
+        $transfer->moveItems($item_to_transfer, 1, $transfer->fields);
+
+        //reload computer
+        $this->boolean($computer->getFromDB($computers_id))->isTrue();
+        //test entities_id
+        $this->integer($computer->fields['entities_id'])->isEqualTo(1);
+
+        $lockedfield = new \Lockedfield();
+        $locks = $lockedfield->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
+        $this->integer(count($locks))->isIdenticalTo(0);
+    }
 }


### PR DESCRIPTION
Fix locked field from transfer

Do not add ```locked field``` when inventory use transfer behavior



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
