### PR TITLE
Support more fields in problems template and fix mandatory field alert

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -3944,7 +3944,8 @@ JS;
 
                      editor.on('submit', function (e) {
                         if ($('#$id').val() == '') {
-                           alert(__('The description field is mandatory'));
+                           const field = $('#$id').parent().parent().find('label').text().replace('*', '').trim();
+                           alert(__('The "' + field + '" field is mandatory'));
                            e.preventDefault();
 
                            // Prevent other events to run

--- a/src/Html.php
+++ b/src/Html.php
@@ -3945,7 +3945,7 @@ JS;
                      editor.on('submit', function (e) {
                         if ($('#$id').val() == '') {
                            const field = $('#$id').parent().parent().find('label').text().replace('*', '').trim();
-                           alert(__('The "' + field + '" field is mandatory'));
+                           alert(__('The %s field is mandatory').replace('%s', field));
                            e.preventDefault();
 
                            // Prevent other events to run

--- a/src/Html.php
+++ b/src/Html.php
@@ -3944,7 +3944,7 @@ JS;
 
                      editor.on('submit', function (e) {
                         if ($('#$id').val() == '') {
-                           const field = $('#$id').parent().parent().find('label').text().replace('*', '').trim();
+                           const field = $('#$id').closest('.form-field').find('label').text().replace('*', '').trim();
                            alert(__('The %s field is mandatory').replace('%s', field));
                            e.preventDefault();
 

--- a/src/ProblemTemplate.php
+++ b/src/ProblemTemplate.php
@@ -58,4 +58,14 @@ class ProblemTemplate extends ITILTemplate
             ProblemTemplatePredefinedField::class,
         ];
     }
+
+    public static function getExtraAllowedFields($withtypeandcategory = 0, $withitemtype = 0)
+    {
+        $problem = new Problem();
+        return [
+            $problem->getSearchOptionIDByField('field', 'impactcontent', 'glpi_problems')  => 'impactcontent',
+            $problem->getSearchOptionIDByField('field', 'causecontent', 'glpi_problems')   => 'causecontent',
+            $problem->getSearchOptionIDByField('field', 'symptomcontent', 'glpi_problems') => 'symptomcontent',
+        ];
+    }
 }

--- a/tests/functionnal/ITILTemplate.php
+++ b/tests/functionnal/ITILTemplate.php
@@ -283,6 +283,9 @@ class ITILTemplate extends DbTestCase
                     13 => 'Associated elements',
                     -2 => 'Approval request',
                     142 => 'Documents',
+                    60 => 'Impacts',
+                    61 => 'Causes',
+                    62 => 'Symptoms',
                 ]
             ]
         ];


### PR DESCRIPTION
Add the 3 following fields to problems' templates:

![image](https://user-images.githubusercontent.com/42734840/210092758-a8df147a-9f85-451c-8502-91b9c9cb1c03.png)

This allow the users to mark them as mandatory.

While testing the mandatory feature, I've noticed that the error message always mention the description field no matter what:

![image](https://user-images.githubusercontent.com/42734840/210092724-42f0cf56-2398-4569-aaec-18b879a3d452.png)

I've fixed it by making it use the closest label instead:

![image](https://user-images.githubusercontent.com/42734840/210093148-c29e2871-24d3-4e61-9df6-2b765007e26b.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26099
