### PR TITLE
fix(API): MassiveAction:update return ERROR_MASSIVEACTION_KEY

### DIFF
--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -3325,12 +3325,14 @@ abstract class API
         $action = explode(':', $action_key);
         $processor = $action[0];
 
-        $params['field'] = array_keys($params)[0];
+        if ($action[1] === 'update') {
+            $params['field'] = array_keys($params)[0];
 
-        foreach (Search::getOptions($itemtype) as $key => $value) {
-            if ($value['field'] == $params['field']) {
-                $params['search_options'][$itemtype] = $key;
-                break;
+            foreach (Search::getOptions($itemtype) as $key => $value) {
+                if ($value['field'] == $params['field'] && ($value['massiveaction'] ?? true) !== false) {
+                    $params['search_options'][$itemtype] = $key;
+                    break;
+                }
             }
         }
 

--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -3325,6 +3325,15 @@ abstract class API
         $action = explode(':', $action_key);
         $processor = $action[0];
 
+        $params['field'] = array_keys($params)[0];
+
+        foreach (Search::getOptions($itemtype) as $key => $value) {
+            if ($value['field'] == $params['field']) {
+                $params['search_options'][$itemtype] = $key;
+                break;
+            }
+        }
+
         $ma = new MassiveAction([
             'action'      => $action[1],
             'action_name' => $action_key,

--- a/tests/web/APIRest.php
+++ b/tests/web/APIRest.php
@@ -1200,6 +1200,37 @@ class APIRest extends APIBaseClass
                         }
                     }
                 }
+            ],
+            [
+                'url' => 'applyMassiveAction/Computer/MassiveAction:update',
+                'payload' => [
+                    'ids' => [getItemByTypeName('Computer', '_test_pc01', true)],
+                    'input' => [
+                        'comment' => "new comment",
+                    ],
+                ],
+                'status' => 200,
+                'response' => [
+                    'ok'       => 1,
+                    'noaction' => 0,
+                    'ko'       => 0,
+                    'noright'  => 0,
+                    'messages' => [],
+                ],
+                'error' => "",
+                'before_test' => function () {
+                    $computer = getItemByTypeName('Computer', '_test_pc01');
+                    $update = $computer->update([
+                        'id'      => $computer->getId(),
+                        'comment' => "test comment",
+                    ]);
+                    $this->boolean($update)->isTrue();
+                    $this->string($computer->fields['comment'])->isEqualTo("test comment");
+                },
+                'after_test' => function () {
+                    $computer = getItemByTypeName('Computer', '_test_pc01');
+                    $this->string($computer->fields['comment'])->isEqualTo("new comment");
+                }
             ]
         ];
     }
@@ -1382,48 +1413,5 @@ class APIRest extends APIBaseClass
 
         $this->integer($data[0]['tickets_id'])->isEqualTo($tickets_id);
         $this->integer($data[0]['groups_id'])->isEqualTo($groups_id);
-    }
-
-    public function test_ITILCategoryUpdate()
-    {
-        $headers = ['Session-Token' => $this->session_token];
-        $rand = mt_rand();
-
-        // Create ITILCategory
-        $input = [
-            'input' => [
-                'name' => "test_ITILCategoryUpdate_ITILCategory_$rand",
-            ]
-        ];
-        $data = $this->query("/ITILCategory", [
-            'headers' => $headers,
-            'verb'    => "POST",
-            'json'    => $input,
-        ], 201);
-        $this->integer($data['id'])->isGreaterThan(0);
-        $itilcategories_id = $data['id'];
-
-        // Update ITILCategory
-        $input = [
-            'input' => [
-                'name' => "test_ITILCategoryUpdate_ITILCategory_$rand",
-                'comment' => "test_ITILCategoryUpdate_ITILCategory_$rand",
-            ]
-        ];
-        $this->query("/ITILCategory/$itilcategories_id", [
-            'headers' => $headers,
-            'verb'    => "PUT",
-            'json'    => $input,
-        ], 200);
-
-        // Check ITILCategory
-        $data = $this->query("/ITILCategory/$itilcategories_id", [
-            'headers' => $headers,
-            'verb'    => "GET",
-        ], 200);
-
-        $this->integer($data['id'])->isEqualTo($itilcategories_id);
-        $this->string($data['name'])->isEqualTo("test_ITILCategoryUpdate_ITILCategory_$rand");
-        $this->string($data['comment'])->isEqualTo("test_ITILCategoryUpdate_ITILCategory_$rand");
     }
 }

--- a/tests/web/APIRest.php
+++ b/tests/web/APIRest.php
@@ -1383,4 +1383,47 @@ class APIRest extends APIBaseClass
         $this->integer($data[0]['tickets_id'])->isEqualTo($tickets_id);
         $this->integer($data[0]['groups_id'])->isEqualTo($groups_id);
     }
+
+    public function test_ITILCategoryUpdate()
+    {
+        $headers = ['Session-Token' => $this->session_token];
+        $rand = mt_rand();
+
+        // Create ITILCategory
+        $input = [
+            'input' => [
+                'name' => "test_ITILCategoryUpdate_ITILCategory_$rand",
+            ]
+        ];
+        $data = $this->query("/ITILCategory", [
+            'headers' => $headers,
+            'verb'    => "POST",
+            'json'    => $input,
+        ], 201);
+        $this->integer($data['id'])->isGreaterThan(0);
+        $itilcategories_id = $data['id'];
+
+        // Update ITILCategory
+        $input = [
+            'input' => [
+                'name' => "test_ITILCategoryUpdate_ITILCategory_$rand",
+                'comment' => "test_ITILCategoryUpdate_ITILCategory_$rand",
+            ]
+        ];
+        $this->query("/ITILCategory/$itilcategories_id", [
+            'headers' => $headers,
+            'verb'    => "PUT",
+            'json'    => $input,
+        ], 200);
+
+        // Check ITILCategory
+        $data = $this->query("/ITILCategory/$itilcategories_id", [
+            'headers' => $headers,
+            'verb'    => "GET",
+        ], 200);
+
+        $this->integer($data['id'])->isEqualTo($itilcategories_id);
+        $this->string($data['name'])->isEqualTo("test_ITILCategoryUpdate_ITILCategory_$rand");
+        $this->string($data['comment'])->isEqualTo("test_ITILCategoryUpdate_ITILCategory_$rand");
+    }
 }


### PR DESCRIPTION
`MassiveAction:update` always returned `ERROR_MASSIVEACTION_KEY` and field wasn't updated.

Example:
```
{{protocol}}://{{host}}/{{api_uri}}/applyMassiveAction/Itilcategory/MassiveAction:update
{
    "ids": [1],
    "input": {
        "is_incident": 0
    }
}
```
Returned:
```
[
    "ERROR_MASSIVEACTION_KEY",
    "Invalid action key parameter, run 'getMassiveActions' endpoint to see available keys; Afficher la documentation dans votre navigateur à http://xxxxx/apirest.php/#ERROR_MASSIVEACTION_KEY"
]
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26324
