### PR TITLE
Fix Github actions permissions

### DIFF
--- a/.github/workflows/audit_dependencies.yml
+++ b/.github/workflows/audit_dependencies.yml
@@ -7,13 +7,12 @@ on:
   # Enable manual run
   workflow_dispatch:
 
-permissions:
-  issues: write
-
 jobs:
   audit:
     # Do not run scheduled audit on tier repositories
     if: github.repository == 'glpi-project/glpi' || github.event_name != 'schedule'
+    permissions:
+      issues: "write"
     name: "Audit dependencies (${{ matrix.branch }})"
     runs-on: "ubuntu-latest"
     strategy:

--- a/.github/workflows/bump_version_after_release.yml
+++ b/.github/workflows/bump_version_after_release.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   bump-version:
+    permissions:
+      contents: "write" # needed to create a new branch and push commits
+      pull-requests: "write" # needed to create a pull request
     name: "Bump version"
     runs-on: "ubuntu-latest"
     steps:

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -6,12 +6,11 @@ on:
       - "labeled"
       - "unlabeled"
 
-permissions:
-  contents: "read"
-  issues: "write"
-
 jobs:
   comment:
+    permissions:
+      contents: "read"
+      issues: "write"
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Add missing permissions on `Bump version after release` action.
2. Move existing permissions to job level.