### PR TITLE
fix(licence template): template name not editable

### DIFF
--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -78,7 +78,7 @@
                         ) }}
                      {% endif %}
 
-                     {% if item.isField('template_name') and withtemplate == 1 %}
+                     {% if item.isField('template_name') and withtemplate == 1 and no_header %}
                         {{ fields.autoNameField(
                            'template_name',
                            item,

--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -78,6 +78,16 @@
                         ) }}
                      {% endif %}
 
+                     {% if item.isField('template_name') and withtemplate == 1 %}
+                        {{ fields.autoNameField(
+                           'template_name',
+                           item,
+                           __('Template name'),
+                           0,
+                           field_options
+                        ) }}
+                     {% endif %}
+
                      {% if item.isField('is_active') %}
                         {% if withtemplate is not empty or withtemplate == 1 %}
                            {{ fields.hiddenField('is_active', item.fields['is_active'], __('Is active'), {


### PR DESCRIPTION
When editing a template, the name of the template (field: `template_name`) was not proposed and therefore not modifiable.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25758
