### PR TITLE
Try to avoid public security issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,6 +7,8 @@ body:
 
         Dear GLPI user.
 
+        **⚠️ Please never use standard issues to report security problems. See [security policy](https://github.com/glpi-project/glpi/security/policy) for more details. ⚠️**
+
         BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:
 
         * We do not support community plugins. Contact directly their authors, or use [the community forum](https://forum.glpi-project.org).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,10 @@ Please note that current repository is about GLPI core only. All related plugins
 
 **Please write only in English!**
 
+## Security
+
+**⚠️ Please never use standard issues to report security problems. See [security policy](https://github.com/glpi-project/glpi/security/policy) for more details. ⚠️**
+
 ## Bugs
 
 Note that issues are handled on a best-effort basis. If you need a quick fix or any guarantee, take a look at **[profesional services](http://services.glpi-network.com/)** or [partners](https://glpi-project.org/partners/).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,23 @@
 # Security Policy
 
+**⚠️ Please never use standard issues to report security problems; vulnerabilities are published once a fix release is available. ⚠️**
+
+## Reporting a Vulnerability
+
+If you found a security issue, please contact us by:
+
+- [our huntr page](https://huntr.dev/repos/glpi-project/glpi/)
+- a mail to \[glpi-security AT ow2.org\]
+
+You should provide us all details about the issue and the way to reproduce it.
+You may also provide a script that can be used to check the issue exists.
+
+Once the report will be handled, and if the issue is not yet fixed (or in progress)
+we'll add it to the GitHub security tab, and add you as observer. Meanwhile,
+you will reserve a CVE for the issue.
+
+Thank you for improving the security of glpi.
+
 ## Supported Versions
 
 | Version | Supported          |
@@ -10,22 +28,3 @@
 | 9.3.x   | :x:                |
 | 9.2.x   | :x:                |
 | < 9.2   | :x:                |
-
-## Reporting a Vulnerability
-
-If you found a security issue, please contact us by:
-
-- [our huntr page](https://huntr.dev/repos/glpi-project/glpi/)
-- a mail to \[glpi-security AT ow2.org\]
-
-Please **never** use standard issues to report security problems;
-vulnerabilities are published once a fix release is available.
-
-You should provide us all details about the issue and the way to reproduce it.
-You may also provide a script that can be used to check the issue exists.
-
-Once the report will be handled, and if the issue is not yet fixed (or in progress)
-we'll add it to the GitHub security tab, and add you as observer. Meanwhile,
-you will reserve a CVE for the issue.
-
-Thank you for improving the security of glpi.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Maybe adding a bold text with a :warning: would prevent some people to open public security issues.