### PR TITLE
fix(inventory): prevent 'Dropdown::import()' for values defined by rules (already an ID)

### DIFF
--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -239,7 +239,11 @@ abstract class InventoryAsset
                 if (!isset($this->known_links[$known_key])) {
                     $entities_id = $this->entities_id;
                     if ($key == "locations_id") {
-                        $this->known_links[$known_key] = Dropdown::importExternal('Location', $value->$key, $entities_id);
+                        if (is_int($value->$key)) {
+                            $this->known_links[$known_key] = $value->$key;
+                        } else {
+                            $this->known_links[$known_key] = Dropdown::importExternal('Location', $value->$key, $entities_id);
+                        }
                     } else if (preg_match('/^.+models_id/', $key)) {
                         // models that need manufacturer relation for dictionary import
                         // see CommonDCModelDropdown::$additional_fields_for_dictionnary

--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -47,6 +47,7 @@ use Group;
 use Lockedfield;
 use Manufacturer;
 use OperatingSystemKernelVersion;
+use User;
 
 abstract class InventoryAsset
 {

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -547,7 +547,7 @@ abstract class MainAsset extends InventoryAsset
                     ) {
                         // force integer type for foreygn key field
                         // RuleImportEntityCollection allow only 'assign' action so it returns only an ID
-                        if (isForeignKeyField($action_key)) {
+                        if (isForeignKeyField($action_key) || $action_key == "groups_id_tech" || $action_key == "users_id_tech") {
                             $this->ruleentity_data[$action_key] = (int) $dataEntity[$action_key];
                         } else {
                             $this->ruleentity_data[$action_key] = $dataEntity[$action_key];

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -545,7 +545,13 @@ abstract class MainAsset extends InventoryAsset
                         && $action_key !== "entities_id"
                         && isset($dataEntity[$action_key])
                     ) {
-                        $this->ruleentity_data[$action_key] = $dataEntity[$action_key];
+                        // force integer type for foreygn key field
+                        // RuleImportEntityCollection allow only 'assign' action so it returns only an ID
+                        if (isForeignKeyField($action_key)) {
+                            $this->ruleentity_data[$action_key] = (int) $dataEntity[$action_key];
+                        } else {
+                            $this->ruleentity_data[$action_key] = $dataEntity[$action_key];
+                        }
                     }
                 }
 


### PR DESCRIPTION
Prevent adding rule value as new ```locations_id``` (because ```RuleImportEntityCollection``` returns an ID for ```ForeignKey```)

Same behavior for  ```users_id_tech``` and  ```groups_id_tech```

Force ```int``` type when inventory manage data returned by ```RuleImportEntityCollection```

```int``` type is usefull to check if value is a real ID

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/glpi-project/glpi-inventory-plugin/issues/276
