### PR TITLE
Fix handling of application/octet-stream images in emails

### DIFF
--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -1680,8 +1680,10 @@ class MailCollector extends CommonDBTM
             $contents = $this->getDecodedContent($part);
             if (file_put_contents($path . $filename, $contents)) {
                 $this->files[$filename] = $filename;
-               // If embeded image, we add a tag
-                if (preg_match('@image/.+@', $content_type)) {
+
+                // If embeded image, we add a tag
+                $mime = Toolbox::getMime($path . $filename);
+                if (preg_match('@image/.+@', $mime)) {
                     end($this->files);
                     $tag = Rule::getUuid();
                     $this->tags[$filename]  = $tag;

--- a/tests/emails-tests/37-image-with-octet-stream-type.eml
+++ b/tests/emails-tests/37-image-with-octet-stream-type.eml
@@ -1,0 +1,40 @@
+Date: Thu, 1 Dec 2022 11:23:48 +0200 (CEST)
+From: Normal User <normal@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>
+Subject: 37 - Image using application/octet-steam content-type
+MIME-Version: 1.0
+Content-Type: multipart/alternative; 
+    boundary="----=_Part_1757883_1359581901.1528365951028"
+
+------=_Part_1757883_1359581901.1528365951028
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+Image:
+
+------=_Part_1757883_1359581901.1528365951028
+Content-Type: multipart/related; 
+    boundary="----=_Part_1757884_1267006027.1528365951028"
+
+------=_Part_1757884_1267006027.1528365951028
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+<html>
+<body>
+Image: <img
+src="cid:image001.png@01D90577.61DCAEC0">
+</body>
+</html>
+------=_Part_1757884_1267006027.1528365951028
+Content-Type: application/octet-stream; name=37-red-dot.png
+Content-Disposition: attachment; filename=37-red-dot.png
+Content-Transfer-Encoding: base64
+Content-ID: <image001.png@01D90577.61DCAEC0>
+
+iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE
+0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==
+------=_Part_1757884_1267006027.1528365951028--
+
+------=_Part_1757883_1359581901.1528365951028--
+

--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -710,6 +710,7 @@ class MailCollector extends DbTestCase
                     '34 - Message with no MessageID header',
                     '35 - Message with some invalid headers',
                     '36 - Microsoft specific code',
+                    '37 - Image using application/octet-steam content-type',
                 ]
             ],
          // Mails having "normal" user as observer (add_cc_to_observer = true)
@@ -841,25 +842,26 @@ HTML,
 
        // Check creation of expected documents
         $expected_docs = [
-            '00-logoteclib.png',
+            '00-logoteclib.png' => 'image/png',
          // Space is missing between "France" and "très" due to a bug in laminas-mail
-            '01-screenshot-2018-4-12-observatoire-francetres-haut-debit.png',
-            '01-test.JPG',
-            '15-image001.png',
-            '18-blank.gif',
-            '19-secl-chas.gif',
-            '20-special-chars.gif',
-            '24.1-zhang-wen-jian-ming-jiang-dao-zhi-nei-rong-chu-zhi-biao-tou-zhong-de-lian-xu-xing.txt',
-            '24.2-zhong-guo-zi-fu.txt',
-            '25-new-text-document.txt',
-            '1234567890',
-            '1234567890_2',
-            '1234567890_3',
+            '01-screenshot-2018-4-12-observatoire-francetres-haut-debit.png' => 'image/png',
+            '01-test.JPG' => 'image/jpeg',
+            '15-image001.png' => 'image/png',
+            '18-blank.gif' => 'image/gif',
+            '19-secl-chas.gif' => 'image/gif',
+            '20-special-chars.gif' => 'image/gif',
+            '24.1-zhang-wen-jian-ming-jiang-dao-zhi-nei-rong-chu-zhi-biao-tou-zhong-de-lian-xu-xing.txt' => 'text/plain',
+            '24.2-zhong-guo-zi-fu.txt' => 'text/plain',
+            '25-new-text-document.txt' => 'text/plain',
+            '1234567890' => 'text/plain',
+            '1234567890_2' => 'text/plain',
+            '1234567890_3' => 'text/plain',
+            '37-red-dot.png' => 'image/png',
         ];
 
         $iterator = $DB->request(
             [
-                'SELECT' => ['d.filename'],
+                'SELECT' => ['d.filename', 'd.mime'],
                 'FROM'   => \Document::getTable() . " AS d",
                 'INNER JOIN'   => [
                     \Document_Item::getTable() . " AS d_item"  => [
@@ -880,7 +882,7 @@ HTML,
 
         $filenames = [];
         foreach ($iterator as $data) {
-            $filenames[] = $data['filename'];
+            $filenames[$data['filename']] = $data['mime'];
         }
         $this->array($filenames)->isIdenticalTo($expected_docs);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13232

Some e-mail clients seems to use `Content-Type: application/octet-stream` for images embedded into email HTML contents. I propose to always fetch the mime type from the actual saved file.

We already rely on this when adding the document, see https://github.com/glpi-project/glpi/blob/10.0/bugfixes/src/Document.php#L1206-L1207