### PR TITLE
fix(ticket): image lost when mandatory field missing on submit

### DIFF
--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -427,22 +427,6 @@ if (typeof tinyMCE != 'undefined') {
             // Update HTML to paste to include "data-upload_id" attributes on images.
             event.content = fragment.html();
         });
-
-        $(editor.formElement).on('submit', function() {
-            // Remove base64 src from images that were handled by upload process.
-            // This will prevent sending too many data on server and will also prevent issues with
-            // regex that are not correctly handling huge strings (see #8044).
-            var fragment = $('<div></div>');
-            fragment.append($(editor.targetElm).val());
-            fragment.find('img').each(function () {
-                const image = $(this);
-                const upload_id = image.attr('data-upload_id');
-                if (upload_id !== undefined) {
-                    image.removeAttr('src');
-                }
-            });
-            $(editor.targetElm).val(fragment.html());
-        });
     });
 }
 


### PR DESCRIPTION
When we create a new ticket and there are mandatory fields not filled in, when we validate the form, the page is reloaded, the ticket is not created (normal) but the images are broken :

![image](https://user-images.githubusercontent.com/8530352/204573536-9e933e14-2e5c-47c0-92b2-9b867d0921a2.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25685
