### PR TITLE
Fix copy/pasting content from Ticket description

### DIFF
--- a/templates/components/itilobject/timeline/main_description.html.twig
+++ b/templates/components/itilobject/timeline/main_description.html.twig
@@ -41,7 +41,7 @@
          {{ include('components/user/picture.html.twig', {'users_id': users_id}, with_context = false) }}
       </div>
       <div class="col-12 col-sm">
-         <span class="mt-2 timeline-content left card">
+         <div class="mt-2 timeline-content left card">
             <div class="card-body">
                <div class="d-flex timeline-header">
                   <div class="d-flex creator">
@@ -92,7 +92,7 @@
                   <div class="ajax-content"></div>
                </div>
             </div>
-         </span>
+         </div>
       </div>
    </div>
 </div>

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -152,7 +152,7 @@
                {% endif %}
             </div>
             <div class="col-12 col-sm d-flex flex-column content-part">
-               <span class="mt-2 timeline-content {{ solution_class }} flex-grow-1 {{ item_position }} card">
+               <div class="mt-2 timeline-content {{ solution_class }} flex-grow-1 {{ item_position }} card">
                   <div class="card-body px-1 px-xxl-3">
                      {{ include('components/itilobject/timeline/timeline_item_header.html.twig') }}
 
@@ -173,7 +173,7 @@
                         <div class="ajax-content"></div>
                      </div>
                   </div>
-               </span>
+               </div>
 
                {% if entry['documents'] is defined %}
                   {{ include('components/itilobject/timeline/sub_documents.html.twig', {


### PR DESCRIPTION
When copy/pasting content from the ticket timeline, some unwanted css is inserted into the editor: 

![image](https://user-images.githubusercontent.com/42734840/203532170-eb813ca1-fc2c-4395-a8eb-dccd3c36d996.png)

Generated HTML:

![image](https://user-images.githubusercontent.com/42734840/203532249-9cf0e05a-9774-4898-a2cb-e67a3213ee79.png)

This is caused by an incorrect use of `span`.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25593
