### PR TITLE
fix(Appliance): do not display deleted appliance from search

### DIFF
--- a/src/Appliance.php
+++ b/src/Appliance.php
@@ -307,6 +307,7 @@ class Appliance extends CommonDBTM
             'itemlink_type'      => 'Appliance',
             'massiveaction'      => false,
             'joinparams'         => [
+                'condition'  => ['NEWTABLE.is_deleted' => 0],
                 'beforejoin' => [
                     'table'      => Appliance_Item::getTable(),
                     'joinparams' => ['jointype' => 'itemtype_item']


### PR DESCRIPTION
Appliance are still displayed from search even if they are deleted (```is_deleted = 1```)

This PR fix this


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25244
