### PR TITLE
Display private followup hint properly in dark mode

### DIFF
--- a/css/includes/components/itilobject/_timeline.scss
+++ b/css/includes/components/itilobject/_timeline.scss
@@ -49,7 +49,7 @@
 
         .timeline-item-buttons {
             .is-private {
-                color: rgba(43, 43, 43, 70%);
+                color: $timeline-badge-fg;
             }
         }
     }


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/42734840/205697645-1a1ba14f-93c9-46cd-9152-1a527aac1146.png)

After:

![image](https://user-images.githubusercontent.com/42734840/205697787-b11d6f0c-be14-4de0-9ca4-4f3eeb581af7.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25349
