### PR TITLE
Enable multi-entity mode immediately after creating entity

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -563,6 +563,8 @@ class Entity extends CommonTreeDropdown
        // Add right to current user - Hack to avoid login/logout
         $_SESSION['glpiactiveentities'][$this->fields['id']] = $this->fields['id'];
         $_SESSION['glpiactiveentities_string']              .= ",'" . $this->fields['id'] . "'";
+        // Root entity cannot be deleted, so if we added an entity this means GLPI is now multi-entity
+        $_SESSION['glpi_multientitiesmode'] = 1;
 
        // clean entity tree cache
         $this->cleanEntitySelectorCache();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Related #13541

After creating a new entity, it is added to your active entitiies in the session variable as a workaround to prevent needing to log out and back in, but the multi-entity mode flag is not changed/enforced.