### PR TITLE
fix(imageasset): array error on multiple pictures upload

### DIFF
--- a/src/Features/AssetImage.php
+++ b/src/Features/AssetImage.php
@@ -107,18 +107,18 @@ trait AssetImage
 
         $new_pictures = [];
         if (isset($input['_pictures'])) {
-            $pic_count = count($input['_pictures']);
+            $input_keys = array_keys($input['_pictures']);
             if (!isset($input['pictures'])) {
                 $input['pictures'] = [];
             }
-            for ($i = 0; $i < $pic_count; $i++) {
-                $filename = $input["_pictures"][$i];
+            foreach ($input_keys as $input_key) {
+                $filename = $input["_pictures"][$input_key];
                 $src = GLPI_TMP_DIR . '/' . $filename;
 
-                $prefix = $input["_prefix_pictures"][$i] ?? '';
+                $prefix = $input["_prefix_pictures"][$input_key] ?? '';
 
                 if ($dest = Toolbox::savePicture($src, $prefix)) {
-                    $new_pictures[$i] = $dest;
+                    $new_pictures[$input_key] = $dest;
                 } else {
                     Session::addMessageAfterRedirect(__('Unable to save picture file.'), true, ERROR);
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A

For example on http://glpi10bf.local/front/computermodel.form.php if you add an image in "Rack pictures" + an image in "Other pictures" at the same time, when adding the model you get a fatal error:

```
[2023-01-13 15:47:20] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key 0 in /home/francois/www/glpi-core/10.0-bugfixes/src/Features/AssetImage.php at line 115
  Backtrace :
  src/CommonDCModelDropdown.php:217                  CommonDCModelDropdown->managePictures()
  src/CommonDBTM.php:1281                            CommonDCModelDropdown->prepareInputForAdd()
  front/dropdown.common.form.php:62                  CommonDBTM->add()
  front/computermodel.form.php:39                    include()
  
[2023-01-13 15:47:20] glpiphplog.CRITICAL:   *** Uncaught Exception TypeError: Glpi\Toolbox\Sanitizer::isNsClassOrCallableIdentifier(): Argument #1 ($value) must be of type string, array given, called in /home/francois/www/glpi-core/10.0-bugfixes/src/DBmysql.php on line 1265 in /home/francois/www/glpi-core/10.0-bugfixes/src/Toolbox/Sanitizer.php at line 224
  Backtrace :
  src/DBmysql.php:1265                               Glpi\Toolbox\Sanitizer::isNsClassOrCallableIdentifier()
  src/DBmysql.php:1296                               DBmysql::quoteValue()
  src/DBmysql.php:1320                               DBmysql->buildInsert()
  src/CommonDBTM.php:721                             DBmysql->insert()
  src/CommonDBTM.php:1326                            CommonDBTM->addToDB()
  front/dropdown.common.form.php:62                  CommonDBTM->add()
  front/computermodel.form.php:39                    include()
```
