### PR TITLE
fix(Socket): Socket can only be linked to one Cable

### DIFF
--- a/ajax/cable.php
+++ b/ajax/cable.php
@@ -66,7 +66,7 @@ switch ($action) {
                     'itemtype'           => $_GET['itemtype'],
                     'items_id'           => $_GET['items_id']
                 ],
-                'used'         => Socket::getSocketAlreadyLinked($_GET['itemtype'], $_GET['items_id']),
+                'used'         => (int)$_GET['items_id'] > 0 ? Socket::getSocketAlreadyLinked($_GET['itemtype'], (int)$_GET['items_id']),
                 'displaywith'  => ['itemtype', 'items_id', 'networkports_id'],
             ]);
         }

--- a/ajax/cable.php
+++ b/ajax/cable.php
@@ -61,7 +61,7 @@ switch ($action) {
             (isset($_GET['itemtype']) && class_exists($_GET['itemtype']))
             && isset($_GET['items_id'])
         ) {
-            Socket::dropdown(['name'         =>  $_GET['dom_name'], 
+            Socket::dropdown(['name'         =>  $_GET['dom_name'],
                 'condition'    => ['socketmodels_id'   => $_GET['socketmodels_id'] ?? 0,
                     'itemtype'           => $_GET['itemtype'],
                     'items_id'           => $_GET['items_id']

--- a/ajax/cable.php
+++ b/ajax/cable.php
@@ -61,12 +61,12 @@ switch ($action) {
             (isset($_GET['itemtype']) && class_exists($_GET['itemtype']))
             && isset($_GET['items_id'])
         ) {
-            Socket::dropdown(['name'         =>  $_GET['dom_name'],
+            Socket::dropdown(['name'         =>  $_GET['dom_name'], 
                 'condition'    => ['socketmodels_id'   => $_GET['socketmodels_id'] ?? 0,
                     'itemtype'           => $_GET['itemtype'],
                     'items_id'           => $_GET['items_id']
                 ],
-                'used'         => (int)$_GET['items_id'] > 0 ? Socket::getSocketAlreadyLinked($_GET['itemtype'], (int)$_GET['items_id']),
+                'used'         => (int)$_GET['items_id'] > 0 ?? Socket::getSocketAlreadyLinked($_GET['itemtype'], (int)$_GET['items_id']),
                 'displaywith'  => ['itemtype', 'items_id', 'networkports_id'],
             ]);
         }

--- a/ajax/cable.php
+++ b/ajax/cable.php
@@ -66,6 +66,7 @@ switch ($action) {
                     'itemtype'           => $_GET['itemtype'],
                     'items_id'           => $_GET['items_id']
                 ],
+                'used'         => Socket::getSocketAlreadyLinked(),
                 'displaywith'  => ['itemtype', 'items_id', 'networkports_id'],
             ]);
         }

--- a/ajax/cable.php
+++ b/ajax/cable.php
@@ -66,7 +66,7 @@ switch ($action) {
                     'itemtype'           => $_GET['itemtype'],
                     'items_id'           => $_GET['items_id']
                 ],
-                'used'         => Socket::getSocketAlreadyLinked(),
+                'used'         => Socket::getSocketAlreadyLinked($_GET['itemtype'], $_GET['items_id']),
                 'displaywith'  => ['itemtype', 'items_id', 'networkports_id'],
             ]);
         }

--- a/ajax/cable.php
+++ b/ajax/cable.php
@@ -66,7 +66,7 @@ switch ($action) {
                     'itemtype'           => $_GET['itemtype'],
                     'items_id'           => $_GET['items_id']
                 ],
-                'used'         => (int)$_GET['items_id'] > 0 ?? Socket::getSocketAlreadyLinked($_GET['itemtype'], (int)$_GET['items_id']),
+                'used'         => (int)$_GET['items_id'] > 0 ? Socket::getSocketAlreadyLinked($_GET['itemtype'], (int)$_GET['items_id']) : [],
                 'displaywith'  => ['itemtype', 'items_id', 'networkports_id'],
             ]);
         }

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -151,6 +151,13 @@ class Dropdown
             $params['value'] = 0;
         }
 
+        // Remove selected value from used to prevent current selected value from being hidden from available values
+        if ($params['multiple']) {
+            $params['used'] = array_diff($params['used'], $params['values']);
+        } else {
+            $params['used'] = array_diff($params['used'], [$params['value']]);
+        }
+
         if (!$params['multiple'] && isset($params['toadd'][$params['value']])) {
             $name = $params['toadd'][$params['value']];
         } else if (

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -272,10 +272,10 @@ class Socket extends CommonDBChild
     }
 
     /**
-     * Get all Socket already linked to Cable
+     * Get all Socket already linked to Cable for given asset
      * @return array Array of linked sockets
      **/
-    public static function getSocketAlreadyLinked()
+    public static function getSocketAlreadyLinked(string $itemtype, int $items_id): array
     {
         global $DB;
         $already_use = [];
@@ -296,6 +296,8 @@ class Socket extends CommonDBChild
                 'NOT' => [
                     'cables.sockets_id_endpoint_a' => 'NULL'
                 ],
+                'sockets.itemtype' => $itemtype,
+                'sockets.items_id' => $items_id
             ],
         ]);
 
@@ -314,6 +316,8 @@ class Socket extends CommonDBChild
                 'NOT' => [
                     'cables.sockets_id_endpoint_b' => 'NULL'
                 ],
+                'sockets.itemtype' => $itemtype,
+                'sockets.items_id' => $items_id
             ],
         ]);
 

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -271,6 +271,63 @@ class Socket extends CommonDBChild
         return $values;
     }
 
+    /**
+     * Get all Socket already linked to Cable
+     * @return array Array of linked sockets
+     **/
+    public static function getSocketAlreadyLinked()
+    {
+        global $DB;
+        $already_use = [];
+        $sub_query = [];
+
+        $sub_query[] = new \QuerySubQuery([
+            'SELECT' => ['sockets.id AS socket_id'],
+            'FROM'   => Socket::getTable() . ' AS sockets',
+            'LEFT JOIN'   => [
+                Cable::getTable() . ' AS cables' => [
+                    'ON'  => [
+                        'cables'  => 'sockets_id_endpoint_a',
+                        'sockets'  => 'id'
+                    ]
+                ],
+            ],
+            'WHERE'  => [
+                'NOT' => [
+                    'cables.sockets_id_endpoint_a' => 'NULL'
+                ],
+            ],
+        ]);
+
+        $sub_query[] = new \QuerySubQuery([
+            'SELECT' => ['sockets.id AS socket_id'],
+            'FROM'   => Socket::getTable() . ' AS sockets',
+            'LEFT JOIN'   => [
+                Cable::getTable() . ' AS cables' => [
+                    'ON'  => [
+                        'cables'  => 'sockets_id_endpoint_b',
+                        'sockets'  => 'id'
+                    ]
+                ],
+            ],
+            'WHERE'  => [
+                'NOT' => [
+                    'cables.sockets_id_endpoint_b' => 'NULL'
+                ],
+            ],
+        ]);
+
+        $sockets_iterator = $DB->request([
+            'FROM' => new \QueryUnion($sub_query)
+        ]);
+
+        foreach ($sockets_iterator as $row) {
+            $already_use[$row['socket_id']] = $row['socket_id'];
+        }
+
+        return $already_use;
+    }
+
 
     /**
      * Dropdown of Wiring Side

--- a/templates/pages/assets/cable.html.twig
+++ b/templates/pages/assets/cable.html.twig
@@ -133,7 +133,7 @@
                               'itemtype': item.fields['itemtype_endpoint_' ~ side],
                               'items_id': item.fields['items_id_endpoint_' ~ side]
                            },
-                           'used': call('Glpi\\Socket::getSocketAlreadyLinked', [item.fields['itemtype_endpoint_' ~ side], item.fields['items_id_endpoint_' ~ side]])
+                           'used': item.fields['items_id_endpoint_' ~ side] is not empty ?call('Glpi\\Socket::getSocketAlreadyLinked', [item.fields['itemtype_endpoint_' ~ side], item.fields['items_id_endpoint_' ~ side]] : [])
                         })
                   ) }}
 

--- a/templates/pages/assets/cable.html.twig
+++ b/templates/pages/assets/cable.html.twig
@@ -132,7 +132,8 @@
                               'socketmodels_id': item.fields['socketmodels_id_endpoint_' ~ side],
                               'itemtype': item.fields['itemtype_endpoint_' ~ side],
                               'items_id': item.fields['items_id_endpoint_' ~ side]
-                           }
+                           },
+                           'used': call('Glpi\\Socket::getSocketAlreadyLinked')
                         })
                   ) }}
 

--- a/templates/pages/assets/cable.html.twig
+++ b/templates/pages/assets/cable.html.twig
@@ -133,7 +133,7 @@
                               'itemtype': item.fields['itemtype_endpoint_' ~ side],
                               'items_id': item.fields['items_id_endpoint_' ~ side]
                            },
-                           'used': item.fields['items_id_endpoint_' ~ side] is not empty ?call('Glpi\\Socket::getSocketAlreadyLinked', [item.fields['itemtype_endpoint_' ~ side], item.fields['items_id_endpoint_' ~ side]] : [])
+                           'used': item.fields['items_id_endpoint_' ~ side] is not empty ? call('Glpi\\Socket::getSocketAlreadyLinked', [item.fields['itemtype_endpoint_' ~ side], item.fields['items_id_endpoint_' ~ side]]) : []
                         })
                   ) }}
 

--- a/templates/pages/assets/cable.html.twig
+++ b/templates/pages/assets/cable.html.twig
@@ -133,7 +133,7 @@
                               'itemtype': item.fields['itemtype_endpoint_' ~ side],
                               'items_id': item.fields['items_id_endpoint_' ~ side]
                            },
-                           'used': call('Glpi\\Socket::getSocketAlreadyLinked', [ item.fields['itemtype_endpoint_' ~ side], item.fields['items_id_endpoint_' ~ side]])
+                           'used': call('Glpi\\Socket::getSocketAlreadyLinked', [item.fields['itemtype_endpoint_' ~ side], item.fields['items_id_endpoint_' ~ side]])
                         })
                   ) }}
 

--- a/templates/pages/assets/cable.html.twig
+++ b/templates/pages/assets/cable.html.twig
@@ -133,7 +133,7 @@
                               'itemtype': item.fields['itemtype_endpoint_' ~ side],
                               'items_id': item.fields['items_id_endpoint_' ~ side]
                            },
-                           'used': call('Glpi\\Socket::getSocketAlreadyLinked')
+                           'used': call('Glpi\\Socket::getSocketAlreadyLinked', [ item.fields['itemtype_endpoint_' ~ side], item.fields['items_id_endpoint_' ~ side]])
                         })
                   ) }}
 


### PR DESCRIPTION
```Socket``` can only be linked to one ```Cable```

So we need to exclude all ```Socket``` already linked from ```dropdown```


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13851
