### PR TITLE
Fix administrator targets

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -3990,6 +3990,15 @@ HTML;
                     'email' => $entity_sender_email,
                     'name'  => $entity_sender_name,
                 ];
+            } elseif ($entity_sender_email !== '') {
+                trigger_error(
+                    sprintf(
+                        'Invalid email address "%s" configured for entity "%s". Default administrator email will be used.',
+                        $entity_sender_email,
+                        $entities_id
+                    ),
+                    E_USER_WARNING
+                );
             }
         }
 
@@ -4002,6 +4011,11 @@ HTML;
                 'email' => $global_sender_email,
                 'name'  => $global_sender_name,
             ];
+        } elseif ($global_sender_email !== '') {
+            trigger_error(
+                sprintf('Invalid email address "%s" configured in "%s".', $global_sender_email, $config_name),
+                E_USER_WARNING
+            );
         }
 
         // No valid values found

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -1950,9 +1950,12 @@ class Entity extends CommonTreeDropdown
         echo "<tr class='tab_bg_1'>";
         echo "<td>" . __('Administrator email address') . "</td>";
         echo "<td>";
-        echo Html::input('admin_email', ['value' => $entity->fields['admin_email']]);
+        echo Html::input('admin_email', ['value' => $entity->fields['admin_email'], 'type' => 'email']);
         if (empty($entity->fields['admin_email']) && $ID > 0) {
             self::inheritedValue(self::getUsedConfig('admin_email', $ID, '', ''));
+        }
+        if (!empty($entity->fields['admin_email']) && !NotificationMailing::isUserAddressValid($entity->fields['admin_email'])) {
+            echo "<span class='red'>" . __('Invalid email address') . "</span>";
         }
         echo "</td>";
         echo "<td>" . __('Administrator name') . "</td><td>";
@@ -1967,9 +1970,12 @@ class Entity extends CommonTreeDropdown
         echo "<tr class='tab_bg_1'>";
         echo "<td>" . __('Email sender address') . "</td>";
         echo "<td>";
-        echo Html::input('from_email', ['value' => $entity->fields['from_email']]);
+        echo Html::input('from_email', ['value' => $entity->fields['from_email'], 'type' => 'email']);
         if (empty($entity->fields['from_email']) && $ID > 0) {
             self::inheritedValue(self::getUsedConfig('from_email', $ID, '', ''));
+        }
+        if (!empty($entity->fields['from_email']) && !NotificationMailing::isUserAddressValid($entity->fields['from_email'])) {
+            echo "<span class='red'>" . __('Invalid email address') . "</span>";
         }
         echo "</td>";
         echo "<td>" . __('Email sender name') . "</td><td>";
@@ -1984,9 +1990,12 @@ class Entity extends CommonTreeDropdown
         echo "<tr class='tab_bg_1'>";
         echo "<td>" . __('No-Reply address') . "</td>";
         echo "<td>";
-        echo Html::input('noreply_email', ['value' => $entity->fields['noreply_email']]);
+        echo Html::input('noreply_email', ['value' => $entity->fields['noreply_email'], 'type' => 'email']);
         if (empty($entity->fields['noreply_email']) && $ID > 0) {
             self::inheritedValue(self::getUsedConfig('noreply_email', $ID, '', ''));
+        }
+        if (!empty($entity->fields['noreply_email']) && !NotificationMailing::isUserAddressValid($entity->fields['noreply_email'])) {
+            echo "<span class='red'>" . __('Invalid email address') . "</span>";
         }
         echo "</td>";
         echo "<td>" . __('No-Reply name') . "</td><td>";
@@ -2001,9 +2010,12 @@ class Entity extends CommonTreeDropdown
         echo "<tr class='tab_bg_1'>";
         echo "<td><label for='replyto_email'>" . __('Reply-To address') . "</label></td>";
         echo "<td>";
-        echo Html::input('replyto_email', ['value' => $entity->fields['replyto_email']]);
+        echo Html::input('replyto_email', ['value' => $entity->fields['replyto_email'], 'type' => 'email']);
         if (empty($entity->fields['replyto_email']) && $ID > 0) {
             self::inheritedValue(self::getUsedConfig('replyto_email', $ID, '', ''));
+        }
+        if (!empty($entity->fields['replyto_email']) && !NotificationMailing::isUserAddressValid($entity->fields['replyto_email'])) {
+            echo "<span class='red'>" . __('Invalid email address') . "</span>";
         }
         echo "</td>";
         echo "<td><label for='replyto_email_name'>" . __('Reply-To name') . "</label></td>";

--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -75,57 +75,39 @@ class NotificationEventMailing extends NotificationEventAbstract
     {
         global $CFG_GLPI;
 
-        if (!NotificationMailing::isUserAddressValid($CFG_GLPI['admin_email'])) {
-            return false;
+        $admin = Config::getAdminEmailSender();
+        if ($admin['email'] !== null) {
+            $admin['language'] = $CFG_GLPI['language'];
+
+            $user = new User();
+            if ($user->getFromDBbyEmail($admin['email'])) {
+                $admin['users_id'] = $user->getID();
+            }
+
+            return $admin;
         }
 
-        $admin = [
-            'email'     => $CFG_GLPI['admin_email'],
-            'name'      => $CFG_GLPI['admin_email_name'],
-            'language'  => $CFG_GLPI['language']
-        ];
-
-        $user = new User();
-        if ($user->getFromDBbyEmail($CFG_GLPI['admin_email'])) {
-            $admin['users_id'] = $user->getID();
-        }
-
-        return $admin;
+        return false;
     }
 
 
     public static function getEntityAdminsData($entity)
     {
-        global $DB, $CFG_GLPI;
+        global $CFG_GLPI;
 
-        $iterator = $DB->request([
-            'FROM'   => 'glpi_entities',
-            'WHERE'  => ['id' => $entity]
-        ]);
+        $admin = Config::getAdminEmailSender($entity);
+        if ($admin['email'] !== null) {
+            $admin['language'] = $CFG_GLPI['language'];
 
-        $admins = [];
-
-        foreach ($iterator as $row) {
-            if (NotificationMailing::isUserAddressValid($row['admin_email'])) {
-                $admin = [
-                    'language'  => $CFG_GLPI['language'],
-                    'email'     => $row['admin_email'],
-                    'name'      => $row['admin_email_name']
-                ];
-
-                $user = new User();
-                if ($user->getFromDBbyEmail($row['admin_email'])) {
-                    $admin['users_id'] = $user->getID();
-                }
-                $admins[] = $admin;
+            $user = new User();
+            if ($user->getFromDBbyEmail($admin['email'])) {
+                $admin['users_id'] = $user->getID();
             }
+
+            return [$admin];
         }
 
-        if (count($admins)) {
-            return $admins;
-        } else {
-            return false;
-        }
+        return false;
     }
 
 

--- a/src/NotificationMailingSetting.php
+++ b/src/NotificationMailingSetting.php
@@ -77,7 +77,7 @@ class NotificationMailingSetting extends NotificationSetting
         if ($CFG_GLPI['notifications_mailing']) {
             $out .= "<tr class='tab_bg_2'>";
             $out .= "<td><label for='admin_email'>" . __('Administrator email address') . "</label></td>";
-            $out .= "<td><input type='text' class='form-control' name='admin_email' id='admin_email' value='" .
+            $out .= "<td><input type='email' class='form-control' name='admin_email' id='admin_email' value='" .
                     $CFG_GLPI["admin_email"] . "'>";
             if (!NotificationMailing::isUserAddressValid($CFG_GLPI["admin_email"])) {
                 $out .= "<br/><span class='red'>&nbsp;" . __('Invalid email address') . "</span>";
@@ -91,7 +91,7 @@ class NotificationMailingSetting extends NotificationSetting
             $out .= "<tr class='tab_bg_2'>";
             $out .= "<td><label for='from_email'>" . __('Email sender address') . " <i class='pointer fa fa-info' title='" .
             __s('Address to use in from for sent emails.') . "\n" . __s('If not set, main or entity administrator email address will be used.')  . "'></i></label></td>";
-            $out .= "<td><input type='text' class='form-control' name='from_email' id='from_email' value='" .
+            $out .= "<td><input type='email' class='form-control' name='from_email' id='from_email' value='" .
                     $CFG_GLPI["from_email"] . "'>";
             if (!empty($CFG_GLPI['from_email']) && !NotificationMailing::isUserAddressValid($CFG_GLPI["from_email"])) {
                 $out .= "<br/><span class='red'>&nbsp;" . __('Invalid email address') . "</span>";
@@ -107,7 +107,7 @@ class NotificationMailingSetting extends NotificationSetting
             $out .= "<tr class='tab_bg_2'>";
             $out .= "<td><label for='replyto_email'>" . __('Reply-To address') . " <i class='pointer fa fa-info' title='" .
             __s('Optionnal reply to address.') . "\n" . __s('If not set, main or entity administrator email address will be used.') . "'></i></label></td>";
-            $out .= "<td><input type='text' class='form-control' name='replyto_email' id='replyto_email' value='" .
+            $out .= "<td><input type='email' class='form-control' name='replyto_email' id='replyto_email' value='" .
                     $CFG_GLPI["replyto_email"] . "'>";
             if (
                 !empty($CFG_GLPI['replyto_email'])
@@ -125,7 +125,7 @@ class NotificationMailingSetting extends NotificationSetting
             $out .= "<tr class='tab_bg_2'>";
             $out .= "<td><label for='noreply_email'>" . __('No-Reply address') . " <i class='pointer fa fa-info' title='" .
             __s('Optionnal No-Reply address.') . "\n" . __s('If set, it will be used for notifications that doesn\'t expect a reply.') . "'></i></label></td>";
-            $out .= "<td><input type='text' class='form-control' name='noreply_email' id='noreply_email' value='" .
+            $out .= "<td><input type='email' class='form-control' name='noreply_email' id='noreply_email' value='" .
                     $CFG_GLPI["noreply_email"] . "'>";
             if (
                 !empty($CFG_GLPI['noreply_email'])

--- a/tests/functionnal/NotificationEventMailing.php
+++ b/tests/functionnal/NotificationEventMailing.php
@@ -89,13 +89,19 @@ class NotificationEventMailing extends DbTestCase
          ]);
 
         $CFG_GLPI['admin_email'] = 'adminlocalhost';
-        $this->boolean(\NotificationEventMailing::getAdminData())->isFalse();
+
+        $this->when(
+            function () {
+                $this->boolean(\NotificationEventMailing::getAdminData())->isFalse();
+            }
+        )->error
+         ->withType(E_USER_WARNING)
+         ->withMessage('Invalid email address "adminlocalhost" configured in "admin_email".')
+         ->exists();
     }
 
     public function testGetEntityAdminsData()
     {
-        $this->boolean(\NotificationEventMailing::getEntityAdminsData(0))->isFalse();
-
         $this->login();
 
         $entity1 = getItemByTypeName('Entity', '_test_child_1');
@@ -107,6 +113,8 @@ class NotificationEventMailing extends DbTestCase
             ])
         )->isTrue();
 
+        $sub_entity1 = $this->createItem(\Entity::class, ['name' => 'sub entity', 'entities_id' => $entity1->getId()]);
+
         $entity2 = getItemByTypeName('Entity', '_test_child_2');
         $this->boolean(
             $entity2->update([
@@ -116,30 +124,31 @@ class NotificationEventMailing extends DbTestCase
             ])
         )->isTrue();
 
-        $this->array(\NotificationEventMailing::getEntityAdminsData($entity1->getID()))
-         ->isIdenticalTo([
-             [
-                 'language' => 'en_GB',
-                 'email' => 'entadmin@localhost',
-                 'name' => 'Entity admin ONE'
-             ]
-         ]);
-        $this->boolean(\NotificationEventMailing::getEntityAdminsData($entity2->getID()))->isFalse();
+        $entity0_result = [
+            [
+                'name'     => '',
+                'email'    => 'admsys@localhost',
+                'language' => 'en_GB',
+            ]
+        ];
+        $this->array(\NotificationEventMailing::getEntityAdminsData(0))->isEqualTo($entity0_result);
+        $entity1_result = [
+            [
+                'name'     => 'Entity admin ONE',
+                'email'    => 'entadmin@localhost',
+                'language' => 'en_GB',
+            ]
+        ];
+        $this->array(\NotificationEventMailing::getEntityAdminsData($entity1->getID()))->isEqualTo($entity1_result);
+        $this->array(\NotificationEventMailing::getEntityAdminsData($sub_entity1->getID()))->isEqualTo($entity1_result);
 
-       //reset
-        $this->boolean(
-            $entity1->update([
-                'id'                 => $entity1->getId(),
-                'admin_email'        => 'NULL',
-                'admin_email_name'   => 'NULL'
-            ])
-        )->isTrue();
-        $this->boolean(
-            $entity2->update([
-                'id'                 => $entity2->getId(),
-                'admin_email'        => 'NULL',
-                'admin_email_name'   => 'NULL'
-            ])
-        )->isTrue();
+        $this->when(
+            function () use ($entity2, $entity0_result) {
+                $this->array(\NotificationEventMailing::getEntityAdminsData($entity2->getID()))->isEqualTo($entity0_result);
+            }
+        )->error
+         ->withType(E_USER_WARNING)
+         ->withMessage('Invalid email address "entadmin2localhost" configured for entity "' . $entity2->getID() . '". Default administrator email will be used.')
+         ->exists();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Entity administrator target was not using inheritence logic.

2. `getEmailSenderFromEntityOrConfig` was silently ignoring invalid email values, so, in some cases, people were not receiving notifications to administrator without understanding why. Adding an entry in logs may help to identify misconfigured addresses.