### PR TITLE
Allow to add pending reasons when item is already pending

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -445,6 +445,7 @@ abstract class CommonITILObject extends CommonDBTM
             'canupdate'               => $canupdate,
             'canpriority'             => $canupdate,
             'canassign'               => $canupdate,
+            'has_pending_reason'      => PendingReason_Item::getForItem($this),
         ]);
 
         return true;
@@ -4292,7 +4293,7 @@ abstract class CommonITILObject extends CommonDBTM
             case 'time_to_own':
                 return 'IF(' . $DB->quoteName($table . '.' . $type) . ' IS NOT NULL
             AND ' . $DB->quoteName($table . '.status') . ' <> ' . self::WAITING . '
-            AND ((' . $DB->quoteName($table . '.takeintoaccountdate') . ' IS NOT NULL AND 
+            AND ((' . $DB->quoteName($table . '.takeintoaccountdate') . ' IS NOT NULL AND
                  ' . $DB->quoteName($table . '.takeintoaccountdate') . ' > ' . $DB->quoteName($table . '.' . $type) . ')
                  OR (' . $DB->quoteName($table . '.takeintoaccountdate') . ' IS NULL AND
                  ' . $DB->quoteName($table . '.takeintoaccount_delay_stat') . '

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -445,7 +445,7 @@ abstract class CommonITILObject extends CommonDBTM
             'canupdate'               => $canupdate,
             'canpriority'             => $canupdate,
             'canassign'               => $canupdate,
-            'has_pending_reason'      => PendingReason_Item::getForItem($this),
+            'has_pending_reason'      => PendingReason_Item::getForItem($this) !== false,
         ]);
 
         return true;

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -1414,8 +1414,9 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
     public function showForm($ID, array $options = [])
     {
         TemplateRenderer::getInstance()->display('components/itilobject/timeline/form_task.html.twig', [
-            'item'      => $options['parent'],
-            'subitem'   => $this
+            'item'               => $options['parent'],
+            'subitem'            => $this,
+            'has_pending_reason' => PendingReason_Item::getForItem($options['parent']),
         ]);
 
         return true;

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -1416,7 +1416,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         TemplateRenderer::getInstance()->display('components/itilobject/timeline/form_task.html.twig', [
             'item'               => $options['parent'],
             'subitem'            => $this,
-            'has_pending_reason' => PendingReason_Item::getForItem($options['parent']),
+            'has_pending_reason' => PendingReason_Item::getForItem($options['parent']) !== false,
         ]);
 
         return true;

--- a/src/Features/ParentStatus.php
+++ b/src/Features/ParentStatus.php
@@ -51,18 +51,27 @@ trait ParentStatus
     {
         $needupdateparent = false;
 
-       // Set pending reason data on parent and self
+       // Set pending reason data on parent and self if not already set
         if ($input['pending'] ?? 0) {
-            PendingReason_Item::createForItem($parentitem, [
-                'pendingreasons_id'           => $input['pendingreasons_id'] ?? 0,
-                'followup_frequency'          => $input['followup_frequency'] ?? 0,
-                'followups_before_resolution' => $input['followups_before_resolution'] ?? 0,
-            ]);
-            PendingReason_Item::createForItem($this, [
-                'pendingreasons_id'           => $input['pendingreasons_id'] ?? 0,
-                'followup_frequency'          => $input['followup_frequency'] ?? 0,
-                'followups_before_resolution' => $input['followups_before_resolution'] ?? 0,
-            ]);
+            $parent_pending_reason = PendingReason_Item::getForItem($this->input['_job']);
+            if (
+                !$parent_pending_reason
+                || (
+                    $parent_pending_reason
+                    && !$parent_pending_reason->fields['pendingreasons_id']
+                )
+            ) {
+                PendingReason_Item::createForItem($parentitem, [
+                    'pendingreasons_id'           => $input['pendingreasons_id'] ?? 0,
+                    'followup_frequency'          => $input['followup_frequency'] ?? 0,
+                    'followups_before_resolution' => $input['followups_before_resolution'] ?? 0,
+                ]);
+                PendingReason_Item::createForItem($this, [
+                    'pendingreasons_id'           => $input['pendingreasons_id'] ?? 0,
+                    'followup_frequency'          => $input['followup_frequency'] ?? 0,
+                    'followups_before_resolution' => $input['followups_before_resolution'] ?? 0,
+                ]);
+            }
         }
 
         if (

--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -743,8 +743,9 @@ class ITILFollowup extends CommonDBChild
         }
 
         TemplateRenderer::getInstance()->display('components/itilobject/timeline/form_followup.html.twig', [
-            'item'      => $options['parent'],
-            'subitem'   => $this
+            'item'               => $options['parent'],
+            'subitem'            => $this,
+            'has_pending_reason' => PendingReason_Item::getForItem($options['parent'])
         ]);
 
         return true;

--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -745,7 +745,7 @@ class ITILFollowup extends CommonDBChild
         TemplateRenderer::getInstance()->display('components/itilobject/timeline/form_followup.html.twig', [
             'item'               => $options['parent'],
             'subitem'            => $this,
-            'has_pending_reason' => PendingReason_Item::getForItem($options['parent'])
+            'has_pending_reason' => PendingReason_Item::getForItem($options['parent']) !== false,
         ]);
 
         return true;

--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -251,17 +251,7 @@ class ITILFollowup extends CommonDBChild
             $this->input["users_id"]
         );
 
-        // Do not update pending reason if already set
-        $parent_pending_reason = PendingReason_Item::getForItem($this->input['_job']);
-        if (
-            !$parent_pending_reason
-            || (
-                $parent_pending_reason
-                && !$parent_pending_reason->fields['pendingreasons_id']
-            )
-        ) {
-            $this->updateParentStatus($this->input['_job'], $this->input);
-        }
+        $this->updateParentStatus($this->input['_job'], $this->input);
 
         $donotif = !isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"];
 

--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -251,7 +251,17 @@ class ITILFollowup extends CommonDBChild
             $this->input["users_id"]
         );
 
-        $this->updateParentStatus($this->input['_job'], $this->input);
+        // Do not update pending reason if already set
+        $parent_pending_reason = PendingReason_Item::getForItem($this->input['_job']);
+        if (
+            !$parent_pending_reason
+            || (
+                $parent_pending_reason
+                && !$parent_pending_reason->fields['pendingreasons_id']
+            )
+        ) {
+            $this->updateParentStatus($this->input['_job'], $this->input);
+        }
 
         $donotif = !isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"];
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4392,6 +4392,7 @@ JAVASCRIPT;
             'canassigntome'      => $canassigntome,
             'load_kb_sol'        => $options['load_kb_sol'] ?? 0,
             'userentities'       => $userentities,
+            'has_pending_reason' => PendingReason_Item::getForItem($this),
         ]);
 
         return true;

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4392,7 +4392,7 @@ JAVASCRIPT;
             'canassigntome'      => $canassigntome,
             'load_kb_sol'        => $options['load_kb_sol'] ?? 0,
             'userentities'       => $userentities,
-            'has_pending_reason' => PendingReason_Item::getForItem($this),
+            'has_pending_reason' => PendingReason_Item::getForItem($this) !== false,
         ]);
 
         return true;

--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -215,8 +215,12 @@
             {{ call_plugin_hook('post_item_form', {"item": subitem, 'options': params}) }}
             <div class="d-flex card-footer mx-n3 mb-n3">
                {% set pending_reasons %}
+                  {% set show_pending_reasons_actions = item.fields['status'] == constant('CommonITILObject::WAITING') and not has_pending_reason and not add_reopen %}
                   {% if get_current_interface() == 'central' and item.isAllowedStatus(item.fields['status'], constant('CommonITILObject::WAITING')) %}
-                     <span class="input-group-text bg-yellow-lt py-0 pe-0" id="pending-reasons-control-{{ rand }}">
+                     <span
+                        class="input-group-text bg-yellow-lt py-0 pe-0 {{ show_pending_reasons_actions ? 'flex-fill' : '' }}"
+                        id="pending-reasons-control-{{ rand }}"
+                     >
                         <span class="d-inline-flex align-items-center" title="{{ __("Set the status to pending") }}"
                               data-bs-toggle="tooltip" data-bs-placement="top" role="button">
                            <i class="fas fa-pause me-2"></i>
@@ -230,8 +234,12 @@
                            </label>
                         </span>
 
-                        {% if item.fields['status'] != constant('CommonITILObject::WAITING') %}
-                           <div class="collapse ps-2 py-1 flex-fill" id="pending-reasons-setup-{{ rand }}">
+                        {% if not has_pending_reason %}
+                           <div
+                              class="collapse ps-2 py-1 flex-fill {{ show_pending_reasons_actions ? 'show' : '' }}"
+                              aria-expanded="{{ show_pending_reasons_actions ? 'true' : 'false' }}"
+                              id="pending-reasons-setup-{{ rand }}"
+                           >
                               {{ include('components/itilobject/timeline/pending_reasons.html.twig') }}
                            </div>
                         {% endif %}

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -389,7 +389,11 @@
             </div>
 
             {% set pending_reasons %}
-               <span class="input-group-text bg-yellow-lt py-0 pe-0" id="pending-reasons-control-{{ rand }}">
+               {% set show_pending_reasons_actions = item.fields['status'] == constant('CommonITILObject::WAITING') and not has_pending_reason %}
+               <span
+                  class="input-group-text bg-yellow-lt py-0 pe-0 {{ show_pending_reasons_actions ? 'flex-fill' : '' }}"
+                  id="pending-reasons-control-{{ rand }}"
+               >
                   <span class="d-inline-flex align-items-center" title="{{ __("Set the status to pending") }}"
                         data-bs-toggle="tooltip" data-bs-placement="top" role="button">
                      <i class="fas fa-pause me-2"></i>
@@ -403,8 +407,12 @@
                      </label>
                   </span>
 
-                  {% if item.fields['status'] != constant('CommonITILObject::WAITING') %}
-                     <div class="collapse ps-2 py-1 flex-fill" id="pending-reasons-setup-{{ rand }}">
+                  {% if not has_pending_reason %}
+                     <div
+                        class="collapse ps-2 py-1 flex-fill {{ show_pending_reasons_actions ? 'show' : '' }}"
+                        aria-expanded="{{ show_pending_reasons_actions ? 'true' : 'false' }}"
+                        id="pending-reasons-setup-{{ rand }}"
+                     >
                         {{ include('components/itilobject/timeline/pending_reasons.html.twig') }}
                      </div>
                   {% endif %}


### PR DESCRIPTION
It is currently impossible to add a pending reason to a pending ticket:

![image](https://user-images.githubusercontent.com/42734840/209796070-5593d3df-6e04-4252-a5a5-aace81a70151.png)

After changes:

![image](https://user-images.githubusercontent.com/42734840/209796147-012e8e6c-06f4-4793-9f7c-fb20f2802e39.png)

Note that if the ticket is pending AND already have a pending reason, the input will still not be shown to avoid overriding the active pending reason.

![image](https://user-images.githubusercontent.com/42734840/209796257-ad7b9db3-46fa-42c5-955f-e17c87b2f675.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26069