### PR TITLE
Fix reservation entity restrictions

### DIFF
--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -383,7 +383,7 @@ class Reservation extends CommonDBChild
             return false;
         }
 
-        return Session::haveAccessToEntity($item->getEntityID());
+        return Session::haveAccessToEntity($item->getEntityID(), $item->isRecursive());
     }
 
 
@@ -547,6 +547,9 @@ JAVASCRIPT;
         foreach ($iterator as $data) {
             $item = new $data['itemtype']();
             if (!$item->getFromDB($data['items_id'])) {
+                continue;
+            }
+            if (!Session::haveAccessToEntity($item->getEntityID(), $item->isRecursive())) {
                 continue;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Reservation of items from all entities were shown on reservation planning.
2. Reservation edit form was "blank" due to missing rights when corresponding item was located in a parent entity but visible due to recursive visibility.