### PR TITLE
Fix empty cases search

### DIFF
--- a/src/Search/Provider/SQLProvider.php
+++ b/src/Search/Provider/SQLProvider.php
@@ -1214,16 +1214,25 @@ final class SQLProvider implements SearchProviderInterface
                 if ($val === 'mygroups') {
                     switch ($searchtype) {
                         case 'equals':
+                            if (count($_SESSION['glpigroups']) < 1) {
+                                return [];
+                            }
                             return [
                                 "$table.id" => $_SESSION['glpigroups']
                             ];
 
                         case 'notequals':
+                            if (count($_SESSION['glpigroups']) < 1) {
+                                return [];
+                            }
                             return [
                                 "$table.id" => ['NOT IN', $_SESSION['glpigroups']]
                             ];
 
                         case 'under':
+                            if (count($_SESSION['glpigroups']) < 1) {
+                                return [];
+                            }
                             $groups = $_SESSION['glpigroups'];
                             foreach ($_SESSION['glpigroups'] as $g) {
                                 $groups += getSonsOf($inittable, $g);
@@ -1234,6 +1243,9 @@ final class SQLProvider implements SearchProviderInterface
                             ];
 
                         case 'notunder':
+                            if (count($_SESSION['glpigroups']) < 1) {
+                                return [];
+                            }
                             $groups = $_SESSION['glpigroups'];
                             foreach ($_SESSION['glpigroups'] as $g) {
                                 $groups += getSonsOf($inittable, $g);

--- a/src/Search/Provider/SQLProvider.php
+++ b/src/Search/Provider/SQLProvider.php
@@ -111,7 +111,10 @@ final class SQLProvider implements SearchProviderInterface
             default:
                 // Plugin can override core definition for its type
                 if ($plug = isPluginItemType($itemtype)) {
-                    $ret[] = new QueryExpression(\Plugin::doOneHook($plug['plugin'], 'addDefaultSelect', $itemtype));
+                    $default_select = \Plugin::doOneHook($plug['plugin'], 'addDefaultSelect', $itemtype);
+                    if ($default_select !== "") {
+                        $ret[] = new QueryExpression($default_select);
+                    }
                 }
         }
         if ($itemtable === 'glpi_entities') {
@@ -890,7 +893,10 @@ final class SQLProvider implements SearchProviderInterface
             default:
                 // Plugin can override core definition for its type
                 if ($plug = isPluginItemType($itemtype)) {
-                    $criteria = [new QueryExpression(\Plugin::doOneHook($plug['plugin'], 'addDefaultWhere', $itemtype))];
+                    $default_where = \Plugin::doOneHook($plug['plugin'], 'addDefaultWhere', $itemtype);
+                    if ($default_where !== '') {
+                        $criteria = [new QueryExpression($default_where)];
+                    }
                 }
                 break;
         }

--- a/src/Search/Provider/SQLProvider.php
+++ b/src/Search/Provider/SQLProvider.php
@@ -1214,7 +1214,7 @@ final class SQLProvider implements SearchProviderInterface
                 if ($val === 'mygroups') {
                     switch ($searchtype) {
                         case 'equals':
-                            if (count($_SESSION['glpigroups']) < 1) {
+                            if (count($_SESSION['glpigroups']) === 0) {
                                 return [];
                             }
                             return [
@@ -1222,7 +1222,7 @@ final class SQLProvider implements SearchProviderInterface
                             ];
 
                         case 'notequals':
-                            if (count($_SESSION['glpigroups']) < 1) {
+                            if (count($_SESSION['glpigroups']) === 0) {
                                 return [];
                             }
                             return [
@@ -1230,7 +1230,7 @@ final class SQLProvider implements SearchProviderInterface
                             ];
 
                         case 'under':
-                            if (count($_SESSION['glpigroups']) < 1) {
+                            if (count($_SESSION['glpigroups']) === 0) {
                                 return [];
                             }
                             $groups = $_SESSION['glpigroups'];
@@ -1243,7 +1243,7 @@ final class SQLProvider implements SearchProviderInterface
                             ];
 
                         case 'notunder':
-                            if (count($_SESSION['glpigroups']) < 1) {
+                            if (count($_SESSION['glpigroups']) === 0) {
                                 return [];
                             }
                             $groups = $_SESSION['glpigroups'];


### PR DESCRIPTION
Recent changes break Formcreator unit tests.

- When a plugin hook generates an empty fragment of SQL query (SELECT, WHERE). Hooks often add SQL depending on the itemtype. If itemtype does not patches anything, then the function returns an empty string
example 
```php
function plugin_formcreator_addDefaultSelect($itemtype) {
   switch ($itemtype) {
      case PluginFormcreatorIssue::class:
         return "`glpi_plugin_formcreator_issues`.`itemtype`, ";
   }
   return "";
}
```

- When a search is done with the meta value 'mygroups', it may be resolved into an empty array, later used un a SQL IN statement. The search engine should ignore the clause in most cases.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
