### PR TITLE
fix: missing csrf token with plugin

### DIFF
--- a/inc/includes.php
+++ b/inc/includes.php
@@ -160,7 +160,7 @@ if (
         define('GLPI_KEEP_CSRF_TOKEN', true);
 
        // For AJAX requests, check CSRF token located into "X-Glpi-Csrf-Token" header.
-        Session::checkCSRF(['_glpi_csrf_token' => $_SERVER['HTTP_X_GLPI_CSRF_TOKEN'] ?? '']);
+        Session::checkCSRF(['_glpi_csrf_token' => $_SERVER['HTTP_X_GLPI_CSRF_TOKEN'] ?? $_POST['_glpi_csrf_token'] ?? '']);
     } else {
         Session::checkCSRF($_POST);
     }


### PR DESCRIPTION
In some cases, the plugin does not send the CSRF token in the HTML header, but in the $_POST.

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25996
