### PR TITLE
Handle missing/corrupted "initialized_rules_collections" config

### DIFF
--- a/src/Rules/RulesManager.php
+++ b/src/Rules/RulesManager.php
@@ -61,6 +61,12 @@ final class RulesManager
             Config::getConfigurationValue('core', 'initialized_rules_collections'),
             true
         );
+        if (!is_array($initialized_collections)) {
+            // Reinitialize configuration value if stored value does not exists or is corrupted.
+            // It can happen either if migration did not worked as expected, either if value
+            // in database was corrupted/deleted.
+            $initialized_collections = [];
+        }
 
         foreach ($rulecollections_types as $rulecollection_type) {
             if (


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Will prevent following fatal error when stored value is not a valid JSON array:
```
Uncaught Exception TypeError: in_array(): Argument #2 ($haystack) must be of type array, null given in /var/www/html/glpi/10.1.git/src/Rules/RulesManager.php at line 68
```