### PR TITLE
fix(states): add missing type

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -193,7 +193,7 @@ $CFG_GLPI["state_types"]                  = ['Computer', 'Monitor', 'NetworkEqui
     'Peripheral', 'Phone', 'Printer', 'SoftwareLicense',
     'Certificate', 'Enclosure', 'PDU', 'Line',
     'Rack', 'SoftwareVersion', 'Cluster', 'Contract',
-    'Appliance', 'DatabaseInstance', 'Cable', 'Unmanaged'
+    'Appliance', 'DatabaseInstance', 'Cable', 'Unmanaged', 'PassiveDCEquipment'
 ];
 
 $CFG_GLPI["asset_types"]                  = ['Computer', 'Monitor', 'NetworkEquipment',


### PR DESCRIPTION
Add missing ```PassiveDCEquipment``` (for ```is_visible_xxxx``` field)

Already present from database.

![image](https://user-images.githubusercontent.com/7335054/212000898-ae6fb63b-be5e-4511-9a4f-a140d90900b7.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26268
