### PR TITLE
bugfix: absent field test in Glpi\Inventory\Asset\Device::hande()

### DIFF
--- a/src/Inventory/Asset/Device.php
+++ b/src/Inventory/Asset/Device.php
@@ -127,7 +127,7 @@ abstract class Device extends InventoryAsset
                             break;
                         }
                         $compare = explode(':', $compare);
-                        if (!isset($i_input[$field]) && !isset($existing_item[$field])) {
+                        if (!isset($i_input[$field]) || !isset($existing_item[$field])) {
                             //field not present, skip
                             continue;
                         }


### PR DESCRIPTION
Fixes
```
[2022-11-19 22:54:52] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "frequency" in src/Inventory/Asset/Device.php at line 143
  Backtrace :
  src/Inventory/Asset/MainAsset.php:862              Glpi\Inventory\Asset\Device->handle()
  src/Inventory/Asset/MainAsset.php:782              Glpi\Inventory\Asset\MainAsset->handleAssets()
  ...
```


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
