### PR TITLE
fix(rule): decode htmlentities from entity completename

### DIFF
--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -1496,7 +1496,7 @@ JAVASCRIPT;
             if (!$item->isEntityAssign()) {
                 $params['entities_id'] = 0;
             } else {
-                $rule['entities_id'] = $DB->escape(Html::entity_decode_deep($rule['entities_id']));
+                $rule['entities_id'] = $DB->escape($rule['entities_id']);
                 $entities_found = $entity->find(['completename' => $rule['entities_id']]);
                 if (!empty($entities_found)) {
                     $entity_found          = array_shift($entities_found);

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -1199,7 +1199,7 @@ JAVASCRIPT;
             $tmprule = new $rule['sub_type']();
            //check entities
             if ($tmprule->isEntityAssign()) {
-                $entities_found = $entity->find(['completename' => $rule['entities_id']]);
+                $entities_found = $entity->find(['completename' => html_entity_decode($rule['entities_id'])]);
                 if (empty($entities_found)) {
                     $rules_refused[$k_rule]['entity'] = true;
                 }

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -1199,7 +1199,8 @@ JAVASCRIPT;
             $tmprule = new $rule['sub_type']();
            //check entities
             if ($tmprule->isEntityAssign()) {
-                $entities_found = $entity->find(['completename' => html_entity_decode($rule['entities_id'])]);
+                $rule['entities_id'] = $DB->escape(Html::entity_decode_deep($rule['entities_id']));
+                $entities_found = $entity->find(['completename' => $rule['entities_id']]);
                 if (empty($entities_found)) {
                     $rules_refused[$k_rule]['entity'] = true;
                 }
@@ -1451,6 +1452,7 @@ JAVASCRIPT;
      **/
     public static function processImportRules()
     {
+        global $DB;
         $ruleCriteria = new RuleCriteria();
         $ruleAction   = new RuleAction();
         $entity       = new Entity();
@@ -1494,6 +1496,7 @@ JAVASCRIPT;
             if (!$item->isEntityAssign()) {
                 $params['entities_id'] = 0;
             } else {
+                $rule['entities_id'] = $DB->escape(Html::entity_decode_deep($rule['entities_id']));
                 $entities_found = $entity->find(['completename' => $rule['entities_id']]);
                 if (!empty($entities_found)) {
                     $entity_found          = array_shift($entities_found);


### PR DESCRIPTION

```SimpleXMLElement->asXML();``` seems to use  ```htmlentities``` 

XML ```Entity``` completename node becomes 

```xml
<entities_id>Entit&#xE9; racine &amp;#62; Sub</entities_id>
```
The import is in error because GLPI seek the correct entity without decode HTML entity

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26386
