### PR TITLE
Fix analysis of raw plugin joins

### DIFF
--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -723,6 +723,8 @@ class DBmysqlIterator implements SeekableIterator, Countable
                 }
                 return $fkey;
             }
+        } else if ($values instanceof QueryExpression) {
+            return $values->getValue();
         }
         trigger_error("BAD FOREIGN KEY, should be [ table1 => key1, table2 => key2 ] or [ table1 => key1, table2 => key2, [criteria]]", E_USER_ERROR);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fixes parsing of join strings to handle table aliases and also gets the full join condition and coverts it to a QueryExpression instead of trying to parse it. Support for QueryExpression join conditions was added to the iterator.