### PR TITLE
Fix styles for deleted Kanban items

### DIFF
--- a/js/modules/Kanban/Kanban.js
+++ b/js/modules/Kanban/Kanban.js
@@ -2086,7 +2086,7 @@ class GLPIKanbanRights {
             const col_body = $(column_el).find('.kanban-body').first();
             const readonly = card['_readonly'] !== undefined && (card['_readonly'] === true || card['_readonly'] === 1);
             let card_el = `
-            <li id="${card['id']}" class="kanban-item card ${readonly ? 'readonly' : ''} ${card['is_deleted'] ? 'deleted' : ''}">
+            <li id="${card['id']}" class="kanban-item card ${readonly ? 'readonly' : ''}">
                 <div class="kanban-item-header">
                     <span class="kanban-item-title" title="${card['title_tooltip']}">
                     <i class="${self.supported_itemtypes[itemtype]['icon']}"></i>
@@ -2113,6 +2113,9 @@ class GLPIKanbanRights {
                 $.each(card['_metadata'], (k, v) => {
                     card_obj.data(k, v);
                 });
+                if (card_obj.data('is_deleted')) {
+                    card_obj.addClass('deleted');
+                }
             }
             card_obj.data('_team', card['_team']);
             self.updateColumnCount(column_el);

--- a/src/Project.php
+++ b/src/Project.php
@@ -1977,7 +1977,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
 
         $required_project_fields = [
             'id', 'name', 'content', 'plan_start_date', 'plan_end_date', 'real_start_date',
-            'real_end_date', 'percent_done', 'projects_id', 'projectstates_id',
+            'real_end_date', 'percent_done', 'projects_id', 'projectstates_id', 'is_deleted'
         ];
         $request = [
             'SELECT' => [
@@ -2203,7 +2203,6 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
                 'id'              => "{$itemtype}-{$item['id']}",
                 'title'           => '<span class="pointer">' . $item['name'] . '</span>',
                 'title_tooltip'   => Html::resume_text(RichText::getTextFromHtml($item['content'] ?? "", false, true), 100),
-                'is_deleted'      => $item['is_deleted'] ?? false,
             ];
 
             $content = "<div class='kanban-plugin-content'>";
@@ -2264,7 +2263,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
             $card['_form_link'] = $itemtype::getFormUrlWithID($item['id']);
             $card['_metadata'] = [];
             $metadata_values = ['name', 'content', 'is_milestone', 'plan_start_date', 'plan_end_date', 'real_start_date', 'real_end_date',
-                'planned_duration', 'effective_duration', 'percent_done'
+                'planned_duration', 'effective_duration', 'percent_done', 'is_deleted'
             ];
             foreach ($metadata_values as $metadata_value) {
                 if (isset($item[$metadata_value])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13651 

Deleted items shown in the Project Kanban were not showing a red background like they should have.