### PR TITLE
fix(simcard): display helper only when is needed

### DIFF
--- a/templates/components/form/item_device.html.twig
+++ b/templates/components/form/item_device.html.twig
@@ -109,6 +109,11 @@
                   {% for specificities in specificities_fields %}
                      {% if specificities['canread'] %}
 
+                        {% set specific_field_options = field_options %}
+                        {% if specificities['tooltip'] is defined %}
+                           {% set specific_field_options = specific_field_options|merge({'helper': specificities['tooltip']}) %}
+                        {% endif %}
+
                         {% if specificities['datatype'] == "dropdown" %}
                            {% set dropdown_itemtype = call('getItemtypeForForeignKeyField', [specificities['field']]) %}
                            {{ fields.dropdownField(
@@ -116,14 +121,14 @@
                               specificities['field'],
                               specificities['value'],
                               specificities['label'],
-                              specificities['dropdown_options']|merge(field_options)
+                              specificities['dropdown_options']|merge(specific_field_options)
                            ) }}
                         {% elseif specificities['protected'] %}
                            {{ fields.passwordField(
                                  specificities['field'],
                                  specificities['value'],
                                  specificities['label'],
-                                 field_options|merge({
+                                 specific_field_options|merge({
                                     'id': specificities['protected_field_id'],
                                     'is_disclosable': true,
                                  })
@@ -133,16 +138,14 @@
                                  specificities['field'],
                                  specificities['value'],
                                  specificities['label'],
-                                 field_options
+                                 specific_field_options
                            ) }}
                         {% else %}
                            {{ fields.textField(
                                  specificities['field'],
                                  specificities['value'],
                                  specificities['label'],
-                                 field_options|merge({
-                                    'helper': specificities['tooltip'],
-                                 })
+                                 specific_field_options
                            ) }}
                         {% endif %}
                      {% endif %}

--- a/templates/components/form/item_device.html.twig
+++ b/templates/components/form/item_device.html.twig
@@ -109,10 +109,6 @@
                   {% for specificities in specificities_fields %}
                      {% if specificities['canread'] %}
 
-                        {% if specificities['tooltip'] is defined %}
-                           {% set field_options = field_options|merge({'helper': specificities['tooltip']}) %}
-                        {% endif %}
-
                         {% if specificities['datatype'] == "dropdown" %}
                            {% set dropdown_itemtype = call('getItemtypeForForeignKeyField', [specificities['field']]) %}
                            {{ fields.dropdownField(
@@ -144,7 +140,9 @@
                                  specificities['field'],
                                  specificities['value'],
                                  specificities['label'],
-                                 field_options
+                                 field_options|merge({
+                                    'helper': specificities['tooltip'],
+                                 })
                            ) }}
                         {% endif %}
                      {% endif %}


### PR DESCRIPTION
```MSIN``` tooltip is displayed for other fields

![image](https://user-images.githubusercontent.com/7335054/211267760-355049b6-33a3-4fcc-90ce-e11d2bb4bc93.png)

This PR fix that

![image](https://user-images.githubusercontent.com/7335054/211267799-34732411-28a1-47d6-b056-9c002e93fbb2.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26194
