### PR TITLE
Save migration progress when it includes multiple versions

### DIFF
--- a/src/Update.php
+++ b/src/Update.php
@@ -260,9 +260,24 @@ class Update
         }
 
         $migrations = $this->getMigrationsToDo($current_version, $force_latest);
-        foreach ($migrations as $file => $function) {
-            include_once($file);
-            $function();
+        foreach ($migrations as $key => $migration_specs) {
+            include_once($migration_specs['file']);
+            $migration_specs['function']();
+
+            if ($key !== array_key_last($migrations)) {
+                // Set current version to target version to ensure complete migrations to not be replayed if one
+                // of remaining migrations fails.
+                //
+                // /!\ Do not dot this for last migration:
+                // 1. This should be done at the end of the whole update process.
+                // 2. Last migration target version value may be higher than GLPI_VERSION, when GLPI_VERSION uses a pre-release suffix.
+                Config::setConfigurationValues(
+                    'core',
+                    [
+                        'version' => $migration_specs['target_version']
+                    ]
+                );
+            }
         }
 
         if (($myisam_count = $DB->getMyIsamTables()->count()) > 0) {
@@ -414,17 +429,21 @@ class Update
                 $force_migration = true;
             }
             if (version_compare($versions_matches['target_version'], $current_version, '>') || $force_migration) {
-                $migrations[$file->getPathname()] = preg_replace(
-                    '/^update_(\d+)\.(\d+)\.(\d+|x)_to_(\d+)\.(\d+)\.(\d+|x)\.php$/',
-                    'update$1$2$3to$4$5$6',
-                    $file->getBasename()
-                );
+                $migrations[$file->getPathname()] = [
+                    'file'           => $file->getPathname(),
+                    'function'       => preg_replace(
+                        '/^update_(\d+)\.(\d+)\.(\d+|x)_to_(\d+)\.(\d+)\.(\d+|x)\.php$/',
+                        'update$1$2$3to$4$5$6',
+                        $file->getBasename()
+                    ),
+                    'target_version' => $versions_matches['target_version'],
+                ];
             }
         }
 
         ksort($migrations, SORT_NATURAL);
 
-        return $migrations;
+        return array_values($migrations);
     }
 
     /**

--- a/tests/functionnal/Update.php
+++ b/tests/functionnal/Update.php
@@ -135,103 +135,193 @@ class Update extends \GLPITestCase
 
         $path = vfsStream::url('install/migrations');
 
+        $migrations_910_to_921 = [
+            [
+                'file'           => $path . '/update_9.1.0_to_9.1.1.php',
+                'function'       => 'update910to911',
+                'target_version' => '9.1.1',
+            ],
+            [
+                'file'           => $path . '/update_9.1.1_to_9.1.3.php',
+                'function'       => 'update911to913',
+                'target_version' => '9.1.3',
+            ],
+            [
+                'file'           => $path . '/update_9.1.x_to_9.2.0.php',
+                'function'       => 'update91xto920',
+                'target_version' => '9.2.0',
+            ],
+            [
+                'file'           => $path . '/update_9.2.0_to_9.2.1.php',
+                'function'       => 'update920to921',
+                'target_version' => '9.2.1',
+            ],
+        ];
+
+        $migrations_921_to_941 = [
+            [
+                'file'           => $path . '/update_9.2.1_to_9.2.2.php',
+                'function'       => 'update921to922',
+                'target_version' => '9.2.2',
+            ],
+            [
+                'file'           => $path . '/update_9.2.2_to_9.2.3.php',
+                'function'       => 'update922to923',
+                'target_version' => '9.2.3',
+            ],
+            [
+                'file'           => $path . '/update_9.2.x_to_9.3.0.php',
+                'function'       => 'update92xto930',
+                'target_version' => '9.3.0',
+            ],
+            [
+                'file'           => $path . '/update_9.3.0_to_9.3.1.php',
+                'function'       => 'update930to931',
+                'target_version' => '9.3.1',
+            ],
+            [
+                'file'           => $path . '/update_9.3.1_to_9.3.2.php',
+                'function'       => 'update931to932',
+                'target_version' => '9.3.2',
+            ],
+            [
+                'file'           => $path . '/update_9.3.x_to_9.4.0.php',
+                'function'       => 'update93xto940',
+                'target_version' => '9.4.0',
+            ],
+            [
+                'file'           => $path . '/update_9.4.0_to_9.4.1.php',
+                'function'       => 'update940to941',
+                'target_version' => '9.4.1',
+            ],
+        ];
+
+        $migrations_941_to_1006 = [
+            [
+                'file'           => $path . '/update_9.4.1_to_9.4.2.php',
+                'function'       => 'update941to942',
+                'target_version' => '9.4.2',
+            ],
+            [
+                'file'           => $path . '/update_9.4.2_to_9.4.3.php',
+                'function'       => 'update942to943',
+                'target_version' => '9.4.3',
+            ],
+            [
+                'file'           => $path . '/update_9.4.3_to_9.4.5.php',
+                'function'       => 'update943to945',
+                'target_version' => '9.4.5',
+            ],
+            [
+                'file'           => $path . '/update_9.4.5_to_9.4.6.php',
+                'function'       => 'update945to946',
+                'target_version' => '9.4.6',
+            ],
+            [
+                'file'           => $path . '/update_9.4.6_to_9.4.7.php',
+                'function'       => 'update946to947',
+                'target_version' => '9.4.7',
+            ],
+            [
+                'file'           => $path . '/update_9.4.x_to_9.5.0.php',
+                'function'       => 'update94xto950',
+                'target_version' => '9.5.0',
+            ],
+            [
+                'file'           => $path . '/update_9.5.1_to_9.5.2.php',
+                'function'       => 'update951to952',
+                'target_version' => '9.5.2',
+            ],
+            [
+                'file'           => $path . '/update_9.5.2_to_9.5.3.php',
+                'function'       => 'update952to953',
+                'target_version' => '9.5.3',
+            ],
+            [
+                'file'           => $path . '/update_9.5.3_to_9.5.4.php',
+                'function'       => 'update953to954',
+                'target_version' => '9.5.4',
+            ],
+            [
+                'file'           => $path . '/update_9.5.4_to_9.5.5.php',
+                'function'       => 'update954to955',
+                'target_version' => '9.5.5',
+            ],
+            [
+                'file'           => $path . '/update_9.5.5_to_9.5.6.php',
+                'function'       => 'update955to956',
+                'target_version' => '9.5.6',
+            ],
+            [
+                'file'           => $path . '/update_9.5.6_to_9.5.7.php',
+                'function'       => 'update956to957',
+                'target_version' => '9.5.7',
+            ],
+            [
+                'file'           => $path . '/update_9.5.x_to_10.0.0.php',
+                'function'       => 'update95xto1000',
+                'target_version' => '10.0.0',
+            ],
+            [
+                'file'           => $path . '/update_10.0.0_to_10.0.1.php',
+                'function'       => 'update1000to1001',
+                'target_version' => '10.0.1',
+            ],
+            [
+                'file'           => $path . '/update_10.0.1_to_10.0.2.php',
+                'function'       => 'update1001to1002',
+                'target_version' => '10.0.2',
+            ],
+            [
+                'file'           => $path . '/update_10.0.2_to_10.0.3.php',
+                'function'       => 'update1002to1003',
+                'target_version' => '10.0.3',
+            ],
+            [
+                'file'           => $path . '/update_10.0.3_to_10.0.4.php',
+                'function'       => 'update1003to1004',
+                'target_version' => '10.0.4',
+            ],
+            [
+                'file'           => $path . '/update_10.0.4_to_10.0.5.php',
+                'function'       => 'update1004to1005',
+                'target_version' => '10.0.5',
+            ],
+            [
+                'file'           => $path . '/update_10.0.5_to_10.0.6.php',
+                'function'       => 'update1005to1006',
+                'target_version' => '10.0.6',
+            ],
+        ];
+
+        $path = vfsStream::url('install/migrations');
+
         // Validates version normalization (9.1 -> 9.1.0).
         yield [
             'current_version'     => '9.1',
             'force_latest'        => false,
-            'expected_migrations' => [
-                $path . '/update_9.1.0_to_9.1.1.php'  => 'update910to911',
-                $path . '/update_9.1.1_to_9.1.3.php'  => 'update911to913',
-                $path . '/update_9.1.x_to_9.2.0.php'  => 'update91xto920',
-                $path . '/update_9.2.0_to_9.2.1.php'  => 'update920to921',
-                $path . '/update_9.2.1_to_9.2.2.php'  => 'update921to922',
-                $path . '/update_9.2.2_to_9.2.3.php'  => 'update922to923',
-                $path . '/update_9.2.x_to_9.3.0.php'  => 'update92xto930',
-                $path . '/update_9.3.0_to_9.3.1.php'  => 'update930to931',
-                $path . '/update_9.3.1_to_9.3.2.php'  => 'update931to932',
-                $path . '/update_9.3.x_to_9.4.0.php'  => 'update93xto940',
-                $path . '/update_9.4.0_to_9.4.1.php'  => 'update940to941',
-                $path . '/update_9.4.1_to_9.4.2.php'  => 'update941to942',
-                $path . '/update_9.4.2_to_9.4.3.php'  => 'update942to943',
-                $path . '/update_9.4.3_to_9.4.5.php'  => 'update943to945',
-                $path . '/update_9.4.5_to_9.4.6.php'  => 'update945to946',
-                $path . '/update_9.4.6_to_9.4.7.php'  => 'update946to947',
-                $path . '/update_9.4.x_to_9.5.0.php'  => 'update94xto950',
-                $path . '/update_9.5.1_to_9.5.2.php'  => 'update951to952',
-                $path . '/update_9.5.2_to_9.5.3.php'  => 'update952to953',
-                $path . '/update_9.5.3_to_9.5.4.php'  => 'update953to954',
-                $path . '/update_9.5.4_to_9.5.5.php'  => 'update954to955',
-                $path . '/update_9.5.5_to_9.5.6.php'  => 'update955to956',
-                $path . '/update_9.5.6_to_9.5.7.php'  => 'update956to957',
-                $path . '/update_9.5.x_to_10.0.0.php' => 'update95xto1000',
-                $path . '/update_10.0.0_to_10.0.1.php' => 'update1000to1001',
-                $path . '/update_10.0.1_to_10.0.2.php' => 'update1001to1002',
-                $path . '/update_10.0.2_to_10.0.3.php' => 'update1002to1003',
-                $path . '/update_10.0.3_to_10.0.4.php' => 'update1003to1004',
-                $path . '/update_10.0.4_to_10.0.5.php' => 'update1004to1005',
-                $path . '/update_10.0.5_to_10.0.6.php' => 'update1005to1006',
-            ],
-        ];
-
-        // Validate version normalization (9.4.1.1 -> 9.4.1).
-        yield [
-            'current_version'     => '9.4.1.1',
-            'force_latest'        => false,
-            'expected_migrations' => [
-                $path . '/update_9.4.1_to_9.4.2.php'  => 'update941to942',
-                $path . '/update_9.4.2_to_9.4.3.php'  => 'update942to943',
-                $path . '/update_9.4.3_to_9.4.5.php'  => 'update943to945',
-                $path . '/update_9.4.5_to_9.4.6.php'  => 'update945to946',
-                $path . '/update_9.4.6_to_9.4.7.php'  => 'update946to947',
-                $path . '/update_9.4.x_to_9.5.0.php'  => 'update94xto950',
-                $path . '/update_9.5.1_to_9.5.2.php'  => 'update951to952',
-                $path . '/update_9.5.2_to_9.5.3.php'  => 'update952to953',
-                $path . '/update_9.5.3_to_9.5.4.php'  => 'update953to954',
-                $path . '/update_9.5.4_to_9.5.5.php'  => 'update954to955',
-                $path . '/update_9.5.5_to_9.5.6.php'  => 'update955to956',
-                $path . '/update_9.5.6_to_9.5.7.php'  => 'update956to957',
-                $path . '/update_9.5.x_to_10.0.0.php' => 'update95xto1000',
-                $path . '/update_10.0.0_to_10.0.1.php' => 'update1000to1001',
-                $path . '/update_10.0.1_to_10.0.2.php' => 'update1001to1002',
-                $path . '/update_10.0.2_to_10.0.3.php' => 'update1002to1003',
-                $path . '/update_10.0.3_to_10.0.4.php' => 'update1003to1004',
-                $path . '/update_10.0.4_to_10.0.5.php' => 'update1004to1005',
-                $path . '/update_10.0.5_to_10.0.6.php' => 'update1005to1006',
-            ],
+            'expected_migrations' => array_merge(
+                $migrations_910_to_921,
+                $migrations_921_to_941,
+                $migrations_941_to_1006,
+            ),
         ];
 
         // Validate 9.2.2 specific case.
         yield [
             'current_version'     => '9.2.2',
             'force_latest'        => false,
-            'expected_migrations' => [
-                $path . '/update_9.2.1_to_9.2.2.php'  => 'update921to922',
-                $path . '/update_9.2.2_to_9.2.3.php'  => 'update922to923',
-                $path . '/update_9.2.x_to_9.3.0.php'  => 'update92xto930',
-                $path . '/update_9.3.0_to_9.3.1.php'  => 'update930to931',
-                $path . '/update_9.3.1_to_9.3.2.php'  => 'update931to932',
-                $path . '/update_9.3.x_to_9.4.0.php'  => 'update93xto940',
-                $path . '/update_9.4.0_to_9.4.1.php'  => 'update940to941',
-                $path . '/update_9.4.1_to_9.4.2.php'  => 'update941to942',
-                $path . '/update_9.4.2_to_9.4.3.php'  => 'update942to943',
-                $path . '/update_9.4.3_to_9.4.5.php'  => 'update943to945',
-                $path . '/update_9.4.5_to_9.4.6.php'  => 'update945to946',
-                $path . '/update_9.4.6_to_9.4.7.php'  => 'update946to947',
-                $path . '/update_9.4.x_to_9.5.0.php'  => 'update94xto950',
-                $path . '/update_9.5.1_to_9.5.2.php'  => 'update951to952',
-                $path . '/update_9.5.2_to_9.5.3.php'  => 'update952to953',
-                $path . '/update_9.5.3_to_9.5.4.php'  => 'update953to954',
-                $path . '/update_9.5.4_to_9.5.5.php'  => 'update954to955',
-                $path . '/update_9.5.5_to_9.5.6.php'  => 'update955to956',
-                $path . '/update_9.5.6_to_9.5.7.php'  => 'update956to957',
-                $path . '/update_9.5.x_to_10.0.0.php' => 'update95xto1000',
-                $path . '/update_10.0.0_to_10.0.1.php' => 'update1000to1001',
-                $path . '/update_10.0.1_to_10.0.2.php' => 'update1001to1002',
-                $path . '/update_10.0.2_to_10.0.3.php' => 'update1002to1003',
-                $path . '/update_10.0.3_to_10.0.4.php' => 'update1003to1004',
-                $path . '/update_10.0.4_to_10.0.5.php' => 'update1004to1005',
-                $path . '/update_10.0.5_to_10.0.6.php' => 'update1005to1006',
-            ],
+            'expected_migrations' => array_merge(
+                $migrations_921_to_941,
+                $migrations_941_to_1006,
+            ),
+        ];
+
+        // Validate version normalization (9.4.1.1 -> 9.4.1).
+        yield [
+            'current_version'     => '9.4.1.1',
+            'force_latest'        => false,
+            'expected_migrations' => $migrations_941_to_1006,
         ];
 
         // Dev versions always triggger latest migration
@@ -242,8 +332,16 @@ class Update extends \GLPITestCase
                 'current_version'     => sprintf('10.0.5-%s', $version_suffix),
                 'force_latest'        => false,
                 'expected_migrations' => [
-                    $path . '/update_10.0.4_to_10.0.5.php' => 'update1004to1005',
-                    $path . '/update_10.0.5_to_10.0.6.php' => 'update1005to1006',
+                    [
+                        'file'           => $path . '/update_10.0.4_to_10.0.5.php',
+                        'function'       => 'update1004to1005',
+                        'target_version' => '10.0.5',
+                    ],
+                    [
+                        'file'           => $path . '/update_10.0.5_to_10.0.6.php',
+                        'function'       => 'update1005to1006',
+                        'target_version' => '10.0.6',
+                    ],
                 ],
             ];
             // and when source version is a latest version
@@ -251,7 +349,11 @@ class Update extends \GLPITestCase
                 'current_version'     => sprintf('10.0.6-%s', $version_suffix),
                 'force_latest'        => false,
                 'expected_migrations' => [
-                    $path . '/update_10.0.5_to_10.0.6.php' => 'update1005to1006',
+                    [
+                        'file'           => $path . '/update_10.0.5_to_10.0.6.php',
+                        'function'       => 'update1005to1006',
+                        'target_version' => '10.0.6',
+                    ],
                 ],
             ];
 
@@ -260,7 +362,11 @@ class Update extends \GLPITestCase
                 'current_version'     => sprintf('10.0.6-%s', $version_suffix),
                 'force_latest'        => true,
                 'expected_migrations' => [
-                    $path . '/update_10.0.5_to_10.0.6.php' => 'update1005to1006',
+                    [
+                        'file'           => $path . '/update_10.0.5_to_10.0.6.php',
+                        'function'       => 'update1005to1006',
+                        'target_version' => '10.0.6',
+                    ],
                 ],
             ];
         }
@@ -278,7 +384,11 @@ class Update extends \GLPITestCase
             'current_version'     => '10.0.6',
             'force_latest'        => true,
             'expected_migrations' => [
-                $path . '/update_10.0.5_to_10.0.6.php' => 'update1005to1006',
+                [
+                    'file'           => $path . '/update_10.0.5_to_10.0.6.php',
+                    'function'       => 'update1005to1006',
+                    'target_version' => '10.0.6',
+                ],
             ],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | see #13338

Initially made on #10780.

When a migration is done, `version` is stored in database only at the end of the process, so if a migration that contains many steps fails, launching the update process will try to re-run the whole migration, including already completed steps.
Our migrations are almost always replayable when you try to re-run a step that has previously failed, but they cannot handle the fact that a step for a future version has already been completed. Storing the corresponding `version` value after each step completion will make the migration restart aftr the latest completed step.

#13338 show multiple errors that may occurs in this case.

Here are some failing cases when replay migration from `9.2.x` to `9.5.x`.

1. If migration fails after in `9.5.0` step, first run will have rename `glpi_computers_softwarelicenses` table to `glpi_items_softwarelicenses`. In second run, call to `$migration->dropKey('glpi_computers_softwarelicenses', 'unicity');` of `9.3.0` will emit a warning on second run (`PHP User Warning (512): Table glpi_computers_softwarelicenses does not exists in src\DbUtils.php at line 621`).

2. If migration fails after in `9.5.0` step, first run will have rename `purge_computer_software_install` config to `purge_item_software_install`. In second run, migration to `9.3.0` will recreate `purge_computer_software_install` config, and migration to `9.5.0` will fail when trying to rename `purge_computer_software_install` config to `purge_item_software_install` (`Error: Duplicate entry 'core-purge_item_software_install' for key 'unicity'`).

3. If migration fails after in `9.5.2` step, first run will have create `glpi_appliancerelations` then renamed it to `glpi_appliances_items_relations`. On second run, `glpi_appliancerelations` will be recreated, and a failure will happen when migration will try to rename it to `glpi_appliances_items_relations` that already exists.
