### PR TITLE
Dashboards: fix reminders visibility

### DIFF
--- a/src/Dashboard/Provider.php
+++ b/src/Dashboard/Provider.php
@@ -37,6 +37,7 @@ namespace Glpi\Dashboard;
 
 use Change;
 use CommonDBTM;
+use CommonDBVisible;
 use CommonITILActor;
 use CommonITILObject;
 use CommonITILValidation;
@@ -905,8 +906,10 @@ class Provider
                 'SELECT' => "$i_table.*",
                 'FROM'   => $i_table
             ],
-            self::getFiltersCriteria($i_table, $params['apply_filters'])
+            self::getFiltersCriteria($i_table, $params['apply_filters']),
+            $item instanceof CommonDBVisible ? $item::getVisibilityCriteria() : []
         );
+
         $iterator = $DB->request($criteria);
 
         $data = [];


### PR DESCRIPTION
This widget:

![image](https://user-images.githubusercontent.com/42734840/207606375-9e1e9f37-ca43-4213-acba-9583dec00bb3.png)

Is not taking into account visibility criteria defined for the reminders.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25922
