### PR TITLE
Fix "Location on map" when geo.enabled is disabled on firefox

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -706,7 +706,7 @@ function _eltRealSize(_elt) {
     return _s;
 }
 
-var initMap = function(parent_elt, map_id, height, initial_view = {position: [43.6112422, 3.8767337], zoom: 6}) {
+var initMap = function(parent_elt, map_id, height, initial_view = {position: [0, 0], zoom: 1}) {
     // default parameters
     map_id = (typeof map_id !== 'undefined') ? map_id : 'map';
     height = (typeof height !== 'undefined') ? height : '200px';

--- a/src/MapGeolocation.php
+++ b/src/MapGeolocation.php
@@ -140,6 +140,14 @@ trait MapGeolocation
                }
             });
          }
+
+         // Geolocation may be disabled in the browser (e.g. geo.enabled = false in firefox)
+         if (!navigator.geolocation) {
+            map_elt = initMap($('#setlocation_container_{$rand}'), 'setlocation_{$rand}', '200px');
+            finalizeMap();
+            return;
+         }
+
          navigator.geolocation.getCurrentPosition(function(pos) {
             // Try to determine an appropriate zoom level based on accuracy
             var acc = pos.coords.accuracy;


### PR DESCRIPTION
If you disable this setting on firefox (about:config), the "Location on map" fields doesn't work anymore.

![image](https://user-images.githubusercontent.com/42734840/205938937-ab4f34de-f009-4074-9a11-d2317134da4a.png)

![image](https://user-images.githubusercontent.com/42734840/205939147-d434404c-8e71-4642-8f9b-4af26b40960b.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25816
