### PR TITLE
Fix 'contact' rule criteria migration

### DIFF
--- a/install/migrations/update_10.0.0_to_10.0.1/fixaction.php
+++ b/install/migrations/update_10.0.0_to_10.0.1/fixaction.php
@@ -41,7 +41,7 @@ $migration->addPostQuery(
     $DB->buildUpdate(
         'glpi_rulecriterias',
         [
-            'pattern' => '/(.*)[,|\\/]/',
+            'pattern' => $DB->escape('/(.*)[,|\/]/'),
         ],
         [
             'id' => 19,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13295 

Previous migration pattern `/(.*)[,|\\/]/` was interpreted as `/(.*)[,|/]/` on MySQL side.
Technical explaination:
1. `$var = '\\/';` creates a variable `$var` that contains `\/` string. Indeed the first backslash is here considered as an escape char for the second backslash.
2. `'\/'` in a MySQL query values is interpreted as a `/` values, as the backslash is considered as considered as an escape char for the slash.

`$var = $DB->escape('/(.*)[,|\/]/')` is equivalent to `$var = '/(.*)[,|\\\\/]/'`.