### PR TITLE
enhance the entity name when selecting all

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -413,7 +413,7 @@ class Session
                 $active
             );
             $_SESSION["glpiactive_entity_shortname"] = getTreeLeafValueName("glpi_entities", $active);
-            if ($is_recursive || $ID == "all") {
+            if ($is_recursive) {
                 //TRANS: %s is the entity name
                 $_SESSION["glpiactive_entity_name"]      = sprintf(
                     __('%1$s (%2$s)'),
@@ -425,6 +425,18 @@ class Session
                      $_SESSION["glpiactive_entity_shortname"],
                      __('tree structure')
                  );
+            } elseif ($ID == "all") {
+                //TRANS: %s is the entity name
+                $_SESSION["glpiactive_entity_name"]      = sprintf(
+                    __('%1$s (%2$s)'),
+                    $_SESSION["glpiactive_entity_name"],
+                    __('full structure')
+                );
+                $_SESSION["glpiactive_entity_shortname"] = sprintf(
+                    __('%1$s (%2$s)'),
+                    $_SESSION["glpiactive_entity_shortname"],
+                    __('full structure')
+                );
             }
 
             if (countElementsInTable('glpi_entities') <= count($_SESSION['glpiactiveentities'])) {


### PR DESCRIPTION
When selecting the active entities, the title is the same if you display all or the 1st entity in tree structure.

Example with this structure:

![image](https://user-images.githubusercontent.com/8530352/207373131-ae115bf8-4231-4f0d-901e-8aa60bf55b19.png)

If we choose "select all" or "entity1" in recursive, we display `Root entity > entity1 (tree structure)` 

Before (both case):
![image](https://user-images.githubusercontent.com/8530352/207375138-a86e586b-8cbb-4b88-a8e3-3bd221f56527.png)

After ("select all" case):
![image](https://user-images.githubusercontent.com/8530352/207374598-f16cd607-16c8-4c55-b7cd-a42fc9ed2056.png)

After ("entity1" case):
![image](https://user-images.githubusercontent.com/8530352/207375328-0fc0b432-1603-462a-84bc-ac50297324a4.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25861
