### PR TITLE
Remove `glpi:` prefix from console commands canonical names

### DIFF
--- a/.github/actions/test_install.sh
+++ b/.github/actions/test_install.sh
@@ -5,25 +5,25 @@ LOG_FILE="./tests/files/_log/install.log"
 mkdir -p $(dirname "$LOG_FILE")
 
 # Execute install
-bin/console glpi:database:install \
+bin/console database:install \
   --config-dir=./tests/config --ansi --no-interaction \
   --force \
   --reconfigure --db-name=glpi --db-host=db --db-user=root \
   --strict-configuration \
   | tee $LOG_FILE
 if [[ -n $(grep "Warning" $LOG_FILE) ]];
-  then echo "glpi:database:install command FAILED" && exit 1;
+  then echo "database:install command FAILED" && exit 1;
 fi
 
 # Check DB
-bin/console glpi:database:check_schema_integrity --config-dir=./tests/config --ansi --no-interaction --strict
-bin/console glpi:tools:check_database_keys --config-dir=./tests/config --ansi --no-interaction --detect-useless-keys
-bin/console glpi:tools:check_database_schema_consistency --config-dir=./tests/config --ansi --no-interaction
+bin/console database:check_schema_integrity --config-dir=./tests/config --ansi --no-interaction --strict
+bin/console tools:check_database_keys --config-dir=./tests/config --ansi --no-interaction --detect-useless-keys
+bin/console tools:check_database_schema_consistency --config-dir=./tests/config --ansi --no-interaction
 tests/bin/test-data-sanitization --ansi --no-interaction
 
 # Execute update
 ## Should do nothing.
-bin/console glpi:database:update --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
+bin/console database:update --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
 if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
-  then echo "glpi:database:update command FAILED" && exit 1;
+  then echo "database:update command FAILED" && exit 1;
 fi

--- a/.github/actions/test_tests-web.sh
+++ b/.github/actions/test_tests-web.sh
@@ -2,7 +2,7 @@
 set -e -u -x -o pipefail
 
 php -S localhost:8088 tests/router.php &>/dev/null &
-bin/console glpi:config:set --config-dir=./tests/config --context=inventory enabled_inventory 1
+bin/console config:set --config-dir=./tests/config --context=inventory enabled_inventory 1
 vendor/bin/atoum \
   -p 'php -d memory_limit=512M' \
   --debug \
@@ -14,4 +14,4 @@ vendor/bin/atoum \
   --fail-if-skipped-methods \
   --max-children-number 1 \
   -d tests/web
-bin/console glpi:config:set --config-dir=./tests/config --context=inventory enabled_inventory 0
+bin/console config:set --config-dir=./tests/config --context=inventory enabled_inventory 0

--- a/.github/actions/test_update-from-9.5.sh
+++ b/.github/actions/test_update-from-9.5.sh
@@ -4,96 +4,96 @@ set -e -u -x -o pipefail
 LOG_FILE="./tests/files/_log/migration.log"
 mkdir -p $(dirname "$LOG_FILE")
 
-bin/console glpi:database:configure \
+bin/console database:configure \
   --config-dir=./tests/config --no-interaction --ansi \
   --reconfigure --db-name=glpitest-9.5 --db-host=db --db-user=root \
   --strict-configuration
 
 # Execute update
 ## First run should do the migration (with no warnings).
-bin/console glpi:database:update --config-dir=./tests/config --ansi --no-interaction --allow-unstable | tee $LOG_FILE
+bin/console database:update --config-dir=./tests/config --ansi --no-interaction --allow-unstable | tee $LOG_FILE
 if [[ -n $(grep "Warning\|No migration needed." $LOG_FILE) ]];
-  then echo "bin/console glpi:database:update command FAILED" && exit 1;
+  then echo "bin/console database:update command FAILED" && exit 1;
 fi
 ## Second run should do nothing.
-bin/console glpi:database:update --config-dir=./tests/config --ansi --no-interaction --allow-unstable | tee $LOG_FILE
+bin/console database:update --config-dir=./tests/config --ansi --no-interaction --allow-unstable | tee $LOG_FILE
 if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
-  then echo "bin/console glpi:database:update command FAILED" && exit 1;
+  then echo "bin/console database:update command FAILED" && exit 1;
 fi
 ## Check DB schema integrity (do not check additionnal migrations)
-bin/console glpi:database:check_schema_integrity \
+bin/console database:check_schema_integrity \
   --config-dir=./tests/config --ansi --no-interaction
 
 # Execute myisam_to_innodb migration
 ## First run should do nothing.
-bin/console glpi:migration:myisam_to_innodb --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
+bin/console migration:myisam_to_innodb --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
 if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
-  then echo "bin/console glpi:migration:myisam_to_innodb command FAILED" && exit 1;
+  then echo "bin/console migration:myisam_to_innodb command FAILED" && exit 1;
 fi
 ## Check DB schema integrity (including myisam_to_innodb migration)
-bin/console glpi:database:check_schema_integrity \
+bin/console database:check_schema_integrity \
   --config-dir=./tests/config --ansi --no-interaction \
   --check-innodb-migration
 
 # Execute timestamps migration
 ## First run should do nothing.
-bin/console glpi:migration:timestamps --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
+bin/console migration:timestamps --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
 if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
-  then echo "bin/console glpi:migration:timestamps command FAILED" && exit 1;
+  then echo "bin/console migration:timestamps command FAILED" && exit 1;
 fi
 ## Check DB schema integrity (including timestamps migration)
-bin/console glpi:database:check_schema_integrity \
+bin/console database:check_schema_integrity \
   --config-dir=./tests/config --ansi --no-interaction \
   --check-timestamps-migration
 
 # Execute dynamic_row_format migration
 ## Result will depend on DB server/version, we just expect that command will not fail.
-bin/console glpi:migration:dynamic_row_format --config-dir=./tests/config --ansi --no-interaction
+bin/console migration:dynamic_row_format --config-dir=./tests/config --ansi --no-interaction
 ## Check DB schema integrity (including dynamic_row_format migration)
-bin/console glpi:database:check_schema_integrity \
+bin/console database:check_schema_integrity \
   --config-dir=./tests/config --ansi --no-interaction \
   --check-dynamic-row-format-migration
 
 # Execute utf8mb4 migration
 ## First run should do the migration (with no warnings).
-bin/console glpi:migration:utf8mb4 --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
+bin/console migration:utf8mb4 --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
 if [[ -n $(grep "Warning\|No migration needed." $LOG_FILE) ]];
-  then echo "bin/console glpi:migration:utf8mb4 command FAILED" && exit 1;
+  then echo "bin/console migration:utf8mb4 command FAILED" && exit 1;
 fi
 ## Second run should do nothing.
-bin/console glpi:migration:utf8mb4 --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
+bin/console migration:utf8mb4 --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
 if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
-  then echo "bin/console glpi:migration:utf8mb4 command FAILED" && exit 1;
+  then echo "bin/console migration:utf8mb4 command FAILED" && exit 1;
 fi
 ## Check DB schema integrity (including utf8mb4 migration)
-bin/console glpi:database:check_schema_integrity \
+bin/console database:check_schema_integrity \
   --config-dir=./tests/config --ansi --no-interaction \
   --check-utf8mb4-migration
 
 # Execute unsigned keys migration
 ## First run should do the migration (with no warnings).
-bin/console glpi:migration:unsigned_keys --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
+bin/console migration:unsigned_keys --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
 if [[ -n $(grep "Warning\|No migration needed." $LOG_FILE) ]];
-  then echo "bin/console glpi:migration:unsigned_keys command FAILED" && exit 1;
+  then echo "bin/console migration:unsigned_keys command FAILED" && exit 1;
 fi
 ## Second run should do nothing.
-bin/console glpi:migration:unsigned_keys --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
+bin/console migration:unsigned_keys --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
 if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
-  then echo "bin/console glpi:migration:unsigned_keys command FAILED" && exit 1;
+  then echo "bin/console migration:unsigned_keys command FAILED" && exit 1;
 fi
 ## Check DB schema integrity (including unsigned keys migration)
-bin/console glpi:database:check_schema_integrity \
+bin/console database:check_schema_integrity \
   --config-dir=./tests/config --ansi --no-interaction \
   --check-unsigned-keys-migration
 
 # Complete DB check
-bin/console glpi:database:check_schema_integrity \
+bin/console database:check_schema_integrity \
   --config-dir=./tests/config --ansi --no-interaction \
   --check-all-migrations
 tests/bin/test-data-sanitization --ansi --no-interaction
 
 # Check updated data
-bin/console glpi:database:configure \
+bin/console database:configure \
   --config-dir=./tests/config --no-interaction --ansi \
   --reconfigure --db-name=glpi --db-host=db --db-user=root \
   --strict-configuration

--- a/.github/actions/test_update-from-older-version.sh
+++ b/.github/actions/test_update-from-older-version.sh
@@ -5,105 +5,105 @@ LOG_FILE="./tests/files/_log/migration.log"
 mkdir -p $(dirname "$LOG_FILE")
 
 # Reconfigure DB
-bin/console glpi:database:configure \
+bin/console database:configure \
   --config-dir=./tests/config --ansi --no-interaction \
   --reconfigure --db-name=glpitest080 --db-host=db --db-user=root
 
 # Execute update
 ## First run should do the migration (with no warnings).
-bin/console glpi:database:update --config-dir=./tests/config --ansi --no-interaction --allow-unstable | tee $LOG_FILE
+bin/console database:update --config-dir=./tests/config --ansi --no-interaction --allow-unstable | tee $LOG_FILE
 if [[ -n $(grep "Warning\|No migration needed." $LOG_FILE) ]];
-  then echo "bin/console glpi:database:update command FAILED" && exit 1;
+  then echo "bin/console database:update command FAILED" && exit 1;
 fi
 ## Second run should do nothing.
-bin/console glpi:database:update --config-dir=./tests/config --ansi --no-interaction --allow-unstable | tee $LOG_FILE
+bin/console database:update --config-dir=./tests/config --ansi --no-interaction --allow-unstable | tee $LOG_FILE
 if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
-  then echo "bin/console glpi:database:update command FAILED" && exit 1;
+  then echo "bin/console database:update command FAILED" && exit 1;
 fi
 ## Check DB schema integrity (do not check additionnal migrations)
-bin/console glpi:database:check_schema_integrity \
+bin/console database:check_schema_integrity \
   --config-dir=./tests/config --ansi --no-interaction
 
 # Execute myisam_to_innodb migration
 ## First run should do the migration (with no warnings).
-bin/console glpi:migration:myisam_to_innodb --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
+bin/console migration:myisam_to_innodb --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
 if [[ -n $(grep "Warning\|No migration needed." $LOG_FILE) ]];
-  then echo "bin/console glpi:migration:myisam_to_innodb command FAILED" && exit 1;
+  then echo "bin/console migration:myisam_to_innodb command FAILED" && exit 1;
 fi
 ## Second run should do nothing.
-bin/console glpi:migration:myisam_to_innodb --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
+bin/console migration:myisam_to_innodb --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
 if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
-  then echo "bin/console glpi:migration:myisam_to_innodb command FAILED" && exit 1;
+  then echo "bin/console migration:myisam_to_innodb command FAILED" && exit 1;
 fi
 ## Check DB schema integrity (including myisam_to_innodb migration)
-bin/console glpi:database:check_schema_integrity \
+bin/console database:check_schema_integrity \
   --config-dir=./tests/config --ansi --no-interaction \
   --check-innodb-migration
 
 # Execute timestamps migration
 ## First run should do the migration (with no warnings).
-bin/console glpi:migration:timestamps --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
+bin/console migration:timestamps --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
 if [[ -n $(grep "Warning\|No migration needed." $LOG_FILE) ]];
-  then echo "bin/console glpi:migration:timestamps command FAILED" && exit 1;
+  then echo "bin/console migration:timestamps command FAILED" && exit 1;
 fi
 ## Second run should do nothing.
-bin/console glpi:migration:timestamps --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
+bin/console migration:timestamps --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
 if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
-  then echo "bin/console glpi:migration:timestamps command FAILED" && exit 1;
+  then echo "bin/console migration:timestamps command FAILED" && exit 1;
 fi
 ## Check DB schema integrity (including timestamps migration)
-bin/console glpi:database:check_schema_integrity \
+bin/console database:check_schema_integrity \
   --config-dir=./tests/config --ansi --no-interaction \
   --check-timestamps-migration
 
 # Execute dynamic_row_format migration
 ## Result will depend on DB server/version, we just expect that command will not fail.
-bin/console glpi:migration:dynamic_row_format --config-dir=./tests/config --ansi --no-interaction
+bin/console migration:dynamic_row_format --config-dir=./tests/config --ansi --no-interaction
 ## Check DB schema integrity (including dynamic_row_format migration)
-bin/console glpi:database:check_schema_integrity \
+bin/console database:check_schema_integrity \
   --config-dir=./tests/config --ansi --no-interaction \
   --check-dynamic-row-format-migration
 
 # Execute utf8mb4 migration
 ## First run should do the migration (with no warnings).
-bin/console glpi:migration:utf8mb4 --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
+bin/console migration:utf8mb4 --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
 if [[ -n $(grep "Warning\|No migration needed." $LOG_FILE) ]];
-  then echo "bin/console glpi:migration:utf8mb4 command FAILED" && exit 1;
+  then echo "bin/console migration:utf8mb4 command FAILED" && exit 1;
 fi
 ## Second run should do nothing.
-bin/console glpi:migration:utf8mb4 --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
+bin/console migration:utf8mb4 --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
 if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
-  then echo "bin/console glpi:migration:utf8mb4 command FAILED" && exit 1;
+  then echo "bin/console migration:utf8mb4 command FAILED" && exit 1;
 fi
 ## Check DB schema integrity (including utf8mb4 migration)
-bin/console glpi:database:check_schema_integrity \
+bin/console database:check_schema_integrity \
   --config-dir=./tests/config --ansi --no-interaction \
   --check-utf8mb4-migration
 
 # Execute unsigned keys migration
 ## First run should do the migration (with no warnings).
-bin/console glpi:migration:unsigned_keys --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
+bin/console migration:unsigned_keys --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
 if [[ -n $(grep "Warning\|No migration needed." $LOG_FILE) ]];
-  then echo "bin/console glpi:migration:unsigned_keys command FAILED" && exit 1;
+  then echo "bin/console migration:unsigned_keys command FAILED" && exit 1;
 fi
 ## Second run should do nothing.
-bin/console glpi:migration:unsigned_keys --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
+bin/console migration:unsigned_keys --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
 if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
-  then echo "bin/console glpi:migration:unsigned_keys command FAILED" && exit 1;
+  then echo "bin/console migration:unsigned_keys command FAILED" && exit 1;
 fi
 ## Check DB schema integrity (including unsigned keys migration)
-bin/console glpi:database:check_schema_integrity \
+bin/console database:check_schema_integrity \
   --config-dir=./tests/config --ansi --no-interaction \
   --check-unsigned-keys-migration
 
 # Complete DB check
-bin/console glpi:database:check_schema_integrity \
+bin/console database:check_schema_integrity \
   --config-dir=./tests/config --ansi --no-interaction \
   --check-all-migrations
 tests/bin/test-data-sanitization --ansi --no-interaction
 
 # Check updated data
-bin/console glpi:database:configure \
+bin/console database:configure \
   --config-dir=./tests/config --no-interaction --ansi \
   --reconfigure --db-name=glpi --db-host=db --db-user=root \
   --strict-configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The present file will list all changes made to the project; according to the
 ### Added
 
 ### Changed
+- `glpi:` command prefix has been removed from console commands canonical name.
 
 ### Deprecated
 

--- a/install/migrations/update_9.4.x_to_9.5.0.php
+++ b/install/migrations/update_9.4.x_to_9.5.0.php
@@ -100,7 +100,7 @@ function update94xto950()
     if (!$DB->fieldExists('glpi_users', 'timezone')) {
         $migration->addField("glpi_users", "timezone", "varchar(50) DEFAULT NULL");
     }
-    $migration->displayWarning("DATETIME fields must be converted to TIMESTAMP for timezones to work. Run bin/console glpi:migration:timestamps");
+    $migration->displayWarning("DATETIME fields must be converted to TIMESTAMP for timezones to work. Run bin/console migration:timestamps");
 
    // Add a config entry for app timezone setting
     $migration->addConfig(['timezone' => null]);

--- a/install/migrations/update_9.5.x_to_10.0.0.php
+++ b/install/migrations/update_9.5.x_to_10.0.0.php
@@ -93,7 +93,7 @@ function update95xto1000()
     $migration->executeMigration();
 
     $migration->displayWarning(
-        '"utf8mb4" support requires additional migration which can be performed via the "php bin/console glpi:migration:utf8mb4" command.'
+        '"utf8mb4" support requires additional migration which can be performed via the "php bin/console migration:utf8mb4" command.'
     );
 
     return $updateresult;

--- a/install/migrations/update_9.5.x_to_10.0.0/schema_fixes.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/schema_fixes.php
@@ -259,7 +259,7 @@ foreach ($useless_keys as $table => $keys) {
     }
 }
 
-// Add missing keys (based on glpi:tools:check_database_keys detection)
+// Add missing keys (based on tools:check_database_keys detection)
 $missing_keys = [
     'glpi_apiclients' => [
         'entities_id',

--- a/src/Central.php
+++ b/src/Central.php
@@ -487,12 +487,12 @@ class Central extends CommonGLPI
             if (($myisam_count = $DB->getMyIsamTables()->count()) > 0) {
                 $messages['warnings'][] = sprintf(__('%d tables are using the deprecated MyISAM storage engine.'), $myisam_count)
                 . ' '
-                . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:myisam_to_innodb');
+                . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:myisam_to_innodb');
             }
             if (($datetime_count = $DB->getTzIncompatibleTables()->count()) > 0) {
                 $messages['warnings'][] = sprintf(__('%1$s columns are using the deprecated datetime storage field type.'), $datetime_count)
                 . ' '
-                . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:timestamps');
+                . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:timestamps');
             }
             /*
              * FIXME: Remove `$exclude_plugins = true` condition in GLPI 10.1.
@@ -502,7 +502,7 @@ class Central extends CommonGLPI
             if (($non_utf8mb4_count = $DB->getNonUtf8mb4Tables(true)->count()) > 0) {
                 $messages['warnings'][] = sprintf(__('%1$s tables are using the deprecated utf8mb3 storage charset.'), $non_utf8mb4_count)
                 . ' '
-                . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:utf8mb4');
+                . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:utf8mb4');
             }
             /*
              * FIXME: Remove `$exclude_plugins = true` condition in GLPI 10.1.
@@ -512,7 +512,7 @@ class Central extends CommonGLPI
             if (($signed_keys_col_count = $DB->getSignedKeysColumns(true)->count()) > 0) {
                 $messages['warnings'][] = sprintf(__('%d primary or foreign keys columns are using signed integers.'), $signed_keys_col_count)
                 . ' '
-                . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:unsigned_keys');
+                . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:unsigned_keys');
             }
         }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -1212,7 +1212,7 @@ class Config extends CommonDBTM
         } else {
             echo __('Timezone usage has not been activated.')
             . ' '
-            . sprintf(__('Run the "php bin/console %1$s" command to activate it.'), 'glpi:database:enable_timezones');
+            . sprintf(__('Run the "%1$s" command to activate it.'), 'php bin/console database:enable_timezones');
         }
 
         echo "<tr class='tab_bg_2'><td><label for='dropdown_default_central_tab$rand'>" . __('Default central tab') . "</label></td>";

--- a/src/Console/AbstractCommand.php
+++ b/src/Console/AbstractCommand.php
@@ -206,7 +206,7 @@ abstract class AbstractCommand extends Command implements GlpiCommandInterface
         if ($core_requirements->hasMissingOptionalRequirements()) {
             $message = __('Some optional system requirements are missing.')
             . ' '
-            . __('Run "php bin/console glpi:system:check_requirements" for more details.');
+            . sprintf(__('Run the "%1$s" command for more details.'), 'php bin/console system:check_requirements');
             $this->output->writeln(
                 '<comment>' . $message . '</comment>',
                 OutputInterface::VERBOSITY_NORMAL

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -231,6 +231,17 @@ class Application extends BaseApplication
         return $this->output;
     }
 
+    protected function getCommandName(InputInterface $input)
+    {
+        $name = parent::getCommandName($input);
+        if ($name !== null) {
+            // strip `glpi:` prefix that was used before GLPI 10.0.6
+            // FIXME Deprecate usage of `glpi:` prefix in GLPI 10.1.
+            $name = preg_replace('/^glpi:/', '', $name);
+        }
+        return $name;
+    }
+
     protected function doRunCommand(Command $command, InputInterface $input, OutputInterface $output)
     {
 
@@ -243,7 +254,7 @@ class Application extends BaseApplication
                 . '</error>'
                 . PHP_EOL
                 . '<error>'
-                . sprintf(__('Run the "php bin/console %1$s" command to process to the update.'), 'glpi:database:update')
+                . sprintf(__('Run the "%1$s" command to process to the update.'), 'php bin/console database:update')
                 . '</error>',
                 OutputInterface::VERBOSITY_QUIET
             );
@@ -496,8 +507,8 @@ class Application extends BaseApplication
 
         if ($core_requirements->hasMissingMandatoryRequirements()) {
             $message = __('Some mandatory system requirements are missing.')
-            . ' '
-            . __('Run "php bin/console glpi:system:check_requirements" for more details.');
+                . ' '
+                . sprintf(__('Run the "%1$s" command for more details.'), 'php bin/console system:check_requirements');
             $this->output->writeln(
                 '<error>' . $message . '</error>',
                 OutputInterface::VERBOSITY_QUIET

--- a/src/Console/Assets/CleanSoftwareCommand.php
+++ b/src/Console/Assets/CleanSoftwareCommand.php
@@ -48,8 +48,7 @@ class CleanSoftwareCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:assets:cleansoftware');
-        $this->setAliases(['assets:cleansoftware']);
+        $this->setName('assets:cleansoftware');
         $this->setDescription(CleanSoftwareCron::getTaskDescription());
 
         $this->addOption(

--- a/src/Console/Build/CompileScssCommand.php
+++ b/src/Console/Build/CompileScssCommand.php
@@ -56,8 +56,7 @@ class CompileScssCommand extends Command
     {
         parent::configure();
 
-        $this->setName('glpi:build:compile_scss');
-        $this->setAliases(['build:compile_scss']);
+        $this->setName('build:compile_scss');
         $this->setDescription('Compile SCSS file.');
 
         $this->addOption(

--- a/src/Console/Cache/ClearCommand.php
+++ b/src/Console/Cache/ClearCommand.php
@@ -56,12 +56,11 @@ class ClearCommand extends Command
     {
         parent::configure();
 
-        $this->setName('glpi:cache:clear');
+        $this->setName('cache:clear');
         $this->setAliases(
             [
-                'cache:clear',
-            // Old command name/alias
-                'glpi:system:clear_cache',
+                // Old command alias
+                // FIXME Remove it in GLPI 10.1.
                 'system:clear_cache'
             ]
         );

--- a/src/Console/Cache/ConfigureCommand.php
+++ b/src/Console/Cache/ConfigureCommand.php
@@ -71,8 +71,7 @@ class ConfigureCommand extends AbstractCommand
     protected function configure()
     {
 
-        $this->setName('glpi:cache:configure');
-        $this->setAliases(['cache:configure']);
+        $this->setName('cache:configure');
         $this->setDescription('Define cache configuration');
 
         $this->addOption(

--- a/src/Console/Cache/DebugCommand.php
+++ b/src/Console/Cache/DebugCommand.php
@@ -49,8 +49,7 @@ class DebugCommand extends Command
     {
         parent::configure();
 
-        $this->setName('glpi:cache:debug');
-        $this->setAliases(['cache:debug']);
+        $this->setName('cache:debug');
         $this->setDescription('Debug GLPI cache.');
 
         $this->addOption(

--- a/src/Console/Cache/SetNamespacePrefixCommand.php
+++ b/src/Console/Cache/SetNamespacePrefixCommand.php
@@ -71,8 +71,7 @@ class SetNamespacePrefixCommand extends AbstractCommand
     protected function configure()
     {
 
-        $this->setName('glpi:cache:set_namespace_prefix');
-        $this->setAliases(['cache:set_namespace_prefix']);
+        $this->setName('cache:set_namespace_prefix');
         $this->setDescription('Define cache namespace prefix');
 
         $this->addArgument('prefix', InputArgument::REQUIRED, 'Namespace prefix');

--- a/src/Console/Config/SetCommand.php
+++ b/src/Console/Config/SetCommand.php
@@ -57,8 +57,7 @@ class SetCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:config:set');
-        $this->setAliases(['config:set']);
+        $this->setName('config:set');
         $this->setDescription(__('Set configuration value'));
         $this->addArgument('key', InputArgument::REQUIRED, 'Configuration key');
         $this->addArgument('value', InputArgument::REQUIRED, 'Configuration value (ommit argument to be prompted for value)');

--- a/src/Console/Database/AbstractConfigureCommand.php
+++ b/src/Console/Database/AbstractConfigureCommand.php
@@ -93,7 +93,7 @@ abstract class AbstractConfigureCommand extends AbstractCommand implements Force
 
         parent::configure();
 
-        $this->setName('glpi:database:install');
+        $this->setName('database:install');
         $this->setAliases(['db:install']);
         $this->setDescription('Install database schema');
 
@@ -467,7 +467,7 @@ abstract class AbstractConfigureCommand extends AbstractCommand implements Force
             if ($this->input->getOption('no-interaction')) {
                  $message = sprintf(
                      __('Fix them and run the "php bin/console %1$s" command to enable timezones.'),
-                     'glpi:database:enable_timezones'
+                     'database:enable_timezones'
                  );
                  $this->output->writeln('<comment>' . $message . '</comment>', OutputInterface::VERBOSITY_QUIET);
             } else {

--- a/src/Console/Database/CheckSchemaIntegrityCommand.php
+++ b/src/Console/Database/CheckSchemaIntegrityCommand.php
@@ -77,11 +77,11 @@ class CheckSchemaIntegrityCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:database:check_schema_integrity');
+        $this->setName('database:check_schema_integrity');
         $this->setAliases(
             [
                 'db:check_schema_integrity',
-                'glpi:database:check', // old name
+                'database:check', // old name
                 'db:check', // old alias
             ]
         );

--- a/src/Console/Database/ConfigureCommand.php
+++ b/src/Console/Database/ConfigureCommand.php
@@ -45,7 +45,7 @@ class ConfigureCommand extends AbstractConfigureCommand
 
         parent::configure();
 
-        $this->setName('glpi:database:configure');
+        $this->setName('database:configure');
         $this->setAliases(['db:configure']);
         $this->setDescription('Define database configuration');
     }

--- a/src/Console/Database/EnableTimezonesCommand.php
+++ b/src/Console/Database/EnableTimezonesCommand.php
@@ -68,7 +68,7 @@ class EnableTimezonesCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:database:enable_timezones');
+        $this->setName('database:enable_timezones');
         $this->setAliases(['db:enable_timezones']);
         $this->setDescription(__('Enable timezones usage.'));
     }
@@ -91,7 +91,7 @@ class EnableTimezonesCommand extends AbstractCommand
         if (($datetime_count = $this->db->getTzIncompatibleTables()->count()) > 0) {
             $message = sprintf(__('%1$s columns are using the deprecated datetime storage field type.'), $datetime_count)
             . ' '
-            . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:timestamps');
+            . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:timestamps');
             throw new \Glpi\Console\Exception\EarlyExitException(
                 '<error>' . $message . '</error>',
                 self::ERROR_TIMESTAMP_FIELDS_REQUIRED

--- a/src/Console/Database/FixHtmlEncodingCommand.php
+++ b/src/Console/Database/FixHtmlEncodingCommand.php
@@ -105,7 +105,7 @@ final class FixHtmlEncodingCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:database:fix_html_encoding');
+        $this->setName('database:fix_html_encoding');
         $this->setAliases(['db:fix_html']);
         $this->setDescription(__('Fix HTML encoding issues in database.'));
 

--- a/src/Console/Database/InstallCommand.php
+++ b/src/Console/Database/InstallCommand.php
@@ -91,7 +91,7 @@ class InstallCommand extends AbstractConfigureCommand
 
         parent::configure();
 
-        $this->setName('glpi:database:install');
+        $this->setName('database:install');
         $this->setAliases(['db:install']);
         $this->setDescription('Install database schema');
 

--- a/src/Console/Database/UpdateCommand.php
+++ b/src/Console/Database/UpdateCommand.php
@@ -88,7 +88,7 @@ class UpdateCommand extends AbstractCommand implements ForceNoPluginsOptionComma
     {
         parent::configure();
 
-        $this->setName('glpi:database:update');
+        $this->setName('database:update');
         $this->setAliases(['db:update']);
         $this->setDescription(__('Update database schema to new version'));
 
@@ -261,7 +261,7 @@ class UpdateCommand extends AbstractCommand implements ForceNoPluginsOptionComma
             $install_version_nohash = preg_replace('/@.+$/', '', $installed_version);
             $error = sprintf(__('The database schema is not consistent with the installed GLPI version (%s).'), $install_version_nohash)
                 . ' '
-                . sprintf(__('Run the "php bin/console %1$s" command to view found differences.'), 'glpi:database:check_schema_integrity');
+                . sprintf(__('Run the "php bin/console %1$s" command to view found differences.'), 'database:check_schema_integrity');
         }
 
         if ($error !== null) {

--- a/src/Console/Ldap/SynchronizeUsersCommand.php
+++ b/src/Console/Ldap/SynchronizeUsersCommand.php
@@ -69,7 +69,7 @@ class SynchronizeUsersCommand extends AbstractCommand
 
         parent::configure();
 
-        $this->setName('glpi:ldap:synchronize_users');
+        $this->setName('ldap:synchronize_users');
         $this->setAliases(['ldap:sync']);
         $this->setDescription(__('Synchronize users against LDAP server information'));
 

--- a/src/Console/Maintenance/DisableMaintenanceModeCommand.php
+++ b/src/Console/Maintenance/DisableMaintenanceModeCommand.php
@@ -48,12 +48,7 @@ class DisableMaintenanceModeCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:maintenance:disable');
-        $this->setAliases(
-            [
-                'maintenance:disable',
-            ]
-        );
+        $this->setName('maintenance:disable');
         $this->setDescription(__('Disable maintenance mode'));
     }
 

--- a/src/Console/Maintenance/EnableMaintenanceModeCommand.php
+++ b/src/Console/Maintenance/EnableMaintenanceModeCommand.php
@@ -49,12 +49,7 @@ class EnableMaintenanceModeCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:maintenance:enable');
-        $this->setAliases(
-            [
-                'maintenance:enable',
-            ]
-        );
+        $this->setName('maintenance:enable');
         $this->setDescription(__('Enable maintenance mode'));
 
         $this->addOption(

--- a/src/Console/Marketplace/DownloadCommand.php
+++ b/src/Console/Marketplace/DownloadCommand.php
@@ -49,8 +49,7 @@ class DownloadCommand extends AbstractMarketplaceCommand
     {
         parent::configure();
 
-        $this->setName('glpi:marketplace:download');
-        $this->setAliases(['marketplace:download']);
+        $this->setName('marketplace:download');
         $this->setDescription(__('Download plugin from the GLPI marketplace'));
 
         $this->addArgument('plugins', InputArgument::REQUIRED | InputArgument::IS_ARRAY, __('The plugin key'));

--- a/src/Console/Marketplace/InfoCommand.php
+++ b/src/Console/Marketplace/InfoCommand.php
@@ -47,8 +47,7 @@ class InfoCommand extends AbstractMarketplaceCommand
     {
         parent::configure();
 
-        $this->setName('glpi:marketplace:info');
-        $this->setAliases(['marketplace:info']);
+        $this->setName('marketplace:info');
         $this->setDescription(__('Get information about a plugin'));
 
         $this->addArgument('plugin', InputArgument::REQUIRED, __('The plugin key'));

--- a/src/Console/Marketplace/SearchCommand.php
+++ b/src/Console/Marketplace/SearchCommand.php
@@ -50,8 +50,7 @@ class SearchCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:marketplace:search');
-        $this->setAliases(['marketplace:search']);
+        $this->setName('marketplace:search');
         $this->setDescription(__('Search GLPI marketplace'));
 
         $this->addArgument('term', InputArgument::OPTIONAL, __('The search term'));

--- a/src/Console/Migration/AppliancesPluginToCoreCommand.php
+++ b/src/Console/Migration/AppliancesPluginToCoreCommand.php
@@ -140,7 +140,7 @@ class AppliancesPluginToCoreCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:migration:appliances_plugin_to_core');
+        $this->setName('migration:appliances_plugin_to_core');
         $this->setDescription(__('Migrate Appliances plugin data into GLPI core tables'));
 
         $this->addOption(

--- a/src/Console/Migration/BuildMissingTimestampsCommand.php
+++ b/src/Console/Migration/BuildMissingTimestampsCommand.php
@@ -47,7 +47,7 @@ class BuildMissingTimestampsCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:migration:build_missing_timestamps');
+        $this->setName('migration:build_missing_timestamps');
         $this->setDescription(__('Set missing `date_creation` and `date_mod` values using log entries.'));
         $this->setHidden(true); // Hide this command as it is when migrating from really old GLPI version
     }

--- a/src/Console/Migration/DatabasesPluginToCoreCommand.php
+++ b/src/Console/Migration/DatabasesPluginToCoreCommand.php
@@ -58,7 +58,7 @@ class DatabasesPluginToCoreCommand extends AbstractPluginToCoreCommand
     {
         parent::configure();
 
-        $this->setName('glpi:migration:databases_plugin_to_core');
+        $this->setName('migration:databases_plugin_to_core');
         $this->setDescription(__('Migrate Databases plugin data into GLPI core tables'));
     }
 

--- a/src/Console/Migration/DomainsPluginToCoreCommand.php
+++ b/src/Console/Migration/DomainsPluginToCoreCommand.php
@@ -49,7 +49,7 @@ class DomainsPluginToCoreCommand extends AbstractPluginToCoreCommand
     {
         parent::configure();
 
-        $this->setName('glpi:migration:domains_plugin_to_core');
+        $this->setName('migration:domains_plugin_to_core');
         $this->setDescription(__('Migrate Domains plugin data into GLPI core tables'));
     }
 

--- a/src/Console/Migration/DynamicRowFormatCommand.php
+++ b/src/Console/Migration/DynamicRowFormatCommand.php
@@ -61,7 +61,7 @@ class DynamicRowFormatCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:migration:dynamic_row_format');
+        $this->setName('migration:dynamic_row_format');
         $this->setDescription(__('Convert database tables to "Dynamic" row format (required for "utf8mb4" character support).'));
     }
 
@@ -85,7 +85,7 @@ class DynamicRowFormatCommand extends AbstractCommand
         if (($myisam_count = $this->db->getMyIsamTables()->count()) > 0) {
             $msg = sprintf(__('%d tables are using the deprecated MyISAM storage engine.'), $myisam_count)
             . ' '
-            . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:myisam_to_innodb');
+            . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:myisam_to_innodb');
             throw new \Glpi\Console\Exception\EarlyExitException('<error>' . $msg . '</error>', self::ERROR_INNODB_REQUIRED);
         }
     }

--- a/src/Console/Migration/MigrateAllCommand.php
+++ b/src/Console/Migration/MigrateAllCommand.php
@@ -46,18 +46,18 @@ class MigrateAllCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:migration:migrate_all');
+        $this->setName('migration:migrate_all');
         $this->setDescription(__('Execute all recommended optional migrations.'));
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $commands = [
-            'glpi:migration:myisam_to_innodb',
-            'glpi:migration:dynamic_row_format',
-            'glpi:migration:timestamps',
-            'glpi:migration:utf8mb4',
-            'glpi:migration:unsigned_keys',
+            'migration:myisam_to_innodb',
+            'migration:dynamic_row_format',
+            'migration:timestamps',
+            'migration:utf8mb4',
+            'migration:unsigned_keys',
         ];
 
         $options = [];

--- a/src/Console/Migration/MyIsamToInnoDbCommand.php
+++ b/src/Console/Migration/MyIsamToInnoDbCommand.php
@@ -60,7 +60,7 @@ class MyIsamToInnoDbCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:migration:myisam_to_innodb');
+        $this->setName('migration:myisam_to_innodb');
         $this->setDescription(__('Migrate MyISAM tables to InnoDB'));
     }
 

--- a/src/Console/Migration/RacksPluginToCoreCommand.php
+++ b/src/Console/Migration/RacksPluginToCoreCommand.php
@@ -157,7 +157,7 @@ class RacksPluginToCoreCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:migration:racks_plugin_to_core');
+        $this->setName('migration:racks_plugin_to_core');
         $this->setDescription(__('Migrate Racks plugin data into GLPI core tables'));
 
         $this->addOption(

--- a/src/Console/Migration/TimestampsCommand.php
+++ b/src/Console/Migration/TimestampsCommand.php
@@ -61,7 +61,7 @@ class TimestampsCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:migration:timestamps');
+        $this->setName('migration:timestamps');
         $this->setDescription(__('Convert "datetime" fields to "timestamp" to use timezones.'));
     }
 
@@ -219,7 +219,7 @@ class TimestampsCommand extends AbstractCommand
             }
             $message = sprintf(
                 __('Fix them and run the "php bin/console %1$s" command to enable timezones.'),
-                'glpi:database:enable_timezones'
+                'database:enable_timezones'
             );
             $output->writeln('<error>' . $message . '</error>', OutputInterface::VERBOSITY_QUIET);
         }

--- a/src/Console/Migration/UnsignedKeysCommand.php
+++ b/src/Console/Migration/UnsignedKeysCommand.php
@@ -61,7 +61,7 @@ class UnsignedKeysCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:migration:unsigned_keys');
+        $this->setName('migration:unsigned_keys');
         $this->setDescription(__('Migrate primary/foreign keys to unsigned integers'));
     }
 

--- a/src/Console/Migration/Utf8mb4Command.php
+++ b/src/Console/Migration/Utf8mb4Command.php
@@ -82,7 +82,7 @@ class Utf8mb4Command extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:migration:utf8mb4');
+        $this->setName('migration:utf8mb4');
         $this->setDescription(__('Convert database character set from "utf8" to "utf8mb4".'));
     }
 
@@ -115,7 +115,7 @@ class Utf8mb4Command extends AbstractCommand
         if (($myisam_count = $this->db->getMyIsamTables()->count()) > 0) {
             $msg = sprintf(__('%d tables are using the deprecated MyISAM storage engine.'), $myisam_count)
             . ' '
-            . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:myisam_to_innodb');
+            . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:myisam_to_innodb');
             throw new \Glpi\Console\Exception\EarlyExitException('<error>' . $msg . '</error>', self::ERROR_INNODB_REQUIRED);
         }
 
@@ -123,7 +123,7 @@ class Utf8mb4Command extends AbstractCommand
         if ($this->db->listTables('glpi\_%', ['row_format' => ['COMPACT', 'REDUNDANT']])->count() > 0) {
             $msg = sprintf(__('%d tables are still using Compact or Redundant row format.'), $myisam_count)
             . ' '
-            . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:dynamic_row_format');
+            . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:dynamic_row_format');
             throw new \Glpi\Console\Exception\EarlyExitException('<error>' . $msg . '</error>', self::ERROR_DYNAMIC_ROW_FORMAT_REQUIRED);
         }
     }

--- a/src/Console/Plugin/ActivateCommand.php
+++ b/src/Console/Plugin/ActivateCommand.php
@@ -52,8 +52,7 @@ class ActivateCommand extends AbstractPluginCommand
     {
         parent::configure();
 
-        $this->setName('glpi:plugin:activate');
-        $this->setAliases(['plugin:activate']);
+        $this->setName('plugin:activate');
         $this->setDescription('Activate plugin(s)');
     }
 

--- a/src/Console/Plugin/DeactivateCommand.php
+++ b/src/Console/Plugin/DeactivateCommand.php
@@ -52,8 +52,7 @@ class DeactivateCommand extends AbstractPluginCommand
     {
         parent::configure();
 
-        $this->setName('glpi:plugin:deactivate');
-        $this->setAliases(['plugin:deactivate']);
+        $this->setName('plugin:deactivate');
         $this->setDescription('Deactivate plugin(s)');
     }
 

--- a/src/Console/Plugin/InstallCommand.php
+++ b/src/Console/Plugin/InstallCommand.php
@@ -58,8 +58,7 @@ class InstallCommand extends AbstractPluginCommand
     {
         parent::configure();
 
-        $this->setName('glpi:plugin:install');
-        $this->setAliases(['plugin:install']);
+        $this->setName('plugin:install');
         $this->setDescription('Run plugin(s) installation script');
 
         $this->addOption(

--- a/src/Console/Rules/ProcessSoftwareCategoryRulesCommand.php
+++ b/src/Console/Rules/ProcessSoftwareCategoryRulesCommand.php
@@ -47,8 +47,7 @@ class ProcessSoftwareCategoryRulesCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:rules:process_software_category_rules');
-        $this->setAliases(['rules:process_software_category_rules']);
+        $this->setName('rules:process_software_category_rules');
         $this->setDescription(__('Process software category rules'));
 
         $this->addOption(

--- a/src/Console/Rules/ReplayDictionnaryRulesCommand.php
+++ b/src/Console/Rules/ReplayDictionnaryRulesCommand.php
@@ -47,8 +47,7 @@ class ReplayDictionnaryRulesCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:rules:replay_dictionnary_rules');
-        $this->setAliases(['rules:replay_dictionnary_rules']);
+        $this->setName('rules:replay_dictionnary_rules');
         $this->setDescription(__('Replay dictionnary rules on existing items'));
 
         $this->addOption(

--- a/src/Console/Security/ChangekeyCommand.php
+++ b/src/Console/Security/ChangekeyCommand.php
@@ -53,7 +53,7 @@ class ChangekeyCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:security:change_key');
+        $this->setName('security:change_key');
         $this->setDescription(__('Change password storage key and update values in database.'));
     }
 

--- a/src/Console/System/CheckRequirementsCommand.php
+++ b/src/Console/System/CheckRequirementsCommand.php
@@ -49,8 +49,7 @@ class CheckRequirementsCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:system:check_requirements');
-        $this->setAliases(['system:check_requirements']);
+        $this->setName('system:check_requirements');
         $this->setDescription(__('Check system requirements'));
     }
 

--- a/src/Console/System/CheckStatusCommand.php
+++ b/src/Console/System/CheckStatusCommand.php
@@ -50,8 +50,7 @@ class CheckStatusCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:system:status');
-        $this->setAliases(['system:status']);
+        $this->setName('system:status');
         $this->setDescription(__('Check system status'));
         $this->addOption(
             'format',

--- a/src/Console/System/ListServicesCommand.php
+++ b/src/Console/System/ListServicesCommand.php
@@ -46,8 +46,7 @@ class ListServicesCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:system:list_services');
-        $this->setAliases(['system:list_services']);
+        $this->setName('system:list_services');
         $this->setDescription(__('List system services'));
     }
 

--- a/src/Console/Task/UnlockCommand.php
+++ b/src/Console/Task/UnlockCommand.php
@@ -50,8 +50,7 @@ class UnlockCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:task:unlock');
-        $this->setAliases(['task:unlock']);
+        $this->setName('task:unlock');
         $this->setDescription(__('Unlock automatic tasks'));
 
         $this->addOption(

--- a/src/GLPIKey.php
+++ b/src/GLPIKey.php
@@ -122,7 +122,7 @@ class GLPIKey
     public function get(): ?string
     {
         if (!file_exists($this->keyfile)) {
-            trigger_error('You must create a security key, see glpi:security:change_key command.', E_USER_WARNING);
+            trigger_error('You must create a security key, see security:change_key command.', E_USER_WARNING);
             return null;
         }
         if (!is_readable($this->keyfile) || ($key = file_get_contents($this->keyfile)) === false) {

--- a/src/Update.php
+++ b/src/Update.php
@@ -183,7 +183,10 @@ class Update
             $this->migration->displayError(
                 __('The database schema is not consistent with the current GLPI version.')
                 . "\n"
-                . __('It is recommended to run the "php bin/console glpi:database:check_schema_integrity" command to see the differences.')
+                . sprintf(
+                    __('It is recommended to run the "%s" command to see the differences.'),
+                    'php bin/console database:check_schema_integrity'
+                )
             );
         }
     }
@@ -273,13 +276,13 @@ class Update
         if (($myisam_count = $DB->getMyIsamTables()->count()) > 0) {
             $message = sprintf(__('%d tables are using the deprecated MyISAM storage engine.'), $myisam_count)
                 . ' '
-                . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:myisam_to_innodb');
+                . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:myisam_to_innodb');
             $this->migration->displayError($message);
         }
         if (($datetime_count = $DB->getTzIncompatibleTables()->count()) > 0) {
             $message = sprintf(__('%1$s columns are using the deprecated datetime storage field type.'), $datetime_count)
                 . ' '
-                . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:timestamps');
+                . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:timestamps');
             $this->migration->displayError($message);
         }
         /*
@@ -292,7 +295,7 @@ class Update
         if ($DB->use_utf8mb4 && ($non_utf8mb4_count = $DB->getNonUtf8mb4Tables(true)->count()) > 0) {
             $message = sprintf(__('%1$s tables are using the deprecated utf8mb3 storage charset.'), $non_utf8mb4_count)
                 . ' '
-                . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:utf8mb4');
+                . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:utf8mb4');
             $this->migration->displayError($message);
         }
         /*
@@ -305,7 +308,7 @@ class Update
         if (!$DB->allow_signed_keys && ($signed_keys_col_count = $DB->getSignedKeysColumns(true)->count()) > 0) {
             $message = sprintf(__('%d primary or foreign keys columns are using signed integers.'), $signed_keys_col_count)
                 . ' '
-                . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:unsigned_keys');
+                . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:unsigned_keys');
             $this->migration->displayError($message);
         }
 
@@ -341,7 +344,13 @@ class Update
        //generate security key if missing, and update db
         $glpikey = new GLPIKey();
         if (!$glpikey->keyExists() && !$glpikey->generate()) {
-            $this->migration->displayWarning(__('Unable to create security key file! You have to run "php bin/console glpi:security:change_key" command to manually create this file.'), true);
+            $this->migration->displayWarning(
+                sprintf(
+                    __('Unable to create security key file! You have to run the "%s" command to manually create this file.'),
+                    'php bin/console security:change_key'
+                ),
+                true
+            );
         }
 
         // Check if schema has differences from the expected one but do not block the upgrade

--- a/src/User.php
+++ b/src/User.php
@@ -2518,7 +2518,7 @@ HTML;
                // Display a warning but only if user is more or less an admin
                 echo __('Timezone usage has not been activated.')
                 . ' '
-                . sprintf(__('Run the "php bin/console %1$s" command to activate it.'), 'glpi:database:enable_timezones');
+                . sprintf(__('Run the "%1$s" command to activate it.'), 'php bin/console database:enable_timezones');
             }
             echo "</td></tr>";
         }
@@ -3009,7 +3009,7 @@ HTML;
                    // Display a warning but only if user is more or less an admin
                     echo __('Timezone usage has not been activated.')
                     . ' '
-                    . sprintf(__('Run the "php bin/console %1$s" command to activate it.'), 'glpi:database:enable_timezones');
+                    . sprintf(__('Run the "%1$s" command to activate it.'), 'php bin/console database:enable_timezones');
                 }
                 echo "</td>";
                 if (

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,11 +21,11 @@ Generating optimized autoload files
 Creating a dedicated database
 -----------------------------
 
-Use the **glpi:database:install** CLI command to create a new database,
+Use the **database:install** CLI command to create a new database,
 only used for the test suite, using the `--config-dir=./tests/config` option:
 
 ```bash
-$ bin/console glpi:database:install --config-dir=./tests/config --db-name=glpitests --db-user=root --db-password=xxxx
+$ bin/console database:install --config-dir=./tests/config --db-name=glpitests --db-user=root --db-password=xxxx
 Creating the database...
 Saving configuration file...
 Loading default schema...
@@ -37,7 +37,7 @@ The configuration file is saved as `tests/config/config_db.php`.
 The database is created using the default schema for current version.
 
 If you need to recreate the database (e.g. for a new schema), you need to run
-**glpi:database:install** CLI command again with the `--force` option.
+**database:install** CLI command again with the `--force` option.
 
 
 Changing database configuration

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -71,7 +71,7 @@ global $CFG_GLPI, $GLPI_CACHE;
 include(GLPI_ROOT . "/inc/based_config.php");
 
 if (!file_exists(GLPI_CONFIG_DIR . '/config_db.php')) {
-    die("\nConfiguration file for tests not found\n\nrun: bin/console glpi:database:install --config-dir=" . GLPI_CONFIG_DIR . " ...\n\n");
+    die("\nConfiguration file for tests not found\n\nrun: php bin/console database:install --config-dir=" . GLPI_CONFIG_DIR . " ...\n\n");
 }
 
 \Glpi\Tests\BootstrapUtils::initVarDirectories();

--- a/tests/functionnal/GLPIKey.php
+++ b/tests/functionnal/GLPIKey.php
@@ -136,7 +136,7 @@ class GLPIKey extends \DbTestCase
             }
         )->error
          ->withType(E_USER_WARNING)
-         ->withMessage('You must create a security key, see glpi:security:change_key command.')
+         ->withMessage('You must create a security key, see security:change_key command.')
          ->exists();
     }
 

--- a/tests/units/Glpi/Console/CommandLoader.php
+++ b/tests/units/Glpi/Console/CommandLoader.php
@@ -58,7 +58,7 @@ PHP
 <?php
 class InstallCommand extends \\Symfony\\Component\\Console\\Command\\Command {
    protected function configure() {
-      \$this->setName('glpi:database:install');
+      \$this->setName('database:install');
       \$this->setAliases(['db:install']);
    }
 }
@@ -71,7 +71,7 @@ PHP
 namespace Glpi;
 class ValidateCommand extends \\Symfony\\Component\\Console\\Command\\Command {
    protected function configure() {
-      \$this->setName('glpi:validate');
+      \$this->setName('validate');
    }
 }
 PHP
@@ -87,7 +87,7 @@ PHP
 namespace Glpi\\Console;
 class TestCommand extends \\Symfony\\Component\\Console\\Command\\Command {
    protected function configure() {
-      \$this->setName('glpi:test');
+      \$this->setName('test');
    }
 }
 PHP
@@ -99,8 +99,7 @@ PHP
 <?php
 class DebugCommand extends \\Symfony\\Component\\Console\\Command\\Command {
    protected function configure() {
-      \$this->setName('glpi:tools:debug');
-      \$this->setAliases(['tools:debug']);
+      \$this->setName('tools:debug');
    }
 }
 PHP
@@ -258,12 +257,11 @@ PHP
         vfsStream::setup('glpi', null, $structure);
 
         $core_names_to_class = [
-            'glpi:database:install' => 'InstallCommand',
-            'db:install'            => 'InstallCommand',
-            'glpi:validate'         => 'Glpi\\ValidateCommand',
-            'glpi:test'             => 'Glpi\\Console\\TestCommand',
-            'glpi:tools:debug'      => 'DebugCommand',
-            'tools:debug'           => 'DebugCommand',
+            'database:install' => 'InstallCommand',
+            'db:install'       => 'InstallCommand',
+            'validate'         => 'Glpi\\ValidateCommand',
+            'test'             => 'Glpi\\Console\\TestCommand',
+            'tools:debug'      => 'DebugCommand',
         ];
 
         $plugins_names_to_class = [

--- a/tools/checkdatabasekeyscommand.class.php
+++ b/tools/checkdatabasekeyscommand.class.php
@@ -66,8 +66,7 @@ class CheckDatabaseKeysCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:tools:check_database_keys');
-        $this->setAliases(['tools:check_database_keys']);
+        $this->setName('tools:check_database_keys');
         $this->setDescription(__('Check database for missing and errounous keys.'));
 
         $this->addOption(

--- a/tools/checkdatabaseschemaconsistencycommand.class.php
+++ b/tools/checkdatabaseschemaconsistencycommand.class.php
@@ -51,8 +51,7 @@ class CheckDatabaseSchemaConsistencyCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:tools:check_database_schema_consistency');
-        $this->setAliases(['tools:check_database_schema_consistency']);
+        $this->setName('tools:check_database_schema_consistency');
         $this->setDescription(__('Check database schema consistency.'));
     }
 

--- a/tools/deleteorphanlogscommand.class.php
+++ b/tools/deleteorphanlogscommand.class.php
@@ -45,12 +45,7 @@ class DeleteOrphanLogsCommand extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('glpi:tools:delete_orphan_logs');
-        $this->setAliases(
-            [
-                'tools:delete_orphan_logs',
-            ]
-        );
+        $this->setName('tools:delete_orphan_logs');
         $this->setDescription(__('Delete orphan logs'));
 
         $this->addOption(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`glpi:` prefix on command name is not really usefull, and removing it improves a bit the console help presentation:
![image](https://user-images.githubusercontent.com/33253653/212096583-b0b4144a-ad2d-4e1f-9d99-8ed4dbfca757.png)

Prefix is still supported to maintain backward compatibility.
See https://github.com/glpi-project/glpi/blob/81846e5b16d72847f46bd643a63f46daf60b5b5a/src/Console/Application.php#L234-L243