### PR TITLE
fix(networkport): add history on add NetworkPort

### DIFF
--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -520,6 +520,7 @@ class NetworkPort extends CommonDBChild
 
     public function post_addItem()
     {
+        parent::post_addItem(); //for history
         $this->updateDependencies(!$this->input['_no_history']);
         $this->updateMetrics();
     }

--- a/tests/functionnal/Glpi/Inventory/Inventory.php
+++ b/tests/functionnal/Glpi/Inventory/Inventory.php
@@ -1777,13 +1777,13 @@ class Inventory extends InventoryTestCase
             'OFFSET' => $nblogsnow,
         ]);
 
-        $this->integer(count($logs))->isIdenticalTo(4444);
+        $this->integer(count($logs))->isIdenticalTo(4448);
 
         $expected_types_count = [
             0 => 4, //Agent version, disks usage
             \Log::HISTORY_ADD_RELATION => 1, //new IPNetwork/IPAddress
             \Log::HISTORY_DEL_RELATION => 2,//monitor-computer relation
-            \Log::HISTORY_ADD_SUBITEM => 3243,//network port/name, ip address, VMs, Software
+            \Log::HISTORY_ADD_SUBITEM => 3247,//network port/name, ip address, VMs, Software
             \Log::HISTORY_UPDATE_SUBITEM => 828,//disks usage, software updates
             \Log::HISTORY_DELETE_SUBITEM => 99,//networkport and networkname, Software?
             \Log::HISTORY_CREATE_ITEM => 265, //virtual machines, os, manufacturer, net ports, net names, software category ...


### PR DESCRIPTION
Actually, when we add a ```NetworkPort``` to a ```Computer``` (manually or from inventory)

GLPI does not log the information of the addition

This PR fix this

![image](https://user-images.githubusercontent.com/7335054/206714074-e97cd240-4547-4654-995e-daa1d3a07fcf.png)

Fix : https://github.com/glpi-project/glpi/issues/10604#issuecomment-1081642373

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
