### PR TITLE
fix(ticket): purge button visible even without PURGE right

### DIFF
--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -254,7 +254,7 @@
                      <span>{{ _x('button', 'Save') }}</span>
                   </button>
 
-                  {% if subitem.can(id, constant('PURGE')) %}
+                  {% if subitem.can(subitem.fields['id'], constant('PURGE')) %}
                      <button class="btn btn-outline-danger me-2" type="submit" name="purge"
                              onclick="return confirm('{{ __('Confirm the final deletion?') }}');">
                         <i class="fas fa-trash-alt"></i>

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -367,7 +367,7 @@
                         }
                      </script>
                      <div class="col-12">
-                        {% if subitem.can(id, constant('UPDATE')) and subitem.fields['begin'] %}
+                        {% if subitem.can(subitem.fields['id'], constant('UPDATE')) and subitem.fields['begin'] %}
                            <script type="text/javascript">
                               showPlanUpdate{{ rand }}();
                            </script>
@@ -428,7 +428,7 @@
                      <span>{{ _x('button', 'Save') }}</span>
                   </button>
 
-                  {% if subitem.can(id, constant('PURGE')) %}
+                  {% if subitem.can(subitem.fields['id'], constant('PURGE')) %}
                      <button class="btn btn-outline-danger me-2" type="submit" name="purge"
                              onclick="return confirm('{{ __('Confirm the final deletion?') }}');">
                         <i class="fas fa-trash-alt"></i>

--- a/templates/components/itilobject/timeline/form_validation.html.twig
+++ b/templates/components/itilobject/timeline/form_validation.html.twig
@@ -275,7 +275,7 @@
                      <span>{{ _x('button', 'Save') }}</span>
                   </button>
 
-                  {% if subitem.can(id, constant('PURGE')) %}
+                  {% if subitem.can(subitem.fields['id'], constant('PURGE')) %}
                      <button class="btn btn-outline-danger me-2" type="submit" name="purge"
                              onclick="return confirm('{{ __('Confirm the final deletion?') }}');">
                         <i class="fas fa-trash-alt"></i>


### PR DESCRIPTION
The purge button was displayed in the follow-up edit form on serf-service profiles when they do not have this right.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25658
