### PR TITLE
fix(task template): user missing when dropdown_max too small

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -3897,30 +3897,32 @@ JAVASCRIPT;
         }
 
         if (isset($post['_one_id']) && $post['_one_id'] > 0) {
-            $post['page_limit'] = -1;
-        }
+            $user = new User();
+            $user->getFromDB($post['_one_id']);
+            $result = [$user->fields];
+        } else {
+            $entity_restrict = -1;
+            if (isset($post['entity_restrict'])) {
+                $entity_restrict = Toolbox::jsonDecode($post['entity_restrict']);
+            }
 
-        $entity_restrict = -1;
-        if (isset($post['entity_restrict'])) {
-            $entity_restrict = Toolbox::jsonDecode($post['entity_restrict']);
+            $start  = intval(($post['page'] - 1) * $post['page_limit']);
+            $searchText = (isset($post['searchText']) ? $post['searchText'] : null);
+            $inactive_deleted = isset($post['inactive_deleted']) ? $post['inactive_deleted'] : 0;
+            $with_no_right = isset($post['with_no_right']) ? $post['with_no_right'] : 0;
+            $result = User::getSqlSearchResult(
+                false,
+                $post['right'],
+                $entity_restrict,
+                $post['value'],
+                $used,
+                $searchText,
+                $start,
+                (int)$post['page_limit'],
+                $inactive_deleted,
+                $with_no_right
+            );
         }
-
-        $start  = intval(($post['page'] - 1) * $post['page_limit']);
-        $searchText = (isset($post['searchText']) ? $post['searchText'] : null);
-        $inactive_deleted = isset($post['inactive_deleted']) ? $post['inactive_deleted'] : 0;
-        $with_no_right = isset($post['with_no_right']) ? $post['with_no_right'] : 0;
-        $result = User::getSqlSearchResult(
-            false,
-            $post['right'],
-            $entity_restrict,
-            $post['value'],
-            $used,
-            $searchText,
-            $start,
-            (int)$post['page_limit'],
-            $inactive_deleted,
-            $with_no_right
-        );
 
         $users = [];
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -3896,7 +3896,7 @@ JAVASCRIPT;
             $post['page_limit'] = $CFG_GLPI['dropdown_max'];
         }
 
-        if (isset($post['_one_id'])) {
+        if (isset($post['_one_id']) && $post['_one_id'] > 0) {
             $post['page_limit'] = -1;
         }
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -3896,6 +3896,10 @@ JAVASCRIPT;
             $post['page_limit'] = $CFG_GLPI['dropdown_max'];
         }
 
+        if (isset($post['_one_id'])) {
+            $post['page_limit'] = -1;
+        }
+
         $entity_restrict = -1;
         if (isset($post['entity_restrict'])) {
             $entity_restrict = Toolbox::jsonDecode($post['entity_restrict']);


### PR DESCRIPTION
When loading a task template with a user value, if the user is, for example, 20th in the list and the `Page size for dropdown (paging using scroll)` parameter is 10. The user's value was not changed.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25874
