### PR TITLE
fix(clone): relation ID not updated between cloned sub items

### DIFF
--- a/tests/functionnal/Project.php
+++ b/tests/functionnal/Project.php
@@ -400,32 +400,20 @@ class Project extends DbTestCase
 
         // Add a task to project
         $task1_name = 'Project testClone - Task' . mt_rand();
-        $this->createItems('ProjectTask', [
-            [
-                'projects_id' => $projects_id,
-                'name'        => $task1_name,
-            ],
+        $task1 = $this->createItem('ProjectTask', [
+            'projects_id' => $projects_id,
+            'name'        => $task1_name,
         ]);
-        $task1_id = getItemByTypeName("ProjectTask", $task1_name, true);
-
-        // Load current task
-        $task1 = new \ProjectTask();
-        $this->boolean($task1->getFromDB($task1_id))->isTrue();
+        $task1_id = $task1->fields['id'];
 
         // Add a task, child of the previous task
         $task2_name = 'Project testClone - Task' . mt_rand();
-        $this->createItems('ProjectTask', [
-            [
-                'projects_id'     => $projects_id,
-                'name'            => $task2_name,
-                'projecttasks_id' => $task1_id,
-            ],
+        $task2 = $this->createItem('ProjectTask', [
+            'projects_id'     => $projects_id,
+            'name'            => $task2_name,
+            'projecttasks_id' => $task1_id,
         ]);
-        $task2_id = getItemByTypeName("ProjectTask", $task2_name, true);
-
-        // Load current task
-        $task2 = new \ProjectTask();
-        $this->boolean($task2->getFromDB($task2_id))->isTrue();
+        $task2_id = $task2->fields['id'];
 
         // Clone project
         $projects_id_clone = $project->clone();

--- a/tests/functionnal/Project.php
+++ b/tests/functionnal/Project.php
@@ -397,5 +397,63 @@ class Project extends DbTestCase
 
        // Compare teams
         $this->array($team_clone)->isEqualTo($team);
+
+        // Add a task to project
+        $task1_name = 'Project testClone - Task' . mt_rand();
+        $this->createItems('ProjectTask', [
+            [
+                'projects_id' => $projects_id,
+                'name'        => $task1_name,
+            ],
+        ]);
+        $task1_id = getItemByTypeName("ProjectTask", $task1_name, true);
+
+        // Load current task
+        $task1 = new \ProjectTask();
+        $this->boolean($task1->getFromDB($task1_id))->isTrue();
+
+        // Add a task, child of the previous task
+        $task2_name = 'Project testClone - Task' . mt_rand();
+        $this->createItems('ProjectTask', [
+            [
+                'projects_id'     => $projects_id,
+                'name'            => $task2_name,
+                'projecttasks_id' => $task1_id,
+            ],
+        ]);
+        $task2_id = getItemByTypeName("ProjectTask", $task2_name, true);
+
+        // Load current task
+        $task2 = new \ProjectTask();
+        $this->boolean($task2->getFromDB($task2_id))->isTrue();
+
+        // Clone project
+        $projects_id_clone = $project->clone();
+        $this->integer($projects_id_clone)->isGreaterThan(0);
+
+        // Load clone
+        $project_clone = new \Project();
+        $this->boolean($project_clone->getFromDB($projects_id_clone))->isTrue();
+
+        // Load clone tasks
+        $project_task = new ProjectTask();
+        $tasks_clone = [];
+        foreach ($project_task->find(['projects_id' => $projects_id_clone]) as $row) {
+            $tasks_clone[] = [
+                'projecttasks_id' => $row['projecttasks_id'],
+            ];
+        }
+
+        $expected = [
+            [
+                'projecttasks_id' => 0,
+            ],
+            [
+                'projecttasks_id' => $task1_id + 2,
+            ],
+        ];
+
+        // Compare tasks
+        $this->array($tasks_clone)->isEqualTo($expected);
     }
 }


### PR DESCRIPTION
If we have a project template with 2 tasks: A and B (B is a child of A).
When creating a project from this template, the father of task B' was task A of the template instead of task A' of the new project.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25528
