### PR TITLE
Prevent PHP notices when LDAP does not provide "modifytimestamp" field

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -1912,7 +1912,7 @@ class AuthLDAP extends CommonDBTM
                              continue;
                         }
 
-                        if ( isset($info[$ligne]['modifytimestamp']) ){
+                        if (isset($info[$ligne]['modifytimestamp'])) {
                             $user_infos[$uid]["timestamp"] = self::ldapStamp2UnixStamp(
                                 $info[$ligne]['modifytimestamp'][0],
                                 $config_ldap->fields['time_offset']
@@ -1932,7 +1932,7 @@ class AuthLDAP extends CommonDBTM
                              $ldap_users[$uid] = $uid;
                         } else {
                            //If ldap synchronisation
-                            if ( isset($info[$ligne]['modifytimestamp']) ){
+                            if (isset($info[$ligne]['modifytimestamp'])) {
                                 $ldap_users[$uid] = self::ldapStamp2UnixStamp(
                                     $info[$ligne]['modifytimestamp'][0],
                                     $config_ldap->fields['time_offset']

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -1918,7 +1918,7 @@ class AuthLDAP extends CommonDBTM
                                 $config_ldap->fields['time_offset']
                             );
                         } else {
-                            $user_infos[$uid]["timestamp"] = 0;
+                            $user_infos[$uid]["timestamp"] = '';
                         }
 
                         $user_infos[$uid]["user_dn"] = $info[$ligne]['dn'];
@@ -1937,6 +1937,8 @@ class AuthLDAP extends CommonDBTM
                                     $info[$ligne]['modifytimestamp'][0],
                                     $config_ldap->fields['time_offset']
                                 );
+                            } else {
+                                $ldap_users[$uid] = '';
                             }
                             $user_infos[$uid]["name"] = $info[$ligne][$login_field][0];
                         }

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -1917,7 +1917,7 @@ class AuthLDAP extends CommonDBTM
                                 $info[$ligne]['modifytimestamp'][0],
                                 $config_ldap->fields['time_offset']
                             );
-            } else {
+                        } else {
                             $user_infos[$uid]["timestamp"] = 0;
                         }
 

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -1912,10 +1912,15 @@ class AuthLDAP extends CommonDBTM
                              continue;
                         }
 
-                        $user_infos[$uid]["timestamp"] = self::ldapStamp2UnixStamp(
-                            $info[$ligne]['modifytimestamp'][0],
-                            $config_ldap->fields['time_offset']
-                        );
+                        if ( isset($info[$ligne]['modifytimestamp']) ){
+                            $user_infos[$uid]["timestamp"] = self::ldapStamp2UnixStamp(
+                                $info[$ligne]['modifytimestamp'][0],
+                                $config_ldap->fields['time_offset']
+                            );
+			} else {
+                            $user_infos[$uid]["timestamp"] = 0;
+                        }
+
                         $user_infos[$uid]["user_dn"] = $info[$ligne]['dn'];
                         $user_infos[$uid][$field_for_sync] = $uid;
                         if ($config_ldap->isSyncFieldEnabled()) {
@@ -1927,10 +1932,12 @@ class AuthLDAP extends CommonDBTM
                              $ldap_users[$uid] = $uid;
                         } else {
                            //If ldap synchronisation
-                            $ldap_users[$uid] = self::ldapStamp2UnixStamp(
-                                $info[$ligne]['modifytimestamp'][0],
-                                $config_ldap->fields['time_offset']
-                            );
+                            if ( isset($info[$ligne]['modifytimestamp']) ){
+                                $ldap_users[$uid] = self::ldapStamp2UnixStamp(
+                                    $info[$ligne]['modifytimestamp'][0],
+                                    $config_ldap->fields['time_offset']
+                                );
+                            }
                             $user_infos[$uid]["name"] = $info[$ligne][$login_field][0];
                         }
                     }

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -1917,7 +1917,7 @@ class AuthLDAP extends CommonDBTM
                                 $info[$ligne]['modifytimestamp'][0],
                                 $config_ldap->fields['time_offset']
                             );
-			} else {
+            } else {
                             $user_infos[$uid]["timestamp"] = 0;
                         }
 


### PR DESCRIPTION
Fix Notice error on LDAP sync with active directory because this error create 20MB of log in phplog file

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
