### PR TITLE
Upgrade tecnickcom/tcpdf to ^6.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "symfony/polyfill-php80": "^1.26",
         "symfony/polyfill-php81": "^1.26",
         "symfony/polyfill-php82": "^1.26",
-        "tecnickcom/tcpdf": "^6.5",
+        "tecnickcom/tcpdf": "^6.6",
         "true/punycode": "^2.1",
         "twig/string-extra": "^3.3",
         "twig/twig": "^3.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "99b828d820c71d65f8cb4b9f0c7cc600",
+    "content-hash": "307479ea328f2580d6dd5efc531e0e84",
     "packages": [
         {
             "name": "blueimp/jquery-file-upload",
@@ -4543,16 +4543,16 @@
         },
         {
             "name": "tecnickcom/tcpdf",
-            "version": "6.5.0",
+            "version": "6.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tecnickcom/TCPDF.git",
-                "reference": "cc54c1503685e618b23922f53635f46e87653662"
+                "reference": "e3cffc9bcbc76e89e167e9eb0bbda0cab7518459"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tecnickcom/TCPDF/zipball/cc54c1503685e618b23922f53635f46e87653662",
-                "reference": "cc54c1503685e618b23922f53635f46e87653662",
+                "url": "https://api.github.com/repos/tecnickcom/TCPDF/zipball/e3cffc9bcbc76e89e167e9eb0bbda0cab7518459",
+                "reference": "e3cffc9bcbc76e89e167e9eb0bbda0cab7518459",
                 "shasum": ""
             },
             "require": {
@@ -4603,7 +4603,7 @@
             ],
             "support": {
                 "issues": "https://github.com/tecnickcom/TCPDF/issues",
-                "source": "https://github.com/tecnickcom/TCPDF/tree/6.5.0"
+                "source": "https://github.com/tecnickcom/TCPDF/tree/6.6.2"
             },
             "funding": [
                 {
@@ -4611,7 +4611,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2022-08-12T07:50:54+00:00"
+            "time": "2022-12-17T10:28:59+00:00"
         },
         {
             "name": "true/punycode",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | maybe
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

According to [release notes](https://github.com/tecnickcom/TCPDF/blob/main/CHANGELOG.TXT), some fixes were made for PHP 8.0/8.1. I propose to upgrade this package on 10.0/bugfixes.