### PR TITLE
fix(notification): prevent twice notification on close

### DIFF
--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -253,7 +253,9 @@ class ITILFollowup extends CommonDBChild
 
         $this->updateParentStatus($this->input['_job'], $this->input);
 
-        $donotif = !isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"];
+        $donotif = !isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"]
+        //skip the notification if it comes from the solution approval
+        && (!isset($this->input['_close']) || !$this->input['_close'] );
 
         if ($donotif) {
             $options = ['followup_id' => $this->fields["id"],


### PR DESCRIPTION

prevent twice notification on close :

Actually GLPI send two notifications on closing ```CommonITILObject```
- one for followup added
- one for closed status 

skip ```add_followup``` when the ```_close``` (added from ```prepareInputForAdd```) ```key``` is found

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Internal ref !25923
