### PR TITLE
fix(notification): 404 error after purge

### DIFF
--- a/front/notification_notificationtemplate.form.php
+++ b/front/notification_notificationtemplate.form.php
@@ -55,8 +55,11 @@ if (isset($_POST["add"])) {
     Html::back();
 } else if (isset($_POST["purge"])) {
     $notiftpl->check($_POST["id"], PURGE);
+    $notiftpl->getFromDB($_POST['id']);
     $notiftpl->delete($_POST, 1);
-    $notiftpl->redirectToList();
+    $notif = new Notification();
+    $notif->getFromDB($notiftpl->fields['notifications_id']);
+    Html::redirect($notif->getLinkURL());
 } else if (isset($_POST["update"])) {
     $notiftpl->check($_POST["id"], UPDATE);
 

--- a/front/notification_notificationtemplate.form.php
+++ b/front/notification_notificationtemplate.form.php
@@ -55,11 +55,8 @@ if (isset($_POST["add"])) {
     Html::back();
 } else if (isset($_POST["purge"])) {
     $notiftpl->check($_POST["id"], PURGE);
-    $notiftpl->getFromDB($_POST['id']);
     $notiftpl->delete($_POST, 1);
-    $notif = new Notification();
-    $notif->getFromDB($notiftpl->fields['notifications_id']);
-    Html::redirect($notif->getLinkURL());
+    Html::redirect(Notification::getFormURLWithID($notiftpl->fields['notifications_id']));
 } else if (isset($_POST["update"])) {
     $notiftpl->check($_POST["id"], UPDATE);
 


### PR DESCRIPTION
404 error when you want to delete a template linked to a notification.

![image](https://user-images.githubusercontent.com/8530352/210384006-9302aae8-c52f-436c-b495-e2fa4e5ba47e.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26091
