### PR TITLE
fix(queuednotification): delete, restore, purge and event logs

### DIFF
--- a/front/queuednotification.form.php
+++ b/front/queuednotification.form.php
@@ -37,6 +37,8 @@
  * @since 0.85
  */
 
+use Glpi\Event;
+
 include('../inc/includes.php');
 
 Session::checkRight('queuednotification', READ);
@@ -45,5 +47,48 @@ if (!isset($_GET["id"])) {
     $_GET["id"] = "";
 }
 
-$menus = ["admin", "queuednotification"];
-QueuedNotification::displayFullPageForItem($_GET["id"], $menus, $_GET);
+$queuednotification = new QueuedNotification();
+
+if (isset($_POST["delete"])) {
+    $queuednotification->check($_POST["id"], DELETE);
+    $queuednotification->delete($_POST);
+
+    Event::log(
+        $_POST["id"],
+        "queuednotifications",
+        4,
+        "notification",
+        //TRANS: %s is the user login
+        sprintf(__('%s deletes an item'), $_SESSION["glpiname"])
+    );
+    $queuednotification->redirectToList();
+} else if (isset($_POST["restore"])) {
+    $queuednotification->check($_POST["id"], DELETE);
+    $queuednotification->restore($_POST);
+
+    Event::log(
+        $_POST["id"],
+        "queuednotifications",
+        4,
+        "notification",
+        //TRANS: %s is the user login
+        sprintf(__('%s restores an item'), $_SESSION["glpiname"])
+    );
+    $queuednotification->redirectToList();
+} else if (isset($_POST["purge"])) {
+    $queuednotification->check($_POST["id"], PURGE);
+    $queuednotification->delete($_POST, 1);
+
+    Event::log(
+        $_POST["id"],
+        "queuednotifications",
+        4,
+        "notification",
+        //TRANS: %s is the user login
+        sprintf(__('%s purges an item'), $_SESSION["glpiname"])
+    );
+    $queuednotification->redirectToList();
+} else {
+    $menus = ["admin", "queuednotification"];
+    QueuedNotification::displayFullPageForItem($_GET["id"], $menus, $_GET);
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A

"Put in trashbin", "Delete permanently", "Restore" buttons in the QueuedNotification form have no effect (displays an empty form), this PR fixes that.

We also add log Events.
