### PR TITLE
fix(ticket): cloning, unexpected automatic task

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -9284,4 +9284,10 @@ abstract class CommonITILObject extends CommonDBTM
 
         return $input;
     }
+
+    public function prepareInputForClone($input)
+    {
+        unset($input['actiontime']);
+        return $input;
+    }
 }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2046,8 +2046,10 @@ class Ticket extends CommonITILObject
         }
 
         if (
-            (isset($this->input["plan"]) && count($this->input["plan"]))
-            || (isset($this->input["actiontime"]) && ($this->input["actiontime"] > 0))
+            (!isset($this->input["clone"]) || (!$this->input["clone"])) && (
+                (isset($this->input["plan"]) && count($this->input["plan"]))
+                || (isset($this->input["actiontime"]) && ($this->input["actiontime"] > 0))
+            )
         ) {
             $task = new TicketTask();
             $type = "new";

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2046,10 +2046,8 @@ class Ticket extends CommonITILObject
         }
 
         if (
-            (!isset($this->input["clone"]) || (!$this->input["clone"])) && (
-                (isset($this->input["plan"]) && count($this->input["plan"]))
-                || (isset($this->input["actiontime"]) && ($this->input["actiontime"] > 0))
-            )
+            (isset($this->input["plan"]) && count($this->input["plan"]))
+            || (isset($this->input["actiontime"]) && ($this->input["actiontime"] > 0))
         ) {
             $task = new TicketTask();
             $type = "new";

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -1788,6 +1788,15 @@ class Ticket extends DbTestCase
         $this->setEntity('Root entity', true);
         $ticket = getItemByTypeName('Ticket', '_ticket01');
 
+        $task = new \TicketTask();
+        $this->integer(
+            (int)$task->add([
+                'tickets_id' => $ticket->getID(),
+                'content'    => 'A task to check cloning',
+                'actiontime' => 3600,
+            ])
+        )->isGreaterThan(0);
+
         $date = date('Y-m-d H:i:s');
         $_SESSION['glpi_currenttime'] = $date;
 
@@ -1797,6 +1806,9 @@ class Ticket extends DbTestCase
 
         $clonedTicket = new \Ticket();
         $this->boolean($clonedTicket->getFromDB($added))->isTrue();
+
+         // Check timeline items are not cloned
+        $this->integer((int)$clonedTicket->getTimelineItems())->isEqualTo(0);
 
         $fields = $ticket->fields;
 


### PR DESCRIPTION
When cloning a ticket with tasks with durations, the created ticket had an automatic completed task, like this:

![image](https://user-images.githubusercontent.com/8530352/208465443-b90bf3d3-18e6-4e63-bd56-afdb0095dce8.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25928
