### PR TITLE
fix: improvement of relative date calculation

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -7032,17 +7032,14 @@ CSS;
             if ($day_diff == 1) {
                 return __('Tomorrow');
             }
-            if ($day_diff < 4) {
-                return date('l', $ts);
+            if ($day_diff < 14) {
+                return sprintf(__('In %s days'), $day_diff);
             }
-            if ($day_diff < 7 + (7 - date('w'))) {
-                return __('next week');
-            }
-            if (floor($day_diff / 7) < 4) {
+            if ($day_diff < 31) {
                 return sprintf(__('In %s weeks'), floor($day_diff / 7));
             }
-            if (date('n', $ts) == date('n') + 1) {
-                return __('next month');
+            if ($day_diff < 60) {
+                return __('Next month');
             }
             return date('F Y', $ts);
         }

--- a/src/Html.php
+++ b/src/Html.php
@@ -7012,7 +7012,9 @@ CSS;
             return date('F Y', $ts);
         } else {
             $diff     = abs($diff);
-            $day_diff = floor($diff / 86400);
+            $today = new DateTime('today');
+            $date = new DateTime(date('Y-m-d', $ts));
+            $day_diff = $today->diff($date)->days;
             if ($day_diff == 0) {
                 if ($diff < 120) {
                     return __('In a minute');
@@ -7036,8 +7038,8 @@ CSS;
             if ($day_diff < 7 + (7 - date('w'))) {
                 return __('next week');
             }
-            if (ceil($day_diff / 7) < 4) {
-                return sprintf(__('In %s weeks'), ceil($day_diff / 7));
+            if (floor($day_diff / 7) < 4) {
+                return sprintf(__('In %s weeks'), floor($day_diff / 7));
             }
             if (date('n', $ts) == date('n') + 1) {
                 return __('next month');

--- a/src/Html.php
+++ b/src/Html.php
@@ -6982,7 +6982,9 @@ CSS;
         if ($diff == 0) {
             return __('Now');
         } else if ($diff > 0) {
-            $day_diff = floor($diff / 86400);
+            $date = new DateTime(date('Y-m-d', $ts));
+            $today = new DateTime('today');
+            $day_diff = $date->diff($today)->days;
             if ($day_diff == 0) {
                 if ($diff < 60) {
                     return __('Just now');
@@ -7001,7 +7003,7 @@ CSS;
                 return sprintf(__('%s days ago'), $day_diff);
             }
             if ($day_diff < 31) {
-                return sprintf(__('%s weeks ago'), ceil($day_diff / 7));
+                return sprintf(__('%s weeks ago'), round($day_diff / 7));
             }
             if ($day_diff < 60) {
                 return __('Last month');

--- a/src/Html.php
+++ b/src/Html.php
@@ -6999,11 +6999,11 @@ CSS;
             if ($day_diff == 1) {
                 return __('Yesterday');
             }
-            if ($day_diff < 7) {
+            if ($day_diff < 14) {
                 return sprintf(__('%s days ago'), $day_diff);
             }
             if ($day_diff < 31) {
-                return sprintf(__('%s weeks ago'), round($day_diff / 7));
+                return sprintf(__('%s weeks ago'), floor($day_diff / 7));
             }
             if ($day_diff < 60) {
                 return __('Last month');


### PR DESCRIPTION
The calculation of the relative date was based on the time difference, which was not precise enough.

For example, it is the 29th at 10am and the item is dated the 27th at 5pm. It shows "Yesterday" when it should be "2 days ago".

Same case with the number of weeks, if the event is 8 days old, we would display "2 weeks ago" when "1 week ago" is more accurate.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25712
