### PR TITLE
fix(inventory): prevent double 'Dropdown::import()'

### DIFF
--- a/src/Inventory/Asset/Software.php
+++ b/src/Inventory/Asset/Software.php
@@ -72,7 +72,7 @@ class Software extends InventoryAsset
     public function prepare(): array
     {
         $mapping = [
-            'publisher'       => 'manufacturers_id',
+            'publisher'       => 'manufacturer',
             'comments'        => 'comment',
             'install_date'     => 'date_install',
             'system_category' => '_system_category'
@@ -152,39 +152,20 @@ class Software extends InventoryAsset
                     && $val->_system_category != ''
                     && $val->_system_category != '0'
                 ) {
-                    if (!isset($mids[$val->_system_category])) {
-                        $new_value = Dropdown::importExternal(
-                            'SoftwareCategory',
-                            addslashes($val->_system_category),
-                            $this->entities_id
-                        );
-                        $mids[$val->_system_category] = $new_value;
-                    }
-                    $val->softwarecategories_id = $mids[$val->_system_category];
+                    $val->softwarecategories_id = $val->_system_category;
                 } else {
                     $val->softwarecategories_id = 0;
                 }
 
                 //If the manufacturer has been modified or set by the rules engine
                 if (isset($res_rule["manufacturer"])) {
-                    $val->manufacturers_id = Dropdown::import(
-                        'Manufacturer',
-                        ['name' => $res_rule['manufacturer']]
-                    );
+                    $val->manufacturers_id = $res_rule['manufacturer'];
                 } else if (
-                    property_exists($val, 'manufacturers_id')
-                    && $val->manufacturers_id != ''
-                    && $val->manufacturers_id != '0'
+                    property_exists($val, 'manufacturer')
+                    && $val->manufacturer != ''
+                    && $val->manufacturer != '0'
                 ) {
-                    if (!isset($mids[$val->manufacturers_id])) {
-                        $new_value = Dropdown::importExternal(
-                            'Manufacturer',
-                            addslashes($val->manufacturers_id),
-                            $this->entities_id
-                        );
-                        $mids[$val->manufacturers_id] = $new_value;
-                    }
-                    $val->manufacturers_id = $mids[$val->manufacturers_id];
+                    $val->manufacturers_id = $val->manufacturer;
                 } else {
                     $val->manufacturers_id = 0;
                 }


### PR DESCRIPTION
Prevent double ```Dropdown::importExternal()```

Which generates ```Manufacturer``` and ```SoftwareCategory``` with numbers

The first from ```src/Inventry/Asset/Software.php``` (which returns an ID as value)

https://github.com/glpi-project/glpi/blob/56f60f6e62bc9094551a0c469cd104ceeb05011c/src/Inventory/Asset/Software.php#L155-L163

The second from  ```src/Inventry/Asset/Software.php``` (which import ID previously generated)
https://github.com/glpi-project/glpi/blob/56f60f6e62bc9094551a0c469cd104ceeb05011c/src/Inventory/Asset/InventoryAsset.php#L253

N.B:
Sometime a number is added as a ```Manufacturer```
In my case I have memories with a number in the ```MANUFACTURER``` XML node 
this case is therefore legitimate

```xml
    <MEMORIES>
      <CAPACITY>8192</CAPACITY>
      <CAPTION>ChannelA-DIMM0</CAPTION>
      <DESCRIPTION>DIMM</DESCRIPTION>
      <MANUFACTURER>1315</MANUFACTURER>
      <MODEL>BLT8G3D1608DT1TX0.</MODEL>
      <NUMSLOTS>1</NUMSLOTS>
      <SERIALNUMBER>A0154896</SERIALNUMBER>
      <SPEED>1600</SPEED>
      <TYPE>DDR3</TYPE>
    </MEMORIES>
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12933 #13459
