### PR TITLE
fix(RuleMatchLog): add missing tab from Agent

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -333,6 +333,7 @@ class Agent extends CommonDBTM
 
         $ong = [];
         $this->addDefaultFormTab($ong);
+        $this->addStandardTab('RuleMatchedLog', $ong, $options);
         $this->addStandardTab('Log', $ong, $options);
 
         return $ong;

--- a/tests/functionnal/Agent.php
+++ b/tests/functionnal/Agent.php
@@ -44,8 +44,9 @@ class Agent extends DbTestCase
     public function testDefineTabs()
     {
         $expected = [
-            'Agent$main'   => 'Agent',
-            'Log$1'        => 'Historical'
+            'Agent$main'        => 'Agent',
+            'RuleMatchedLog$0'  => 'Import information',
+            'Log$1'             => 'Historical'
         ];
         $this
          ->given($this->newTestedInstance)


### PR DESCRIPTION
The ```RuleMatchedLog``` class contains code to display data from an ```Agent```

https://github.com/glpi-project/glpi/blob/94445120413835b2421af54d91d5c44c9f21d2a3/src/RuleMatchedLog.php#L286-L297

Add missing tab from ```Agent```

![image](https://user-images.githubusercontent.com/7335054/206386681-6b1fbdbb-536b-4a15-b08c-2ad264d5c886.png)

Useful to see what the agent brings up.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
