### PR TITLE
Allow PHP 8.2

### DIFF
--- a/index.php
+++ b/index.php
@@ -36,8 +36,8 @@
 // Check PHP version not to have trouble
 // Need to be the very fist step before any include
 if (
-    version_compare(PHP_VERSION, '7.4.0-dev', '<') ||
-    version_compare(PHP_VERSION, '8.3.0-dev', '>=')
+    version_compare(PHP_VERSION, '7.4.0', '<') ||
+    version_compare(PHP_VERSION, '8.3.0', '>=')
 ) {
     die('PHP 7.4.0 - 8.3.0 (exclusive) required');
 }

--- a/index.php
+++ b/index.php
@@ -36,10 +36,10 @@
 // Check PHP version not to have trouble
 // Need to be the very fist step before any include
 if (
-    version_compare(PHP_VERSION, '7.4.0', '<') ||
-    version_compare(PHP_VERSION, '8.2.0', '>=')
+    version_compare(PHP_VERSION, '7.4.0-dev', '<') ||
+    version_compare(PHP_VERSION, '8.3.0-dev', '>=')
 ) {
-    die('PHP 7.4.0 - 8.2.0 (exclusive) required');
+    die('PHP 7.4.0 - 8.3.0 (exclusive) required');
 }
 
 use Glpi\Application\View\TemplateRenderer;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13758 

Allowed PHP version has been updated in `inc/define.php` but not in `index.php`.
https://github.com/glpi-project/glpi/blob/0046d6d6b5d7fc509ca139c62d4c2e65d2ce4d50/inc/define.php#L51-L52

We did not detect it earlier as we are probably all using a pre-release version (that is considered as less than `8.2.0`). Using `-dev` suffixes in comparison will prevent PHP 8.3 pre-releases to be accepted. Test will be similar to the test done in requirements checking:
https://github.com/glpi-project/glpi/blob/0046d6d6b5d7fc509ca139c62d4c2e65d2ce4d50/src/System/Requirement/PhpVersion.php#L79-L84

Note that checks has been refactore in main to simplify versions declaration: #13260