### PR TITLE
fix: timeline button visibility

### DIFF
--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -170,6 +170,11 @@
 <script type="text/javascript">
 
 (function(){
+    {#
+     # Form is displayed using bootstrap `data-bs-toggle="collapse"` that is available before full page load.
+     # Therefore, `.answer-action` event listener have to be registered ASAP and should not be wrapped into a `$()` call.
+     # We use a `(function(){})();` autocall wrapper to not expose globally the variables define in current script.
+     #}
    var scrollToTimelineStart = function() {
         // scroll body to ensure we are at bottom (useful for responsive display)
         $('html, body').animate({

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -173,7 +173,9 @@ $(function() {
       scrollToTimelineStart();
       {% if timeline_btn_layout == constant('Config::TIMELINE_ACTION_BTN_MERGED') %}
          // hide answer button after clicking on it only for merge btn
-         $(this).closest(".main-actions").hide();
+         if ($(this).is(':visible')) {
+            $(this).closest(".main-actions").hide();
+         }
       {% endif %}
    });
 

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -168,24 +168,8 @@
 {% set is_timeline_reversed = user_pref('timeline_order') == constant('CommonITILObject::TIMELINE_ORDER_REVERSE') %}
 
 <script type="text/javascript">
-$(function() {
-   $(document).on("click", "#itil-footer .answer-action", function() {
-      scrollToTimelineStart();
-      {% if timeline_btn_layout == constant('Config::TIMELINE_ACTION_BTN_MERGED') %}
-         // hide answer button after clicking on it only for merge btn
-         if ($(this).is(':visible')) {
-            $(this).closest(".main-actions").hide();
-         }
-      {% endif %}
-   });
 
-   // when close button of new answer block is clicked, show again the new answer button
-   {% if timeline_btn_layout == constant('Config::TIMELINE_ACTION_BTN_MERGED') %}
-      $(document).on("click", "#new-itilobject-form .close-itil-answer", function() {
-         $("#itil-footer .main-actions").show();
-      });
-   {% endif %}
-
+(function(){
    var scrollToTimelineStart = function() {
         // scroll body to ensure we are at bottom (useful for responsive display)
         $('html, body').animate({
@@ -199,13 +183,31 @@ $(function() {
         });
    };
 
-   {% if openfollowup %}
-      // trigger for reopen, show followup form in timeline
-      var myCollapse = document.getElementById('new-ITILFollowup-block')
-      var bsCollapse = new bootstrap.Collapse(myCollapse);
-      bsCollapse.show();
-
+   $(document).on("click", "#itil-footer .answer-action", function() {
       scrollToTimelineStart();
-   {% endif %}
-});
+      {% if timeline_btn_layout == constant('Config::TIMELINE_ACTION_BTN_MERGED') %}
+         // hide answer button after clicking on it only for merge btn
+         $(this).closest(".main-actions").hide();
+      {% endif %}
+   });
+
+   $(function() {
+      // when close button of new answer block is clicked, show again the new answer button
+      {% if timeline_btn_layout == constant('Config::TIMELINE_ACTION_BTN_MERGED') %}
+         $(document).on("click", "#new-itilobject-form .close-itil-answer", function() {
+            $("#itil-footer .main-actions").show();
+         });
+      {% endif %}
+
+      {% if openfollowup %}
+         // trigger for reopen, show followup form in timeline
+         var myCollapse = document.getElementById('new-ITILFollowup-block')
+         var bsCollapse = new bootstrap.Collapse(myCollapse);
+         bsCollapse.show();
+
+         scrollToTimelineStart();
+      {% endif %}
+   });
+})();
+
 </script>

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -229,9 +229,7 @@ $(function() {
       timeline_item.find('.timeline-item-buttons').addClass('d-none');
       timeline_item.find('.close-edit-content').removeClass('d-none');
 
-      if($(this).is(":visible")) {
-         $("#itil-footer").find(".main-actions").hide();
-      }
+      $("#itil-footer").find(".main-actions").hide();
    });
 
    $(document).on("click", ".close-edit-content", function() {

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -229,7 +229,9 @@ $(function() {
       timeline_item.find('.timeline-item-buttons').addClass('d-none');
       timeline_item.find('.close-edit-content').removeClass('d-none');
 
-      $("#itil-footer").find(".main-actions").hide();
+      if($(this).is(":visible")) {
+         $("#itil-footer").find(".main-actions").hide();
+      }
    });
 
    $(document).on("click", ".close-edit-content", function() {


### PR DESCRIPTION
When the Answer button is clicked (e.g. to add a follow-up) before the page is fully loaded, the button remains displayed

![image](https://user-images.githubusercontent.com/8530352/211507970-f8160449-0226-4db5-a892-68d600d26c63.png)

If you click Answer instead of Add to validate, the form disappears and so does the Answer button, so the follow-up is not recorded and is lost.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
