### PR TITLE
Fix reservation repetition group value

### DIFF
--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -125,7 +125,7 @@ if (isset($_POST["update"])) {
             $input['reservationitems_id'] = $reservationitems_id;
             $input['comment']             = $_POST['comment'];
 
-            if (count($dates_to_add)) {
+            if (count($dates_to_add) > 1) {
                 $input['group'] = $rr->getUniqueGroupFor($reservationitems_id);
             }
             foreach ($dates_to_add as $begin => $end) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13536

Reservation `group` should only create when there is more than 1 date added at once.