### PR TITLE
fix(external event): guest display in the search

### DIFF
--- a/src/Features/PlanningEvent.php
+++ b/src/Features/PlanningEvent.php
@@ -1039,7 +1039,7 @@ trait PlanningEvent
                 'table'         => static::getTable(),
                 'field'         => 'users_id_guests',
                 'name'          => __('Guests'),
-                'datatype'      => 'text',
+                'datatype'      => 'specific',
             ];
         }
 
@@ -1075,5 +1075,30 @@ trait PlanningEvent
         }
 
         return $tab;
+    }
+
+    public static function getSpecificValueToDisplay($field, $values, array $options = [])
+    {
+
+        if (!is_array($values)) {
+            $values = [$field => $values];
+        }
+        switch ($field) {
+            case 'users_id_guests':
+                $users = [];
+                if (empty($values[$field])) {
+                    return '';
+                }
+                foreach (json_decode($values[$field], true) as $user_id) {
+                    $user = User::getById($user_id);
+                    $users[] = sprintf(
+                        '<a href="%s">%s</a>',
+                        User::getFormURLWithID($user->fields['id']),
+                        $user->fields['name']
+                    );
+                }
+                return implode(', ', $users);
+        }
+        return parent::getSpecificValueToDisplay($field, $values, $options);
     }
 }

--- a/src/Features/PlanningEvent.php
+++ b/src/Features/PlanningEvent.php
@@ -1090,11 +1090,10 @@ trait PlanningEvent
                     return '';
                 }
                 foreach (json_decode($values[$field], true) as $user_id) {
-                    $user = User::getById($user_id);
                     $users[] = sprintf(
                         '<a href="%s">%s</a>',
-                        User::getFormURLWithID($user->fields['id']),
-                        $user->fields['name']
+                        User::getFormURLWithID($user_id),
+                        getUserName($user_id, 1)
                     );
                 }
                 return implode(', ', $users);


### PR DESCRIPTION
The IDs of the guests were displayed in place of their names.

Before:
![image](https://user-images.githubusercontent.com/8530352/212691607-8e7b848e-0e8e-4cdc-8b76-cfba6c3fd987.png)


After:
![image](https://user-images.githubusercontent.com/8530352/212691498-80b4604c-3397-4875-9d6e-2a76c7bd8bbf.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
