### PR TITLE
fix php warning when user views a change 

### DIFF
--- a/src/Change.php
+++ b/src/Change.php
@@ -226,6 +226,7 @@ class Change extends CommonITILObject
         if (static::canView()) {
             switch ($item->getType()) {
                 case __CLASS__:
+                    $ong = [];
                     if ($item->canUpdate()) {
                          $ong[1] = __('Statistics');
                     }


### PR DESCRIPTION
error happened when the user has no update right on changes


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
