### PR TITLE
fix(ruleimportasset): correctly handle condition for TAG criteria

### DIFF
--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -408,6 +408,10 @@ abstract class MainAsset extends InventoryAsset
             $input['tag'] = $this->getAgent()->fields['tag'];
         }
 
+        if (isset($this->getAgent()->fields['deviceid'])) {
+            $input['deviceid'] = $this->getAgent()->fields['deviceid'];
+        }
+
         $models_id = $this->getModelsFieldName();
         foreach ($val as $prop => $value) {
             switch ($prop) {

--- a/src/RuleImportAsset.php
+++ b/src/RuleImportAsset.php
@@ -413,6 +413,10 @@ class RuleImportAsset extends Rule
             }
         }
 
+        foreach ($this->getCriteriaByID('tag') as $crit) {
+            $this->complex_criteria[] = $crit;
+        }
+
         foreach ($this->getCriteriaByID('states_id') as $crit) {
             $this->complex_criteria[] = $crit;
         }
@@ -768,6 +772,21 @@ class RuleImportAsset extends Rule
                         $it_criteria['SELECT'][] = 'glpi_networkports.id AS portid';
                     }
                     $it_criteria['WHERE'][] = [$ntable . '.logical_number' => $input['ifnumber']];
+                    break;
+
+                case 'tag':
+                    if (isset($input['tag'])) {
+                        $it_criteria['LEFT JOIN']['glpi_agents'] = [
+                            'ON'  => [
+                                'glpi_agents'  => 'items_id',
+                                $itemtable     => 'id'
+                            ]
+                        ];
+                        $it_criteria['WHERE'][] = [
+                            'glpi_agents.deviceid' => $input['deviceid'],
+                            'glpi_agents.tag' => $input['tag']
+                        ];
+                    }
                     break;
 
                 case 'serial':

--- a/src/RuleImportAsset.php
+++ b/src/RuleImportAsset.php
@@ -775,7 +775,7 @@ class RuleImportAsset extends Rule
                     break;
 
                 case 'tag':
-                    if (isset($input['tag'])) {
+                    if (isset($input['tag']) && isset($input['deviceid'])) {
                         $it_criteria['LEFT JOIN']['glpi_agents'] = [
                             'ON'  => [
                                 'glpi_agents'  => 'items_id',

--- a/tests/functionnal/RuleImportAsset.php
+++ b/tests/functionnal/RuleImportAsset.php
@@ -1148,4 +1148,100 @@ class RuleImportAsset extends DbTestCase
         $this->string($rule->fields['name'])->isIdenticalTo("Computer update (by serial + uuid is empty in GLPI)");
         $this->string($this->itemtype)->isIdenticalTo('Computer');
     }
+
+    /**
+     * Create rules for update Computer based on computer name and TAG
+     *
+     * @return void
+     */
+    private function updateComputerAgentTagRules()
+    {
+       // Create rules
+        $this->addRule(
+            "Computer update (by name and tag)",
+            [
+                [
+                    'condition' => 0,
+                    'criteria'  => 'itemtype',
+                    'pattern'   => 'Computer',
+                ],
+                [
+                    'condition' => \RuleImportAsset::PATTERN_FIND,
+                    'criteria'  => 'name',
+                    'pattern'   => '1',
+                ],
+                [
+                    'condition' => \RuleImportAsset::PATTERN_EXISTS,
+                    'criteria'  => 'name',
+                    'pattern'   => '1',
+                ],
+                [
+                    'condition' => \RuleImportAsset::PATTERN_FIND,
+                    'criteria'  => 'tag',
+                    'pattern'   => '1',
+                ],
+                [
+                    'condition' => \RuleImportAsset::PATTERN_EXISTS,
+                    'criteria'  => 'tag',
+                    'pattern'   => '1',
+                ],
+            ],
+            [
+                'action_type' => 'assign',
+                'field'       => '_inventory',
+                'value'       => \RuleImportAsset::RULE_ACTION_LINK_OR_IMPORT,
+            ],
+            "Computer constraint (name)"
+        );
+    }
+
+    public function testUpdateComputerByNameAndTag()
+    {
+        global $DB;
+
+        $this->updateComputerAgentTagRules();
+
+        //create computer
+        $computer = new \Computer();
+        $computers_id = (int)$computer->add([
+            'entities_id' => 0,
+            'name'        => 'pc-11', // to be sure the name rule not works before mac rule
+        ]);
+        $this->integer($computers_id)->isGreaterThan(0);
+
+        //create linked agent
+        $agent = new \Agent();
+        $agenttype = $DB->request(['FROM' => \AgentType::getTable(), 'WHERE' => ['name' => 'Core']])->current();
+        $agents_id = (int)$agent->add([
+            'deviceid' => 'my_specific_agent_deviceid',
+            'tag' => 'my_specific_agent_tag',
+            'itemtype' => "Computer",
+            'agenttypes_id' => $agenttype['id'],
+            'items_id' => $computers_id,
+            'name'        => 'pc-11', // to be sure the name rule not works before mac rule
+        ]);
+        $this->integer($agents_id)->isGreaterThan(0);
+
+        $input = [
+            'itemtype'      => 'Computer',
+            'name'          => 'pc-11',
+            'tag'           => 'my_specific_agent_tag',
+            'deviceid'     => 'my_specific_agent_deviceid',
+            'ip'            => ['192.168.0.10'],
+            'entities_id'   => 0
+        ];
+        $ruleCollection = new \RuleImportAssetCollection();
+        $rule = new \RuleImportAsset();
+
+        $data = $ruleCollection->processAllRules($input, [], ['class' => $this]);
+
+        $this->array($data)->hasKey('_ruleid');
+        $_rule_id = (int)$data['_ruleid'];
+        $this->integer($_rule_id)->isGreaterThan(0);
+
+        $this->boolean($rule->getFromDB($_rule_id))->isTrue();
+        $this->string($rule->fields['name'])->isIdenticalTo("Computer update (by name and tag)");
+        $this->integer($this->items_id)->isIdenticalTo($computers_id);
+        $this->string($this->itemtype)->isIdenticalTo('Computer');
+    }
 }

--- a/tests/functionnal/RuleImportAsset.php
+++ b/tests/functionnal/RuleImportAsset.php
@@ -1205,7 +1205,7 @@ class RuleImportAsset extends DbTestCase
         $computer = new \Computer();
         $computers_id = (int)$computer->add([
             'entities_id' => 0,
-            'name'        => 'pc-11', // to be sure the name rule not works before mac rule
+            'name'        => 'pc-11',
         ]);
         $this->integer($computers_id)->isGreaterThan(0);
 
@@ -1218,7 +1218,7 @@ class RuleImportAsset extends DbTestCase
             'itemtype' => "Computer",
             'agenttypes_id' => $agenttype['id'],
             'items_id' => $computers_id,
-            'name'        => 'pc-11', // to be sure the name rule not works before mac rule
+            'name'        => 'pc-11',
         ]);
         $this->integer($agents_id)->isGreaterThan(0);
 


### PR DESCRIPTION
```TAG``` criterion can use ```PATTERN_FIND``` and ```PATTERN_IS_EMPTY```
But ```handleFieldsCriteria()``` does not manage this criterion.

This PR try to fix this.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/glpi-project/glpi-inventory-plugin/issues/256
