### PR TITLE
fix(ldap): do not exit processing servers on error

### DIFF
--- a/src/Console/Ldap/SynchronizeUsersCommand.php
+++ b/src/Console/Ldap/SynchronizeUsersCommand.php
@@ -180,6 +180,8 @@ class SynchronizeUsersCommand extends AbstractCommand
         $begin_date  = $input->getOption('begin-date');
         $end_date    = $input->getOption('end-date');
 
+        $ldap_server_error = false;
+
         $actions = [];
         if ($only_create) {
             $actions = [
@@ -294,6 +296,8 @@ class SynchronizeUsersCommand extends AbstractCommand
                 );
 
                 if (false === $users) {
+                    $ldap_server_error = true;
+
                     if ($limitexceeded) {
                         $message = sprintf(
                             __('LDAP server "%s" size limit exceeded.'),
@@ -311,7 +315,7 @@ class SynchronizeUsersCommand extends AbstractCommand
                         '<error>' . $message . '</error>',
                         OutputInterface::VERBOSITY_QUIET
                     );
-                     return $code;
+                    continue;
                 }
 
                  $action_message = '';
@@ -426,6 +430,9 @@ class SynchronizeUsersCommand extends AbstractCommand
             }
         }
 
+        if ($ldap_server_error) {
+            return 1; // At least one LDAP server had an error
+        }
         return 0; // Success
     }
 

--- a/src/Console/Ldap/SynchronizeUsersCommand.php
+++ b/src/Console/Ldap/SynchronizeUsersCommand.php
@@ -50,6 +50,7 @@ class SynchronizeUsersCommand extends AbstractCommand
      * Error code returned if LDAP connection failed.
      *
      * @var integer
+     * @FIXME Remove in GLPI 10.1.
      */
     const ERROR_LDAP_CONNECTION_FAILED = 1;
 
@@ -57,6 +58,7 @@ class SynchronizeUsersCommand extends AbstractCommand
      * Error code returned if LDAP limit exceeded.
      *
      * @var integer
+     * @FIXME Remove in GLPI 10.1.
      */
     const ERROR_LDAP_LIMIT_EXCEEDED = 2;
 
@@ -303,13 +305,11 @@ class SynchronizeUsersCommand extends AbstractCommand
                             __('LDAP server "%s" size limit exceeded.'),
                             $server_id
                         );
-                        $code = self::ERROR_LDAP_LIMIT_EXCEEDED;
                     } else {
                         $message = sprintf(
                             __('Error while contacting the LDAP server "%s".'),
                             $server_id
                         );
-                        $code = self::ERROR_LDAP_CONNECTION_FAILED;
                     }
                     $output->writeln(
                         '<error>' . $message . '</error>',
@@ -431,9 +431,9 @@ class SynchronizeUsersCommand extends AbstractCommand
         }
 
         if ($ldap_server_error) {
-            return 1; // At least one LDAP server had an error
+            return self::FAILURE; // At least one LDAP server had an error
         }
-        return 0; // Success
+        return self::SUCCESS; // Success
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A


Currently during a synchronization of several directories, if one of them is in error, the script stops immediately: preventing the following servers from being synchronized.