### PR TITLE
Replace unexpected usages of html_entity_decode

### DIFF
--- a/ajax/planning.php
+++ b/ajax/planning.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Toolbox\Sanitizer;
+
 include('../inc/includes.php');
 
 Session::checkCentralAccess();
@@ -80,7 +82,7 @@ if ($_REQUEST["action"] == "get_externalevent_template") {
         $template = new PlanningExternalEventTemplate();
         $template->getFromDB($_POST[$key]);
 
-        $template->fields = array_map('html_entity_decode', $template->fields);
+        $template->fields = Sanitizer::decodeHtmlSpecialCharsRecursive($template->fields);
         $template->fields['rrule'] = json_decode($template->fields['rrule'], true);
         header("Content-Type: application/json; charset=UTF-8");
         echo json_encode($template->fields, JSON_NUMERIC_CHECK);

--- a/ajax/projecttask.php
+++ b/ajax/projecttask.php
@@ -37,6 +37,8 @@
  * @since 9.2
  */
 
+use Glpi\Toolbox\Sanitizer;
+
 $AJAX_INCLUDE = 1;
 
 include('../inc/includes.php');
@@ -59,6 +61,6 @@ if (isset($_POST['projecttasktemplates_id']) && ($_POST['projecttasktemplates_id
         );
     }
 
-    $template->fields = array_map('html_entity_decode', $template->fields);
+    $template->fields = Sanitizer::decodeHtmlSpecialCharsRecursive($template->fields);
     echo json_encode($template->fields);
 }

--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -1042,7 +1042,7 @@ class Item_Devices extends CommonDBRelation
                                 $content = Html::progressBar("percent" . mt_rand(), [
                                     'create'  => true,
                                     'percent' => $percent,
-                                    'message' => sprintf(__('%1$s (%2$d%%) '), html_entity_decode(Html::formatNumber($this->fields[$field], false, 0)), $percent),
+                                    'message' => sprintf(__('%1$s (%2$d%%) '), Html::formatNumber($this->fields[$field], false, 0), $percent),
                                     'display' => false
                                 ]);
                                 break;

--- a/src/RichText/RichText.php
+++ b/src/RichText/RichText.php
@@ -477,9 +477,9 @@ HTML;
         }
         $out .= "</div>";
 
-       // Decode images urls
+        // Unsanitize images urls
         $imgs = array_map(function ($img) {
-            $img['src'] = html_entity_decode($img['src']);
+            $img['src'] = Sanitizer::decodeHtmlSpecialChars($img['src']);
             return $img;
         }, $imgs);
 

--- a/src/Search.php
+++ b/src/Search.php
@@ -8365,7 +8365,7 @@ HTML;
                    // Use a regex to keep only the link, there may be other content
                    // after that we don't need (script, tooltips, ...)
                     if (preg_match('/<a.*<\/a>/', $value, $matches)) {
-                        $out = html_entity_decode(strip_tags($matches[0]));
+                        $out = Sanitizer::decodeHtmlSpecialChars(strip_tags($matches[0]));
                     }
                 }
                 break;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Following error occurs on PHP 8.2 when trying to use a project task template:
```
*** PHP Deprecated function (8192): html_entity_decode(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/glpi/ajax/projecttask.php at line 62
  Backtrace :
  :                                                  html_entity_decode()
  ajax/projecttask.php:62                            array_map()
```

I figured out that there are at some place, `html_entity_decode` was used to revert the HTML special chars encoding process of the sanitizer, and therefore should use corresponding methods of `Glpi\Toolbox\Sanitizer` class.