### PR TITLE
Hide reservation comment if user has no right on it

### DIFF
--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -540,7 +540,7 @@ JAVASCRIPT;
 
             if ($canedit_admin || $my_item) {
                 $user->getFromDB($data['users_id']);
-                $username = $user->getFriendlyName();
+                $data['comment'] .= '<br />' . sprintf(__("Reserved by %s"), $user->getFriendlyName());
             }
 
             $name = $item->getName([
@@ -554,10 +554,7 @@ JAVASCRIPT;
                 'resourceId'  => $data['itemtype'] . "-" . $data['items_id'],
                 'start'       => $data['begin'],
                 'end'         => $data['end'],
-                'comment'     => $data['comment'] .
-                             $canedit_admin || $my_item
-                              ? "\n" . sprintf(__("Reserved by %s"), $username)
-                              : "",
+                'comment'     => $canedit_admin || $my_item ? $data['comment'] : '',
                 'title'       => $params['reservationitems_id'] ? "" : $name,
                 'icon'        => $item->getIcon(),
                 'description' => $item->getTypeName(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Code was trigerring an error. Anyway, comment should not be visible if user has no rights to see reservation details.

Error was:
```
PHP Warning (2): Undefined variable $username in /var/www/glpi/src/Reservation.php at line 559
  Backtrace :
  ajax/reservations.php:46                           Reservation::getEvents()
```