### PR TITLE
Self-service: better handling of users that can't see tickets

### DIFF
--- a/front/tracking.injector.php
+++ b/front/tracking.injector.php
@@ -78,7 +78,7 @@ if (isset($_POST['add'])) {
         unset($_POST['_actors']['requester'], $_POST['_actors']['assign']);
     }
     if ($track->add($_POST)) {
-        if ($_SESSION['glpibackcreated']) {
+        if ($_SESSION['glpibackcreated'] && Ticket::canView()) {
             Html::redirect($track->getLinkURL());
         }
         if (isset($_POST["_type"]) && ($_POST["_type"] == "Helpdesk")) {

--- a/src/Html.php
+++ b/src/Html.php
@@ -1648,9 +1648,8 @@ HTML;
         }
 
         if (
-            Session::haveRight("ticket", CREATE)
+            Session::haveRight("ticket", READ)
             || Session::haveRight("ticket", Ticket::READMY)
-            || Session::haveRight("followup", ITILFollowup::SEEPUBLIC)
         ) {
             $menu['tickets'] = [
                 'default' => '/front/ticket.php',


### PR DESCRIPTION
It's possible for a self-service profile to have the right to create tickets but not see them.

![image](https://user-images.githubusercontent.com/42734840/210597412-83ff31ee-e802-428f-a00d-4629956f55a3.png)

If they also have the 'go to item on creation' setting enabled, creating a ticket will send them to this page:

![image](https://user-images.githubusercontent.com/42734840/210597942-aba23ae7-ac67-4c50-8cec-f91354302550.png)

Which is confusing and may make them think that their ticket wasn't created correctly.

I've handled this case and hidden the 'tickets' menu if the user can't see them (current conditions to display it were a bit weird)

PS: I know its a cursed usecase, you can check the internal ref for more details.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26007
