### PR TITLE
fix(lockedfield): fix lockedfield load

### DIFF
--- a/src/Lock.php
+++ b/src/Lock.php
@@ -136,8 +136,19 @@ class Lock extends CommonGLPI
                         continue;
                     }
                     $query['WHERE'][] = $connexity_criteria['WHERE'];
+                } else { //is CommonDBTM (ie : Monitor / DatabaseInstance)
+                    //we need to restrict scope with Computer_Item to prevent loading of all lockedfield
+                    $query['LEFT JOIN'][getTableForItemType(Computer_Item::class)] =
+                    [
+                        'FKEY'   => [
+                            getTableForItemType(Computer_Item::class)  => 'items_id',
+                            getTableForItemType($lockable_itemtype)   => 'id'
+                        ]
+                    ];
+                    $query['WHERE'][] = [
+                        getTableForItemType(Computer_Item::class) . '.computers_id'  => $ID
+                    ];
                 }
-
                 $subquery[] = new \QuerySubQuery($query);
             }
 

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -136,17 +136,22 @@ class Lock extends CommonGLPI
                         continue;
                     }
                     $query['WHERE'][] = $connexity_criteria['WHERE'];
-                } else { //is CommonDBTM (ie : Monitor / DatabaseInstance)
+                } elseif (in_array($lockable_itemtype, $CFG_GLPI['directconnect_types'])) {
                     //we need to restrict scope with Computer_Item to prevent loading of all lockedfield
-                    $query['LEFT JOIN'][getTableForItemType(Computer_Item::class)] =
+                    $query['LEFT JOIN'][Computer_Item::getTable()] =
                     [
                         'FKEY'   => [
-                            getTableForItemType(Computer_Item::class)  => 'items_id',
-                            getTableForItemType($lockable_itemtype)   => 'id'
+                            Computer_Item::getTable()  => 'items_id',
+                            $lockable_itemtype::getTable()   => 'id'
                         ]
                     ];
                     $query['WHERE'][] = [
-                        getTableForItemType(Computer_Item::class) . '.computers_id'  => $ID
+                        Computer_Item::getTable() . '.computers_id'  => $ID
+                    ];
+                } elseif ($lockable_object->isField('itemtype') && $lockable_object->isField('items_id')) {
+                    $query['WHERE'][] = [
+                        $lockable_itemtype::getTable() . '.itemtype'  => $itemtype,
+                        $lockable_itemtype::getTable() . '.items_id'  => $ID
                     ];
                 }
                 $subquery[] = new \QuerySubQuery($query);


### PR DESCRIPTION
From ```CommonDBTM``` object (```Monitor```, ```DatabaseInstance```)
GLPI load all object without restrict scope

```sql
SELECT  `glpi_lockedfields`.*
	FROM `glpi_lockedfields`
	LEFT JOIN `glpi_monitors`
	ON (`glpi_lockedfields`.`items_id` = `glpi_monitors`.`id`)
	WHERE ((`glpi_lockedfields`.`itemtype` = 'Monitor' AND `glpi_lockedfields`.`items_id` = glpi_monitors.id) OR (`glpi_lockedfields`.`itemtype` = 'Monitor' AND `glpi_lockedfields`.`is_global` = '1')))
```
This PR fix this by adding :

- ```LEFT JOIN``` with ```Computer_Item```
- ```WHERE``` on ```current item ID```

```sql
SELECT  `glpi_lockedfields`.*
	FROM `glpi_lockedfields`
	LEFT JOIN `glpi_monitors`
	ON (`glpi_lockedfields`.`items_id` = `glpi_monitors`.`id`)
	LEFT JOIN `glpi_computers_items`
	ON (`glpi_computers_items`.`items_id` = `glpi_monitors`.`id`)
	WHERE ((`glpi_lockedfields`.`itemtype` = 'Monitor' AND `glpi_lockedfields`.`items_id` = glpi_monitors.id) OR 	(`glpi_lockedfields`.`itemtype` = 'Monitor' AND `glpi_lockedfields`.`is_global` = '1'))
	AND (`glpi_computers_items`.`computers_id` = '7')))
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25474
