### PR TITLE
fix(picture): always keep ratio aspect

### DIFF
--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -1031,28 +1031,24 @@ class Toolbox
         if (empty($img_height)) {
             $img_height = $img_infos[1];
         }
-        if (empty($new_width)) {
-            $new_width  = $img_infos[0];
-        }
-        if (empty($new_height)) {
-            $new_height = $img_infos[1];
+
+        if (
+            empty($max_size)
+            && (
+                !empty($new_width)
+                || !empty($new_height)
+            )
+        ) {
+            $max_size = ($new_width > $new_height ? $new_width : $new_height);
         }
 
-       // Image max size is 500 pixels : is set to 0 no resize
-        if ($max_size > 0) {
-            if (
-                ($img_width > $max_size)
-                || ($img_height > $max_size)
-            ) {
-                $source_aspect_ratio = $img_width / $img_height;
-                if ($source_aspect_ratio < 1) {
-                    $new_width  = ceil($max_size * $source_aspect_ratio);
-                    $new_height = $max_size;
-                } else {
-                    $new_width  = $max_size;
-                    $new_height = ceil($max_size / $source_aspect_ratio);
-                }
-            }
+        $source_aspect_ratio = $img_width / $img_height;
+        if ($source_aspect_ratio < 1) {
+            $new_width  = ceil($max_size * $source_aspect_ratio);
+            $new_height = $max_size;
+        } else {
+            $new_width  = $max_size;
+            $new_height = ceil($max_size / $source_aspect_ratio);
         }
 
         $img_type = $img_infos[2];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26291

I think that it is not necessary to condition the aspect ratio preservation on the fact that the image is greater than the max size.

Hence, for users' images that are not of a "square" ratio, the image is distorted currently, and people don't like having a distorted head :D

Before

![image](https://user-images.githubusercontent.com/470612/212360852-dbaea533-cb73-4b56-a125-989753ca0555.png)
![image](https://user-images.githubusercontent.com/470612/212361032-b7243b7c-b303-4f15-b113-91fcb637496f.png)

After

![image](https://user-images.githubusercontent.com/470612/212361507-5e902df9-80ca-41f0-9dcb-c27388f4c504.png)
