### PR TITLE
ITIL: take into account user pref for default requester or tech

### DIFF
--- a/src/Change.php
+++ b/src/Change.php
@@ -887,15 +887,27 @@ class Change extends CommonITILObject
 
     public static function getDefaultValues($entity = 0)
     {
+        $users_id_requester = 0;
+        $users_id_assign    = 0;
+
+        if (is_numeric(Session::getLoginUserID(false))) {
+            if (Session::haveRight(self::$rightname, UPDATE) && $_SESSION['glpiset_default_requester']) {
+                $users_id_requester = Session::getLoginUserID();
+            }
+            if (Session::haveRight(self::$rightname, CREATE) && $_SESSION['glpiset_default_tech']) {
+                $users_id_assign = Session::getLoginUserID();
+            }
+        }
+
         $default_use_notif = Entity::getUsedConfig('is_notif_enable_default', $_SESSION['glpiactive_entity'], '', 1);
         return [
-            '_users_id_requester'        => Session::getLoginUserID(),
+            '_users_id_requester'        => $users_id_requester,
             '_users_id_requester_notif'  => [
                 'use_notification'  => $default_use_notif,
                 'alternative_email' => ''
             ],
             '_groups_id_requester'       => 0,
-            '_users_id_assign'           => 0,
+            '_users_id_assign'           => $users_id_assign,
             '_users_id_assign_notif'     => [
                 'use_notification'  => $default_use_notif,
                 'alternative_email' => ''

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -1166,17 +1166,27 @@ abstract class CommonITILObject extends CommonDBTM
      *
      * @param integer $type type to search (see constants)
      *
-     * @return boolean
+     * @return int
      **/
     public function getDefaultActor($type)
     {
-
-       /// TODO own_ticket -> own_itilobject
         if ($type == CommonITILActor::ASSIGN) {
-            if (Session::haveRight("ticket", Ticket::OWN)) {
+            if (
+                $this->canAssignToMe()
+                && $_SESSION['glpiset_default_tech']
+            ) {
                 return Session::getLoginUserID();
             }
         }
+        if ($type == CommonITILActor::REQUESTER) {
+            if (
+                static::canCreate()
+                && $_SESSION['glpiset_default_requester']
+            ) {
+                return Session::getLoginUserID();
+            }
+        }
+
         return 0;
     }
 

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -1502,15 +1502,27 @@ class Problem extends CommonITILObject
 
     public static function getDefaultValues($entity = 0)
     {
+        $users_id_requester = 0;
+        $users_id_assign    = 0;
+
+        if (is_numeric(Session::getLoginUserID(false))) {
+            if (Session::haveRight(self::$rightname, UPDATE) && $_SESSION['glpiset_default_requester']) {
+                $users_id_requester = Session::getLoginUserID();
+            }
+            if (Session::haveRight(self::$rightname, CREATE) && $_SESSION['glpiset_default_tech']) {
+                $users_id_assign = Session::getLoginUserID();
+            }
+        }
+
         $default_use_notif = Entity::getUsedConfig('is_notif_enable_default', $_SESSION['glpiactive_entity'], '', 1);
         return [
-            '_users_id_requester'        => Session::getLoginUserID(),
+            '_users_id_requester'        => $users_id_requester,
             '_users_id_requester_notif'  => [
                 'use_notification'  => $default_use_notif,
                 'alternative_email' => ''
             ],
             '_groups_id_requester'       => 0,
-            '_users_id_assign'           => 0,
+            '_users_id_assign'           => $users_id_assign,
             '_users_id_assign_notif'     => [
                 'use_notification'  => $default_use_notif,
                 'alternative_email' => ''

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -684,32 +684,6 @@ class Ticket extends CommonITILObject
     }
 
     /**
-     * @see CommonITILObject::getDefaultActor()
-     **/
-    public function getDefaultActor($type)
-    {
-
-        if ($type == CommonITILActor::ASSIGN) {
-            if (
-                Session::haveRight(self::$rightname, self::OWN)
-                && $_SESSION['glpiset_default_tech']
-            ) {
-                return Session::getLoginUserID();
-            }
-        }
-        if ($type == CommonITILActor::REQUESTER) {
-            if (
-                Session::haveRight(self::$rightname, CREATE)
-                && $_SESSION['glpiset_default_requester']
-            ) {
-                return Session::getLoginUserID();
-            }
-        }
-        return 0;
-    }
-
-
-    /**
      * @see CommonITILObject::getDefaultActorRightSearch()
      **/
     public function getDefaultActorRightSearch($type)


### PR DESCRIPTION
These two settings only affect tickets:

![image](https://user-images.githubusercontent.com/42734840/211055510-062e52e5-e7d0-4ec6-8c08-7b53ac119aa5.png)

There is no way to opt-out of being the default requester or technician of a change or a problem.

These changes modify the behavior of problems and changes to take into account this setting.
Maybe it should be renamed to indicate that it affect all ITIL objects but I'm not sure how.
Perhaps something simpler like `Pre-select me as technician`  can do the trick ?

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25937
