### PR TITLE
sqlprovider backward compatibility

### DIFF
--- a/src/Search/Provider/SQLProvider.php
+++ b/src/Search/Provider/SQLProvider.php
@@ -113,6 +113,10 @@ final class SQLProvider implements SearchProviderInterface
                 if ($plug = isPluginItemType($itemtype)) {
                     $default_select = \Plugin::doOneHook($plug['plugin'], 'addDefaultSelect', $itemtype);
                     if ($default_select !== "") {
+                        $default_select = trim($default_select);
+                        if (substr($default_select, -1) === ',') {
+                            $default_select = substr($default_select, 0, -1);
+                        }
                         $ret[] = new QueryExpression($default_select);
                     }
                 }

--- a/src/Search/Provider/SQLProvider.php
+++ b/src/Search/Provider/SQLProvider.php
@@ -113,11 +113,7 @@ final class SQLProvider implements SearchProviderInterface
                 if ($plug = isPluginItemType($itemtype)) {
                     $default_select = \Plugin::doOneHook($plug['plugin'], 'addDefaultSelect', $itemtype);
                     if ($default_select !== "") {
-                        $default_select = trim($default_select);
-                        if (substr($default_select, -1) === ',') {
-                            $default_select = substr($default_select, 0, -1);
-                        }
-                        $ret[] = new QueryExpression($default_select);
+                        $ret[] = new QueryExpression(rtrim($default_select, ' ,'));
                     }
                 }
         }


### PR DESCRIPTION
SQLProvider breaks hook addDefaultSelect because plugins must add a final comma to fields list to ensure proper concatenation with other fields in the search engine.

This PR removes the final coma, if found.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
