### PR TITLE
Initialize rules after DB migrations

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -347,6 +347,7 @@ $empty_data_builder = new class
             'planning_work_days' => exportArrayToDB([0, 1, 2, 3, 4, 5, 6]),
             'system_user' => 6,
             'support_legacy_data' => 0, // New installation should not support legacy data
+            'initialized_rules_collections' => '[]',
         ];
 
         $tables['glpi_configs'] = [];

--- a/install/migrations/update_10.0.5_to_10.0.6/rule.php
+++ b/install/migrations/update_10.0.5_to_10.0.6/rule.php
@@ -78,10 +78,13 @@ $result = $DB->request(
     ]
 );
 
-//foreach crierias, change 'name' key to desired
+//foreach criteria, change 'name' key to desired
 foreach ($result as $data) {
     $query = "UPDATE `glpi_rulecriterias`
                SET `criteria` = '" . array_search($data['sub_type'], $subType) . "'
                WHERE `id` = " . $data['criteria_id'];
     $DB->queryOrDie($query, "10.0.6 change crtieria name");
 }
+
+// Init 'initialized_rules_collections' config
+$migration->addConfig(['initialized_rules_collections' => '[]']);

--- a/install/migrations/update_10.0.5_to_10.0.6/rule.php
+++ b/install/migrations/update_10.0.5_to_10.0.6/rule.php
@@ -85,11 +85,3 @@ foreach ($result as $data) {
                WHERE `id` = " . $data['criteria_id'];
     $DB->queryOrDie($query, "10.0.6 change crtieria name");
 }
-
-//create default dictionnaries if needed
-foreach (array_values($subType) as $ruleDictionnaryType) {
-    if (method_exists($ruleDictionnaryType, 'initRules') && countElementsInTable(Rule::getTable(), ['sub_type' => $ruleDictionnaryType]) === 0) {
-        //default rules.
-        $ruleDictionnaryType::initRules(false, false, true);
-    }
-}

--- a/install/migrations/update_9.5.x_to_10.0.0/native_inventory.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/native_inventory.php
@@ -158,12 +158,6 @@ if (!$DB->tableExists('glpi_rulematchedlogs')) {
     $migration->addKey('glpi_rulematchedlogs', 'rules_id');
 }
 
-
-if (countElementsInTable(Rule::getTable(), ['sub_type' => 'RuleImportAsset']) === 0) {
-    //default rules.
-    RuleImportAsset::initRules(false, false, true);
-}
-
 //locked fields
 if (!$DB->tableExists('glpi_lockedfields')) {
     $query = "CREATE TABLE `glpi_lockedfields` (

--- a/src/Rules/RulesManager.php
+++ b/src/Rules/RulesManager.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2022 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Rules;
+
+use Rule;
+use RuleCollection;
+
+final class RulesManager
+{
+    /**
+     * Initialize rules for each collection that does not yet contains any rule.
+     */
+    public static function initializeRules(): void
+    {
+        global $CFG_GLPI;
+
+        $itemtypes = array_unique(array_merge($CFG_GLPI['rulecollections_types'], $CFG_GLPI['dictionnary_types']));
+
+        foreach ($itemtypes as $itemtype) {
+            $rulecollection = RuleCollection::getClassByType($itemtype);
+            if (!($rulecollection instanceof RuleCollection)) {
+                continue;
+            }
+            $ruleclass = $rulecollection->getRuleClass();
+            if (!is_a($ruleclass, Rule::class, true) || !method_exists($ruleclass, 'initRules')) {
+                continue;
+            }
+            if (countElementsInTable(Rule::getTable(), ['sub_type' => $ruleclass]) > 0) {
+                continue; // Skip collections that already contains rules
+            }
+
+            $ruleclass::initRules(false, false, false);
+        }
+    }
+}

--- a/src/Rules/RulesManager.php
+++ b/src/Rules/RulesManager.php
@@ -75,7 +75,7 @@ final class RulesManager
             $initialized_collections[] = get_class($rulecollection);
             Config::setConfigurationValues(
                 'core',
-                ['initialized_rules_collections', json_encode($initialized_collections)]
+                ['initialized_rules_collections' => json_encode($initialized_collections)]
             );
         }
     }

--- a/src/Rules/RulesManager.php
+++ b/src/Rules/RulesManager.php
@@ -60,7 +60,7 @@ final class RulesManager
             $ruleclass = $rulecollection instanceof RuleCollection ? $rulecollection->getRuleClass() : null;
 
             if (
-                in_array($rulecollection, $initialized_collections)
+                in_array(get_class($rulecollection), $initialized_collections)
                 || !is_a($ruleclass, Rule::class, true) || !method_exists($ruleclass, 'initRules')
             ) {
                 continue;

--- a/src/Rules/RulesManager.php
+++ b/src/Rules/RulesManager.php
@@ -72,7 +72,7 @@ final class RulesManager
 
             // Mark collection as already initialized, to not reinitialize it on next update
             // if admin remove all corresponding rules.
-            $initialized_collections[] = $rulecollection;
+            $initialized_collections[] = get_class($rulecollection);
             Config::setConfigurationValues(
                 'core',
                 ['initialized_rules_collections', json_encode($initialized_collections)]

--- a/src/Rules/RulesManager.php
+++ b/src/Rules/RulesManager.php
@@ -57,12 +57,15 @@ final class RulesManager
 
         foreach ($itemtypes as $itemtype) {
             $rulecollection = RuleCollection::getClassByType($itemtype);
-            $ruleclass = $rulecollection instanceof RuleCollection ? $rulecollection->getRuleClass() : null;
-
             if (
-                in_array(get_class($rulecollection), $initialized_collections)
-                || !is_a($ruleclass, Rule::class, true) || !method_exists($ruleclass, 'initRules')
+                !($rulecollection instanceof RuleCollection)
+                || in_array(get_class($rulecollection), $initialized_collections)
             ) {
+                continue;
+            }
+
+            $ruleclass = $rulecollection instanceof RuleCollection ? $rulecollection->getRuleClassName() : null;
+            if (!is_a($ruleclass, Rule::class, true) || !method_exists($ruleclass, 'initRules')) {
                 continue;
             }
 

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -36,6 +36,7 @@
 use Glpi\Console\Application;
 use Glpi\Event;
 use Glpi\Mail\Protocol\ProtocolInterface;
+use Glpi\Rules\RulesManager;
 use Glpi\Toolbox\Sanitizer;
 use Glpi\Toolbox\VersionParser;
 use Laminas\Mail\Storage\AbstractStorage;
@@ -2393,11 +2394,8 @@ class Toolbox
                 }
             }
 
-            //rules
-            RuleImportAsset::initRules();
-            RuleDictionnaryOperatingSystemVersion::initRules();
-            RuleDictionnaryOperatingSystemEdition::initRules();
-            RuleDictionnaryOperatingSystem::initRules();
+            // Initalize rules
+            RulesManager::initializeRules();
 
            // update default language
             Config::setConfigurationValues(

--- a/src/Update.php
+++ b/src/Update.php
@@ -33,6 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Rules\RulesManager;
 use Glpi\System\Diagnostic\DatabaseSchemaIntegrityChecker;
 use Glpi\Toolbox\VersionParser;
 
@@ -264,6 +265,10 @@ class Update
             include_once($file);
             $function();
         }
+
+        // Initalize rules
+        $this->migration->displayTitle(__('Initializing rules...'));
+        RulesManager::initializeRules();
 
         if (($myisam_count = $DB->getMyIsamTables()->count()) > 0) {
             $message = sprintf(__('%d tables are using the deprecated MyISAM storage engine.'), $myisam_count)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Using `initRules()` methods during update process may lead to issues in the future. Indeed, these methods are also used when reinitializing rules from rules admin UI and are expecting that database is up to date, and so calling them with a database not fully upgraded may cause failures, if database structure change in the future.

With proposed code, rules will be initialized after database migration, using the same logic that the one used in install process.