### PR TITLE
Create issue when dependencies audit fails

### DIFF
--- a/.github/workflows/audit_dependencies.yml
+++ b/.github/workflows/audit_dependencies.yml
@@ -50,12 +50,43 @@ jobs:
       - name: "Show versions"
         run: |
           .github/actions/init_show-versions.sh
-      - name: "Build dependencies / translations"
-        run: |
-          docker-compose exec -T app .github/actions/init_build.sh
       - name: "Audit npm dependencies"
+        continue-on-error: true
+        id: "npmaudit"
         run: |
-          npm audit
+          set -o pipefail
+          CODE=0
+          LOG=$( npm audit package-lock-only 2>&1 | tee /dev/stderr ) || CODE=$?
+          echo "CODE=$CODE" >> $GITHUB_OUTPUT
+          printf "LOG<<EOF\n$LOG\nEOF" >> $GITHUB_OUTPUT
+      - name: "Create issue if npm audit fails"
+        if: "${{ steps.npmaudit.outputs.CODE != '0' }}"
+        uses: "actions/github-script@v6"
+        with:
+          script: |
+            const result = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'npm audit failed (${{ matrix.branch }})',
+              body: '```\n' + ${{ toJSON(steps.npmaudit.outputs.LOG) }} + '\n```',
+            });
       - name: "Audit composer dependencies"
+        continue-on-error: true
+        id: "composeraudit"
         run: |
-          composer audit
+          set -o pipefail
+          CODE=0
+          LOG=$( composer audit --locked 2>&1 | tee /dev/stderr ) || CODE=$?
+          echo "CODE=$CODE" >> $GITHUB_OUTPUT
+          printf "LOG<<EOF\n$LOG\nEOF" >> $GITHUB_OUTPUT
+      - name: "Create issue if composer audit fails"
+        if: "${{ steps.composeraudit.outputs.CODE != '0' }}"
+        uses: "actions/github-script@v6"
+        with:
+          script: |
+            const result = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'composer audit failed (${{ matrix.branch }})',
+              body: '```\n# composer audit report\n\n' + ${{ toJSON(steps.composeraudit.outputs.LOG) }} + '\n```',
+            });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. An issue will be created if `npm audit` found vulnerabilities, and another one will be created if `composer audit` found vulnerabilities.
2. Job will not fail anymore when vulnerabilities are found. As issue is created, there is no need to trigger failure to notify about vulnerabilities.
3. Job execution time is improved by working directly with locked files, removing the requirement of installing dependencies.

I tested the job using commit https://github.com/cedric-anne/glpi/commit/d479f850ae7da36e42acddcb282c05872d285611, result was creation of 2 issues (https://github.com/cedric-anne/glpi/issues/395 and https://github.com/cedric-anne/glpi/issues/396) for 10.0 branch (vulnerabilities found by both npm and composer), and none for 9.5 branch (no vulnerabilities found).

It is possible to define assignees and/or labels when issues are created, should we do it ?