### PR TITLE
fix(inventory): exclude 0.0.0.0 from management port

### DIFF
--- a/install/migrations/update_10.0.5_to_10.0.6/blacklist.php
+++ b/install/migrations/update_10.0.5_to_10.0.6/blacklist.php
@@ -38,7 +38,7 @@
  * @var Migration $migration
  */
 
-if (countElementsInTable(Blacklist::getTable(), ["type" => blackList::IP, "value" => "::1"]) === 0) {
+if (countElementsInTable(Blacklist::getTable(), ["type" => Blacklist::IP, "value" => "::1"]) === 0) {
     $migration->addPostQuery(
         $DB->buildInsert(
             'glpi_blacklists',

--- a/install/migrations/update_10.0.5_to_10.0.6/blacklist.php
+++ b/install/migrations/update_10.0.5_to_10.0.6/blacklist.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2022 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+if (countElementsInTable(Blacklist::getTable(), ["type" => blackList::IP, "value" => "::1"]) === 0) {
+    $migration->addPostQuery(
+        $DB->buildInsert(
+            'glpi_blacklists',
+            [
+                'name'      => 'IPV6 localhost',
+                'value' => '::1',
+                'type' => Blacklist::IP,
+            ]
+        )
+    );
+}

--- a/src/Blacklist.php
+++ b/src/Blacklist.php
@@ -467,6 +467,9 @@ class Blacklist extends CommonDropdown
             ], [
                 'name' => 'localhost',
                 'value' => '127.0.0.1'
+            ], [
+                'name' => 'IPV6 localhost',
+                'value' => '::1'
             ]
         ];
 

--- a/src/Inventory/Asset/NetworkEquipment.php
+++ b/src/Inventory/Asset/NetworkEquipment.php
@@ -37,7 +37,6 @@
 namespace Glpi\Inventory\Asset;
 
 use Blacklist;
-use BlacklistedMailContent;
 use Glpi\Toolbox\Sanitizer;
 use NetworkEquipmentModel;
 use NetworkEquipmentType;

--- a/src/Inventory/Asset/NetworkEquipment.php
+++ b/src/Inventory/Asset/NetworkEquipment.php
@@ -115,9 +115,7 @@ class NetworkEquipment extends MainAsset
                //add internal port(s)
                 foreach ($device->ips as $ip) {
                     if (
-                        $ip != '127.0.0.1'
-                        && $ip != '::1'
-                        && !in_array($ip, $port->ipaddress)
+                        !in_array($ip, $port->ipaddress)
                         && '' != $blacklist->process(Blacklist::IP, $ip)
                     ) {
                         $port->ipaddress[] = $ip;

--- a/src/Inventory/Asset/NetworkEquipment.php
+++ b/src/Inventory/Asset/NetworkEquipment.php
@@ -36,6 +36,8 @@
 
 namespace Glpi\Inventory\Asset;
 
+use Blacklist;
+use BlacklistedMailContent;
 use Glpi\Toolbox\Sanitizer;
 use NetworkEquipmentModel;
 use NetworkEquipmentType;
@@ -68,6 +70,7 @@ class NetworkEquipment extends MainAsset
         $val = $this->data[0];
         $model_field = $this->getModelsFieldName();
         $types_field = $this->getTypesFieldName();
+        $blacklist = new Blacklist();
 
         if (isset($this->extra_data['network_device'])) {
             $device = (object)$this->extra_data['network_device'];
@@ -111,7 +114,12 @@ class NetworkEquipment extends MainAsset
 
                //add internal port(s)
                 foreach ($device->ips as $ip) {
-                    if ($ip != '127.0.0.1' && $ip != '0.0.0.0' && $ip != '::1' && !in_array($ip, $port->ipaddress)) {
+                    if (
+                        $ip != '127.0.0.1'
+                        && $ip != '::1'
+                        && !in_array($ip, $port->ipaddress)
+                        && '' != $blacklist->process(Blacklist::IP, $ip)
+                    ) {
                         $port->ipaddress[] = $ip;
                     }
                 }

--- a/src/Inventory/Asset/NetworkEquipment.php
+++ b/src/Inventory/Asset/NetworkEquipment.php
@@ -111,7 +111,7 @@ class NetworkEquipment extends MainAsset
 
                //add internal port(s)
                 foreach ($device->ips as $ip) {
-                    if ($ip != '127.0.0.1' && $ip != '::1' && !in_array($ip, $port->ipaddress)) {
+                    if ($ip != '127.0.0.1' && $ip != '0.0.0.0' && $ip != '::1' && !in_array($ip, $port->ipaddress)) {
                         $port->ipaddress[] = $ip;
                     }
                 }

--- a/tests/functionnal/Blacklist.php
+++ b/tests/functionnal/Blacklist.php
@@ -51,7 +51,7 @@ class Blacklist extends DbTestCase
             \Blacklist::MAC => 19,
             \Blacklist::MODEL => 7,
             \Blacklist::MANUFACTURER => 1,
-            \Blacklist::IP => 3
+            \Blacklist::IP => 4
         ];
         $this->array(array_keys($defaults))->isIdenticalTo(array_keys($expecteds));
 
@@ -90,6 +90,12 @@ class Blacklist extends DbTestCase
             ], [
                 'input'    => ['name' => 'My name', 'serial' => 'XYZ01'],
                 'expected' => ['name' => 'My name', 'serial' => 'XYZ01']
+            ], [
+                'input'    => ['name' => 'My name', 'ip' => '::1'],
+                'expected' => ['name' => 'My name']
+            ], [
+                'input'    => ['name' => 'My name', 'ip' => '127.0.0.1'],
+                'expected' => ['name' => 'My name']
             ]
         ];
     }

--- a/tests/functionnal/Blacklist.php
+++ b/tests/functionnal/Blacklist.php
@@ -96,6 +96,9 @@ class Blacklist extends DbTestCase
             ], [
                 'input'    => ['name' => 'My name', 'ip' => '127.0.0.1'],
                 'expected' => ['name' => 'My name']
+            ], [
+                'input'    => ['name' => 'My name', 'ip' => '0.0.0.0'],
+                'expected' => ['name' => 'My name']
             ]
         ];
     }

--- a/tests/functionnal/Glpi/Inventory/Assets/Printer.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Printer.php
@@ -1461,7 +1461,86 @@ class Printer extends AbstractInventoryAsset
          */
         $date_now = date('Y-m-d H:i:s');
         $_SESSION['glpi_currenttime'] = $date_now;
-        $json_str = file_get_contents(self::INV_FIXTURES . 'printer_4.json');
+        $json_str = '{
+          "content": {
+              "cartridges": [
+                  {
+                      "tonerblack": "71"
+                  }
+              ],
+              "firmwares": [
+                  {
+                      "date": "2019-09-16",
+                      "description": "device firmware",
+                      "manufacturer": "Hewlett-Packard",
+                      "name": "CANON MP5353",
+                      "type": "device",
+                      "version": "2409048_052887"
+                  }
+              ],
+              "network_device": {
+                  "firmware": "2409048_052887",
+                  "ips": [
+                       "10.59.29.208",
+                       "0.0.0.0",
+                       "127.0.0.1"
+                  ],
+                  "mac": "00:68:eb:f2:be:10",
+                  "manufacturer": "Hewlett-Packard",
+                  "model": "CANON MP5353",
+                  "name": "NPIF2BE10",
+                  "ram": 512,
+                  "serial": "PHCVN191TG",
+                  "type": "Printer",
+                  "uptime": "7 days, 01:26:41.98",
+                  "credentials": 4
+              },
+              "pagecounters": {
+                  "rectoverso": 831,
+                  "total": 1802
+              },
+              "network_ports": [
+                  {
+                      "ifdescr": "CANON MP5353",
+                      "ifinerrors": 0,
+                      "ifinbytes": 0,
+                      "ifinternalstatus": 1,
+                      "iflastchange": "0.00 seconds",
+                      "ifmtu": 1536,
+                      "ifname": "CANON MP5353",
+                      "ifnumber": 1,
+                      "ifouterrors": 0,
+                      "ifoutbytes": 0,
+                      "ifspeed": 0,
+                      "ifstatus": 1,
+                      "iftype": 24
+                  },
+                  {
+                      "ifdescr": "CANON MP5353",
+                      "ifinerrors": 0,
+                      "ifinbytes": 68906858,
+                      "ifinternalstatus": 1,
+                      "iflastchange": "0.00 seconds",
+                      "ifmtu": 1500,
+                      "ifname": "CANON MP5353",
+                      "ifnumber": 2,
+                      "ifouterrors": 0,
+                      "ifoutbytes": 514488,
+                      "ifspeed": 1000000000,
+                      "ifstatus": 1,
+                      "iftype": 6,
+                      "ips": [
+                          "10.59.29.175"
+                      ],
+                      "mac": "00:68:eb:f2:be:10"
+                  }
+              ],
+              "versionclient": "missing"
+          },
+          "action": "netinventory",
+          "deviceid": "NPIF2BE10-2020-12-31-11-28-51",
+          "itemtype": "Printer"
+       }';
 
         $json = json_decode($json_str);
 

--- a/tests/functionnal/Glpi/Inventory/Assets/Printer.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Printer.php
@@ -1453,4 +1453,87 @@ class Printer extends AbstractInventoryAsset
         $this->boolean($printer->getFromDB($printer->fields['id']))->isTrue();
         $this->string($printer->fields['name'])->isIdenticalTo($new_name);
     }
+
+    public function testSnmpPrinterManagementPortCleaned()
+    {
+        /**
+         * This check if management port is well cleaned
+         */
+        $date_now = date('Y-m-d H:i:s');
+        $_SESSION['glpi_currenttime'] = $date_now;
+        $json_str = file_get_contents(self::INV_FIXTURES . 'printer_4.json');
+
+        $json = json_decode($json_str);
+
+        $printer = new \Printer();
+
+        $data = (array)$json->content;
+        $inventory = new \Glpi\Inventory\Inventory();
+        $this->boolean($inventory->setData($json))->isTrue();
+
+        $agent = new \Agent();
+        $this->integer($agent->handleAgent($inventory->extractMetadata()))->isIdenticalTo(0);
+
+        $main = new \Glpi\Inventory\Asset\Printer($printer, $json);
+        $main->setAgent($agent)->setExtraData($data);
+        $main->checkConf(new \Glpi\Inventory\Conf());
+        $result = $main->prepare();
+        $this->array($result)->hasSize(1);
+        $this->array((array)$result[0])->isIdenticalTo([
+            'autoupdatesystems_id' => 'GLPI Native Inventory',
+            'last_inventory_update' => $date_now,
+            "is_deleted" => 0,
+            'firmware' => '2409048_052887',
+            'ips' => ['10.59.29.208', '0.0.0.0', '127.0.0.1'],
+            'mac' => '00:68:eb:f2:be:10',
+            'manufacturer' => 'Hewlett-Packard',
+            'model' => 'CANON MP5353',
+            'name' => 'NPIF2BE10',
+            'serial' => 'PHCVN191TG',
+            'type' => 'Printer',
+            'uptime' => '7 days, 01:26:41.98',
+            'printermodels_id' => 'CANON MP5353',
+            'printertypes_id' => 'Printer',
+            'manufacturers_id' => 'Hewlett-Packard',
+            'snmpcredentials_id' => 4,
+            'have_usb' => 0,
+            'have_ethernet' => 1,
+            'memory_size' => 512,
+            'last_pages_counter' => 1802
+        ]);
+
+        //get no management port
+        $this->array($main->getManagementPorts())->hasSize(1);
+
+        //do real inventory to check dataDB
+        $json_str = file_get_contents(self::INV_FIXTURES . 'printer_4.json');
+        $json = json_decode($json_str);
+        $this->doInventory($json);
+
+        $printer = new \Printer();
+        $this->boolean($printer->getFromDbByCrit(['name' => 'NPIF2BE10', 'serial' => 'PHCVN191TG']))->isTrue();
+
+        //1 NetworkPort
+        $np = new \NetworkPort();
+        $this->integer(
+            countElementsInTable(
+                $np::getTable(),
+                [['itemtype' => 'Printer', 'items_id' => $printer->fields['id'] , 'instantiation_type' => 'NetworkPortEthernet']]
+            )
+        )->isIdenticalTo(1);
+
+        //1 NetworkPortAggregate
+        $this->boolean($np->getFromDbByCrit(['itemtype' => 'Printer', 'items_id' => $printer->fields['id'] , 'instantiation_type' => 'NetworkPortAggregate']))->isTrue();
+
+        //1 NetworkName form NetworkPortAggregate
+        $nm = new \NetworkName();
+        $this->boolean($nm->getFromDbByCrit(["itemtype" => "NetworkPort", "items_id" => $np->fields['id']]))->isTrue();
+
+        //1 IPAdress form NetworkName
+        $ip = new \IPAddress();
+        $this->boolean($ip->getFromDbByCrit(["name" => "10.59.29.208", "itemtype" => "NetworkName", "items_id" => $nm->fields['id']]))->isTrue();
+
+        //remove printer for other test
+        $printer->delete($printer->fields);
+    }
 }

--- a/tests/functionnal/Glpi/Inventory/Assets/Printer.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Printer.php
@@ -1585,7 +1585,6 @@ class Printer extends AbstractInventoryAsset
         $this->array($main->getManagementPorts())->hasSize(1);
 
         //do real inventory to check dataDB
-        $json_str = file_get_contents(self::INV_FIXTURES . 'printer_4.json');
         $json = json_decode($json_str);
         $this->doInventory($json);
 


### PR DESCRIPTION
Alternative to https://github.com/glpi-project/glpi/pull/13591

Exclude ```0.0.0.0``` from ``` management port```


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/glpi-project/glpi/issues/13523#issuecomment-1347896226
