### PR TITLE
fix(external event): missing visibility restriction

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -4526,6 +4526,10 @@ JAVASCRIPT;
 
                 break;
 
+            case 'PlanningExternalEvent':
+                $condition .= PlanningExternalEvent::addVisibilityRestrict();
+                break;
+
             default:
                // Plugin can override core definition for its type
                 if ($plug = isPluginItemType($itemtype)) {


### PR DESCRIPTION
The schedule view restriction was not checked for external events, so the user always saw all external events.

![image](https://user-images.githubusercontent.com/8530352/212652935-6f458335-6cab-4372-bd3f-6157f987f899.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26244
