### PR TITLE
ProjectTemplate: show/edit name after creation

### DIFF
--- a/src/Project.php
+++ b/src/Project.php
@@ -1559,6 +1559,19 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
                 echo "<td colspan='2'>&nbsp;</td>";
             }
             echo "</tr>";
+        } elseif ($is_template & !$this->isNewItem()) {
+            // Show template name after creation (creation is already handled by
+            // showFormHeader which add the template name in a special header
+            // only displayed on creation)
+            echo "<tr class='tab_bg_1'>";
+            echo "<td>" . __('Template name') . "</td>";
+            echo "<td>";
+            echo Html::input('template_name', [
+                'value' => $this->fields['template_name']
+            ]);
+            echo "</td>";
+            echo "<td colspan='2'>&nbsp;</td>";
+            echo "</tr>";
         }
 
         echo "<tr class='tab_bg_1'>";


### PR DESCRIPTION
Project template name is visible on creation in a special header:

![image](https://user-images.githubusercontent.com/42734840/213735514-5806bc69-6e67-4104-8520-43701fa5ff85.png)

But after creation this header is no longer displayed (since global changes made in GLPI 10.0.4) and thus we can't edit it anymore :

![image](https://user-images.githubusercontent.com/42734840/213735779-b7490f14-c373-4518-83ea-6bbba8d959a3.png)

I've added the field at the top to fix this:

![image](https://user-images.githubusercontent.com/42734840/213735975-de4681be-0a96-487b-9b0e-4a4bce97de54.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26272
