### PR TITLE
Remove cache headers on inventory files

### DIFF
--- a/front/document.send.php
+++ b/front/document.send.php
@@ -87,8 +87,6 @@ if (isset($_GET['docid'])) { // docid for document
         if ($splitter[0] == "_inventory") {
             $iconf = new Conf();
             if ($iconf->isInventoryFile(GLPI_INVENTORY_DIR . '/' . $splitter[1])) {
-               // Can use expires header as picture file path changes when picture changes.
-                $expires_headers = true;
                 $send = GLPI_INVENTORY_DIR . '/' . $splitter[1];
 
                 $finfo = new finfo(FILEINFO_MIME_TYPE);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Inventory file download response had a one week duration `Expires` header, meaning that if it was already downloaded within last 7 days, browsers would not even try to contact server if user tries to download it again.
As file is subject to change quiet often and has a constant path, such header should not be added.