### PR TITLE
feat(itilobject): display entity completename with last as HTML link

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -3944,6 +3944,13 @@ class Entity extends CommonTreeDropdown
         return self::getUsedConfig('contracts_strategy_default', $entities_id, 'contracts_id_default', 0);
     }
 
+    /**
+     * Return HTML code for entity badge showing its completename.
+     *
+     * @param string $entity_string
+     *
+     * @return string|null
+     */
     public static function badgeCompletename(string $entity_string = ""): string
     {
         // `completename` is expected to be received as it is stored in DB,
@@ -3983,6 +3990,57 @@ class Entity extends CommonTreeDropdown
         $entity = new self();
         if ($entity->getFromDB($entity_id)) {
             return self::badgeCompletename($entity->fields['completename']);
+        }
+        return null;
+    }
+
+    /**
+     * Return HTML code for entity badge showing its completename with last entity as HTML link.
+     *
+     * @param object $entity
+     *
+     * @return string|null
+     */
+    public static function badgeCompletenameLink(object $entity): string
+    {
+        // `completename` is expected to be received as it is stored in DB,
+        // meaning that `>` separator is not encoded, but `<`, `>` and `&` from self or parent names are encoded.
+        $names     = explode(' > ', trim($entity->fields['completename']));
+        $last_name = Sanitizer::decodeHtmlSpecialChars(array_pop($names));
+        $last_url  = '<i class="fas fa-caret-right mx-1"></i>' . '<a href="' . $entity->getLinkURL() .'" title="' . htmlspecialchars($last_name) . '">' . $last_name . '</a>';
+
+        // Convert the whole completename into decoded HTML.
+        foreach ($names as &$name) {
+            $name = Sanitizer::decodeHtmlSpecialChars($name);
+        }
+
+        // Construct HTML with special chars encoded.
+        $title = htmlspecialchars(implode(' > ', $names));
+        $breadcrumbs = implode(
+            '<i class="fas fa-caret-right mx-1"></i>',
+            array_map(
+                function (string $name): string {
+                    return '<span class="text-nowrap text-muted">' . htmlspecialchars($name) . '</span>';
+                },
+                $names
+            )
+        );
+
+        return '<span class="glpi-badge" title="' . $title . '">' . $breadcrumbs . $last_url . '</span>';
+    }
+
+    /**
+     * Return HTML code for entity badge showing its completename with last entity as HTML link.
+     *
+     * @param int $entity_id
+     *
+     * @return string|null
+     */
+    public static function badgeCompletenameLinkById(int $entity_id): ?string
+    {
+        $entity = new self();
+        if ($entity->getFromDB($entity_id)) {
+            return self::badgeCompletenameLink($entity);
         }
         return null;
     }

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -4005,17 +4005,15 @@ class Entity extends CommonTreeDropdown
     {
         // `completename` is expected to be received as it is stored in DB,
         // meaning that `>` separator is not encoded, but `<`, `>` and `&` from self or parent names are encoded.
-        $names     = explode(' > ', trim($entity->fields['completename']));
+        $names = explode(' > ', trim($entity->fields['completename']));
         // Convert the whole completename into decoded HTML.
         foreach ($names as &$name) {
             $name = Sanitizer::decodeHtmlSpecialChars($name);
         }
 
-        $last_name = array_pop($names);
-        $last_url  = '<i class="fas fa-caret-right mx-1"></i>' . '<a href="' . $entity->getLinkURL() . '" title="' . htmlspecialchars($last_name) . '">' . htmlspecialchars($last_name) . '</a>';
-
         // Construct HTML with special chars encoded.
-        $title = htmlspecialchars(implode(' > ', $names));
+        $title       = htmlspecialchars(implode(' > ', $names));
+        $last_name   = array_pop($names);
         $breadcrumbs = implode(
             '<i class="fas fa-caret-right mx-1"></i>',
             array_map(
@@ -4025,6 +4023,8 @@ class Entity extends CommonTreeDropdown
                 $names
             )
         );
+
+        $last_url  = '<i class="fas fa-caret-right mx-1"></i>' . '<a href="' . $entity->getLinkURL() . '" title="' . $title . '">' . htmlspecialchars($last_name) . '</a>';
 
         return '<span class="glpi-badge" title="' . $title . '">' . $breadcrumbs . $last_url . '</span>';
     }

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -4006,13 +4006,13 @@ class Entity extends CommonTreeDropdown
         // `completename` is expected to be received as it is stored in DB,
         // meaning that `>` separator is not encoded, but `<`, `>` and `&` from self or parent names are encoded.
         $names     = explode(' > ', trim($entity->fields['completename']));
-        $last_name = Sanitizer::decodeHtmlSpecialChars(array_pop($names));
-        $last_url  = '<i class="fas fa-caret-right mx-1"></i>' . '<a href="' . $entity->getLinkURL() .'" title="' . htmlspecialchars($last_name) . '">' . $last_name . '</a>';
-
         // Convert the whole completename into decoded HTML.
         foreach ($names as &$name) {
             $name = Sanitizer::decodeHtmlSpecialChars($name);
         }
+
+        $last_name = array_pop($names);
+        $last_url  = '<i class="fas fa-caret-right mx-1"></i>' . '<a href="' . $entity->getLinkURL() .'" title="' . htmlspecialchars($last_name) . '">' . htmlspecialchars($last_name) . '</a>';
 
         // Construct HTML with special chars encoded.
         $title = htmlspecialchars(implode(' > ', $names));

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -4012,7 +4012,7 @@ class Entity extends CommonTreeDropdown
         }
 
         $last_name = array_pop($names);
-        $last_url  = '<i class="fas fa-caret-right mx-1"></i>' . '<a href="' . $entity->getLinkURL() .'" title="' . htmlspecialchars($last_name) . '">' . htmlspecialchars($last_name) . '</a>';
+        $last_url  = '<i class="fas fa-caret-right mx-1"></i>' . '<a href="' . $entity->getLinkURL() . '" title="' . htmlspecialchars($last_name) . '">' . htmlspecialchars($last_name) . '</a>';
 
         // Construct HTML with special chars encoded.
         $title = htmlspecialchars(implode(' > ', $names));

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -75,7 +75,7 @@
                   ) }}
                {% else %}
                   {% set entity_html %}
-                     {{ call('Entity::badgeCompletenameById', [item.fields['entities_id']])|raw }}
+                     {{ call('Entity::badgeCompletenameLinkById', [item.fields['entities_id']])|raw }}
                   {% endset %}
 
                   {{ fields.field(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A


On ITILObject panel, the idea is to make the last displayed name for entities clickable.

Before (no HTML link)
![image](https://user-images.githubusercontent.com/470612/211811636-2ea03827-dc90-4274-bab4-913b728bdb2f.png)

After (last name entry with an HTML link)
![image](https://user-images.githubusercontent.com/470612/211811690-b0e18126-8ff3-4c4c-811a-a341205f1308.png)

