### PR TITLE
Prevent version files directory to be hidden in file managers

### DIFF
--- a/.github/workflows/bump_version_after_release.yml
+++ b/.github/workflows/bump_version_after_release.yml
@@ -54,8 +54,8 @@ jobs:
           git config --local user.email "$(git log --format='%ae' HEAD^!)"
           git config --local user.name "$(git log --format='%an' HEAD^!)"
           git checkout -b ${{ env.BUMP_BRANCH }}
-          echo "Renaming .version file..."
-          git mv .version/${{ env.TAG }} .version/${{ env.NEXT_VERSION }}
+          echo "Renaming version file..."
+          git mv version/${{ env.TAG }} version/${{ env.NEXT_VERSION }}
           echo "Replacing version in inc/define.php..."
           sed -i "s/define('GLPI_VERSION', '[^)]*');/define('GLPI_VERSION', '${{ env.NEXT_VERSION }}-dev');/g" inc/define.php
           echo "Archiving MySQL empty schema file..."

--- a/src/System/Requirement/InstallationNotOverriden.php
+++ b/src/System/Requirement/InstallationNotOverriden.php
@@ -56,7 +56,7 @@ final class InstallationNotOverriden extends AbstractRequirement
      */
     private $version_dir;
 
-    public function __construct(?DBmysql $db, string $version_dir = GLPI_ROOT . '/.version')
+    public function __construct(?DBmysql $db, string $version_dir = GLPI_ROOT . '/version')
     {
         $this->db = $db;
         $this->version_dir = $version_dir;
@@ -75,7 +75,7 @@ final class InstallationNotOverriden extends AbstractRequirement
 
         if ($version_files_count == 0) {
             // Cannot do the check.
-            // Indicating that `.version` directory is missing would be useless, as it would probably incitate administrator
+            // Indicating that `version` directory is missing would be useless, as it would probably incitate administrator
             // to restore it, and it would result in a "false positive" type validation.
             $this->out_of_context = true;
             return;
@@ -113,14 +113,14 @@ final class InstallationNotOverriden extends AbstractRequirement
                 $previous_version = VersionParser::getNormalizedVersion($previous_version, false);
             }
         }
-        if ($previous_version === null || version_compare($previous_version, '10.0.4', '<')) {
+        if ($previous_version === null || version_compare($previous_version, '10.0.6', '<')) {
             // If previous version is unknown, validation will be mostly a "false positive" type validation.
             // Cases corresponding to an unknown previous version:
             // - new installation;
             // - update from an empty directory (where DB config has not even been restored);
             // - update from version < 0.85.
             //
-            // If previous version is < 10.0.4, version file form previous version should not be available.
+            // If previous version is < 10.0.6, version file form previous version should not be available.
             // In this case, we cannot detect presence of previous versions files.
             $this->out_of_context = true;
             return;

--- a/tests/units/Glpi/System/Requirement/InstallationNotOverriden.php
+++ b/tests/units/Glpi/System/Requirement/InstallationNotOverriden.php
@@ -42,7 +42,7 @@ class InstallationNotOverriden extends \GLPITestCase
 {
     protected function versionDirectoryProvider(): iterable
     {
-        // Missing .version directory
+        // Missing version directory
         // -> out of context
         yield [
             'files'            => null,
@@ -52,7 +52,7 @@ class InstallationNotOverriden extends \GLPITestCase
             'out_of_context'   => true,
         ];
 
-        // Empty .version directory
+        // Empty version directory
         // -> out of context
         yield [
             'files'            => [],
@@ -129,7 +129,7 @@ class InstallationNotOverriden extends \GLPITestCase
      */
     public function testCheck(?array $files, ?string $previous_version, bool $validated, array $messages, bool $out_of_context = false)
     {
-        vfsStream::setup('root', null, $files !== null ? ['.version' => $files] : []);
+        vfsStream::setup('root', null, $files !== null ? ['version' => $files] : []);
 
         $this->mockGenerator->orphanize('__construct');
         $db = new \mock\DB();
@@ -147,7 +147,7 @@ class InstallationNotOverriden extends \GLPITestCase
             );
         };
 
-        $this->newTestedInstance($db, vfsStream::url('root/.version'));
+        $this->newTestedInstance($db, vfsStream::url('root/version'));
         $this->boolean($this->testedInstance->isOutOfContext())->isEqualTo($out_of_context);
         $this->boolean($this->testedInstance->isValidated())->isEqualTo($validated);
         $this->array($this->testedInstance->getValidationMessages())->isEqualTo($messages);

--- a/tests/units/Glpi/System/Requirement/InstallationNotOverriden.php
+++ b/tests/units/Glpi/System/Requirement/InstallationNotOverriden.php
@@ -62,10 +62,10 @@ class InstallationNotOverriden extends \GLPITestCase
             'out_of_context'   => true,
         ];
 
-        // Unique version file that matches current version during update from < GLPI 10.0.4
+        // Unique version file that matches current version during update from < GLPI 10.0.6
         // -> out of context
         $current_version = VersionParser::getNormalizedVersion(GLPI_VERSION, false);
-        foreach ([null, '9.1', '9.5.9', '10.0.0-dev', '10.0.3'] as $previous_version) {
+        foreach ([null, '9.1', '9.5.9', '10.0.0-dev', '10.0.3', '10.0.5'] as $previous_version) {
             yield [
                 'files'            => [
                     $current_version => '',
@@ -109,7 +109,7 @@ class InstallationNotOverriden extends \GLPITestCase
         // Unique version file that matches current version during update from >= GLPI 10.0.4
         // -> validated
         $current_version = VersionParser::getNormalizedVersion(GLPI_VERSION, false);
-        foreach (['10.0.4', '10.0.6', '10.1.0-dev', '11.3.4'] as $previous_version) {
+        foreach (['10.0.6', '10.0.7', '10.1.0-dev', '11.3.4'] as $previous_version) {
             yield [
                 'files'            => [
                     $current_version => '',

--- a/tools/build_glpi.sh
+++ b/tools/build_glpi.sh
@@ -69,8 +69,8 @@ composer update nothing --ansi --no-interaction --ignore-platform-reqs --no-dev 
 # Remove user generated files (i.e. cache and log from CLI commands ran during release)
 find $WORKING_DIR/files -depth -mindepth 2 -exec rm -rf {} \;
 
-# Remove hidden files and directory, except .version directory and .htaccess files
-find $WORKING_DIR -depth \( -iname ".*" ! -iname ".version" ! -iname ".htaccess" \) -exec rm -rf {} \;
+# Remove hidden files and directory, except .htaccess files
+find $WORKING_DIR -depth \( -iname ".*" ! -iname ".htaccess" \) -exec rm -rf {} \;
 
 # Remove useless dev files and directories
 dev_nodes=(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

See #13553.

When an administrator updates the GLPI code base using a file manager, during the step `Ensure the target directory is empty and extract files there.`, he browses the GLPI directory, selects all files and directories and deletes them. The problem is that in many cases file managers do not show hidden files by default, and therefore the `.version` directory will not be selectable and therefore will not be deleted.

Although this check is only performed on users who try the nightly build (the check was not present in the previous version), this is not the first user to experience this problem. IMHO many people use file managers to update their GLPI and we will probably have many issues opened after each new version release if we keep this check as it is. I suggest renaming the `.version` directory to prevent it from being hidden.