### PR TITLE
Handle FontAwesome icons aliases in icon selector

### DIFF
--- a/js/Forms/FaIconSelector.js
+++ b/js/Forms/FaIconSelector.js
@@ -76,20 +76,26 @@ GLPI.Forms.FaIconSelector = class {
 
         for (let i = 0; i < document.styleSheets.length; i++) {
             const rules = document.styleSheets[i].cssRules;
-            for(var j = 0; j < rules.length; j++) {
+            for(let j = 0; j < rules.length; j++) {
                 const rule = rules[j];
                 if (rule.constructor.name !== 'CSSStyleRule') {
                     continue;
                 }
-                let matches = rule.selectorText.match(/^\.(fa-[a-z-]+)::before$/);
-                if (matches !== null) {
-                    const cls = matches[1];
-                    const entry = {
-                        id: cls,
-                        text: cls
-                    };
-                    if (!icons.includes(entry)) {
-                        icons.push(entry);
+                // On minified CSS, similar icons will be grouped,
+                // e.g. `.fa-arrow-turn-right::before,.fa-mail-forward::before,.fa-share::before`.
+                // Split them to handle the separately.
+                const selectors = rule.selectorText.split(',');
+                for(let k = 0; k < selectors.length; k++) {
+                    let matches = selectors[k].trim().match(/^\.(fa-[a-z-]+)::before$/);
+                    if (matches !== null) {
+                        const cls = matches[1];
+                        const entry = {
+                            id: cls,
+                            text: cls
+                        };
+                        if (!icons.includes(entry)) {
+                            icons.push(entry);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13604 

When minified CSS is used, FontAwesome icons list in incomplete. This is due to the fact that icons are groupes into a unique selector, and are not matching the expected pattern.
```css
.fa-arrow-turn-right::before,.fa-mail-forward::before,.fa-share::before{content:""}
```
