### PR TITLE
Inventory: Fix item devices creation

### DIFF
--- a/src/Inventory/Asset/Device.php
+++ b/src/Inventory/Asset/Device.php
@@ -119,10 +119,11 @@ abstract class Device extends InventoryAsset
                 }
 
                 //check if deviceitem should be updated or added.
+                $equals = false;
                 foreach ($existing[$device_id] ?? [] as $key => $existing_item) {
                     $equals = true;
                     foreach ($i_criteria as $field => $compare) {
-                        if ($equals === false) {
+                        if (!$equals) {
                             //no need to continue if one of conditions is false already
                             break;
                         }
@@ -149,7 +150,7 @@ abstract class Device extends InventoryAsset
                         }
                     }
 
-                    if ($equals === true) {
+                    if ($equals) {
                         $itemdevice->getFromDB($existing_item['id']);
                         $itemdevice_data = [
                             'id'                 => $existing_item['id'],
@@ -164,7 +165,7 @@ abstract class Device extends InventoryAsset
                     }
                 }
 
-                if (($equals ?? false) !== true) {
+                if (!$equals) {
                     $itemdevice->getEmpty();
                     $itemdevice_data = [
                         $fk => $device_id,


### PR DESCRIPTION
Depending on existing data, some missing item devices may not be created.
It seems to me that the `equals` variable is not reseted correctly between iteration thus tagging some missing items as existing.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26029
