### PR TITLE
fix bad right check on change validationn

### DIFF
--- a/templates/components/itilobject/timeline/form_validation.html.twig
+++ b/templates/components/itilobject/timeline/form_validation.html.twig
@@ -201,12 +201,16 @@
                     'input_class': 'col-xxl-8 flex-wrap',
                     'add_field_html': '<span id="show_validator_field' ~ rand ~ '" class="flex-grow-1">&nbsp;</span>',
                     }) }}
+                    {% set right = 'validate' %}
+                    {% if (item.getType() is same as 'Ticket') %}
+                        {% set right = item.fields['type'] == 2 ? 'validate_request' : 'validate_incident' %}
+                    {% endif %}
                     {% if subitem.fields['validatortype'] is not null %}
                     <script type="application/javascript">
                         $('#show_validator_field{{ rand }}').load(CFG_GLPI.root_doc + '/ajax/dropdownValidator.php', {
                             id: {{ subitem.fields['id'] }},
                             entity: {{ item.fields['entities_id'] }},
-                            right: "{{ item.getType() is same as 'Ticket' and item.fields['type'] == 2 ? 'validate_request' : 'validate_incident' }}",
+                            right: '{{ right }}',
                             validatortype: "{{ subitem.fields['users_id_validate']['groups_id'] is defined ? 'Group' : (subitem.fields['users_id_validate'] is not empty ? 'User' : '') }}"
                         });
                     </script>
@@ -216,7 +220,7 @@
                             CFG_GLPI.root_doc + '/ajax/dropdownValidator.php', {
                                 id: 0,
                                 entity: {{ item.fields['entities_id'] }},
-                                right: "{{ item.getType() is same as 'Ticket' and item.fields['type'] == 2 ? 'validate_request' : 'validate_incident' }}",
+                                right: '{{ right }}',
                                 validatortype: '__VALUE__',
                                 groups_id: 0
                             });


### PR DESCRIPTION
When adding a validation to a change, the users dropdown is configured to filter users with ticket validation right (**validate_incident** or **validate_request**). A change validation supports only **validate** .

To reproduce

Create a blank profile, with standard interface. Give rights to access changes and change validation.

![image](https://user-images.githubusercontent.com/14139801/204084265-fff586a5-c3ff-4644-b9ff-8102b9062e5f.png)


Create a new user and add it to the previous profile.

Create a change with GLPI, then try to add the new user as a validator of the change. The user is not available in the list.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
