### PR TITLE
fix(inventory): prevent SQL error when handle manufacturer rule

### DIFF
--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -743,7 +743,7 @@ abstract class CommonDropdown extends CommonDBTM
     ) {
 
         $value = trim($value);
-        if (empty($value)) {
+        if (strlen($value) == 0) {
             return 0;
         }
 

--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -743,7 +743,7 @@ abstract class CommonDropdown extends CommonDBTM
     ) {
 
         $value = trim($value);
-        if (strlen($value) == 0) {
+        if (empty($value)) {
             return 0;
         }
 

--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -251,7 +251,7 @@ abstract class InventoryAsset
                         );
                     } else if (isset($foreignkey_itemtype[$key])) {
                         $this->known_links[$known_key] = Dropdown::importExternal($foreignkey_itemtype[$key], $value->$key, $entities_id);
-                    } else if ($key !== 'entities_id' && $key !== 'states_id' && isForeignKeyField($key) && is_a($itemtype = getItemtypeForForeignKeyField($key), CommonDropdown::class, true)) {
+                    } else if ($value->$key !== 0 && $key !== 'entities_id' && $key !== 'states_id' && isForeignKeyField($key) && is_a($itemtype = getItemtypeForForeignKeyField($key), CommonDropdown::class, true)) {
                         $foreignkey_itemtype[$key] = $itemtype;
 
                         $this->known_links[$known_key] = Dropdown::importExternal(

--- a/src/Inventory/Asset/Software.php
+++ b/src/Inventory/Asset/Software.php
@@ -759,11 +759,6 @@ class Software extends InventoryAsset
             if (!isset($this->versions[$vkey])) {
                  $version_name = $val->version;
                  $stmt_columns = $this->cleanInputToPrepare((array)$val, $version_fields);
-                 //OperatingSystem is a CommonDropdown
-                 //InventoryAsset->handleLinks with Dropdown::importExternal return -1 if name is 0
-                 $stmt_columns['operatingsystems_id'] = ($stmt_columns['operatingsystems_id'] > 0) ? $stmt_columns['operatingsystems_id'] : 0 ;
-                 $stmt_columns['name'] = $version_name;
-                 $stmt_columns['softwares_id'] = $softwares_id;
                 if ($stmt === null) {
                     $stmt_types = str_repeat('s', count($stmt_columns));
                     $reference = array_fill_keys(

--- a/src/Inventory/Asset/Software.php
+++ b/src/Inventory/Asset/Software.php
@@ -209,7 +209,9 @@ class Software extends InventoryAsset
                 $val->is_template_item = 0;
                 $val->is_deleted_item = 0;
 
-                $val->operatingsystems_id = 0;
+                //OperatingSystem is a CommonDropdown
+                //InventoryAsset->handleLinks with Dropdown::importExternal return -1 if name is 0
+                $val->operatingsystems_id = '';
                 $val->entities_id = 0;
                 $val->is_recursive = 0;
 

--- a/src/Inventory/Asset/Software.php
+++ b/src/Inventory/Asset/Software.php
@@ -208,10 +208,7 @@ class Software extends InventoryAsset
                 //not a template, not deleted, ...
                 $val->is_template_item = 0;
                 $val->is_deleted_item = 0;
-
-                //OperatingSystem is a CommonDropdown
-                //InventoryAsset->handleLinks with Dropdown::importExternal return -1 if name is 0
-                $val->operatingsystems_id = '';
+                $val->operatingsystems_id = 0;
                 $val->entities_id = 0;
                 $val->is_recursive = 0;
 
@@ -762,6 +759,7 @@ class Software extends InventoryAsset
             if (!isset($this->versions[$vkey])) {
                  $version_name = $val->version;
                  $stmt_columns = $this->cleanInputToPrepare((array)$val, $version_fields);
+                 $stmt_columns['operatingsystems_id'] = ($stmt_columns['operatingsystems_id'] > 0) ? $stmt_columns['operatingsystems_id'] : 0;
                  $stmt_columns['name'] = $version_name;
                  $stmt_columns['softwares_id'] = $softwares_id;
                 if ($stmt === null) {

--- a/src/Inventory/Asset/Software.php
+++ b/src/Inventory/Asset/Software.php
@@ -375,7 +375,7 @@ class Software extends InventoryAsset
 
             //update softwarecategories if needed
             //reconciles the software without the version (no needed here)
-            $sckey = 'softwarecategories_id' . ($val->softwarecategories_id ?? 0);
+            $sckey = md5('softwarecategories_id' . ($val->softwarecategories_id ?? 0));
             if (
                 isset($db_software_data[$key_wo_version])
                 && $db_software_data[$key_wo_version]['softwarecategories'] != ($this->known_links[$sckey] ?? 0)
@@ -578,7 +578,7 @@ class Software extends InventoryAsset
                 continue;
             }
 
-            $mkey = 'manufacturers_id' . $val->manufacturers_id;
+            $mkey = md5('manufacturers_id' . $val->manufacturers_id);
             $input = Sanitizer::encodeHtmlSpecialCharsRecursive([
                 'name'             => $val->name,
                 'manufacturers_id' => $this->known_links[$mkey] ?? 0

--- a/src/Inventory/Asset/Software.php
+++ b/src/Inventory/Asset/Software.php
@@ -759,6 +759,8 @@ class Software extends InventoryAsset
             if (!isset($this->versions[$vkey])) {
                  $version_name = $val->version;
                  $stmt_columns = $this->cleanInputToPrepare((array)$val, $version_fields);
+                 $stmt_columns['name'] = $version_name;
+                 $stmt_columns['softwares_id'] = $softwares_id;
                 if ($stmt === null) {
                     $stmt_types = str_repeat('s', count($stmt_columns));
                     $reference = array_fill_keys(

--- a/src/Inventory/Asset/Software.php
+++ b/src/Inventory/Asset/Software.php
@@ -145,7 +145,7 @@ class Software extends InventoryAsset
 
                 //If the software category has been modified or set by the rules engine
                 if (isset($res_rule["softwarecategories_id"])) {
-                    $sckey = 'softwarecategories_id' . $res_rule["softwarecategories_id"];
+                    $sckey = md5('softwarecategories_id' . $res_rule["softwarecategories_id"]);
                     $this->known_links[$sckey] = $res_rule["softwarecategories_id"];
                     $sc = new \SoftwareCategory();
                     $sc->getFromDB($res_rule["softwarecategories_id"]);
@@ -156,7 +156,7 @@ class Software extends InventoryAsset
                     && $val->_system_category != '0'
                 ) {
                     $val->softwarecategories_id = $val->_system_category;
-                    $sckey = 'softwarecategories_id' . $val->_system_category;
+                    $sckey = md5('softwarecategories_id' . $val->_system_category);
                     if (!isset($this->known_links[$sckey])) {
                         $new_value = Dropdown::importExternal(
                             'SoftwareCategory',
@@ -171,7 +171,7 @@ class Software extends InventoryAsset
 
                 //If the manufacturer has been modified or set by the rules engine
                 if (isset($res_rule["manufacturer"])) {
-                    $mkey = 'manufacturers_id' . $res_rule['manufacturer'];
+                    $mkey = md5('manufacturers_id' . $res_rule['manufacturer']);
                     $mid = Dropdown::import(
                         'Manufacturer',
                         ['name' => $res_rule['manufacturer']]
@@ -183,7 +183,7 @@ class Software extends InventoryAsset
                     && $val->manufacturers_id != ''
                     && $val->manufacturers_id != '0'
                 ) {
-                    $mkey = 'manufacturers_id' . $val->manufacturers_id;
+                    $mkey = md5('manufacturers_id' . $val->manufacturers_id);
                     if (!isset($this->known_links[$mkey])) {
                         $new_value = Dropdown::importExternal(
                             'Manufacturer',
@@ -208,6 +208,7 @@ class Software extends InventoryAsset
                 //not a template, not deleted, ...
                 $val->is_template_item = 0;
                 $val->is_deleted_item = 0;
+
                 $val->operatingsystems_id = 0;
                 $val->entities_id = 0;
                 $val->is_recursive = 0;
@@ -808,7 +809,7 @@ class Software extends InventoryAsset
             if (!isset($known_fields[$column])) {
                 unset($input[$column]);
             } else {
-                $key = $column . $input[$column];
+                $key = md5($column . $input[$column]);
                 if (isset($this->known_links[$key])) {
                     $input[$column] = $this->known_links[$key];
                 }

--- a/src/Inventory/Asset/Software.php
+++ b/src/Inventory/Asset/Software.php
@@ -759,7 +759,9 @@ class Software extends InventoryAsset
             if (!isset($this->versions[$vkey])) {
                  $version_name = $val->version;
                  $stmt_columns = $this->cleanInputToPrepare((array)$val, $version_fields);
-                 $stmt_columns['operatingsystems_id'] = ($stmt_columns['operatingsystems_id'] > 0) ? $stmt_columns['operatingsystems_id'] : 0;
+                 //OperatingSystem is a CommonDropdown
+                 //InventoryAsset->handleLinks with Dropdown::importExternal return -1 if name is 0
+                 $stmt_columns['operatingsystems_id'] = ($stmt_columns['operatingsystems_id'] > 0) ? $stmt_columns['operatingsystems_id'] : 0 ;
                  $stmt_columns['name'] = $version_name;
                  $stmt_columns['softwares_id'] = $softwares_id;
                 if ($stmt === null) {

--- a/tests/functionnal/Glpi/Inventory/Assets/Software.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Software.php
@@ -601,4 +601,163 @@ class Software extends AbstractInventoryAsset
         $this->boolean($version->getFromDB($first_computer_soft['softwareversions_id']))->isTrue();
         $this->string($version->fields['name'])->isEqualTo("1.4");
     }
+
+    public function testSoftwareRuledictionnaryManufacturer()
+    {
+        $this->login();
+
+        $rule         = new \RuleDictionnaryManufacturer();
+        $rulecriteria = new \RuleCriteria();
+        $ruleaction   = new \RuleAction();
+
+        $rules_id = $rule->add([
+            'is_active'    => 1,
+            'name'         => 'Microsoft',
+            'match'        => 'AND',
+            'sub_type'     => \RuleDictionnaryManufacturer::class,
+            'is_recursive' => 1,
+            'ranking'      => 1,
+        ]);
+        $this->integer((int) $rules_id)->isGreaterThan(0);
+
+        $this->integer((int) $rulecriteria->add([
+            'rules_id'    => $rules_id,
+            'criteria'  => "name",
+            'pattern'   => "Microsoft",
+            'condition' => \Rule::PATTERN_CONTAIN
+        ]))->isGreaterThan(0);
+
+        $this->integer((int) $ruleaction->add([
+            'rules_id'    => $rules_id,
+            'action_type' => 'assign',
+            'field'       => 'name',
+            'value'       => 'Personal_Publisher',
+        ]))->isGreaterThan(0);
+
+        $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<REQUEST>
+  <CONTENT>
+    <SOFTWARES>
+      <ARCH>x86_64</ARCH>
+      <COMMENTS></COMMENTS>
+      <FILESIZE>67382735</FILESIZE>
+      <FROM>rpm</FROM>
+      <INSTALLDATE>03/10/2021</INSTALLDATE>
+      <NAME>test_software</NAME>
+      <PUBLISHER>Microsoft</PUBLISHER>
+      <SYSTEM_CATEGORY>Unspecified</SYSTEM_CATEGORY>
+      <VERSION>1.1</VERSION>
+    </SOFTWARES>
+    <HARDWARE>
+      <NAME>pc_test_entity</NAME>
+    </HARDWARE>
+    <BIOS>
+      <SSN>ssnexample</SSN>
+    </BIOS>
+    <VERSIONCLIENT>test-agent</VERSIONCLIENT>
+    <ACCOUNTINFO>
+      <KEYNAME>TAG</KEYNAME>
+      <KEYVALUE>testtag_2</KEYVALUE>
+    </ACCOUNTINFO>
+  </CONTENT>
+  <DEVICEID>pc_test_entity</DEVICEID>
+  <QUERY>INVENTORY</QUERY>
+</REQUEST>";
+
+        $this->doInventory($xml_source, true);
+
+        $computer = new \Computer();
+        $found_computers = $computer->find(['name' => "pc_test_entity"]);
+        $this->integer(count($found_computers))->isIdenticalTo(1);
+
+        $soft = new \Software();
+        $softs = $soft->find(['name' => "test_software"]);
+        $this->integer(count($softs))->isIdenticalTo(1);
+        $first_soft = array_pop($softs);
+
+        $manufacturer = new \Manufacturer();
+        $manufacturer->getFromDB($first_soft['manufacturers_id']);
+
+        $this->string($manufacturer->fields['name'])->isEqualTo('Personal_Publisher');
+    }
+
+    public function testSoftwareRuledictionnarySoftware()
+    {
+        $this->login();
+
+        $rule         = new \RuleDictionnarySoftware();
+        $rulecriteria = new \RuleCriteria();
+        $ruleaction   = new \RuleAction();
+
+        $rules_id = $rule->add([
+            'is_active'    => 1,
+            'name'         => 'Apple',
+            'match'        => 'AND',
+            'sub_type'     => \RuleDictionnarySoftware::class,
+            'is_recursive' => 1,
+            'ranking'      => 1,
+        ]);
+        $this->integer((int) $rules_id)->isGreaterThan(0);
+
+        $this->integer((int) $rulecriteria->add([
+            'rules_id'    => $rules_id,
+            'criteria'  => "manufacturer",
+            'pattern'   => "Apple",
+            'condition' => \Rule::PATTERN_CONTAIN
+        ]))->isGreaterThan(0);
+
+        $this->integer((int) $ruleaction->add([
+            'rules_id'    => $rules_id,
+            'action_type' => 'assign',
+            'field'       => 'manufacturer',
+            'value'       => 'Other_Publisher',
+        ]))->isGreaterThan(0);
+
+
+        $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<REQUEST>
+  <CONTENT>
+    <SOFTWARES>
+      <ARCH>x86_64</ARCH>
+      <COMMENTS></COMMENTS>
+      <FILESIZE>67382735</FILESIZE>
+      <FROM>rpm</FROM>
+      <INSTALLDATE>03/10/2021</INSTALLDATE>
+      <NAME>test_software</NAME>
+      <PUBLISHER>Apple</PUBLISHER>
+      <SYSTEM_CATEGORY>Unspecified</SYSTEM_CATEGORY>
+      <VERSION>1.1</VERSION>
+    </SOFTWARES>
+    <HARDWARE>
+      <NAME>pc_test_entity</NAME>
+    </HARDWARE>
+    <BIOS>
+      <SSN>ssnexample</SSN>
+    </BIOS>
+    <VERSIONCLIENT>test-agent</VERSIONCLIENT>
+    <ACCOUNTINFO>
+      <KEYNAME>TAG</KEYNAME>
+      <KEYVALUE>testtag_2</KEYVALUE>
+    </ACCOUNTINFO>
+  </CONTENT>
+  <DEVICEID>pc_test_entity</DEVICEID>
+  <QUERY>INVENTORY</QUERY>
+</REQUEST>";
+
+        $this->doInventory($xml_source, true);
+
+        $computer = new \Computer();
+        $found_computers = $computer->find(['name' => "pc_test_entity"]);
+        $this->integer(count($found_computers))->isIdenticalTo(1);
+
+        $soft = new \Software();
+        $softs = $soft->find(['name' => "test_software"]);
+        $this->integer(count($softs))->isIdenticalTo(1);
+        $first_soft = array_pop($softs);
+
+        $manufacturer = new \Manufacturer();
+        $manufacturer->getFromDB($first_soft['manufacturers_id']);
+
+        $this->string($manufacturer->fields['name'])->isEqualTo('Other_Publisher');
+    }
 }


### PR DESCRIPTION
Prevent SQL error 
```sql
Incorrect integer value: 'Microsoft' for column glpi_softwares.manufacturers_id at row 1 in src\DBmysql.php at line 1969
```

1. To fix SQL : fix Bad use of ```$this->known_links``` from ```Software```, ```key``` are never  use ```md5```
2. this fix caused a problem with the management of the operating system of the software version 

```OperatingSystem``` is a ```CommonDropdown``` and ```InventoryAsset->handleLinks``` with ```Dropdown::importExternal``` return``` -1``` if name is ```0```

Because 

```CommonDropdown::importExternal``` check if ```strlen($value) == 0``` (true if this case)
then call ```CommonDropdown::importExternal``` which check if ```empty($value)``` (false if this case and return ```-1```)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13925 [#301](https://github.com/glpi-project/glpi-inventory-plugin/issues/301)
