### PR TITLE
Drop support of PHP 8.0

### DIFF
--- a/.composer-require-checker.config.json
+++ b/.composer-require-checker.config.json
@@ -12,9 +12,6 @@
     "// Missing constant in Alpine Linux",
     "GLOB_BRACE",
 
-    "// PHP 8.1 symbols",
-    "Ldap\\Connection",
-
     "// GLPI config classes",
     "DB", "DBSlave",
 

--- a/.composer-require-checker.config.json
+++ b/.composer-require-checker.config.json
@@ -12,6 +12,9 @@
     "// Missing constant in Alpine Linux",
     "GLOB_BRACE",
 
+    "// PHP 8.1 symbols",
+    "Ldap\\Connection",
+
     "// GLPI config classes",
     "DB", "DBSlave",
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {php-version: "8.0"} # Lint on lower PHP version to detected too early usage of new syntaxes
+          - {php-version: "8.1"} # Lint on lower PHP version to detected too early usage of new syntaxes
           - {php-version: "8.2"} # Lint on higher PHP version to detected deprecated elements usage
     env:
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml"
@@ -107,7 +107,6 @@ jobs:
           - {php-version: "8.2", db-image: "mysql:8.0", always: true}
           # test other PHP versions
           - {php-version: "8.1", db-image: "mariadb:10.9", always: false}
-          - {php-version: "8.0", db-image: "mariadb:10.9", always: false}
           # test other DB servers/versions
           - {php-version: "8.2", db-image: "mariadb:10.3", always: false}
           - {php-version: "8.2", db-image: "percona:8.0", always: false}

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -22,7 +22,7 @@ jobs:
           # build on lower supported version to ensure building tools are compatible with this version
           - {branch: "9.5/bugfixes", php-version: "7.2"}
           - {branch: "10.0/bugfixes", php-version: "7.4"}
-          - {branch: "main", php-version: "8.0"}
+          - {branch: "main", php-version: "8.1"}
     services:
       app:
         image: "ghcr.io/glpi-project/githubactions-php:${{ matrix.php-version }}"

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ It is distributed under the GNU GENERAL PUBLIC LICENSE Version 3 - please consul
     | ------------ | ----------- | ----------- |
     | 9.5.X        | 7.2         | 8.0         |
     | 10.0.X       | 7.4         | 8.1         |
-    | 10.1.X       | 8.0         | 8.1         |
+    | 10.1.X       | 8.1         | 8.2         |
 * Mandatory PHP extensions:
     - dom, fileinfo, json, session, simplexml (these are enabled in PHP by default)
     - curl (access to remote resources, like inventory agents, marketplace API, RSS feeds, ...)

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "docs": "https://github.com/glpi-project/doc"
     },
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-fileinfo": "*",
@@ -97,7 +97,7 @@
     "config": {
         "optimize-autoloader": true,
         "platform": {
-            "php": "8.0.99"
+            "php": "8.1.99"
         },
         "sort-packages": true
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eb4318e0b0791af8222c728fc5c43ff2",
+    "content-hash": "2c7077bd7630c130a66df55d561e14ea",
     "packages": [
         {
             "name": "blueimp/jquery-file-upload",
@@ -6173,7 +6173,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-fileinfo": "*",
@@ -6190,7 +6190,7 @@
         "ext-xml": "*"
     },
     "platform-overrides": {
-        "php": "8.0.99"
+        "php": "8.1.99"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/inc/define.php
+++ b/inc/define.php
@@ -48,7 +48,7 @@ if (!defined('GLPI_MARKETPLACE_PRERELEASES')) {
     define('GLPI_MARKETPLACE_PRERELEASES', preg_match('/-(dev|alpha\d*|beta\d*|rc\d*)$/', GLPI_VERSION) === 1);
 }
 
-define('GLPI_MIN_PHP', '8.0'); // Must also be changed in top of index.php
+define('GLPI_MIN_PHP', '8.1'); // Must also be changed in top of index.php
 define('GLPI_MAX_PHP', '8.2'); // Must also be changed in top of index.php
 define('GLPI_YEAR', '2023');
 

--- a/index.php
+++ b/index.php
@@ -36,10 +36,10 @@
 // Check PHP version not to have trouble
 // Need to be the very fist step before any include
 if (
-    version_compare(PHP_VERSION, '8.0.0', '<') ||
+    version_compare(PHP_VERSION, '8.1.0', '<') ||
     version_compare(PHP_VERSION, '8.2.999', '>')
 ) {
-    die('PHP version must be between 8.0 and 8.2.');
+    die('PHP version must be between 8.1 and 8.2.');
 }
 
 use Glpi\Application\View\TemplateRenderer;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,7 +11,6 @@ parameters:
     stubFiles:
         - stubs/glpi_constants.php
     ignoreErrors:
-        - '/Class Ldap\\Connection not found/'
         - '/Instantiated class (DB|DBSlave) not found/'
         - '/Instantiated class XHProfRuns_Default not found/'
         - '/\w+ has been replaced by \w+/'

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -2964,7 +2964,7 @@ class AuthLDAP extends CommonDBTM
      * @param boolean $use_bind      do we need to do an ldap_bind? (true by default)
      * @param string  $tls_version   TLS VERSION (default '')
      *
-     * @return resource|false|\LDAP\Connection link to the LDAP server : false if connection failed
+     * @return false|\LDAP\Connection link to the LDAP server : false if connection failed
      */
     public static function connectToServer(
         $host,

--- a/src/User.php
+++ b/src/User.php
@@ -1763,7 +1763,7 @@ class User extends CommonDBTM
             return false;
         }
 
-        if (is_resource($ldap_connection) || $ldap_connection instanceof \Ldap\Connection) {
+        if ($ldap_connection instanceof \Ldap\Connection) {
            //Set all the search fields
             $this->fields['password'] = "";
 

--- a/tests/LDAP/AuthLdap.php
+++ b/tests/LDAP/AuthLdap.php
@@ -673,7 +673,7 @@ class AuthLDAP extends DbTestCase
         $ldap = getItemByTypeName('AuthLDAP', '_local_ldap');
         $this->boolean(\AuthLDAP::testLDAPConnection($ldap->getID()))->isTrue();
 
-        $this->checkLdapConnection($ldap->connect());
+        $this->object($ldap->connect())->isInstanceOf('\LDAP\Connection');
     }
 
     /**
@@ -834,7 +834,7 @@ class AuthLDAP extends DbTestCase
         $ldap = $this->ldap;
 
         $connection = $ldap->connect();
-        $this->checkLdapConnection($connection);
+        $this->object($connection)->isInstanceOf('\LDAP\Connection');
 
         $cn = \AuthLDAP::getGroupCNByDn($connection, 'ou=not,ou=exists,dc=glpi,dc=org');
         $this->boolean($cn)->isFalse();
@@ -1201,7 +1201,7 @@ class AuthLDAP extends DbTestCase
          ->string['user_dn']->isIdenticalTo('uid=brazil6,ou=people,ou=ldap3,dc=glpi,dc=org');
         $this->boolean($auth->user_present)->isFalse();
         $this->boolean($auth->user_dn)->isFalse();
-        $this->checkLdapConnection($auth->ldap_connection);
+        $this->object($auth->ldap_connection)->isInstanceOf('\LDAP\Connection');
 
        //import user; then try to login
         $ldap = $this->ldap;
@@ -1239,7 +1239,7 @@ class AuthLDAP extends DbTestCase
 
         $this->boolean($auth->user_present)->isTrue();
         $this->string($auth->user_dn)->isIdenticalTo($user->fields['user_dn']);
-        $this->checkLdapConnection($auth->ldap_connection);
+        $this->object($auth->ldap_connection)->isInstanceOf('\LDAP\Connection');
 
        //change user login, and try again. Existing user should be updated.
         $this->boolean(
@@ -1272,7 +1272,7 @@ class AuthLDAP extends DbTestCase
          ->string['user_dn']->isIdenticalTo('uid=brazil7test,ou=people,ou=ldap3,dc=glpi,dc=org');
 
         $this->boolean($auth->user_present)->isTrue();
-        $this->checkLdapConnection($auth->ldap_connection);
+        $this->object($auth->ldap_connection)->isInstanceOf('\LDAP\Connection');
 
        //ensure duplicated DN on different authldaps_id does not prevent login
         $this->boolean(
@@ -2123,7 +2123,7 @@ class AuthLDAP extends DbTestCase
             ->string['user_dn']->isIdenticalTo('uid=brazil5,ou=people,ou=ldap3,dc=glpi,dc=org');
         $this->boolean($auth->user_present)->isFalse();
         $this->boolean($auth->user_dn)->isFalse();
-        $this->checkLdapConnection($auth->ldap_connection);
+        $this->object($auth->ldap_connection)->isInstanceOf('\LDAP\Connection');
 
         // Get original LDAP server port
         $original_port = $this->ldap->fields['port'];
@@ -2149,15 +2149,6 @@ class AuthLDAP extends DbTestCase
         // Verify trying to log in while LDAP unavailable does not disable user's GLPI account
         $this->integer($user->fields['is_active'])->isEqualTo(1);
         $this->integer($user->fields['is_deleted_ldap'])->isEqualTo(0);
-    }
-
-    private function checkLdapConnection($ldap_connection)
-    {
-        if (version_compare(phpversion(), '8.1.0-dev', '<')) {
-            $this->resource($ldap_connection)->isOfType('ldap link');
-        } else {
-            $this->object($ldap_connection)->isInstanceOf('\LDAP\Connection');
-        }
     }
 
     public function testIgnoreImport()

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -153,7 +153,7 @@ fi
 APPLICATION_ROOT=$(readlink -f "$WORKING_DIR/..")
 [[ ! -z "$APP_CONTAINER_HOME" ]] || APP_CONTAINER_HOME=$(mktemp -d -t glpi-tests-home-XXXXXXXXXX)
 [[ ! -z "$DB_IMAGE" ]] || DB_IMAGE=githubactions-mysql:8.0
-[[ ! -z "$PHP_IMAGE" ]] || PHP_IMAGE=githubactions-php:8.0
+[[ ! -z "$PHP_IMAGE" ]] || PHP_IMAGE=githubactions-php:8.1
 
 # Backup configuration files
 BACKUP_DIR=$(mktemp -d -t glpi-tests-backup-XXXXXXXXXX)

--- a/tests/units/Glpi/Application/ErrorHandler.php
+++ b/tests/units/Glpi/Application/ErrorHandler.php
@@ -87,42 +87,16 @@ class ErrorHandler extends \GLPITestCase
             ],
         ];
 
-        if (version_compare(PHP_VERSION, '8.0.0-dev', '>=')) {
-            $data[] = [
-                'error_call'           => function () {
-                    $param = new \ReflectionParameter([\Config::class, 'getTypeName'], 0);
-                    $param->isCallable();
-                },
-                'expected_log_level'   => LogLevel::NOTICE,
-                'expected_msg_pattern' => $log_prefix
-               . preg_quote('PHP Deprecated function (' . E_DEPRECATED . '): Method ReflectionParameter::isCallable() is deprecated', '/')
-               . $log_suffix,
-            ];
-        } else {
-            $data[] = [
-                'error_call'           => function () {
-                    $inst = new class {
-                        public function nonstatic()
-                        {
-                        }
-                    };
-                    $inst::nonstatic();
-                },
-                'expected_log_level'   => LogLevel::NOTICE,
-                'expected_msg_pattern' => $log_prefix
-               . preg_quote('PHP Deprecated function (' . E_DEPRECATED . '): Non-static method class@anonymous::nonstatic() should not be called statically', '/')
-               . $log_suffix,
-            ];
-            $data[] = [
-                'error_call'           => function () {
-                    $a = $b;
-                },
-                'expected_log_level'   => LogLevel::NOTICE,
-                'expected_msg_pattern' => $log_prefix
-               . preg_quote('PHP Notice (' . E_NOTICE . '): Undefined variable: b', '/')
-               . $log_suffix,
-            ];
-        }
+        $data[] = [
+            'error_call'           => function () {
+                $param = new \ReflectionParameter([\Config::class, 'getTypeName'], 0);
+                $param->isCallable();
+            },
+            'expected_log_level'   => LogLevel::NOTICE,
+            'expected_msg_pattern' => $log_prefix
+           . preg_quote('PHP Deprecated function (' . E_DEPRECATED . '): Method ReflectionParameter::isCallable() is deprecated', '/')
+           . $log_suffix,
+        ];
 
         return $data;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Next GLPI major version will likely not be released before end of the year. At this date, PHP 8.1 have reached its EOL.

At this date, all major OS distributions will support PHP 8.1.

| OS               | Release date | PHP version |
| ---------------- | ------------ | ----------- |
| ~~RHEL 8.5~~         | ~~11/2021~~      | ~~7.4~~         |
| ~~RHEL 8.6/9.0~~     | ~~05/2022~~      | ~~8.0~~         |
| RHEL 8.7/9.1     | 11/2022      | 8.1         |
| ~~Debian Bullseye~~  | ~~08/2021~~      | ~~7.4~~         |
| Debian Bookworm  | mid 2023     | 8.1         |
| ~~Ubuntu 20.04~~     | ~~04/2020~~      | ~~7.4~~         |
| Ubuntu 22.04     | 04/2022      | 8.1         |
