### PR TITLE
Fix reservations date range endpoints comparison in "free period search tool"

### DIFF
--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -635,8 +635,8 @@ class ReservationItem extends CommonDBChild
                         'glpi_reservationitems' => 'id',
                         'glpi_reservations'     => 'reservationitems_id', [
                             'AND' => [
-                                'glpi_reservations.end'    => ['>=', $begin],
-                                'glpi_reservations.begin'  => ['<=', $end]
+                                'glpi_reservations.end'    => ['>', $begin],
+                                'glpi_reservations.begin'  => ['<', $end]
                             ]
                         ]
                     ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | ?
| Fixed tickets | #GH-13548

This PR aims to fix #GH-13548 by simply changing the comparison operators used when comparing date range endpoints of existing reservations .