### PR TITLE
Search engine: fix negative conditions on linked children

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -4129,6 +4129,7 @@ abstract class CommonITILObject extends CommonDBTM
             'name'               => _n('Requester', 'Requesters', 1),
             'forcegroupby'       => true,
             'massiveaction'      => false,
+            'use_subquery'       => true,
             'joinparams'         => [
                 'beforejoin'         => [
                     'table'              => getTableForItemType($this->userlinkclass),
@@ -4157,6 +4158,7 @@ abstract class CommonITILObject extends CommonDBTM
             'forcegroupby'       => true,
             'massiveaction'      => false,
             'condition'          => ['is_requester' => 1],
+            'use_subquery'       => true,
             'joinparams'         => [
                 'beforejoin'         => [
                     'table'              => getTableForItemType($this->grouplinkclass),
@@ -4211,6 +4213,7 @@ abstract class CommonITILObject extends CommonDBTM
             'name'               => _n('Watcher', 'Watchers', 1),
             'forcegroupby'       => true,
             'massiveaction'      => false,
+            'use_subquery'       => true,
             'joinparams'         => [
                 'beforejoin'         => [
                     'table'              => getTableForItemType($this->userlinkclass),
@@ -4231,6 +4234,7 @@ abstract class CommonITILObject extends CommonDBTM
             'forcegroupby'       => true,
             'massiveaction'      => false,
             'condition'          => ['is_watcher' => 1],
+            'use_subquery'       => true,
             'joinparams'         => [
                 'beforejoin'         => [
                     'table'              => getTableForItemType($this->grouplinkclass),
@@ -4256,6 +4260,7 @@ abstract class CommonITILObject extends CommonDBTM
             'name'               => __('Technician'),
             'forcegroupby'       => true,
             'massiveaction'      => false,
+            'use_subquery'       => true,
             'joinparams'         => [
                 'beforejoin'         => [
                     'table'              => getTableForItemType($this->userlinkclass),
@@ -4275,6 +4280,7 @@ abstract class CommonITILObject extends CommonDBTM
             'name'               => __('Assigned to a supplier'),
             'forcegroupby'       => true,
             'massiveaction'      => false,
+            'use_subquery'       => true,
             'joinparams'         => [
                 'beforejoin'         => [
                     'table'              => getTableForItemType($this->supplierlinkclass),
@@ -4295,6 +4301,7 @@ abstract class CommonITILObject extends CommonDBTM
             'forcegroupby'       => true,
             'massiveaction'      => false,
             'condition'          => ['is_assign' => 1],
+            'use_subquery'       => true,
             'joinparams'         => [
                 'beforejoin'         => [
                     'table'              => getTableForItemType($this->grouplinkclass),

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -4129,6 +4129,7 @@ abstract class CommonITILObject extends CommonDBTM
             'name'               => _n('Requester', 'Requesters', 1),
             'forcegroupby'       => true,
             'massiveaction'      => false,
+            'use_subquery'       => true,
             'joinparams'         => [
                 'beforejoin'         => [
                     'table'              => getTableForItemType($this->userlinkclass),
@@ -4212,6 +4213,7 @@ abstract class CommonITILObject extends CommonDBTM
             'name'               => _n('Watcher', 'Watchers', 1),
             'forcegroupby'       => true,
             'massiveaction'      => false,
+            'use_subquery'       => true,
             'joinparams'         => [
                 'beforejoin'         => [
                     'table'              => getTableForItemType($this->userlinkclass),
@@ -4258,6 +4260,7 @@ abstract class CommonITILObject extends CommonDBTM
             'name'               => __('Technician'),
             'forcegroupby'       => true,
             'massiveaction'      => false,
+            'use_subquery'       => true,
             'joinparams'         => [
                 'beforejoin'         => [
                     'table'              => getTableForItemType($this->userlinkclass),

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -4129,7 +4129,6 @@ abstract class CommonITILObject extends CommonDBTM
             'name'               => _n('Requester', 'Requesters', 1),
             'forcegroupby'       => true,
             'massiveaction'      => false,
-            'use_subquery'       => true,
             'joinparams'         => [
                 'beforejoin'         => [
                     'table'              => getTableForItemType($this->userlinkclass),
@@ -4213,7 +4212,6 @@ abstract class CommonITILObject extends CommonDBTM
             'name'               => _n('Watcher', 'Watchers', 1),
             'forcegroupby'       => true,
             'massiveaction'      => false,
-            'use_subquery'       => true,
             'joinparams'         => [
                 'beforejoin'         => [
                     'table'              => getTableForItemType($this->userlinkclass),
@@ -4260,7 +4258,6 @@ abstract class CommonITILObject extends CommonDBTM
             'name'               => __('Technician'),
             'forcegroupby'       => true,
             'massiveaction'      => false,
-            'use_subquery'       => true,
             'joinparams'         => [
                 'beforejoin'         => [
                     'table'              => getTableForItemType($this->userlinkclass),

--- a/src/Search.php
+++ b/src/Search.php
@@ -4740,7 +4740,6 @@ JAVASCRIPT;
                     }
                 }
                 break;
-                break;
         }
 
        //Check in current item if a specific where is defined

--- a/src/Search.php
+++ b/src/Search.php
@@ -4634,7 +4634,7 @@ JAVASCRIPT;
         // These search options will need an additionnal subquery in their WHERE
         // clause to ensure accurate results
         // See https://github.com/glpi-project/glpi/pull/13684 for detailed examples
-        $where_on_linked_children = ($searchopt[$ID]["joinparams"]["beforejoin"]["joinparams"]["jointype"] ?? '') == 'child';
+        $where_on_linked_children = $searchopt[$ID]["use_subquery"] ?? false;
 
         // Default mode for most search types that use a subquery
         $use_subquery_on_id_search = false;

--- a/src/Search.php
+++ b/src/Search.php
@@ -4882,6 +4882,7 @@ JAVASCRIPT;
                         false,
                         'OR'
                     );
+                    break;
                 } else {
                     return $link . " (((`$table`.`$name1` $SEARCH
                         $tmplink `$table`.`$name2` $SEARCH

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -2245,14 +2245,14 @@ class Search extends DbTestCase
     /**
      * Test all possible combination of operators for a given criteria
      *
-     * @param string $itemtype       Itemtype being searched for
-     * @param array  $base_condition Common condition for all searches
-     * @param array  $all            Search results for the base condition
-     * @param array  $expected       Items names that must be found if the condition is positive
-     * @param int    $field          Search option id
-     * @param string $searchtype     Positive searchtype (equals, under, contains, ...)
-     * @param mixed  $value          Value being searched
-     * @param mixed  $not_expected   Optional, item expected to be found is the condition is negative
+     * @param string     $itemtype       Itemtype being searched for
+     * @param array      $base_condition Common condition for all searches
+     * @param array      $all            Search results for the base condition
+     * @param array      $expected       Items names that must be found if the condition is positive
+     * @param int        $field          Search option id
+     * @param string     $searchtype     Positive searchtype (equals, under, contains, ...)
+     * @param mixed      $value          Value being searched
+     * @param null|array $not_expected   Optional, item expected to be found is the condition is negative
      *                               If null, will be computed from $all and $expected
      */
     protected function testCriteriaWithSubqueriesProvider_getAllCombination(

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -2242,6 +2242,233 @@ class Search extends DbTestCase
         $this->array($names)->isEqualTo($expected);
     }
 
+    /**
+     * Test all possible combination of operators for a given criteria
+     *
+     * @param string $itemtype       Itemtype being searched for
+     * @param array  $base_condition Common condition for all searches
+     * @param array  $all            Search results for the base condition
+     * @param array  $expected       Items names that must be found if the condition is positive
+     * @param int    $field          Search option id
+     * @param string $searchtype     Positive searchtype (equals, under, contains, ...)
+     * @param mixed  $value          Value being searched
+     */
+    protected function testCriteriaWithSubqueriesProvider_getAllCombination(
+        string $itemtype,
+        array $base_condition,
+        array $all,
+        array $expected,
+        int $field,
+        string $searchtype,
+        $value
+    ): iterable {
+        // Invert expected items
+        $not_expected = array_diff($all, $expected);
+
+        // Inverted criteria
+        $not_searchtype = "not$searchtype";
+
+        // All possible combinations of operators leading to a positive condition
+        yield [
+            'itemtype' => $itemtype,
+            'criteria' => [
+                $base_condition,
+                [
+                    'link'       => 'AND',
+                    'field'      => $field,
+                    'searchtype' => $searchtype,
+                    'value'      => $value,
+                ]
+            ],
+            'expected' => $expected,
+        ];
+        yield [
+            'itemtype' => $itemtype,
+            'criteria' => [
+                $base_condition,
+                [
+                    'link'       => 'AND NOT',
+                    'field'      => $field,
+                    'searchtype' => $not_searchtype,
+                    'value'      => $value,
+                ]
+            ],
+            'expected' => $expected,
+        ];
+        yield [
+            'itemtype' => $itemtype,
+            'criteria' => [
+                $base_condition,
+                [
+                    'link' => 'AND',
+                    'criteria' => [
+                        [
+                            'link'       => 'AND',
+                            'field'      => $field,
+                            'searchtype' => $searchtype,
+                            'value'      => $value,
+                        ]
+                    ]
+                ]
+            ],
+            'expected' => $expected,
+        ];
+        yield [
+            'itemtype' => $itemtype,
+            'criteria' => [
+                $base_condition,
+                [
+                    'link' => 'AND',
+                    'criteria' => [
+                        [
+                            'link'       => 'AND NOT',
+                            'field'      => $field,
+                            'searchtype' => $not_searchtype,
+                            'value'      => $value,
+                        ]
+                    ]
+                ]
+            ],
+            'expected' => $expected,
+        ];
+        yield [
+            'itemtype' => $itemtype,
+            'criteria' => [
+                $base_condition,
+                [
+                    'link' => 'AND NOT',
+                    'criteria' => [
+                        [
+                            'link'       => 'AND',
+                            'field'      => $field,
+                            'searchtype' => $not_searchtype,
+                            'value'      => $value,
+                        ]
+                    ]
+                ]
+            ],
+            'expected' => $expected,
+        ];
+        yield [
+            'itemtype' => $itemtype,
+            'criteria' => [
+                $base_condition,
+                [
+                    'link' => 'AND NOT',
+                    'criteria' => [
+                        [
+                            'link'       => 'AND NOT',
+                            'field'      => $field,
+                            'searchtype' => $searchtype,
+                            'value'      => $value,
+                        ]
+                    ]
+                ]
+            ],
+            'expected' => $expected,
+        ];
+
+        // All possible combinations of operators leading to a negative condition
+        yield [
+            'itemtype' => $itemtype,
+            'criteria' => [
+                $base_condition,
+                [
+                    'link'       => 'AND NOT',
+                    'field'      => $field,
+                    'searchtype' => $searchtype,
+                    'value'      => $value,
+                ]
+            ],
+            'expected' => $not_expected,
+        ];
+        yield [
+            'itemtype' => $itemtype,
+            'criteria' => [
+                $base_condition,
+                [
+                    'link'       => 'AND',
+                    'field'      => $field,
+                    'searchtype' => $not_searchtype,
+                    'value'      => $value,
+                ]
+            ],
+            'expected' => $not_expected,
+        ];
+        yield [
+            'itemtype' => $itemtype,
+            'criteria' => [
+                $base_condition,
+                [
+                    'link' => 'AND NOT',
+                    'criteria' => [
+                        [
+                            'link'       => 'AND NOT',
+                            'field'      => $field,
+                            'searchtype' => $not_searchtype,
+                            'value'      => $value,
+                        ]
+                    ]
+                ]
+            ],
+            'expected' => $not_expected,
+        ];
+        yield [
+            'itemtype' => $itemtype,
+            'criteria' => [
+                $base_condition,
+                [
+                    'link' => 'AND NOT',
+                    'criteria' => [
+                        [
+                            'link'       => 'AND',
+                            'field'      => $field,
+                            'searchtype' => $searchtype,
+                            'value'      => $value,
+                        ]
+                    ]
+                ]
+            ],
+            'expected' => $not_expected,
+        ];
+        yield [
+            'itemtype' => $itemtype,
+            'criteria' => [
+                $base_condition,
+                [
+                    'link' => 'NOT',
+                    'criteria' => [
+                        [
+                            'link'       => 'AND NOT',
+                            'field'      => $field,
+                            'searchtype' => $searchtype,
+                            'value'      => $value,
+                        ]
+                    ]
+                ]
+            ],
+            'expected' => $not_expected,
+        ];
+        yield [
+            'itemtype' => $itemtype,
+            'criteria' => [
+                $base_condition,
+                [
+                    'link' => 'NOT',
+                    'criteria' => [
+                        [
+                            'link'       => 'NOT',
+                            'field'      => $field,
+                            'searchtype' => $not_searchtype,
+                            'value'      => $value,
+                        ]
+                    ]
+                ]
+            ],
+            'expected' => $not_expected,
+        ];
+    }
+
     protected function testCriteriaWithSubqueriesProvider(): iterable
     {
         $this->login();
@@ -2267,7 +2494,7 @@ class Search extends DbTestCase
             'expected' => [],
         ];
 
-        // Create the needed groups for our data
+        // Create test groups
         $this->createItems('Group', [
             [
                 'name' => 'Group 1',
@@ -2288,31 +2515,49 @@ class Search extends DbTestCase
         ]);
         $group_1A = getItemByTypeName('Group', 'Group 1A', true);
 
-        $this->createItems('Ticket', [
+        // Assign ourself to group 2 (special case to valide "mygroups" criteria)
+        $this->createItem('Group_User', [
+            'users_id'  => getItemByTypeName('User', TU_USER, true),
+            'groups_id' => $group_1,
+        ]);
+        $_SESSION['glpigroups'] = [$group_1];
+
+        // Create test suppliers
+        $this->createItems('Supplier', [
             [
-                'name' => 'Ticket group 1',
+                'name' => 'Supplier 1',
+                'entities_id' => $root,
+            ],
+            [
+                'name' => 'Supplier 2',
+                'entities_id' => $root,
+            ],
+        ]);
+        $supplier_1 = getItemByTypeName('Supplier', 'Supplier 1', true);
+        $supplier_2 = getItemByTypeName('Supplier', 'Supplier 2', true);
+
+        $this->createItems('Ticket', [
+            // Test set on watcher group
+            [
+                'name' => 'Ticket group 1 (W)',
                 'content' => '',
                 'entities_id' => $root,
                 'itilcategories_id' => $category,
                 '_actors' => [
-                    'observer' => [['itemtype' => 'Group', 'items_id' => $group_1]]
+                    'observer' => [['itemtype' => 'Group', 'items_id' => $group_1]],
                 ]
-            ]
-        ]);
-        $this->createItems('Ticket', [
+            ],
             [
-                'name' => 'Ticket group 2',
+                'name' => 'Ticket group 2 (W)',
                 'content' => '',
                 'entities_id' => $root,
                 'itilcategories_id' => $category,
                 '_actors' => [
                     'observer' => [['itemtype' => 'Group', 'items_id' => $group_2]]
                 ]
-            ]
-        ]);
-        $this->createItems('Ticket', [
+            ],
             [
-                'name' => 'Ticket group 1 + group 2',
+                'name' => 'Ticket group 1 (W) + group 2 (W)',
                 'content' => '',
                 'entities_id' => $root,
                 'itilcategories_id' => $category,
@@ -2322,11 +2567,9 @@ class Search extends DbTestCase
                         ['itemtype' => 'Group', 'items_id' => $group_2],
                     ]
                 ]
-            ]
-        ]);
-        $this->createItems('Ticket', [
+            ],
             [
-                'name' => 'Ticket group 1A + group 2',
+                'name' => 'Ticket group 1A (W) + group 2 (W)',
                 'content' => '',
                 'entities_id' => $root,
                 'itilcategories_id' => $category,
@@ -2336,7 +2579,61 @@ class Search extends DbTestCase
                         ['itemtype' => 'Group', 'items_id' => $group_2],
                     ]
                 ]
-            ]
+            ],
+
+            // Test set on assigned group
+            [
+                'name' => 'Ticket group 1 (A)',
+                'content' => '',
+                'entities_id' => $root,
+                'itilcategories_id' => $category,
+                '_actors' => [
+                    'assign' => [['itemtype' => 'Group', 'items_id' => $group_1]],
+                ]
+            ],
+
+            // Test set on requester group
+            [
+                'name' => 'Ticket group 1 (R)',
+                'content' => '',
+                'entities_id' => $root,
+                'itilcategories_id' => $category,
+                '_actors' => [
+                    'requester' => [['itemtype' => 'Group', 'items_id' => $group_1]],
+                ]
+            ],
+
+            // Test set on supplier
+            [
+                'name' => 'Ticket supplier 1',
+                'content' => '',
+                'entities_id' => $root,
+                'itilcategories_id' => $category,
+                '_actors' => [
+                    'assign' => [['itemtype' => 'Supplier', 'items_id' => $supplier_1]],
+                ]
+            ],
+            [
+                'name' => 'Ticket supplier 2',
+                'content' => '',
+                'entities_id' => $root,
+                'itilcategories_id' => $category,
+                '_actors' => [
+                    'assign' => [['itemtype' => 'Supplier', 'items_id' => $supplier_2]],
+                ]
+            ],
+            [
+                'name' => 'Ticket supplier 1 + supplier 2',
+                'content' => '',
+                'entities_id' => $root,
+                'itilcategories_id' => $category,
+                '_actors' => [
+                    'assign' => [
+                        ['itemtype' => 'Supplier', 'items_id' => $supplier_1],
+                        ['itemtype' => 'Supplier', 'items_id' => $supplier_2],
+                    ],
+                ]
+            ],
         ]);
 
         // Validate all items are here as expected
@@ -2346,636 +2643,192 @@ class Search extends DbTestCase
             'searchtype' => 'equals',
             'value'      => $category,
         ];
+        $all_tickets = [
+            // Test set on watcher group
+            'Ticket group 1 (W)',
+            'Ticket group 2 (W)',
+            'Ticket group 1 (W) + group 2 (W)',
+            'Ticket group 1A (W) + group 2 (W)',
+
+            // Test set on assigned group
+            'Ticket group 1 (A)',
+
+            // Test set on requester group
+            'Ticket group 1 (R)',
+
+            // Test set on supplier
+            'Ticket supplier 1',
+            'Ticket supplier 2',
+            'Ticket supplier 1 + supplier 2',
+        ];
         yield [
             'itemtype' => 'Ticket',
             'criteria' => [$base_condition],
-            'expected' => [
-                'Ticket group 1',
-                'Ticket group 2',
-                'Ticket group 1 + group 2',
-                'Ticket group 1A + group 2'
-            ],
+            'expected' => $all_tickets,
         ];
 
-        // Ticket where watcher group is "Group 1"
-        $expected = [
-            'Ticket group 1',
-            'Ticket group 1 + group 2',
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link'       => 'AND',
-                    'field'      => 65, // Watcher group
-                    'searchtype' => 'equals',
-                    'value'      => $group_1,
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link'       => 'AND NOT',
-                    'field'      => 65, // Watcher group
-                    'searchtype' => 'notequals',
-                    'value'      => $group_1,
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link' => 'AND',
-                    'criteria' => [
-                        [
-                            'link'       => 'AND',
-                            'field'      => 65, // Watcher group
-                            'searchtype' => 'equals',
-                            'value'      => $group_1,
-                        ]
-                    ]
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link' => 'AND',
-                    'criteria' => [
-                        [
-                            'link'       => 'AND NOT',
-                            'field'      => 65, // Watcher group
-                            'searchtype' => 'notequals',
-                            'value'      => $group_1,
-                        ]
-                    ]
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link' => 'AND NOT',
-                    'criteria' => [
-                        [
-                            'link'       => 'AND',
-                            'field'      => 65, // Watcher group
-                            'searchtype' => 'notequals',
-                            'value'      => $group_1,
-                        ]
-                    ]
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link' => 'AND NOT',
-                    'criteria' => [
-                        [
-                            'link'       => 'AND NOT',
-                            'field'      => 65, // Watcher group
-                            'searchtype' => 'equals',
-                            'value'      => $group_1,
-                        ]
-                    ]
-                ]
-            ],
-            'expected' => $expected,
-        ];
+        // Run tests for watcher group
+        yield from $this->testCriteriaWithSubqueriesProvider_getAllCombination(
+            'Ticket',
+            $base_condition,
+            $all_tickets,
+            ['Ticket group 1 (W)', 'Ticket group 1 (W) + group 2 (W)'],
+            65, // Watcher group
+            'equals',
+            $group_1
+        );
+        yield from $this->testCriteriaWithSubqueriesProvider_getAllCombination(
+            'Ticket',
+            $base_condition,
+            $all_tickets,
+            ['Ticket group 1 (W)', 'Ticket group 1 (W) + group 2 (W)', 'Ticket group 1A (W) + group 2 (W)'],
+            65, // Watcher group
+            'contains',
+            "group 1"
+        );
+        yield from $this->testCriteriaWithSubqueriesProvider_getAllCombination(
+            'Ticket',
+            $base_condition,
+            $all_tickets,
+            ['Ticket group 1 (W)', 'Ticket group 1 (W) + group 2 (W)', 'Ticket group 1A (W) + group 2 (W)'],
+            65, // Watcher group
+            'under',
+            $group_1
+        );
 
-        // Ticket where watcher group is not "Group 1"
-        $expected = [
-            'Ticket group 2',
-            'Ticket group 1A + group 2',
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link'       => 'AND NOT',
-                    'field'      => 65, // Watcher group
-                    'searchtype' => 'equals',
-                    'value'      => $group_1,
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link'       => 'AND',
-                    'field'      => 65, // Watcher group
-                    'searchtype' => 'notequals',
-                    'value'      => $group_1,
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link' => 'AND NOT',
-                    'criteria' => [
-                        [
-                            'link'       => 'AND NOT',
-                            'field'      => 65, // Watcher group
-                            'searchtype' => 'notequals',
-                            'value'      => $group_1,
-                        ]
-                    ]
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link' => 'AND NOT',
-                    'criteria' => [
-                        [
-                            'link'       => 'AND',
-                            'field'      => 65, // Watcher group
-                            'searchtype' => 'equals',
-                            'value'      => $group_1,
-                        ]
-                    ]
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link' => 'NOT',
-                    'criteria' => [
-                        [
-                            'link'       => 'AND NOT',
-                            'field'      => 65, // Watcher group
-                            'searchtype' => 'equals',
-                            'value'      => $group_1,
-                        ]
-                    ]
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link' => 'NOT',
-                    'criteria' => [
-                        [
-                            'link'       => 'NOT',
-                            'field'      => 65, // Watcher group
-                            'searchtype' => 'notequals',
-                            'value'      => $group_1,
-                        ]
-                    ]
-                ]
-            ],
-            'expected' => $expected,
-        ];
+        // Run test for assigned groups
+        yield from $this->testCriteriaWithSubqueriesProvider_getAllCombination(
+            'Ticket',
+            $base_condition,
+            $all_tickets,
+            ['Ticket group 1 (A)'],
+            8, // Assigned group
+            'equals',
+            $group_1
+        );
+        yield from $this->testCriteriaWithSubqueriesProvider_getAllCombination(
+            'Ticket',
+            $base_condition,
+            $all_tickets,
+            ['Ticket group 1 (A)'],
+            8, // Assigned group
+            'contains',
+            "group 1"
+        );
+        yield from $this->testCriteriaWithSubqueriesProvider_getAllCombination(
+            'Ticket',
+            $base_condition,
+            $all_tickets,
+            ['Ticket group 1 (A)'],
+            8, // Assigned group
+            'under',
+            $group_1
+        );
 
-        // Ticket where watcher group contains "group 1"
-        $expected = [
-            'Ticket group 1',
-            'Ticket group 1 + group 2',
-            'Ticket group 1A + group 2',
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link'       => 'AND',
-                    'field'      => 65, // Watcher group
-                    'searchtype' => 'contains',
-                    'value'      => "group 1",
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link'       => 'AND NOT',
-                    'field'      => 65, // Watcher group
-                    'searchtype' => 'notcontains',
-                    'value'      => "group 1",
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link' => 'AND',
-                    'criteria' => [
-                        [
-                            'link'       => 'AND',
-                            'field'      => 65, // Watcher group
-                            'searchtype' => 'contains',
-                            'value'      => "group 1",
-                        ]
-                    ]
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link' => 'AND',
-                    'criteria' => [
-                        [
-                            'link'       => 'AND NOT',
-                            'field'      => 65, // Watcher group
-                            'searchtype' => 'notcontains',
-                            'value'      => "group 1",
-                        ]
-                    ]
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link' => 'AND NOT',
-                    'criteria' => [
-                        [
-                            'link'       => 'AND',
-                            'field'      => 65, // Watcher group
-                            'searchtype' => 'notcontains',
-                            'value'      => "group 1",
-                        ]
-                    ]
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link' => 'AND NOT',
-                    'criteria' => [
-                        [
-                            'link'       => 'AND NOT',
-                            'field'      => 65, // Watcher group
-                            'searchtype' => 'contains',
-                            'value'      => "group 1",
-                        ]
-                    ]
-                ]
-            ],
-            'expected' => $expected,
-        ];
+        // Run test for requester group
+        yield from $this->testCriteriaWithSubqueriesProvider_getAllCombination(
+            'Ticket',
+            $base_condition,
+            $all_tickets,
+            ['Ticket group 1 (R)'],
+            71, // Requester group
+            'equals',
+            $group_1
+        );
+        yield from $this->testCriteriaWithSubqueriesProvider_getAllCombination(
+            'Ticket',
+            $base_condition,
+            $all_tickets,
+            ['Ticket group 1 (R)'],
+            71, // Requester group
+            'contains',
+            "group 1"
+        );
+        yield from $this->testCriteriaWithSubqueriesProvider_getAllCombination(
+            'Ticket',
+            $base_condition,
+            $all_tickets,
+            ['Ticket group 1 (R)'],
+            71, // Requester group
+            'under',
+            $group_1
+        );
 
-        // Ticket where watcher group doesn't contains "group 1"
-        $expected = ['Ticket group 2'];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link'       => 'AND NOT',
-                    'field'      => 65, // Watcher group
-                    'searchtype' => 'contains',
-                    'value'      => "group 1",
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link'       => 'AND',
-                    'field'      => 65, // Watcher group
-                    'searchtype' => 'notcontains',
-                    'value'      => "group 1",
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link' => 'AND NOT',
-                    'criteria' => [
-                        [
-                            'link'       => 'AND NOT',
-                            'field'      => 65, // Watcher group
-                            'searchtype' => 'notcontains',
-                            'value'      => "group 1",
-                        ]
-                    ]
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link' => 'AND NOT',
-                    'criteria' => [
-                        [
-                            'link'       => 'AND',
-                            'field'      => 65, // Watcher group
-                            'searchtype' => 'contains',
-                            'value'      => "group 1",
-                        ]
-                    ]
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link' => 'NOT',
-                    'criteria' => [
-                        [
-                            'link'       => 'AND NOT',
-                            'field'      => 65, // Watcher group
-                            'searchtype' => 'contains',
-                            'value'      => "group 1",
-                        ]
-                    ]
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link' => 'NOT',
-                    'criteria' => [
-                        [
-                            'link'       => 'NOT',
-                            'field'      => 65, // Watcher group
-                            'searchtype' => 'notcontains',
-                            'value'      => "group 1",
-                        ]
-                    ]
-                ]
-            ],
-            'expected' => $expected,
-        ];
+        // Run tests for 'mygroup'
+        yield from $this->testCriteriaWithSubqueriesProvider_getAllCombination(
+            'Ticket',
+            $base_condition,
+            $all_tickets,
+            ['Ticket group 1 (R)'],
+            71, // Requester group
+            'equals',
+            'mygroups'
+        );
+        yield from $this->testCriteriaWithSubqueriesProvider_getAllCombination(
+            'Ticket',
+            $base_condition,
+            $all_tickets,
+            ['Ticket group 1 (A)'],
+            8, // Assigned group
+            'equals',
+            'mygroups'
+        );
+        yield from $this->testCriteriaWithSubqueriesProvider_getAllCombination(
+            'Ticket',
+            $base_condition,
+            $all_tickets,
+            ['Ticket group 1 (W)', 'Ticket group 1 (W) + group 2 (W)'],
+            65, // Watcher group
+            'equals',
+            'mygroups'
+        );
+        yield from $this->testCriteriaWithSubqueriesProvider_getAllCombination(
+            'Ticket',
+            $base_condition,
+            $all_tickets,
+            ['Ticket group 1 (R)'],
+            71, // Requester group
+            'under',
+            'mygroups'
+        );
+        yield from $this->testCriteriaWithSubqueriesProvider_getAllCombination(
+            'Ticket',
+            $base_condition,
+            $all_tickets,
+            ['Ticket group 1 (A)'],
+            8, // Assigned group
+            'under',
+            'mygroups'
+        );
+        yield from $this->testCriteriaWithSubqueriesProvider_getAllCombination(
+            'Ticket',
+            $base_condition,
+            $all_tickets,
+            ['Ticket group 1 (W)', 'Ticket group 1 (W) + group 2 (W)', 'Ticket group 1A (W) + group 2 (W)'],
+            65, // Watcher group
+            'under',
+            'mygroups'
+        );
 
-        // Ticket where watcher group is under "group 1"
-        $expected = [
-            'Ticket group 1',
-            'Ticket group 1 + group 2',
-            'Ticket group 1A + group 2',
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link'       => 'AND',
-                    'field'      => 65, // Watcher group
-                    'searchtype' => 'under',
-                    'value'      => $group_1,
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link'       => 'AND NOT',
-                    'field'      => 65, // Watcher group
-                    'searchtype' => 'notunder',
-                    'value'      => $group_1,
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link' => 'AND',
-                    'criteria' => [
-                        [
-                            'link'       => 'AND',
-                            'field'      => 65, // Watcher group
-                            'searchtype' => 'under',
-                            'value'      => $group_1,
-                        ]
-                    ]
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link' => 'AND',
-                    'criteria' => [
-                        [
-                            'link'       => 'AND NOT',
-                            'field'      => 65, // Watcher group
-                            'searchtype' => 'notunder',
-                            'value'      => $group_1,
-                        ]
-                    ]
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link' => 'AND NOT',
-                    'criteria' => [
-                        [
-                            'link'       => 'AND',
-                            'field'      => 65, // Watcher group
-                            'searchtype' => 'notunder',
-                            'value'      => $group_1,
-                        ]
-                    ]
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link' => 'AND NOT',
-                    'criteria' => [
-                        [
-                            'link'       => 'AND NOT',
-                            'field'      => 65, // Watcher group
-                            'searchtype' => 'under',
-                            'value'      => $group_1,
-                        ]
-                    ]
-                ]
-            ],
-            'expected' => $expected,
-        ];
-
-        // Ticket where watcher group is not under "group 1"
-        $expected = ['Ticket group 2'];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link'       => 'AND NOT',
-                    'field'      => 65, // Watcher group
-                    'searchtype' => 'under',
-                    'value'      => $group_1,
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link'       => 'AND',
-                    'field'      => 65, // Watcher group
-                    'searchtype' => 'notunder',
-                    'value'      => $group_1,
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link' => 'AND NOT',
-                    'criteria' => [
-                        [
-                            'link'       => 'AND NOT',
-                            'field'      => 65, // Watcher group
-                            'searchtype' => 'notunder',
-                            'value'      => $group_1,
-                        ]
-                    ]
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link' => 'AND NOT',
-                    'criteria' => [
-                        [
-                            'link'       => 'AND',
-                            'field'      => 65, // Watcher group
-                            'searchtype' => 'under',
-                            'value'      => $group_1,
-                        ]
-                    ]
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link' => 'NOT',
-                    'criteria' => [
-                        [
-                            'link'       => 'AND NOT',
-                            'field'      => 65, // Watcher group
-                            'searchtype' => 'under',
-                            'value'      => $group_1,
-                        ]
-                    ]
-                ]
-            ],
-            'expected' => $expected,
-        ];
-        yield [
-            'itemtype' => 'Ticket',
-            'criteria' => [
-                $base_condition,
-                [
-                    'link' => 'NOT',
-                    'criteria' => [
-                        [
-                            'link'       => 'NOT',
-                            'field'      => 65, // Watcher group
-                            'searchtype' => 'notunder',
-                            'value'      => $group_1,
-                        ]
-                    ]
-                ]
-            ],
-            'expected' => $expected,
-        ];
+        // Run tests for suppliers
+        yield from $this->testCriteriaWithSubqueriesProvider_getAllCombination(
+            'Ticket',
+            $base_condition,
+            $all_tickets,
+            ['Ticket supplier 1', 'Ticket supplier 1 + supplier 2'],
+            6, // Supplier
+            'equals',
+            $supplier_1
+        );
+        yield from $this->testCriteriaWithSubqueriesProvider_getAllCombination(
+            'Ticket',
+            $base_condition,
+            $all_tickets,
+            ['Ticket supplier 1', 'Ticket supplier 1 + supplier 2'],
+            6, // Supplier
+            'contains',
+            "Supplier 1"
+        );
     }
 
     /**
@@ -3000,7 +2853,11 @@ class Search extends DbTestCase
         // Validate results
         sort($names);
         sort($expected);
-        $this->array($names)->isEqualTo($expected);
+        $this->array($names)->isEqualTo($expected)->executeOnFailure(
+            function () use ($data) {
+                var_dump($data['sql']['raw']['WHERE']);
+            }
+        );
     }
 }
 

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -2687,8 +2687,14 @@ class Search extends DbTestCase
                 'entities_id' => $root,
                 'itilcategories_id' => $category,
                 '_actors' => [
-                    // FIXME: Does not seem to work (maybe not possible from a form ?), will add user manually below
-                    'requester' => [['itemtype' => 'User', 'items_id' => 0, "alternative_email" => "myemail@email.com"]],
+                    'requester' => [
+                        [
+                            'itemtype' => 'User',
+                            'items_id' => 0,
+                            "alternative_email" => "myemail@email.com",
+                            'use_notification' => true
+                        ]
+                    ],
                 ]
             ],
 
@@ -2713,15 +2719,6 @@ class Search extends DbTestCase
                     'assign' => [['itemtype' => 'User', 'items_id' => $user_1]],
                 ]
             ],
-        ]);
-
-        // Not sure how to add anonymous user directiy from _actors; adding it manually
-        $ticket = getItemByTypeName('Ticket', 'Ticket anonymous user (R)', true);
-        $this->createItem('Ticket_User', [
-            'tickets_id'        => $ticket,
-            'users_id'          => 0,
-            'alternative_email' => "myemail@email.com",
-            'type'              => CommonITILActor::REQUESTER,
         ]);
 
         // Validate all items are here as expected


### PR DESCRIPTION
### Data set

I'm using the following set of data to demonstrate the issue:

![image](https://user-images.githubusercontent.com/42734840/210083362-b0ab9dc4-8c9a-4e12-b35d-6f5580fc31fa.png)

We have four tickets, two of which have multiple groups.
The tickets with multiple groups are the one that are not going to behave correctly in the tests below.

### 1. Tickets where the watcher group doesn't contains "Group 1"

![image](https://user-images.githubusercontent.com/42734840/210083580-7d75f554-0e80-4eb4-88a8-b65ea24f9c52.png)

After fix:

![image](https://user-images.githubusercontent.com/42734840/210083615-e356e124-7cb5-4c77-b505-bd147b5b5d60.png)

### 2. Tickets where the watcher group is not "Group 1"

![image](https://user-images.githubusercontent.com/42734840/210083727-f0970bfa-a29c-4f17-8ce6-04be7b35aae4.png)

After fix:

![image](https://user-images.githubusercontent.com/42734840/210083752-1d455a61-d96c-4336-a7f1-300c266ddc64.png)

### 3. Tickets where the watcher group is not under "Group 1"

![image](https://user-images.githubusercontent.com/42734840/210083903-7028a93c-91b6-4f2c-bfce-63cb9ace7db4.png)

After fix:

![image](https://user-images.githubusercontent.com/42734840/210083924-19099bf6-d3e7-4794-affb-aabdbfa316ca.png)

### Explanations

The search engine is joining the data like this (simplified) :

![image](https://user-images.githubusercontent.com/42734840/210084737-0bd7a113-3d52-4ff9-8885-523e1e4a2611.png)

When we add the condition, we remove the rows that don't match the expected group:

![image](https://user-images.githubusercontent.com/42734840/210084981-41362860-f6a4-426b-a6e9-09beb0daf098.png)

Tickets 50 is incorrectly returned because one of his linked groups (Group 2) satisfy the condition (Group != Group 1).

This is logical when looking at the query, but it doesn't make sense for the users.
When the user ask GLPI "Give me all the tickets that don't have Group 1 as an observer", ticket 50 should not be part of the results because it has indeed group 1 as an observer (even if it also has another group that is not group 1).

The proposed fix is to use a `NOT IN` subquery to filter the results more strictly.
In our simplified example the query become :

![image](https://user-images.githubusercontent.com/42734840/210085529-b903a6f0-093d-442f-8784-4cc49a96d2ed.png)

Now any tickets that have this group will not be returned by the query (ticket 50 is gone).

We still keep the `LEFT JOIN` above as we need to retrieve the data in the `SELECT` clause to display the search results.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23972
