### PR TITLE
fix(core): manage unrecongnized langage

### DIFF
--- a/src/Inventory/Asset/Software.php
+++ b/src/Inventory/Asset/Software.php
@@ -103,12 +103,12 @@ class Software extends InventoryAsset
 
             if (
                 !property_exists($val, 'name')
-                || ($val->name == ''
-                || str_starts_with(Toolbox::slugify($val->name), 'nok_')
-                )
+                || empty($val->name)
             ) {
                 if (property_exists($val, 'guid') && $val->guid != '') {
                     $val->name = $val->guid;
+                } elseif (property_exists($val, 'comments') && $val->comments != '') {
+                    $val->name = $val->comments;
                 }
             }
 

--- a/src/Inventory/Asset/Software.php
+++ b/src/Inventory/Asset/Software.php
@@ -447,7 +447,7 @@ class Software extends InventoryAsset
      */
     protected function getSoftwareKey($name, $manufacturers_id): string
     {
-        return $this->getCompareKey([Toolbox::slugify($name), $manufacturers_id]);
+        return $this->getCompareKey([Toolbox::slugify($name, 'slug_', true), $manufacturers_id]);
     }
 
     /**

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2622,16 +2622,20 @@ class Toolbox
     /**
      * Slugify
      *
-     * @param string $string String to slugify
+     * @param string $str String to slugify
      * @param string $prefix Prefix to use (anchors cannot begin with a number)
      *
      * @return string
      */
-    public static function slugify($string, $prefix = 'slug_')
+    public static function slugify($str, $prefix = 'slug_')
     {
-        $string = transliterator_transliterate("Any-Latin; Latin-ASCII; [^a-zA-Z0-9\.\ -_] Remove;", $string);
+        $string = transliterator_transliterate("Any-Latin; Latin-ASCII; [^a-zA-Z0-9\.\ -_] Remove;", $str);
+        //if langage are no supported and return empty string
+        //replace it by original string
+        if (empty(trim($string))) {
+            $string = $str;
+        }
         $string = str_replace(' ', '-', self::strtolower($string, 'UTF-8'));
-        $string = preg_replace('~[^0-9a-z_\.]+~i', '-', $string);
         $string = trim($string, '-');
         if ($string == '') {
            //prevent empty slugs; see https://github.com/glpi-project/glpi/issues/2946

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2627,15 +2627,18 @@ class Toolbox
      *
      * @return string
      */
-    public static function slugify($str, $prefix = 'slug_')
+    public static function slugify($str, $prefix = 'slug_', $allow_special_chars = false)
     {
         $string = transliterator_transliterate("Any-Latin; Latin-ASCII; [^a-zA-Z0-9\.\ -_] Remove;", $str);
         //if langage are no supported and return empty string
         //replace it by original string
-        if (empty(trim($string))) {
+        if (empty(trim($string)) && $allow_special_chars) {
             $string = $str;
         }
         $string = str_replace(' ', '-', self::strtolower($string, 'UTF-8'));
+        if (!$allow_special_chars) {
+            $string = preg_replace('~[^0-9a-z_\.]+~i', '-', $string);
+        }
         $string = trim($string, '-');
         if ($string == '') {
            //prevent empty slugs; see https://github.com/glpi-project/glpi/issues/2946

--- a/tests/functionnal/Toolbox.php
+++ b/tests/functionnal/Toolbox.php
@@ -66,15 +66,109 @@ class Toolbox extends DbTestCase
     {
         return [
             [
+                'string'   => '10-a-valid-one-with-number',
+                'expected' => 'slug_10-a-valid-one-with-number',
+                'allow_special_char' => false
+            ],
+            [
                 'string'   => 'My - string èé  Ê À ß',
-                'expected' => 'my-string-ee-e-a-ss'
-            ], [
+                'expected' => 'my-string-ee-e-a-ss',
+                'allow_special_char' => false
+            ],
+            [
             //https://github.com/glpi-project/glpi/issues/2946
                 'string'   => 'Έρευνα ικανοποίησης - Αιτήματα',
-                'expected' => 'ereuna-ikanopoieses-aitemata'
-            ], [
+                'expected' => 'ereuna-ikanopoieses-aitemata',
+                'allow_special_char' => false
+            ],
+            [
                 'string'   => 'a-valid-one',
                 'expected' => 'a-valid-one',
+                'allow_special_char' => false
+            ],
+            [
+                //Maïthili
+                'string'     => 'आविष्कारक मूल निवासी glpi',
+                'expected'  => 'aviskaraka-mula-nivasi-glpi',
+                'allow_special_char' => false
+            ],
+            [
+                //odia
+                'string'     => 'नेटिभ GLPI सूची',
+                'expected'  => 'netibha-glpi-suci',
+                'allow_special_char' => false
+            ],
+            [
+                //nepal
+                'string'     => 'ଦେଶୀ GLPI ଭଣ୍ଡାର |',
+                'expected'  => 'desi-glpi-bhandara',
+                'allow_special_char' => false
+            ],
+            [
+                //cambodian
+                'string'     => 'ភាសាខ្មែរ កញ្ចប់បទពិសោធន៍ផ្ទៃក្នុង',
+                'expected'  => 'ភាសាខ្មែរ-កញ្ចប់បទពិសោធន៍ផ្ទៃក្នុង',
+                'allow_special_char' => true
+            ],
+            [
+                //thaï
+                'string'     => 'สินค้าคงคลัง GLPI ดั้งเดิม',
+                'expected'  => 'sinkha-khngkhlang-glpi-dangdeim',
+                'allow_special_char' => false
+            ],
+            [
+                //tigrina
+                'string'     => 'ተወላዲ GLPI ዝርዝር ኣቑሑት።',
+                'expected'  => 'teweladi-glpi-riri-aqhuhhuti',
+                'allow_special_char' => false
+            ],
+            [
+                //latin
+                'string'     => 'Adobe Photoshop',
+                'expected'  => 'adobe-photoshop',
+                'allow_special_char' => false
+            ],
+            [
+                //cyrillic
+                'string'     => 'Песня про надежду',
+                'expected'  => 'pesna-pro-nadezdu',
+                'allow_special_char' => false
+            ],
+            [
+                //korean
+                'string' => '저는 7년 동안 한국에서 살았어요',
+                'expected'  => 'jeoneun-7nyeon-dong-an-hangug-eseo-sal-ass-eoyo',
+                'allow_special_char' => false
+            ],
+            [
+                //japan
+                'string' => 'グルピ ネイティブ インベントリ',
+                "expected" => "gurupi-neitibu-inbentori",
+                'allow_special_char' => false
+            ],
+            [
+                //ukrainian
+                'string' => 'інвентаризація нативного фонду GLPI',
+                "expected" => "inventarizacia-nativnogo-fondu-glpi",
+                'allow_special_char' => false
+            ],
+            [
+                //estonian
+                'string' => 'glpi algupärane inventuur',
+                "expected" => "glpi-alguparane-inventuur",
+                'allow_special_char' => false
+            ],
+            [
+                //kazakh
+                'string' => 'GLPI жергілікті түгендеу',
+                "expected" => "glpi-zergilikti-tgendeu",
+                'allow_special_char' => false
+            ],
+            [
+                //kurd
+                'string' => 'Envantera GLPI ya xwecihî',
+                "expected" => "envantera-glpi-ya-xwecihi",
+                'allow_special_char' => false
             ]
         ];
     }
@@ -82,9 +176,9 @@ class Toolbox extends DbTestCase
     /**
      * @dataProvider slugifyProvider
      */
-    public function testSlugify($string, $expected)
+    public function testSlugify($string, $expected, $allow_special_char)
     {
-        $this->string(\Toolbox::slugify($string))->isIdenticalTo($expected);
+        $this->string(\Toolbox::slugify($string, 'slug_', $allow_special_char))->isIdenticalTo($expected);
     }
 
     protected function filenameProvider()
@@ -1516,91 +1610,4 @@ class Toolbox extends DbTestCase
         }
         $this->boolean(call_user_func_array('Toolbox::isUrlSafe', $params))->isEqualTo($expected);
     }
-
-
-    protected function prepareDateForSafeTransliterate(): iterable
-    {
-        return [
-            [
-                //Maïthili
-                'string'     => 'आविष्कारक मूल निवासी glpi',
-                'expected'  => 'aviskaraka-mula-nivasi-glpi',
-            ],
-            [
-                //odia
-                'string'     => 'नेटिभ GLPI सूची',
-                'expected'  => 'netibha-glpi-suci',
-            ],
-            [
-                //nepal
-                'string'     => 'ଦେଶୀ GLPI ଭଣ୍ଡାର |',
-                'expected'  => 'desi-glpi-bhandara',
-            ],
-            [
-                //cambodian
-                'string'     => 'ភាសាខ្មែរ កញ្ចប់បទពិសោធន៍ផ្ទៃក្នុង',
-                'expected'  => 'ភាសាខ្មែរ-កញ្ចប់បទពិសោធន៍ផ្ទៃក្នុង',
-            ],
-            [
-                //thaï
-                'string'     => 'สินค้าคงคลัง GLPI ดั้งเดิม',
-                'expected'  => 'sinkha-khngkhlang-glpi-dangdeim',
-            ],
-            [
-                //tigrina
-                'string'     => 'ተወላዲ GLPI ዝርዝር ኣቑሑት።',
-                'expected'  => 'teweladi-glpi-riri-aqhuhhuti',
-            ],
-            [
-                //latin
-                'string'     => 'Adobe Photoshop',
-                'expected'  => 'adobe-photoshop',
-            ],
-            [
-                //cyrillic
-                'string'     => 'Песня про надежду',
-                'expected'  => 'pesna-pro-nadezdu',
-            ],
-            [
-                //korean
-                'string' => '저는 7년 동안 한국에서 살았어요',
-                'expected'  => 'jeoneun-7nyeon-dong-an-hangug-eseo-sal-ass-eoyo'
-            ],
-            [
-                //japan
-                'string' => 'グルピ ネイティブ インベントリ',
-                "expected" => "gurupi-neitibu-inbentori"
-            ],
-            [
-                //ukrainian
-                'string' => 'інвентаризація нативного фонду GLPI',
-                "expected" => "inventarizacia-nativnogo-fondu-glpi"
-            ],
-            [
-                //estonian
-                'string' => 'glpi algupärane inventuur',
-                "expected" => "glpi-alguparane-inventuur"
-            ],
-            [
-                //kazakh
-                'string' => 'GLPI жергілікті түгендеу',
-                "expected" => "glpi-zergilikti-tgendeu"
-            ],
-            [
-                //kurd
-                'string' => 'Envantera GLPI ya xwecihî',
-                "expected" => "envantera-glpi-ya-xwecihi"
-            ]
-        ];
-    }
-
-
-    /**
-     * @dataProvider prepareDateForSafeTransliterate
-     */
-    public function testPrepareDateForSafeTransliterate(string $string, string $expected): void
-    {
-        $this->string(\Toolbox::slugify($string))->isEqualTo($expected);
-    }
-
 }

--- a/tests/functionnal/Toolbox.php
+++ b/tests/functionnal/Toolbox.php
@@ -1516,4 +1516,91 @@ class Toolbox extends DbTestCase
         }
         $this->boolean(call_user_func_array('Toolbox::isUrlSafe', $params))->isEqualTo($expected);
     }
+
+
+    protected function prepareDateForSafeTransliterate(): iterable
+    {
+        return [
+            [
+                //Maïthili
+                'string'     => 'आविष्कारक मूल निवासी glpi',
+                'expected'  => 'aviskaraka-mula-nivasi-glpi',
+            ],
+            [
+                //odia
+                'string'     => 'नेटिभ GLPI सूची',
+                'expected'  => 'netibha-glpi-suci',
+            ],
+            [
+                //nepal
+                'string'     => 'ଦେଶୀ GLPI ଭଣ୍ଡାର |',
+                'expected'  => 'desi-glpi-bhandara',
+            ],
+            [
+                //cambodian
+                'string'     => 'ភាសាខ្មែរ កញ្ចប់បទពិសោធន៍ផ្ទៃក្នុង',
+                'expected'  => 'ភាសាខ្មែរ-កញ្ចប់បទពិសោធន៍ផ្ទៃក្នុង',
+            ],
+            [
+                //thaï
+                'string'     => 'สินค้าคงคลัง GLPI ดั้งเดิม',
+                'expected'  => 'sinkha-khngkhlang-glpi-dangdeim',
+            ],
+            [
+                //tigrina
+                'string'     => 'ተወላዲ GLPI ዝርዝር ኣቑሑት።',
+                'expected'  => 'teweladi-glpi-riri-aqhuhhuti',
+            ],
+            [
+                //latin
+                'string'     => 'Adobe Photoshop',
+                'expected'  => 'adobe-photoshop',
+            ],
+            [
+                //cyrillic
+                'string'     => 'Песня про надежду',
+                'expected'  => 'pesna-pro-nadezdu',
+            ],
+            [
+                //korean
+                'string' => '저는 7년 동안 한국에서 살았어요',
+                'expected'  => 'jeoneun-7nyeon-dong-an-hangug-eseo-sal-ass-eoyo'
+            ],
+            [
+                //japan
+                'string' => 'グルピ ネイティブ インベントリ',
+                "expected" => "gurupi-neitibu-inbentori"
+            ],
+            [
+                //ukrainian
+                'string' => 'інвентаризація нативного фонду GLPI',
+                "expected" => "inventarizacia-nativnogo-fondu-glpi"
+            ],
+            [
+                //estonian
+                'string' => 'glpi algupärane inventuur',
+                "expected" => "glpi-alguparane-inventuur"
+            ],
+            [
+                //kazakh
+                'string' => 'GLPI жергілікті түгендеу',
+                "expected" => "glpi-zergilikti-tgendeu"
+            ],
+            [
+                //kurd
+                'string' => 'Envantera GLPI ya xwecihî',
+                "expected" => "envantera-glpi-ya-xwecihi"
+            ]
+        ];
+    }
+
+
+    /**
+     * @dataProvider prepareDateForSafeTransliterate
+     */
+    public function testPrepareDateForSafeTransliterate(string $string, string $expected): void
+    {
+        $this->string(\Toolbox::slugify($string))->isEqualTo($expected);
+    }
+
 }


### PR DESCRIPTION
'transliterator_transliterate' maybe incompatible with some langage (cambodian) and return an empty string

We get an error from inventory with this software (for example)
```json
         {
            "arch": "neutral",
            "folder": "C:\\Program Files\\WindowsApps\\Microsoft.LanguageExperiencePackkm-KH_19038.0.1.0_neutral__8wekyb3d8bbwe",
            "from": "uwp",
            "install_date": "2022-01-01",
            "name": "ភាសាខ្មែរ កញ្ចប់បទពិសោធន៍ផ្ទៃក្នុង",
            "publisher": "Microsoft Corporation",
            "system_category": "store",
            "version": "19038.0.1.0"
         },
```

1. If ```transliterator_transliterate``` return an empty string, reuses original string
2. Remove ```preg_replace``` on ```latin``` char (for no latin char).
3. Add TU to be sure ```slugify``` return a string (```!=``` ```nok_```)

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
