### PR TITLE
Fix saved search creation form when many criteria are used

### DIFF
--- a/ajax/savedsearch.php
+++ b/ajax/savedsearch.php
@@ -76,11 +76,13 @@ if (
     }
 }
 
-if (!isset($_GET['action'])) {
+if (!isset($_REQUEST['action'])) {
     return;
 }
 
-if ($_GET['action'] == 'display_mine') {
+$action = $_REQUEST['action'] ?? null;
+
+if ($action == 'display_mine') {
     header("Content-Type: text/html; charset=UTF-8");
     $savedsearch->displayMine(
         $_GET["itemtype"],
@@ -89,20 +91,20 @@ if ($_GET['action'] == 'display_mine') {
     );
 }
 
-if ($_GET['action'] == 'reorder') {
+if ($action == 'reorder') {
     $savedsearch->saveOrder($_GET['ids']);
     header("Content-Type: application/json; charset=UTF-8");
     echo json_encode(['res' => true]);
 }
 
 // Create or update a saved search
-if ($_GET['action'] == 'create') {
+if ($action == 'create') {
     header("Content-Type: text/html; charset=UTF-8");
 
-    if (!isset($_GET['type'])) {
-        $_GET['type'] = -1;
+    if (!isset($_REQUEST['type'])) {
+        $_REQUEST['type'] = -1;
     } else {
-        $_GET['type']  = (int)$_GET['type'];
+        $_REQUEST['type']  = (int)$_REQUEST['type'];
     }
 
     $id = 0;
@@ -111,7 +113,7 @@ if ($_GET['action'] == 'create') {
    // If an id was supplied in the query and that the matching saved search
    // is private OR the current user is allowed to edit public searches, then
    // pass the id to showForm
-    if (($requested_id = $_GET['id'] ?? 0) > 0 && $saved_search->getFromDB($requested_id)) {
+    if (($requested_id = $_REQUEST['id'] ?? 0) > 0 && $saved_search->getFromDB($requested_id)) {
         $is_private = $saved_search->fields['is_private'];
         $can_update_public = Session::haveRight(SavedSearch::$rightname, UPDATE);
 
@@ -123,9 +125,9 @@ if ($_GET['action'] == 'create') {
     $savedsearch->showForm(
         $id,
         [
-            'type'      => $_GET['type'],
-            'url'       => $_GET["url"],
-            'itemtype'  => $_GET["itemtype"],
+            'type'      => $_REQUEST['type'],
+            'url'       => $_REQUEST["url"],
+            'itemtype'  => $_REQUEST["itemtype"],
             'ajax'      => true
         ]
     );

--- a/js/modules/Search/GenericView.js
+++ b/js/modules/Search/GenericView.js
@@ -101,8 +101,9 @@ window.GLPI.Search.GenericView = class GenericView {
             `);
             const bs_modal = new bootstrap.Modal(modal.get(0), {show: false});
             modal.on('show.bs.modal', () => {
-                const url = modal.attr('data-url')+'&url=' + encodeURIComponent(window.location.pathname + window.location.search);
-                modal.find('.modal-body').load(url, {});
+                const params = JSON.parse(modal.attr('data-params'));
+                params['url'] = window.location.pathname + window.location.search;
+                modal.find('.modal-body').load(CFG_GLPI.root_doc + '/ajax/savedsearch.php', params);
             });
             bs_modal.show();
         });

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -903,8 +903,6 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
      **/
     public static function showSaveButton($type, $itemtype = 0, bool $active = false)
     {
-        global $CFG_GLPI;
-
         echo "<a href='#' class='btn btn-ghost-secondary btn-icon btn-sm me-1 bookmark_record save'
              title='" . __s('Save current search') . "'>";
         echo "<i class='ti ti-star " . ($active ? 'active' : '') . "'></i>";
@@ -922,9 +920,9 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
             $params['id'] = $_GET['savedsearches_id'];
         }
 
-        $url = $CFG_GLPI['root_doc'] . "/ajax/savedsearch.php?" . http_build_query($params);
+        $json_params = htmlspecialchars(json_encode($params), ENT_QUOTES);
 
-        echo "<div id='savedsearch-modal' class='modal' data-url='$url'></div>";
+        echo "<div id='savedsearch-modal' class='modal' data-params='$json_params'></div>";
     }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13425

Modal loading was using a POST request but with all parameters located in URL query string. I moved parameters into POST body to prevent issues with URL length limits.