### PR TITLE
Better handling of numeric attributes of devices

### DIFF
--- a/src/DeviceBattery.php
+++ b/src/DeviceBattery.php
@@ -81,7 +81,7 @@ class DeviceBattery extends CommonDevice
             'table'              => $this->getTable(),
             'field'              => 'capacity',
             'name'               => __('Capacity'),
-            'datatype'           => 'string',
+            'datatype'           => 'integer',
         ];
 
         $tab[] = [
@@ -89,7 +89,7 @@ class DeviceBattery extends CommonDevice
             'table'              => $this->getTable(),
             'field'              => 'voltage',
             'name'               => __('Voltage'),
-            'datatype'           => 'string',
+            'datatype'           => 'integer',
         ];
 
         $tab[] = [

--- a/src/DeviceGraphicCard.php
+++ b/src/DeviceGraphicCard.php
@@ -100,7 +100,7 @@ class DeviceGraphicCard extends CommonDevice
             'table'              => $this->getTable(),
             'field'              => 'memory_default',
             'name'               => __('Memory by default'),
-            'datatype'           => 'string',
+            'datatype'           => 'integer',
         ];
 
         $tab[] = [

--- a/src/DeviceHardDrive.php
+++ b/src/DeviceHardDrive.php
@@ -65,7 +65,7 @@ class DeviceHardDrive extends CommonDevice
                 [
                     'name'  => 'cache',
                     'label' => __('Cache'),
-                    'type'  => 'text',
+                    'type'  => 'integer',
                     'unit'  => __('Mio')
                 ],
                 [
@@ -92,7 +92,7 @@ class DeviceHardDrive extends CommonDevice
             'table'              => $this->getTable(),
             'field'              => 'capacity_default',
             'name'               => __('Capacity by default'),
-            'datatype'           => 'string',
+            'datatype'           => 'integer',
         ];
 
         $tab[] = [
@@ -108,7 +108,7 @@ class DeviceHardDrive extends CommonDevice
             'table'              => $this->getTable(),
             'field'              => 'cache',
             'name'               => __('Cache'),
-            'datatype'           => 'string',
+            'datatype'           => 'integer',
         ];
 
         $tab[] = [

--- a/src/DeviceMemory.php
+++ b/src/DeviceMemory.php
@@ -60,7 +60,8 @@ class DeviceMemory extends CommonDevice
                 [
                     'name'  => 'frequence',
                     'label' => __('Frequency'),
-                    'type'  => 'text',
+                    'type'  => 'integer',
+                    'min'   => 0,
                     'unit'  => __('MHz')
                 ],
                 [
@@ -87,7 +88,7 @@ class DeviceMemory extends CommonDevice
             'table'              => $this->getTable(),
             'field'              => 'size_default',
             'name'               => __('Size by default'),
-            'datatype'           => 'string',
+            'datatype'           => 'integer',
         ];
 
         $tab[] = [
@@ -95,7 +96,7 @@ class DeviceMemory extends CommonDevice
             'table'              => $this->getTable(),
             'field'              => 'frequence',
             'name'               => __('Frequency'),
-            'datatype'           => 'string',
+            'datatype'           => 'integer',
         ];
 
         $tab[] = [

--- a/src/DeviceProcessor.php
+++ b/src/DeviceProcessor.php
@@ -95,7 +95,7 @@ class DeviceProcessor extends CommonDevice
             'table'              => $this->getTable(),
             'field'              => 'frequency_default',
             'name'               => __('Frequency by default'),
-            'datatype'           => 'string',
+            'datatype'           => 'integer',
         ];
 
         $tab[] = [
@@ -103,7 +103,7 @@ class DeviceProcessor extends CommonDevice
             'table'              => $this->getTable(),
             'field'              => 'frequence',
             'name'               => __('Frequency'),
-            'datatype'           => 'string',
+            'datatype'           => 'integer',
         ];
 
         $tab[] = [

--- a/src/DeviceSimcard.php
+++ b/src/DeviceSimcard.php
@@ -79,7 +79,7 @@ class DeviceSimcard extends CommonDevice
             'table'              => $this->getTable(),
             'field'              => 'voltage',
             'name'               => __('Voltage'),
-            'datatype'           => 'string',
+            'datatype'           => 'integer',
         ];
 
         $tab[] = [

--- a/src/Item_DeviceGraphicCard.php
+++ b/src/Item_DeviceGraphicCard.php
@@ -47,15 +47,14 @@ class Item_DeviceGraphicCard extends Item_Devices
     public static function getSpecificities($specif = '')
     {
 
-        return ['memory' => ['long name'  => sprintf(
-            __('%1$s (%2$s)'),
-            _n('Memory', 'Memories', 1),
-            __('Mio')
-        ),
-            'short name' => _n('Memory', 'Memories', 1),
-            'size'       => 10,
-            'id'         => 20,
-        ],
+        return [
+            'memory' => [
+                'long name'  => sprintf(__('%1$s (%2$s)'), _n('Memory', 'Memories', 1), __('Mio')),
+                'short name' => _n('Memory', 'Memories', 1),
+                'size'       => 10,
+                'id'         => 20,
+                'datatype'   => 'integer',
+            ],
             'serial' => parent::getSpecificities('serial'),
             'otherserial' => parent::getSpecificities('otherserial'),
             'locations_id' => parent::getSpecificities('locations_id'),

--- a/src/Item_DeviceHardDrive.php
+++ b/src/Item_DeviceHardDrive.php
@@ -46,15 +46,14 @@ class Item_DeviceHardDrive extends Item_Devices
     public static function getSpecificities($specif = '')
     {
 
-        return ['capacity' => ['long name'  => sprintf(
-            __('%1$s (%2$s)'),
-            __('Capacity'),
-            __('Mio')
-        ),
-            'short name' => __('Capacity'),
-            'size'       => 10,
-            'id'         => 20,
-        ],
+        return [
+            'capacity' => [
+                'long name'  => sprintf(__('%1$s (%2$s)'), __('Capacity'), __('Mio')),
+                'short name' => __('Capacity'),
+                'size'       => 10,
+                'id'         => 20,
+                'datatype'   => 'integer',
+            ],
             'serial'   => parent::getSpecificities('serial'),
             'otherserial' => parent::getSpecificities('otherserial'),
             'locations_id' => parent::getSpecificities('locations_id'),

--- a/src/Item_DeviceMemory.php
+++ b/src/Item_DeviceMemory.php
@@ -52,15 +52,14 @@ class Item_DeviceMemory extends Item_Devices
     public static function getSpecificities($specif = '')
     {
 
-        return ['size'   => ['long name'  => sprintf(
-            __('%1$s (%2$s)'),
-            __('Size'),
-            __('Mio')
-        ),
-            'short name' => __('Size'),
-            'size'       => 10,
-            'id'         => 20,
-        ],
+        return [
+            'size'   => [
+                'long name'  => sprintf(__('%1$s (%2$s)'), __('Size'), __('Mio')),
+                'short name' => __('Size'),
+                'size'       => 10,
+                'id'         => 20,
+                'datatype'   => 'integer',
+            ],
             'serial' => parent::getSpecificities('serial'),
             'otherserial' => parent::getSpecificities('otherserial'),
             'locations_id' => parent::getSpecificities('locations_id'),

--- a/src/Item_DeviceProcessor.php
+++ b/src/Item_DeviceProcessor.php
@@ -47,28 +47,31 @@ class Item_DeviceProcessor extends Item_Devices
     public static function getSpecificities($specif = '')
     {
 
-        return ['frequency' => ['long name'  => sprintf(
-            __('%1$s (%2$s)'),
-            __('Frequency'),
-            __('MHz')
-        ),
-            'short name' => __('Frequency'),
-            'size'       => 10,
-            'id'         => 20,
-        ],
+        return [
+            'frequency' => [
+                'long name'  => sprintf(__('%1$s (%2$s)'), __('Frequency'), __('MHz')),
+                'short name' => __('Frequency'),
+                'size'       => 10,
+                'id'         => 20,
+                'datatype'   => 'integer',
+            ],
             'serial'    => parent::getSpecificities('serial'),
             'otherserial' => parent::getSpecificities('otherserial'),
             'locations_id' => parent::getSpecificities('locations_id'),
             'states_id' => parent::getSpecificities('states_id'),
-            'nbcores'   => ['long name'  => __('Number of cores'),
+            'nbcores'   => [
+                'long name'  => __('Number of cores'),
                 'short name' => __('Cores'),
                 'size'       => 2,
                 'id'         => 21,
+                'datatype'   => 'integer',
             ],
-            'nbthreads' => ['long name' => __('Number of threads'),
+            'nbthreads' => [
+                'long name'  => __('Number of threads'),
                 'short name' => __('Threads'),
                 'size'       => 2,
                 'id'         => 22,
+                'datatype'   => 'integer',
             ],
             'busID'     => parent::getSpecificities('busID')
         ];

--- a/templates/components/form/item_device.html.twig
+++ b/templates/components/form/item_device.html.twig
@@ -122,9 +122,8 @@
                               specificities['label'],
                               specificities['dropdown_options']|merge(field_options)
                            ) }}
-                        {% else %}
-                           {% if specificities['protected'] %}
-                              {{ fields.passwordField(
+                        {% elseif specificities['protected'] %}
+                           {{ fields.passwordField(
                                  specificities['field'],
                                  specificities['value'],
                                  specificities['label'],
@@ -132,15 +131,21 @@
                                     'id': specificities['protected_field_id'],
                                     'is_disclosable': true,
                                  })
-                              ) }}
-                           {% else %}
-                              {{ fields.textField(
+                           ) }}
+                        {% elseif specificities['datatype'] == "integer" %}
+                           {{ fields.numberField(
                                  specificities['field'],
                                  specificities['value'],
                                  specificities['label'],
                                  field_options
-                              ) }}
-                           {% endif %}
+                           ) }}
+                        {% else %}
+                           {{ fields.textField(
+                                 specificities['field'],
+                                 specificities['value'],
+                                 specificities['label'],
+                                 field_options
+                           ) }}
                         {% endif %}
                      {% endif %}
                   {% endfor %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | partially #13633

Use `integer` search option `datatype` to be able to use `>` and `<` operators in search terms and `input type="number"` in form.