### PR TITLE
Fix KB related documents migration

### DIFF
--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -205,6 +205,9 @@ class Document_Item extends CommonDBRelation
     }
 
 
+    /**
+     * @TODO Remove `_do_update_ticket` handling in GLPI 10.1, it is not used anymore.
+     */
     public function post_addItem()
     {
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13341

Migration to `9.5.2` was using the `CommonDBTM::add()` method to add `Document_Item` elements. Problem is that it triggers some routines that are not expected to be run in the middle of a migration, and that are, therefore, not able to handle this case.

We already had to fix an unexpected behaviour in #9018 and to use `_disablenotif` to ensure that no notification are sent, but #13341 reveals that the only solution is to use direct DB queries.