### PR TITLE
Fix lost token info after autocomplete transform

### DIFF
--- a/js/modules/SearchTokenizer/SearchInput.js
+++ b/js/modules/SearchTokenizer/SearchInput.js
@@ -214,7 +214,9 @@ export default class SearchInput {
 
         input.on('blur', '.search-input-tag-input', (e) => {
             const tag_input = $(e.target).closest('.search-input-tag-input');
-            this.tagifyInputNode(tag_input);
+            if (tag_input.length > 0 && tag_input.text().trim().length > 0) {
+                this.tagifyInputNode(tag_input);
+            }
         });
 
         input.on('keydown', '.search-input-tag-input', (e) => {
@@ -475,7 +477,9 @@ export default class SearchInput {
                 const term_text = $(`<span>${last_token.term}</span>`).text();
                 if (autocomplete_value.localeCompare(term_text, undefined, { sensitivity: 'accent' }) === 0) {
                     last_token.term = t;
-                    node.replaceWith($(this.tokenToTagHtml(last_token)));
+                    const replacement = $(this.tokenToTagHtml(last_token));
+                    replacement.data('token', last_token);
+                    node.replaceWith(replacement);
                 }
             });
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13593

Token data attribute was lost after handling term transformation from the autocomplete data which broke any Kanban filter that used auto-suggested terms (like the types for Project Kanban).

This PR also adds a check to prevent trying to transform empty input into a tag which could trigger unnecessary tokenization and result change checks.