### PR TITLE
Use twig for debug panel and make SQL table sortable

### DIFF
--- a/css/includes/components/_debug-panel.scss
+++ b/css/includes/components/_debug-panel.scss
@@ -32,64 +32,11 @@
  */
 
 .debug-panel {
-    background: $light;
-    bottom: 0;
-    display: none;
     font-size: $font-size-sm;
-    padding: 0;
-    position: sticky;
     z-index: 9999;
+    display: none;
 
     .card-body {
         height: 300px;
-        overflow: auto;
-
-        .tab-content {
-            .tab-pane {
-                table {
-                    width: 100%;
-
-                    th,
-                    td {
-                        padding: 0.25em;
-                    }
-
-                    td {
-                        vertical-align: top;
-
-                        a {
-                            // expand link
-                            color: $link-hover-color;
-                            font-weight: bold;
-                        }
-                    }
-
-                    &.array-debug td {
-                        &:nth-child(1),
-                        &:nth-child(2) {
-                            white-space: nowrap;
-                        }
-
-                        &:nth-child(3) {
-                            width: 100%;
-                            word-break: break-all;
-                        }
-                    }
-
-                    &.sql-debug td {
-                        &:nth-child(1),
-                        &:nth-child(3) {
-                            white-space: nowrap;
-                        }
-
-                        &:nth-child(2),
-                        &:nth-child(4) {
-                            width: 100%;
-                            word-break: break-all;
-                        }
-                    }
-                }
-            }
-        }
     }
 }

--- a/js/common.js
+++ b/js/common.js
@@ -1503,3 +1503,58 @@ function copyDisclosablePasswordFieldToClipboard(item) {
     }
     hideDisclosablePasswordField(item);
 }
+
+/**
+ * Convert an HTML table with static content to a basic sortable table
+ * @param element_id The ID of the table to be converted
+ */
+function initSortableTable(element_id) {
+    const element = $(`#${element_id}`);
+    const sort_table = (column_index) => {
+        const current_sort = element.data('sort');
+        element.data('sort', column_index);
+        const current_order = element.data('order');
+        const new_order = current_sort === column_index && current_order === 'asc' ? 'desc' : 'asc';
+        element.data('order', new_order);
+        const col = element.find('thead').first().find('th').eq(column_index);
+
+        const sort_icon = col.find('i');
+        if (sort_icon.length === 0) {
+            // Add sort icon
+            col.eq(0).append(`<i class="fas fa-sort-${new_order}"></i>`);
+        } else {
+            sort_icon.removeClass('fa-sort fa-sort-asc fa-sort-desc');
+            sort_icon.addClass(new_order === 'asc' ? 'fa-sort-asc' : 'fa-sort-desc');
+        }
+
+        const rows = element.find('tbody tr');
+        const sorted_rows = rows.sort((a, b) => {
+            let a_value = $(a).find('td').eq(column_index).text();
+            let b_value = $(b).find('td').eq(column_index).text();
+            // if the values are numberic, cast them to numbers to sort them correctly
+            if (!isNaN(a_value) && !isNaN(b_value)) {
+                a_value = Number(a_value);
+                b_value = Number(b_value);
+            }
+
+            if (a_value === b_value) {
+                return 0;
+            }
+            if (new_order === 'asc') {
+                return a_value < b_value ? -1 : 1;
+            }
+            return a_value > b_value ? -1 : 1;
+        });
+        element.find('tbody').html(sorted_rows);
+    };
+
+    // Make all th in thead appear clickable and bold
+    element.find('thead th').css('cursor', 'pointer');
+    element.find('thead th').css('font-weight', 'bold');
+
+    element.find('thead th').each((index, header) => {
+        $(header).on('click', () => {
+            sort_table(index);
+        });
+    });
+}

--- a/js/common.js
+++ b/js/common.js
@@ -1516,14 +1516,16 @@ function initSortableTable(element_id) {
         const current_order = element.data('order');
         const new_order = current_sort === column_index && current_order === 'asc' ? 'desc' : 'asc';
         element.data('order', new_order);
-        const col = element.find('thead').first().find('th').eq(column_index);
+        const sortable_header = element.find('thead').first();
+        const col = sortable_header.find('th').eq(column_index);
+        // Remove all sort icon classes
+        sortable_header.find('th i[class*="fa-sort"]').removeClass('fa-sort fa-sort-asc fa-sort-desc');
 
         const sort_icon = col.find('i');
         if (sort_icon.length === 0) {
             // Add sort icon
             col.eq(0).append(`<i class="fas fa-sort-${new_order}"></i>`);
         } else {
-            sort_icon.removeClass('fa-sort fa-sort-asc fa-sort-desc');
             sort_icon.addClass(new_order === 'asc' ? 'fa-sort-asc' : 'fa-sort-desc');
         }
 

--- a/js/common.js
+++ b/js/common.js
@@ -1549,8 +1549,8 @@ function initSortableTable(element_id) {
     };
 
     // Make all th in thead appear clickable and bold
-    element.find('thead th').css('cursor', 'pointer');
-    element.find('thead th').css('font-weight', 'bold');
+    element.find('thead th').attr('role', 'button');
+    element.find('thead th').addClass('fw-bold');
 
     element.find('thead th').each((index, header) => {
         $(header).on('click', () => {

--- a/src/Application/View/Extension/DataHelpersExtension.php
+++ b/src/Application/View/Extension/DataHelpersExtension.php
@@ -53,6 +53,7 @@ class DataHelpersExtension extends AbstractExtension
             new TwigFilter('formatted_datetime', [$this, 'getFormattedDatetime']),
             new TwigFilter('formatted_duration', [$this, 'getFormattedDuration']),
             new TwigFilter('formatted_number', [$this, 'getFormattedNumber']),
+            new TwigFilter('formatted_size', [$this, 'getFormattedSize']),
             new TwigFilter('html_to_text', [$this, 'getTextFromHtml']),
             new TwigFilter('picture_url', [$this, 'getPictureUrl']),
             new TwigFilter('relative_datetime', [$this, 'getRelativeDatetime']),
@@ -123,6 +124,21 @@ class DataHelpersExtension extends AbstractExtension
     public function getFormattedNumber($number): string
     {
         return Html::formatNumber($number);
+    }
+
+    /**
+     * Return size formatted in a compact way (mo, ko, etc).
+     *
+     * @param mixed $number
+     *
+     * @return string
+     */
+    public function getFormattedSize($number): string
+    {
+        if (!is_numeric($number)) {
+            return '';
+        }
+        return Toolbox::getSize($number);
     }
 
     /**

--- a/src/Application/View/Extension/PhpExtension.php
+++ b/src/Application/View/Extension/PhpExtension.php
@@ -51,6 +51,7 @@ class PhpExtension extends AbstractExtension
             new TwigFunction('php_config', [$this, 'phpConfig']),
             new TwigFunction('call', [$this, 'call']),
             new TwigFunction('get_static', [$this, 'getStatic']),
+            new TwigFunction('get_class', 'get_class'),
         ];
     }
 
@@ -59,6 +60,8 @@ class PhpExtension extends AbstractExtension
         return [
             new TwigTest('instanceof', [$this, 'isInstanceOf']),
             new TwigTest('usingtrait', [$this, 'isUsingTrait']),
+            new TwigTest('array', 'is_array'),
+            new TwigTest('object', 'is_object'),
         ];
     }
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -704,33 +704,6 @@ class Html
         echo "</div>";
     }
 
-
-    /**
-     * Clean Display of Request
-     *
-     * @since 0.83.1
-     *
-     * @param string $request  SQL request
-     *
-     * @return string
-     **/
-    public static function cleanSQLDisplay($request)
-    {
-
-        $request = str_replace("<", "&lt;", $request);
-        $request = str_replace(">", "&gt;", $request);
-        $request = str_ireplace("UNION", "<br/>UNION<br/>", $request);
-        $request = str_ireplace("UNION ALL", "<br/>UNION ALL<br/>", $request);
-        $request = str_ireplace("FROM", "<br/>FROM", $request);
-        $request = str_ireplace("WHERE", "<br/>WHERE", $request);
-        $request = str_ireplace("INNER JOIN", "<br/>INNER JOIN", $request);
-        $request = str_ireplace("LEFT JOIN", "<br/>LEFT JOIN", $request);
-        $request = str_ireplace("ORDER BY", "<br/>ORDER BY", $request);
-        $request = str_ireplace("SORT", "<br/>SORT", $request);
-
-        return $request;
-    }
-
     /**
      * Display Debug Information
      *
@@ -773,7 +746,7 @@ class Html
                 foreach ($DEBUG_SQL['queries'] as $num => $query) {
                     $info = [
                         'num'       => $num,
-                        'query'     => self::cleanSQLDisplay($query),
+                        'query'     => $query,
                         'time'      => $DEBUG_SQL['times'][$num] ?? '',
                         'rows'      => $DEBUG_SQL['rows'][$num] ?? 0,
                         'errors'    => $DEBUG_SQL['errors'][$num] ?? '',

--- a/src/Html.php
+++ b/src/Html.php
@@ -760,7 +760,7 @@ class Html
             $execution_time = $TIMER_DEBUG->getTime();
             $summary = [
                 'execution_time'    => sprintf(_n('%s second', '%s seconds', $execution_time), $execution_time),
-                'memory_usage'      => Toolbox::getSize(memory_get_usage()),
+                'memory_usage'      => memory_get_usage(),
                 'sql_queries_count'     => $CFG_GLPI["debug_sql"] ? $SQL_TOTAL_REQUEST : 0,
                 'sql_queries_duration'  => $CFG_GLPI["debug_sql"] ? sprintf(_n('%s second', '%s seconds', $queries_duration), $queries_duration) : 0,
             ];

--- a/src/Html.php
+++ b/src/Html.php
@@ -751,7 +751,7 @@ class Html
 
             $plugin_tabs = [];
             if (isset($PLUGIN_HOOKS[Hooks::DEBUG_TABS])) {
-                foreach ($PLUGIN_HOOKS[Hooks::DEBUG_TABS] as $plugin => $tabs) {
+                foreach ($PLUGIN_HOOKS[Hooks::DEBUG_TABS] as $tabs) {
                     $plugin_tabs = array_merge($plugin_tabs, $tabs);
                 }
             }

--- a/src/Html.php
+++ b/src/Html.php
@@ -756,117 +756,55 @@ class Html
                 }
             }
 
-            echo "<div id='debugpanel$rand' class='container-fluid card debug-panel " . ($ajax ? "debug_ajax" : "") . "'>";
+            $queries_duration = $CFG_GLPI["debug_sql"] ? array_sum($DEBUG_SQL['times']) : 0;
+            $execution_time = $TIMER_DEBUG->getTime();
+            $summary = [
+                'execution_time'    => sprintf(_n('%s second', '%s seconds', $execution_time), $execution_time),
+                'memory_usage'      => Toolbox::getSize(memory_get_usage()),
+                'sql_queries_count'     => $CFG_GLPI["debug_sql"] ? $SQL_TOTAL_REQUEST : 0,
+                'sql_queries_duration'  => $CFG_GLPI["debug_sql"] ? sprintf(_n('%s second', '%s seconds', $queries_duration), $queries_duration) : 0,
+            ];
+            $sql_info = [];
 
-            echo "<ul class='nav nav-tabs' data-bs-toggle='tabs'>";
-            echo "<li class='nav-item'><a class='nav-link active' data-bs-toggle='tab' href='#debugsummary$rand'>SUMMARY</a></li>";
-            if ($CFG_GLPI["debug_sql"]) {
-                echo "<li class='nav-item'><a class='nav-link' data-bs-toggle='tab' href='#debugsql$rand'>SQL REQUEST</a></li>";
-            }
-            if ($CFG_GLPI["debug_vars"]) {
-                echo "<li class='nav-item'><a class='nav-link' data-bs-toggle='tab' href='#debugpost$rand'>POST VARIABLE</a></li>";
-                echo "<li class='nav-item'><a class='nav-link' data-bs-toggle='tab' href='#debugget$rand'>GET VARIABLE</a></li>";
-                if ($with_session) {
-                    echo "<li class='nav-item'><a class='nav-link' data-bs-toggle='tab' href='#debugsession$rand'>SESSION VARIABLE</a></li>";
-                }
-                echo "<li class='nav-item'><a class='nav-link' data-bs-toggle='tab' href='#debugserver$rand'>SERVER VARIABLE</a></li>";
-            }
-            foreach ($plugin_tabs as $tab_id => $tab_info) {
-                echo "<li class='nav-item'><a class='nav-link' data-bs-toggle='tab' href='#debug$tab_id$rand'>{$tab_info['title']}</a></li>";
-            }
-            echo "<li class='nav-item ms-auto'><a class='nav-link' href='#' id='close_debug$rand'><i class='fa fa-2x fa-times'></i><span class='sr-only'>" . __('Close') . "</span></a></li>";
-            echo "</ul>";
-
-            echo "<div class='card-body'>";
-            echo "<div class='tab-content'>";
-
-            echo "<div id='debugsummary$rand' class='tab-pane active'>";
-            echo "<dl class='row'>";
-            echo "<dt class='col-sm-3'>Execution time</dt>";
-            echo "<dd class='col-sm-9'>" . sprintf(_n('%s second', '%s seconds', $TIMER_DEBUG->getTime()), $TIMER_DEBUG->getTime()) . "</dd>";
-            echo "<dt class='col-sm-3'>Memory usage</dt>";
-            echo "<dd class='col-sm-9'>" . Toolbox::getSize(memory_get_usage()) . "</dd>";
-            if ($CFG_GLPI["debug_sql"]) {
-                $queries_duration = array_sum($DEBUG_SQL['times']);
-                echo "<dt class='col-sm-3'>SQL queries count</dt>";
-                echo "<dd class='col-sm-9'>{$SQL_TOTAL_REQUEST}</dd>";
-                echo "<dt class='col-sm-3'>SQL queries duration</dt>";
-                echo "<dd class='col-sm-9'>" . sprintf(_n('%s second', '%s seconds', $queries_duration), $queries_duration) . "</dd>";
-            }
-            echo "</dl>";
-            echo "</div>";
-
-            if ($CFG_GLPI["debug_sql"]) {
-                echo "<div id='debugsql$rand' class='tab-pane'>";
-                echo "<h1>" . $SQL_TOTAL_REQUEST . " Queries ";
-                echo "took  " . array_sum($DEBUG_SQL['times']) . "s</h1>";
-
-                echo "<table class='sql-debug table table-striped'><tr><th>N&#176; </th><th>Queries</th><th>Time</th>";
-                echo "<th>Rows</th><th>Errors</th><th>SQL warnings</th></tr>";
-
+            if ($CFG_GLPI['debug_sql']) {
+                $sql_info['total_requests'] = $summary['sql_queries_count'];
+                $sql_info['total_duration'] = $summary['sql_queries_duration'];
+                $sql_info['queries'] = [];
                 foreach ($DEBUG_SQL['queries'] as $num => $query) {
-                    echo "<tr><td>$num</td><td>";
-                    echo self::cleanSQLDisplay($query);
-                    echo "</td><td>";
-                    echo $DEBUG_SQL['times'][$num];
-                    echo "</td><td>";
-                    echo $DEBUG_SQL['rows'][$num] ?? 0;
-                    echo "</td><td>";
-                    if (isset($DEBUG_SQL['errors'][$num])) {
-                        echo $DEBUG_SQL['errors'][$num];
-                    } else {
-                        echo "&nbsp;";
-                    }
-                    echo "</td><td>";
+                    $info = [
+                        'num'       => $num,
+                        'query'     => self::cleanSQLDisplay($query),
+                        'time'      => $DEBUG_SQL['times'][$num] ?? '',
+                        'rows'      => $DEBUG_SQL['rows'][$num] ?? 0,
+                        'errors'    => $DEBUG_SQL['errors'][$num] ?? '',
+                        'warnings'  => '',
+                    ];
                     if (isset($DEBUG_SQL['warnings'][$num])) {
                         foreach ($DEBUG_SQL['warnings'][$num] as $warning) {
-                            echo sprintf('%s: %s', $warning['Code'], $warning['Message']) . '<br />';
+                            $info['warnings'] .= sprintf('%s: %s', $warning['Code'], $warning['Message']) . "\n";
                         }
-                    } else {
-                        echo "&nbsp;";
                     }
-                    echo "</td></tr>";
+                    $sql_info['queries'][] = $info;
                 }
-                echo "</table>";
-                echo "</div>";
             }
-            if ($CFG_GLPI["debug_vars"]) {
-                echo "<div id='debugpost$rand' class='tab-pane'>";
-                self::printCleanArray($_POST, 0, true);
-                echo "</div>";
-                echo "<div id='debugget$rand' class='tab-pane'>";
-                self::printCleanArray($_GET, 0, true);
-                echo "</div>";
-                if ($with_session) {
-                    echo "<div id='debugsession$rand' class='tab-pane'>";
-                    self::printCleanArray($_SESSION, 0, true);
-                    echo "</div>";
-                }
-                echo "<div id='debugserver$rand' class='tab-pane'>";
-                self::printCleanArray($_SERVER, 0, true);
-                echo "</div>";
-            }
-            foreach ($plugin_tabs as $tab_id => $tab_info) {
-                if (isset($tab_info['display_callable']) && !is_callable($tab_info['display_callable'])) {
-                    trigger_error(sprintf('Debug tab "%s"(%s) display callable is invalid.', $tab_info['title'] ?? '', $tab_id), E_USER_WARNING);
-                    continue;
-                }
-                echo "<div id='debug$tab_id$rand' class='tab-pane'>";
-                $tab_info['display_callable']([
-                    'with_session' => $with_session,
-                    'ajax'         => $ajax,
-                    'rand'         => $rand,
-                ]);
-                echo "</div>";
-            }
-            echo "</div>";
+            $vars_info = [
+                'get'      => $_GET ?? [],
+                'post'     => $_POST ?? [],
+                'session'  => $_SESSION ?? [],
+                'server'   => $_SERVER ?? [],
+            ];
 
-            echo Html::scriptBlock("
-            $('#close_debug$rand').click(function() {
-                $('#debugpanel$rand').css('display', 'none');
-            });");
-
-            echo "</div></div>";
+            TemplateRenderer::getInstance()->display('debug_panel.html.twig', [
+                'summary'       => $summary,
+                'sql_info'      => $sql_info,
+                'vars_info'     => $vars_info,
+                'with_session'  => $with_session,
+                'debug_sql'     => $CFG_GLPI['debug_sql'],
+                'debug_vars'    => $CFG_GLPI['debug_vars'],
+                'ajax'          => $ajax,
+                'rand'          => $rand,
+                'plugin_tabs'   => $plugin_tabs,
+            ]);
         }
     }
 
@@ -4194,9 +4132,9 @@ JAVASCRIPT
                 $key = Sanitizer::encodeHtmlSpecialChars($key);
                 echo "<tr><td>";
                 echo $key;
+                echo "</td><td>";
                 $is_array = is_array($val);
                 $rand     = mt_rand();
-                echo "</td><td>";
                 if ($jsexpand && $is_array) {
                     echo "<a href=\"javascript:showHideDiv('content$key$rand','','','')\">";
                     echo "=></a>";

--- a/src/Html.php
+++ b/src/Html.php
@@ -704,6 +704,33 @@ class Html
         echo "</div>";
     }
 
+
+    /**
+     * Clean Display of Request
+     *
+     * @since 0.83.1
+     *
+     * @param string $request  SQL request
+     *
+     * @return string
+     **/
+    public static function cleanSQLDisplay($request)
+    {
+
+        $request = str_replace("<", "&lt;", $request);
+        $request = str_replace(">", "&gt;", $request);
+        $request = str_ireplace("UNION", "<br/>UNION<br/>", $request);
+        $request = str_ireplace("UNION ALL", "<br/>UNION ALL<br/>", $request);
+        $request = str_ireplace("FROM", "<br/>FROM", $request);
+        $request = str_ireplace("WHERE", "<br/>WHERE", $request);
+        $request = str_ireplace("INNER JOIN", "<br/>INNER JOIN", $request);
+        $request = str_ireplace("LEFT JOIN", "<br/>LEFT JOIN", $request);
+        $request = str_ireplace("ORDER BY", "<br/>ORDER BY", $request);
+        $request = str_ireplace("SORT", "<br/>SORT", $request);
+
+        return $request;
+    }
+
     /**
      * Display Debug Information
      *

--- a/templates/debug_panel.html.twig
+++ b/templates/debug_panel.html.twig
@@ -41,20 +41,20 @@
             <th>=></th>
             <th>VALUE</th>
          </tr>
-         {% for key,value in data %}
+         {% for key, value in data %}
             {% set row_rand = random() %}
             <tr>
                <td>{{ key }}</td>
                <td>
                   {% if js_expand and val is array %}
-                     <a href="javascript:showHideDiv('content{{ key ~ row_rand}}', '', '', '')">=></a>
+                     <a href="javascript:showHideDiv('content{{ key ~ row_rand }}', '', '', '')">=></a>
                   {% else %}
                      =>
                   {% endif %}
                </td>
                <td>
                   {% if val is array %}
-                     <div id="content{{ key ~ row_rand}}" {{ js_expand ? 'style="display: none"' : '' }}>
+                     <div id="content{{ key ~ row_rand }}" {{ js_expand ? 'style="display: none"' : '' }}>
                         {{ _self.print_clean_array(value, pad + 1) }}
                      </div>
                   {% else %}
@@ -89,7 +89,7 @@
          {% endif %}
          <li class="nav-item"><a class="nav-link" data-bs-toggle="tab" href="#debugserver{{ rand }}">SERVER VARIABLE</a></li>
       {% endif %}
-      {% for tab_id,tab_info in plugin_tabs %}
+      {% for tab_id, tab_info in plugin_tabs %}
          <li class="nav-item"><a class="nav-link" data-bs-toggle="tab" href="#debug{{ tab_id ~ rand }}">{{ tab_info['title'] }}</a></li>
       {% endfor %}
       <li class="nav-item ms-auto">
@@ -172,7 +172,7 @@
             </div>
          {% endif %}
 
-         {% for tab_id,tab_info in plugin_tabs %}
+         {% for tab_id, tab_info in plugin_tabs %}
             {% if tab_info['display_callable'] is defined %}
                <div id="debug{{ tab_id ~ rand }}" class="tab-pane">
                   {{ call(tab_info['display_callable'], {

--- a/templates/debug_panel.html.twig
+++ b/templates/debug_panel.html.twig
@@ -46,24 +46,24 @@
             <tr>
                <td>{{ key }}</td>
                <td>
-                  {% if js_expand and val is array %}
+                  {% if js_expand and value is array %}
                      <a href="javascript:showHideDiv('content{{ key ~ row_rand }}', '', '', '')">=></a>
                   {% else %}
                      =>
                   {% endif %}
                </td>
                <td>
-                  {% if val is array %}
+                  {% if value is array %}
                      <div id="content{{ key ~ row_rand }}" {{ js_expand ? 'style="display: none"' : '' }}>
                         {{ _self.print_clean_array(value, pad + 1) }}
                      </div>
                   {% else %}
-                     {% if val is same as(true) or val is same as(false) %}
-                        {{ val ? 'true' : 'false' }}
-                     {% elseif val is object %}
-                        {{ call([val, '__toString'])|default('(object) ' ~ get_class(val)) }}
+                     {% if value is same as(true) or value is same as(false) %}
+                        {{ value ? 'true' : 'false' }}
+                     {% elseif value is object %}
+                        {{ call([value, '__toString'])|default('(object) ' ~ get_class(value)) }}
                      {% else %}
-                        {{ val }}
+                        {{ value }}
                      {% endif %}
                   {% endif %}
                </td>

--- a/templates/debug_panel.html.twig
+++ b/templates/debug_panel.html.twig
@@ -38,7 +38,7 @@
       <table class="array-debug table table-striped card-table">
          <tr>
             <th>KEY</th>
-            <th>=></th>
+            <th>=&gt;</th>
             <th>VALUE</th>
          </tr>
          {% for key, value in data %}
@@ -46,24 +46,39 @@
             <tr>
                <td>{{ key }}</td>
                <td>
-                  {% if js_expand and value is array %}
-                     <a class="fw-bolder" href="javascript:showHideDiv('content{{ key ~ row_rand }}', '', '', '')">=></a>
+                  {% if js_expand and (value is array or value is object) %}
+                     <a class="fw-bolder" href="javascript:showHideDiv('content{{ key ~ row_rand }}', '', '', '')">=&gt;</a>
                   {% else %}
-                     =>
+                     =&gt;
                   {% endif %}
                </td>
                <td>
                   {% if value is array %}
+                     {% if js_expand %}
+                        <a class="fw-bolder" href="javascript:showHideDiv('content{{ key ~ row_rand }}', '', '', '')">array({{ value|length }})</a>
+                     {% else %}
+                        array({{ value|length }})
+                     {% endif %}
                      <div id="content{{ key ~ row_rand }}" {{ js_expand ? 'style="display: none"' : '' }}>
                         {{ _self.print_clean_array(value, pad + 1) }}
                      </div>
                   {% else %}
-                     {% if value is same as(true) or value is same as(false) %}
-                        {{ value ? 'true' : 'false' }}
-                     {% elseif value is object %}
-                        {{ call([value, '__toString'])|default('(object) ' ~ get_class(value)) }}
+                     {% if value is object %}
+                        {% set out %}
+                           {{ dump(value) }}
+                        {% endset %}
+                        {# Split the type info and object contents #}
+                        {% set out = out|trim|split(' ', 2) %}
+                        {% if js_expand %}
+                           <a class="fw-bolder" href="javascript:showHideDiv('content{{ key ~ row_rand }}', '', '', '')">{{ out[0] }}</a>
+                        {% else %}
+                           {{ out[0] }}
+                        {% endif %}
+                        <div id="content{{ key ~ row_rand }}" {{ js_expand ? 'style="display: none"' : '' }}>
+                           <pre>{{ out[1]|trim }}</pre>
+                        </div>
                      {% else %}
-                        {{ value }}
+                        {{ dump(value) }}
                      {% endif %}
                   {% endif %}
                </td>
@@ -143,8 +158,8 @@
                            <td>{{ query['query']|raw }}</td>
                            <td>{{ query['time'] }}</td>
                            <td>{{ query['rows'] }}</td>
-                           <td>{{ query['warnings'] }}</td>
-                           <td>{{ query['errors'] }}</td>
+                           <td>{{ query['warnings']|nl2br }}</td>
+                           <td>{{ query['errors']|nl2br }}</td>
                         </tr>
                      {% endfor %}
                   </tbody>

--- a/templates/debug_panel.html.twig
+++ b/templates/debug_panel.html.twig
@@ -90,6 +90,20 @@
    {% endif %}
 {% endmacro %}
 
+{% macro display_clean_sql(query) %}
+   {{ query|replace({
+      'UNION': '</br>UNION</br>',
+      'FROM': '</br>FROM',
+      'WHERE': '</br>WHERE',
+      'INNER JOIN': '</br>INNER JOIN',
+      'LEFT JOIN': '</br>LEFT JOIN',
+      'ORDER BY': '</br>ORDER BY',
+      'SORT': '</br>SORT',
+      '>': '&gt;',
+      '<': '&lt;',
+   })|raw }}
+{% endmacro %}
+
 <div id="debugpanel{{ rand }}" class="container-fluid card debug-panel {{ ajax ? "debug_ajax" : "" }} p-0 position-sticky bottom-0">
    <ul class="nav nav-tabs" data-bs-toggle="tabs">
       <li class="nav-item"><a class="nav-link active" data-bs-toggle="tab" href="#debugsummary{{ rand }}">SUMMARY</a></li>
@@ -155,7 +169,7 @@
                      {% for query in sql_info['queries'] %}
                         <tr>
                            <td>{{ query['num'] }}</td>
-                           <td>{{ query['query']|raw }}</td>
+                           <td>{{ _self.display_clean_sql(query['query']) }}</td>
                            <td>{{ query['time'] }}</td>
                            <td>{{ query['rows'] }}</td>
                            <td>{{ query['warnings']|nl2br }}</td>

--- a/templates/debug_panel.html.twig
+++ b/templates/debug_panel.html.twig
@@ -140,7 +140,7 @@
                      {% for query in sql_info['queries'] %}
                         <tr>
                            <td>{{ query['num'] }}</td>
-                           <td>{{ query['query'] }}</td>
+                           <td>{{ query['query']|raw }}</td>
                            <td>{{ query['time'] }}</td>
                            <td>{{ query['rows'] }}</td>
                            <td>{{ query['warnings'] }}</td>

--- a/templates/debug_panel.html.twig
+++ b/templates/debug_panel.html.twig
@@ -64,11 +64,8 @@
                      </div>
                   {% else %}
                      {% if value is object %}
-                        {% set out %}
-                           {{ dump(value) }}
-                        {% endset %}
                         {# Split the type info and object contents #}
-                        {% set out = out|trim|split(' ', 2) %}
+                        {% set out = dump(value)|trim|split(' ', 2) %}
                         {% if js_expand %}
                            <a class="fw-bolder" href="javascript:showHideDiv('content{{ key ~ row_rand }}', '', '', '')">{{ out[0] }}</a>
                         {% else %}

--- a/templates/debug_panel.html.twig
+++ b/templates/debug_panel.html.twig
@@ -127,7 +127,7 @@
                <dt class="col-sm-3">Execution time</dt>
                <dd class="col-sm-9">{{ summary['execution_time'] }}</dd>
                <dt class="col-sm-3">Memory usage</dt>
-               <dd class="col-sm-9">{{ summary['memory_usage'] }}</dd>
+               <dd class="col-sm-9">{{ summary['memory_usage']|formatted_size }}</dd>
                {% if debug_sql %}
                   <dt class="col-sm-3">SQL queries count</dt>
                   <dd class="col-sm-9">{{ summary['sql_queries_count'] }}</dd>

--- a/templates/debug_panel.html.twig
+++ b/templates/debug_panel.html.twig
@@ -1,0 +1,188 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2022 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% set rand = rand|default(random()) %}
+
+{% macro print_clean_array(data, pad = 0, js_expand = false) %}
+   {% if data|length > 0 %}
+      <table class="array-debug table table-striped">
+         <tr>
+            <th>KEY</th>
+            <th>=></th>
+            <th>VALUE</th>
+         </tr>
+         {% for key,value in data %}
+            {% set row_rand = random() %}
+            <tr>
+               <td>{{ key }}</td>
+               <td>
+                  {% if js_expand and val is array %}
+                     <a href="javascript:showHideDiv('content{{ key ~ row_rand}}', '', '', '')">=></a>
+                  {% else %}
+                     =>
+                  {% endif %}
+               </td>
+               <td>
+                  {% if val is array %}
+                     <div id="content{{ key ~ row_rand}}" {{ js_expand ? 'style="display: none"' : '' }}>
+                        {{ _self.print_clean_array(value, pad + 1) }}
+                     </div>
+                  {% else %}
+                     {% if val is same as(true) or val is same as(false) %}
+                        {{ val ? 'true' : 'false' }}
+                     {% elseif val is object %}
+                        {{ call([val, '__toString'])|default('(object) ' ~ get_class(val)) }}
+                     {% else %}
+                        {{ val }}
+                     {% endif %}
+                  {% endif %}
+               </td>
+            </tr>
+         {% endfor %}
+      </table>
+   {% else %}
+      {{ __('Empty array') }}
+   {% endif %}
+{% endmacro %}
+
+<div id="debugpanel{{ rand }}" class="container-fluid card debug-panel {{ ajax ? "debug_ajax" : "" }}">
+   <ul class="nav nav-tabs" data-bs-toggle="tabs">
+      <li class="nav-item"><a class="nav-link active" data-bs-toggle="tab" href="#debugsummary{{ rand }}">SUMMARY</a></li>
+      {% if debug_sql %}
+         <li class="nav-item"><a class="nav-link" data-bs-toggle="tab" href="#debugsql{{ rand }}">SQL REQUEST</a></li>
+      {% endif %}
+      {% if debug_vars %}
+         <li class="nav-item"><a class="nav-link" data-bs-toggle="tab" href="#debugpost{{ rand }}">POST VARIABLE</a></li>
+         <li class="nav-item"><a class="nav-link" data-bs-toggle="tab" href="#debugget{{ rand }}">GET VARIABLE</a></li>
+         {% if with_session %}
+            <li class="nav-item"><a class="nav-link" data-bs-toggle="tab" href="#debugsession{{ rand }}">SESSION VARIABLE</a></li>
+         {% endif %}
+         <li class="nav-item"><a class="nav-link" data-bs-toggle="tab" href="#debugserver{{ rand }}">SERVER VARIABLE</a></li>
+      {% endif %}
+      {% for tab_id,tab_info in plugin_tabs %}
+         <li class="nav-item"><a class="nav-link" data-bs-toggle="tab" href="#debug{{ tab_id ~ rand }}">{{ tab_info['title'] }}</a></li>
+      {% endfor %}
+      <li class="nav-item ms-auto">
+         <a id="close_debug{{ rand }}" class="nav-link" href="#">
+            <i class="fas fa-2x fa-times"></i>
+            <span class="sr-only">{{ __('Close') }}</span>
+         </a>
+         <script>
+            $('#close_debug{{ rand }}').on('click', function() {
+               $('#debugpanel{{ rand }}').css('display', 'none');
+            });
+         </script>
+      </li>
+   </ul>
+
+   <div class="card-body">
+      <div class="tab-content">
+         <div id="debugsummary{{ rand }}" class="tab-pane active">
+            <dl class="row">
+               <dt class="col-sm-3">Execution time</dt>
+               <dd class="col-sm-9">{{ summary['execution_time'] }}</dd>
+               <dt class="col-sm-3">Memory usage</dt>
+               <dd class="col-sm-9">{{ summary['memory_usage'] }}</dd>
+               {% if debug_sql %}
+                  <dt class="col-sm-3">SQL queries count</dt>
+                  <dd class="col-sm-9">{{ summary['sql_queries_count'] }}</dd>
+                  <dt class="col-sm-3">SQL queries duration</dt>
+                  <dd class="col-sm-9">{{ summary['sql_queries_duration'] }}</dd>
+               {% endif %}
+            </dl>
+         </div>
+
+         {% if debug_sql %}
+            <div id="debugsql{{ rand }}" class="tab-pane">
+               <h1>{{ sql_info['total_requests'] }} Queries took {{ sql_info['total_duration'] }}</h1>
+               <table id="debugsql{{ rand }}_table" class="table">
+                  <thead>
+                     <tr>
+                        <th>N°</th>
+                        <th>Query</th>
+                        <th>Time</th>
+                        <th>Rows</th>
+                        <th>Warnings</th>
+                        <th>Errors</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     {% for query in sql_info['queries'] %}
+                        <tr>
+                           <td>{{ query['num'] }}</td>
+                           <td>{{ query['query'] }}</td>
+                           <td>{{ query['time'] }}</td>
+                           <td>{{ query['rows'] }}</td>
+                           <td>{{ query['warnings'] }}</td>
+                           <td>{{ query['errors'] }}</td>
+                        </tr>
+                     {% endfor %}
+                  </tbody>
+               </table>
+               <script>
+                  initSortableTable('debugsql{{ rand }}_table');
+               </script>
+            </div>
+         {% endif %}
+
+         {% if debug_vars %}
+            <div id="debugpost{{ rand }}" class="tab-pane">
+               {{ _self.print_clean_array(vars_info['post'], 0, true) }}
+            </div>
+            <div id="debugget{{ rand }}" class="tab-pane">
+               {{ _self.print_clean_array(vars_info['get'], 0, true) }}
+            </div>
+            {% if with_session %}
+               <div id="debugsession{{ rand }}" class="tab-pane">
+                  {{ _self.print_clean_array(vars_info['session'], 0, true) }}
+               </div>
+            {% endif %}
+            <div id="debugserver{{ rand }}" class="tab-pane">
+               {{ _self.print_clean_array(vars_info['server'], 0, true) }}
+            </div>
+         {% endif %}
+
+         {% for tab_id,tab_info in plugin_tabs %}
+            {% if tab_info['display_callable'] is defined %}
+               <div id="debug{{ tab_id ~ rand }}" class="tab-pane">
+                  {{ call(tab_info['display_callable'], {
+                     'with_session': with_session,
+                     'ajax': ajax,
+                     'rand': rand,
+                  }) }}
+               </div>
+            {% endif %}
+         {% endfor %}
+      </div>
+   </div>
+</div>

--- a/templates/debug_panel.html.twig
+++ b/templates/debug_panel.html.twig
@@ -35,7 +35,7 @@
 
 {% macro print_clean_array(data, pad = 0, js_expand = false) %}
    {% if data|length > 0 %}
-      <table class="array-debug table table-striped">
+      <table class="array-debug table table-striped card-table">
          <tr>
             <th>KEY</th>
             <th>=></th>
@@ -47,7 +47,7 @@
                <td>{{ key }}</td>
                <td>
                   {% if js_expand and value is array %}
-                     <a href="javascript:showHideDiv('content{{ key ~ row_rand }}', '', '', '')">=></a>
+                     <a class="fw-bold" href="javascript:showHideDiv('content{{ key ~ row_rand }}', '', '', '')">=></a>
                   {% else %}
                      =>
                   {% endif %}
@@ -75,7 +75,7 @@
    {% endif %}
 {% endmacro %}
 
-<div id="debugpanel{{ rand }}" class="container-fluid card debug-panel {{ ajax ? "debug_ajax" : "" }}">
+<div id="debugpanel{{ rand }}" class="container-fluid card debug-panel {{ ajax ? "debug_ajax" : "" }} p-0 position-sticky bottom-0">
    <ul class="nav nav-tabs" data-bs-toggle="tabs">
       <li class="nav-item"><a class="nav-link active" data-bs-toggle="tab" href="#debugsummary{{ rand }}">SUMMARY</a></li>
       {% if debug_sql %}
@@ -105,7 +105,7 @@
       </li>
    </ul>
 
-   <div class="card-body">
+   <div class="card-body overflow-auto" style="height: 300px">
       <div class="tab-content">
          <div id="debugsummary{{ rand }}" class="tab-pane active">
             <dl class="row">
@@ -125,7 +125,7 @@
          {% if debug_sql %}
             <div id="debugsql{{ rand }}" class="tab-pane">
                <h1>{{ sql_info['total_requests'] }} Queries took {{ sql_info['total_duration'] }}</h1>
-               <table id="debugsql{{ rand }}_table" class="table">
+               <table id="debugsql{{ rand }}_table" class="table card-table">
                   <thead>
                      <tr>
                         <th>N°</th>

--- a/templates/debug_panel.html.twig
+++ b/templates/debug_panel.html.twig
@@ -5,7 +5,7 @@
  #
  # http://glpi-project.org
  #
- # @copyright 2015-2022 Teclib' and contributors.
+ # @copyright 2015-2023 Teclib' and contributors.
  # @copyright 2003-2014 by the INDEPNET Development Team.
  # @licence   https://www.gnu.org/licenses/gpl-3.0.html
  #

--- a/templates/debug_panel.html.twig
+++ b/templates/debug_panel.html.twig
@@ -47,7 +47,7 @@
                <td>{{ key }}</td>
                <td>
                   {% if js_expand and value is array %}
-                     <a class="fw-bold" href="javascript:showHideDiv('content{{ key ~ row_rand }}', '', '', '')">=></a>
+                     <a class="fw-bolder" href="javascript:showHideDiv('content{{ key ~ row_rand }}', '', '', '')">=></a>
                   {% else %}
                      =>
                   {% endif %}

--- a/tests/units/Html.php
+++ b/tests/units/Html.php
@@ -736,13 +736,6 @@ class Html extends \GLPITestCase
         $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isEmpty();
     }
 
-    public function testCleanSQLDisplay()
-    {
-        $sql = "SELECT * FROM mytable WHERE myfield < 10 ORDER BY id";
-        $expected = "SELECT * <br/>FROM mytable <br/>WHERE myfield &lt; 10 <br/>ORDER BY id";
-        $this->string(\Html::cleanSQLDisplay($sql))->isIdenticalTo($expected);
-    }
-
     public function testDisplayBackLink()
     {
         $this->output(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Originally, I just wanted a way to be able to sort the SQL requests table to quickly identify slow queries. For that, I converted the panel to Twig and added a simple JS method to make a regular HTML table with static content sortable.