### PR TITLE
Fix followup template use

### DIFF
--- a/ajax/itilfollowup.php
+++ b/ajax/itilfollowup.php
@@ -90,13 +90,11 @@ $template->fields['content'] = $template->getRenderedContent($parent);
 //need when template is used and when GLPI preselected type if defined
 $template->fields['requesttypes_name'] = "";
 if ($template->fields['requesttypes_id']) {
-    $entityRestrict = getEntitiesRestrictCriteria(getTableForItemType(RequestType::getType()), "", $parent->fields['entities_id'], true);
-
     $requesttype = new RequestType();
     if (
         $requesttype->getFromDBByCrit([
             "id" => $template->fields['requesttypes_id'],
-        ] + $entityRestrict)
+        ])
     ) {
         $template->fields['requesttypes_name'] = Dropdown::getDropdownName(
             getTableForItemType(RequestType::getType()),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13392

There is a partial failure in the AJAX request from trying to check entities_id field for request types when they do not have an entity field. In debug mode, it returns the SQL error as part of the JSON payload which breaks the loading of data from templates completely. When not in debug mode, it just doesn't load the request source information.