### PR TITLE
Drop unused true/punycode package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The present file will list all changes made to the project; according to the
 - `codemirror` library has been upgraded to version 6.x.
 - `photoswipe` library has been upgraded to version 5.x.
 - `phpmailer/phpmailer` library has been replaced by `symfony/mailer`.
+- `true/punycode` library has been removed.
 - `Symfony` libraries have been upgraded to version 6.0.
 - `users_id_validate` field in `CommonITILValidation` will now have a `0` value until someone approves or refuses the validation.
   Approval targets (who the approval is for) is now indicated by `itemtype_target` and `items_id_target` fields.

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,6 @@
         "symfony/polyfill-php81": "^1.26",
         "symfony/polyfill-php82": "^1.26",
         "tecnickcom/tcpdf": "^6.5",
-        "true/punycode": "^2.1",
         "twig/string-extra": "^3.3",
         "twig/twig": "^3.3",
         "wapmorgan/unified-archive": "^1.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1144491300a88789dc8d2039665242b5",
+    "content-hash": "d79057e72961c302fffa406bc15a8e50",
     "packages": [
         {
             "name": "blueimp/jquery-file-upload",
@@ -5093,57 +5093,6 @@
                 }
             ],
             "time": "2022-08-12T07:50:54+00:00"
-        },
-        {
-            "name": "true/punycode",
-            "version": "v2.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/true/php-punycode.git",
-                "reference": "a4d0c11a36dd7f4e7cd7096076cab6d3378a071e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/true/php-punycode/zipball/a4d0c11a36dd7f4e7cd7096076cab6d3378a071e",
-                "reference": "a4d0c11a36dd7f4e7cd7096076cab6d3378a071e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0",
-                "symfony/polyfill-mbstring": "^1.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.7",
-                "squizlabs/php_codesniffer": "~2.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "TrueBV\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Renan Gonçalves",
-                    "email": "renan.saddam@gmail.com"
-                }
-            ],
-            "description": "A Bootstring encoding of Unicode for Internationalized Domain Names in Applications (IDNA)",
-            "homepage": "https://github.com/true/php-punycode",
-            "keywords": [
-                "idna",
-                "punycode"
-            ],
-            "support": {
-                "issues": "https://github.com/true/php-punycode/issues",
-                "source": "https://github.com/true/php-punycode/tree/master"
-            },
-            "abandoned": true,
-            "time": "2016-11-16T10:37:54+00:00"
         },
         {
             "name": "twig/string-extra",

--- a/src/Config.php
+++ b/src/Config.php
@@ -2289,9 +2289,6 @@ HTML;
             [ 'name'    => 'michelf/php-markdown',
                 'check'   => 'Michelf\\Markdown'
             ],
-            [ 'name'    => 'true/punycode',
-                'check'   => 'TrueBV\\Punycode'
-            ],
             [ 'name'    => 'iamcal/lib_autolink',
                 'check'   => 'autolink'
             ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`php-intl` is a required dependency, so we can use `idn_to_ascii` safely instead of using abandonned `true/punycode` package.