### PR TITLE
Add `stale_agent_config` hook

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -901,7 +901,7 @@ class Agent extends CommonDBTM
                             continue;
                         }
                         // Run the action
-                        if ($action['callback']($agent, $config, $item)) {
+                        if ($action['action_callback']($agent, $config, $item)) {
                             $task->addVolume(1);
                             $total++;
                         } else {

--- a/src/Plugin/Hooks.php
+++ b/src/Plugin/Hooks.php
@@ -131,6 +131,8 @@ class Hooks
     const HANDLE_WAKEONLAN_TASK    = 'handle_wakeonlan_task';
     const HANDLE_REMOTEINV_TASK    = 'handle_remoteinventory_task';
 
+    const STALE_AGENT_CONFIG = 'stale_agent_config';
+
    // Debug / Development hooks
     const DEBUG_TABS = 'debug_tabs';
 

--- a/tests/functionnal/Agent.php
+++ b/tests/functionnal/Agent.php
@@ -474,7 +474,7 @@ class Agent extends DbTestCase
 
         //run crontask
         $task = new \CronTask();
-        $this->boolean(\Agent::cronCleanoldagents($task))->isTrue();
+        $this->integer(\Agent::cronCleanoldagents($task))->isIdenticalTo(1);
 
         //check item has been updated
         $this->boolean($item->getFromDB($item->fields['id']))->isTrue();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Partial backport of #12060.

It introduces a `stale_agent_config` hook that permit to a plugin to register more actions to execute when stale agents are found. See also https://github.com/pluginsGLPI/uninstall/pull/68 .