### PR TITLE
feat(rules): display criterias/actions on list

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -75,8 +75,8 @@ $timeline-badge-bg: rgba(97, 97, 97, 15%) !default;
 $timeline-badge-fg: rgba(43, 43, 43, 80%) !default;
 $input-border: $dark-mode-text !default;
 $dropdowns-list-contrast: rgba(167, 171, 175, 10%) !default;
-$entity-badge-bg: theme-color-lighter($link-color, true) !default;
-$entity-badge-fg: $link-color !default;
+$glpi-badge-bg: theme-color-lighter($link-color, true) !default;
+$glpi-badge-fg: $link-color !default;
 
 // helpers
 $topbar-height: 79px;
@@ -247,13 +247,13 @@ table {
     }
 }
 
-.entity-badge {
+.glpi-badge {
     display: inline-flex;
     flex-wrap: wrap;
     justify-content: center;
     align-items: center;
-    background: $entity-badge-bg;
-    color: $entity-badge-fg !important;
+    background: $glpi-badge-bg;
+    color: $glpi-badge-fg !important;
     padding: calc(0.25rem - 1px) 0.25rem;
     border: 1px solid transparent;
     border-radius: 4px;

--- a/front/rule.common.php
+++ b/front/rule.common.php
@@ -148,7 +148,7 @@ Html::header(
 );
 
 $rulecollection->display([
-    'criterias' => 1,
-    'actions'   => 1,
+    'display_criterias' => true,
+    'display_actions'   => true,
 ]);
 Html::footer();

--- a/front/rule.common.php
+++ b/front/rule.common.php
@@ -147,5 +147,8 @@ Html::header(
     $rulecollection->menu_option
 );
 
-$rulecollection->display();
+$rulecollection->display([
+    'criterias' => 1,
+    'actions'   => 1,
+]);
 Html::footer();

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -3968,7 +3968,7 @@ class Entity extends CommonTreeDropdown
         );
 
 
-        return '<span class="entity-badge" title="' . $title . '">' . $breadcrumbs . "</span>";
+        return '<span class="glpi-badge" title="' . $title . '">' . $breadcrumbs . "</span>";
     }
 
     /**

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -2029,7 +2029,7 @@ class Rule extends CommonDBTM
             echo "<td>";
             foreach ($RuleCriterias->getRuleCriterias($this->fields['id']) as $RuleCriteria) {
                 $to_display = $this->getMinimalCriteria($RuleCriteria->fields);
-                echo implode('<i class="fas fa-caret-right mx-1"></i>', $to_display) . '<br />';
+                echo "<span class='glpi-badge mb-1'>" . implode('<i class="fas fa-caret-right mx-1"></i>', $to_display) . '</span><br />';
             }
             echo "</td>";
         }
@@ -2040,7 +2040,7 @@ class Rule extends CommonDBTM
             echo "<td>";
             foreach ($RuleAction->getRuleActions($this->fields['id']) as $RuleAction) {
                 $to_display = $this->getMinimalAction($RuleAction->fields);
-                echo implode('<i class="fas fa-caret-right mx-1"></i>', $to_display) . '<br />';
+                echo "<span class='glpi-badge mb-1'>" . implode('<i class="fas fa-caret-right mx-1"></i>', $to_display) . '</span><br />';
             }
             echo "</td>";
         }

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -1999,8 +1999,8 @@ class Rule extends CommonDBTM
         // bool $display_criterias = false,
         // bool $display_actions = false
     ) {
-    $display_criterias = func_get_args()[5] ?? false;
-    $display_actions = func_get_args()[6] ?? false;
+        $display_criterias = func_get_args()[5] ?? false;
+        $display_actions = func_get_args()[6] ?? false;
         $canedit = (self::canUpdate() && !$display_entities);
         echo "<tr class='tab_bg_1' data-rule-id='" . $this->fields['id'] . "'>";
 

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -1986,9 +1986,18 @@ class Rule extends CommonDBTM
      * @param $last               is it the last rule ? (false by default)
      * @param $display_entities   display entities / make it read only display (false by default)
      * @param $active_condition   active condition used (default 0)
+     * @param $display_criterias  display rule criterias (false by default)
+     * @param $display_actions    display rule actions(false by default)
      **/
-    public function showMinimalForm($target, $first = false, $last = false, $display_entities = false, $active_condition = 0)
-    {
+    public function showMinimalForm(
+        $target,
+        $first = false,
+        $last = false,
+        $display_entities = false,
+        $active_condition = 0,
+        $display_criterias = 0,
+        $display_actions = 0
+    ) {
         $canedit = (self::canUpdate() && !$display_entities);
         echo "<tr class='tab_bg_1' data-rule-id='" . $this->fields['id'] . "'>";
 
@@ -2012,6 +2021,28 @@ class Rule extends CommonDBTM
         echo "<td>" . $this->fields["description"] . "</td>";
         if ($this->useConditions()) {
             echo "<td>" . $this->getConditionName($this->fields["condition"]) . "</td>";
+        }
+        if (
+            $display_criterias
+            && ($RuleCriterias = getItemForItemtype($this->rulecriteriaclass))
+        ) {
+            echo "<td>";
+            foreach ($RuleCriterias->getRuleCriterias($this->fields['id']) as $RuleCriteria) {
+                $to_display = $this->getMinimalCriteria($RuleCriteria->fields);
+                echo implode('<i class="fas fa-caret-right mx-1"></i>', $to_display) . '<br />';
+            }
+            echo "</td>";
+        }
+        if (
+            $display_actions
+            && ($RuleAction = getItemForItemtype($this->ruleactionclass))
+        ) {
+            echo "<td>";
+            foreach ($RuleAction->getRuleActions($this->fields['id']) as $RuleAction) {
+                $to_display = $this->getMinimalAction($RuleAction->fields);
+                echo implode('<i class="fas fa-caret-right mx-1"></i>', $to_display) . '<br />';
+            }
+            echo "</td>";
         }
 
         $output = sprintf(
@@ -2272,6 +2303,18 @@ class Rule extends CommonDBTM
      **/
     public function getMinimalCriteriaText($fields, $addtotd = '')
     {
+        $to_display = $this->getMinimalCriteria($fields);
+        $text  = "<td $addtotd>" . $to_display['criterion'] . "</td>";
+        $text .= "<td $addtotd>" . $to_display['condition'] . "</td>";
+        $text .= "<td $addtotd>" . $to_display['pattern'] . "</td>";
+        return $text;
+    }
+
+    /**
+     * @param $fields
+     **/
+    public function getMinimalCriteria($fields)
+    {
         $criterion = $this->getCriteriaName($fields["criteria"]);
         $condition = RuleCriteria::getConditionByID($fields["condition"], get_class($this), $fields["criteria"]);
         $pattern   = $this->getCriteriaDisplayPattern($fields["criteria"], $fields["condition"], $fields["pattern"]);
@@ -2280,18 +2323,30 @@ class Rule extends CommonDBTM
         // but some data may have been build from translation or from some plugin code and may be not sanitized.
         // First, extract the verbatim value (i.e. with non encoded specia chars), then encode special chars to
         // ensure HTML validity (and to prevent XSS).
-        $text  = "<td $addtotd>" . Sanitizer::encodeHtmlSpecialChars(Sanitizer::getVerbatimValue($criterion)) . "</td>";
-        $text .= "<td $addtotd>" . Sanitizer::encodeHtmlSpecialChars(Sanitizer::getVerbatimValue($condition)) . "</td>";
-        $text .= "<td $addtotd>" . Sanitizer::encodeHtmlSpecialChars(Sanitizer::getVerbatimValue($pattern)) . "</td>";
-        return $text;
+        return [
+            'criterion' => Sanitizer::encodeHtmlSpecialChars(Sanitizer::getVerbatimValue($criterion)),
+            'condition' => Sanitizer::encodeHtmlSpecialChars(Sanitizer::getVerbatimValue($condition)),
+            'pattern'   => Sanitizer::encodeHtmlSpecialChars(Sanitizer::getVerbatimValue($pattern)),
+        ];
     }
-
 
     /**
      * @param $fields
      * @param $addtotd   (default '')
      **/
     public function getMinimalActionText($fields, $addtotd = '')
+    {
+        $to_display = $this->getMinimalAction($fields);
+        $text  = "<td $addtotd>" . $to_display['field'] . "</td>";
+        $text .= "<td $addtotd>" . $to_display['type'] . "</td>";
+        $text .= "<td $addtotd>" . $to_display['value'] . "</td>";
+        return $text;
+    }
+
+    /**
+     * @param $fields
+     **/
+    public function getMinimalAction($fields)
     {
         $field = $this->getActionName($fields["field"]);
         $type  = RuleAction::getActionByID($fields["action_type"]);
@@ -2303,12 +2358,12 @@ class Rule extends CommonDBTM
         // but some data may have been build from translation or from some plugin code and may be not sanitized.
         // First, extract the verbatim value (i.e. with non encoded specia chars), then encode special chars to
         // ensure HTML validity (and to prevent XSS).
-        $text  = "<td $addtotd>" . Sanitizer::encodeHtmlSpecialChars(Sanitizer::getVerbatimValue($field)) . "</td>";
-        $text .= "<td $addtotd>" . Sanitizer::encodeHtmlSpecialChars(Sanitizer::getVerbatimValue($type)) . "</td>";
-        $text .= "<td $addtotd>" . Sanitizer::encodeHtmlSpecialChars(Sanitizer::getVerbatimValue($value)) . "</td>";
-        return $text;
+        return [
+            'field' => Sanitizer::encodeHtmlSpecialChars(Sanitizer::getVerbatimValue($field)),
+            'type'  => Sanitizer::encodeHtmlSpecialChars(Sanitizer::getVerbatimValue($type)),
+            'value' => Sanitizer::encodeHtmlSpecialChars(Sanitizer::getVerbatimValue($value)),
+        ];
     }
-
 
     /**
      * Return a value associated with a pattern associated to a criteria to display it

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -1994,10 +1994,13 @@ class Rule extends CommonDBTM
         $first = false,
         $last = false,
         $display_entities = false,
-        $active_condition = 0,
-        $display_criterias = 0,
-        $display_actions = 0
+        $active_condition = 0
+        // FIXME Uncomment this in GLPI 10.1
+        // bool $display_criterias = false,
+        // bool $display_actions = false
     ) {
+    $display_criterias = func_get_args()[5] ?? false;
+    $display_actions = func_get_args()[6] ?? false;
         $canedit = (self::canUpdate() && !$display_entities);
         echo "<tr class='tab_bg_1' data-rule-id='" . $this->fields['id'] . "'>";
 
@@ -2313,7 +2316,7 @@ class Rule extends CommonDBTM
     /**
      * @param $fields
      **/
-    public function getMinimalCriteria($fields)
+    private function getMinimalCriteria(array $fields): array
     {
         $criterion = $this->getCriteriaName($fields["criteria"]);
         $condition = RuleCriteria::getConditionByID($fields["condition"], get_class($this), $fields["criteria"]);
@@ -2346,7 +2349,7 @@ class Rule extends CommonDBTM
     /**
      * @param $fields
      **/
-    public function getMinimalAction($fields)
+    private function getMinimalAction(array $fields): array
     {
         $field = $this->getActionName($fields["field"]);
         $type  = RuleAction::getActionByID($fields["action_type"]);

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -479,7 +479,7 @@ class RuleCollection extends CommonDBTM
             }
         }
 
-        foreach (['criterias', 'actions'] as $param) {
+        foreach (['display_criterias', 'display_actions'] as $param) {
             if (
                 isset($options[$param])
             ) {

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -467,6 +467,8 @@ class RuleCollection extends CommonDBTM
         $p['condition'] = 0;
         $p['_glpi_tab'] = $options['_glpi_tab'];
         $rand           = mt_rand();
+        $p['criterias'] = 0;
+        $p['actions']   = 0;
 
         foreach (['inherited','childrens', 'condition'] as $param) {
             if (
@@ -477,9 +479,19 @@ class RuleCollection extends CommonDBTM
             }
         }
 
-        $rule             = $this->getRuleClass();
-        $display_entities = ($this->isRuleRecursive()
-                           && ($p['inherited'] || $p['childrens']));
+        foreach (['criterias', 'actions'] as $param) {
+            if (
+                isset($options[$param])
+            ) {
+                $p[$param] = $options[$param];
+            }
+        }
+
+        $rule              = $this->getRuleClass();
+        $display_entities  = ($this->isRuleRecursive()
+                            && ($p['inherited'] || $p['childrens']));
+        $display_criterias = $p['criterias'];
+        $display_actions   = $p['actions'];
 
        // Do not know what it is ?
         $canedit    = (self::canUpdate()
@@ -540,6 +552,12 @@ class RuleCollection extends CommonDBTM
         if ($use_conditions) {
             $colspan++;
         }
+        if ($display_criterias) {
+            $colspan++;
+        }
+        if ($display_actions) {
+            $colspan++;
+        }
 
         $can_sort = $canedit && $nb;
         if (count($this->RuleList->list)) {
@@ -564,8 +582,13 @@ class RuleCollection extends CommonDBTM
         if ($use_conditions) {
             $header_row .= "<th>" . __('Use rule for') . "</th>";
         }
+        if ($display_criterias) {
+            $header_row .= "<th>" . RuleCriteria::getTypeName(2) . "</th>";
+        }
+        if ($display_actions) {
+            $header_row .= "<th>" . RuleAction::getTypeName(2) . "</th>";
+        }
         $header_row .= "<th>" . __('Active') . "</th>";
-
         if ($display_entities) {
             $header_row .= "<th>" . Entity::getTypeName(1) . "</th>";
         }
@@ -577,7 +600,15 @@ class RuleCollection extends CommonDBTM
 
         echo "<tbody class='sortable-rules'>";
         for ($i = $p['start'],$j = 0; isset($this->RuleList->list[$j]); $i++,$j++) {
-            $this->RuleList->list[$j]->showMinimalForm($target, $i == 0, $i == $nb - 1, $display_entities, $p['condition']);
+            $this->RuleList->list[$j]->showMinimalForm(
+                $target,
+                $i == 0,
+                $i == $nb - 1,
+                $display_entities,
+                $p['condition'],
+                $display_criterias,
+                $display_actions
+            );
             Session::addToNavigateListItems($ruletype, $this->RuleList->list[$j]->fields['id']);
         }
         echo "</tbody>";

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -467,8 +467,8 @@ class RuleCollection extends CommonDBTM
         $p['condition'] = 0;
         $p['_glpi_tab'] = $options['_glpi_tab'];
         $rand           = mt_rand();
-        $p['criterias'] = 0;
-        $p['actions']   = 0;
+        $p['display_criterias'] = false;
+        $p['display_actions']   = false;
 
         foreach (['inherited','childrens', 'condition'] as $param) {
             if (
@@ -490,8 +490,8 @@ class RuleCollection extends CommonDBTM
         $rule              = $this->getRuleClass();
         $display_entities  = ($this->isRuleRecursive()
                             && ($p['inherited'] || $p['childrens']));
-        $display_criterias = $p['criterias'];
-        $display_actions   = $p['actions'];
+        $display_criterias = $p['display_criterias'];
+        $display_actions   = $p['display_actions'];
 
        // Do not know what it is ?
         $canedit    = (self::canUpdate()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A

When you have a large number of rules, it sometimes takes a long time to have to go through them to find in which rule a particular criterion/action has been added.

This PR therefore makes it possible to display them in the list, thus making it possible to do a search (ctrl+f).

I don't know which branch is better (bug fixes or main).

Before

![image](https://user-images.githubusercontent.com/470612/211048553-41a618eb-b103-451d-99ca-8f07a3c1570b.png)

After

![image](https://user-images.githubusercontent.com/470612/211048571-4bf40454-65a0-42c9-9b11-31f6f26d2505.png)

Perhaps an improvement: rather than having the display forced into the code, we could imagine two "toggle" buttons next to the "Actions" button (with persistent in-session choice).

![image](https://user-images.githubusercontent.com/470612/211049667-e9231884-1b82-4168-801a-fe4732c37fdd.png)
