### PR TITLE
fix(snmp): do not delete management port each time

### DIFF
--- a/src/Inventory/Asset/InventoryNetworkPort.php
+++ b/src/Inventory/Asset/InventoryNetworkPort.php
@@ -115,10 +115,12 @@ trait InventoryNetworkPort
         if (!$this->isMainPartial()) {
             $this->cleanUnmanageds();
         }
+
+        $this->handleDeletesManagementPorts();
         $this->handleIpNetworks();
         $this->handleUpdates();
         $this->handleCreates();
-        $this->handleDeletesManagementPorts();
+
         if (method_exists($this, 'handleAggregations')) {
             $this->handleAggregations();
         }

--- a/src/Inventory/Asset/Printer.php
+++ b/src/Inventory/Asset/Printer.php
@@ -36,6 +36,7 @@
 
 namespace Glpi\Inventory\Asset;
 
+use Blacklist;
 use CommonDBTM;
 use Glpi\Toolbox\Sanitizer;
 use IPAddress;
@@ -365,20 +366,25 @@ class Printer extends NetworkEquipment
      */
     public static function needToBeUpdatedFromDiscovery(CommonDBTM $item, $val)
     {
-        if (property_exists($val, 'ips') && isset($val->ips[0])) {
-            $ip = $val->ips[0];
-            //try to find IP (get from discovery) from known IP of Printer
-            //if found refuse update
-            //if no, printer IP have changed so  we allow the update from discovery
-            $ipadress = new IPAddress($ip);
-            $tmp['mainitems_id'] = $item->fields['id'];
-            $tmp['mainitemtype'] = $item::getType();
-            $tmp['is_dynamic']   = 1;
-            $tmp['name']         = $ipadress->getTextual();
-            if ($ipadress->getFromDBByCrit(Sanitizer::sanitize($tmp))) {
-                return false;
+        if (property_exists($val, 'ips')) {
+            foreach ($val->ips as $ip) {
+                $blacklist = new Blacklist();
+                //exclude IP if needed
+                if ('' != $blacklist->process(Blacklist::IP, $ip)) {
+                    //try to find IP (get from discovery) from known IP of Printer
+                    //if found refuse update
+                    //if no, printer IP have changed so  we allow the update from discovery
+                    $ipadress = new IPAddress($ip);
+                    $tmp['mainitems_id'] = $item->fields['id'];
+                    $tmp['mainitemtype'] = $item::getType();
+                    $tmp['is_dynamic']   = 1;
+                    $tmp['name']         = $ipadress->getTextual();
+                    if ($ipadress->getFromDBByCrit(Sanitizer::sanitize($tmp))) {
+                        return false;
+                    }
+                    return true;
+                }
             }
-            return true;
         }
         return false;
     }

--- a/tests/functionnal/Glpi/Inventory/Assets/Printer.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Printer.php
@@ -1655,7 +1655,21 @@ class Printer extends AbstractInventoryAsset
         </REQUEST>';
 
 
-        $this->doInventory($xml_source, true);
+
+        $converter = new \Glpi\Inventory\Converter();
+        $source = json_decode($converter->convert($xml_source));
+        $inventory = new \Glpi\Inventory\Inventory($source);
+
+        if ($inventory->inError()) {
+            $this->dump($inventory->getErrors());
+        }
+        $this->boolean($inventory->inError())->isFalse();
+        $this->array($inventory->getErrors())->isEmpty();
+
+        //do a discovery
+        $inventory->setDiscovery(true);
+        $inventory->doInventory($xml_source, true);
+
 
         $printer = new \Printer();
         $this->boolean($printer->getFromDbByCrit(['name' => 'CLPSF99', 'serial' => 'E1234567890']))->isTrue();
@@ -1665,8 +1679,9 @@ class Printer extends AbstractInventoryAsset
         $this->boolean($np_aggregate->getFromDbByCrit(['itemtype' => 'Printer', 'items_id' => $printer->fields['id'] , 'instantiation_type' => 'NetworkPortAggregate']))->isTrue();
 
 
-        //redo an inventory
-        $this->doInventory($xml_source, true);
+        //redo a discovery
+        $inventory->setDiscovery(true);
+        $inventory->doInventory($xml_source, true);
 
         $printer = new \Printer();
         $this->boolean($printer->getFromDbByCrit(['name' => 'CLPSF99', 'serial' => 'E1234567890']))->isTrue();
@@ -1677,6 +1692,137 @@ class Printer extends AbstractInventoryAsset
 
 
         $this->integer($np_aggregate->fields['id'])->isEqualTo($np_aggregate_after_reimport->fields['id']);
+
+        $xml_network_inventory = '<?xml version="1.0" encoding="UTF-8"?>
+        <REQUEST>
+          <CONTENT>
+            <DEVICE>
+              <CARTRIDGES>
+                <TONERBLACK>20</TONERBLACK>
+                <TONERCYAN>20</TONERCYAN>
+                <TONERMAGENTA>40</TONERMAGENTA>
+                <TONERYELLOW>20</TONERYELLOW>
+                <WASTETONER>100</WASTETONER>
+              </CARTRIDGES>
+              <INFO>
+                <COMMENTS>RICOH MP C5503 1.38 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</COMMENTS>
+                <ID>1</ID>
+                <IPS>
+                  <IP>0.0.0.0</IP>
+                  <IP>10.100.51.207</IP>
+                  <IP>127.0.0.1</IP>
+                </IPS>
+                <LOCATION>Location</LOCATION>
+                <MAC>00:26:73:12:34:56</MAC>
+                <MANUFACTURER>Ricoh</MANUFACTURER>
+                <MEMORY>1</MEMORY>
+                <MODEL>MP C5503</MODEL>
+                <NAME>CLPSF99</NAME>
+                <RAM>1973</RAM>
+                <SERIAL>E1234567890</SERIAL>
+                <TYPE>PRINTER</TYPE>
+                <UPTIME>33 days, 22:19:01.00</UPTIME>
+              </INFO>
+              <PAGECOUNTERS>
+                <TOTAL>1164615</TOTAL>
+              </PAGECOUNTERS>
+              <PORTS>
+                <PORT>
+                  <IFDESCR>ncmac0</IFDESCR>
+                  <IFINERRORS>0</IFINERRORS>
+                  <IFINOCTETS>2656604236</IFINOCTETS>
+                  <IFINTERNALSTATUS>1</IFINTERNALSTATUS>
+                  <IFLASTCHANGE>33 days, 22:19:01.00</IFLASTCHANGE>
+                  <IFMTU>1500</IFMTU>
+                  <IFNAME>ncmac0</IFNAME>
+                  <IFNUMBER>1</IFNUMBER>
+                  <IFOUTERRORS>0</IFOUTERRORS>
+                  <IFOUTOCTETS>1271117255</IFOUTOCTETS>
+                  <IFSPEED>100000000</IFSPEED>
+                  <IFSTATUS>1</IFSTATUS>
+                  <IFTYPE>6</IFTYPE>
+                  <IP>10.100.51.207</IP>
+                  <IPS>
+                    <IP>10.100.51.207</IP>
+                  </IPS>
+                  <MAC>00:26:73:12:34:56</MAC>
+                </PORT>
+                <PORT>
+                  <IFDESCR>lo0</IFDESCR>
+                  <IFINERRORS>0</IFINERRORS>
+                  <IFINOCTETS>232223048</IFINOCTETS>
+                  <IFINTERNALSTATUS>1</IFINTERNALSTATUS>
+                  <IFLASTCHANGE>0.00 seconds</IFLASTCHANGE>
+                  <IFMTU>33196</IFMTU>
+                  <IFNAME>lo0</IFNAME>
+                  <IFNUMBER>2</IFNUMBER>
+                  <IFOUTERRORS>0</IFOUTERRORS>
+                  <IFOUTOCTETS>232223048</IFOUTOCTETS>
+                  <IFSPEED>0</IFSPEED>
+                  <IFSTATUS>1</IFSTATUS>
+                  <IFTYPE>24</IFTYPE>
+                  <IP>127.0.0.1</IP>
+                  <IPS>
+                    <IP>127.0.0.1</IP>
+                  </IPS>
+                </PORT>
+                <PORT>
+                  <IFDESCR>ppp0</IFDESCR>
+                  <IFINERRORS>0</IFINERRORS>
+                  <IFINOCTETS>0</IFINOCTETS>
+                  <IFINTERNALSTATUS>2</IFINTERNALSTATUS>
+                  <IFLASTCHANGE>0.00 seconds</IFLASTCHANGE>
+                  <IFMTU>1500</IFMTU>
+                  <IFNAME>ppp0</IFNAME>
+                  <IFNUMBER>3</IFNUMBER>
+                  <IFOUTERRORS>0</IFOUTERRORS>
+                  <IFOUTOCTETS>0</IFOUTOCTETS>
+                  <IFSPEED>0</IFSPEED>
+                  <IFSTATUS>2</IFSTATUS>
+                  <IFTYPE>1</IFTYPE>
+                  <IP>0.0.0.0</IP>
+                  <IPS>
+                    <IP>0.0.0.0</IP>
+                  </IPS>
+                </PORT>
+              </PORTS>
+            </DEVICE>
+            <MODULEVERSION>5.1</MODULEVERSION>
+            <PROCESSNUMBER>7</PROCESSNUMBER>
+          </CONTENT>
+          <DEVICEID>foo</DEVICEID>
+          <QUERY>SNMPQUERY</QUERY>
+        </REQUEST>
+        ';
+
+        //do a network inventory
+        $inventory->setDiscovery(false);
+        $inventory->doInventory($xml_network_inventory, true);
+
+
+        $printer = new \Printer();
+        $this->boolean($printer->getFromDbByCrit(['name' => 'CLPSF99', 'serial' => 'E1234567890']))->isTrue();
+
+        //1 NetworkPortAggregate
+        $np_aggregate_after_networkinventory = new \NetworkPort();
+        $this->boolean($np_aggregate_after_networkinventory->getFromDbByCrit(['itemtype' => 'Printer', 'items_id' => $printer->fields['id'] , 'instantiation_type' => 'NetworkPortAggregate']))->isTrue();
+
+
+        $this->integer($np_aggregate_after_reimport->fields['id'])->isEqualTo($np_aggregate_after_networkinventory->fields['id']);
+
+        //redo an discovery
+        $inventory->setDiscovery(true);
+        $inventory->doInventory($xml_source, true);
+
+        $printer = new \Printer();
+        $this->boolean($printer->getFromDbByCrit(['name' => 'CLPSF99', 'serial' => 'E1234567890']))->isTrue();
+
+        //1 NetworkPortAggregate
+        $np_aggregate_after_reimport = new \NetworkPort();
+        $this->boolean($np_aggregate_after_reimport->getFromDbByCrit(['itemtype' => 'Printer', 'items_id' => $printer->fields['id'] , 'instantiation_type' => 'NetworkPortAggregate']))->isTrue();
+
+
+        $this->integer($np_aggregate_after_reimport->fields['id'])->isEqualTo($np_aggregate_after_reimport->fields['id']);
 
         //remove printer for other test
         $printer->delete($printer->fields);

--- a/tests/functionnal/Glpi/Inventory/Assets/Printer.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Printer.php
@@ -1681,6 +1681,4 @@ class Printer extends AbstractInventoryAsset
         //remove printer for other test
         $printer->delete($printer->fields);
     }
-
-
 }

--- a/tests/functionnal/Glpi/Inventory/Assets/Printer.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Printer.php
@@ -1619,7 +1619,7 @@ class Printer extends AbstractInventoryAsset
     public function testSnmpPrinterManagementPortNotRecreated()
     {
         /**
-         * This check if management port is well cleaned
+         * This check if management port is not recreated at each inventory (network discovery / network inventory)
          */
         $date_now = date('Y-m-d H:i:s');
         $_SESSION['glpi_currenttime'] = $date_now;


### PR DESCRIPTION
Do not delete management port at each inventory

Because ```handleUpdate``` unset management network port after handle it (and ```handleDeletesManagementPorts``` thinks that there is no)

https://github.com/stonebuzz/glpi/blob/88d839ade9f0fc28c0fb6f51d252dd0ad78a0b9f/src/Inventory/Asset/InventoryNetworkPort.php#L370-L380

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |https://github.com/glpi-project/glpi/issues/13609
