### PR TITLE
feat(timeline): add capability to change the layout of button

### DIFF
--- a/css/includes/components/itilobject/_footer.scss
+++ b/css/includes/components/itilobject/_footer.scss
@@ -59,6 +59,11 @@
         color: $timeline-sol-fg;
     }
 
+    .action-validation {
+        background-color: $timeline-itilc-bg;
+        color: $timeline-itilc-fg;
+    }
+
     .action-document {
         background-color: $timeline-doc-bg;
         color: $timeline-doc-fg;

--- a/inc/define.php
+++ b/inc/define.php
@@ -466,7 +466,7 @@ $CFG_GLPI['user_pref_field'] = ['backcreated', 'csv_delimiter', 'date_format',
     'highcontrast_css', 'default_dashboard_central', 'default_dashboard_assets',
     'default_dashboard_helpdesk', 'default_dashboard_mini_ticket', 'default_central_tab',
     'fold_menu', 'fold_search', 'savedsearches_pinned', 'richtext_layout', 'timeline_order',
-    'itil_layout'
+    'itil_layout', 'timeline_action_btn_layout'
 ];
 
 $CFG_GLPI['lock_lockable_objects'] = ['Budget',  'Change', 'Contact', 'Contract', 'Document',

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -348,6 +348,7 @@ $empty_data_builder = new class
             'system_user' => self::USER_SYSTEM,
             'support_legacy_data' => 0, // New installation should not support legacy data
             'initialized_rules_collections' => '[]',
+            'timeline_action_btn_layout' => 0,
         ];
 
         $tables['glpi_configs'] = [];

--- a/install/migrations/update_10.0.5_to_10.0.6/configs.php
+++ b/install/migrations/update_10.0.5_to_10.0.6/configs.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2022 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var Migration $migration
+ */
+
+$migration->displayMessage('Add new configurations / user preferences');
+$migration->addConfig([
+    'timeline_action_btn_layout'   => 0,
+]);
+$migration->addField('glpi_users', 'timeline_action_btn_layout', 'tinyint DEFAULT 0');

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -7627,6 +7627,7 @@ CREATE TABLE `glpi_users` (
   `default_dashboard_mini_ticket` varchar(100) DEFAULT NULL,
   `default_central_tab` tinyint DEFAULT '0',
   `nickname` varchar(255) DEFAULT NULL,
+  `timeline_action_btn_layout` tinyint DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicityloginauth` (`name`,`authtype`,`auths_id`),
   KEY `firstname` (`firstname`),

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -6491,6 +6491,7 @@ abstract class CommonITILObject extends CommonDBTM
             'class'         => 'ITILFollowup',
             'icon'          => 'ti ti-message-circle',
             'label'         => _x('button', 'Answer'),
+            'short_label'   => _x('button', 'Answer'),
             'template'      => 'components/itilobject/timeline/form_followup.html.twig',
             'item'          => $fup,
             'hide_in_menu'  => !$canadd_fup
@@ -6500,6 +6501,7 @@ abstract class CommonITILObject extends CommonDBTM
             'class'         => $task_class,
             'icon'          => 'ti ti-checkbox',
             'label'         => _x('button', 'Create a task'),
+            'short_label'   => _x('button', 'Task'),
             'template'      => 'components/itilobject/timeline/form_task.html.twig',
             'item'          => $task,
             'hide_in_menu'  => !$canadd_task
@@ -6509,6 +6511,7 @@ abstract class CommonITILObject extends CommonDBTM
             'class'         => 'ITILSolution',
             'icon'          => 'ti ti-check',
             'label'         => _x('button', 'Add a solution'),
+            'short_label'   => _x('button', 'Solution'),
             'template'      => 'components/itilobject/timeline/form_solution.html.twig',
             'item'          => new ITILSolution(),
             'hide_in_menu'  => !$canadd_solution
@@ -6518,6 +6521,7 @@ abstract class CommonITILObject extends CommonDBTM
             'class'         => Document_Item::class,
             'icon'          => Document_Item::getIcon(),
             'label'         => _x('button', 'Add a document'),
+            'short_label'   => _x('button', 'Document'),
             'template'      => 'components/itilobject/timeline/form_document_item.html.twig',
             'item'          => new Document_Item(),
             'hide_in_menu'  => !$canadd_document
@@ -6528,6 +6532,7 @@ abstract class CommonITILObject extends CommonDBTM
                 'class'         => $validation::getType(),
                 'icon'          => 'ti ti-thumb-up',
                 'label'         => _x('button', 'Ask for validation'),
+                'short_label'   => _x('button', 'Validation'),
                 'template'      => 'components/itilobject/timeline/form_validation.html.twig',
                 'item'          => $validation,
                 'hide_in_menu'  => !$canadd_validation

--- a/src/Config.php
+++ b/src/Config.php
@@ -55,6 +55,9 @@ class Config extends CommonDBTM
     public const GLOBAL_MANAGEMENT = 1;
     public const NO_MANAGEMENT = 2;
 
+    public const TIMELINE_ACTION_BTN_MERGED = 0;
+    public const TIMELINE_ACTION_BTN_SPLITTED = 1;
+
    // From CommonGLPI
     protected $displaylist         = false;
 
@@ -1282,6 +1285,22 @@ class Config extends CommonDBTM
             } else {
                 echo Dropdown::getYesNo(0);
             }
+
+            echo "<tr class='tab_bg_2'><td><label for='timeline_action_btn_layout$rand'>" . __('Action button layout') .
+              "</label></td><td>";
+            if (!$userpref || Session::haveRight('ticket', Ticket::OWN)) {
+
+                Dropdown::showFromArray('timeline_action_btn_layout', [
+                    self::TIMELINE_ACTION_BTN_MERGED => __('Merged'),
+                    self::TIMELINE_ACTION_BTN_SPLITTED => __('Splitted'),
+                ], [
+                    'value' => $data['timeline_action_btn_layout'],
+                    'rand' => $rand
+                ]);
+            } else {
+                echo Dropdown::getYesNo(0);
+            }
+            echo "</td><td></td></tr>";
             echo "</td></tr>";
 
             echo "<tr class='tab_bg_2'>";

--- a/src/Config.php
+++ b/src/Config.php
@@ -1289,7 +1289,6 @@ class Config extends CommonDBTM
             echo "<tr class='tab_bg_2'><td><label for='timeline_action_btn_layout$rand'>" . __('Action button layout') .
               "</label></td><td>";
             if (!$userpref || Session::haveRight('ticket', Ticket::OWN)) {
-
                 Dropdown::showFromArray('timeline_action_btn_layout', [
                     self::TIMELINE_ACTION_BTN_MERGED => __('Merged'),
                     self::TIMELINE_ACTION_BTN_SPLITTED => __('Splitted'),

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -66,7 +66,7 @@
                         {% if loop.index0 > 0 %}
                               <button class="ms-2 mb-2 btn btn-primary answer-action action-{{ action }}" data-bs-toggle="collapse" data-bs-target="#new-{{ timeline_itemtype.class }}-block">
                                  <i class="{{ timeline_itemtype.icon }}"></i>
-                                 <span>{{ timeline_itemtype.label }}</span>
+                                 <span>{{ timeline_itemtype.short_label }}</span>
                               </button>
                               {% endif %}
                         {% endfor %}

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -33,6 +33,7 @@
 
 {% set timeline_btns_cls = left_regular_cls %}
 {% set form_btns_cls     = is_expanded ? right_expanded_cls : "col-lg" %}
+{% set timeline_btn_layout = session('glpitimeline_action_btn_layout') %}
 {% set switch_btn_cls    = "fa-caret-left" %}
 {% if is_expanded %}
     {% set timeline_btns_cls = left_expanded_cls %}
@@ -47,7 +48,8 @@
             {% set default_action_data = timeline_itemtypes|first %}
             {% if item.isNotSolved() and default_action_data != false %}
                {% if timeline_itemtypes|length > 1 %}
-                  <div class="btn-group me-2 main-actions" style="{{ load_kb_sol > 0 ? 'display:none;' : '' }}">
+                  {% set btn_class = timeline_btn_layout == constant('Config::TIMELINE_ACTION_BTN_SPLITTED') ? "" : "btn-group" %}
+                  <div class="{{ btn_class }} me-2 main-actions" style="{{ load_kb_sol > 0 ? 'display:none;' : '' }}">
                {% else %}
                   {# Don't use d-inline-flex class as it add an '!important' tag that mess with our javascript that will hide this div #}
                   <div class="main-actions" style="display:inline-flex">
@@ -59,20 +61,31 @@
 
                   {% set main_actions_itemtypes = timeline_itemtypes|filter((v, k) => v.hide_in_menu is not defined or v.hide_in_menu != true) %}
                   {% if main_actions_itemtypes|length > 1 %}
-                    <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
-                        <span class="visually-hidden">{{ __('View other actions') }}</span>
-                    </button>
-                    <ul class="dropdown-menu">
+                     {% if timeline_btn_layout == constant('Config::TIMELINE_ACTION_BTN_SPLITTED') %}
                         {% for action, timeline_itemtype in main_actions_itemtypes %}
-                            {% if loop.index0 > 0 %}
-                            <li><a class="dropdown-item action-{{ action }} answer-action" href="#"
-                                data-bs-toggle="collapse" data-bs-target="#new-{{ timeline_itemtype.class }}-block">
-                                <i class="{{ timeline_itemtype.icon }}"></i>
-                                <span>{{ timeline_itemtype.label }}</span>
-                            </a></li>
-                            {% endif %}
+                        {% if loop.index0 > 0 %}
+                              <button class="ms-2 btn btn-primary answer-action action-{{ action }}" data-bs-toggle="collapse" data-bs-target="#new-{{ timeline_itemtype.class }}-block">
+                                 <i class="{{ timeline_itemtype.icon }}"></i>
+                                 <span>{{ timeline_itemtype.label }}</span>
+                              </button>
+                              {% endif %}
                         {% endfor %}
-                    </ul>
+                     {% else %}
+                        <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+                           <span class="visually-hidden">{{ __('View other actions') }}</span>
+                        </button>
+                        <ul class="dropdown-menu">
+                              {% for action, timeline_itemtype in main_actions_itemtypes %}
+                                 {% if loop.index0 > 0 %}
+                                 <li><a class="dropdown-item action-{{ action }} answer-action" href="#"
+                                    data-bs-toggle="collapse" data-bs-target="#new-{{ timeline_itemtype.class }}-block">
+                                    <i class="{{ timeline_itemtype.icon }}"></i>
+                                    <span>{{ timeline_itemtype.label }}</span>
+                                 </a></li>
+                                 {% endif %}
+                              {% endfor %}
+                        </ul>
+                     {% endif %}
                   {% endif %}
                </div>
             {% endif %}
@@ -158,15 +171,18 @@
 $(function() {
    $(document).on("click", "#itil-footer .answer-action", function() {
       scrollToTimelineStart();
-
-      // hide answer button after clicking on it
-      $(this).closest(".main-actions").hide();
+      {% if timeline_btn_layout == constant('Config::TIMELINE_ACTION_BTN_MERGED') %}
+         // hide answer button after clicking on it only for merge btn
+         $(this).closest(".main-actions").hide();
+      {% endif %}
    });
 
    // when close button of new answer block is clicked, show again the new answer button
-   $(document).on("click", "#new-itilobject-form .close-itil-answer", function() {
-      $("#itil-footer .main-actions").show();
-   });
+   {% if timeline_btn_layout == constant('Config::TIMELINE_ACTION_BTN_MERGED') %}
+      $(document).on("click", "#new-itilobject-form .close-itil-answer", function() {
+         $("#itil-footer .main-actions").show();
+      });
+   {% endif %}
 
    var scrollToTimelineStart = function() {
         // scroll body to ensure we are at bottom (useful for responsive display)

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -43,7 +43,7 @@
 
 <div class="mx-n2 mb-n2 itil-footer itil-footer p-0 border-top" id="itil-footer">
    <div class="buttons-bar d-flex py-2">
-      <div class="col {{ timeline_btns_cls }} ps-3 timeline-buttons">
+      <div class="col {{ timeline_btns_cls }} ps-3 timeline-buttons d-flex">
          {% if not item.isNewItem() %}
             {% set default_action_data = timeline_itemtypes|first %}
             {% if item.isNotSolved() and default_action_data != false %}

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -54,7 +54,7 @@
                   {# Don't use d-inline-flex class as it add an '!important' tag that mess with our javascript that will hide this div #}
                   <div class="main-actions" style="display:inline-flex">
                {% endif %}
-                  <button class="btn btn-primary answer-action" data-bs-toggle="collapse" data-bs-target="#new-{{ default_action_data.class }}-block">
+                  <button class="btn btn-primary answer-action mb-2" data-bs-toggle="collapse" data-bs-target="#new-{{ default_action_data.class }}-block">
                      <i class="{{ default_action_data.icon }}"></i>
                      <span>{{ default_action_data.label }}</span>
                   </button>
@@ -64,14 +64,14 @@
                      {% if timeline_btn_layout == constant('Config::TIMELINE_ACTION_BTN_SPLITTED') %}
                         {% for action, timeline_itemtype in main_actions_itemtypes %}
                         {% if loop.index0 > 0 %}
-                              <button class="ms-2 btn btn-primary answer-action action-{{ action }}" data-bs-toggle="collapse" data-bs-target="#new-{{ timeline_itemtype.class }}-block">
+                              <button class="ms-2 mb-2 btn btn-primary answer-action action-{{ action }}" data-bs-toggle="collapse" data-bs-target="#new-{{ timeline_itemtype.class }}-block">
                                  <i class="{{ timeline_itemtype.icon }}"></i>
                                  <span>{{ timeline_itemtype.label }}</span>
                               </button>
                               {% endif %}
                         {% endfor %}
                      {% else %}
-                        <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+                        <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split mb-2" data-bs-toggle="dropdown" aria-expanded="false">
                            <span class="visually-hidden">{{ __('View other actions') }}</span>
                         </button>
                         <ul class="dropdown-menu">

--- a/templates/components/itilobject/timeline/filter_timeline.html.twig
+++ b/templates/components/itilobject/timeline/filter_timeline.html.twig
@@ -81,7 +81,7 @@
    }) %}
 {% endif %}
 
-<div class="filter-timeline float-end position-relative">
+<div class="filter-timeline float-end position-relative ms-auto">
    <span data-bs-toggle="tooltip" data-bs-placement="top" title="{{ __('Timeline filter') }}">
       <button type="button"
             class="btn btn-icon btn-ghost-secondary open-timeline-filter-popover"

--- a/templates/components/itilobject/timeline/filter_timeline.html.twig
+++ b/templates/components/itilobject/timeline/filter_timeline.html.twig
@@ -81,7 +81,7 @@
    }) %}
 {% endif %}
 
-<div class="filter-timeline float-end position-relative ms-auto">
+<div class="filter-timeline position-relative ms-auto">
    <span data-bs-toggle="tooltip" data-bs-placement="top" title="{{ __('Timeline filter') }}">
       <button type="button"
             class="btn btn-icon btn-ghost-secondary open-timeline-filter-popover"


### PR DESCRIPTION
Add user pref option to split or not timeline action button.

Standard layout (```merged```)
![image](https://user-images.githubusercontent.com/7335054/207080052-8b6d9d31-36c3-46bf-a852-93ee3a0c8eef.png)

New layout (```splitted```)
![image](https://user-images.githubusercontent.com/7335054/207080176-d22b3559-c37e-4db0-b710-46f5e3dad530.png)

NB : do not hide buttons when form (```task```, ```followup```, ```solution``` ... ) are open

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
