### PR TITLE
Fix html encoding formcreator

### DIFF
--- a/src/Console/Database/FixHtmlEncodingCommand.php
+++ b/src/Console/Database/FixHtmlEncodingCommand.php
@@ -339,7 +339,6 @@ final class FixHtmlEncodingCommand extends AbstractCommand
     {
         $output = $input;
 
-        // Add the missing semicolon to &quot; HTML entity
         $pattern = '#<br />#';
         $replace = '&lt;br /&gt;';
         $output = preg_replace($pattern, $replace, $output);

--- a/src/Console/Database/FixHtmlEncodingCommand.php
+++ b/src/Console/Database/FixHtmlEncodingCommand.php
@@ -38,6 +38,7 @@ namespace Glpi\Console\Database;
 use CommonDBTM;
 use Glpi\Console\AbstractCommand;
 use ITILFollowup;
+use Plugin;
 use Search;
 use Session;
 use Ticket;
@@ -358,6 +359,11 @@ final class FixHtmlEncodingCommand extends AbstractCommand
         $table_iterator = $DB->listTables();
         foreach ($table_iterator as $table_data) {
             $table = $table_data['TABLE_NAME'];
+            if (preg_match("/^glpi_plugin_([a-z0-9]+)/", $table, $matches)) {
+                if (!Plugin::isPluginActive($matches[1])) {
+                    continue;
+                }
+            }
             $itemtype = getItemTypeForTable($table);
 
             if (!is_a($itemtype, CommonDBTM::class, true)) {


### PR DESCRIPTION
Handle ITIL objects created by Formcreator for GLPI 9.5 or older.

In some cases, the HTML may contain raw BR tag. This PR escapes it.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
