### PR TITLE
Fix ##glpi.url## tag definition in notifications

### DIFF
--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -133,6 +133,8 @@ class NotificationTarget extends CommonDBChild
         unset($this->data);
         Plugin::doHook(Hooks::ITEM_ADD_TARGETS, $this);
         asort($this->notification_targets);
+
+        $this->registerGlobalTags();
     }
 
 
@@ -1327,19 +1329,45 @@ class NotificationTarget extends CommonDBChild
      **/
     public function &getForTemplate($event, $options)
     {
-        global $CFG_GLPI;
-
         $this->data = [];
-        $this->addTagToList(['tag'   => 'glpi.url',
-            'value' => $CFG_GLPI['root_doc'],
-            'label' => __('URL of the application')
-        ]);
 
         $this->addDataForTemplate($event, $options);
+
+        // Add global tags data, use `+` operator to preserve overriden values
+        $this->data += $this->getGlobalTagsData();
 
         Plugin::doHook(Hooks::ITEM_GET_DATA, $this);
 
         return $this->data;
+    }
+
+    /**
+     * Register global tags.
+     *
+     * @return void
+     */
+    private function registerGlobalTags(): void
+    {
+        $this->addTagToList([
+            'tag'   => 'glpi.url',
+            'value' => true,
+            'label' => __('URL of the application'),
+            'lang'  => false,
+        ]);
+    }
+
+    /**
+     * Define global tags data.
+     *
+     * @return array
+     */
+    private function getGlobalTagsData(): array
+    {
+        global $CFG_GLPI;
+
+        return [
+            '##glpi.url##' => $CFG_GLPI['url_base'],
+        ];
     }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

There was a piece of code related to a `##glpi.url##` tag in notifications but it was not working.

1. I moved tag registration to constructor, to ensure tag is registerd as soon as possible and is visible in `Available tags` list.
2. I fixed tag value definition.