### PR TITLE
fix(inventory): prevent PHP warning for 'entities_id_default'

### DIFF
--- a/install/migrations/update_10.0.5_to_10.0.6/inventory.php
+++ b/install/migrations/update_10.0.5_to_10.0.6/inventory.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2022 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+
+$conf = new \Glpi\Inventory\Conf();
+$conf->saveConf(['entities_id_default' => 0]);

--- a/tests/functionnal/Glpi/Inventory/Assets/Computer.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Computer.php
@@ -745,26 +745,18 @@ class Computer extends AbstractInventoryAsset
         <DEVICEID>glpixps.teclib.infra-2018-10-03-08-42-36</DEVICEID>
         <QUERY>INVENTORY</QUERY>
         </REQUEST>";
-        //per default, do not change states_id
-        $this->login();
-        $conf = new \Glpi\Inventory\Conf();
-        $this->boolean(
-            $conf->saveConf([
-                'entities_id_default' => 0
-            ])
-        )->isTrue();
-        $this->logout();
 
         $inventory = $this->doInventory($xml_source, true);
         $computers_id = $inventory->getItem()->fields['id'];
         $this->integer($computers_id)->isGreaterThan(0);
 
-        //load computer and check entities_id
+        //load computer and check entities_id (0 by default)
         $computer->getFromDB($computers_id);
         $this->integer($computer->fields['entities_id'])->isEqualTo(0);
 
 
-        //per default, use entities_id 1
+        //per default, use entities_id 0
+        //so change entities_id to 1
         $this->login();
         $conf = new \Glpi\Inventory\Conf();
         $this->boolean(


### PR DESCRIPTION
Prevent PHP warning about ```entities_id_default```

Initialize conf to ```0``` default

```shell
[2022-11-22 08:29:09] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "entities_id_default" in /home/stanislas/TECLIB/DEV/GLPI/10.0-bugfixes/src/Inventory/Conf.php at line 971
  Backtrace :
  src/Inventory/Asset/MainAsset.php:532              Glpi\Inventory\Conf->__get()
  src/Inventory/Inventory.php:706                    Glpi\Inventory\Asset\MainAsset->handle()
  src/Inventory/Inventory.php:341                    Glpi\Inventory\Inventory->handleItem()
  src/Inventory/Request.php:360                      Glpi\Inventory\Inventory->doInventory()
  src/Inventory/Request.php:90                       Glpi\Inventory\Request->inventory()
  src/Agent/Communication/AbstractRequest.php:332    Glpi\Inventory\Request->handleAction()
  src/Agent/Communication/AbstractRequest.php:244    Glpi\Agent\Communication\AbstractRequest->handleJSONRequest()
  front/inventory.php:92                             Glpi\Agent\Communication\AbstractRequest->handleRequest()
``` 

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
