### PR TITLE
Twig template for projects' tasks

### DIFF
--- a/ajax/projecttask.php
+++ b/ajax/projecttask.php
@@ -55,7 +55,7 @@ if (isset($_POST['projecttasktemplates_id']) && ($_POST['projecttasktemplates_id
             $template->getType(),
             'content',
             $_SESSION['glpilanguage'],
-            $template->fields['content']
+            $template->fields['description']
         );
     }
 

--- a/ajax/projecttask.php
+++ b/ajax/projecttask.php
@@ -50,7 +50,7 @@ if (isset($_POST['projecttasktemplates_id']) && ($_POST['projecttasktemplates_id
     $template->getFromDB($_POST['projecttasktemplates_id']);
 
     if (DropdownTranslation::isDropdownTranslationActive()) {
-        $template->fields['content'] = DropdownTranslation::getTranslatedValue(
+        $template->fields['description'] = DropdownTranslation::getTranslatedValue(
             $template->getID(),
             $template->getType(),
             'content',

--- a/ajax/projecttask.php
+++ b/ajax/projecttask.php
@@ -53,7 +53,7 @@ if (isset($_POST['projecttasktemplates_id']) && ($_POST['projecttasktemplates_id
         $template->fields['description'] = DropdownTranslation::getTranslatedValue(
             $template->getID(),
             $template->getType(),
-            'content',
+            'description',
             $_SESSION['glpilanguage'],
             $template->fields['description']
         );

--- a/src/Application/View/Extension/DataHelpersExtension.php
+++ b/src/Application/View/Extension/DataHelpersExtension.php
@@ -99,15 +99,18 @@ class DataHelpersExtension extends AbstractExtension
      * Return human readable duration.
      *
      * @param mixed $duration
+     * @param bool $display_seconds (default: true)
      *
      * @return string|null
      */
-    public function getFormattedDuration($duration): ?string
-    {
+    public function getFormattedDuration(
+        $duration,
+        bool $display_seconds = true
+    ): ?string {
         if (!is_numeric($duration)) {
             return null;
         }
-        return Html::timestampToString($duration);
+        return Html::timestampToString($duration, $display_seconds);
     }
 
     /**

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -586,12 +586,13 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
     {
         if ($ID > 0) {
             $this->check($ID, READ);
-            $duration = ProjectTask_Ticket::getTicketsTotalActionTime($this->getID());
+            $duration        = ProjectTask_Ticket::getTicketsTotalActionTime($this->getID());
             $projects_id     = $this->fields['projects_id'];
             $projecttasks_id = $this->fields['projecttasks_id'];
             $recursive       = null; // Wont be used in the case, value is irrelevant
         } else {
             $this->check(-1, CREATE, $options);
+            $duration        = null;
             $projects_id     = $options['projects_id'];
             $projecttasks_id = $options['projecttasks_id'];
             $recursive       = $this->fields['is_recursive'];

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -585,23 +585,16 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
     public function showForm($ID, array $options = [])
     {
         if ($ID > 0) {
-            $duration = ProjectTask_Ticket::getTicketsTotalActionTime($this->getID());
             $this->check($ID, READ);
+            $duration = ProjectTask_Ticket::getTicketsTotalActionTime($this->getID());
             $projects_id     = $this->fields['projects_id'];
             $projecttasks_id = $this->fields['projecttasks_id'];
             $recursive       = null; // Wont be used in the case, value is irrelevant
-            $ticket_duration = Html::timestampToString($duration, false);
-            $total_duration  = Html::timestampToString(
-                $duration + $this->fields["effective_duration"],
-                false
-            );
         } else {
             $this->check(-1, CREATE, $options);
             $projects_id     = $options['projects_id'];
             $projecttasks_id = $options['projecttasks_id'];
             $recursive       = $this->fields['is_recursive'];
-            $ticket_duration = null; // Wont be used in the case, value is irrelevant
-            $total_duration  = null; // Wont be used in the case, value is irrelevant
         }
 
         $duration_dropdown_to_add = [];
@@ -619,9 +612,8 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
             'projecttasks_id'          => $projecttasks_id,
             'recursive'                => $recursive,
             'duration_dropdown_to_add' => $duration_dropdown_to_add,
-            'ticket_duration'          => $ticket_duration,
-            'total_duration'           => $total_duration,
-            'safe_content'             => RichText::getSafeHtml($this->fields["content"], true),
+            'duration'                 => $duration,
+            'rand'                     => mt_rand(),
         ]);
         return true;
     }

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -33,6 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\View\TemplateRenderer;
 use Glpi\CalDAV\Contracts\CalDAVCompatibleItemInterface;
 use Glpi\CalDAV\Traits\VobjectConverterTrait;
 use Glpi\RichText\RichText;
@@ -583,315 +584,45 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
      **/
     public function showForm($ID, array $options = [])
     {
-        global $CFG_GLPI;
-
-        $rand_template           = mt_rand();
-        $rand_name               = mt_rand();
-        $rand_description        = mt_rand();
-        $rand_comment            = mt_rand();
-        $rand_project            = mt_rand();
-        $rand_state              = mt_rand();
-        $rand_type               = mt_rand();
-        $rand_percent            = mt_rand();
-        $rand_milestone          = mt_rand();
-        $rand_plan_start_date    = mt_rand();
-        $rand_plan_end_date      = mt_rand();
-        $rand_real_start_date    = mt_rand();
-        $rand_real_end_date      = mt_rand();
-        $rand_effective_duration = mt_rand();
-        $rand_planned_duration   = mt_rand();
-
         if ($ID > 0) {
+            $duration = ProjectTask_Ticket::getTicketsTotalActionTime($this->getID());
             $this->check($ID, READ);
             $projects_id     = $this->fields['projects_id'];
             $projecttasks_id = $this->fields['projecttasks_id'];
+            $recursive       = null; // Wont be used in the case, value is irrelevant
+            $ticket_duration = Html::timestampToString($duration, false);
+            $total_duration  = Html::timestampToString(
+                $duration + $this->fields["effective_duration"],
+                false
+            );
         } else {
             $this->check(-1, CREATE, $options);
             $projects_id     = $options['projects_id'];
             $projecttasks_id = $options['projecttasks_id'];
             $recursive       = $this->fields['is_recursive'];
+            $ticket_duration = null; // Wont be used in the case, value is irrelevant
+            $total_duration  = null; // Wont be used in the case, value is irrelevant
         }
 
-        $this->showFormHeader($options);
-
-        echo "<tr class='tab_bg_1'>";
-        echo "<td style='width:100px'>" . _n('Project task template', 'Project task templates', 1) . "</td><td>";
-        ProjectTaskTemplate::dropdown(['value'     => $this->fields['projecttasktemplates_id'],
-            'entity'    => $this->getEntityID(),
-            'rand'      => $rand_template,
-            'on_change' => 'projecttasktemplate_update(this.value)'
-        ]);
-        echo "</td>";
-        echo "<td colspan='2'></td>";
-        echo "</tr>";
-        echo Html::scriptBlock('
-         function projecttasktemplate_update(value) {
-            $.ajax({
-               url: "' . $CFG_GLPI["root_doc"] . '/ajax/projecttask.php",
-               type: "POST",
-               data: {
-                  projecttasktemplates_id: value
-               }
-            }).done(function(data) {
-
-               // set input name
-               $("#textfield_name' . $rand_name . '").val(data.name);
-
-               // set textarea description
-               if (tasktinymce = tinymce.get("description' . $rand_description . '")) {
-                  tasktinymce.setContent(data.description);
-               }
-                // set textarea comment
-               $("#comment' . $rand_comment . '").val(data.comments);
-
-               // set project task
-               $("#dropdown_projecttasks_id' . $rand_project . '").trigger("setValue", data.projecttasks_id);
-               // set state
-               $("#dropdown_projectstates_id' . $rand_state . '").trigger("setValue", data.projectstates_id);
-               // set type
-               $("#dropdown_projecttasktypes_id' . $rand_type . '").trigger("setValue", data.projecttasktypes_id);
-               // set percent done
-               $("#dropdown_percent_done' . $rand_percent . '").trigger("setValue", data.percent_done);
-               // set milestone
-               $("#dropdown_is_milestone' . $rand_milestone . '").trigger("setValue", data.is_milestone);
-
-               // set plan_start_date
-               $("#showdate' . $rand_plan_start_date . '").val(data.plan_start_date);
-               // set plan_end_date
-               $("#showdate' . $rand_plan_end_date . '").val(data.plan_end_date);
-               // set real_start_date
-               $("#showdate' . $rand_real_start_date . '").val(data.real_start_date);
-               // set real_end_date
-               $("#showdate' . $rand_real_end_date . '").val(data.real_end_date);
-
-               // set effective_duration
-               $("#dropdown_effective_duration' . $rand_effective_duration . '").trigger("setValue", data.effective_duration);
-               // set planned_duration
-               $("#dropdown_planned_duration' . $rand_planned_duration . '").trigger("setValue", data.planned_duration);
-
-            });
-         }
-      ');
-
-        echo "<tr class='tab_bg_1'><td>" . _n('Project', 'Projects', Session::getPluralNumber()) . "</td>";
-        echo "<td>";
-        if ($this->isNewID($ID)) {
-            echo "<input type='hidden' name='projects_id' value='$projects_id'>";
-            echo "<input type='hidden' name='is_recursive' value='$recursive'>";
-        }
-        echo "<a href='" . Project::getFormURLWithID($projects_id) . "'>" .
-             Dropdown::getDropdownName("glpi_projects", $projects_id) . "</a>";
-        echo "</td>";
-        echo "<td>" . __('As child of') . "</td>";
-        echo "<td>";
-        $this->dropdown([
-            'entity'    => $this->fields['entities_id'],
-            'value'     => $projecttasks_id,
-            'rand'      => $rand_project,
-            'condition' => ['glpi_projecttasks.projects_id' => $this->fields['projects_id']],
-            'used'      => [$this->fields['id']]
-        ]);
-        echo "</td></tr>";
-
-        $showuserlink = 0;
-        if (Session::haveRight('user', READ)) {
-            $showuserlink = 1;
-        }
-
-        if ($ID) {
-            echo "<tr class='tab_bg_1'>";
-            echo "<td>" . __('Creation date') . "</td>";
-            echo "<td>";
-            echo sprintf(
-                __('%1$s by %2$s'),
-                Html::convDateTime($this->fields["date_creation"]),
-                getUserName($this->fields["users_id"], $showuserlink)
-            );
-            echo "</td>";
-            echo "<td>" . __('Last update') . "</td>";
-            echo "<td>";
-            echo Html::convDateTime($this->fields["date_mod"]);
-            echo "</td></tr>";
-        }
-
-        echo "<tr class='tab_bg_1'><td>" . __('Name') . "</td>";
-        echo "<td colspan='3'>";
-        echo Html::input(
-            'name',
-            [
-                'value' => $this->fields['name'],
-                'id'    => "textfield_name$rand_name",
-                'size'  => '80',
-            ]
-        );
-        echo "</td></tr>\n";
-
-        echo "<tr class='tab_bg_1'>";
-        echo "<td>" . _x('item', 'State') . "</td>";
-        echo "<td>";
-        ProjectState::dropdown(['value' => $this->fields["projectstates_id"],
-            'rand'  => $rand_state
-        ]);
-        echo "</td>";
-        echo "<td>" . _n('Type', 'Types', 1) . "</td>";
-        echo "<td>";
-        ProjectTaskType::dropdown(['value' => $this->fields["projecttasktypes_id"],
-            'rand'  => $rand_type
-        ]);
-        echo "</td></tr>";
-
-        echo "<tr class='tab_bg_1'>";
-        echo "<td>" . __('Percent done') . "</td>";
-        echo "<td>";
-        $percent_done_params = [
-            'value' => $this->fields['percent_done'],
-            'rand'  => $rand_percent,
-            'min'   => 0,
-            'max'   => 100,
-            'step'  => 5,
-            'unit'  => '%'
-        ];
-        if ($this->fields['auto_percent_done']) {
-            $percent_done_params['specific_tags'] = ['disabled' => 'disabled'];
-        }
-        Dropdown::showNumber("percent_done", $percent_done_params);
-        $auto_percent_done_params = [
-            'type'      => 'checkbox',
-            'name'      => 'auto_percent_done',
-            'title'     => __('Automatically calculate'),
-            'onclick'   => "$(\"select[name='percent_done']\").prop('disabled', !$(\"input[name='auto_percent_done']\").prop('checked'));"
-        ];
-        if ($this->fields['auto_percent_done']) {
-            $auto_percent_done_params['checked'] = 'checked';
-        }
-        Html::showCheckbox($auto_percent_done_params);
-        echo "<span class='ms-3'>";
-        Html::showToolTip(__('When automatic computation is active, percentage is computed based on the average of all child task percent done.'));
-        echo "</span></td>";
-
-        echo "</td>";
-        echo "<td>";
-        echo __('Milestone');
-        echo "</td>";
-        echo "<td>";
-        Dropdown::showYesNo("is_milestone", $this->fields["is_milestone"], -1, ['rand' => $rand_milestone]);
-        $js = "$('#dropdown_is_milestone$rand_milestone').on('change', function(e) {
-         $('tr.is_milestone').toggleClass('starthidden');
-      })";
-        echo Html::scriptBlock($js);
-        echo "</td>";
-        echo "</tr>";
-
-        echo "<tr><td colspan='4' class='subheader'>" . __('Planning') . "</td></tr>";
-
-        echo "<tr class='tab_bg_1'>";
-        echo "<td>" . __('Planned start date') . "</td>";
-        echo "<td>";
-        Html::showDateTimeField(
-            "plan_start_date",
-            ['value' => $this->fields['plan_start_date'],
-                'rand'  => $rand_plan_start_date
-            ]
-        );
-        echo "</td>";
-        echo "<td>" . __('Real start date') . "</td>";
-        echo "<td>";
-        Html::showDateTimeField(
-            "real_start_date",
-            ['value' => $this->fields['real_start_date'],
-                'rand'  => $rand_real_start_date
-            ]
-        );
-        echo "</td></tr>\n";
-
-        echo "<tr class='tab_bg_1'>";
-        echo "<td>" . __('Planned end date') . "</td>";
-        echo "<td>";
-        Html::showDateTimeField("plan_end_date", ['value' => $this->fields['plan_end_date'],
-            'rand'  => $rand_plan_end_date
-        ]);
-        echo "</td>";
-        echo "<td>" . __('Real end date') . "</td>";
-        echo "<td>";
-        Html::showDateTimeField("real_end_date", ['value' => $this->fields['real_end_date'],
-            'rand'  => $rand_real_end_date
-        ]);
-        echo "</td></tr>\n";
-
-        echo "<tr class='tab_bg_1 is_milestone" . ($this->fields['is_milestone'] ? ' starthidden' : '')  . "'>";
-        echo "<td>" . __('Planned duration') . "</td>";
-        echo "<td>";
-
-        $toadd = [];
+        $duration_dropdown_to_add = [];
         for ($i = 9; $i <= 100; $i++) {
-            $toadd[] = $i * HOUR_TIMESTAMP;
+            $duration_dropdown_to_add[] = $i * HOUR_TIMESTAMP;
         }
 
-        Dropdown::showTimeStamp(
-            "planned_duration",
-            ['min'             => 0,
-                'max'             => 8 * HOUR_TIMESTAMP,
-                'rand'            => $rand_planned_duration,
-                'value'           => $this->fields["planned_duration"],
-                'addfirstminutes' => true,
-                'inhours'         => true,
-                'toadd'           => $toadd
-            ]
-        );
-        echo "</td>";
-        echo "<td>" . __('Effective duration') . "</td>";
-        echo "<td>";
-        Dropdown::showTimeStamp(
-            "effective_duration",
-            ['min'             => 0,
-                'max'             => 8 * HOUR_TIMESTAMP,
-                'rand'            => $rand_effective_duration,
-                'value'           => $this->fields["effective_duration"],
-                'addfirstminutes' => true,
-                'inhours'         => true,
-                'toadd'           => $toadd
-            ]
-        );
-        if ($ID) {
-            $ticket_duration = ProjectTask_Ticket::getTicketsTotalActionTime($this->getID());
-            echo "<br>";
-            printf(
-                __('%1$s: %2$s'),
-                __('Tickets duration'),
-                Html::timestampToString($ticket_duration, false)
-            );
-            echo '<br>';
-            printf(
-                __('%1$s: %2$s'),
-                __('Total duration'),
-                Html::timestampToString(
-                    $ticket_duration + $this->fields["effective_duration"],
-                    false
-                )
-            );
-        }
-        echo "</td></tr>\n";
-
-        echo "<tr class='tab_bg_1'>";
-        echo "<td>" . __('Description') . "</td>";
-        echo "<td colspan='3'>";
-        Html::textarea([
-            'name'            => 'content',
-            'enable_richtext' => true,
-            'editor_id'       => "description$rand_description",
-            'value'           => RichText::getSafeHtml($this->fields["content"], true),
+        $this->initForm($ID, $options);
+        TemplateRenderer::getInstance()->display('pages/tools/project_task.html.twig', [
+            'id'                       => $ID,
+            'item'                     => $this,
+            'params'                   => $options,
+            'parent'                   => Project::getById($projects_id),
+            'projects_id'              => $projects_id,
+            'projecttasks_id'          => $projecttasks_id,
+            'recursive'                => $recursive,
+            'duration_dropdown_to_add' => $duration_dropdown_to_add,
+            'ticket_duration'          => $ticket_duration,
+            'total_duration'           => $total_duration,
+            'safe_content'             => RichText::getSafeHtml($this->fields["content"], true),
         ]);
-        echo "</td></tr>";
-
-        echo "<tr class='tab_bg_1'>";
-        echo "<td>" . __('Comments') . "</td>";
-        echo "<td colspan='3'>";
-        echo "<textarea id='comment$rand_comment' name='comment' cols='90' rows='6'>" . $this->fields["comment"] .
-           "</textarea>";
-        echo "</td></tr>\n";
-
-        $this->showFormButtons($options);
-
         return true;
     }
 

--- a/templates/pages/tools/project_task.html.twig
+++ b/templates/pages/tools/project_task.html.twig
@@ -35,6 +35,7 @@
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
 {% set form_id = 'project_task_' ~ rand %}
+{% set content_field_id = 'content_' ~ rand %}
 {% set params = {
     'formoptions': 'id="' ~ form_id ~ '"'
 } %}
@@ -73,7 +74,7 @@
                 form.find('input[name=real_end_date]').parent()[0]._flatpickr.setDate(data.real_end_date);
 
                 // Set tinymce
-                if (tasktinymce = tinymce.get("editor_content")) {
+                if (tasktinymce = tinymce.get("{{ content_field_id }}")) {
                     tasktinymce.setContent(data.description);
                 }
 
@@ -243,7 +244,7 @@
 
     {% if id %}
         {% set ticket_duration %}
-            <span class="fw-normal col-form-label d-inline-flex ">{{ (duration)|formatted_duration(false) }}</span>
+            <span class="fw-normal col-form-label d-inline-flex ">{{ duration|formatted_duration(false) }}</span>
         {% endset %}
         {{ fields.field(
             '_ticket_duration',
@@ -273,7 +274,7 @@
         {
             'name': 'content',
             'enable_richtext': true,
-            'id': "editor_content",
+            'id': content_field_id,
             'label_class': "col-xxl-2",
             'input_class': "col-xxl-10",
             'field_class' : "col-12",

--- a/templates/pages/tools/project_task.html.twig
+++ b/templates/pages/tools/project_task.html.twig
@@ -87,17 +87,17 @@
     {{ fields.nullField() }}
 
     {% set project_link %}
-        <span class="col-form-label d-inline-flex">{{parent.getLink()|raw}}</span>
+        <span class="col-form-label d-inline-flex">{{ parent.getLink()|raw }}</span>
     {% endset %}
     {{ fields.field(
         '_project',
-        project_link | raw,
+        project_link|raw,
         parent.getTypeName(),
     ) }}
 
     {% if item.isNewID(id) %}
-        <input type='hidden' name='projects_id' value='{{projects_id}}'>
-        <input type='hidden' name='is_recursive' value='{{recursive}}'>
+        <input type='hidden' name='projects_id' value='{{ projects_id }}'>
+        <input type='hidden' name='is_recursive' value='{{ recursive }}'>
     {% endif %}
 
     {{ fields.dropdownField(

--- a/templates/pages/tools/project_task.html.twig
+++ b/templates/pages/tools/project_task.html.twig
@@ -1,0 +1,289 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2022 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% extends "generic_show_form.html.twig" %}
+{% import 'components/form/fields_macros.html.twig' as fields %}
+{% set params  = params ?? [] %}
+
+{% block form_fields %}
+
+    {{ fields.dropdownField(
+        'ProjectTaskTemplate',
+        'projecttasktemplates_id',
+        item.fields.projecttasktemplates_id,
+        _n('Project task template', 'Project task templates', 1),
+        {
+            'entity': item.getEntityID(),
+            'on_change': 'projecttasktemplate_update(this.value)'
+        }
+    ) }}
+
+    <script>
+        function projecttasktemplate_update(value) {
+            $.ajax({
+                url: CFG_GLPI.root_doc + "/ajax/projecttask.php",
+                type: "POST",
+                data: {
+                    projecttasktemplates_id: value
+                }
+            }).done(function(data) {
+                // Set simple inputs
+                $('input[name=name]').val(data.name);
+                $('textarea[name=comment]').val(data.comments);
+
+                // Set flatpickr dates
+                $('input[name=plan_start_date]').parent()[0]._flatpickr.setDate(data.plan_start_date);
+                $('input[name=plan_end_date]').parent()[0]._flatpickr.setDate(data.plan_end_date);
+                $('input[name=real_start_date]').parent()[0]._flatpickr.setDate(data.real_start_date);
+                $('input[name=real_end_date]').parent()[0]._flatpickr.setDate(data.real_end_date);
+
+                // Set tinymce
+                if (tasktinymce = tinymce.get("editor_content")) {
+                    tasktinymce.setContent(data.description);
+                }
+
+                // Set dropdowns and dates
+                $('select[name=projecttasks_id]').trigger("setValue", data.projecttasks_id);
+                $('select[name=projectstates_id]').trigger("setValue", data.projectstates_id);
+                $('select[name=projecttasktypes_id]').trigger("setValue", data.projecttasktypes_id);
+                $('select[name=percent_done]').trigger("setValue", data.percent_done);
+                $('select[name=is_milestone]').trigger("setValue", data.is_milestone);
+                $('select[name=effective_duration]').trigger("setValue", data.effective_duration);
+                $('select[name=planned_duration]').trigger("setValue", data.planned_duration);
+            });
+         }
+    </script>
+
+    {{ fields.nullField() }}
+
+    {% set project_link %}
+        <span class="col-form-label d-inline-flex">{{parent.getLink()|raw}}</span>
+    {% endset %}
+    {{ fields.field(
+        '_project',
+        project_link | raw,
+        parent.getTypeName(),
+    ) }}
+
+    {% if item.isNewID(id) %}
+        <input type='hidden' name='projects_id' value='{{projects_id}}'>
+        <input type='hidden' name='is_recursive' value='{{recursive}}'>
+    {% endif %}
+
+    {{ fields.dropdownField(
+        'ProjectTask',
+        'projecttasks_id',
+        projecttasks_id,
+        __('As child of'),
+        {
+            'entity': item.getEntityID(),
+            'condition': {'glpi_projecttasks.projects_id': projects_id},
+            'used': [item.getID()],
+        }
+    ) }}
+
+    {{ fields.textField(
+        'name',
+        item.fields.name,
+        __('Name'),
+    ) }}
+
+    {{ fields.nullField() }}
+
+    {{ fields.dropdownField(
+        'ProjectState',
+        'projectstates_id',
+        item.fields.projectstates_id,
+        _x('item', 'State'),
+    ) }}
+
+    {{ fields.dropdownField(
+        'ProjectTaskType',
+        'projecttasktypes_id',
+        item.fields.projecttasktypes_id,
+        _n('Type', 'Types', 1),
+    ) }}
+
+    {{ fields.dropdownNumberField(
+        'percent_done',
+        item.fields.percent_done,
+        __('Percent done'),
+        {
+            'value': item.fields.percent_done,
+            'min': 0,
+            'max': 100,
+            'step': 5,
+            'unit': '%',
+         }|merge(item.fields.auto_percent_done ? {'specific_tags': {'disabled': 'disabled'}} : {})
+    ) }}
+
+    {% set tooltip %}
+        {% do call('Html::showToolTip', [
+            __('When automatic computation is active, percentage is computed based on the average of all child task percent done.')
+        ]) %}
+    {% endset %}
+    {{ fields.checkboxField(
+        'auto_percent_done',
+        item.fields.auto_percent_done,
+        __('Automatically calculate'),
+        {
+            'add_field_html': tooltip,
+        }
+    ) }}
+    <script>
+        $("input[name=auto_percent_done]").on('change', function() {
+            $("select[name='percent_done']").prop('disabled', $("input[name='auto_percent_done']").eq(1).prop('checked'));
+        });
+    </script>
+
+    {{ fields.dropdownYesNo(
+        'is_milestone',
+        item.fields.is_milestone,
+        __('Milestone'),
+    ) }}
+    <script>
+        $('select[name=is_milestone]').on('change', function() {
+            $('.is_milestone').toggleClass('d-none', Boolean(Number(this.value)));
+        });
+    </script>
+
+    {{ fields.nullField() }}
+
+    <div class="hr-text">
+        <i class="ti ti-calendar-event"></i>
+        <span>{{ __('Planning') }}</span>
+    </div>
+
+    {{ fields.datetimeField(
+        'plan_start_date',
+        item.fields.plan_start_date,
+        __('Planned start date'),
+    ) }}
+
+    {{ fields.datetimeField(
+        'real_start_date',
+        item.fields.real_start_date,
+        __('Real start date'),
+    ) }}
+
+    {{ fields.datetimeField(
+        'plan_end_date',
+        item.fields.plan_end_date,
+        __('Planned end date'),
+    ) }}
+
+    {{ fields.datetimeField(
+        'real_end_date',
+        item.fields.real_end_date,
+        __('Real end date'),
+    ) }}
+
+    {{ fields.dropdownTimestampField(
+        'planned_duration',
+        item.fields.planned_duration,
+        __('Planned duration'),
+        {
+            'min': 0,
+            'max': 8 * constant('HOUR_TIMESTAMP'),
+            'addfirstminutes': true,
+            'inhours': true,
+            'toadd': duration_dropdown_to_add,
+            'field_class': 'col-12 col-sm-6 is_milestone ' ~ (item.fields.is_milestone ? 'd-none' : ''),
+        },
+    ) }}
+
+    {{ fields.dropdownTimestampField(
+        'effective_duration',
+        item.fields.effective_duration,
+        __('Effective duration'),
+        {
+            'min': 0,
+            'max': 8 * constant('HOUR_TIMESTAMP'),
+            'addfirstminutes': true,
+            'inhours': true,
+            'toadd': duration_dropdown_to_add,
+            'field_class': 'col-12 col-sm-6 is_milestone ' ~ (item.fields.is_milestone ? 'd-none' : ''),
+        },
+    ) }}
+
+    {% if id %}
+        {% set ticket_duration %}
+            <span class="fw-normal col-form-label d-inline-flex ">{{ ticket_duration }}</span>
+        {% endset %}
+        {{ fields.field(
+            '_ticket_duration',
+            ticket_duration,
+            __("Tickets duration"),
+        ) }}
+
+        {% set total_duration %}
+            <span class="fw-normal col-form-label d-inline-flex ">{{ total_duration }}</span>
+        {% endset %}
+        {{ fields.field(
+            '_total_duration',
+            total_duration,
+            __("Total duration"),
+        ) }}
+    {% endif %}
+
+    <div class="hr-text">
+        <i class="ti ti-file-description"></i>
+        <span>{{ __('Details') }}</span>
+    </div>
+
+    {{ fields.textareaField(
+        'content',
+        safe_content,
+        __("Description"),
+        {
+            'name': 'content',
+            'enable_richtext': true,
+            'id': "editor_content",
+            'label_class': "col-xxl-2",
+            'input_class': "col-xxl-10",
+            'field_class' : "col-12",
+        }
+    ) }}
+
+    {{ fields.textareaField(
+        'comment',
+        item.fields.comment,
+        __("Comments"),
+        {
+            'label_class': "col-xxl-2",
+            'input_class': "col-xxl-10",
+            'field_class' : "col-12",
+        }
+    ) }}
+
+{% endblock %}

--- a/templates/pages/tools/project_task.html.twig
+++ b/templates/pages/tools/project_task.html.twig
@@ -33,7 +33,11 @@
 
 {% extends "generic_show_form.html.twig" %}
 {% import 'components/form/fields_macros.html.twig' as fields %}
-{% set params  = params ?? [] %}
+
+{% set form_id = 'project_task_' ~ rand %}
+{% set params = {
+    'formoptions': 'id="' ~ form_id ~ '"'
+} %}
 
 {% block form_fields %}
 
@@ -41,7 +45,7 @@
         'ProjectTaskTemplate',
         'projecttasktemplates_id',
         item.fields.projecttasktemplates_id,
-        _n('Project task template', 'Project task templates', 1),
+        'ProjectTaskTemplate'|itemtype_name,
         {
             'entity': item.getEntityID(),
             'on_change': 'projecttasktemplate_update(this.value)'
@@ -49,6 +53,7 @@
     ) }}
 
     <script>
+        const form = $('#{{ form_id }}');
         function projecttasktemplate_update(value) {
             $.ajax({
                 url: CFG_GLPI.root_doc + "/ajax/projecttask.php",
@@ -58,14 +63,14 @@
                 }
             }).done(function(data) {
                 // Set simple inputs
-                $('input[name=name]').val(data.name);
-                $('textarea[name=comment]').val(data.comments);
+                form.find('input[name=name]').val(data.name);
+                form.find('textarea[name=comment]').val(data.comments);
 
                 // Set flatpickr dates
-                $('input[name=plan_start_date]').parent()[0]._flatpickr.setDate(data.plan_start_date);
-                $('input[name=plan_end_date]').parent()[0]._flatpickr.setDate(data.plan_end_date);
-                $('input[name=real_start_date]').parent()[0]._flatpickr.setDate(data.real_start_date);
-                $('input[name=real_end_date]').parent()[0]._flatpickr.setDate(data.real_end_date);
+                form.find('input[name=plan_start_date]').parent()[0]._flatpickr.setDate(data.plan_start_date);
+                form.find('input[name=plan_end_date]').parent()[0]._flatpickr.setDate(data.plan_end_date);
+                form.find('input[name=real_start_date]').parent()[0]._flatpickr.setDate(data.real_start_date);
+                form.find('input[name=real_end_date]').parent()[0]._flatpickr.setDate(data.real_end_date);
 
                 // Set tinymce
                 if (tasktinymce = tinymce.get("editor_content")) {
@@ -73,13 +78,13 @@
                 }
 
                 // Set dropdowns and dates
-                $('select[name=projecttasks_id]').trigger("setValue", data.projecttasks_id);
-                $('select[name=projectstates_id]').trigger("setValue", data.projectstates_id);
-                $('select[name=projecttasktypes_id]').trigger("setValue", data.projecttasktypes_id);
-                $('select[name=percent_done]').trigger("setValue", data.percent_done);
-                $('select[name=is_milestone]').trigger("setValue", data.is_milestone);
-                $('select[name=effective_duration]').trigger("setValue", data.effective_duration);
-                $('select[name=planned_duration]').trigger("setValue", data.planned_duration);
+                form.find('select[name=projecttasks_id]').trigger("setValue", data.projecttasks_id);
+                form.find('select[name=projectstates_id]').trigger("setValue", data.projectstates_id);
+                form.find('select[name=projecttasktypes_id]').trigger("setValue", data.projecttasktypes_id);
+                form.find('select[name=percent_done]').trigger("setValue", data.percent_done);
+                form.find('select[name=is_milestone]').trigger("setValue", data.is_milestone);
+                form.find('select[name=effective_duration]').trigger("setValue", data.effective_duration);
+                form.find('select[name=planned_duration]').trigger("setValue", data.planned_duration);
             });
          }
     </script>
@@ -161,7 +166,7 @@
         }
     ) }}
     <script>
-        $("input[name=auto_percent_done]").on('change', function() {
+        form.find("input[name=auto_percent_done]").on('change', function() {
             $("select[name='percent_done']").prop('disabled', $("input[name='auto_percent_done']").eq(1).prop('checked'));
         });
     </script>
@@ -172,7 +177,7 @@
         __('Milestone'),
     ) }}
     <script>
-        $('select[name=is_milestone]').on('change', function() {
+        form.find('select[name=is_milestone]').on('change', function() {
             $('.is_milestone').toggleClass('d-none', Boolean(Number(this.value)));
         });
     </script>
@@ -238,7 +243,7 @@
 
     {% if id %}
         {% set ticket_duration %}
-            <span class="fw-normal col-form-label d-inline-flex ">{{ ticket_duration }}</span>
+            <span class="fw-normal col-form-label d-inline-flex ">{{ (duration)|formatted_duration(false) }}</span>
         {% endset %}
         {{ fields.field(
             '_ticket_duration',
@@ -247,7 +252,7 @@
         ) }}
 
         {% set total_duration %}
-            <span class="fw-normal col-form-label d-inline-flex ">{{ total_duration }}</span>
+            <span class="fw-normal col-form-label d-inline-flex ">{{ (duration + item.fields.effective_duration)|formatted_duration(false) }}</span>
         {% endset %}
         {{ fields.field(
             '_total_duration',
@@ -263,7 +268,7 @@
 
     {{ fields.textareaField(
         'content',
-        safe_content,
+        item.fields.content,
         __("Description"),
         {
             'name': 'content',

--- a/templates/pages/tools/project_task.html.twig
+++ b/templates/pages/tools/project_task.html.twig
@@ -5,7 +5,7 @@
  #
  # http://glpi-project.org
  #
- # @copyright 2015-2022 Teclib' and contributors.
+ # @copyright 2015-2023 Teclib' and contributors.
  # @copyright 2003-2014 by the INDEPNET Development Team.
  # @licence   https://www.gnu.org/licenses/gpl-3.0.html
  #


### PR DESCRIPTION
Viewing projects' tasks from the "Your planning" widget of the  "Personal view" tab of the home page is broken:

![image](https://user-images.githubusercontent.com/42734840/210385996-a07abc17-78bf-48f1-b683-981b1dbf0c5a.png)

It seems to be outdated table based html that isn't really responsive and can't deal with the smaller available width.

I've migrated it to twig to fix the issue.

After fix:

![image](https://user-images.githubusercontent.com/42734840/210386272-942bc9ee-a115-4dd3-abc1-adba5c1d0a82.png)

And here the before/after from the project task main tab:

![image](https://user-images.githubusercontent.com/42734840/210386490-5fec2266-13a5-44cb-97de-cec30cae96a8.png)

![image](https://user-images.githubusercontent.com/42734840/210386522-522976be-9b34-41eb-ac78-2a76eba95ff0.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26056
