### PR TITLE
Fix uploads on self-service ticket form reload

### DIFF
--- a/templates/components/itilobject/selfservice.html.twig
+++ b/templates/components/itilobject/selfservice.html.twig
@@ -232,6 +232,14 @@
                   right_field_options
                ) }}
 
+               {% set uploads = [] %}
+               {% if params._content is defined %}
+                  {% set uploads = uploads|merge({'_content': params._content, '_tag_content': params._tag_content}) %}
+               {% endif %}
+               {% if params._filename is defined %}
+                  {% set uploads = uploads|merge({'_filename': params._filename, '_tag_filename': params._tag_filename}) %}
+               {% endif %}
+
                {{ fields.textareaField(
                   'content',
                   params['content'],
@@ -239,6 +247,7 @@
                   right_field_options|merge({
                      'enable_richtext': true,
                      'enable_fileupload': (itiltemplate.isHiddenField('_documents_id')) ? false : true,
+                     'uploads': uploads,
                   })
                ) }}
             </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13793

When self-service form was reloaded (on category change for instance), uploads were not restored.