### PR TITLE
Disable dependabot auto rebase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
     open-pull-requests-limit: 100
     target-branch: "10.0/bugfixes"
     versioning-strategy: "increase"
+    rebase-strategy: "disabled"
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
@@ -27,6 +28,7 @@ updates:
     open-pull-requests-limit: 100
     target-branch: "10.0/bugfixes"
     versioning-strategy: "increase"
+    rebase-strategy: "disabled"
 
 
   # Update production dependencies on future release branch (main).
@@ -39,6 +41,7 @@ updates:
     open-pull-requests-limit: 100
     target-branch: "main"
     versioning-strategy: "increase"
+    rebase-strategy: "disabled"
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
@@ -48,3 +51,4 @@ updates:
     open-pull-requests-limit: 100
     target-branch: "main"
     versioning-strategy: "increase"
+    rebase-strategy: "disabled"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Almost everytime a dependabot PR is merged, dependabot rebases all other PR to fix potential conflicts. It fills the CI queue and rerun many times the test suite for the same PR.
I propose to disable this auto-rebase. We will just have to add 2 comments when we are ready to merge a PR: `@dependabot rebase` then `@dependabot merge`. By doing this, dependabot will rebase the PR and merge it once CI will have pass.