### PR TITLE
Fix satisfaction search options

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -572,7 +572,7 @@ $CFG_GLPI['javascript'] = [
         'ticket'    => array_merge(['rateit', 'tinymce', 'kanban'], $dashboard_libs),
         'problem'   => ['tinymce', 'kanban', 'sortable'],
         'change'    => ['tinymce', 'kanban', 'sortable', 'rateit'],
-        'stat'      => ['charts']
+        'stat'      => ['charts', 'rateit']
     ],
     'tools'     => [
         'project'                 => ['kanban', 'tinymce', 'sortable'],

--- a/install/migrations/update_10.0.x_to_10.1.0/changesatisfactions.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/changesatisfactions.php
@@ -144,3 +144,17 @@ $DB->updateOrDie(
     ],
     'Replace old TICKETCATEGORY tags in Entity inquest_URL field with ITILCATEGORY'
 );
+
+// Keep track of satisfaction on a fixed scale (for stats)
+foreach (['glpi_changesatisfactions', 'glpi_ticketsatisfactions'] as $table) {
+    if (!$DB->fieldExists($table, 'satisfaction_scaled_to_5')) {
+        $migration->addField($table, 'satisfaction_scaled_to_5', 'float DEFAULT NULL', [
+            'after' => 'satisfaction',
+        ]);
+        $migration->addPostQuery(
+            $DB->buildUpdate($table, [
+                'satisfaction_scaled_to_5' => new QueryExpression($DB->quoteName('satisfaction'))
+            ], [1])
+        );
+    }
+}

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -7301,6 +7301,7 @@ CREATE TABLE `glpi_ticketsatisfactions` (
   `date_begin` timestamp NULL DEFAULT NULL,
   `date_answered` timestamp NULL DEFAULT NULL,
   `satisfaction` int DEFAULT NULL,
+  `satisfaction_scaled_to_5` float DEFAULT NULL,
   `comment` text,
   PRIMARY KEY (`id`),
   UNIQUE KEY `tickets_id` (`tickets_id`)
@@ -9371,6 +9372,7 @@ CREATE TABLE `glpi_changesatisfactions` (
    `date_begin` timestamp NULL DEFAULT NULL,
    `date_answered` timestamp NULL DEFAULT NULL,
    `satisfaction` int DEFAULT NULL,
+   `satisfaction_scaled_to_5` float DEFAULT NULL,
    `comment` text,
    PRIMARY KEY (`id`),
    UNIQUE KEY `changes_id` (`changes_id`)

--- a/src/Change.php
+++ b/src/Change.php
@@ -721,7 +721,7 @@ class Change extends CommonITILObject
 
         $tab = array_merge($tab, ChangeValidation::rawSearchOptionsToAdd());
 
-        $tab = array_merge($tab, CommonITILSatisfaction::rawSearchOptionsToAdd('glpi_changesatisfactions', 200));
+        $tab = array_merge($tab, ChangeSatisfaction::rawSearchOptionsToAdd());
 
         $tab = array_merge($tab, ITILFollowup::rawSearchOptionsToAdd());
 

--- a/src/Change.php
+++ b/src/Change.php
@@ -721,6 +721,8 @@ class Change extends CommonITILObject
 
         $tab = array_merge($tab, ChangeValidation::rawSearchOptionsToAdd());
 
+        $tab = array_merge($tab, CommonITILSatisfaction::rawSearchOptionsToAdd('glpi_changesatisfactions', 200));
+
         $tab = array_merge($tab, ITILFollowup::rawSearchOptionsToAdd());
 
         $tab = array_merge($tab, ChangeTask::rawSearchOptionsToAdd());

--- a/src/ChangeSatisfaction.php
+++ b/src/ChangeSatisfaction.php
@@ -41,4 +41,9 @@ class ChangeSatisfaction extends CommonITILSatisfaction
     {
         return "_change";
     }
+
+    public static function getSearchOptionIDOffset(): int
+    {
+        return 200;
+    }
 }

--- a/src/ChangeSatisfaction.php
+++ b/src/ChangeSatisfaction.php
@@ -36,4 +36,9 @@
 class ChangeSatisfaction extends CommonITILSatisfaction
 {
     public static $rightname = 'change';
+
+    public static function getConfigSufix(): string
+    {
+        return "_change";
+    }
 }

--- a/src/CommonITILSatisfaction.php
+++ b/src/CommonITILSatisfaction.php
@@ -284,21 +284,19 @@ abstract class CommonITILSatisfaction extends CommonDBTM
             $value = $max_rate;
         }
 
-        if ($use_js) {
-            $rand = mt_rand();
-            $out = "<input type='hidden' id='backing_$rand'>";
-            $out .= "<div id='rateit_$rand' class='rateit'></div>";
-            $out .= Html::scriptBlock("
-                $(function () {
-                    $('#rateit_$rand').rateit({
-                        max: $max_rate,
-                        resetable: false,
-                        value: $value,
-                        readonly: true,
-                    });
+        $rand = mt_rand();
+        $out = "<input type='hidden' id='backing_$rand'>";
+        $out .= "<div id='rateit_$rand' class='rateit'></div>";
+        $out .= Html::scriptBlock("
+            $(function () {
+                $('#rateit_$rand').rateit({
+                    max: $max_rate,
+                    resetable: false,
+                    value: $value,
+                    readonly: true,
                 });
-            ");
-        }
+            });
+        ");
 
         return $out;
     }

--- a/src/CommonITILSatisfaction.php
+++ b/src/CommonITILSatisfaction.php
@@ -49,6 +49,7 @@ abstract class CommonITILSatisfaction extends CommonDBTM
     public const TYPE_EXTERNAL = 2;
 
     abstract public static function getConfigSufix(): string;
+    abstract public static function getSearchOptionIDOffset(): int;
 
     public static function getTypeName($nb = 0)
     {
@@ -354,8 +355,11 @@ abstract class CommonITILSatisfaction extends CommonDBTM
         return $itemtype::getFormURLWithID($satisfaction->fields[$itemtype::getForeignKeyField()]) . '&forcetab=' . $itemtype::getType() . '$3';
     }
 
-    public static function rawSearchOptionsToAdd(string $table, $base_id = 0)
+    public static function rawSearchOptionsToAdd()
     {
+        $base_id = static::getSearchOptionIDOffset();
+        $table = static::getTable();
+
         $tab[] = [
             'id'                 => 'satisfaction',
             'name'               => __('Satisfaction survey')

--- a/src/CommonITILSatisfaction.php
+++ b/src/CommonITILSatisfaction.php
@@ -48,6 +48,8 @@ abstract class CommonITILSatisfaction extends CommonDBTM
      */
     public const TYPE_EXTERNAL = 2;
 
+    abstract public static function getConfigSufix(): string;
+
     public static function getTypeName($nb = 0)
     {
         return __('Satisfaction');
@@ -248,18 +250,38 @@ abstract class CommonITILSatisfaction extends CommonDBTM
      *
      * @param int $value Between 0 and 10
      **/
-    public static function displaySatisfaction($value)
+    public static function displaySatisfaction($value, $entities_id)
     {
+        if (is_null($value)) {
+            return "";
+        }
+
+        $max_rate = Entity::getUsedConfig(
+            'inquest_config',
+            $entities_id,
+            'inquest_max_rate' . static::getConfigSufix()
+        );
 
         if ($value < 0) {
             $value = 0;
         }
-        if ($value > 10) {
-            $value = 10;
+        if ($value > $max_rate) {
+            $value = $max_rate;
         }
 
-        $out = "<div class='rateit' data-rateit-value='$value' data-rateit-ispreset='true'
-               data-rateit-readonly='true'></div>";
+        $rand = mt_rand();
+        $out = "<input type='hidden' id='backing_$rand'>";
+        $out .= "<div id='rateit_$rand' class='rateit'></div>";
+        $out .= Html::scriptBlock("
+            $(function () {
+                $('#rateit_$rand').rateit({
+                    max: $max_rate,
+                    resetable: false,
+                    value: $value,
+                    readonly: true,
+                });
+            });
+        ");
 
         return $out;
     }
@@ -330,5 +352,77 @@ abstract class CommonITILSatisfaction extends CommonDBTM
         /** @var CommonDBTM $itemtype */
         $itemtype = static::getItemtype();
         return $itemtype::getFormURLWithID($satisfaction->fields[$itemtype::getForeignKeyField()]) . '&forcetab=' . $itemtype::getType() . '$3';
+    }
+
+    public static function rawSearchOptionsToAdd(string $table, $base_id = 0)
+    {
+        $tab[] = [
+            'id'                 => 'satisfaction',
+            'name'               => __('Satisfaction survey')
+        ];
+
+        $tab[] = [
+            'id'                 => 31 + $base_id,
+            'table'              => $table,
+            'field'              => 'type',
+            'name'               => _n('Type', 'Types', 1),
+            'massiveaction'      => false,
+            'searchtype'         => ['equals', 'notequals'],
+            'searchequalsonfield' => true,
+            'joinparams'         => [
+                'jointype'           => 'child'
+            ],
+            'datatype'           => 'specific'
+        ];
+
+        $tab[] = [
+            'id'                 => 60 + $base_id,
+            'table'              => $table,
+            'field'              => 'date_begin',
+            'name'               => __('Creation date'),
+            'datatype'           => 'datetime',
+            'massiveaction'      => false,
+            'joinparams'         => [
+                'jointype'           => 'child'
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => 61 + $base_id,
+            'table'              => $table,
+            'field'              => 'date_answered',
+            'name'               => __('Response date'),
+            'datatype'           => 'datetime',
+            'massiveaction'      => false,
+            'joinparams'         => [
+                'jointype'           => 'child'
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => 62 + $base_id,
+            'table'              => $table,
+            'field'              => 'satisfaction',
+            'name'               => __('Satisfaction'),
+            'datatype'           => 'number',
+            'massiveaction'      => false,
+            'joinparams'         => [
+                'jointype'           => 'child'
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => 63 + $base_id,
+            'table'              => $table,
+            'field'              => 'comment',
+            'name'               => __('Comments'),
+            'datatype'           => 'text',
+            'massiveaction'      => false,
+            'joinparams'         => [
+                'jointype'           => 'child'
+            ]
+        ];
+
+        return $tab;
     }
 }

--- a/src/CommonITILSatisfaction.php
+++ b/src/CommonITILSatisfaction.php
@@ -219,7 +219,7 @@ abstract class CommonITILSatisfaction extends CommonDBTM
             $item = static::getItemtype();
             $item = new $item();
             $fkey = static::getIndexName();
-            if ($item->getFromDB($this->fields[$fkey] ?? $this->fields[$fkey])) {
+            if ($item->getFromDB($input[$fkey] ?? $this->fields[$fkey])) {
                 $max_rate = Entity::getUsedConfig(
                     'inquest_config',
                     $item->fields['entities_id'],
@@ -285,8 +285,7 @@ abstract class CommonITILSatisfaction extends CommonDBTM
         }
 
         $rand = mt_rand();
-        $out = "<input type='hidden' id='backing_$rand'>";
-        $out .= "<div id='rateit_$rand' class='rateit'></div>";
+        $out = "<div id='rateit_$rand' class='rateit'></div>";
         $out .= Html::scriptBlock("
             $(function () {
                 $('#rateit_$rand').rateit({

--- a/src/CommonITILSatisfaction.php
+++ b/src/CommonITILSatisfaction.php
@@ -265,7 +265,7 @@ abstract class CommonITILSatisfaction extends CommonDBTM
      *
      * @param int $value Between 0 and 10
      **/
-    public static function displaySatisfaction($value, $entities_id, $use_js = true)
+    public static function displaySatisfaction($value, $entities_id)
     {
         if (is_null($value)) {
             return "";

--- a/src/CommonITILSatisfaction.php
+++ b/src/CommonITILSatisfaction.php
@@ -429,6 +429,7 @@ abstract class CommonITILSatisfaction extends CommonDBTM
             'joinparams'         => [
                 'jointype'           => 'child'
             ],
+            'additionalfields' => ['TABLE.entities_id'],
         ];
 
         $tab[] = [

--- a/src/Search/Provider/SQLProvider.php
+++ b/src/Search/Provider/SQLProvider.php
@@ -5297,7 +5297,21 @@ final class SQLProvider implements SearchProviderInterface
 
                 case 'glpi_ticketsatisfactions.satisfaction':
                     if ($html_output) {
-                        return \TicketSatisfaction::displaySatisfaction($data[$ID][0]['name']);
+                        $ticket = Ticket::getById($data['raw']['id']);
+                        return \TicketSatisfaction::displaySatisfaction(
+                            $data[$ID][0]['name'],
+                            $ticket->fields['entities_id']
+                        );
+                    }
+                    break;
+
+                case 'glpi_changesatisfactions.satisfaction':
+                    if ($html_output) {
+                        $change = Change::getById($data['raw']['id']);
+                        return \ChangeSatisfaction::displaySatisfaction(
+                            $data[$ID][0]['name'],
+                            $change->fields['entities_id']
+                        );
                     }
                     break;
 

--- a/src/Search/Provider/SQLProvider.php
+++ b/src/Search/Provider/SQLProvider.php
@@ -206,18 +206,24 @@ final class SQLProvider implements SearchProviderInterface
             && count($opt["additionalfields"])
         ) {
             foreach ($opt["additionalfields"] as $key) {
+                if (preg_match('/^TABLE\./', $key) === 1) {
+                    $key = preg_replace('/^TABLE\./', '', $key);
+                    $additionalfield_field = $DB->quoteName($orig_table . '.' . $key);
+                } else {
+                    $additionalfield_field = $DB->quoteName($table . $addtable . '.' . $key);
+                }
                 if ($meta || $opt->isForceGroupBy()) {
                     $ADDITONALFIELDS[] = new QueryExpression("
                         IFNULL(
                             GROUP_CONCAT(
                                 DISTINCT CONCAT(
-                                    IFNULL(`$table$addtable`.`$key`, '" . \Search::NULLVALUE . "'),
+                                    IFNULL($additionalfield_field, '" . \Search::NULLVALUE . "'),
                                     '" . \Search::SHORTSEP . "', $tocomputeid
                                 ) ORDER BY $tocomputeid SEPARATOR '" . \Search::LONGSEP . "'
                             ), '" . \Search::NULLVALUE . \Search::SHORTSEP . "'
                         ) AS `{$NAME}_$key`");
                 } else {
-                    $ADDITONALFIELDS[] = "`$table$addtable`.`$key` AS `" . $NAME . "_$key`";
+                    $ADDITONALFIELDS[] = "$additionalfield_field AS `" . $NAME . "_$key`";
                 }
             }
         }
@@ -5297,20 +5303,18 @@ final class SQLProvider implements SearchProviderInterface
 
                 case 'glpi_ticketsatisfactions.satisfaction':
                     if ($html_output) {
-                        $ticket = Ticket::getById($data['raw']['id']);
                         return \TicketSatisfaction::displaySatisfaction(
                             $data[$ID][0]['name'],
-                            $ticket->fields['entities_id']
+                            $data['raw']['ITEM_Ticket_62_entities_id']
                         );
                     }
                     break;
 
                 case 'glpi_changesatisfactions.satisfaction':
                     if ($html_output) {
-                        $change = Change::getById($data['raw']['id']);
                         return \ChangeSatisfaction::displaySatisfaction(
                             $data[$ID][0]['name'],
-                            $change->fields['entities_id']
+                            $data['raw']['ITEM_Change_262_entities_id']
                         );
                     }
                     break;

--- a/src/Stat.php
+++ b/src/Stat.php
@@ -736,7 +736,18 @@ class Stat extends CommonGLPI
                     if ($nb_answersatisfaction > 0) {
                         $avgsatisfaction = round(array_sum($satisfaction) / $nb_answersatisfaction, 1);
                         if ($output_type == Search::HTML_OUTPUT) {
-                            $avgsatisfaction = TicketSatisfaction::displaySatisfaction($avgsatisfaction);
+                            // Display using the max number of stars defined in the root entity
+                            $max_rate = Entity::getUsedConfig(
+                                'inquest_config',
+                                0,
+                                'inquest_max_rate' . TicketSatisfaction::getConfigSufix()
+                            );
+                            if (!$max_rate) {
+                                $max_rate = 5;
+                            }
+                            // Scale satisfaction accordingly
+                            $avgsatisfaction = $avgsatisfaction * ($max_rate / 5);
+                            $avgsatisfaction = TicketSatisfaction::displaySatisfaction($avgsatisfaction, 0);
                         }
                     } else {
                         $avgsatisfaction = '&nbsp;';
@@ -1490,7 +1501,7 @@ class Stat extends CommonGLPI
                 $criteria = [
                     'SELECT'    => [
                         $date_unix,
-                        'AVG'  => "glpi_ticketsatisfactions.satisfaction AS total_visites"
+                        'AVG'  => "glpi_ticketsatisfactions.satisfaction_scaled_to_5 AS total_visites"
                     ],
                     'FROM'      => $table,
                     'WHERE'     => $WHERE,

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -3109,7 +3109,7 @@ JAVASCRIPT;
         }
         $tab = array_merge($tab, $validation_options);
 
-        $tab = array_merge($tab, CommonITILSatisfaction::rawSearchOptionsToAdd('glpi_ticketsatisfactions'));
+        $tab = array_merge($tab, TicketSatisfaction::rawSearchOptionsToAdd());
 
         $tab = array_merge($tab, ITILFollowup::rawSearchOptionsToAdd());
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -3109,72 +3109,7 @@ JAVASCRIPT;
         }
         $tab = array_merge($tab, $validation_options);
 
-        $tab[] = [
-            'id'                 => 'satisfaction',
-            'name'               => __('Satisfaction survey')
-        ];
-
-        $tab[] = [
-            'id'                 => '31',
-            'table'              => 'glpi_ticketsatisfactions',
-            'field'              => 'type',
-            'name'               => _n('Type', 'Types', 1),
-            'massiveaction'      => false,
-            'searchtype'         => ['equals', 'notequals'],
-            'searchequalsonfield' => true,
-            'joinparams'         => [
-                'jointype'           => 'child'
-            ],
-            'datatype'           => 'specific'
-        ];
-
-        $tab[] = [
-            'id'                 => '60',
-            'table'              => 'glpi_ticketsatisfactions',
-            'field'              => 'date_begin',
-            'name'               => __('Creation date'),
-            'datatype'           => 'datetime',
-            'massiveaction'      => false,
-            'joinparams'         => [
-                'jointype'           => 'child'
-            ]
-        ];
-
-        $tab[] = [
-            'id'                 => '61',
-            'table'              => 'glpi_ticketsatisfactions',
-            'field'              => 'date_answered',
-            'name'               => __('Response date'),
-            'datatype'           => 'datetime',
-            'massiveaction'      => false,
-            'joinparams'         => [
-                'jointype'           => 'child'
-            ]
-        ];
-
-        $tab[] = [
-            'id'                 => '62',
-            'table'              => 'glpi_ticketsatisfactions',
-            'field'              => 'satisfaction',
-            'name'               => __('Satisfaction'),
-            'datatype'           => 'number',
-            'massiveaction'      => false,
-            'joinparams'         => [
-                'jointype'           => 'child'
-            ]
-        ];
-
-        $tab[] = [
-            'id'                 => '63',
-            'table'              => 'glpi_ticketsatisfactions',
-            'field'              => 'comment',
-            'name'               => __('Comments'),
-            'datatype'           => 'text',
-            'massiveaction'      => false,
-            'joinparams'         => [
-                'jointype'           => 'child'
-            ]
-        ];
+        $tab = array_merge($tab, CommonITILSatisfaction::rawSearchOptionsToAdd('glpi_ticketsatisfactions'));
 
         $tab = array_merge($tab, ITILFollowup::rawSearchOptionsToAdd());
 

--- a/src/TicketSatisfaction.php
+++ b/src/TicketSatisfaction.php
@@ -36,4 +36,9 @@
 class TicketSatisfaction extends CommonITILSatisfaction
 {
     public static $rightname = 'ticket';
+
+    public static function getConfigSufix(): string
+    {
+        return "";
+    }
 }

--- a/src/TicketSatisfaction.php
+++ b/src/TicketSatisfaction.php
@@ -41,4 +41,9 @@ class TicketSatisfaction extends CommonITILSatisfaction
     {
         return "";
     }
+
+    public static function getSearchOptionIDOffset(): int
+    {
+        return 0;
+    }
 }


### PR DESCRIPTION
A few issues on the satisfaction search options :
* It's missing from changes
* It does not show values above 5 stars (we can go to 10 with the new config)
* It disappears when reloading the search results

1\)  It's missing from changes
-> Added it to changes. 
They don't share the same searchoptions id as the original ids are sadly not available for changes.
Instead they match the ticket's ids + 200 (kinda hacky - any plan to drop number based search options ids in the future ?).

2\) It does not show values above 5 stars (we can go to 10 with the new config)
-> Rewrote `displaySatisfaction` to take into account entity config

3\) It disappears when reloading the search results
-> Rewrote `displaySatisfaction` to use javascript to trigger the rateit library.
The previous method (relying on data-xxxx attributes) does not seem to trigger on ajax reloads.

![image](https://user-images.githubusercontent.com/42734840/202232972-5d0d4bee-76c6-4eec-a9b2-d715d3e5456a.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25160