### PR TITLE
fix(inventory): use ifdescr if ifname is empty for NetworkPort

### DIFF
--- a/src/Inventory/Asset/NetworkPort.php
+++ b/src/Inventory/Asset/NetworkPort.php
@@ -131,6 +131,10 @@ class NetworkPort extends InventoryAsset
                 }
             }
 
+            if ((!property_exists($val, 'name') || empty($val->name)) && property_exists($val, 'ifdescr')) {
+                $val->name = $val->ifdescr;
+            }
+
             if ((!property_exists($val, 'ifdescr') || empty($val->ifdescr)) && property_exists($val, 'name')) {
                 $val->ifdescr = $val->name;
             }


### PR DESCRIPTION
When GLPI handle ```NetworkPort``` (from ```inventory``` process)

If ```ifname``` not exist or is empty, use ```ifdescr``` (if possible)

Before : 

![image](https://user-images.githubusercontent.com/7335054/212006582-40cea394-8109-456d-ae2e-c75dc8e94377.png)


After : 

![image](https://user-images.githubusercontent.com/7335054/212006503-47ff1fa5-59a1-4255-886c-a1d503b032f0.png)


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26198
