### PR TITLE
Fix adding translations on NotificationTargetCronTask

### DIFF
--- a/src/NotificationTargetCronTask.php
+++ b/src/NotificationTargetCronTask.php
@@ -34,9 +34,9 @@
  */
 
 /**
- * NotificationTargetCrontask Class
+ * NotificationTargetCronTask Class
  **/
-class NotificationTargetCrontask extends NotificationTarget
+class NotificationTargetCronTask extends NotificationTarget
 {
     public function getEvents()
     {


### PR DESCRIPTION
Trying to add a translation to a notification on the "Automatic Action" itemtype will fail due to a case error on the class name:

![image](https://user-images.githubusercontent.com/42734840/210397873-34f12d74-0d47-443a-a471-a2ba84403ae4.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26110
