### PR TITLE
Protect `php bin/console` string in translations

### DIFF
--- a/src/Console/Database/AbstractConfigureCommand.php
+++ b/src/Console/Database/AbstractConfigureCommand.php
@@ -466,8 +466,8 @@ abstract class AbstractConfigureCommand extends AbstractCommand implements Force
             );
             if ($this->input->getOption('no-interaction')) {
                  $message = sprintf(
-                     __('Fix them and run the "php bin/console %1$s" command to enable timezones.'),
-                     'database:enable_timezones'
+                     __('Fix them and run the "%1$s" command to enable timezones.'),
+                     'php bin/console database:enable_timezones'
                  );
                  $this->output->writeln('<comment>' . $message . '</comment>', OutputInterface::VERBOSITY_QUIET);
             } else {

--- a/src/Console/Database/UpdateCommand.php
+++ b/src/Console/Database/UpdateCommand.php
@@ -261,7 +261,7 @@ class UpdateCommand extends AbstractCommand implements ForceNoPluginsOptionComma
             $install_version_nohash = preg_replace('/@.+$/', '', $installed_version);
             $error = sprintf(__('The database schema is not consistent with the installed GLPI version (%s).'), $install_version_nohash)
                 . ' '
-                . sprintf(__('Run the "php bin/console %1$s" command to view found differences.'), 'database:check_schema_integrity');
+                . sprintf(__('Run the "%1$s" command to view found differences.'), 'php bin/console database:check_schema_integrity');
         }
 
         if ($error !== null) {

--- a/src/Console/Migration/TimestampsCommand.php
+++ b/src/Console/Migration/TimestampsCommand.php
@@ -218,8 +218,8 @@ class TimestampsCommand extends AbstractCommand
                 );
             }
             $message = sprintf(
-                __('Fix them and run the "php bin/console %1$s" command to enable timezones.'),
-                'database:enable_timezones'
+                __('Fix them and run the "%1$s" command to enable timezones.'),
+                'php bin/console database:enable_timezones'
             );
             $output->writeln('<error>' . $message . '</error>', OutputInterface::VERBOSITY_QUIET);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

It is preferable to move the `php bin/console` string outside translations to ensure that ranslators will not alter it.