### PR TITLE
Fix $db_escape value in Sanitizer::sanitize() recursive calls

### DIFF
--- a/src/Toolbox/Sanitizer.php
+++ b/src/Toolbox/Sanitizer.php
@@ -62,8 +62,8 @@ class Sanitizer
     {
         if (is_array($value)) {
             return array_map(
-                function ($val) {
-                    return self::sanitize($val);
+                function ($val) use ($db_escape) {
+                    return self::sanitize($val, $db_escape);
                 },
                 $value
             );

--- a/tests/units/Glpi/Toolbox/Sanitizer.php
+++ b/tests/units/Glpi/Toolbox/Sanitizer.php
@@ -163,7 +163,12 @@ class Sanitizer extends \GLPITestCase
         $dbescaped_value = null
     ) {
         $sanitizer = $this->newTestedInstance();
-        $this->variable($sanitizer->sanitize($value))->isEqualTo($sanitized_value);
+        $this->variable($sanitizer->sanitize($value, true))->isEqualTo($sanitized_value);
+
+        if ($htmlencoded_value !== null) {
+            // Calling `sanitize()` with `$db_escape = false` should produce HTML enoded value
+            $this->variable($sanitizer->sanitize($value, false))->isEqualTo($htmlencoded_value);
+        }
 
         // Calling sanitize on sanitized value should have no effect
         $this->variable($sanitizer->sanitize($sanitized_value))->isEqualTo($sanitized_value);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Seen while reviewing #12451 