### PR TITLE
Fix anonymous file upload

### DIFF
--- a/ajax/fileupload.php
+++ b/ajax/fileupload.php
@@ -41,7 +41,7 @@ use Glpi\Application\ErrorHandler;
 
 include('../inc/includes.php');
 
-Session::checkLoginUser();
+Session::checkValidSessionId(true);
 
 // Ensure warnings will not break ajax output.
 ErrorHandler::getInstance()->disableOutput();

--- a/ajax/getFileTag.php
+++ b/ajax/getFileTag.php
@@ -44,7 +44,7 @@ include('../inc/includes.php');
 header('Content-type: application/json');
 Html::header_nocache();
 
-Session::checkLoginUser();
+Session::checkValidSessionId(true);
 
 if (isset($_POST['data'])) {
     $response = [];

--- a/front/document.send.php
+++ b/front/document.send.php
@@ -38,7 +38,8 @@ use Glpi\Inventory\Conf;
 include('../inc/includes.php');
 
 if (!$CFG_GLPI["use_public_faq"]) {
-    Session::checkLoginUser();
+    // Might be displaying image for anonymous users on formcreator
+    Session::checkValidSessionId(true);
 }
 
 $doc = new Document();

--- a/src/Session.php
+++ b/src/Session.php
@@ -871,9 +871,12 @@ class Session
      *
      * @see https://wiki.php.net/rfc/strict_sessions
      *
+     * @param bool $allow_anonymous If enabled, we will only check if
+     *                              $_SESSION['valid_id'] is set correctly
+     *
      * @return void|true
      **/
-    public static function checkValidSessionId()
+    public static function checkValidSessionId(bool $allow_anonymous = false)
     {
         global $DB;
 
@@ -882,6 +885,10 @@ class Session
             || ($_SESSION['valid_id'] !== session_id())
         ) {
             Html::redirectToLogin('error=3');
+        }
+
+        if ($allow_anonymous) {
+            return true;
         }
 
         $user_id    = self::getLoginUserID();


### PR DESCRIPTION
The changes introduced in https://github.com/glpi-project/glpi/commit/edb815973a4359c05d9ad1ae85706b79b128487e broke file upload for formcreator on public forms.

These changes revert this behavior for the `fileupload.php` endpoint, which mean we only check the `valid_id` session's data, which is generated correctly by formcreator in the context of public forms.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
