### PR TITLE
fix(cleansoftware): some versions were not deleted

### DIFF
--- a/src/CleanSoftwareCron.php
+++ b/src/CleanSoftwareCron.php
@@ -82,13 +82,6 @@ class CleanSoftwareCron extends CommonDBTM
     {
         $total = 0;
 
-        // Purge deleted links
-        $item_softwareVersion = new Item_SoftwareVersion();
-        $item_softwareVersion->deleteByCriteria([
-            'is_deleted' => 1,
-            'is_dynamic' => 1,
-        ]);
-
        // Delete software versions with no installation
         $total += self::deleteItems(
             self::getVersionsWithNoInstallationCriteria(),
@@ -137,6 +130,9 @@ class CleanSoftwareCron extends CommonDBTM
                             'id' => new QuerySubQuery([
                                 'SELECT' => 'softwareversions_id',
                                 'FROM'   => Item_SoftwareVersion::getTable(),
+                                'WHERE'  => [
+                                    'is_deleted' => 0,
+                                ],
                             ])
                         ],
                         [

--- a/src/CleanSoftwareCron.php
+++ b/src/CleanSoftwareCron.php
@@ -82,6 +82,13 @@ class CleanSoftwareCron extends CommonDBTM
     {
         $total = 0;
 
+        // Purge deleted links
+        $item_softwareVersion = new Item_SoftwareVersion();
+        $item_softwareVersion->deleteByCriteria([
+            'is_deleted' => 1,
+            'is_dynamic' => 1,
+        ]);
+
        // Delete software versions with no installation
         $total += self::deleteItems(
             self::getVersionsWithNoInstallationCriteria(),


### PR DESCRIPTION
In some cases, an uninstalled software version was not deleted, because the link between the item and this version remained in the trash bin.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25983
