### PR TITLE
Bump inventory format sysdescr

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -281,16 +281,16 @@
         },
         {
             "name": "glpi-project/inventory_format",
-            "version": "1.1.23",
+            "version": "1.1.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/glpi-project/inventory_format.git",
-                "reference": "9230fd5e2b07d866ecf0be21751f27f4d5f06591"
+                "reference": "cb312aea14898c41ac53f82edbbc799bf5182b90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/glpi-project/inventory_format/zipball/9230fd5e2b07d866ecf0be21751f27f4d5f06591",
-                "reference": "9230fd5e2b07d866ecf0be21751f27f4d5f06591",
+                "url": "https://api.github.com/repos/glpi-project/inventory_format/zipball/cb312aea14898c41ac53f82edbbc799bf5182b90",
+                "reference": "cb312aea14898c41ac53f82edbbc799bf5182b90",
                 "shasum": ""
             },
             "require": {
@@ -340,7 +340,7 @@
                 "issues": "https://github.com/glpi-project/inventory_format/issues",
                 "source": "https://github.com/glpi-project/inventory_format"
             },
-            "time": "2022-11-21T07:33:56+00:00"
+            "time": "2022-11-24T08:27:09+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/tests/functionnal/Glpi/Inventory/Assets/NetworkEquipment.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/NetworkEquipment.php
@@ -85,7 +85,7 @@ class NetworkEquipment extends AbstractInventoryAsset
   <DEVICEID>foo</DEVICEID>
   <QUERY>SNMPQUERY</QUERY>
 </REQUEST>",
-                'asset'  => '{"autoupdatesystems_id":"GLPI Native Inventory","last_inventory_update": "DATE_NOW","contact":"noc@glpi-project.org","cpu":4,"firmware":"5.0(3)N2(4.02b)","location":"paris.pa3","mac":"8c:60:4f:8d:ae:fc","manufacturer":"Cisco","model":"UCS 6248UP 48-Port","name":"ucs6248up-cluster-pa3-B","serial":"SSI1912014B","type":"Networking","uptime":"482 days, 05:42:18.50","ips":["127.0.0.1","10.2.5.10","192.168.12.5"],"locations_id":"paris.pa3","networkequipmentmodels_id":"UCS 6248UP 48-Port","networkequipmenttypes_id":"Networking","manufacturers_id":"Cisco"}'
+                'asset'  => '{"description":"Cisco NX-OS(tm) ucs, Software (ucs-6100-k9-system), Version 5.0(3)N2(4.02b), RELEASE SOFTWARE Copyright (c) 2002-2013 by Cisco Systems, Inc.   Compiled 1/16/2019 18:00:00", "sysdescr":"Cisco NX-OS(tm) ucs, Software (ucs-6100-k9-system), Version 5.0(3)N2(4.02b), RELEASE SOFTWARE Copyright (c) 2002-2013 by Cisco Systems, Inc.   Compiled 1/16/2019 18:00:00", "autoupdatesystems_id":"GLPI Native Inventory","last_inventory_update": "DATE_NOW","contact":"noc@glpi-project.org","cpu":4,"firmware":"5.0(3)N2(4.02b)","location":"paris.pa3","mac":"8c:60:4f:8d:ae:fc","manufacturer":"Cisco","model":"UCS 6248UP 48-Port","name":"ucs6248up-cluster-pa3-B","serial":"SSI1912014B","type":"Networking","uptime":"482 days, 05:42:18.50","ips":["127.0.0.1","10.2.5.10","192.168.12.5"],"locations_id":"paris.pa3","networkequipmentmodels_id":"UCS 6248UP 48-Port","networkequipmenttypes_id":"Networking","manufacturers_id":"Cisco"}'
             ], [
                 'xml'   => "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
 <REQUEST>
@@ -154,7 +154,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
   <DEVICEID>foo</DEVICEID>
   <QUERY>SNMPQUERY</QUERY>
 </REQUEST>",
-                'asset'  => '{"autoupdatesystems_id":"GLPI Native Inventory","last_inventory_update": "DATE_NOW","cpu":47,"firmware":"12.2(55)SE6","ips":["10.1.0.100","10.1.0.22","10.1.0.41","10.1.0.45","10.1.0.59","10.11.11.1","10.11.11.5","10.11.13.1","10.11.13.5","172.21.0.1","172.21.0.7","172.22.0.1","172.22.0.5","172.23.0.1","172.23.0.5","172.24.0.1","172.24.0.5","172.25.1.15","172.28.200.1","172.28.200.5","172.28.211.5","172.28.215.1","172.28.221.1","185.10.253.65","185.10.253.97","185.10.254.1","185.10.255.146","185.10.255.224","185.10.255.250"],"location":"paris.pa3","mac":"00:23:ac:6a:01:00","manufacturer":"Cisco","model":"Catalyst 3750-24\\/48","name":"3k-1-pa3.teclib.infra","ram":128,"serial":"FOC1243W0ED","type":"Networking","uptime":"103 days, 13:53:28.28","locations_id":"paris.pa3","networkequipmentmodels_id":"Catalyst 3750-24\\/48","networkequipmenttypes_id":"Networking","manufacturers_id":"Cisco"}'
+                'asset'  => '{"autoupdatesystems_id":"GLPI Native Inventory","last_inventory_update":"DATE_NOW","cpu":47,"firmware":"12.2(55)SE6","ips":["10.1.0.100","10.1.0.22","10.1.0.41","10.1.0.45","10.1.0.59","10.11.11.1","10.11.11.5","10.11.13.1","10.11.13.5","172.21.0.1","172.21.0.7","172.22.0.1","172.22.0.5","172.23.0.1","172.23.0.5","172.24.0.1","172.24.0.5","172.25.1.15","172.28.200.1","172.28.200.5","172.28.211.5","172.28.215.1","172.28.221.1","185.10.253.65","185.10.253.97","185.10.254.1","185.10.255.146","185.10.255.224","185.10.255.250"],"location":"paris.pa3","mac":"00:23:ac:6a:01:00","manufacturer":"Cisco","model":"Catalyst 3750-24\/48","name":"3k-1-pa3.teclib.infra","ram":128,"serial":"FOC1243W0ED","type":"Networking","uptime":"103 days, 13:53:28.28","description":"Cisco IOS Software, C3750 Software (C3750-IPSERVICESK9-M), Version 12.2(55)SE6, RELEASE SOFTWARE (fc1)\nTechnical Support: http:\/\/www.cisco.com\/techsupport\nCopyright (c) 1986-2012 by Cisco Systems, Inc.\nCompiled Mon 23-Jul-12 13:22 by prod_rel_team","sysdescr":"Cisco IOS Software, C3750 Software (C3750-IPSERVICESK9-M), Version 12.2(55)SE6, RELEASE SOFTWARE (fc1)\nTechnical Support: http:\/\/www.cisco.com\/techsupport\nCopyright (c) 1986-2012 by Cisco Systems, Inc.\nCompiled Mon 23-Jul-12 13:22 by prod_rel_team","locations_id":"paris.pa3","networkequipmentmodels_id":"Catalyst 3750-24\/48","networkequipmenttypes_id":"Networking","manufacturers_id":"Cisco"}'
             ]
         ];
     }
@@ -1880,5 +1880,116 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         // check port
         $this->boolean($networkPort->getFromDBByCrit(['name' => 'port48']));
         $this->boolean($networkPort_NetworkPort->getFromDBForNetworkPort($networkPort->fields['id']))->isTrue();
+    }
+
+    public function testSysdescr()
+    {
+        $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+        <REQUEST>
+          <CONTENT>
+            <DEVICE>
+              <FIRMWARES>
+                <DESCRIPTION>device firmware</DESCRIPTION>
+                <MANUFACTURER>Cisco</MANUFACTURER>
+                <NAME>UCS 6248UP 48-Port</NAME>
+                <TYPE>device</TYPE>
+                <VERSION>5.0(3)N2(4.02b)</VERSION>
+              </FIRMWARES>
+              <INFO>
+                <COMMENTS>this a sysdescr</COMMENTS>
+                <CONTACT>noc@glpi-project.org</CONTACT>
+                <CPU>4</CPU>
+                <FIRMWARE>5.0(3)N2(4.02b)</FIRMWARE>
+                <ID>0</ID>
+                <LOCATION>paris.pa3</LOCATION>
+                <MAC>8c:60:4f:8d:ae:fc</MAC>
+                <MANUFACTURER>Cisco</MANUFACTURER>
+                <MODEL>UCS 6248UP 48-Port</MODEL>
+                <NAME>ucs6248up-cluster-pa3-B</NAME>
+                <SERIAL>SSI1912014B</SERIAL>
+                <TYPE>NETWORKING</TYPE>
+                <UPTIME>482 days, 05:42:18.50</UPTIME>
+                <IPS>
+                  <IP>127.0.0.1</IP>
+                  <IP>10.2.5.10</IP>
+                  <IP>192.168.12.5</IP>
+                </IPS>
+              </INFO>
+            </DEVICE>
+            <MODULEVERSION>4.1</MODULEVERSION>
+            <PROCESSNUMBER>1</PROCESSNUMBER>
+          </CONTENT>
+          <DEVICEID>foo</DEVICEID>
+          <QUERY>SNMPQUERY</QUERY>
+        </REQUEST>";
+
+          // Import the switch into GLPI
+          $converter = new \Glpi\Inventory\Converter();
+          $data = json_decode($converter->convert($xml_source));
+          $inventory = new \Glpi\Inventory\Inventory($data);
+
+          $this->boolean($inventory->inError())->isFalse();
+          $this->array($inventory->getErrors())->isIdenticalTo([]);
+
+          // check sysdescr
+          $networkequipement = new \NetworkEquipment();
+          $found_np = $networkequipement->find(['name' => "ucs6248up-cluster-pa3-B"]);
+          $this->integer(count($found_np))->isIdenticalTo(1);
+          $first_np = array_pop($found_np);
+          $this->string($first_np['sysdescr'])->isIdenticalTo("this a sysdescr");
+
+          $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+          <REQUEST>
+            <CONTENT>
+              <DEVICE>
+                <FIRMWARES>
+                  <DESCRIPTION>device firmware</DESCRIPTION>
+                  <MANUFACTURER>Cisco</MANUFACTURER>
+                  <NAME>UCS 6248UP 48-Port</NAME>
+                  <TYPE>device</TYPE>
+                  <VERSION>5.0(3)N2(4.02b)</VERSION>
+                </FIRMWARES>
+                <INFO>
+                  <COMMENTS>this a updated sysdescr</COMMENTS>
+                  <CONTACT>noc@glpi-project.org</CONTACT>
+                  <CPU>4</CPU>
+                  <FIRMWARE>5.0(3)N2(4.02b)</FIRMWARE>
+                  <ID>0</ID>
+                  <LOCATION>paris.pa3</LOCATION>
+                  <MAC>8c:60:4f:8d:ae:fc</MAC>
+                  <MANUFACTURER>Cisco</MANUFACTURER>
+                  <MODEL>UCS 6248UP 48-Port</MODEL>
+                  <NAME>ucs6248up-cluster-pa3-B</NAME>
+                  <SERIAL>SSI1912014B</SERIAL>
+                  <TYPE>NETWORKING</TYPE>
+                  <UPTIME>482 days, 05:42:18.50</UPTIME>
+                  <IPS>
+                    <IP>127.0.0.1</IP>
+                    <IP>10.2.5.10</IP>
+                    <IP>192.168.12.5</IP>
+                  </IPS>
+                </INFO>
+              </DEVICE>
+              <MODULEVERSION>4.1</MODULEVERSION>
+              <PROCESSNUMBER>1</PROCESSNUMBER>
+            </CONTENT>
+            <DEVICEID>foo</DEVICEID>
+            <QUERY>SNMPQUERY</QUERY>
+          </REQUEST>";
+
+          // Import the switch into GLPI
+          $converter = new \Glpi\Inventory\Converter();
+          $data = json_decode($converter->convert($xml_source));
+          $inventory = new \Glpi\Inventory\Inventory($data);
+
+          $this->boolean($inventory->inError())->isFalse();
+          $this->array($inventory->getErrors())->isIdenticalTo([]);
+
+          // check sysdescr
+          $networkequipement = new \NetworkEquipment();
+          $found_np = $networkequipement->find(['name' => "ucs6248up-cluster-pa3-B"]);
+          $this->integer(count($found_np))->isIdenticalTo(1);
+          $first_np = array_pop($found_np);
+          $this->string($first_np['sysdescr'])->isIdenticalTo("this a updated sysdescr");
     }
 }


### PR DESCRIPTION
Bump ```inventory_format``` to correctly handle ```sysdescr``` for ```NetworkEquipment``` 


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13382
