### PR TITLE
Show only assets with specific states in assistance

### DIFF
--- a/install/migrations/update_10.0.x_to_10.1.0/state_show_in_assistance.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/state_show_in_assistance.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+$migration->addField('glpi_states', 'show_in_assistance', 'bool', ['value' => 1]);

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -3677,6 +3677,10 @@ JAVASCRIPT;
             $where['is_template'] = 0;
         }
 
+        if ($item->isField('states_id')) {
+            $where[] = State::getDisplayConditionForAssistance();
+        }
+
         if (isset($_POST['searchText']) && (strlen($post['searchText']) > 0)) {
             $search = ['LIKE', Search::makeTextSearchValue($post['searchText'])];
             $orwhere = $item->isField('name') ? [

--- a/src/State.php
+++ b/src/State.php
@@ -65,6 +65,13 @@ class State extends CommonTreeDropdown
     {
 
         $fields   = parent::getAdditionalFields();
+
+        $fields[] = [
+            'label' => __('Show items with this status in assistance'),
+            'name'  => 'show_in_assistance',
+            'type'  => 'bool',
+        ];
+
         $fields[] = ['label' => __('Visibility'),
             'name'  => 'header',
             'list'  => false
@@ -77,6 +84,7 @@ class State extends CommonTreeDropdown
                 'list'  => true
             ];
         }
+
         return $fields;
     }
 
@@ -582,5 +590,24 @@ class State extends CommonTreeDropdown
             $fields[$type] = 'is_visible_' . strtolower($type);
         }
         return $fields;
+    }
+
+    /**
+     * Criteria to apply to assets dropdown when shown in assistance
+     *
+     * @return array
+     */
+    public static function getDisplayConditionForAssistance(): array
+    {
+        return [
+            'OR' =>  [
+                'states_id' => new QuerySubQuery([
+                    'SELECT' => 'id',
+                    'FROM'   => State::getTable(),
+                    'WHERE'  => ['show_in_assistance' => true]
+                ]),
+                ['states_id' => 0]
+            ]
+        ];
     }
 }


### PR DESCRIPTION
Add a new setting for assets' states:

![image](https://user-images.githubusercontent.com/42734840/213251551-1b59c9e5-a74b-4f25-9662-269e6f73f6c9.png)

It's enabled by default and allow to filter assets that are shown in GLPI's assistance depending on their states:

![image](https://user-images.githubusercontent.com/42734840/213250690-9b3cfa17-ad6a-4b88-9b12-d3270ffb979e.png)


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26043
