### PR TITLE
Don't try other agent addresses when we get a client exception

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -687,7 +687,7 @@ class Agent extends CommonDBTM
                 'connect_timeout' => self::TIMEOUT,
             ];
 
-           // add proxy string if configured in glpi
+            // add proxy string if configured in glpi
             if (!empty($CFG_GLPI["proxy_name"])) {
                 $proxy_creds      = !empty($CFG_GLPI["proxy_user"])
                 ? $CFG_GLPI["proxy_user"] . ":" . (new GLPIKey())->decrypt($CFG_GLPI["proxy_passwd"]) . "@"
@@ -696,14 +696,17 @@ class Agent extends CommonDBTM
                 $options['proxy'] = $proxy_string;
             }
 
-           // init guzzle client with base options
+            // init guzzle client with base options
             $httpClient = new Guzzle_Client($options);
             try {
                 $response = $httpClient->request('GET', $endpoint, []);
                 self::$found_address = $address;
                 break;
+            } catch (\GuzzleHttp\Exception\RequestException $e) {
+                // got an error response, we don't need to try other addresses
+                break;
             } catch (Exception $e) {
-                //many addresses will be incorrect
+                // many addresses will be incorrect
             }
         }
 
@@ -722,16 +725,16 @@ class Agent extends CommonDBTM
      */
     public function requestStatus()
     {
-       //must return json
+        // must return json
         try {
             $response = $this->requestAgent('status');
             return $this->handleAgentResponse($response, self::ACTION_STATUS);
         } catch (\GuzzleHttp\Exception\ClientException $e) {
             ErrorHandler::getInstance()->handleException($e);
-           //not authorized
+            // not authorized
             return ['answer' => __('Not allowed')];
         } catch (Exception $e) {
-           //no response
+            // no response
             return ['answer' => __('Unknown')];
         }
     }
@@ -743,16 +746,16 @@ class Agent extends CommonDBTM
      */
     public function requestInventory()
     {
-       //must return json
+        // must return json
         try {
             $this->requestAgent('now');
             return $this->handleAgentResponse(new Response(), self::ACTION_INVENTORY);
         } catch (\GuzzleHttp\Exception\ClientException $e) {
             ErrorHandler::getInstance()->handleException($e);
-           //not authorized
+            // not authorized
             return ['answer' => __('Not allowed')];
         } catch (Exception $e) {
-           //no response
+            // no response
             return ['answer' => __('Unknown')];
         }
     }


### PR DESCRIPTION
 * requesting an inventory, we can really have a 'Not allowed' status when agent don't trust server and inventory reports many addresses
 * requestAgent() can return earlier when inventory reports many addresses

Actually, we catch all Guzzle exception to try other agent computed addresses. But indeed we should only try on connection failure like connection timeout or domain name resolving failure. Checking this [Guzzle exceptions documentation](https://github.com/guzzle/guzzle/blob/master/docs/quickstart.rst#exceptions), having `RequestException` exception type means we reached the agent and don't need to continue our tries.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
