### PR TITLE
Adding a location-based filter on reservation search tool

### DIFF
--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -555,6 +555,21 @@ class ReservationItem extends CommonDBChild
         ]);
 
         echo "</td></tr>";
+
+        // Location dropdown
+        $user = new User();
+        $user->getFromDB(Session::getLoginUserID());
+        $entities = Profile_User::getUserEntities($user->fields['id'], true);
+        $locrand = mt_rand();
+        echo "<tr class='tab_bg_1'><td><label for='dropdown_locations_id$locrand'>" . __('Item location') . "</label></td><td>";
+        Location::dropdown([
+            // Fill with submitted data if any, otherwise use user's location
+            'value'  => $_POST['locations_id'] ?? $user->fields['locations_id'],
+            'rand'   => $locrand,
+            'entity' => count($entities) <= 0 ? -1 : $entities,
+        ]);
+
+        echo "</td></tr>";
         echo "</table>";
         Html::closeForm();
         echo "</div>";
@@ -658,6 +673,13 @@ class ReservationItem extends CommonDBChild
                     ];
                     $criteria['WHERE'][] = ["$itemtable.peripheraltypes_id" => $tmp[1]];
                 }
+            }
+
+            // Filter locations if location was provided/submitted
+            if (isset($_POST['locations_id']) && !empty($_POST['locations_id'])) {
+                $criteria['WHERE'][] = [
+                    'glpi_locations.id' => getSonsOf('glpi_locations', (int) $_POST['locations_id']),
+                ];
             }
 
             $iterator = $DB->request($criteria);

--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -676,7 +676,7 @@ class ReservationItem extends CommonDBChild
             }
 
             // Filter locations if location was provided/submitted
-            if (isset($_POST['locations_id']) && !empty($_POST['locations_id'])) {
+            if ((int)($_POST['locations_id'] ?? 0) > 0) {
                 $criteria['WHERE'][] = [
                     'glpi_locations.id' => getSonsOf('glpi_locations', (int) $_POST['locations_id']),
                 ];

--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -557,13 +557,11 @@ class ReservationItem extends CommonDBChild
         echo "</td></tr>";
 
         // Location dropdown
-        $user = new User();
-        $user->getFromDB(Session::getLoginUserID());
         $locrand = mt_rand();
         echo "<tr class='tab_bg_1'><td><label for='dropdown_locations_id$locrand'>" . __('Item location') . "</label></td><td>";
         Location::dropdown([
             // Fill with submitted data if any, otherwise use user's location
-            'value'  => $_POST['locations_id'] ?? $user->fields['locations_id'],
+            'value'  => (int)($_POST['locations_id'] ?? User::getById(Session::getLoginUserID())->fields['locations_id'] ?? 0),
             'rand'   => $locrand,
             'entity' => $_SESSION['glpiactiveentities'],
         ]);

--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -559,7 +559,6 @@ class ReservationItem extends CommonDBChild
         // Location dropdown
         $user = new User();
         $user->getFromDB(Session::getLoginUserID());
-        $entities = Profile_User::getUserEntities($user->fields['id'], true);
         $locrand = mt_rand();
         echo "<tr class='tab_bg_1'><td><label for='dropdown_locations_id$locrand'>" . __('Item location') . "</label></td><td>";
         Location::dropdown([

--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -566,7 +566,7 @@ class ReservationItem extends CommonDBChild
             // Fill with submitted data if any, otherwise use user's location
             'value'  => $_POST['locations_id'] ?? $user->fields['locations_id'],
             'rand'   => $locrand,
-            'entity' => count($entities) <= 0 ? -1 : $entities,
+            'entity' => $_SESSION['glpiactiveentities'],
         ]);
 
         echo "</td></tr>";


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Implemented tickets | [UserEcho 2149](https://glpi.userecho.com/communities/1/topics/2149-allow-filtering-by-location-when-looking-for-a-free-item-in-a-specific-period-reservation-tool)

This PR is to implement the suggested feature of being able to filter by location when searching for a free item to book.

I did not used a location dropdown that gives the user the ability to set "is", "is not", "under" or "not under" criteria and simply used a "under" (inclusive) operator.

The added code re-use existing location dropdown system and sub/child location fetching.

I hope the code style is compliant with GLPI's standards (we'll see what the CI think of it very soon).