### PR TITLE
Fix references to outdated FontAwesome version

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -60,7 +60,7 @@ module.exports = {
             true,
             {
                 "ignoreFontFamilies": [
-                    "Font Awesome 5 Free",
+                    "Font Awesome 6 Free",
                     "tabler-icons",
                 ],
             }

--- a/css/legacy/includes/_styles.scss
+++ b/css/legacy/includes/_styles.scss
@@ -1112,7 +1112,7 @@
       }
 
       &:after {
-         font-family: 'Font Awesome 5 Free';
+         font-family: 'Font Awesome 6 Free';
          position: relative;
          left: -15px;
          top: 1px;

--- a/js/Forms/FaIconSelector.js
+++ b/js/Forms/FaIconSelector.js
@@ -106,9 +106,10 @@ GLPI.Forms.FaIconSelector = class {
     * @returns {HTMLElement}
     */
     renderIcon(option) {
-        const faFontFamilies = '\'Font Awesome 5 Free\', \'Font Awesome 5 Brands\'';
+        // Forces font family values to fallback on ".fab" family font if char is not available in ".fas" family.
+        const faFontFamilies = '\'Font Awesome 6 Free\', \'Font Awesome 6 Brands\'';
         let container = document.createElement('span');
-        container.innerHTML = `<i class="fa-lg fa-fw fas ${option.id}" style="font-family:${faFontFamilies};"></i> ${option.id}`;
+        container.innerHTML = `<i class="fa-lg fa-fw fa ${option.id}" style="font-family:${faFontFamilies};"></i> ${option.id}`;
         return container;
     }
 };

--- a/src/ManualLink.php
+++ b/src/ManualLink.php
@@ -361,8 +361,9 @@ JAVASCRIPT
         $target = $fields['open_window'] == 1 ? '_blank' : '_self';
         $html .= '<a href="' . Html::entities_deep($fields['url']) . '" target="' . $target . '">';
         if (!empty($fields['icon'])) {
-            $html .= '<i class="fa-lg fa-fw fas ' . Html::entities_deep($fields['icon']) . '"'
-            . ' style="font-family:\'Font Awesome 5 Free\', \'Font Awesome 5 Brands\';"></i>&nbsp;';
+            // Forces font family values to fallback on ".fab" family font if char is not available in ".fas" family.
+            $html .= '<i class="fa-lg fa-fw fa ' . Html::entities_deep($fields['icon']) . '"'
+            . ' style="font-family:\'Font Awesome 6 Free\', \'Font Awesome 6 Brands\';"></i>&nbsp;';
         }
         $html .= !empty($fields['name']) ? $fields['name'] : $fields['url'];
         $html .= '</a>';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`Font Awesome 5` font families are still valid, but I guess they will be removed someday.