### PR TITLE
fix(project task template): as child of was not visible

### DIFF
--- a/src/ProjectTaskTemplate.php
+++ b/src/ProjectTaskTemplate.php
@@ -135,7 +135,7 @@ class ProjectTaskTemplate extends CommonDropdown
             'id'       => '6',
             'name'     => __('As child of'),
             'field'    => 'name',
-            'table'    => 'glpi_projects',
+            'table'    => 'glpi_projecttasks',
             'datatype' => 'itemlink',
         ];
 


### PR DESCRIPTION
`As child of` column was always empty:

![image](https://user-images.githubusercontent.com/8530352/215052982-a0bca1dd-4427-4a9e-a2d7-b03b7335e9e0.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26479
