### PR TITLE
improving the `password_update` right label

### DIFF
--- a/src/Profile.php
+++ b/src/Profile.php
@@ -2989,7 +2989,7 @@ class Profile extends CommonDBTM
             'id'                 => '4',
             'table'              => 'glpi_profilerights',
             'field'              => 'rights',
-            'name'               => __('Update password'),
+            'name'               => __('Update own password'),
             'datatype'           => 'bool',
             'joinparams'         => [
                 'jointype'           => 'child',

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -760,7 +760,7 @@ class Profile extends CommonDBTM
         );
         echo "</td></tr>\n";
 
-        echo "<tr class='tab_bg_1'><td>" . __('Update password') . "</td><td>";
+        echo "<tr class='tab_bg_1'><td>" . __('Update own password') . "</td><td>";
         Html::showCheckbox(['name'    => '_password_update',
             'checked' => $this->fields['password_update']
         ]);


### PR DESCRIPTION
The right label was not specific enough, because the right only allows you to change your own password and not those of other users.

![image](https://user-images.githubusercontent.com/8530352/214778963-01e8e45e-e90d-4809-bf07-48b9d556fd06.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25947
