### PR TITLE
fix(notification template translation): link was added on images

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5555,7 +5555,8 @@ class CommonDBTM extends CommonGLPI
             $input[$options['content_field']] = Toolbox::convertTagToImage(
                 $input[$options['content_field']],
                 $this,
-                $docadded
+                $docadded,
+                $options['_add_link'] ?? true,
             );
 
             if (isset($this->input['_forcenotif'])) {

--- a/src/NotificationTemplateTranslation.php
+++ b/src/NotificationTemplateTranslation.php
@@ -309,7 +309,8 @@ class NotificationTemplateTranslation extends CommonDBChild
         $this->input = $this->addFiles($this->input, [
             'force_update' => true,
             'name' => 'content_html',
-            'content_field' => 'content_html'
+            'content_field' => 'content_html',
+            '_add_link' => false
         ]);
 
         parent::post_addItem($history);
@@ -322,7 +323,8 @@ class NotificationTemplateTranslation extends CommonDBChild
         $this->input = $this->addFiles($this->input, [
             'force_update' => true,
             'name' => 'content_html',
-            'content_field' => 'content_html'
+            'content_field' => 'content_html',
+            '_add_link' => false
         ]);
 
         parent::post_updateItem($history);

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2679,7 +2679,7 @@ class Toolbox
      *
      * @return string                the $content_text param after parsing
      **/
-    public static function convertTagToImage($content_text, CommonDBTM $item, $doc_data = [])
+    public static function convertTagToImage($content_text, CommonDBTM $item, $doc_data = [], bool $add_link = true)
     {
         global $CFG_GLPI;
 
@@ -2760,7 +2760,7 @@ class Toolbox
                                 $id,
                                 $width,
                                 $height,
-                                true,
+                                $add_link,
                                 $object_url_param
                             );
                             if (empty($new_image)) {


### PR DESCRIPTION
A link was systematically added on the images in the templates

Before:
![image](https://user-images.githubusercontent.com/8530352/203260995-99625ba4-05df-4251-a9bb-5d12a8824bf3.png)

After:
![image](https://user-images.githubusercontent.com/8530352/203261072-57fd7939-312d-4c83-a0dc-96d1c8b6995e.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25497
