### PR TITLE
Fix peer dependencies resolution

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

On recent `npm` versions, installing dependencies triggers following error:
```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: jquery.autogrow-textarea@0.4.1
npm ERR! Found: jquery@3.5.1
npm ERR! node_modules/jquery
npm ERR!   jquery@"^3.4.1" from the root project
npm ERR!   jquery@"^1.8 || 2 || 3" from gridstack@0.6.3
npm ERR!   node_modules/gridstack
npm ERR!     gridstack@"^0.6.0" from the root project
npm ERR!   7 more (jquery-migrate, jquery-prettytextdiff, jquery-ui, ...)
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer jquery@"2.x" from jquery.autogrow-textarea@0.4.1
npm ERR! node_modules/jquery.autogrow-textarea
npm ERR!   jquery.autogrow-textarea@"^0.4.1" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: jquery@2.2.4
npm ERR! node_modules/jquery
npm ERR!   peer jquery@"2.x" from jquery.autogrow-textarea@0.4.1
npm ERR!   node_modules/jquery.autogrow-textarea
npm ERR!     jquery.autogrow-textarea@"^0.4.1" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /home/www-data/.npm/eresolve-report.txt for a full report.
```

Forcing `legacy-peer-deps=true` fixing this issue. This problem is present only on 9.5 branch.