### PR TITLE
feat(inventory): improved port to stack member mapping

### DIFF
--- a/src/Inventory/Asset/NetworkEquipment.php
+++ b/src/Inventory/Asset/NetworkEquipment.php
@@ -344,6 +344,60 @@ class NetworkEquipment extends MainAsset
     }
 
     /**
+     * Returns a mapping of port indexes to chassis id
+     *
+     * @return array
+     */
+    public function getStackedPortsMap(): array
+    {
+        $components = $this->extra_data['network_components'] ?? [];
+        foreach ($components as $i => $component) {
+            foreach (['type', 'contained_index', 'index'] as $prop) {
+                if (!property_exists($component, $prop)) {
+                    unset($components[$i]);
+                    continue 2;
+                }
+            }
+        }
+        if (!count($components)) {
+            return [];
+        }
+
+        $map = [];
+        foreach ($components as $component) {
+            if ($component->type == 'port') {
+                $chassis_id = $this->traverseComponents($components, $component->contained_index);
+                if ($chassis_id) {
+                    $map[$component->index] = $chassis_id;
+                }
+            }
+        }
+
+        return $map;
+    }
+
+    private function traverseComponents(array $components, int $index, int $depth = 0): ?int
+    {
+        // max level of recursion
+        if ($depth > 5) {
+            return null;
+        }
+
+        foreach ($components as $component) {
+            if ($component->index == $index) {
+                if ($component->type == 'chassis') {
+                    return $component->index;
+                } else {
+                    $depth++;
+                    return $this->traverseComponents($components, $component->contained_index, $depth);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Is device a wireless controller
      * Relies on level/dependencies of network_components
      *

--- a/src/Inventory/Asset/NetworkPort.php
+++ b/src/Inventory/Asset/NetworkPort.php
@@ -771,14 +771,21 @@ class NetworkPort extends InventoryAsset
         //handle ports for stacked switches
         if ($mainasset->isStackedSwitch()) {
             $bkp_ports = $this->ports;
+            $portid_to_chassisid = $mainasset->getStackedPortsMap();
+            $stack_id = $mainasset->getStackId();
             foreach ($this->ports as $k => $val) {
                 $matches = [];
-                if (preg_match('@[\w-]+(\d+)/\d+/\d+@', $val->name, $matches)) {
-                    if ($matches[1] != $mainasset->getStackId()) {
-                        //port attached to another stack entry, remove from here
-                        unset($this->ports[$k]);
-                        continue;
-                    }
+                if (
+                    (property_exists($val, 'ifnumber')
+                    && isset($portid_to_chassisid[$val->ifnumber])
+                    && $portid_to_chassisid[$val->ifnumber] != $stack_id)
+                        ||
+                    (preg_match('@[\w-]+(\d+)/\d+/\d+@', $val->name, $matches)
+                    && $matches[1] != $stack_id)
+                ) {
+                    //port attached to another stack entry, remove from here
+                    unset($this->ports[$k]);
+                    continue;
                 }
             }
         }


### PR DESCRIPTION
I have stacks of switches where network ports names have zeroes in the chassis-id part, e.g. `Gi0/1`, and Glpi currently can't have `$stack_id == 0`. We can try to parse `network_components` section to find out ports to stack members assignment.

Links to https://github.com/glpi-project/glpi-agent/pull/260


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
