### PR TITLE
fix(udpate): fix inventory conf always reset

### DIFF
--- a/install/migrations/update_10.0.5_to_10.0.6/inventory.php
+++ b/install/migrations/update_10.0.5_to_10.0.6/inventory.php
@@ -37,7 +37,4 @@
  * @var DB $DB
  * @var Migration $migration
  */
-
-
-$conf = new \Glpi\Inventory\Conf();
-$conf->saveConf(['entities_id_default' => 0]);
+$migration->addConfig(["entities_id_default" => 0], 'inventory');


### PR DESCRIPTION
```entities_id_default``` is always reset to ```0``` when an update is processed.

use dedicated function.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
