### PR TITLE
Fix password forget token validity

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -6603,7 +6603,7 @@ JAVASCRIPT;
 
     /**
      * Find one user which match the given token and asked for a password reset
-     * less than one day ago
+     * less than `password_init_token_delay` (config option) days ago
      *
      * @param string $token password_forget_token
      *
@@ -6619,7 +6619,7 @@ JAVASCRIPT;
         }
 
         // Find users which match the given token and asked for a password reset
-        // less than one day ago
+        // less than `password_init_token_delay` days ago
         $iterator = $DB->request([
             'SELECT' => 'id',
             'FROM'   => self::getTable(),

--- a/src/User.php
+++ b/src/User.php
@@ -6625,7 +6625,7 @@ JAVASCRIPT;
             'FROM'   => self::getTable(),
             'WHERE'  => [
                 'password_forget_token'       => $token,
-                new \QueryExpression('NOW() < ADDDATE(' . $DB->quoteName('password_forget_token_date') . ', ' . $CFG_GLPI['password_init_token_delay'] . ')')
+                new \QueryExpression('NOW() < ADDDATE(' . $DB::quoteName('password_forget_token_date') . ', INTERVAL ' . $CFG_GLPI['password_init_token_delay'] . ' SECOND)')
             ]
         ]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The behavior of the `ADDDATE` function in MySQL when the second argument doesn't start with `INTERVAL` is to treat it like a number of days. The `password_init_token_delay` config value however is stored as a number of seconds, not days.

Bug only affects main branch.