### PR TITLE
Fix auth label for mail accounts

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -1170,7 +1170,7 @@ class Auth extends CommonGLPI
                 $auth = new AuthMail();
                 if ($auth->getFromDB($auths_id)) {
                     //TRANS: %1$s is the auth method type, %2$s the auth method name or link
-                    return sprintf(__('%1$s: %2$s'), AuthLDAP::getTypeName(1), $auth->getLink());
+                    return sprintf(__('%1$s: %2$s'), AuthMail::getTypeName(1), $auth->getLink());
                 }
                 return sprintf(__('%1$s: %2$s'), __('Email server'), $name);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Accounts from mail servers shows "LDAP directory: " under the authentication info block in their form instead of "Mail server: ".