### PR TITLE
fix(inventory): prevent double 'Dropdown::import()' 

### DIFF
--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -252,6 +252,7 @@ abstract class InventoryAsset
                         );
                     } else if (isset($foreignkey_itemtype[$key])) {
                         //if SoftwareCategory Or Manufacturer and integer do not process importExternal
+                        //dropdown already handle from Inventory/asset/Software.php
                         if (
                             $foreignkey_itemtype[$key] == SoftwareCategory::class
                             || ($foreignkey_itemtype[$key] == Manufacturer::class && is_int($value->$key))
@@ -263,6 +264,7 @@ abstract class InventoryAsset
                     } else if ($key !== 'entities_id' && $key !== 'states_id' && isForeignKeyField($key) && is_a($itemtype = getItemtypeForForeignKeyField($key), CommonDropdown::class, true)) {
                         $foreignkey_itemtype[$key] = $itemtype;
                         //if SoftwareCategory Or Manufacturer and integer do not process importExternal
+                        //dropdown already handle from Inventory/asset/Software.php
                         if (
                             $foreignkey_itemtype[$key] == SoftwareCategory::class
                             || ($foreignkey_itemtype[$key] == Manufacturer::class && is_int($value->$key))

--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -251,16 +251,22 @@ abstract class InventoryAsset
                             ['manufacturer' => $manufacturer_name]
                         );
                     } else if (isset($foreignkey_itemtype[$key])) {
-                        //if integer, drodpown already import
-                        if ($foreignkey_itemtype[$key] == SoftwareCategory::class || is_int($value->$key)) {
+                        //if SoftwareCategory Or Manufacturer and integer do not process importExternal
+                        if (
+                            $foreignkey_itemtype[$key] == SoftwareCategory::class
+                            || ($foreignkey_itemtype[$key] == Manufacturer::class && is_int($value->$key))
+                        ) {
                             $this->known_links[$known_key] = $value->$key;
                         } else {
                             $this->known_links[$known_key] = Dropdown::importExternal($foreignkey_itemtype[$key], $value->$key, $entities_id);
                         }
                     } else if ($key !== 'entities_id' && $key !== 'states_id' && isForeignKeyField($key) && is_a($itemtype = getItemtypeForForeignKeyField($key), CommonDropdown::class, true)) {
                         $foreignkey_itemtype[$key] = $itemtype;
-                        //if integer, drodpown already import
-                        if ($foreignkey_itemtype[$key] == SoftwareCategory::class || is_int($value->$key)) {
+                        //if SoftwareCategory Or Manufacturer and integer do not process importExternal
+                        if (
+                            $foreignkey_itemtype[$key] == SoftwareCategory::class
+                            || ($foreignkey_itemtype[$key] == Manufacturer::class && is_int($value->$key))
+                        ) {
                             $this->known_links[$known_key] = $value->$key;
                         } else {
                             $this->known_links[$known_key] = Dropdown::importExternal(

--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -47,7 +47,6 @@ use Lockedfield;
 use Manufacturer;
 use OperatingSystemKernelVersion;
 use SoftwareCategory;
-use Toolbox;
 
 abstract class InventoryAsset
 {

--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -250,29 +250,38 @@ abstract class InventoryAsset
                             ['manufacturer' => $manufacturer_name]
                         );
                     } else if (isset($foreignkey_itemtype[$key])) {
-                        $this->known_links[$known_key] = Dropdown::importExternal($foreignkey_itemtype[$key], $value->$key, $entities_id);
+                        //if integer, drodpown already import
+                        if (is_int($value->$key)) {
+                            $this->known_links[$known_key] = $value->$key;
+                        } else {
+                            $this->known_links[$known_key] = Dropdown::importExternal($foreignkey_itemtype[$key], $value->$key, $entities_id);
+                        }
                     } else if ($key !== 'entities_id' && $key !== 'states_id' && isForeignKeyField($key) && is_a($itemtype = getItemtypeForForeignKeyField($key), CommonDropdown::class, true)) {
-                        $foreignkey_itemtype[$key] = $itemtype;
+                        //if integer, drodpown already import
+                        if (is_int($value->$key)) {
+                            $this->known_links[$known_key] = $value->$key;
+                        } else {
+                            $foreignkey_itemtype[$key] = $itemtype;
+                            $this->known_links[$known_key] = Dropdown::importExternal(
+                                $foreignkey_itemtype[$key],
+                                $value->$key,
+                                $entities_id
+                            );
 
-                        $this->known_links[$known_key] = Dropdown::importExternal(
-                            $foreignkey_itemtype[$key],
-                            $value->$key,
-                            $entities_id
-                        );
-
-                        if (
-                            $key == 'operatingsystemkernelversions_id'
-                            && property_exists($value, 'operatingsystemkernels_id')
-                            && (int)$this->known_links[$known_key] > 0
-                        ) {
-                            $kversion = new OperatingSystemKernelVersion();
-                            $kversion->getFromDB($this->known_links[$known_key]);
-                            $oskernels_id = $this->known_links[md5('operatingsystemkernels_id' . $value->operatingsystemkernels_id)];
-                            if ($kversion->fields['operatingsystemkernels_id'] != $oskernels_id) {
-                                $kversion->update([
-                                    'id'                          => $kversion->getID(),
-                                    'operatingsystemkernels_id'   => $oskernels_id
-                                ]);
+                            if (
+                                $key == 'operatingsystemkernelversions_id'
+                                && property_exists($value, 'operatingsystemkernels_id')
+                                && (int)$this->known_links[$known_key] > 0
+                            ) {
+                                $kversion = new OperatingSystemKernelVersion();
+                                $kversion->getFromDB($this->known_links[$known_key]);
+                                $oskernels_id = $this->known_links[md5('operatingsystemkernels_id' . $value->operatingsystemkernels_id)];
+                                if ($kversion->fields['operatingsystemkernels_id'] != $oskernels_id) {
+                                    $kversion->update([
+                                        'id'                          => $kversion->getID(),
+                                        'operatingsystemkernels_id'   => $oskernels_id
+                                    ]);
+                                }
                             }
                         }
                     }

--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -254,8 +254,8 @@ abstract class InventoryAsset
                         //if SoftwareCategory Or Manufacturer and integer do not process importExternal
                         //dropdown already handle from Inventory/asset/Software.php
                         if (
-                            $foreignkey_itemtype[$key] == SoftwareCategory::class
-                            || ($foreignkey_itemtype[$key] == Manufacturer::class && is_int($value->$key))
+                            in_array($foreignkey_itemtype[$key], [Manufacturer::class, SoftwareCategory::class])
+                            && is_int($value->$key)
                         ) {
                             $this->known_links[$known_key] = $value->$key;
                         } else {
@@ -266,8 +266,8 @@ abstract class InventoryAsset
                         //if SoftwareCategory Or Manufacturer and integer do not process importExternal
                         //dropdown already handle from Inventory/asset/Software.php
                         if (
-                            $foreignkey_itemtype[$key] == SoftwareCategory::class
-                            || ($foreignkey_itemtype[$key] == Manufacturer::class && is_int($value->$key))
+                            in_array($foreignkey_itemtype[$key], [Manufacturer::class, SoftwareCategory::class])
+                            && is_int($value->$key)
                         ) {
                             $this->known_links[$known_key] = $value->$key;
                         } else {

--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -46,6 +46,8 @@ use Glpi\Inventory\Request;
 use Lockedfield;
 use Manufacturer;
 use OperatingSystemKernelVersion;
+use SoftwareCategory;
+use Toolbox;
 
 abstract class InventoryAsset
 {
@@ -251,17 +253,17 @@ abstract class InventoryAsset
                         );
                     } else if (isset($foreignkey_itemtype[$key])) {
                         //if integer, drodpown already import
-                        if (is_int($value->$key)) {
+                        if ($foreignkey_itemtype[$key] == SoftwareCategory::class || is_int($value->$key)) {
                             $this->known_links[$known_key] = $value->$key;
                         } else {
                             $this->known_links[$known_key] = Dropdown::importExternal($foreignkey_itemtype[$key], $value->$key, $entities_id);
                         }
                     } else if ($key !== 'entities_id' && $key !== 'states_id' && isForeignKeyField($key) && is_a($itemtype = getItemtypeForForeignKeyField($key), CommonDropdown::class, true)) {
+                        $foreignkey_itemtype[$key] = $itemtype;
                         //if integer, drodpown already import
-                        if (is_int($value->$key)) {
+                        if ($foreignkey_itemtype[$key] == SoftwareCategory::class || is_int($value->$key)) {
                             $this->known_links[$known_key] = $value->$key;
                         } else {
-                            $foreignkey_itemtype[$key] = $itemtype;
                             $this->known_links[$known_key] = Dropdown::importExternal(
                                 $foreignkey_itemtype[$key],
                                 $value->$key,

--- a/tests/functionnal/Glpi/Inventory/Inventory.php
+++ b/tests/functionnal/Glpi/Inventory/Inventory.php
@@ -1777,7 +1777,7 @@ class Inventory extends InventoryTestCase
             'OFFSET' => $nblogsnow,
         ]);
 
-        $this->integer(count($logs))->isIdenticalTo(4448);
+        $this->integer(count($logs))->isIdenticalTo(4413);
 
         $expected_types_count = [
             0 => 4, //Agent version, disks usage
@@ -1786,7 +1786,7 @@ class Inventory extends InventoryTestCase
             \Log::HISTORY_ADD_SUBITEM => 3247,//network port/name, ip address, VMs, Software
             \Log::HISTORY_UPDATE_SUBITEM => 828,//disks usage, software updates
             \Log::HISTORY_DELETE_SUBITEM => 99,//networkport and networkname, Software?
-            \Log::HISTORY_CREATE_ITEM => 265, //virtual machines, os, manufacturer, net ports, net names, software category ...
+            \Log::HISTORY_CREATE_ITEM => 230, //virtual machines, os, manufacturer, net ports, net names, software category ...
             \Log::HISTORY_UPDATE_RELATION => 2,//kernel version
         ];
 


### PR DESCRIPTION
Alternative to https://github.com/glpi-project/glpi/pull/13634

Prevent double ```Dropdown::importExternal()```

Which generates ```Manufacturer``` and ```SoftwareCategory``` with numbers

The first from ```src/Inventry/Asset/Software.php``` (which returns an ID as value)

https://github.com/glpi-project/glpi/blob/56f60f6e62bc9094551a0c469cd104ceeb05011c/src/Inventory/Asset/Software.php#L155-L163

The second from  ```src/Inventry/Asset/Software.php``` (which import ID previously generated)
https://github.com/glpi-project/glpi/blob/56f60f6e62bc9094551a0c469cd104ceeb05011c/src/Inventory/Asset/InventoryAsset.php#L253

Or 
https://github.com/glpi-project/glpi/blob/56f60f6e62bc9094551a0c469cd104ceeb05011c/src/Inventory/Asset/InventoryAsset.php#L257


N.B:
Sometime a number is added as a ```Manufacturer```
In my case I have memories with a number in the ```MANUFACTURER``` XML node 
this case is therefore legitimate

```xml
    <MEMORIES>
      <CAPACITY>8192</CAPACITY>
      <CAPTION>ChannelA-DIMM0</CAPTION>
      <DESCRIPTION>DIMM</DESCRIPTION>
      <MANUFACTURER>1315</MANUFACTURER>
      <MODEL>BLT8G3D1608DT1TX0.</MODEL>
      <NUMSLOTS>1</NUMSLOTS>
      <SERIALNUMBER>A0154896</SERIALNUMBER>
      <SPEED>1600</SPEED>
      <TYPE>DDR3</TYPE>
    </MEMORIES>
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12933 #13459
