### PR TITLE
Localize month name

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -6977,6 +6977,8 @@ CSS;
         if (!ctype_digit($ts)) {
             $ts = strtotime($ts);
         }
+        $ts_date = new DateTime();
+        $ts_date->setTimestamp($ts);
 
         $diff = time() - $ts;
         if ($diff == 0) {
@@ -7007,7 +7009,7 @@ CSS;
                 return __('Last month');
             }
 
-            return date('F Y', $ts);
+            return IntlDateFormatter::formatObject($ts_date, 'MMMM Y', $_SESSION['glpilanguage'] ?? 'en_GB');
         } else {
             $diff     = abs($diff);
             $day_diff = floor($diff / 86400);
@@ -7040,7 +7042,8 @@ CSS;
             if (date('n', $ts) == date('n') + 1) {
                 return __('next month');
             }
-            return date('F Y', $ts);
+
+            return IntlDateFormatter::formatObject($ts_date, 'MMMM Y', $_SESSION['glpilanguage'] ?? 'en_GB');
         }
 
         return "";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13422

Localize the month name for relative datetime strings.