### PR TITLE
Preserve URL protocol on autolink

### DIFF
--- a/src/RichText/RichText.php
+++ b/src/RichText/RichText.php
@@ -250,6 +250,8 @@ final class RichText
 
         if ($enhanced_html) {
             // URLs have to be transformed into <a> tags.
+            global $autolink_options;
+            $autolink_options['strip_protocols'] = false;
             $content = autolink($content, false, ' target="_blank"');
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Stripping `http|https` protocol on autolink does not seems really usefull and can, in some case, be an unwanted behaviour. I propose to deactivate this behaviour.