### PR TITLE
Revert "fix backdrop blocking on planning page"

### DIFF
--- a/js/glpi_dialog.js
+++ b/js/glpi_dialog.js
@@ -142,7 +142,6 @@ var glpi_html_dialog = function({
 
         // remove html on modal close
         $('#'+id).remove();
-        $('.modal-backdrop').remove();
     });
 
     return id;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

It seems that #13831 was not a correct fix (see #13839), we should revert it.