### PR TITLE
Drop unexpected ruleImportAsset_addGlobalCriteria hook call

### DIFF
--- a/src/RuleImportAsset.php
+++ b/src/RuleImportAsset.php
@@ -2358,24 +2358,6 @@ class RuleImportAsset extends Rule
             'action'    => '_deny'
         ];
 
-        //load default rules from plugins
-        if ($with_plugins && isset($PLUGIN_HOOKS['add_rules'])) {
-            $ria = new self();
-            foreach ($PLUGIN_HOOKS['add_rules'] as $plugin => $val) {
-                if (!Plugin::isPluginActive($plugin)) {
-                    continue;
-                }
-                $rules = array_merge(
-                    $rules,
-                    Plugin::doOneHook(
-                        $plugin,
-                        "ruleImportAsset_addGlobalCriteria",
-                        $ria->getGlobalCriteria()
-                    )
-                );
-            }
-        }
-
         $ranking = 0;
         foreach ($rules as $rule) {
             $rulecollection = new RuleImportAssetCollection();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Removed hook call is invalid. Indeed, `ruleImportAsset_addGlobalCriteria` hook is call in `RuleImportAsset::getGlobalCriteria()` and current call is probably resulting in a bad copy/paste (maybe it something like `ruleImportAsset_addRules` should have been called instead).

I propose to remove this call. Fixing it does not seems valuable as noone asked for it.