### PR TITLE
Icons on object tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ The present file will list all changes made to the project; according to the
   The previous recipient option still exists if needed. This replacement will only happen once during the upgrade.
 - `GLPIMailer` mailer class does not extends anymore `PHPMailer\PHPMailer\PHPMailer`.
   We added a compatibility layer to handle main usages found in plugins, but we cannot ensure compatibility with all properties and methods that were inherited from `PHPMailer\PHPMailer\PHPMailer`.
+- `CommonGLPI::createTabEntry()` signature changed.
 
 #### Deprecated
 - Usage of `GLPI_USE_CSRF_CHECK` constant.

--- a/src/Appliance_Item.php
+++ b/src/Appliance_Item.php
@@ -71,7 +71,7 @@ class Appliance_Item extends CommonDBRelation
                     $nb = self::countForMainItem($item);
                 }
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType(), 'ti ti-package');
         } else if (in_array($item->getType(), Appliance::getTypes(true))) {
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = self::countForItem($item);

--- a/src/Appliance_Item.php
+++ b/src/Appliance_Item.php
@@ -71,12 +71,12 @@ class Appliance_Item extends CommonDBRelation
                     $nb = self::countForMainItem($item);
                 }
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         } else if (in_array($item->getType(), Appliance::getTypes(true))) {
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = self::countForItem($item);
             }
-            return self::createTabEntry(Appliance::getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry(Appliance::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
 
         return '';

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -1514,7 +1514,7 @@ class Auth extends CommonGLPI
             switch ($item->getType()) {
                 case 'User':
                     if (Session::haveRight("user", User::UPDATEAUTHENT)) {
-                        return __('Synchronization');
+                        return self::createTabEntry(__('Synchronization'), 0, $item::getType(), 'ti ti-refresh');
                     }
                     break;
             }

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -4200,13 +4200,13 @@ class AuthLDAP extends CommonDBTM
             && $item->can($item->getField('id'), READ)
         ) {
             $ong     = [];
-            $ong[1]  = _sx('button', 'Test');                     // test connexion
-            $ong[2]  = User::getTypeName(Session::getPluralNumber());
-            $ong[3]  = Group::getTypeName(Session::getPluralNumber());
+            $ong[1]  = self::createTabEntry(_sx('button', 'Test'));                     // test connexion
+            $ong[2]  = self::createTabEntry(User::getTypeName(Session::getPluralNumber()), 0, $item::getType(), User::getIcon());
+            $ong[3]  = self::createTabEntry(Group::getTypeName(Session::getPluralNumber()), 0, $item::getType(), User::getIcon());
            // TODO clean fields entity_XXX if not used
            // $ong[4]  = Entity::getTypeName(1);                  // params for entity config
-            $ong[5]  = __('Advanced information');   // params for entity advanced config
-            $ong[6]  = _n('Replicate', 'Replicates', Session::getPluralNumber());
+            $ong[5]  = self::createTabEntry(__('Advanced information'));   // params for entity advanced config
+            $ong[6]  = self::createTabEntry(_n('Replicate', 'Replicates', Session::getPluralNumber()));
 
             return $ong;
         }

--- a/src/Budget.php
+++ b/src/Budget.php
@@ -83,8 +83,8 @@ class Budget extends CommonDropdown
         if (!$withtemplate) {
             switch ($item->getType()) {
                 case __CLASS__:
-                    return [1 => __('Main'),
-                        2 => _n('Item', 'Items', Session::getPluralNumber())
+                    return [1 => self::createTabEntry(__('Main')),
+                        2 => self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), 0, $item::getType(), 'ti ti-package')
                     ];
             }
         }

--- a/src/CableStrand.php
+++ b/src/CableStrand.php
@@ -77,7 +77,7 @@ class CableStrand extends CommonDropdown
                             ['cablestrands_id' => $item->getID()]
                         );
                     }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
             }
         }
         return '';

--- a/src/CalendarSegment.php
+++ b/src/CalendarSegment.php
@@ -433,7 +433,7 @@ class CalendarSegment extends CommonDBChild
                             ['calendars_id' => $item->getID()]
                         );
                     }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
             }
         }
         return '';

--- a/src/Calendar_Holiday.php
+++ b/src/Calendar_Holiday.php
@@ -201,7 +201,8 @@ class Calendar_Holiday extends CommonDBRelation
                     }
                     return self::createTabEntry(
                         _n('Close time', 'Close times', Session::getPluralNumber()),
-                        $nb
+                        $nb,
+                        $item::getType()
                     );
             }
         }

--- a/src/Cartridge.php
+++ b/src/Cartridge.php
@@ -1350,13 +1350,13 @@ class Cartridge extends CommonDBRelation
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = self::countForPrinter($item);
                     }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
 
                 case 'CartridgeItem':
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = self::countForCartridgeItem($item);
                     }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
             }
         }
         return '';

--- a/src/Cartridge.php
+++ b/src/Cartridge.php
@@ -1350,13 +1350,13 @@ class Cartridge extends CommonDBRelation
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = self::countForPrinter($item);
                     }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
 
                 case 'CartridgeItem':
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = self::countForCartridgeItem($item);
                     }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
             }
         }
         return '';

--- a/src/CartridgeItem_PrinterModel.php
+++ b/src/CartridgeItem_PrinterModel.php
@@ -78,7 +78,7 @@ class CartridgeItem_PrinterModel extends CommonDBRelation
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = self::countForItem($item);
                     }
-                    return self::createTabEntry(PrinterModel::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(PrinterModel::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
             }
         }
         return '';

--- a/src/Certificate_Item.php
+++ b/src/Certificate_Item.php
@@ -85,11 +85,11 @@ class Certificate_Item extends CommonDBRelation
             ) {
                 if ($_SESSION['glpishow_count_on_tabs']) {
                     return self::createTabEntry(
-                        _n('Associated item', 'Associated items', Session::getPluralNumber()),
+                        _n('Associated item', 'Associated items', Session::getPluralNumber(), $item::getType()),
                         self::countForMainItem($item)
                     );
                 }
-                return _n('Associated item', 'Associated items', Session::getPluralNumber());
+                return _n('Associated item', 'Associated items', Session::getPluralNumber(), $item::getType());
             } else if (
                 in_array($item->getType(), Certificate::getTypes(true))
                 && Certificate::canView()

--- a/src/Certificate_Item.php
+++ b/src/Certificate_Item.php
@@ -83,13 +83,11 @@ class Certificate_Item extends CommonDBRelation
                 $item->getType() == 'Certificate'
                 && count(Certificate::getTypes(false))
             ) {
+                $nb = 0;
                 if ($_SESSION['glpishow_count_on_tabs']) {
-                    return self::createTabEntry(
-                        _n('Associated item', 'Associated items', Session::getPluralNumber(), $item::getType()),
-                        self::countForMainItem($item)
-                    );
+                    $nb = self::countForMainItem($item);
                 }
-                return _n('Associated item', 'Associated items', Session::getPluralNumber(), $item::getType());
+                return self::createTabEntry(_n('Associated item', 'Associated items', Session::getPluralNumber()), $nb, $item::getType(), 'ti ti-package');
             } else if (
                 in_array($item->getType(), Certificate::getTypes(true))
                 && Certificate::canView()

--- a/src/Change.php
+++ b/src/Change.php
@@ -382,14 +382,14 @@ class Change extends CommonITILObject
                 case __CLASS__:
                     $ong = [];
                     if ($item->canUpdate()) {
-                         $ong[1] = __('Statistics');
+                         $ong[1] = static::createTabEntry(__('Statistics'), 0, null, 'ti ti-chart-pie');
                     }
                     $satisfaction = new ChangeSatisfaction();
                     if (
                         $satisfaction->getFromDB($item->getID())
                         && in_array($item->fields['status'], self::getClosedStatusArray())
                     ) {
-                        $ong[3] = __('Satisfaction');
+                        $ong[3] = ChangeSatisfaction::createTabEntry(__('Satisfaction'), 0, static::getType());
                     }
 
                     return $ong;

--- a/src/Change_Item.php
+++ b/src/Change_Item.php
@@ -233,7 +233,7 @@ class Change_Item extends CommonItilObject_Item
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = self::countForMainItem($item);
                     }
-                    return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::getType());
 
                 case 'User':
                 case 'Group':
@@ -249,7 +249,7 @@ class Change_Item extends CommonItilObject_Item
                         ])->current();
                         $nb = $result['cpt'];
                     }
-                    return self::createTabEntry(Change::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(Change::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
 
                 default:
                     if (Session::haveRight("change", Change::READALL)) {
@@ -270,7 +270,7 @@ class Change_Item extends CommonItilObject_Item
                                 }
                             }
                         }
-                        return self::createTabEntry(Change::getTypeName(Session::getPluralNumber()), $nb);
+                        return self::createTabEntry(Change::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
                     }
             }
         }

--- a/src/Change_Problem.php
+++ b/src/Change_Problem.php
@@ -71,7 +71,7 @@ class Change_Problem extends CommonITILObject_CommonITILObject
                             ['changes_id' => $item->getID()]
                         );
                     }
-                    return self::createTabEntry(Problem::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(Problem::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
 
                 case 'Problem':
                     if ($_SESSION['glpishow_count_on_tabs']) {
@@ -80,7 +80,7 @@ class Change_Problem extends CommonITILObject_CommonITILObject
                             ['problems_id' => $item->getID()]
                         );
                     }
-                    return self::createTabEntry(Change::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(Change::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
             }
         }
         return '';

--- a/src/Change_Ticket.php
+++ b/src/Change_Ticket.php
@@ -69,7 +69,7 @@ class Change_Ticket extends CommonITILObject_CommonITILObject
                             ['changes_id' => $item->getID()]
                         );
                     }
-                    return self::createTabEntry(Ticket::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(Ticket::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
 
                 case 'Ticket':
                     if ($_SESSION['glpishow_count_on_tabs']) {
@@ -78,7 +78,7 @@ class Change_Ticket extends CommonITILObject_CommonITILObject
                             ['tickets_id' => $item->getID()]
                         );
                     }
-                    return self::createTabEntry(Change::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(Change::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
             }
         }
         return '';

--- a/src/CommonDBRelation.php
+++ b/src/CommonDBRelation.php
@@ -238,6 +238,22 @@ abstract class CommonDBRelation extends CommonDBConnexity
         return false;
     }
 
+    /**
+     * Get the opposite itemtype
+     * @param class-string<CommonDBTM>|null $itemtype The itemtype to get the opposite of (may be null)
+     * @return class-string<CommonDBTM>|null The opposite itemtype or null if not found
+     */
+    public static function getOppositeItemtype(?string $itemtype): ?string
+    {
+        if (static::$itemtype_1 === $itemtype || (static::$itemtype_1 === 'itemtype' && static::$itemtype_2 !== null)) {
+            return static::$itemtype_2;
+        }
+
+        if (static::$itemtype_2 === $itemtype || (static::$itemtype_2 === 'itemtype' && static::$itemtype_1 !== null)) {
+            return static::$itemtype_1;
+        }
+        return null;
+    }
 
     /**
      * @since 0.84

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -711,11 +711,6 @@ class CommonGLPI implements CommonGLPIInterface
         $tab_itemtype = static::class;
         $itemtype = $tab_itemtype;
 
-        // Try using the icon from the tab itemtype first
-        if (is_subclass_of($tab_itemtype, CommonDBTM::class)) {
-            $icon = $tab_itemtype::getIcon();
-        }
-
         if ($icon === $default_icon && is_subclass_of($tab_itemtype, CommonDBRelation::class)) {
             // Get opposite itemtype than this
             if ($tab_itemtype::$itemtype_1 === $form_itemtype || ($tab_itemtype::$itemtype_1 === 'itemtype' && $tab_itemtype::$itemtype_2 !== null)) {

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -706,10 +706,17 @@ class CommonGLPI implements CommonGLPIInterface
      */
     private static function getTabIconClass(?string $form_itemtype = null): string
     {
-        $icon = '';
+        $default_icon = CommonDBTM::getIcon();
+        $icon = $default_icon;
         $tab_itemtype = static::class;
         $itemtype = $tab_itemtype;
-        if (is_subclass_of($tab_itemtype, CommonDBRelation::class)) {
+
+        // Try using the icon from the tab itemtype first
+        if (is_subclass_of($tab_itemtype, CommonDBTM::class)) {
+            $icon = $tab_itemtype::getIcon();
+        }
+
+        if ($icon === $default_icon && is_subclass_of($tab_itemtype, CommonDBRelation::class)) {
             // Get opposite itemtype than this
             if ($tab_itemtype::$itemtype_1 === $form_itemtype || ($tab_itemtype::$itemtype_1 === 'itemtype' && $tab_itemtype::$itemtype_2 !== null)) {
                 $itemtype = $tab_itemtype::$itemtype_2;
@@ -717,10 +724,10 @@ class CommonGLPI implements CommonGLPIInterface
                 $itemtype = $tab_itemtype::$itemtype_1;
             }
         }
-        if (!class_exists($itemtype)) {
+        if ($icon === $default_icon && !class_exists($itemtype)) {
             $itemtype = $tab_itemtype;
         }
-        if (method_exists($itemtype, 'getIcon')) {
+        if ($icon === $default_icon && method_exists($itemtype, 'getIcon')) {
             $icon = $itemtype::getIcon();
         }
         return $icon;

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -711,7 +711,7 @@ class CommonGLPI implements CommonGLPIInterface
         $tab_itemtype = static::class;
         $itemtype = $tab_itemtype;
 
-        if ($icon === $default_icon && is_subclass_of($tab_itemtype, CommonDBRelation::class)) {
+        if (is_subclass_of($tab_itemtype, CommonDBRelation::class)) {
             // Get opposite itemtype than this
             if ($tab_itemtype::$itemtype_1 === $form_itemtype || ($tab_itemtype::$itemtype_1 === 'itemtype' && $tab_itemtype::$itemtype_2 !== null)) {
                 $itemtype = $tab_itemtype::$itemtype_2;

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -713,10 +713,9 @@ class CommonGLPI implements CommonGLPIInterface
 
         if (is_subclass_of($tab_itemtype, CommonDBRelation::class)) {
             // Get opposite itemtype than this
-            if ($tab_itemtype::$itemtype_1 === $form_itemtype || ($tab_itemtype::$itemtype_1 === 'itemtype' && $tab_itemtype::$itemtype_2 !== null)) {
-                $itemtype = $tab_itemtype::$itemtype_2;
-            } else if ($tab_itemtype::$itemtype_2 === $form_itemtype || ($tab_itemtype::$itemtype_2 === 'itemtype' && $tab_itemtype::$itemtype_1 !== null)) {
-                $itemtype = $tab_itemtype::$itemtype_1;
+            $new_itemtype = $tab_itemtype::getOppositeItemtype($form_itemtype);
+            if ($new_itemtype !== null) {
+                $itemtype = $new_itemtype;
             }
         }
         if ($icon === $default_icon && !class_exists($itemtype)) {

--- a/src/CommonITILCost.php
+++ b/src/CommonITILCost.php
@@ -48,6 +48,10 @@ abstract class CommonITILCost extends CommonDBChild
         return _n('Cost', 'Costs', $nb);
     }
 
+    public static function getIcon()
+    {
+        return Infocom::getIcon();
+    }
 
     public function getItilObjectItemType()
     {
@@ -73,7 +77,7 @@ abstract class CommonITILCost extends CommonDBChild
                     [$item->getForeignKeyField() => $item->getID()]
                 );
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7395,12 +7395,9 @@ abstract class CommonITILObject extends CommonDBTM
 
         $timeline    = $this->getTimelineItems(['with_logs' => false]);
         $nb_elements = count($timeline);
-        $label = $this->getTypeName(1);
-        if ($nb_elements > 0) {
-            $label .= " <span class='badge'>$nb_elements</span>";
-        }
+        $label = static::getTypeName(1);
 
-        $ong[$this->getType() . '$main'] = $label;
+        $ong[static::getType() . '$main'] = static::createTabEntry($label, $nb_elements, static::getType());
         return $this;
     }
 

--- a/src/CommonITILSatisfaction.php
+++ b/src/CommonITILSatisfaction.php
@@ -56,6 +56,11 @@ abstract class CommonITILSatisfaction extends CommonDBTM
         return __('Satisfaction');
     }
 
+    public static function getIcon()
+    {
+        return 'ti ti-star';
+    }
+
     /**
      * Get the itemtype this satisfaction is for
      * @return string

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -218,7 +218,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
                 }
                 $nb = countElementsInTable($this->getTable(), $restrict);
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -59,7 +59,10 @@ abstract class CommonITILValidation extends CommonDBChild
     const ACCEPTED  = 3; // accepted
     const REFUSED   = 4; // rejected
 
-
+    public static function getIcon()
+    {
+        return 'ti ti-thumb-up';
+    }
 
     public function getItilObjectItemType()
     {

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -240,7 +240,7 @@ abstract class CommonITILValidation extends CommonDBChild
                 }
                 $nb = countElementsInTable(static::getTable(), $restrict);
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/CommonItilObject_Item.php
+++ b/src/CommonItilObject_Item.php
@@ -42,6 +42,11 @@ use Glpi\Application\View\TemplateRenderer;
 
 abstract class CommonItilObject_Item extends CommonDBRelation
 {
+    public static function getIcon()
+    {
+        return 'ti ti-package';
+    }
+
     public function getForbiddenStandardMassiveAction()
     {
 

--- a/src/CommonItilObject_Item.php
+++ b/src/CommonItilObject_Item.php
@@ -515,7 +515,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
                                 ]
                             );
                         }
-                        return static::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb);
+                        return static::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::getType());
                     }
             }
         }

--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -91,7 +91,7 @@ abstract class CommonTreeDropdown extends CommonDropdown
                     [$this->getForeignKeyField() => $item->getID()]
                 );
             }
-            return self::createTabEntry($this->getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry($this->getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/ComputerAntivirus.php
+++ b/src/ComputerAntivirus.php
@@ -70,7 +70,7 @@ class ComputerAntivirus extends CommonDBChild
                     ["computers_id" => $item->getID(), 'is_deleted' => 0 ]
                 );
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/ComputerVirtualMachine.php
+++ b/src/ComputerVirtualMachine.php
@@ -58,6 +58,11 @@ class ComputerVirtualMachine extends CommonDBChild
         return __('Virtualization');
     }
 
+    public static function getIcon()
+    {
+        return 'ti ti-cpu';
+    }
+
     public function useDeletedToLockIfDynamic()
     {
         return false;
@@ -78,7 +83,7 @@ class ComputerVirtualMachine extends CommonDBChild
                     ['computers_id' => $item->getID(), 'is_deleted' => 0 ]
                 );
             }
-            return self::createTabEntry(self::getTypeName(), $nb);
+            return self::createTabEntry(self::getTypeName(), $nb, $item::getType());
         }
         return '';
     }

--- a/src/Computer_Item.php
+++ b/src/Computer_Item.php
@@ -57,6 +57,10 @@ class Computer_Item extends CommonDBRelation
         return $forbidden;
     }
 
+    public static function getIcon()
+    {
+        return 'ti ti-sitemap';
+    }
 
     /**
      * Count connection for a Computer and an itemtype
@@ -799,7 +803,8 @@ class Computer_Item extends CommonDBRelation
             if ($canview) {
                 return self::createTabEntry(
                     _n('Connection', 'Connections', Session::getPluralNumber()),
-                    $nb
+                    $nb,
+                    $item::getType()
                 );
             }
         }

--- a/src/Config.php
+++ b/src/Config.php
@@ -2444,37 +2444,37 @@ HTML;
                     User::canUpdate()
                     && $item->currentUserHaveMoreRightThan($item->getID())
                 ) {
-                    return __('Settings');
+                    return self::createTabEntry(__('Settings'));
                 }
                 break;
 
             case __CLASS__:
                 $tabs = [
-                    1 => __('General setup'),  // Display
-                    2 => __('Default values'), // Prefs
-                    3 => _n('Asset', 'Assets', Session::getPluralNumber()),
-                    4 => __('Assistance'),
-                    12 => __('Management'),
+                    1 => self::createTabEntry(__('General setup')),  // Display
+                    2 => self::createTabEntry(__('Default values')), // Prefs
+                    3 => self::createTabEntry(_n('Asset', 'Assets', Session::getPluralNumber()), 0, $item::getType(), 'ti ti-package'),
+                    4 => self::createTabEntry(__('Assistance'), 0, $item::getType(), 'ti ti-headset'),
+                    12 => self::createTabEntry(__('Management'), 0, $item::getType(), 'ti ti-wallet'),
                 ];
                 if (Config::canUpdate()) {
-                    $tabs[9]  = __('Logs purge');
-                    $tabs[5]  = __('System');
-                    $tabs[10] = __('Security');
-                    $tabs[7]  = __('Performance');
-                    $tabs[8]  = __('API');
-                    $tabs[11] = Impact::getTypeName();
+                    $tabs[9]  = self::createTabEntry(__('Logs purge'), 0, $item::getType(), Glpi\Event::getIcon());
+                    $tabs[5]  = self::createTabEntry(__('System'));
+                    $tabs[10] = self::createTabEntry(__('Security'), 0, $item::getType(), 'ti ti-shield-lock');
+                    $tabs[7]  = self::createTabEntry(__('Performance'), 0, $item::getType(), 'ti ti-dashboard');
+                    $tabs[8]  = self::createTabEntry(__('API'), 0, $item::getType(), 'ti ti-api-app');
+                    $tabs[11] = self::createTabEntry(Impact::getTypeName(), 0, $item::getType(), Impact::getIcon());
                 }
 
                 if (
                     DBConnection::isDBSlaveActive()
                     && Config::canUpdate()
                 ) {
-                    $tabs[6]  = _n('SQL replica', 'SQL replicas', Session::getPluralNumber());  // Slave
+                    $tabs[6]  = self::createTabEntry(_n('SQL replica', 'SQL replicas', Session::getPluralNumber()), 0, $item::getType(), 'ti ti-database');  // Slave
                 }
                 return $tabs;
 
             case 'GLPINetwork':
-                return 'GLPI Network';
+                return self::createTabEntry(GLPINetwork::getTypeName(), 0, $item::getType(), GLPINetwork::getIcon());
 
             case Impact::getType():
                 return Impact::getTypeName();

--- a/src/Consumable.php
+++ b/src/Consumable.php
@@ -836,7 +836,7 @@ class Consumable extends CommonDBChild
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb =  self::countForConsumableItem($item);
                     }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
             }
         }
         return '';

--- a/src/Contact_Supplier.php
+++ b/src/Contact_Supplier.php
@@ -68,13 +68,13 @@ class Contact_Supplier extends CommonDBRelation
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb =  self::countForItem($item);
                     }
-                    return self::createTabEntry(Contact::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(Contact::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
 
                 case 'Contact':
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = self::countForItem($item);
                     }
-                    return self::createTabEntry(Supplier::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(Supplier::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
             }
         }
         return '';

--- a/src/ContractCost.php
+++ b/src/ContractCost.php
@@ -48,6 +48,10 @@ class ContractCost extends CommonDBChild
         return _n('Cost', 'Costs', $nb);
     }
 
+    public static function getIcon()
+    {
+        return Infocom::getIcon();
+    }
 
     public function prepareInputForAdd($input)
     {

--- a/src/ContractCost.php
+++ b/src/ContractCost.php
@@ -93,7 +93,7 @@ class ContractCost extends CommonDBChild
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = countElementsInTable('glpi_contractcosts', ['contracts_id' => $item->getID()]);
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/Contract_Item.php
+++ b/src/Contract_Item.php
@@ -220,7 +220,7 @@ class Contract_Item extends CommonDBRelation
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = self::countForMainItem($item);
                     }
-                    return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::getType());
 
                 default:
                     if (
@@ -229,7 +229,7 @@ class Contract_Item extends CommonDBRelation
                     ) {
                         $nb = self::countForItem($item);
                     }
-                    return self::createTabEntry(Contract::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(Contract::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
             }
         }
         return '';

--- a/src/Contract_Item.php
+++ b/src/Contract_Item.php
@@ -220,7 +220,7 @@ class Contract_Item extends CommonDBRelation
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = self::countForMainItem($item);
                     }
-                    return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::getType());
+                    return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::getType(), 'ti ti-package');
 
                 default:
                     if (

--- a/src/Contract_Supplier.php
+++ b/src/Contract_Supplier.php
@@ -66,7 +66,8 @@ class Contract_Supplier extends CommonDBRelation
                         }
                         return self::createTabEntry(
                             Contract::getTypeName(Session::getPluralNumber()),
-                            $nb
+                            $nb,
+                            $item::getType()
                         );
                     }
                     break;
@@ -76,7 +77,7 @@ class Contract_Supplier extends CommonDBRelation
                         if ($_SESSION['glpishow_count_on_tabs']) {
                               $nb = self::countForItem($item);
                         }
-                        return self::createTabEntry(Supplier::getTypeName(Session::getPluralNumber()), $nb);
+                        return self::createTabEntry(Supplier::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
                     }
                     break;
             }

--- a/src/CronTaskLog.php
+++ b/src/CronTaskLog.php
@@ -44,6 +44,10 @@ class CronTaskLog extends CommonDBTM
     const STATE_STOP  = 2;
     const STATE_ERROR = 3;
 
+    public static function getIcon()
+    {
+        return CronTask::getIcon();
+    }
 
     /**
      * Clean old event for a task
@@ -79,7 +83,7 @@ class CronTaskLog extends CommonDBTM
             switch ($item->getType()) {
                 case 'CronTask':
                     $ong    = [];
-                    $ong[1] = __('Statistics');
+                    $ong[1] = self::createTabEntry(__('Statistics'));
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb =  countElementsInTable(
                             $this->getTable(),

--- a/src/CronTaskLog.php
+++ b/src/CronTaskLog.php
@@ -88,7 +88,7 @@ class CronTaskLog extends CommonDBTM
                             ]
                         );
                     }
-                    $ong[2] = self::createTabEntry(_n('Log', 'Logs', Session::getPluralNumber()), $nb);
+                    $ong[2] = self::createTabEntry(_n('Log', 'Logs', Session::getPluralNumber()), $nb, $item::getType());
                     return $ong;
             }
         }

--- a/src/DCRoom.php
+++ b/src/DCRoom.php
@@ -369,7 +369,8 @@ class DCRoom extends CommonDBTM
                 }
                 return self::createTabEntry(
                     self::getTypeName(Session::getPluralNumber()),
-                    $nb
+                    $nb,
+                    $item::getType()
                 );
              break;
         }

--- a/src/Database.php
+++ b/src/Database.php
@@ -391,7 +391,7 @@ class Database extends CommonDBChild
                     ]
                 );
             }
-            return self::createTabEntry(self::getTypeName(), $nb);
+            return self::createTabEntry(self::getTypeName(), $nb, $item::getType());
         }
         return '';
     }

--- a/src/DatabaseInstance.php
+++ b/src/DatabaseInstance.php
@@ -542,7 +542,7 @@ class DatabaseInstance extends CommonDBTM
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = countElementsInTable(self::getTable(), ['itemtype' => $item->getType(), 'items_id' => $item->fields['id']]);
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -284,7 +284,7 @@ class Document_Item extends CommonDBRelation
                     'Associated item',
                     'Associated items',
                     Session::getPluralNumber()
-                ), $nbdoc, $item::getType());
+                ), $nbdoc, $item::getType(), 'ti ti-package');
                 $ong[2] = self::createTabEntry(
                     Document::getTypeName(Session::getPluralNumber()),
                     $nbitem,

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -284,10 +284,11 @@ class Document_Item extends CommonDBRelation
                     'Associated item',
                     'Associated items',
                     Session::getPluralNumber()
-                ), $nbdoc);
+                ), $nbdoc, $item::getType());
                 $ong[2] = self::createTabEntry(
                     Document::getTypeName(Session::getPluralNumber()),
-                    $nbitem
+                    $nbitem,
+                    $item::getType()
                 );
                 return $ong;
 
@@ -304,7 +305,8 @@ class Document_Item extends CommonDBRelation
                     }
                     return self::createTabEntry(
                         Document::getTypeName(Session::getPluralNumber()),
-                        $nbitem
+                        $nbitem,
+                        $item::getType()
                     );
                 }
         }

--- a/src/DomainRecord.php
+++ b/src/DomainRecord.php
@@ -52,7 +52,7 @@ class DomainRecord extends CommonDBChild
     {
         if ($item->getType() == 'Domain') {
             if ($_SESSION['glpishow_count_on_tabs']) {
-                return self::createTabEntry(_n('Record', 'Records', Session::getPluralNumber()), self::countForDomain($item));
+                return self::createTabEntry(_n('Record', 'Records', Session::getPluralNumber()), self::countForDomain($item), $item::getType());
             }
             return _n('Record', 'Records', Session::getPluralNumber());
         }

--- a/src/Domain_Item.php
+++ b/src/Domain_Item.php
@@ -65,18 +65,20 @@ class Domain_Item extends CommonDBRelation
             $item->getType() == 'Domain'
             && count(Domain::getTypes(false))
         ) {
+            $nb = 0;
             if ($_SESSION['glpishow_count_on_tabs']) {
-                return self::createTabEntry(_n('Associated item', 'Associated items', Session::getPluralNumber()), self::countForDomain($item), $item::getType());
+                $nb = self::countForDomain($item);
             }
-            return _n('Associated item', 'Associated items', Session::getPluralNumber());
+            return self::createTabEntry(_n('Associated item', 'Associated items', Session::getPluralNumber()), $nb, $item::getType(), 'ti ti-package');
         } else if (
             $item->getType() == 'DomainRelation' || in_array($item->getType(), Domain::getTypes(true))
                   && Session::haveRight('domain', READ)
         ) {
+            $nb = 0;
             if ($_SESSION['glpishow_count_on_tabs']) {
-                return self::createTabEntry(Domain::getTypeName(Session::getPluralNumber()), self::countForItem($item), $item::getType());
+                $nb = self::countForItem($item);
             }
-            return Domain::getTypeName(2);
+            return self::createTabEntry(Domain::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/Domain_Item.php
+++ b/src/Domain_Item.php
@@ -66,7 +66,7 @@ class Domain_Item extends CommonDBRelation
             && count(Domain::getTypes(false))
         ) {
             if ($_SESSION['glpishow_count_on_tabs']) {
-                return self::createTabEntry(_n('Associated item', 'Associated items', Session::getPluralNumber()), self::countForDomain($item));
+                return self::createTabEntry(_n('Associated item', 'Associated items', Session::getPluralNumber()), self::countForDomain($item), $item::getType());
             }
             return _n('Associated item', 'Associated items', Session::getPluralNumber());
         } else if (
@@ -74,7 +74,7 @@ class Domain_Item extends CommonDBRelation
                   && Session::haveRight('domain', READ)
         ) {
             if ($_SESSION['glpishow_count_on_tabs']) {
-                return self::createTabEntry(Domain::getTypeName(Session::getPluralNumber()), self::countForItem($item));
+                return self::createTabEntry(Domain::getTypeName(Session::getPluralNumber()), self::countForItem($item), $item::getType());
             }
             return Domain::getTypeName(2);
         }

--- a/src/DropdownTranslation.php
+++ b/src/DropdownTranslation.php
@@ -74,7 +74,7 @@ class DropdownTranslation extends CommonDBChild
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = self::getNumberOfTranslationsForItem($item);
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/DropdownTranslation.php
+++ b/src/DropdownTranslation.php
@@ -53,6 +53,10 @@ class DropdownTranslation extends CommonDBChild
         return _n('Translation', 'Translations', $nb);
     }
 
+    public static function getIcon()
+    {
+        return 'ti ti-language';
+    }
 
     /**
      * Forbidden massives actions

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -457,11 +457,11 @@ class Entity extends CommonTreeDropdown
             switch ($item->getType()) {
                 case __CLASS__:
                     $ong    = [];
-                    $ong[1] = $this->getTypeName(Session::getPluralNumber());
-                    $ong[2] = __('Address');
-                    $ong[3] = __('Advanced information');
+                    $ong[1] = self::createTabEntry(self::getTypeName(Session::getPluralNumber()));
+                    $ong[2] = self::createTabEntry(__('Address'), 0, $item::getType(), Location::getIcon());
+                    $ong[3] = self::createTabEntry(__('Advanced information'));
                     if (Notification::canView()) {
-                        $ong[4] = _n('Notification', 'Notifications', Session::getPluralNumber());
+                        $ong[4] = self::createTabEntry(Notification::getTypeName(Session::getPluralNumber()), 0, $item::getType(), Notification::getIcon());
                     }
                     if (
                         Session::haveRightsOr(
@@ -469,11 +469,11 @@ class Entity extends CommonTreeDropdown
                             [self::READHELPDESK, self::UPDATEHELPDESK]
                         )
                     ) {
-                        $ong[5] = __('Assistance');
+                        $ong[5] = self::createTabEntry(__('Assistance'), 0, $item::getType(), 'ti ti-headset');
                     }
-                    $ong[6] = _n('Asset', 'Assets', Session::getPluralNumber());
+                    $ong[6] = self::createTabEntry(_n('Asset', 'Assets', Session::getPluralNumber()), 0, $item::getType(), 'ti ti-package');
                     if (Session::haveRight(Config::$rightname, UPDATE)) {
-                        $ong[7] = __('UI customization');
+                        $ong[7] = self::createTabEntry(__('UI customization'), 0, $item::getType(), 'ti ti-palette');
                     }
 
                     return $ong;

--- a/src/FQDNLabel.php
+++ b/src/FQDNLabel.php
@@ -55,6 +55,10 @@ abstract class FQDNLabel extends CommonDBChild
         );
     }
 
+    public static function getIcon()
+    {
+        return 'ti ti-signature';
+    }
 
     /**
      * Get the internet name from a label and a domain ID

--- a/src/FieldUnicity.php
+++ b/src/FieldUnicity.php
@@ -117,7 +117,7 @@ class FieldUnicity extends CommonDropdown
 
         if (!$withtemplate) {
             if ($item->getType() == $this->getType()) {
-                return __('Duplicates');
+                return self::createTabEntry(__('Duplicates'), 0, $item::getType(), 'ti ti-copy');
             }
         }
         return '';

--- a/src/GLPINetwork.php
+++ b/src/GLPINetwork.php
@@ -40,7 +40,12 @@ class GLPINetwork extends CommonGLPI
 {
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        return 'GLPI Network';
+        return self::createTabEntry('GLPI Network');
+    }
+
+    public static function getIcon()
+    {
+        return 'ti ti-headset';
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)

--- a/src/Group.php
+++ b/src/Group.php
@@ -127,7 +127,7 @@ class Group extends CommonTreeDropdown
                             ['groups_id' => $item->getID()]
                         );
                     }
-                    $ong[4] = self::createTabEntry(__('Child groups'), $nb);
+                    $ong[4] = self::createTabEntry(__('Child groups'), $nb, $item::getType());
 
                     if ($item->getField('is_itemgroup')) {
                         $ong[1] = __('Used items');

--- a/src/Group.php
+++ b/src/Group.php
@@ -130,10 +130,10 @@ class Group extends CommonTreeDropdown
                     $ong[4] = self::createTabEntry(__('Child groups'), $nb, $item::getType());
 
                     if ($item->getField('is_itemgroup')) {
-                        $ong[1] = __('Used items');
+                        $ong[1] = self::createTabEntry(__('Used items'), 0, $item::getType(), 'ti ti-package');
                     }
                     if ($item->getField('is_assign')) {
-                        $ong[2] = __('Managed items');
+                        $ong[2] = self::createTabEntry(__('Managed items'), 0, $item::getType(), 'ti ti-package');
                     }
                     if (
                         $item->getField('is_usergroup')
@@ -141,7 +141,7 @@ class Group extends CommonTreeDropdown
                         && Session::haveRight("user", User::UPDATEAUTHENT)
                         && AuthLDAP::useAuthLdap()
                     ) {
-                        $ong[3] = __('LDAP directory link');
+                        $ong[3] = self::createTabEntry(__('LDAP directory link'), 0, $item::getType(), 'ti ti-login');
                     }
                     return $ong;
             }

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -816,7 +816,7 @@ class Group_User extends CommonDBRelation
                         if ($_SESSION['glpishow_count_on_tabs']) {
                             $nb = self::countForItem($item);
                         }
-                        return self::createTabEntry(Group::getTypeName(Session::getPluralNumber()), $nb);
+                        return self::createTabEntry(Group::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
                     }
                     break;
 
@@ -825,7 +825,7 @@ class Group_User extends CommonDBRelation
                         if ($_SESSION['glpishow_count_on_tabs']) {
                               $nb = self::countForItem($item);
                         }
-                        return self::createTabEntry(User::getTypeName(Session::getPluralNumber()), $nb);
+                        return self::createTabEntry(User::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
                     }
                     break;
             }

--- a/src/IPAddress.php
+++ b/src/IPAddress.php
@@ -360,7 +360,7 @@ class IPAddress extends CommonDBChild
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = self::countForItem($item);
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/IPNetwork_Vlan.php
+++ b/src/IPNetwork_Vlan.php
@@ -238,7 +238,7 @@ class IPNetwork_Vlan extends CommonDBRelation
                             ['ipnetworks_id' => $item->getID()]
                         );
                     }
-                    return self::createTabEntry(Vlan::getTypeName(), $nb);
+                    return self::createTabEntry(Vlan::getTypeName(), $nb, $item::getType());
             }
         }
         return '';

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -70,7 +70,7 @@ class ITILSolution extends CommonDBChild
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = self::countFor($item->getType(), $item->getID());
             }
-            return self::createTabEntry($title, $nb);
+            return self::createTabEntry($title, $nb, $item::getType());
         }
         return '';
     }

--- a/src/ITILTemplateHiddenField.php
+++ b/src/ITILTemplateHiddenField.php
@@ -63,7 +63,7 @@ abstract class ITILTemplateHiddenField extends ITILTemplateField
                     [static::$items_id => $item->getID()]
                 );
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/ITILTemplateMandatoryField.php
+++ b/src/ITILTemplateMandatoryField.php
@@ -63,7 +63,7 @@ abstract class ITILTemplateMandatoryField extends ITILTemplateField
                     [static::$items_id => $item->getID()]
                 );
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/ITILTemplatePredefinedField.php
+++ b/src/ITILTemplatePredefinedField.php
@@ -126,7 +126,7 @@ abstract class ITILTemplatePredefinedField extends ITILTemplateField
                     [static::$items_id => $item->getID()]
                 );
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/Impact.php
+++ b/src/Impact.php
@@ -70,7 +70,7 @@ class Impact extends CommonGLPI
 
     public static function getIcon()
     {
-        return 'ti ti-chart-dots-3';
+        return 'ti ti-affiliate';
     }
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
@@ -126,7 +126,7 @@ class Impact extends CommonGLPI
             ]));
         }
 
-        return self::createTabEntry(__("Impact analysis"), $total);
+        return self::createTabEntry(__("Impact analysis"), $total, $item::getType());
     }
 
     public static function displayTabContentForItem(

--- a/src/Impact.php
+++ b/src/Impact.php
@@ -68,6 +68,11 @@ class Impact extends CommonGLPI
         return __('Impact analysis');
     }
 
+    public static function getIcon()
+    {
+        return 'ti ti-chart-dots-3';
+    }
+
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         global $DB;

--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -145,7 +145,7 @@ class Infocom extends CommonDBChild
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = self::countForSupplier($item);
                     }
-                    return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::getType());
 
                 default:
                     if ($_SESSION['glpishow_count_on_tabs']) {
@@ -156,7 +156,7 @@ class Infocom extends CommonDBChild
                             ]
                         );
                     }
-                    return self::createTabEntry(__('Management'), $nb);
+                    return self::createTabEntry(__('Management'), $nb, $item::getType());
             }
         }
         return '';
@@ -1892,6 +1892,6 @@ class Infocom extends CommonDBChild
 
     public static function getIcon()
     {
-        return "fas fa-wallet";
+        return "ti ti-wallet";
     }
 }

--- a/src/Item_Cluster.php
+++ b/src/Item_Cluster.php
@@ -55,7 +55,7 @@ class Item_Cluster extends CommonDBRelation
         if ($_SESSION['glpishow_count_on_tabs']) {
             $nb = self::countForMainItem($item);
         }
-        return self::createTabEntry(_n('Item', 'Items', $nb), $nb, $item::getType());
+        return self::createTabEntry(_n('Item', 'Items', $nb), $nb, $item::getType(), 'ti ti-package');
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)

--- a/src/Item_Cluster.php
+++ b/src/Item_Cluster.php
@@ -55,7 +55,7 @@ class Item_Cluster extends CommonDBRelation
         if ($_SESSION['glpishow_count_on_tabs']) {
             $nb = self::countForMainItem($item);
         }
-        return self::createTabEntry(_n('Item', 'Items', $nb));
+        return self::createTabEntry(_n('Item', 'Items', $nb), $nb, $item::getType());
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)

--- a/src/Item_DeviceCamera_ImageFormat.php
+++ b/src/Item_DeviceCamera_ImageFormat.php
@@ -59,7 +59,7 @@ class Item_DeviceCamera_ImageFormat extends CommonDBRelation
                         ]
                     );
                 }
-                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/Item_DeviceCamera_ImageResolution.php
+++ b/src/Item_DeviceCamera_ImageResolution.php
@@ -59,7 +59,7 @@ class Item_DeviceCamera_ImageResolution extends CommonDBRelation
                         ]
                     );
                 }
-                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -563,7 +563,8 @@ class Item_Devices extends CommonDBRelation
                 }
                 return self::createTabEntry(
                     _n('Component', 'Components', Session::getPluralNumber()),
-                    $nb
+                    $nb,
+                    $item::getType()
                 );
             }
             if ($item instanceof CommonDevice) {
@@ -579,7 +580,7 @@ class Item_Devices extends CommonDBRelation
                         ]
                     );
                 }
-                return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb);
+                return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::getType());
             }
         }
         return '';

--- a/src/Item_Disk.php
+++ b/src/Item_Disk.php
@@ -90,7 +90,7 @@ class Item_Disk extends CommonDBChild
                     ]
                 );
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/Item_Disk.php
+++ b/src/Item_Disk.php
@@ -55,6 +55,11 @@ class Item_Disk extends CommonDBChild
         return _n('Volume', 'Volumes', $nb);
     }
 
+    public static function getIcon()
+    {
+        return 'fas fa-hdd';
+    }
+
     public function post_getEmpty()
     {
 

--- a/src/Item_Enclosure.php
+++ b/src/Item_Enclosure.php
@@ -55,7 +55,7 @@ class Item_Enclosure extends CommonDBRelation
         if ($_SESSION['glpishow_count_on_tabs']) {
             $nb = self::countForMainItem($item);
         }
-        return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+        return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)

--- a/src/Item_Environment.php
+++ b/src/Item_Environment.php
@@ -70,7 +70,7 @@ final class Item_Environment extends CommonDBChild
             if (!$_SESSION['glpishow_count_on_tabs']) {
                 $nb = 0;
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
 
         return '';

--- a/src/Item_Line.php
+++ b/src/Item_Line.php
@@ -52,7 +52,7 @@ class Item_Line extends CommonDBRelation
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = self::countForMainItem($item) + self::countSimcardItemsForLine($item);
             }
-            return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::getType(), 'ti ti-package');
         } else {
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = self::countForItem($item) + self::countSimcardLinesForItem($item);

--- a/src/Item_Line.php
+++ b/src/Item_Line.php
@@ -52,12 +52,12 @@ class Item_Line extends CommonDBRelation
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = self::countForMainItem($item) + self::countSimcardItemsForLine($item);
             }
-            return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb);
+            return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::getType());
         } else {
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = self::countForItem($item) + self::countSimcardLinesForItem($item);
             }
-            return self::createTabEntry(Line::getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry(Line::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
     }
 

--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -58,7 +58,7 @@ class Item_OperatingSystem extends CommonDBRelation
                 if ($_SESSION['glpishow_count_on_tabs']) {
                     $nb = self::countForItem($item);
                 }
-                return self::createTabEntry(OperatingSystem::getTypeName(Session::getPluralNumber()), $nb);
+                return self::createTabEntry(OperatingSystem::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/Item_Problem.php
+++ b/src/Item_Problem.php
@@ -229,7 +229,7 @@ class Item_Problem extends CommonItilObject_Item
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = self::countForMainItem($item);
                     }
-                    return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::getType());
 
                 case 'User':
                 case 'Group':
@@ -245,7 +245,7 @@ class Item_Problem extends CommonItilObject_Item
                         ])->current();
                         $nb = $result['cpt'];
                     }
-                    return self::createTabEntry(Problem::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(Problem::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
 
                 default:
                     if (Session::haveRight("problem", Problem::READALL)) {
@@ -266,7 +266,7 @@ class Item_Problem extends CommonItilObject_Item
                                 }
                             }
                         }
-                        return self::createTabEntry(Problem::getTypeName(Session::getPluralNumber()), $nb);
+                        return self::createTabEntry(Problem::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
                     }
             }
         }

--- a/src/Item_Process.php
+++ b/src/Item_Process.php
@@ -70,7 +70,7 @@ class Item_Process extends CommonDBChild
             if (!$_SESSION['glpishow_count_on_tabs']) {
                 $nb = 0;
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
 
         return '';

--- a/src/Item_Project.php
+++ b/src/Item_Project.php
@@ -229,7 +229,7 @@ class Item_Project extends CommonDBRelation
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = self::countForMainItem($item);
                     }
-                    return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::getType());
 
                 default:
                    // Not used now
@@ -251,7 +251,7 @@ class Item_Project extends CommonDBRelation
                                 }
                             }
                         }
-                        return self::createTabEntry(Project::getTypeName(Session::getPluralNumber()), $nb);
+                        return self::createTabEntry(Project::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
                     }
             }
         }

--- a/src/Item_Project.php
+++ b/src/Item_Project.php
@@ -229,7 +229,7 @@ class Item_Project extends CommonDBRelation
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = self::countForMainItem($item);
                     }
-                    return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::getType());
+                    return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::getType(), 'ti ti-package');
 
                 default:
                    // Not used now

--- a/src/Item_Rack.php
+++ b/src/Item_Rack.php
@@ -64,7 +64,7 @@ class Item_Rack extends CommonDBRelation
                         ['racks_id'  => $item->getID()]
                     );
                 }
-                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/Item_RemoteManagement.php
+++ b/src/Item_RemoteManagement.php
@@ -67,7 +67,7 @@ class Item_RemoteManagement extends CommonDBChild
                         ]
                     );
                 }
-                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/Item_SoftwareLicense.php
+++ b/src/Item_SoftwareLicense.php
@@ -1011,7 +1011,8 @@ JAVASCRIPT;
                     return [1 => __('Summary'),
                         2 => self::createTabEntry(
                             _n('Item', 'Items', Session::getPluralNumber()),
-                            $nb
+                            $nb,
+                            $item::getType()
                         )
                     ];
                 }

--- a/src/Item_SoftwareLicense.php
+++ b/src/Item_SoftwareLicense.php
@@ -1008,11 +1008,12 @@ JAVASCRIPT;
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = self::countForLicense($item->getID());
                     }
-                    return [1 => __('Summary'),
+                    return [1 => self::createTabEntry(__('Summary'), 0, $item::getType()),
                         2 => self::createTabEntry(
                             _n('Item', 'Items', Session::getPluralNumber()),
                             $nb,
-                            $item::getType()
+                            $item::getType(),
+                            'ti ti-package'
                         )
                     ];
                 }

--- a/src/Item_SoftwareVersion.php
+++ b/src/Item_SoftwareVersion.php
@@ -1602,7 +1602,7 @@ class Item_SoftwareVersion extends CommonDBRelation
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = self::countForSoftware($item->getID());
                     }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
                 }
                 break;
 
@@ -1614,7 +1614,8 @@ class Item_SoftwareVersion extends CommonDBRelation
                     return [1 => __('Summary'),
                         2 => self::createTabEntry(
                             self::getTypeName(Session::getPluralNumber()),
-                            $nb
+                            $nb,
+                            $item::getType()
                         )
                     ];
                 }
@@ -1626,7 +1627,7 @@ class Item_SoftwareVersion extends CommonDBRelation
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = self::countForItem($item);
                     }
-                    return self::createTabEntry(Software::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(Software::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
                 }
                 break;
         }

--- a/src/Itil_Project.php
+++ b/src/Itil_Project.php
@@ -79,7 +79,7 @@ class Itil_Project extends CommonDBRelation
                             ]
                         );
                     }
-                    $label = self::createTabEntry(Project::getTypeName(Session::getPluralNumber()), $nb);
+                    $label = self::createTabEntry(Project::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
                     break;
 
                 case Project::class:
@@ -88,7 +88,8 @@ class Itil_Project extends CommonDBRelation
                     }
                     $label = self::createTabEntry(
                         _n('Itil item', 'Itil items', Session::getPluralNumber()),
-                        $nb
+                        $nb,
+                        $item::getType()
                     );
                     break;
             }

--- a/src/Itil_Project.php
+++ b/src/Itil_Project.php
@@ -89,7 +89,8 @@ class Itil_Project extends CommonDBRelation
                     $label = self::createTabEntry(
                         _n('Itil item', 'Itil items', Session::getPluralNumber()),
                         $nb,
-                        $item::getType()
+                        $item::getType(),
+                        Ticket::getIcon()
                     );
                     break;
             }

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -253,7 +253,8 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
                         }
                         $ong[2] = self::createTabEntry(
                             _n('Target', 'Targets', Session::getPluralNumber()),
-                            $nb
+                            $nb,
+                            $item::getType()
                         );
                         $ong[3] = __('Edit');
                     }

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -246,7 +246,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
             $nb = 0;
             switch ($item->getType()) {
                 case __CLASS__:
-                    $ong[1] = $this->getTypeName(1);
+                    $ong[1] = self::createTabEntry(self::getTypeName(1));
                     if ($item->canUpdateItem()) {
                         if ($_SESSION['glpishow_count_on_tabs']) {
                             $nb = $item->countVisibilities();
@@ -256,7 +256,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
                             $nb,
                             $item::getType()
                         );
-                        $ong[3] = __('Edit');
+                        $ong[3] = self::createTabEntry(__('Edit'), 0, $item::getType(), 'ti ti-pencil');
                     }
                     return $ong;
             }

--- a/src/KnowbaseItemTranslation.php
+++ b/src/KnowbaseItemTranslation.php
@@ -57,6 +57,10 @@ class KnowbaseItemTranslation extends CommonDBChild
         return _n('Translation', 'Translations', $nb);
     }
 
+    public static function getIcon()
+    {
+        return 'ti ti-language';
+    }
 
     public function defineTabs($options = [])
     {

--- a/src/KnowbaseItemTranslation.php
+++ b/src/KnowbaseItemTranslation.php
@@ -99,7 +99,7 @@ class KnowbaseItemTranslation extends CommonDBChild
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = self::getNumberOfTranslationsForItem($item);
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
 
         return '';

--- a/src/KnowbaseItem_Comment.php
+++ b/src/KnowbaseItem_Comment.php
@@ -68,7 +68,7 @@ class KnowbaseItem_Comment extends CommonDBTM
                 $where
             );
         }
-        return self::createTabEntry(self::getTypeName($nb), $nb);
+        return self::createTabEntry(self::getTypeName($nb), $nb, $item::getType());
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)

--- a/src/KnowbaseItem_Comment.php
+++ b/src/KnowbaseItem_Comment.php
@@ -33,13 +33,21 @@
  * ---------------------------------------------------------------------
  */
 
-/// Class KnowbaseItem_Comment
-/// since version 9.2
+/**
+ * Class KnowbaseItem_Comment
+ * @since 9.2.0
+ * @todo Extend CommonDBChild
+ */
 class KnowbaseItem_Comment extends CommonDBTM
 {
     public static function getTypeName($nb = 0)
     {
         return _n('Comment', 'Comments', $nb);
+    }
+
+    public static function getIcon()
+    {
+        return 'ti ti-message-circle';
     }
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)

--- a/src/KnowbaseItem_Item.php
+++ b/src/KnowbaseItem_Item.php
@@ -86,7 +86,7 @@ class KnowbaseItem_Item extends CommonDBRelation
                 $type_name = __('Knowledge base');
             }
 
-            return self::createTabEntry($type_name, $nb);
+            return self::createTabEntry($type_name, $nb, $item::getType());
         }
         return '';
     }

--- a/src/KnowbaseItem_KnowbaseItemCategory.php
+++ b/src/KnowbaseItem_KnowbaseItemCategory.php
@@ -135,7 +135,7 @@ class KnowbaseItem_KnowbaseItemCategory extends CommonDBRelation
 
             $type_name = _n('Category', 'Categories', 1);
 
-            return self::createTabEntry($type_name, $nb);
+            return self::createTabEntry($type_name, $nb, $item::getType());
         }
         return '';
     }

--- a/src/KnowbaseItem_Revision.php
+++ b/src/KnowbaseItem_Revision.php
@@ -33,13 +33,21 @@
  * ---------------------------------------------------------------------
  */
 
-/// Class KnowbaseItem_Revision
-/// since version 9.2
+/**
+ * Class KnowbaseItem_Revision
+ * @since 9.2.0
+ * @todo Extend CommonDBChild
+ */
 class KnowbaseItem_Revision extends CommonDBTM
 {
     public static function getTypeName($nb = 0)
     {
         return _n('Revision', 'Revisions', $nb);
+    }
+
+    public static function getIcon()
+    {
+        return 'ti ti-history';
     }
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)

--- a/src/KnowbaseItem_Revision.php
+++ b/src/KnowbaseItem_Revision.php
@@ -68,7 +68,7 @@ class KnowbaseItem_Revision extends CommonDBTM
                 $where
             );
         }
-        return self::createTabEntry(self::getTypeName($nb), $nb);
+        return self::createTabEntry(self::getTypeName($nb), $nb, $item::getType());
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)

--- a/src/LevelAgreement.php
+++ b/src/LevelAgreement.php
@@ -567,7 +567,7 @@ abstract class LevelAgreement extends CommonDBChild
                             ['slms_id' => $item->getField('id')]
                         );
                     }
-                    return self::createTabEntry(static::getTypeName($nb), $nb);
+                    return self::createTabEntry(static::getTypeName($nb), $nb, $item::getType());
             }
         }
         return '';

--- a/src/LevelAgreementLevel.php
+++ b/src/LevelAgreementLevel.php
@@ -391,7 +391,7 @@ abstract class LevelAgreementLevel extends RuleTicket
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb =  countElementsInTable(static::getTable(), [static::$fkparent => $item->getID()]);
                     }
-                    return self::createTabEntry(static::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(static::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
             }
         }
         return '';

--- a/src/Link.php
+++ b/src/Link.php
@@ -89,7 +89,7 @@ class Link extends CommonDBTM
                     ] + $entity_criteria
                 );
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/Link.php
+++ b/src/Link.php
@@ -54,7 +54,6 @@ class Link extends CommonDBTM
         return _n('External link', 'External links', $nb);
     }
 
-
     /**
      * For plugins, add a tag to the links tags
      *

--- a/src/Link_Itemtype.php
+++ b/src/Link_Itemtype.php
@@ -173,7 +173,7 @@ class Link_Itemtype extends CommonDBChild
                         'Associated item type',
                         'Associated item types',
                         Session::getPluralNumber()
-                    ), $nb);
+                    ), $nb, $item::getType());
             }
         }
         return '';

--- a/src/Link_Itemtype.php
+++ b/src/Link_Itemtype.php
@@ -173,7 +173,7 @@ class Link_Itemtype extends CommonDBChild
                         'Associated item type',
                         'Associated item types',
                         Session::getPluralNumber()
-                    ), $nb, $item::getType());
+                    ), $nb, $item::getType(), Link::getIcon());
             }
         }
         return '';

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -55,6 +55,10 @@ class Lock extends CommonGLPI
         return _n('Lock', 'Locks', $nb);
     }
 
+    public static function getIcon()
+    {
+        return "ti ti-lock";
+    }
 
     /**
      * Display form to unlock fields and links
@@ -871,7 +875,7 @@ class Lock extends CommonGLPI
     {
 
         if ($item->isDynamic() && $item->can($item->fields['id'], UPDATE)) {
-            return Lock::getTypeName(Session::getPluralNumber());
+            return self::createTabEntry(Lock::getTypeName(Session::getPluralNumber()));
         }
         return '';
     }

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -875,7 +875,7 @@ class Lock extends CommonGLPI
     {
 
         if ($item->isDynamic() && $item->can($item->fields['id'], UPDATE)) {
-            return self::createTabEntry(Lock::getTypeName(Session::getPluralNumber()));
+            return self::createTabEntry(Lock::getTypeName(Session::getPluralNumber()), 0, $item::getType());
         }
         return '';
     }

--- a/src/Log.php
+++ b/src/Log.php
@@ -102,7 +102,7 @@ class Log extends CommonDBTM
                 ]
             );
         }
-        return self::createTabEntry(self::getTypeName(1), $nb);
+        return self::createTabEntry(self::getTypeName(1), $nb, $item::getType());
     }
 
 

--- a/src/Log.php
+++ b/src/Log.php
@@ -85,6 +85,10 @@ class Log extends CommonDBTM
         return __('Historical');
     }
 
+    public static function getIcon()
+    {
+        return 'ti ti-history';
+    }
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -202,7 +202,7 @@ class MailCollector extends CommonDBTM
         if (!$withtemplate) {
             switch ($item->getType()) {
                 case __CLASS__:
-                    return _n('Action', 'Actions', Session::getPluralNumber());
+                    return self::createTabEntry(_n('Action', 'Actions', Session::getPluralNumber()));
             }
         }
         return '';

--- a/src/ManualLink.php
+++ b/src/ManualLink.php
@@ -77,7 +77,7 @@ class ManualLink extends CommonDBChild
                  );
             }
         }
-        return self::createTabEntry(_n('Link', 'Links', Session::getPluralNumber()), $count);
+        return self::createTabEntry(_n('Link', 'Links', Session::getPluralNumber()), $count, $item::getType());
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -770,7 +770,7 @@ class MassiveAction
                 $actions[$self_pref . 'update'] = _x('button', 'Update');
 
                 if ($cancreate && Toolbox::hasTrait($itemtype, Clonable::class)) {
-                    $actions[$self_pref . 'clone'] = "<i class='fa-fw far fa-clone'></i>" . _x('button', 'Clone');
+                    $actions[$self_pref . 'clone'] = "<i class='ti ti-copy'></i>" . _x('button', 'Clone');
                 }
             }
 

--- a/src/NetworkAlias.php
+++ b/src/NetworkAlias.php
@@ -518,7 +518,7 @@ class NetworkAlias extends FQDNLabel
                         );
                 }
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/NetworkName.php
+++ b/src/NetworkName.php
@@ -959,7 +959,7 @@ class NetworkName extends FQDNLabel
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = self::countForItem($item);
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1755,7 +1755,7 @@ class NetworkPort extends CommonDBChild
                 if ($_SESSION['glpishow_count_on_tabs']) {
                     $nb = self::countForItem($item);
                 }
-                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
             }
         }
 
@@ -1765,7 +1765,7 @@ class NetworkPort extends CommonDBChild
                 ['networkports_id_alias' => $item->getField('id')]
             );
             if ($nbAlias > 0) {
-                $aliases = self::createTabEntry(NetworkPortAlias::getTypeName(Session::getPluralNumber()), $nbAlias);
+                $aliases = self::createTabEntry(NetworkPortAlias::getTypeName(Session::getPluralNumber()), $nbAlias, $item::getType());
             } else {
                 $aliases = '';
             }
@@ -1776,7 +1776,8 @@ class NetworkPort extends CommonDBChild
             if ($nbAggregates > 0) {
                 $aggregates = self::createTabEntry(
                     NetworkPortAggregate::getTypeName(Session::getPluralNumber()),
-                    $nbAggregates
+                    $nbAggregates,
+                    $item::getType()
                 );
             } else {
                 $aggregates = '';

--- a/src/NetworkPortConnectionLog.php
+++ b/src/NetworkPortConnectionLog.php
@@ -69,7 +69,7 @@ class NetworkPortConnectionLog extends CommonDBChild
 
         if ($item->getType() == 'NetworkPort') {
             $cnt = countElementsInTable([static::getTable()], $this->getCriteria($item));
-            $array_ret[] = self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $cnt);
+            $array_ret[] = self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $cnt, $item::getType());
         }
         return $array_ret;
     }

--- a/src/NetworkPortMetrics.php
+++ b/src/NetworkPortMetrics.php
@@ -70,7 +70,7 @@ class NetworkPortMetrics extends CommonDBChild
 
         if ($item->getType() == 'NetworkPort') {
             $cnt = countElementsInTable([static::getTable()], [static::$items_id => $item->getField('id')]);
-            $array_ret[] = self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $cnt);
+            $array_ret[] = self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $cnt, $item::getType());
         }
         return $array_ret;
     }

--- a/src/NetworkPort_Vlan.php
+++ b/src/NetworkPort_Vlan.php
@@ -338,7 +338,7 @@ class NetworkPort_Vlan extends CommonDBRelation
                             ["networkports_id" => $item->getID()]
                         );
                     }
-                    return self::createTabEntry(Vlan::getTypeName(), $nb);
+                    return self::createTabEntry(Vlan::getTypeName(), $nb, $item::getType());
                 case 'Vlan':
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = countElementsInTable(
@@ -346,7 +346,7 @@ class NetworkPort_Vlan extends CommonDBRelation
                             ["vlans_id" => $item->getID()]
                         );
                     }
-                    return self::createTabEntry(NetworkPort::getTypeName(), $nb);
+                    return self::createTabEntry(NetworkPort::getTypeName(), $nb, $item::getType());
             }
         }
         return '';

--- a/src/Notepad.php
+++ b/src/Notepad.php
@@ -120,7 +120,7 @@ class Notepad extends CommonDBChild
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = self::countForItem($item);
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return false;
     }

--- a/src/Notepad.php
+++ b/src/Notepad.php
@@ -56,6 +56,10 @@ class Notepad extends CommonDBChild
         return _n('Note', 'Notes', $nb);
     }
 
+    public static function getIcon()
+    {
+        return 'ti ti-notes';
+    }
 
     public function getLogTypeID()
     {

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -1413,7 +1413,8 @@ class NotificationTarget extends CommonDBChild
                     }
                     return self::createTabEntry(
                         Notification::getTypeName(Session::getPluralNumber()),
-                        $nb
+                        $nb,
+                        $item::getType()
                     );
 
                 case 'Notification':
@@ -1423,7 +1424,7 @@ class NotificationTarget extends CommonDBChild
                             ['notifications_id' => $item->getID()]
                         );
                     }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
             }
         }
         return '';

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -141,6 +141,10 @@ class NotificationTarget extends CommonDBChild
         return parent::getTable(__CLASS__);
     }
 
+    public static function getIcon()
+    {
+        return Notification::getIcon();
+    }
 
     /**
      * Retrieve an item from the database for a specific target

--- a/src/NotificationTemplate.php
+++ b/src/NotificationTemplate.php
@@ -66,6 +66,10 @@ class NotificationTemplate extends CommonDBTM
         return _n('Notification template', 'Notification templates', $nb);
     }
 
+    public static function getIcon()
+    {
+        return 'ti ti-template';
+    }
 
     public static function canCreate()
     {

--- a/src/NotificationTemplateTranslation.php
+++ b/src/NotificationTemplateTranslation.php
@@ -53,6 +53,11 @@ class NotificationTemplateTranslation extends CommonDBChild
         return _n('Template translation', 'Template translations', $nb);
     }
 
+    public static function getIcon()
+    {
+        return 'ti ti-language';
+    }
+
     public static function getNameField()
     {
         return 'id';

--- a/src/NotificationTemplateTranslation.php
+++ b/src/NotificationTemplateTranslation.php
@@ -479,7 +479,7 @@ class NotificationTemplateTranslation extends CommonDBChild
                             ['notificationtemplates_id' => $item->getID()]
                         );
                     }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
             }
         }
         return '';

--- a/src/Notification_NotificationTemplate.php
+++ b/src/Notification_NotificationTemplate.php
@@ -75,7 +75,7 @@ class Notification_NotificationTemplate extends CommonDBRelation
                             ['notifications_id' => $item->getID()]
                         );
                     }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
                 break;
                 case NotificationTemplate::class:
                     if ($_SESSION['glpishow_count_on_tabs']) {
@@ -84,7 +84,7 @@ class Notification_NotificationTemplate extends CommonDBRelation
                             ['notificationtemplates_id' => $item->getID()]
                         );
                     }
-                    return self::createTabEntry(Notification::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(Notification::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
                 break;
             }
         }

--- a/src/OLA.php
+++ b/src/OLA.php
@@ -51,6 +51,11 @@ class OLA extends LevelAgreement
         return __('OLA');
     }
 
+    public static function getIcon()
+    {
+        return SLM::getIcon();
+    }
+
     public function showFormWarning()
     {
         global $CFG_GLPI;

--- a/src/Pdu_Plug.php
+++ b/src/Pdu_Plug.php
@@ -61,7 +61,7 @@ class Pdu_Plug extends CommonDBRelation
                         [$field  => $item->getID()]
                     );
                 }
-                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/PrinterLog.php
+++ b/src/PrinterLog.php
@@ -57,6 +57,11 @@ class PrinterLog extends CommonDBChild
         return __('Page counters');
     }
 
+    public static function getIcon()
+    {
+        return 'ti ti-chart-line';
+    }
+
     /**
      * Get the tab name used for item
      *

--- a/src/PrinterLog.php
+++ b/src/PrinterLog.php
@@ -71,7 +71,7 @@ class PrinterLog extends CommonDBChild
 
         if ($item->getType() == 'Printer') {
             $cnt = countElementsInTable([static::getTable()], [static::$items_id => $item->getField('id')]);
-            $array_ret[] = self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $cnt);
+            $array_ret[] = self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $cnt, $item::getType());
         }
         return $array_ret;
     }

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -177,7 +177,7 @@ class Problem extends CommonITILObject
             switch ($item->getType()) {
                 case __CLASS__:
                     if ($item->canUpdate()) {
-                        $ong[1] = __('Statistics');
+                        $ong[1] = static::createTabEntry(__('Statistics'), 0, null, 'ti ti-chart-pie');
                     }
 
                     return $ong;

--- a/src/Problem_Ticket.php
+++ b/src/Problem_Ticket.php
@@ -64,14 +64,14 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
                         $problems = self::getTicketProblemsData($item->getID());
                         $nb = count($problems);
                     }
-                    return self::createTabEntry(Problem::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(Problem::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
 
                 case 'Problem':
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $tickets = self::getProblemTicketsData($item->getID());
                         $nb = count($tickets);
                     }
-                    return self::createTabEntry(Ticket::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(Ticket::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
             }
         }
         return '';

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -153,18 +153,18 @@ class Profile extends CommonDBTM
             switch ($item->getType()) {
                 case __CLASS__:
                     if ($item->fields['interface'] == 'helpdesk') {
-                        $ong[3] = __('Assistance'); // Helpdesk
-                        $ong[4] = __('Life cycles');
-                        $ong[6] = __('Tools');
-                        $ong[8] = __('Setup');
+                        $ong[3] = self::createTabEntry(__('Assistance'), 0, $item::getType(), 'ti ti-headset'); // Helpdesk
+                        $ong[4] = self::createTabEntry(__('Life cycles'));
+                        $ong[6] = self::createTabEntry(__('Tools'), 0, $item::getType(), 'ti ti-briefcase');
+                        $ong[8] = self::createTabEntry(__('Setup'), 0, $item::getType(), 'ti ti-cog');
                     } else {
-                        $ong[2] = _n('Asset', 'Assets', Session::getPluralNumber());
-                        $ong[3] = __('Assistance');
-                        $ong[4] = __('Life cycles');
-                        $ong[5] = __('Management');
-                        $ong[6] = __('Tools');
-                        $ong[7] = __('Administration');
-                        $ong[8] = __('Setup');
+                        $ong[2] = self::createTabEntry(_n('Asset', 'Assets', Session::getPluralNumber()), 0, $item::getType(), 'ti ti-package');
+                        $ong[3] = self::createTabEntry(__('Assistance'), 0, $item::getType(), 'ti ti-headset');
+                        $ong[4] = self::createTabEntry(__('Life cycles'));
+                        $ong[5] = self::createTabEntry(__('Management'), 0, $item::getType(), 'ti ti-wallet');
+                        $ong[6] = self::createTabEntry(__('Tools'), 0, $item::getType(), 'ti ti-briefcase');
+                        $ong[7] = self::createTabEntry(__('Administration'), 0, $item::getType(), 'ti ti-shield-check');
+                        $ong[8] = self::createTabEntry(__('Setup'), 0, $item::getType(), 'ti ti-settings');
                     }
                     return $ong;
             }

--- a/src/Profile_User.php
+++ b/src/Profile_User.php
@@ -1079,7 +1079,7 @@ class Profile_User extends CommonDBRelation
                             ])->current();
                             $nb        = $count['cpt'];
                         }
-                        return self::createTabEntry(User::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                        return self::createTabEntry(User::getTypeName(Session::getPluralNumber()), $nb, $item::getType(), User::getIcon());
                     }
                     break;
 

--- a/src/Profile_User.php
+++ b/src/Profile_User.php
@@ -1079,7 +1079,7 @@ class Profile_User extends CommonDBRelation
                             ])->current();
                             $nb        = $count['cpt'];
                         }
-                        return self::createTabEntry(User::getTypeName(Session::getPluralNumber()), $nb);
+                        return self::createTabEntry(User::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
                     }
                     break;
 
@@ -1088,7 +1088,7 @@ class Profile_User extends CommonDBRelation
                         if ($_SESSION['glpishow_count_on_tabs']) {
                               $nb = self::countForItem($item);
                         }
-                        return self::createTabEntry(User::getTypeName(Session::getPluralNumber()), $nb);
+                        return self::createTabEntry(User::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
                     }
                     break;
 
@@ -1100,7 +1100,7 @@ class Profile_User extends CommonDBRelation
                         'Authorization',
                         'Authorizations',
                         Session::getPluralNumber()
-                    ), $nb);
+                    ), $nb, $item::getType());
             }
         }
         return '';

--- a/src/Project.php
+++ b/src/Project.php
@@ -163,7 +163,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
                             ]
                         );
                     }
-                    $ong[1] = self::createTabEntry($this->getTypeName(Session::getPluralNumber()), $nb);
+                    $ong[1] = self::createTabEntry($this->getTypeName(Session::getPluralNumber()), $nb, $item::getType());
                     $ong[3] = __('Kanban');
                     return $ong;
             }

--- a/src/Project.php
+++ b/src/Project.php
@@ -164,7 +164,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
                         );
                     }
                     $ong[1] = self::createTabEntry($this->getTypeName(Session::getPluralNumber()), $nb, $item::getType());
-                    $ong[3] = __('Kanban');
+                    $ong[3] = self::createTabEntry(__('Kanban'));
                     return $ong;
             }
         }

--- a/src/ProjectCost.php
+++ b/src/ProjectCost.php
@@ -97,7 +97,7 @@ class ProjectCost extends CommonDBChild
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = countElementsInTable('glpi_projectcosts', ['projects_id' => $item->getID()]);
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/ProjectCost.php
+++ b/src/ProjectCost.php
@@ -48,6 +48,10 @@ class ProjectCost extends CommonDBChild
         return _n('Cost', 'Costs', $nb);
     }
 
+    public static function getIcon()
+    {
+        return Infocom::getIcon();
+    }
 
     /**
      * @see CommonDBChild::prepareInputForAdd()

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -1179,7 +1179,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
                         ['projects_id' => $item->getID()]
                     );
                 }
-                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
 
             case __CLASS__:
                 if ($_SESSION['glpishow_count_on_tabs']) {
@@ -1188,7 +1188,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
                         ['projecttasks_id' => $item->getID()]
                     );
                 }
-                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/ProjectTaskTeam.php
+++ b/src/ProjectTaskTeam.php
@@ -93,7 +93,7 @@ class ProjectTaskTeam extends CommonDBRelation
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = $item->getTeamCount();
                     }
-                    return self::createTabEntry(self::getTypeName(1), $nb);
+                    return self::createTabEntry(self::getTypeName(1), $nb, $item::getType());
             }
         }
         return '';

--- a/src/ProjectTask_Ticket.php
+++ b/src/ProjectTask_Ticket.php
@@ -79,13 +79,13 @@ class ProjectTask_Ticket extends CommonDBRelation
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = self::countForItem($item);
                     }
-                    return self::createTabEntry(Ticket::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(Ticket::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
 
                 case 'Ticket':
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = self::countForItem($item);
                     }
-                    return self::createTabEntry(ProjectTask::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(ProjectTask::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
             }
         }
         return '';

--- a/src/ProjectTeam.php
+++ b/src/ProjectTeam.php
@@ -96,7 +96,7 @@ class ProjectTeam extends CommonDBRelation
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = $item->getTeamCount();
                     }
-                    return self::createTabEntry(self::getTypeName(1), $nb);
+                    return self::createTabEntry(self::getTypeName(1), $nb, $item::getType());
             }
         }
         return '';

--- a/src/ProjectTeam.php
+++ b/src/ProjectTeam.php
@@ -67,12 +67,15 @@ class ProjectTeam extends CommonDBRelation
         return 'id';
     }
 
-
     public static function getTypeName($nb = 0)
     {
         return _n('Project team', 'Project teams', $nb);
     }
 
+    public static function getIcon()
+    {
+        return 'ti ti-users';
+    }
 
     public function getForbiddenStandardMassiveAction()
     {

--- a/src/RSSFeed.php
+++ b/src/RSSFeed.php
@@ -549,7 +549,7 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria
             $nb = 0;
             switch ($item->getType()) {
                 case 'RSSFeed':
-                    $showtab = [1 => __('Content')];
+                    $showtab = [1 => self::createTabEntry(__('Content'))];
                     if (Session::haveRight('rssfeed_public', UPDATE)) {
                         if ($_SESSION['glpishow_count_on_tabs']) {
                             $nb = $item->countVisibilities();

--- a/src/RSSFeed.php
+++ b/src/RSSFeed.php
@@ -558,7 +558,7 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria
                             'Target',
                             'Targets',
                             Session::getPluralNumber()
-                        ), $nb);
+                        ), $nb, $item::getType());
                     }
                     return $showtab;
             }

--- a/src/Rack.php
+++ b/src/Rack.php
@@ -312,7 +312,8 @@ class Rack extends CommonDBTM
                 }
                 return self::createTabEntry(
                     self::getTypeName(Session::getPluralNumber()),
-                    $nb
+                    $nb,
+                    $item::getType()
                 );
              break;
         }

--- a/src/Reminder.php
+++ b/src/Reminder.php
@@ -536,7 +536,7 @@ class Reminder extends CommonDBVisible implements
                             'Target',
                             'Targets',
                             Session::getPluralNumber()
-                        ), $nb)
+                        ), $nb, $item::getType())
                         ];
                     }
             }

--- a/src/ReminderTranslation.php
+++ b/src/ReminderTranslation.php
@@ -84,7 +84,7 @@ class ReminderTranslation extends CommonDBChild
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = self::getNumberOfTranslationsForItem($item);
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
 
         return '';

--- a/src/ReminderTranslation.php
+++ b/src/ReminderTranslation.php
@@ -49,13 +49,15 @@ class ReminderTranslation extends CommonDBChild
 
     public static $rightname       = 'reminder_public';
 
-
-
     public static function getTypeName($nb = 0)
     {
         return _n('Translation', 'Translations', $nb);
     }
 
+    public static function getIcon()
+    {
+        return 'ti ti-language';
+    }
 
     public function getForbiddenStandardMassiveAction()
     {

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -65,7 +65,7 @@ class Reservation extends CommonDBChild
             !$withtemplate
             && Session::haveRight("reservation", READ)
         ) {
-            return self::getTypeName(Session::getPluralNumber());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()));
         }
         return '';
     }

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -65,7 +65,7 @@ class Reservation extends CommonDBChild
             !$withtemplate
             && Session::haveRight("reservation", READ)
         ) {
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()));
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), 0, $item::getType());
         }
         return '';
     }

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -3442,7 +3442,7 @@ class Rule extends CommonDBTM
                              );
                         }
                     }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
 
                 case 'SLA':
                 case 'OLA':
@@ -3454,7 +3454,7 @@ class Rule extends CommonDBTM
                             ]
                         );
                     }
-                    return self::createTabEntry(self::getTypeName($nb), $nb);
+                    return self::createTabEntry(self::getTypeName($nb), $nb, $item::getType());
 
                 default:
                     if ($item instanceof Rule) {
@@ -3474,11 +3474,13 @@ class Rule extends CommonDBTM
 
                         $ong[1] = self::createTabEntry(
                             RuleCriteria::getTypeName(Session::getPluralNumber()),
-                            $nbcriteria
+                            $nbcriteria,
+                            $item::getType()
                         );
                         $ong[2] = self::createTabEntry(
                             RuleAction::getTypeName(Session::getPluralNumber()),
-                            $nbaction
+                            $nbaction,
+                            $item::getType()
                         );
                         return $ong;
                     }

--- a/src/RuleMatchedLog.php
+++ b/src/RuleMatchedLog.php
@@ -61,6 +61,10 @@ class RuleMatchedLog extends CommonDBTM
         return __('Matched rules');
     }
 
+    public static function getIcon()
+    {
+        return Rule::getIcon();
+    }
 
     /**
      * Count number of elements

--- a/src/RuleMatchedLog.php
+++ b/src/RuleMatchedLog.php
@@ -98,18 +98,18 @@ class RuleMatchedLog extends CommonDBTM
         $array_ret = [];
 
         if ($item->getType() == 'Agent') {
-            $array_ret[0] = self::createTabEntry(__('Import information'));
+            $array_ret[0] = self::createTabEntry(__('Import information'), 0, $item::getType());
         } else {
             $continue = true;
 
             switch ($item->getType()) {
                 case 'Agent':
-                    $array_ret[0] = self::createTabEntry(__('Import information'));
+                    $array_ret[0] = self::createTabEntry(__('Import information'), 0, $item::getType());
                     break;
 
                 case 'Unmanaged':
                     $cnt = self::countForItem($item);
-                    $array_ret[1] = self::createTabEntry(__('Import information'), $cnt);
+                    $array_ret[1] = self::createTabEntry(__('Import information'), $cnt, $item::getType());
                     break;
 
                 case 'Computer':
@@ -127,7 +127,7 @@ class RuleMatchedLog extends CommonDBTM
                 return [];
             } else if (empty($array_ret)) {
                 $cnt = self::countForItem($item);
-                $array_ret[1] = self::createTabEntry(__('Import information'), $cnt);
+                $array_ret[1] = self::createTabEntry(__('Import information'), $cnt, $item::getType());
             }
         }
         return $array_ret;

--- a/src/SLA.php
+++ b/src/SLA.php
@@ -55,6 +55,11 @@ class SLA extends LevelAgreement
         return __('SLA');
     }
 
+    public static function getIcon()
+    {
+        return SLM::getIcon();
+    }
+
     public function showFormWarning()
     {
     }

--- a/src/SavedSearch_Alert.php
+++ b/src/SavedSearch_Alert.php
@@ -59,6 +59,10 @@ class SavedSearch_Alert extends CommonDBChild
         return _n('Saved search alert', 'Saved searches alerts', $nb);
     }
 
+    public static function getIcon()
+    {
+        return 'ti ti-bell';
+    }
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {

--- a/src/SavedSearch_Alert.php
+++ b/src/SavedSearch_Alert.php
@@ -75,7 +75,7 @@ class SavedSearch_Alert extends CommonDBChild
                     ['savedsearches_id' => $item->getID()]
                 );
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
     }

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -68,6 +68,11 @@ class Socket extends CommonDBChild
     const FRONT   = 2;
     const BOTH    = 3;
 
+    public static function getIcon()
+    {
+        return NetworkPort::getIcon();
+    }
+
     public function canCreateItem()
     {
         return Session::haveRight(static::$rightname, CREATE);

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -631,7 +631,7 @@ class Socket extends CommonDBChild
                             ['locations_id' => $item->getID()]
                         );
                     }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
                 default:
                     if (in_array($item->getType(), $CFG_GLPI['socket_types'])) {
                         if ($_SESSION['glpishow_count_on_tabs']) {
@@ -642,7 +642,7 @@ class Socket extends CommonDBChild
                                   ]
                               );
                         }
-                        return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+                        return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
                     }
             }
         }

--- a/src/SoftwareLicense.php
+++ b/src/SoftwareLicense.php
@@ -1201,7 +1201,8 @@ class SoftwareLicense extends CommonTreeDropdown
                     }
                     return self::createTabEntry(
                         self::getTypeName(Session::getPluralNumber()),
-                        (($nb >= 0) ? $nb : '&infin;')
+                        (($nb >= 0) ? $nb : '&infin;'),
+                        $item::getType()
                     );
                 break;
                 case 'SoftwareLicense':
@@ -1216,7 +1217,8 @@ class SoftwareLicense extends CommonTreeDropdown
                     }
                     return self::createTabEntry(
                         self::getTypeName(Session::getPluralNumber()),
-                        (($nb >= 0) ? $nb : '&infin;')
+                        (($nb >= 0) ? $nb : '&infin;'),
+                        $item::getType()
                     );
                 break;
             }

--- a/src/SoftwareVersion.php
+++ b/src/SoftwareVersion.php
@@ -53,6 +53,11 @@ class SoftwareVersion extends CommonDBChild
         return _n('Version', 'Versions', $nb);
     }
 
+    public static function getIcon()
+    {
+        return Software::getIcon();
+    }
+
 
     public function cleanDBonPurge()
     {

--- a/src/SoftwareVersion.php
+++ b/src/SoftwareVersion.php
@@ -409,7 +409,7 @@ class SoftwareVersion extends CommonDBChild
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = countElementsInTable($this->getTable(), ['softwares_id' => $item->getID()]);
                     }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
             }
         }
         return '';

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -835,16 +835,16 @@ class Ticket extends CommonITILObject
             case __CLASS__:
                 $ong    = [];
 
-               // enquete si statut clos
+                // enquete si statut clos
                 $satisfaction = new TicketSatisfaction();
                 if (
                     $satisfaction->getFromDB($item->getID())
                     && $item->fields['status'] == self::CLOSED
                 ) {
-                    $ong[3] = __('Satisfaction');
+                    $ong[3] = TicketSatisfaction::createTabEntry(__('Satisfaction'), 0, static::getType());
                 }
                 if ($item->canView()) {
-                    $ong[4] = __('Statistics');
+                    $ong[4] = static::createTabEntry(__('Statistics'), 0, null, 'ti ti-chart-pie');
                 }
                 return $ong;
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -826,7 +826,7 @@ class Ticket extends CommonITILObject
             }
            // Not for Ticket class
             if ($item->getType() != __CLASS__) {
-                return self::createTabEntry($title, $nb);
+                return self::createTabEntry($title, $nb, $item::getType());
             }
         }
 

--- a/src/Ticket_Contract.php
+++ b/src/Ticket_Contract.php
@@ -56,12 +56,12 @@ class Ticket_Contract extends CommonDBRelation
                 if ($_SESSION['glpishow_count_on_tabs']) {
                     $nb = count(self::getListForItem($item));
                 }
-                return self::createTabEntry(Contract::getTypeName(Session::getPluralNumber()), $nb);
+                return self::createTabEntry(Contract::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
             } else if (get_class($item) == Contract::class) {
                 if ($_SESSION['glpishow_count_on_tabs']) {
                     $nb = count(self::getListForItem($item));
                 }
-                return self::createTabEntry(Ticket::getTypeName(Session::getPluralNumber()), $nb);
+                return self::createTabEntry(Ticket::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
             } else {
                 return '';
             }

--- a/src/User.php
+++ b/src/User.php
@@ -255,12 +255,12 @@ class User extends CommonDBTM
         switch ($item->getType()) {
             case __CLASS__:
                 $ong    = [];
-                $ong[1] = __('Used items');
-                $ong[2] = __('Managed items');
+                $ong[1] = self::createTabEntry(__('Used items'), 0, $item::getType(), 'ti ti-package');
+                $ong[2] = self::createTabEntry(__('Managed items'), 0, $item::getType(), 'ti ti-package');
                 return $ong;
 
             case 'Preference':
-                return __('Main');
+                return self::createTabEntry(__('Main'));
         }
         return '';
     }

--- a/src/ValidatorSubstitute.php
+++ b/src/ValidatorSubstitute.php
@@ -48,7 +48,7 @@ final class ValidatorSubstitute extends CommonDBTM
             case Preference::class:
                 $user = User::getById(Session::getLoginUserID());
                 $nb = $_SESSION['glpishow_count_on_tabs'] ? count($user->getSubstitutes()) : 0;
-                return self::createTabEntry(self::getTypeName($nb), $nb);
+                return self::createTabEntry(self::getTypeName($nb), $nb, $item::getType());
         }
 
         return '';

--- a/templates/pages/setup/setup_notifications.html.twig
+++ b/templates/pages/setup/setup_notifications.html.twig
@@ -98,14 +98,14 @@
             <div class="list-group list-group-flush">
                {% if has_profile_right('config', constant('READ')) %}
                   <a href="{{ path('front/notificationtemplate.php') }}" class="list-group-item list-group-item-action">
-                     <i class="fa-fw ti ti-template"></i>
+                     <i class="{{ 'NotificationTemplate'|itemtype_icon }}"></i>
                      <span>{{ _n('Notification template', 'Notification templates', get_plural_number()) }}</span>
                   </a>
                {% endif %}
 
                {% if has_profile_right('notification', constant('READ')) %}
                   <a href="{{ path('front/notification.php') }}" class="list-group-item list-group-item-action">
-                     <i class="fa-fw ti ti-bell "></i>
+                     <i class="{{ 'Notification'|itemtype_icon }}"></i>
                      <span>{{ _n('Notification', 'Notifications', get_plural_number()) }}</span>
                   </a>
                {% else %}

--- a/tests/LDAP/AuthLdap.php
+++ b/tests/LDAP/AuthLdap.php
@@ -248,8 +248,9 @@ class AuthLDAP extends DbTestCase
     {
         $ldap     = new \AuthLDAP();
         $tabs     = $ldap->defineTabs();
-        $expected = ['AuthLDAP$main' => 'LDAP directory',
-            'Log$1'         => 'Historical'
+        $expected = [
+            'AuthLDAP$main' => "<span><i class='far fa-address-book me-2'></i>LDAP directory</span>",
+            'Log$1'         => "<span><i class='ti ti-history me-2'></i>Historical</span>"
         ];
         $this->array($tabs)->isIdenticalTo($expected);
     }
@@ -538,11 +539,12 @@ class AuthLDAP extends DbTestCase
 
         $ldap   = getItemByTypeName('AuthLDAP', 'LDAP1');
         $result = $ldap->getTabNameForItem($ldap);
-        $expected = [1 => 'Test',
-            2 => 'Users',
-            3 => 'Groups',
-            5 => 'Advanced information',
-            6 => 'Replicates'
+        $expected = [
+            1 => "<span><i class='far fa-address-book me-2'></i>Test</span>",
+            2 => "<span><i class='ti ti-user me-2'></i>Users</span>",
+            3 => "<span><i class='ti ti-user me-2'></i>Groups</span>",
+            5 => "<span><i class='far fa-address-book me-2'></i>Advanced information</span>",
+            6 => "<span><i class='far fa-address-book me-2'></i>Replicates</span>"
         ];
         $this->array($result)->isIdenticalTo($expected);
 

--- a/tests/functionnal/Agent.php
+++ b/tests/functionnal/Agent.php
@@ -44,9 +44,9 @@ class Agent extends DbTestCase
     public function testDefineTabs()
     {
         $expected = [
-            'Agent$main'        => 'Agent',
-            'RuleMatchedLog$0'  => 'Import information',
-            'Log$1'             => 'Historical'
+            'Agent$main'       => "<span><i class='ti ti-robot me-2'></i>Agent</span>",
+            'RuleMatchedLog$0' => "<span><i class='ti ti-book me-2'></i>Import information</span>",
+            'Log$1'            => "<span><i class='ti ti-history me-2'></i>Historical</span>",
         ];
         $this
          ->given($this->newTestedInstance)

--- a/tests/functionnal/Appliance.php
+++ b/tests/functionnal/Appliance.php
@@ -42,10 +42,10 @@ class Appliance extends DbTestCase
     public function testDefineTabs()
     {
         $expected = [
-            'Appliance$main'     => 'Appliance',
-            'Impact$1'           => 'Impact analysis',
-            'ManualLink$1'       => 'Links',
-            'Log$1'              => 'Historical',
+            'Appliance$main'     => "<span><i class='ti ti-versions me-2'></i>Appliance</span>",
+            'Impact$1'           => "<span><i class='ti ti-affiliate me-2'></i>Impact analysis</span>",
+            'ManualLink$1'       => "<span><i class='fas fa-link me-2'></i>Links</span>",
+            'Log$1'              => "<span><i class='ti ti-history me-2'></i>Historical</span>",
         ];
         $this
          ->given($this->newTestedInstance)

--- a/tests/functionnal/Config.php
+++ b/tests/functionnal/Config.php
@@ -88,13 +88,13 @@ class Config extends DbTestCase
     public function testDefineTabs()
     {
         $expected = [
-            'Config$1'      => 'General setup',
-            'Config$2'      => 'Default values',
-            'Config$3'      => 'Assets',
-            'Config$4'      => 'Assistance',
-            'Config$12'     => 'Management',
-            'GLPINetwork$1' => 'GLPI Network',
-            'Log$1'         => 'Historical',
+            'Config$1'      => "<span><i class='ti ti-adjustments me-2'></i>General setup</span>",
+            'Config$2'      => "<span><i class='ti ti-adjustments me-2'></i>Default values</span>",
+            'Config$3'      => "<span><i class='ti ti-package me-2'></i>Assets</span>",
+            'Config$4'      => "<span><i class='ti ti-headset me-2'></i>Assistance</span>",
+            'Config$12'     => "<span><i class='ti ti-wallet me-2'></i>Management</span>",
+            'GLPINetwork$1' => "<span><i class='ti ti-headset me-2'></i>GLPI Network</span>",
+            'Log$1'         => "<span><i class='ti ti-history me-2'></i>Historical</span>",
         ];
         $this
          ->given($this->newTestedInstance)
@@ -114,19 +114,19 @@ class Config extends DbTestCase
        //check extra tabs from superadmin profile
         $this->login();
         $expected = [
-            'Config$1'      => 'General setup',
-            'Config$2'      => 'Default values',
-            'Config$3'      => 'Assets',
-            'Config$4'      => 'Assistance',
-            'Config$12'     => 'Management',
-            'Config$9'      => 'Logs purge',
-            'Config$5'      => 'System',
-            'Config$10'     => 'Security',
-            'Config$7'      => 'Performance',
-            'Config$8'      => 'API',
-            'Config$11'      => \Impact::getTypeName(),
-            'GLPINetwork$1' => 'GLPI Network',
-            'Log$1'         => 'Historical',
+            'Config$1'      => "<span><i class='ti ti-adjustments me-2'></i>General setup</span>",
+            'Config$2'      => "<span><i class='ti ti-adjustments me-2'></i>Default values</span>",
+            'Config$3'      => "<span><i class='ti ti-package me-2'></i>Assets</span>",
+            'Config$4'      => "<span><i class='ti ti-headset me-2'></i>Assistance</span>",
+            'Config$12'     => "<span><i class='ti ti-wallet me-2'></i>Management</span>",
+            'Config$9'      => "<span><i class='ti ti-news me-2'></i>Logs purge</span>",
+            'Config$5'      => "<span><i class='ti ti-adjustments me-2'></i>System</span>",
+            'Config$10'     => "<span><i class='ti ti-shield-lock me-2'></i>Security</span>",
+            'Config$7'      => "<span><i class='ti ti-dashboard me-2'></i>Performance</span>",
+            'Config$8'      => "<span><i class='ti ti-api-app me-2'></i>API</span>",
+            'Config$11'      => "<span><i class='ti ti-affiliate me-2'></i>Impact analysis</span>",
+            'GLPINetwork$1' => "<span><i class='ti ti-headset me-2'></i>GLPI Network</span>",
+            'Log$1'         => "<span><i class='ti ti-history me-2'></i>Historical</span>",
         ];
         $this
          ->given($this->newTestedInstance)

--- a/tests/functionnal/Document.php
+++ b/tests/functionnal/Document.php
@@ -93,10 +93,10 @@ class Document extends DbTestCase
     public function testDefineTabs()
     {
         $expected = [
-            'Document$main'   => 'Document',
-            'Document_Item$1' => 'Associated items',
-            'Document_Item$2' => 'Documents',
-            'Log$1'           => 'Historical'
+            'Document$main'   => "<span><i class='ti ti-files me-2'></i>Document</span>",
+            'Document_Item$1' => "<span><i class='ti ti-package me-2'></i>Associated items</span>",
+            'Document_Item$2' => "<span><i class='ti ti-files me-2'></i>Documents</span>",
+            'Log$1'           => "<span><i class='ti ti-history me-2'></i>Historical</span>"
 
         ];
         $this

--- a/tests/functionnal/Impact.php
+++ b/tests/functionnal/Impact.php
@@ -148,7 +148,7 @@ class Impact extends \DbTestCase
         $tab_name = $impact->getTabNameForItem($computer);
         $_SESSION['glpishow_count_on_tabs'] = $old_session;
 
-        $this->string($tab_name)->isEqualTo("Impact analysis");
+        $this->string($tab_name)->isEqualTo("<span><i class='ti ti-affiliate me-2'></i>Impact analysis</span>");
     }
 
     public function testGetTabNameForItem_enabledAsset()
@@ -169,7 +169,7 @@ class Impact extends \DbTestCase
         $tab_name = $impact->getTabNameForItem($computer2);
         $_SESSION['glpishow_count_on_tabs'] = $old_session;
 
-        $this->string($tab_name)->isEqualTo("Impact analysis <span class='badge'>2</span>");
+        $this->string($tab_name)->isEqualTo("<span><i class='ti ti-affiliate me-2'></i>Impact analysis</span> <span class='badge'>2</span>");
     }
 
     public function testGetTabNameForItem_ITILObject()
@@ -205,7 +205,7 @@ class Impact extends \DbTestCase
         $tab_name = $impact->getTabNameForItem($ticket);
         $_SESSION['glpishow_count_on_tabs'] = $old_session;
 
-        $this->string($tab_name)->isEqualTo("Impact analysis");
+        $this->string($tab_name)->isEqualTo("<span><i class='ti ti-affiliate me-2'></i>Impact analysis</span>");
     }
 
     public function testBuildGraph_empty()

--- a/tests/functionnal/Item_OperatingSystem.php
+++ b/tests/functionnal/Item_OperatingSystem.php
@@ -94,7 +94,7 @@ class Item_OperatingSystem extends DbTestCase
         $this->boolean($ios->getFromDB($ios->getID()))->isTrue();
 
         $this->string($ios->getTabNameForItem($computer))
-         ->isIdenticalTo("Operating systems <span class='badge'>1</span>");
+         ->isIdenticalTo("<span><i class='ti ti-edit me-2'></i>Operating systems</span> <span class='badge'>1</span>");
         $this->integer(
             (int)\Item_OperatingSystem::countForItem($computer)
         )->isIdenticalTo(1);
@@ -129,7 +129,7 @@ class Item_OperatingSystem extends DbTestCase
         $this->boolean($ios->getFromDB($ios->getID()))->isTrue();
 
         $this->string($ios->getTabNameForItem($computer))
-         ->isIdenticalTo("Operating systems <span class='badge'>2</span>");
+         ->isIdenticalTo("<span><i class='ti ti-edit me-2'></i>Operating systems</span> <span class='badge'>2</span>");
         $this->integer(
             (int)\Item_OperatingSystem::countForItem($computer)
         )->isIdenticalTo(2);

--- a/tests/functionnal/Item_SoftwareLicense.php
+++ b/tests/functionnal/Item_SoftwareLicense.php
@@ -234,7 +234,8 @@ class Item_SoftwareLicense extends DbTestCase
         $expected = [1 => __('Summary'),
             2 => \Item_SoftwareLicense::createTabEntry(
                 _n('Item', 'Items', \Session::getPluralNumber()),
-                2
+                2,
+                $license::getType()
             )
         ];
         $this->array($cSoftwareLicense->getTabNameForItem($license, 0))->isIdenticalTo($expected);

--- a/tests/functionnal/Item_SoftwareLicense.php
+++ b/tests/functionnal/Item_SoftwareLicense.php
@@ -225,17 +225,20 @@ class Item_SoftwareLicense extends DbTestCase
         $this->string($cSoftwareLicense->getTabNameForItem($license, 1))->isEmpty();
 
         $_SESSION['glpishow_count_on_tabs'] = 0;
-        $expected = [1 => __('Summary'),
-            2 => _n('Item', 'Items', \Session::getPluralNumber())
+        $expected = [
+            1 => "<span><i class='ti ti-key me-2'></i>Summary</span>",
+            2 => "<span><i class='ti ti-package me-2'></i>" . _n('Item', 'Items', \Session::getPluralNumber()) . "</span>"
         ];
         $this->array($cSoftwareLicense->getTabNameForItem($license, 0))->isIdenticalTo($expected);
 
         $_SESSION['glpishow_count_on_tabs'] = 1;
-        $expected = [1 => __('Summary'),
+        $expected = [
+            1 => "<span><i class='ti ti-key me-2'></i>Summary</span>",
             2 => \Item_SoftwareLicense::createTabEntry(
                 _n('Item', 'Items', \Session::getPluralNumber()),
                 2,
-                $license::getType()
+                $license::getType(),
+                'ti ti-package'
             )
         ];
         $this->array($cSoftwareLicense->getTabNameForItem($license, 0))->isIdenticalTo($expected);

--- a/tests/functionnal/Itil_Project.php
+++ b/tests/functionnal/Itil_Project.php
@@ -83,9 +83,10 @@ class Itil_Project extends DbTestCase
             )->isGreaterThan(0);
 
            // Count displayed in tab name should be equal to count of ITIL items linked to project
-            $this->integer(
-                (int)preg_replace('/[^\d]*(\d+)[^\d]*/', '$1', $itil_project->getTabNameForItem($project))
-            )->isEqualTo(count($items));
+            $item_count = count($items);
+            $this->string($itil_project->getTabNameForItem($project))->isIdenticalTo(
+                "<span><i class='ti ti-alert-circle me-2'></i>Itil items</span> <span class='badge'>{$item_count}</span>"
+            );
         }
 
        //add a task

--- a/tests/functionnal/KnowbaseItem_Comment.php
+++ b/tests/functionnal/KnowbaseItem_Comment.php
@@ -141,15 +141,15 @@ class KnowbaseItem_Comment extends DbTestCase
         $kbcom = new \KnowbaseItem_Comment();
 
         $name = $kbcom->getTabNameForItem($kb1, true);
-        $this->string($name)->isIdenticalTo('Comments <span class=\'badge\'>5</span>');
+        $this->string($name)->isIdenticalTo("<span><i class='ti ti-message-circle me-2'></i>Comments</span> <span class='badge'>5</span>");
 
         $_SESSION['glpishow_count_on_tabs'] = 1;
         $name = $kbcom->getTabNameForItem($kb1);
-        $this->string($name)->isIdenticalTo('Comments <span class=\'badge\'>5</span>');
+        $this->string($name)->isIdenticalTo("<span><i class='ti ti-message-circle me-2'></i>Comments</span> <span class='badge'>5</span>");
 
         $_SESSION['glpishow_count_on_tabs'] = 0;
         $name = $kbcom->getTabNameForItem($kb1);
-        $this->string($name)->isIdenticalTo('Comments');
+        $this->string($name)->isIdenticalTo("<span><i class='ti ti-message-circle me-2'></i>Comments</span>");
     }
 
     public function testDisplayComments()

--- a/tests/functionnal/KnowbaseItem_Item.php
+++ b/tests/functionnal/KnowbaseItem_Item.php
@@ -199,23 +199,23 @@ class KnowbaseItem_Item extends DbTestCase
 
         $_SESSION['glpishow_count_on_tabs'] = 1;
         $name = $kb_item->getTabNameForItem($kb1);
-        $this->string($name)->isIdenticalTo('Associated elements <span class=\'badge\'>3</span>');
+        $this->string($name)->isIdenticalTo("<span><i class='ti ti-lifebuoy me-2'></i>Associated elements</span> <span class='badge'>3</span>");
 
         $_SESSION['glpishow_count_on_tabs'] = 0;
         $name = $kb_item->getTabNameForItem($kb1);
-        $this->string($name)->isIdenticalTo('Associated elements');
+        $this->string($name)->isIdenticalTo("<span><i class='ti ti-lifebuoy me-2'></i>Associated elements</span>");
 
         $ticket3 = getItemByTypeName(\Ticket::getType(), '_ticket03');
 
         $_SESSION['glpishow_count_on_tabs'] = 1;
         $name = $kb_item->getTabNameForItem($ticket3, true);
-        $this->string($name)->isIdenticalTo('Knowledge base <span class=\'badge\'>2</span>');
+        $this->string($name)->isIdenticalTo("<span><i class='ti ti-lifebuoy me-2'></i>Knowledge base</span> <span class='badge'>2</span>");
 
         $name = $kb_item->getTabNameForItem($ticket3);
-        $this->string($name)->isIdenticalTo('Knowledge base <span class=\'badge\'>2</span>');
+        $this->string($name)->isIdenticalTo("<span><i class='ti ti-lifebuoy me-2'></i>Knowledge base</span> <span class='badge'>2</span>");
 
         $_SESSION['glpishow_count_on_tabs'] = 0;
         $name = $kb_item->getTabNameForItem($ticket3);
-        $this->string($name)->isIdenticalTo('Knowledge base');
+        $this->string($name)->isIdenticalTo("<span><i class='ti ti-lifebuoy me-2'></i>Knowledge base</span>");
     }
 }

--- a/tests/functionnal/KnowbaseItem_Revision.php
+++ b/tests/functionnal/KnowbaseItem_Revision.php
@@ -180,7 +180,7 @@ class KnowbaseItem_Revision extends DbTestCase
 
         $_SESSION['glpishow_count_on_tabs'] = 1;
         $name = $kb_rev->getTabNameForItem($kb1);
-        $this->string($name)->isIdenticalTo('Revision <span class=\'badge\'>1</span>');
+        $this->string($name)->isIdenticalTo("<span><i class='ti ti-history me-2'></i>Revision</span> <span class='badge'>1</span>");
 
         $this->boolean(
             $kb1->update(
@@ -192,11 +192,11 @@ class KnowbaseItem_Revision extends DbTestCase
         )->isTrue();
 
         $name = $kb_rev->getTabNameForItem($kb1);
-        $this->string($name)->isIdenticalTo('Revisions <span class=\'badge\'>2</span>');
+        $this->string($name)->isIdenticalTo("<span><i class='ti ti-history me-2'></i>Revisions</span> <span class='badge'>2</span>");
 
         $_SESSION['glpishow_count_on_tabs'] = 0;
         $name = $kb_rev->getTabNameForItem($kb1);
-        $this->string($name)->isIdenticalTo('Revisions');
+        $this->string($name)->isIdenticalTo("<span><i class='ti ti-history me-2'></i>Revisions</span>");
     }
 
     private function getNewKbItem()

--- a/tests/functionnal/Notification_NotificationTemplate.php
+++ b/tests/functionnal/Notification_NotificationTemplate.php
@@ -65,11 +65,11 @@ class Notification_NotificationTemplate extends DbTestCase
 
         $this->login();
         $name = $n_nt->getTabNameForItem($notif);
-        $this->string($name)->isIdenticalTo('Templates <span class=\'badge\'>1</span>');
+        $this->string($name)->isIdenticalTo("<span><i class='ti ti-template me-2'></i>Templates</span> <span class='badge'>1</span>");
 
         $_SESSION['glpishow_count_on_tabs'] = 0;
         $name = $n_nt->getTabNameForItem($notif);
-        $this->string($name)->isIdenticalTo('Templates');
+        $this->string($name)->isIdenticalTo("<span><i class='ti ti-template me-2'></i>Templates</span>");
 
         $toadd = $n_nt->fields;
         unset($toadd['id']);
@@ -78,7 +78,7 @@ class Notification_NotificationTemplate extends DbTestCase
 
         $_SESSION['glpishow_count_on_tabs'] = 1;
         $name = $n_nt->getTabNameForItem($notif);
-        $this->string($name)->isIdenticalTo('Templates <span class=\'badge\'>2</span>');
+        $this->string($name)->isIdenticalTo("<span><i class='ti ti-template me-2'></i>Templates</span> <span class='badge'>2</span>");
     }
 
     public function testShowForNotification()

--- a/tests/functionnal/OperatingSystem.php
+++ b/tests/functionnal/OperatingSystem.php
@@ -59,8 +59,8 @@ class OperatingSystem extends CommonDropdown
     protected function getTabs()
     {
         return [
-            'OperatingSystem$main'  => 'Operating system',
-            'Log$1'                 => 'Historical'
+            'OperatingSystem$main'  => "<span><i class='ti ti-edit me-2'></i>Operating system</span>",
+            'Log$1'                 => "<span><i class='ti ti-history me-2'></i>Historical</span>"
         ];
     }
 

--- a/tests/functionnal/OperatingSystemArchitecture.php
+++ b/tests/functionnal/OperatingSystemArchitecture.php
@@ -59,8 +59,8 @@ class OperatingSystemArchitecture extends CommonDropdown
     protected function getTabs()
     {
         return [
-            'OperatingSystemArchitecture$main'  => 'Operating system architecture',
-            'Log$1'                             => 'Historical'
+            'OperatingSystemArchitecture$main'  => "<span><i class='ti ti-edit me-2'></i>Operating system architecture</span>",
+            'Log$1'                             => "<span><i class='ti ti-history me-2'></i>Historical</span>"
         ];
     }
 

--- a/tests/functionnal/OperatingSystemEdition.php
+++ b/tests/functionnal/OperatingSystemEdition.php
@@ -67,8 +67,8 @@ class OperatingSystemEdition extends CommonDropdown
     protected function getTabs()
     {
         return [
-            'OperatingSystemEdition$main' => 'Edition',
-            'Log$1'                       => 'Historical'
+            'OperatingSystemEdition$main' => "<span><i class='ti ti-edit me-2'></i>Edition</span>",
+            'Log$1'                       => "<span><i class='ti ti-history me-2'></i>Historical</span>"
         ];
     }
 

--- a/tests/functionnal/OperatingSystemKernel.php
+++ b/tests/functionnal/OperatingSystemKernel.php
@@ -59,8 +59,8 @@ class OperatingSystemKernel extends CommonDropdown
     protected function getTabs()
     {
         return [
-            'OperatingSystemKernel$main'  => 'Kernel',
-            'Log$1'                       => 'Historical'
+            'OperatingSystemKernel$main'  => "<span><i class='ti ti-edit me-2'></i>Kernel</span>",
+            'Log$1'                       => "<span><i class='ti ti-history me-2'></i>Historical</span>"
         ];
     }
 

--- a/tests/functionnal/OperatingSystemKernelVersion.php
+++ b/tests/functionnal/OperatingSystemKernelVersion.php
@@ -74,8 +74,8 @@ class OperatingSystemKernelVersion extends CommonDropdown
     protected function getTabs()
     {
         return [
-            'OperatingSystemKernelVersion$main' => 'Kernel version',
-            'Log$1'                             => 'Historical'
+            'OperatingSystemKernelVersion$main' => "<span><i class='ti ti-edit me-2'></i>Kernel version</span>",
+            'Log$1'                             => "<span><i class='ti ti-history me-2'></i>Historical</span>"
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

![Selection_120](https://user-images.githubusercontent.com/17678637/204643943-d2c9c72c-d9d4-4e6a-be1b-a57d1ef2d12c.png)

A lot of itemtypes already have icons, so they will "just work" now as long as they use `createTabEntry` to generate the tab names. There are some classes that will need icons added still.