### PR TITLE
Show full KB article at once

### DIFF
--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -2326,7 +2326,9 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
         } else {
             $answer = $this->fields["answer"];
         }
-        $answer = RichText::getEnhancedHtml($answer);
+        $answer = RichText::getEnhancedHtml($answer, [
+            'text_maxsize' => 0 // Show all text without read more button
+        ]);
 
         $callback = function ($matches) {
           //1 => tag name, 2 => existing attributes, 3 => title contents

--- a/src/RichText/RichText.php
+++ b/src/RichText/RichText.php
@@ -295,7 +295,7 @@ final class RichText
             $content = self::replaceImagesByGallery($content);
         }
 
-        if ($content_size > $p['text_maxsize']) {
+        if ($p['text_maxsize'] > 0 && $content_size > $p['text_maxsize']) {
             $content = <<<HTML
 <div class="long_text">$content
     <p class='read_more'>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When viewing a long KB article, the article is cut off by a read more button that you need to click to show the rest of the text. Given that the full text is already all loaded at once, and the article is the only content in the main form, it should be OK to always show the full content.

Ref: https://forum.glpi-project.org/viewtopic.php?id=285616