### PR TITLE
feat(entity): more anonymising options

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -67,9 +67,12 @@ class Entity extends CommonTreeDropdown
     /**
      * Possible values for "anonymize_support_agents" setting
      */
-    const ANONYMIZE_DISABLED     = 0;
-    const ANONYMIZE_USE_GENERIC  = 1;
-    const ANONYMIZE_USE_NICKNAME = 2;
+    const ANONYMIZE_DISABLED            = 0;
+    const ANONYMIZE_USE_GENERIC         = 1;
+    const ANONYMIZE_USE_NICKNAME        = 2;
+    const ANONYMIZE_USE_GENERIC_USER    = 3;
+    const ANONYMIZE_USE_NICKNAME_USER   = 4;
+    const ANONYMIZE_USE_GENERIC_GROUP   = 5;
 
    // Array of "right required to update" => array of fields allowed
    // Missing field here couldn't be update (no right)
@@ -3488,8 +3491,11 @@ class Entity extends CommonTreeDropdown
         return [
             self::CONFIG_PARENT => __('Inheritance of the parent entity'),
             self::ANONYMIZE_DISABLED => __('Disabled'),
-            self::ANONYMIZE_USE_GENERIC => __("Replace the agent's name with a generic name"),
-            self::ANONYMIZE_USE_NICKNAME => __("Replace the agent's name with a customisable nickname"),
+            self::ANONYMIZE_USE_GENERIC => __("Replace the agent and group name with a generic name"),
+            self::ANONYMIZE_USE_NICKNAME => __("Replace the agent and group name with a customisable nickname"),
+            self::ANONYMIZE_USE_GENERIC_USER => __("Replace the agent's name with a generic name"),
+            self::ANONYMIZE_USE_NICKNAME_USER => __("Replace the agent's name with a customisable nickname"),
+            self::ANONYMIZE_USE_GENERIC_GROUP => __("Replace the group's name with a generic name"),
         ];
     }
 

--- a/src/Group.php
+++ b/src/Group.php
@@ -1057,6 +1057,7 @@ class Group extends CommonTreeDropdown
 
             case Entity::ANONYMIZE_USE_GENERIC:
             case Entity::ANONYMIZE_USE_NICKNAME:
+            case Entity::ANONYMIZE_USE_GENERIC_GROUP:
                 return __("Helpdesk group");
         }
     }

--- a/src/User.php
+++ b/src/User.php
@@ -2749,7 +2749,10 @@ HTML;
             }
 
             if (
-                Entity::getAnonymizeConfig() == Entity::ANONYMIZE_USE_NICKNAME
+                (
+                    Entity::getAnonymizeConfig() == Entity::ANONYMIZE_USE_NICKNAME
+                    || Entity::getAnonymizeConfig() == Entity::ANONYMIZE_USE_NICKNAME_USER
+                )
                 && Session::getCurrentInterface() == "central"
             ) {
                 echo "<tr class='tab_bg_1'>";
@@ -3161,7 +3164,10 @@ HTML;
             echo "</td></tr>";
 
             if (
-                Entity::getAnonymizeConfig() == Entity::ANONYMIZE_USE_NICKNAME
+                (
+                    Entity::getAnonymizeConfig() == Entity::ANONYMIZE_USE_NICKNAME
+                    || Entity::getAnonymizeConfig() == Entity::ANONYMIZE_USE_NICKNAME_USER
+                )
                 && Session::getCurrentInterface() == "central"
             ) {
                 echo "<tr class='tab_bg_1'>";
@@ -6251,9 +6257,11 @@ HTML;
                 return null;
 
             case Entity::ANONYMIZE_USE_GENERIC:
+            case Entity::ANONYMIZE_USE_GENERIC_USER:
                 return __("Helpdesk user");
 
             case Entity::ANONYMIZE_USE_NICKNAME:
+            case Entity::ANONYMIZE_USE_NICKNAME_USER:
                 return $this->fields['nickname'];
         }
 
@@ -6276,9 +6284,11 @@ HTML;
                 return null;
 
             case Entity::ANONYMIZE_USE_GENERIC:
+            case Entity::ANONYMIZE_USE_GENERIC_USER:
                 return __("Helpdesk user");
 
             case Entity::ANONYMIZE_USE_NICKNAME:
+            case Entity::ANONYMIZE_USE_NICKNAME_USER:
                 $user = new User();
                 if (!$user->getFromDB($users_id)) {
                     return '';

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -743,6 +743,16 @@ class Entity extends DbTestCase
                 'expected'  => 'user_nick_6436345654',
                 'user_nick' => 'user_nick_6436345654'
             ],
+            [
+                'interface' => 'central',
+                'setting'   => \Entity::ANONYMIZE_USE_GENERIC_GROUP,
+                'expected'  => 'test_anon_user',
+            ],
+            [
+                'interface' => 'helpdesk',
+                'setting'   => \Entity::ANONYMIZE_USE_GENERIC_GROUP,
+                'expected'  => 'test_anon_user',
+            ],
         ];
     }
 
@@ -908,11 +918,13 @@ class Entity extends DbTestCase
             ]
         ]);
         foreach ($notif_data['followups'] as $n_fup) {
-            foreach ($possible_values as $value) {
-                if ($value == $expected) {
-                    $this->string($n_fup['##followup.author##'])->contains($value);
-                } else {
-                    $this->string($n_fup['##followup.author##'])->notContains($value);
+            if ($n_fup['##followup.author##'] !== null) {
+                foreach ($possible_values as $value) {
+                    if ($value == $expected) {
+                        $this->string($n_fup['##followup.author##'])->contains($value);
+                    } else {
+                        $this->string($n_fup['##followup.author##'])->notContains($value);
+                    }
                 }
             }
         }

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -721,6 +721,28 @@ class Entity extends DbTestCase
                 'expected'  => 'user_nick_6436345654',
                 'user_nick' => 'user_nick_6436345654'
             ],
+            [
+                'interface' => 'central',
+                'setting'   => \Entity::ANONYMIZE_USE_GENERIC_USER,
+                'expected'  => 'test_anon_user',
+            ],
+            [
+                'interface' => 'helpdesk',
+                'setting'   => \Entity::ANONYMIZE_USE_GENERIC_USER,
+                'expected'  => "Helpdesk user",
+            ],
+            [
+                'interface' => 'central',
+                'setting'   => \Entity::ANONYMIZE_USE_NICKNAME_USER,
+                'expected'  => 'test_anon_user',
+                'user_nick' => 'user_nick_6436345654'
+            ],
+            [
+                'interface' => 'helpdesk',
+                'setting'   => \Entity::ANONYMIZE_USE_NICKNAME_USER,
+                'expected'  => 'user_nick_6436345654',
+                'user_nick' => 'user_nick_6436345654'
+            ],
         ];
     }
 


### PR DESCRIPTION
Allows to distinguish between anonymising the user and anonymising the group:

![image](https://user-images.githubusercontent.com/8530352/215503322-c147f6f2-5f82-43ea-83cd-5cf755fbc460.png)

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24779
