### PR TITLE
Optimize User LDAP Sync

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -5057,7 +5057,6 @@ HTML;
             'is_deleted_ldap' => 1,
         ];
         $myuser = new self();
-        $myuser->getFromDB($users_id);
 
         switch ($CFG_GLPI['user_deleted_ldap']) {
            //DO nothing


### PR DESCRIPTION
Drop unused sql query when user ldap sync


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
