### PR TITLE
Fix ITILSolution timeline hooks

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -6443,7 +6443,8 @@ abstract class CommonITILObject extends CommonDBTM
                     }
                 }
                 break;
-            case 'Solution':
+            case 'Solution': // FIXME Remove it in GLPI 10.1, it may be still used in some edge cases in GLPI 10.0
+            case ITILSolution::class:
                 $pos = self::TIMELINE_RIGHT;
                 break;
         }
@@ -6712,7 +6713,7 @@ abstract class CommonITILObject extends CommonDBTM
         ]);
         foreach ($solution_items as $solution_item) {
             $timeline["ITILSolution_" . $solution_item['id'] ] = [
-                'type'     => 'Solution',
+                'type'     => ITILSolution::class,
                 'itiltype' => 'Solution',
                 'item'     => [
                     'id'                 => $solution_item['id'],

--- a/src/NotificationTargetCommonITILObject.php
+++ b/src/NotificationTargetCommonITILObject.php
@@ -1592,12 +1592,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
             foreach ($timeline as $timeline_data) {
                 $tmptimelineitem = [];
 
-                if ($timeline_data['type'] == "Solution") {
-                    $tmptimelineitem['##timelineitems.type##'] = ITILSolution::getType();
-                } else {
-                    $tmptimelineitem['##timelineitems.type##'] = $timeline_data['type']::getType();
-                }
-
+                $tmptimelineitem['##timelineitems.type##']        = $timeline_data['type']::getType();
                 $tmptimelineitem['##timelineitems.typename##']    = $tmptimelineitem['##timelineitems.type##']::getTypeName(0);
                 $tmptimelineitem['##timelineitems.date##']        = $timeline_data['item']['date'];
                 $tmptimelineitem['##timelineitems.description##'] = $timeline_data['item']['content'];

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -53,11 +53,6 @@
       {% set is_current_user = users_id == session('glpiID') %}
       {% set anonym_user = (get_current_interface() == 'helpdesk' and not is_current_user and entity_config('anonymize_support_agents', session('glpiactive_entity')) != constant('Entity::ANONYMIZE_DISABLED')) %}
 
-      {# Fix solution type #}
-      {% if entry['type'] is same as 'Solution' %}
-         {% set entry = entry|merge({'type': 'ITILSolution'}) %}
-      {% endif %}
-
       {% set can_edit_i  = entry_i['can_edit'] %}
       {% set can_promote = (entry['type'] == 'ITILFollowup' or entry['type'] == 'TicketTask') and can_edit_i and not status_closed %}
       {% set is_promoted = can_promote and entry_i['sourceof_items_id'] > 0 %}

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -1917,7 +1917,7 @@ class Ticket extends DbTestCase
             )->isEqualto(true);
 
             $this->integer(
-                (int)$tkt->getTimelinePosition($tickets_id, 'Solution', $uid)
+                (int)$tkt->getTimelinePosition($tickets_id, 'ITILSolution', $uid)
             )->isEqualTo($user['pos']);
         }
     }
@@ -1988,7 +1988,7 @@ class Ticket extends DbTestCase
                         $this->integer((int)$item['item']['timeline_position'])->isEqualTo(\CommonITILObject::TIMELINE_RIGHT);
                     }
                     break;
-                case 'Solution':
+                case 'ITILSolution':
                     $this->integer((int)$item['item']['timeline_position'])->isEqualTo(\CommonITILObject::TIMELINE_RIGHT);
                     break;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`getTimelineItems()` was returning entries with `type="Solution"` instead of entries with `type="ITILSolution"`. Result was that item passed to `pre|post_item_form` hooks was null, due to the fact that `get_item("Solution", XXX)` was not able to find the `Solution` class.