### PR TITLE
fix: check URL with &

### DIFF
--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -3459,7 +3459,7 @@ HTML;
        // (or would require usage of a dedicated lib).
         return (preg_match(
             "/^(?:http[s]?:\/\/(?:[^\s`!(){};'\",<>«»“”‘’+]+|[^\s`!()\[\]{};:'\".,<>?«»“”‘’+]))$/iu",
-            $url
+            str_replace('&#38;', '&', $url)
         ) === 1);
     }
 


### PR DESCRIPTION
URLs containing `&` were considered invalid

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26471
