### PR TITLE
Hide locked fields for deleted relation

### DIFF
--- a/src/Lock.php
+++ b/src/Lock.php
@@ -819,7 +819,7 @@ class Lock extends CommonGLPI
             echo "<th width='10'></th>";
             echo "<th>" . DatabaseInstance::getTypeName(Session::getPluralNumber()) . "</th>";
             echo "<th>" . __('Name') . "</th>";
-            echo "<th>" . __('Version') . "</th>";
+            echo "<th>" . _n('Version', 'Versions', 1) . "</th>";
             echo "<th>" . __('Automatic inventory') . "</th>";
             echo "</tr>";
         }

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -136,6 +136,11 @@ class Lock extends CommonGLPI
                         continue;
                     }
                     $query['WHERE'][] = $connexity_criteria['WHERE'];
+                    if ($lockable_object->isField('is_deleted')) {
+                        $query['WHERE'][] = [
+                            $lockable_object->getTableField('is_deleted') => 0
+                        ];
+                    }
                 } elseif (in_array($lockable_itemtype, $CFG_GLPI['directconnect_types'])) {
                     //we need to restrict scope with Computer_Item to prevent loading of all lockedfield
                     $query['LEFT JOIN'][Computer_Item::getTable()] =

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -146,7 +146,8 @@ class Lock extends CommonGLPI
                         ]
                     ];
                     $query['WHERE'][] = [
-                        Computer_Item::getTable() . '.computers_id'  => $ID
+                        Computer_Item::getTable() . '.computers_id'  => $ID,
+                        Computer_Item::getTable() . '.is_deleted' => 0
                     ];
                 } elseif ($lockable_object->isField('itemtype') && $lockable_object->isField('items_id')) {
                     $query['WHERE'][] = [

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -138,7 +138,7 @@ class Lock extends CommonGLPI
                     $query['WHERE'][] = $connexity_criteria['WHERE'];
                     if ($lockable_object->isField('is_deleted')) {
                         $query['WHERE'][] = [
-                            $lockable_object->getTableField('is_deleted') => 0
+                            $lockable_object::getTableField('is_deleted') => 0
                         ];
                     }
                 } elseif (in_array($lockable_itemtype, $CFG_GLPI['directconnect_types'])) {
@@ -159,6 +159,11 @@ class Lock extends CommonGLPI
                         $lockable_itemtype::getTable() . '.itemtype'  => $itemtype,
                         $lockable_itemtype::getTable() . '.items_id'  => $ID
                     ];
+                    if ($lockable_object->isField('is_deleted')) {
+                        $query['WHERE'][] = [
+                            $lockable_object::getTableField('is_deleted') => 0
+                        ];
+                    }
                 }
                 $subquery[] = new \QuerySubQuery($query);
             }
@@ -795,6 +800,44 @@ class Lock extends CommonGLPI
                     echo "</tr>\n";
                 }
             }
+        }
+
+        // Show deleted DatabaseInstance
+        $data = $DB->request([
+            'SELECT' => 'id',
+            'FROM' => DatabaseInstance::getTable(),
+            'WHERE' => [
+                DatabaseInstance::getTableField('is_dynamic') => 1,
+                DatabaseInstance::getTableField('is_deleted') => 1,
+                DatabaseInstance::getTableField('items_id')   =>  $ID,
+                DatabaseInstance::getTableField('itemtype')   => $itemtype,
+            ]
+        ]);
+        if (count($data)) {
+            // Print header
+            echo "<tr>";
+            echo "<th width='10'></th>";
+            echo "<th>" . DatabaseInstance::getTypeName(Session::getPluralNumber()) . "</th>";
+            echo "<th>" . __('Name') . "</th>";
+            echo "<th>" . __('Version') . "</th>";
+            echo "<th>" . __('Automatic inventory') . "</th>";
+            echo "</tr>";
+        }
+
+        foreach ($data as $row) {
+            $database_instance = DatabaseInstance::getById($row['id']);
+            echo "<tr class='tab_bg_1'>";
+            echo "<td class='center' width='10'>";
+            if ($database_instance->can($row['id'], UPDATE) || $database_instance->can($row['id'], PURGE)) {
+                $header = true;
+                echo "<input type='checkbox' name='DatabaseInstance[" . $row['id'] . "]'>";
+            }
+            echo "</td>";
+            echo "<td class='left'>" . $database_instance->getLink() . "</td>";
+            echo "<td class='left'>" . $database_instance->getName() . "</td>";
+            echo "<td class='left'>" . $database_instance->fields['version'] . "</td>";
+            echo "<td class='left'>" . Dropdown::getYesNo($database_instance->fields['is_dynamic']) . "</td>";
+            echo "</tr>\n";
         }
 
         if ($header) {


### PR DESCRIPTION
From the "Locks" tab of a monitor, I can see the computer locked fields AND the locked fields of items linked to the computer:

![image](https://user-images.githubusercontent.com/42734840/205690747-c53c09a5-dea5-4706-8a34-5d6fe250aa3e.png)

@stonebuzz tell me that this is done on purpose (to make it easier to browse all locked fields from the parent computer) so no issues at this point.

However, the linked fields are still shown even if the relation is deleted:

![image](https://user-images.githubusercontent.com/42734840/205691602-d3b7ad74-ff2b-4caa-a3ee-a2dc77fc5cb2.png)

They should be hidden in the case (the fields are irrelevant because the items are no longer linked).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25474
