### PR TITLE
fix(knowbase): root category show all articles

### DIFF
--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -1530,14 +1530,16 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
             ];
         }
 
+        $criteria['LEFT JOIN'][KnowbaseItem_KnowbaseItemCategory::getTable()] = [
+            'FKEY' => [
+                KnowbaseItem_KnowbaseItemCategory::getTable() => KnowbaseItem::getForeignKeyField(),
+                KnowbaseItem::getTable() => 'id',
+            ],
+        ];
         if ($params['knowbaseitemcategories_id'] > 0) {
-            $criteria['LEFT JOIN'][KnowbaseItem_KnowbaseItemCategory::getTable()] = [
-                'FKEY' => [
-                    KnowbaseItem_KnowbaseItemCategory::getTable() => KnowbaseItem::getForeignKeyField(),
-                    KnowbaseItem::getTable() => 'id',
-                ],
-            ];
             $criteria['WHERE'][KnowbaseItem_KnowbaseItemCategory::getTableField('knowbaseitemcategories_id')] = $params['knowbaseitemcategories_id'];
+        } else {
+            $criteria['WHERE'][KnowbaseItem_KnowbaseItemCategory::getTableField('knowbaseitemcategories_id')] = null;
         }
 
         if (


### PR DESCRIPTION
All articles were listed in the root category and not only those without category.
The counter was already good.

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13336
