### PR TITLE
Fix duplicate entry issues on migration

### DIFF
--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -1072,41 +1072,38 @@ class Migration extends \GLPITestCase
         $DB = $this->db;
 
         $this->calling($this->db)->request = function ($request) {
-            if (!isset($request['FROM'])) {
-                  return new \ArrayIterator([]);
+            if (isset($request['INNER JOIN'])) {
+                $result = [];
+                if ($request['INNER JOIN'][\DisplayPreference::getTable() . ' AS old']['ON'][0]['AND']['new.itemtype'] === 'Printer') {
+                    // Simulate duplicated search options on 'Printer'
+                    $result = [
+                        [
+                            'id' => 12,
+                        ],
+                        [
+                            'id' => 156,
+                        ],
+                        [
+                            'id' => 421,
+                        ]
+                    ];
+                }
+                return new \ArrayIterator($result);
             }
-            if ($request['FROM'] === \DisplayPreference::getTable()) {
-                 return new \ArrayIterator([
-                     [
-                         'id'        => 0,
-                         'itemtype'  => 'Computer',
-                         'num'       => 40,
-                     ],
-                     [
-                         'id'        => 1,
-                         'itemtype'  => 'Computer',
-                         'num'       => 41,
-                     ],
-                     [
-                         'id'        => 2,
-                         'itemtype'  => 'Monitor',
-                         'num'       => 40,
-                     ]
-                 ]);
-            } else if ($request['FROM'] === \SavedSearch::getTable()) {
+            if ($request['FROM'] === \SavedSearch::getTable()) {
                 return new \ArrayIterator([
                     [
-                        'id'        => 0,
+                        'id'        => 1,
                         'itemtype'  => 'Computer',
                         'query'     => 'is_deleted=0&as_map=0&criteria%5B0%5D%5Blink%5D=AND&criteria%5B0%5D%5Bfield%5D=40&criteria%5B0%5D%5Bsearchtype%5D=contains&criteria%5B0%5D%5Bvalue%5D=LT1&criteria%5B1%5D%5Blink%5D=AND&criteria%5B1%5D%5Bitemtype%5D=Budget&criteria%5B1%5D%5Bmeta%5D=1&criteria%5B1%5D%5Bfield%5D=4&criteria%5B1%5D%5Bsearchtype%5D=contains&criteria%5B1%5D%5Bvalue%5D=&search=Search&itemtype=Computer'
                     ],
                     [
-                        'id'        => 1,
+                        'id'        => 2,
                         'itemtype'  => 'Budget',
                         'query'     => 'is_deleted=0&as_map=0&criteria%5B0%5D%5Blink%5D=AND&criteria%5B0%5D%5Bfield%5D=40&criteria%5B0%5D%5Bsearchtype%5D=contains&criteria%5B0%5D%5Bvalue%5D=LT1&criteria%5B1%5D%5Blink%5D=AND&criteria%5B1%5D%5Bitemtype%5D=Computer&criteria%5B1%5D%5Bmeta%5D=1&criteria%5B1%5D%5Bfield%5D=40&criteria%5B1%5D%5Bsearchtype%5D=contains&criteria%5B1%5D%5Bvalue%5D=&search=Search&itemtype=Computer'
                     ],
                     [
-                        'id'        => 2,
+                        'id'        => 3,
                         'itemtype'  => 'Monitor',
                         'query'     => 'is_deleted=0&as_map=0&criteria%5B0%5D%5Blink%5D=AND&criteria%5B0%5D%5Bfield%5D=40&criteria%5B0%5D%5Bsearchtype%5D=contains&criteria%5B0%5D%5Bvalue%5D=LT1&criteria%5B1%5D%5Blink%5D=AND&criteria%5B1%5D%5Bitemtype%5D=Budget&criteria%5B1%5D%5Bmeta%5D=1&criteria%5B1%5D%5Bfield%5D=40&criteria%5B1%5D%5Bsearchtype%5D=contains&criteria%5B1%5D%5Bvalue%5D=&search=Search&itemtype=Monitor'
                     ]
@@ -1116,6 +1113,7 @@ class Migration extends \GLPITestCase
         };
 
         $this->migration->changeSearchOption('Computer', 40, 100);
+        $this->migration->changeSearchOption('Printer', 20, 10);
 
         $this->output(
             function () {
@@ -1125,8 +1123,10 @@ class Migration extends \GLPITestCase
 
         $this->array($this->queries)->isIdenticalTo([
             "UPDATE `glpi_displaypreferences` SET `num` = '100' WHERE `itemtype` = 'Computer' AND `num` = '40'",
-            "UPDATE `glpi_savedsearches` SET `query` = 'is_deleted=0&as_map=0&criteria%5B0%5D%5Blink%5D=AND&criteria%5B0%5D%5Bfield%5D=100&criteria%5B0%5D%5Bsearchtype%5D=contains&criteria%5B0%5D%5Bvalue%5D=LT1&criteria%5B1%5D%5Blink%5D=AND&criteria%5B1%5D%5Bitemtype%5D=Budget&criteria%5B1%5D%5Bmeta%5D=1&criteria%5B1%5D%5Bfield%5D=4&criteria%5B1%5D%5Bsearchtype%5D=contains&criteria%5B1%5D%5Bvalue%5D=&search=Search&itemtype=Computer' WHERE `id` = '0'",
-            "UPDATE `glpi_savedsearches` SET `query` = 'is_deleted=0&as_map=0&criteria%5B0%5D%5Blink%5D=AND&criteria%5B0%5D%5Bfield%5D=40&criteria%5B0%5D%5Bsearchtype%5D=contains&criteria%5B0%5D%5Bvalue%5D=LT1&criteria%5B1%5D%5Blink%5D=AND&criteria%5B1%5D%5Bitemtype%5D=Computer&criteria%5B1%5D%5Bmeta%5D=1&criteria%5B1%5D%5Bfield%5D=100&criteria%5B1%5D%5Bsearchtype%5D=contains&criteria%5B1%5D%5Bvalue%5D=&search=Search&itemtype=Computer' WHERE `id` = '1'",
+            "DELETE `glpi_displaypreferences` FROM `glpi_displaypreferences` WHERE `id` IN ('12', '156', '421')",
+            "UPDATE `glpi_displaypreferences` SET `num` = '10' WHERE `itemtype` = 'Printer' AND `num` = '20'",
+            "UPDATE `glpi_savedsearches` SET `query` = 'is_deleted=0&as_map=0&criteria%5B0%5D%5Blink%5D=AND&criteria%5B0%5D%5Bfield%5D=100&criteria%5B0%5D%5Bsearchtype%5D=contains&criteria%5B0%5D%5Bvalue%5D=LT1&criteria%5B1%5D%5Blink%5D=AND&criteria%5B1%5D%5Bitemtype%5D=Budget&criteria%5B1%5D%5Bmeta%5D=1&criteria%5B1%5D%5Bfield%5D=4&criteria%5B1%5D%5Bsearchtype%5D=contains&criteria%5B1%5D%5Bvalue%5D=&search=Search&itemtype=Computer' WHERE `id` = '1'",
+            "UPDATE `glpi_savedsearches` SET `query` = 'is_deleted=0&as_map=0&criteria%5B0%5D%5Blink%5D=AND&criteria%5B0%5D%5Bfield%5D=40&criteria%5B0%5D%5Bsearchtype%5D=contains&criteria%5B0%5D%5Bvalue%5D=LT1&criteria%5B1%5D%5Blink%5D=AND&criteria%5B1%5D%5Bitemtype%5D=Computer&criteria%5B1%5D%5Bmeta%5D=1&criteria%5B1%5D%5Bfield%5D=100&criteria%5B1%5D%5Bsearchtype%5D=contains&criteria%5B1%5D%5Bvalue%5D=&search=Search&itemtype=Computer' WHERE `id` = '2'",
         ]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13076

During migration, if a search option is changed and if there is search options existing for both old and new SO key, an SQL error will be thrown and migration will be blocked.

This is an edge case than can happen:
 - when multiple migrations are replayed (migration to v0.2 adds the old SO, migration to v0.3 change it to new SO, migration to v0.4 fails, then migration from v0.1 to v0.4 is replayed);
 - when a specific patch or a plugin has previously defined in the past a SO that uses the key of the new SO.