### PR TITLE
fix(ticket rule): action status + solution template

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7724,11 +7724,15 @@ abstract class CommonITILObject extends CommonDBTM
         }
 
         $solution = new ITILSolution();
-        $solution->add([
+        $input = [
             '_solutiontemplates_id' => $this->input['_solutiontemplates_id'],
-            'itemtype'              => static::getType(),
-            'items_id'              => $this->fields['id'],
-        ]);
+            'itemtype'              => $this->getType(),
+            'items_id'              => $this->getID(),
+        ];
+        if (isset($this->input['_do_not_compute_status'])) {
+            $input['_do_not_compute_status'] = $this->input['_do_not_compute_status'];
+        }
+        $solution->add($input);
     }
 
     /**

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -220,6 +220,9 @@ class ITILSolution extends CommonDBChild
             $input = array_replace($template_fields, $input);
         }
 
+        if (isset($input['_do_not_compute_status'])) {
+            return $input;
+        }
        // check itil object is not already solved
         if (in_array($this->item->fields["status"], $this->item->getSolvedStatusArray())) {
             Session::addMessageAfterRedirect(

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -220,44 +220,43 @@ class ITILSolution extends CommonDBChild
             $input = array_replace($template_fields, $input);
         }
 
-        if (isset($input['_do_not_compute_status'])) {
-            return $input;
-        }
-       // check itil object is not already solved
-        if (in_array($this->item->fields["status"], $this->item->getSolvedStatusArray())) {
-            Session::addMessageAfterRedirect(
-                __("The item is already solved, did anyone pushed a solution before you?"),
-                false,
-                ERROR
-            );
-            return false;
-        }
-
-       //default status for global solutions
-        $status = CommonITILValidation::ACCEPTED;
-
-       //handle autoclose, for tickets only
-        if ($input['itemtype'] == Ticket::getType()) {
-            $autoclosedelay =  Entity::getUsedConfig(
-                'autoclose_delay',
-                $this->item->getEntityID(),
-                '',
-                Entity::CONFIG_NEVER
-            );
-
-           // 0  or ticket status CLOSED = immediately
-            if ($autoclosedelay != 0 && $this->item->fields["status"] != $this->item::CLOSED) {
-                $status = CommonITILValidation::WAITING;
+        if (!$this->item->isStatusComputationBlocked($input)) {
+        // check itil object is not already solved
+            if (in_array($this->item->fields["status"], $this->item->getSolvedStatusArray())) {
+                Session::addMessageAfterRedirect(
+                    __("The item is already solved, did anyone pushed a solution before you?"),
+                    false,
+                    ERROR
+                );
+                return false;
             }
-        }
 
-       //Accepted; store user and date
-        if ($status == CommonITILValidation::ACCEPTED) {
-            $input['users_id_approval'] = Session::getLoginUserID();
-            $input['date_approval'] = $_SESSION["glpi_currenttime"];
-        }
+            //default status for global solutions
+            $status = CommonITILValidation::ACCEPTED;
 
-        $input['status'] = $status;
+            //handle autoclose, for tickets only
+            if ($input['itemtype'] == Ticket::getType()) {
+                $autoclosedelay =  Entity::getUsedConfig(
+                    'autoclose_delay',
+                    $this->item->getEntityID(),
+                    '',
+                    Entity::CONFIG_NEVER
+                );
+
+                // 0  or ticket status CLOSED = immediately
+                if ($autoclosedelay != 0 && $this->item->fields["status"] != $this->item::CLOSED) {
+                    $status = CommonITILValidation::WAITING;
+                }
+            }
+
+            //Accepted; store user and date
+            if ($status == CommonITILValidation::ACCEPTED) {
+                $input['users_id_approval'] = Session::getLoginUserID();
+                $input['date_approval'] = $_SESSION["glpi_currenttime"];
+            }
+
+            $input['status'] = $status;
+        }
 
        // Render twig content, needed for massives action where we the content
        // can't be rendered directly in the form


### PR DESCRIPTION
In business rules for tickets, actions to change status and add solution template can be used in same rules but are not compatible.
The status change is done before the solution is added, and therefore the solution fails, because the ticket is already resolved.
In this case (when the status is forced) adding the template should not compute the status again.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25009
