### PR TITLE
Protect vendor directory using .htaccess

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,8 @@
 /tools/vendor/
 /tools/api/
 /tools/htmlcov/
-/vendor/
+/vendor/*
+!/vendor/.htaccess
 phpunit.xml
 /tests/code-coverage/
 /tests/coverage-*/

--- a/vendor/.htaccess
+++ b/vendor/.htaccess
@@ -1,0 +1,6 @@
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+  deny from all
+</IfModule>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

It will protect only apache servers that allows usage of `.htaccess` files, but, according to https://telemetry.glpi-project.org/, it may represent a large majority of GLPI installations.