### PR TITLE
Handle LDAP serch errors

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -1865,6 +1865,13 @@ class AuthLDAP extends CommonDBTM
                     ]
                 ];
                 $sr = ldap_search($ds, $values['basedn'], $filter, $attrs, 0, -1, -1, LDAP_DEREF_NEVER, $controls);
+                if ($sr === false) {
+                    trigger_error(
+                        sprintf('LDAP search failed with error (%s) %s', ldap_errno($ds), ldap_error($ds)),
+                        E_USER_WARNING
+                    );
+                    return false;
+                }
                 ldap_parse_result($ds, $sr, $errcode, $matcheddn, $errmsg, $referrals, $controls);
                 if (isset($controls[LDAP_CONTROL_PAGEDRESULTS]['value']['cookie'])) {
                     $cookie = $controls[LDAP_CONTROL_PAGEDRESULTS]['value']['cookie'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | see #13396

When `ldap_search()` fails, trying to parse results lead to following error:
```
PHP Warning (2): ldap_parse_result() expects parameter 2 to be resource, bool given in /var/www/html/src/AuthLDAP.php at line 1868
```

All the logic of user research being a big plate of spaghetti, it is difficult to implement a clear message on UI/console, but proposed change will probably make log messages clearer and could help to debug..