### PR TITLE
Fix encryption warning

### DIFF
--- a/src/Item_Disk.php
+++ b/src/Item_Disk.php
@@ -578,6 +578,10 @@ class Item_Disk extends CommonDBChild
      */
     public static function getEncryptionStatus($status)
     {
+        if ($status === "") {
+            return NOT_AVAILABLE;
+        }
+
         $all = self::getAllEncryptionStatus();
         if (!isset($all[$status])) {
             trigger_error(


### PR DESCRIPTION
Fix this warning for the "Volumes - Encryption status" search option.
This warning appears if computers have no defined volumes (and the search option is active).

> [2022-11-30 17:33:06] glpiphplog.WARNING:   *** PHP User Warning (512): Encryption status  does not exists! in /var/www/html/glpi/src/Item_Disk.php at line 588
Backtrace :
  src/Item_Disk.php:588                              trigger_error()
  src/Item_Disk.php:665                              Item_Disk::getEncryptionStatus()
  src/Search.php:7528                                Item_Disk::getSpecificValueToDisplay()
  src/Search.php:1690                                Search::giveItem()
  src/Search.php:447                                 Search::constructData()
  ajax/search.php:79                                 Search::getDatas()



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
