### PR TITLE
improve kanban actors stack

### DIFF
--- a/ajax/getUserPicture.php
+++ b/ajax/getUserPicture.php
@@ -72,10 +72,11 @@ foreach ($_GET['users_id'] as $user_id) {
                 $path = User::getURLForPicture($user->fields['picture']);
             }
             $img = Html::image($path, [
-                'title'  => getUserName($user_id),
-                'width'  => $_GET['size'],
-                'height' => $_GET['size'],
-                'class'  => $_GET['class'] ?? ''
+                'title'          => getUserName($user_id),
+                'data-bs-toggle' => 'tooltip',
+                'width'          => $_GET['size'],
+                'height'         => $_GET['size'],
+                'class'          => $_GET['class'] ?? ''
             ]);
             if (isset($_GET['link']) && $_GET['link']) {
                  $imgs[$user_id] = Html::link($img, User::getFormURLWithID($user_id));

--- a/css/includes/components/_kanban.scss
+++ b/css/includes/components/_kanban.scss
@@ -367,8 +367,8 @@
                             }
 
                             &:hover {
+                                margin-right: 0;
 
-                            margin-right: 0;
                                 span {
                                     margin-right: 2px;
                                 }

--- a/css/includes/components/_kanban.scss
+++ b/css/includes/components/_kanban.scss
@@ -344,13 +344,18 @@
                             display: flex;
                             padding-right: 10px;
                             padding-bottom: 10px;
+                            margin-right: 10px;
 
                             span:first-of-type {
                                 margin-left: auto;
                             }
 
                             span {
-                                margin-right: 2px;
+                                margin-right: -10px;
+                                border-radius: 50%;
+                                border: 3px solid $card-bg;
+                                box-sizing: content-box;
+                                min-height: 24px;
 
                                 img {
                                     border-radius: 50%;
@@ -358,6 +363,14 @@
 
                                 &.fa-stack {
                                     width: 2em;
+                                }
+                            }
+
+                            &:hover {
+
+                            margin-right: 0;
+                                span {
+                                    margin-right: 2px;
                                 }
                             }
                         }

--- a/js/modules/Kanban/Kanban.js
+++ b/js/modules/Kanban/Kanban.js
@@ -1639,7 +1639,7 @@ class GLPIKanbanRights {
             context.fillText(initials, self.team_image_size / 2, self.team_image_size / 2);
             const src = canvas.toDataURL("image/png");
             const name = teammember['name'].replace(/"/g, '&quot;').replace(/'/g, '&#39;');
-            return "<span><img src='" + src + "' title='" + name + "'/></span>";
+            return "<span><img src='" + src + "' title='" + name + "' data-bs-toggle='tooltip'/></span>";
         };
 
         /**
@@ -1656,7 +1656,7 @@ class GLPIKanbanRights {
             return `
             <span class='fa-stack fa-lg' style='font-size: ${(self.team_image_size / 2)}px'>
                 <i class='fas fa-circle fa-stack-2x' style="color: ${bg_color}" title="${teammember['name']}"></i>
-                <i class='fas ${icon} fa-stack-1x' title="${name}"></i>
+                <i class='fas ${icon} fa-stack-1x' title="${name}" data-bs-toggle='tooltip'></i>
             </span>
          `;
         };
@@ -1686,7 +1686,7 @@ class GLPIKanbanRights {
             context.textBaseline = 'middle';
             context.fillText("+" + overflow_count, self.team_image_size / 2, self.team_image_size / 2);
             const src = canvas.toDataURL("image/png");
-            return "<span><img src='" + src + "' title='" + __('%d other team members').replace('%d', overflow_count) + "'/></span>";
+            return "<span><img src='" + src + "' title='" + __('%d other team members').replace('%d', overflow_count) + "' data-bs-toggle='tooltip'/></span>";
         };
 
         /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

While browsing kanban for answering an incoming change, i though stack of actors in kanban can be slightly improved:

**From**:
![image](https://user-images.githubusercontent.com/418844/215454418-30cfc42d-58be-4a37-9468-71f8a1b9db39.png)

**To**:
![image](https://user-images.githubusercontent.com/418844/215454084-4e10f6c7-626a-46d4-ba39-0cb1ca7b812a.png)


PS: i didn't had the time to check, but global kanban in ticket doesn't save columns anymore on my instance. @cconard96 Do you have an idea ?

