### PR TITLE
fix(lock): check itemtype / items_id before load locked field

### DIFF
--- a/src/Lock.php
+++ b/src/Lock.php
@@ -222,7 +222,6 @@ class Lock extends CommonGLPI
                     //get real type name from CommonDBRelation
                     // ex: get 'Operating System' instead of 'Item operating systems'
                     } elseif (get_parent_class($row['itemtype']) == CommonDBRelation::class) {
-
                         //For CommonDBRelation
                         // $itemtype_1 / $items_id_1 and $itemtype_2 / $items_id_2 can be inverted
 

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -222,9 +222,29 @@ class Lock extends CommonGLPI
                     //get real type name from CommonDBRelation
                     // ex: get 'Operating System' instead of 'Item operating systems'
                     } elseif (get_parent_class($row['itemtype']) == CommonDBRelation::class) {
-                        $default_itemtype =  $row['itemtype']::$itemtype_1;
-                        $default_items_id =  $row['itemtype']::$items_id_1;
-                        $default_itemtype_label = $row['itemtype']::$itemtype_1::getTypeName();
+
+                        //For CommonDBRelation
+                        // $itemtype_1 / $items_id_1 and $itemtype_2 / $items_id_2 can be inverted
+
+                        //ex: Item_Software have
+                        // $itemtype_1 = 'itemtype';
+                        // $items_id_1 = 'items_id';
+                        // $itemtype_2 = 'SoftwareVersion';
+                        // $items_id_2 = 'softwareversions_id';
+                        if (preg_match('/^itemtype/', $row['itemtype']::$itemtype_1)) {
+                            $default_itemtype =  $row['itemtype']::$itemtype_2;
+                            $default_items_id =  $row['itemtype']::$items_id_2;
+                            $default_itemtype_label = $row['itemtype']::$itemtype_2::getTypeName();
+                        } else {
+                            //ex: Item_OperatingSystem have
+                            // $itemtype_1 = 'OperatingSystem';
+                            // $items_id_1 = 'operatingsystems_id';
+                            // $itemtype_2 = 'itemtype';
+                            // $items_id_2 = 'items_id';
+                            $default_itemtype =  $row['itemtype']::$itemtype_1;
+                            $default_items_id =  $row['itemtype']::$items_id_1;
+                            $default_itemtype_label = $row['itemtype']::$itemtype_1::getTypeName();
+                        }
                     }
 
                     // specific link for CommonDBRelation itemtype (like Item_OperatingSystem)


### PR DESCRIPTION
Prevent PHP error when trying to get ```ìtemtype``` ```items_id``` from locked field

```shell
[2022-11-22 09:44:18] glpiphplog.CRITICAL:   *** Uncaught Exception Error: Class "itemtype" not found in /home/TECLIB/DEV/GLPI/10.0-bugfixes/src/Lock.php at line 227
  Backtrace :
  src/Lock.php:804                                   Lock::showForItem()
  src/CommonGLPI.php:689                             Lock::displayTabContentForItem()
  ajax/common.tabs.php:116                           CommonGLPI::displayStandardTab()
```

 Declaration of ```CommonDBRelation``` sides are sometimes reversed

 Item_Software have
```php
$itemtype_1 = 'itemtype';
$items_id_1 = 'items_id';
$itemtype_2 = 'SoftwareVersion';
$items_id_2 = 'softwareversions_id';
```

Item_OperatingSystem have
```php
$itemtype_1 = 'OperatingSystem';
$items_id_1 = 'operatingsystems_id';
$itemtype_2 = 'itemtype';
$items_id_2 = 'items_id';
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
