### PR TITLE
Changes: Fix notifications setting for assigned techs

### DIFF
--- a/ajax/dropdownItilActors.php
+++ b/ajax/dropdownItilActors.php
@@ -106,13 +106,14 @@ if (isset($_POST["type"])
 
             if ($CFG_GLPI["notifications_mailing"]) {
                echo "<br><span id='notif_user_$rand'>";
+               echo __('Email followup').'&nbsp;';
+               $rand = Dropdown::showYesNo('_itil_'.$_POST["actortype"].'[use_notification]', $_POST["use_notif"]);
                if ($withemail) {
-                  echo __('Email followup').'&nbsp;';
-                  $rand = Dropdown::showYesNo('_itil_'.$_POST["actortype"].'[use_notification]', $_POST["use_notif"]);
                   echo '<br>';
-                  printf(__('%1$s: %2$s'), _n('Email', 'Emails', 1),
-                         "<input type='text' size='25' name='_itil_".$_POST["actortype"].
-                           "[alternative_email]'>");
+                  printf(
+                     __('%1$s: %2$s'),
+                     _n('Email', 'Emails', 1),
+                     "<input type='text' size='25' name='_itil_" . $_POST["actortype"] . "[alternative_email]'>");
                }
                echo "</span>";
             }


### PR DESCRIPTION
It seems that when adding a tech to a change in GLPI 9.5 notifications are always disabled by default:

![image](https://user-images.githubusercontent.com/42734840/210546489-28ca3fd7-eb23-475b-9232-d4d41aea506c.png)

It does work correctly for tickets so I suppose some magic code add the correct value somewhere but has been forgotten for changes.

It seems to be me the easiest way to fix it is to always display the notification dropdown, like for requester and observers:

![image](https://user-images.githubusercontent.com/42734840/210546702-e85d688c-51ed-4d2d-b101-bed10acacb2a.png)

This way the value is sent with the form and the notification usage is enabled/disabled accordingly.

In GLPI 10 this part was rewritten due to the new UI and seems to work fine.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26009
