### PR TITLE
Restore usability of NS classes in API

### DIFF
--- a/src/Api/APIRest.php
+++ b/src/Api/APIRest.php
@@ -379,13 +379,17 @@ class APIRest extends API
                 }
 
                // Load namespace for deprecated
-                if (Toolbox::isAPIDeprecated($itemtype)) {
-                     $itemtype = "Glpi\Api\Deprecated\\$itemtype";
+                $deprecated = Toolbox::isAPIDeprecated($itemtype);
+                if ($deprecated) {
+                    $itemtype = "Glpi\Api\Deprecated\\$itemtype";
                 }
 
                // Get case sensitive itemtype name
-                $rc = new \ReflectionClass($itemtype);
-                $itemtype = $rc->getShortName();
+                $itemtype = (new \ReflectionClass($itemtype))->getName();
+                if ($deprecated) {
+                    // Remove deprecated namespace
+                    $itemtype = str_replace("Glpi\Api\Deprecated\\", "", $itemtype);
+                }
                 return $itemtype;
             }
             $this->returnError(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

It seems like before 9.5, it was possible to use a namespaced class with the API by using `%5C` (backslash). When the handling of deprecated itemtypes was added, the itemtype name was normalized using the short name rather than the full name as it was before.

This PR will always use the full class name, and then removes the `Glpi\Api\Deprecated` namespace prefix if needed. This even allows namespaced itemtypes to be deprecated. For example, if `Glpi\Event` gets deprecated, the deprecation class would be `Glpi\Api\Deprecated\Glpi\Event`.