### PR TITLE
Prevent collector to fail on address that contains unexpected chars length

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -124,12 +124,14 @@
         "post-install-cmd": [
             "@php -r \"file_put_contents('.composer.hash', sha1_file('composer.lock'));\"",
             "@php -f vendor/bin/build_hw_jsons",
-            "patch -f -p1 -d vendor/laminas/laminas-mail/ < tools/patches/laminas-mail-invalid-header-ignore.patch || true"
+            "patch -f -p1 -d vendor/laminas/laminas-mail/ < tools/patches/laminas-mail-invalid-header-ignore.patch || true",
+            "patch -f -p1 -d vendor/laminas/laminas-mail/ < tools/patches/laminas-mail-address-no-length-check.patch || true"
         ],
         "post-update-cmd": [
             "@php -r \"file_put_contents('.composer.hash', sha1_file('composer.lock'));\"",
             "@php -f vendor/bin/build_hw_jsons",
-            "patch -f -p1 -d vendor/laminas/laminas-mail/ < tools/patches/laminas-mail-invalid-header-ignore.patch || true"
+            "patch -f -p1 -d vendor/laminas/laminas-mail/ < tools/patches/laminas-mail-invalid-header-ignore.patch || true",
+            "patch -f -p1 -d vendor/laminas/laminas-mail/ < tools/patches/laminas-mail-address-no-length-check.patch || true"
         ],
         "build": [
             "bin/console dependencies install && bin/console locales:compile"

--- a/tests/emails-tests/38-email-address-too-long.eml
+++ b/tests/emails-tests/38-email-address-too-long.eml
@@ -1,0 +1,12 @@
+Date: Sun, 25 Apr 2021 03:17:07 +0000
+From: Normal User <normal@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>
+CC: John Doe
+    <IMCEAEX-_o=ExchangeLabs_ou=Exchange+20Administrative+20Group+20+28FYDIBOHF23SPDLT+29_cn=Recipients_cn=User+206ed4e168-addd-4b03-95f5-b9c9a421957358d@mgd.domain.com>
+Message-ID: <1695134010.1757889.1528365951040.JavaMail.zimbra@glpi-project.org>
+Subject: 38 - E-mail address too long
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+CC address is too long according to RFC 3696.

--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -711,6 +711,7 @@ class MailCollector extends DbTestCase
                     '35 - Message with some invalid headers',
                     '36 - Microsoft specific code',
                     '37 - Image using application/octet-steam content-type',
+                    '38 - E-mail address too long',
                 ]
             ],
          // Mails having "normal" user as observer (add_cc_to_observer = true)

--- a/tools/patches/laminas-mail-address-no-length-check.patch
+++ b/tools/patches/laminas-mail-address-no-length-check.patch
@@ -1,0 +1,18 @@
+diff --git a/src/Address.php b/src/Address.php
+index 7b2956f2..8bcbd14d 100644
+--- a/src/Address.php
++++ b/src/Address.php
+@@ -60,7 +60,12 @@ class Address implements Address\AddressInterface
+      */
+     public function __construct($email, $name = null, $comment = null)
+     {
+-        $emailAddressValidator = new EmailAddressValidator(Hostname::ALLOW_DNS | Hostname::ALLOW_LOCAL);
++        $emailAddressValidator = new EmailAddressValidator(
++            [
++                'allow'  => Hostname::ALLOW_DNS | Hostname::ALLOW_LOCAL,
++                'strict' => false,
++            ]
++        );
+         if (! is_string($email) || empty($email)) {
+             throw new Exception\InvalidArgumentException('Email must be a valid email address');
+         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24408

`laminas-mail` uses default strictness of `Laminas\Validator\EmailAddress` validator, that is checking that addresses are respecting the length limitation defined in RFC 3696.

Problem is that this limitation does not seems to be respected, even by Microsoft, that is sometimes generating far too long addresses in some cases.

Patch will prevent following error:
```
glpiphplog.CRITICAL:   *** Uncaught Exception Laminas\Mail\Exception\InvalidArgumentException: The input exceeds the allowed length in /var/www/glpi/vendor/laminas/laminas-mail/src/Address.php at line 74
  Backtrace :
  vendor/laminas/laminas-mail/src/Address.php:50     Laminas\Mail\Address->__construct()
  ...inas-mail/src/Header/AbstractAddressList.php:92 Laminas\Mail\Address::fromString()
  :                                                  Laminas\Mail\Header\AbstractAddressList::Laminas\Mail\Header\{closure}()
  ...inas-mail/src/Header/AbstractAddressList.php:70 array_map()
  vendor/laminas/laminas-mail/src/Headers.php:556    Laminas\Mail\Header\AbstractAddressList::fromString()
  vendor/laminas/laminas-mail/src/Headers.php:282    Laminas\Mail\Headers->loadHeader()
  vendor/laminas/laminas-mail/src/Headers.php:102    Laminas\Mail\Headers->addHeaderLine()
  vendor/laminas/laminas-mime/src/Decode.php:162     Laminas\Mail\Headers::fromString()
  ...r/laminas/laminas-mail/src/Storage/Part.php:106 Laminas\Mime\Decode::splitMessage()
  ...laminas/laminas-mail/src/Storage/Message.php:47 Laminas\Mail\Storage\Part->__construct()
  ...r/laminas/laminas-mail/src/Storage/Imap.php:121 Laminas\Mail\Storage\Message->__construct()
  ...aminas-mail/src/Storage/AbstractStorage.php:270 Laminas\Mail\Storage\Imap->getMessage()
  src/MailCollector.php:731                          Laminas\Mail\Storage\AbstractStorage->current()
  front/mailcollector.form.php:103                   MailCollector->collect()
```