### PR TITLE
Backport joins dropdown filter

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -2671,8 +2671,18 @@ JAVASCRIPT;
             $toadd = [];
         }
 
-        if (isset($post['condition']) && ($post['condition'] != '')) {
-            $where = array_merge($where, $post['condition']);
+        $ljoin = [];
+
+        if (isset($post['condition']) && !empty($post['condition'])) {
+            if (isset($post['condition']['LEFT JOIN'])) {
+                $ljoin = $post['condition']['LEFT JOIN'];
+                unset($post['condition']['LEFT JOIN']);
+            }
+            if (isset($post['condition']['WHERE'])) {
+                $where = array_merge($where, $post['condition']['WHERE']);
+            } else {
+                $where = array_merge($where, $post['condition']);
+            }
         }
 
         $one_item = -1;
@@ -2775,7 +2785,6 @@ JAVASCRIPT;
             }
 
             $addselect = [];
-            $ljoin = [];
             if (Session::haveTranslations($post['itemtype'], 'completename')) {
                 $addselect[] = "namet.value AS transcompletename";
                 $ljoin['glpi_dropdowntranslations AS namet'] = [
@@ -3117,7 +3126,7 @@ JAVASCRIPT;
                 $where[] = ['OR' => $orwhere];
             }
             $addselect = [];
-            $ljoin = [];
+
             if (Session::haveTranslations($post['itemtype'], $field)) {
                 $addselect[] = "namet.value AS transname";
                 $ljoin['glpi_dropdowntranslations AS namet'] = [

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -2840,12 +2840,13 @@ JAVASCRIPT;
             }
 
             $criteria = [
-                'SELECT' => array_merge(["$table.*"], $addselect),
-                'FROM'   => $table,
-                'WHERE'  => $where,
-                'ORDER'  => $order,
-                'START'  => $start,
-                'LIMIT'  => $limit
+                'SELECT'   => array_merge(["$table.*"], $addselect),
+                'DISTINCT' => true,
+                'FROM'     => $table,
+                'WHERE'    => $where,
+                'ORDER'    => $order,
+                'START'    => $start,
+                'LIMIT'    => $limit
             ];
             if (count($ljoin)) {
                 $criteria['LEFT JOIN'] = $ljoin;
@@ -3255,9 +3256,10 @@ JAVASCRIPT;
             $criteria = array_merge(
                 $criteria,
                 [
-                    'WHERE'  => $where,
-                    'START'  => $start,
-                    'LIMIT'  => $limit
+                    'DISTINCT' => true,
+                    'WHERE'    => $where,
+                    'START'    => $start,
+                    'LIMIT'    => $limit
                 ]
             );
 


### PR DESCRIPTION
Hi

Formcreator 2.14 contains a new feature which allows admins to define a filter for dropdowns, based on the search engine query builder. See https://github.com/pluginsGLPI/formcreator/pull/3087

I target to maintain compatibility of Formcreator 2.14 with GLPI 10.0 and 10.1, then this backports helps to provide the plugin's feature earlier.  Also it has been requested for years (and often) by customers and community.

```php
Computer::dropdown([
   'condition' => [
      'LEFT JOIN' => ...
      'WHERE' => ...
   ]
]);
```
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
