### PR TITLE
fix(inventory):  rework Management Port (with remote_addr)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -281,16 +281,16 @@
         },
         {
             "name": "glpi-project/inventory_format",
-            "version": "1.1.26",
+            "version": "1.1.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/glpi-project/inventory_format.git",
-                "reference": "140b9aed1abe16e55a9112814b8869414734879c"
+                "reference": "dd7e48b2920114dd75d3decb82977470996db202"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/glpi-project/inventory_format/zipball/140b9aed1abe16e55a9112814b8869414734879c",
-                "reference": "140b9aed1abe16e55a9112814b8869414734879c",
+                "url": "https://api.github.com/repos/glpi-project/inventory_format/zipball/dd7e48b2920114dd75d3decb82977470996db202",
+                "reference": "dd7e48b2920114dd75d3decb82977470996db202",
                 "shasum": ""
             },
             "require": {
@@ -340,7 +340,7 @@
                 "issues": "https://github.com/glpi-project/inventory_format/issues",
                 "source": "https://github.com/glpi-project/inventory_format"
             },
-            "time": "2023-01-25T10:44:38+00:00"
+            "time": "2023-02-02T08:13:18+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/src/Inventory/Asset/InventoryNetworkPort.php
+++ b/src/Inventory/Asset/InventoryNetworkPort.php
@@ -46,6 +46,7 @@ use NetworkName;
 use NetworkPort;
 use NetworkPortAggregate;
 use QueryParam;
+use Toolbox;
 use Unmanaged;
 
 trait InventoryNetworkPort
@@ -116,7 +117,6 @@ trait InventoryNetworkPort
             $this->cleanUnmanageds();
         }
 
-        $this->handleDeletesManagementPorts();
         $this->handleIpNetworks();
         $this->handleUpdates();
         $this->handleCreates();
@@ -631,18 +631,7 @@ trait InventoryNetworkPort
      */
     private function handleDeletesManagementPorts()
     {
-        if (method_exists($this, 'getManagementPorts')) {
-            if (empty($this->getManagementPorts())) {
-                //remove all port management ports
-                $networkport = new NetworkPort();
-                $networkport->deleteByCriteria([
-                    "itemtype"           => $this->itemtype,
-                    "items_id"           => $this->items_id,
-                    "instantiation_type" => NetworkPortAggregate::getType(),
-                    "name"               => "Management"
-                ], 1);
-            }
-        }
+        Toolbox::deprecated();
     }
 
     protected function portCreated(\stdClass $port, int $netports_id)

--- a/src/Inventory/Asset/NetworkEquipment.php
+++ b/src/Inventory/Asset/NetworkEquipment.php
@@ -99,7 +99,7 @@ class NetworkEquipment extends MainAsset
                 $val->$key = $property;
             }
 
-            if (property_exists($device, 'ips')) {
+            if (property_exists($device, 'remote_addr')) {
                 $portkey = 'management';
                 $port = new \stdClass();
                 if (property_exists($device, 'mac')) {
@@ -111,16 +111,13 @@ class NetworkEquipment extends MainAsset
                 $port->is_internal = true;
                 $port->ipaddress = [];
 
-               //add internal port(s)
-                foreach ($device->ips as $ip) {
-                    if (
-                        !in_array($ip, $port->ipaddress)
-                        && '' != $blacklist->process(Blacklist::IP, $ip)
-                    ) {
-                        $port->ipaddress[] = $ip;
-                    }
+                //add internal port
+                if (
+                    !in_array($device->remote_addr, $port->ipaddress)
+                    && '' != $blacklist->process(Blacklist::IP, $device->remote_addr)
+                ) {
+                    $port->ipaddress[] = $device->remote_addr;
                 }
-
                 $this->management_ports[$portkey] = $port;
             }
         }

--- a/src/Inventory/Asset/NetworkPort.php
+++ b/src/Inventory/Asset/NetworkPort.php
@@ -772,7 +772,10 @@ class NetworkPort extends InventoryAsset
         //remove management port if need for Printer
         if (get_class($mainasset) == Printer::class && !$this->item->isNewItem()) {
             if (empty($this->extra_data['\Glpi\Inventory\Asset\\' . $this->item->getType()]->getManagementPorts())) {
-                //remove all port management ports
+                // remove all port management ports
+                // to prevent twice IP from search
+                //  - one from NetworkPortEthernet
+                //  - another for NetworkPortAggregate
                 $networkport = new GlobalNetworkPort();
                 $networkport->deleteByCriteria([
                     "itemtype"           => $this->item->getType(),

--- a/src/Inventory/Asset/Printer.php
+++ b/src/Inventory/Asset/Printer.php
@@ -162,20 +162,21 @@ class Printer extends NetworkEquipment
             }
         }
 
-        //try to know if management port IP is already known as IP port
-        //if yes remove it from management port
+        // try to know if remote_addr IP is already known as IP port
+        // if yes remove it from management port
+        // to prevent twice IP from search
+        //  - one from NetworkPortEthernet
+        //  - another for NetworkPortAggregate
         $known_ports = $port_managment = $this->getManagementPorts();
         if (isset($known_ports['management']) && property_exists($known_ports['management'], 'ipaddress')) {
             foreach ($known_ports['management']->ipaddress as $pa_ip_key => $pa_ip_val) {
                 if (property_exists($this->raw_data->content, 'network_ports')) {
                     foreach ($this->raw_data->content->network_ports as $port_obj) {
                         if (property_exists($port_obj, 'ips')) {
-                            foreach ($port_obj->ips as $port_ip) {
-                                if ($pa_ip_val == $port_ip) {
-                                    unset($port_managment['management']->ipaddress[$pa_ip_key]);
-                                    if (empty($port_managment['management']->ipaddress)) {
-                                        unset($port_managment['management']);
-                                    }
+                            if ($pa_ip_val == $port_obj->remote_addr) {
+                                unset($port_managment['management']->ipaddress[$pa_ip_key]);
+                                if (empty($port_managment['management']->ipaddress)) {
+                                    unset($port_managment['management']);
                                 }
                             }
                         }

--- a/tests/functionnal/Glpi/Inventory/Assets/Printer.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Printer.php
@@ -234,18 +234,9 @@ class Printer extends AbstractInventoryAsset
             'last_pages_counter' => 800
         ]);
 
-        //get one management port only
-        $this->array($mports = $main->getManagementPorts())->hasSize(1)->hasKey('management');
-        $this->array((array)$mports['management'])->isIdenticalTo([
-            'mac' => '00:85:eb:f4:be:20',
-            'name' => 'Management',
-            'netname' => 'internal',
-            'instantiation_type' => 'NetworkPortAggregate',
-            'is_internal' => true,
-            'ipaddress' => [
-                '10.59.29.176'
-            ]
-        ]);
+        //no management port from netinventory
+        //<IP> then remote_addr are not availaible
+        $this->array($mports = $main->getManagementPorts())->hasSize(0);
 
         //do real inventory to check dataDB
         $json_str = file_get_contents(self::INV_FIXTURES . 'printer_2.json');
@@ -256,7 +247,7 @@ class Printer extends AbstractInventoryAsset
         $this->boolean($printer->getFromDbByCrit(['name' => 'MX5970', 'serial' => 'SDFSDF9874']))->isTrue();
 
         $np = new \NetworkPort();
-        $this->boolean($np->getFromDbByCrit(['itemtype' => 'Printer', 'items_id' => $printer->fields['id'] , 'instantiation_type' => 'NetworkPortAggregate']))->isTrue();
+        $this->boolean($np->getFromDbByCrit(['itemtype' => 'Printer', 'items_id' => $printer->fields['id'] , 'instantiation_type' => 'NetworkPortAggregate']))->isFalse();
         $this->boolean($np->getFromDbByCrit(['itemtype' => 'Printer', 'items_id' => $printer->fields['id'] , 'instantiation_type' => 'NetworkPortEthernet']))->isTrue();
 
         //remove printer for other test
@@ -1581,8 +1572,9 @@ class Printer extends AbstractInventoryAsset
             'last_pages_counter' => 1802
         ]);
 
-        //get no management port
-        $this->array($main->getManagementPorts())->hasSize(1);
+        //no management port from netinventory
+        //<IP> then remote_addr are not availaible
+        $this->array($main->getManagementPorts())->hasSize(0);
 
         //do real inventory to check dataDB
         $json = json_decode($json_str);
@@ -1601,15 +1593,7 @@ class Printer extends AbstractInventoryAsset
         )->isIdenticalTo(1);
 
         //1 NetworkPortAggregate
-        $this->boolean($np->getFromDbByCrit(['itemtype' => 'Printer', 'items_id' => $printer->fields['id'] , 'instantiation_type' => 'NetworkPortAggregate']))->isTrue();
-
-        //1 NetworkName form NetworkPortAggregate
-        $nm = new \NetworkName();
-        $this->boolean($nm->getFromDbByCrit(["itemtype" => "NetworkPort", "items_id" => $np->fields['id']]))->isTrue();
-
-        //1 IPAdress form NetworkName
-        $ip = new \IPAddress();
-        $this->boolean($ip->getFromDbByCrit(["name" => "10.59.29.208", "itemtype" => "NetworkName", "items_id" => $nm->fields['id']]))->isTrue();
+        $this->boolean($np->getFromDbByCrit(['itemtype' => 'Printer', 'items_id' => $printer->fields['id'] , 'instantiation_type' => 'NetworkPortAggregate']))->isFalse();
 
         //remove printer for other test
         $printer->delete($printer->fields);

--- a/tests/functionnal/Glpi/Inventory/Assets/Unmanaged.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Unmanaged.php
@@ -76,7 +76,7 @@ class Unmanaged extends AbstractInventoryAsset
                             "type": "Unmanaged",
                             "mac": "4c:cc:6a:02:13:a9",
                             "name": "DESKTOP-A3J16LF",
-                            "ip": "192.168.1.20",
+                            "remote_addr": "192.168.1.20",
                             "ips": [
                                 "192.168.1.20"
                             ]

--- a/tests/functionnal/Glpi/Inventory/Inventory.php
+++ b/tests/functionnal/Glpi/Inventory/Inventory.php
@@ -1931,11 +1931,12 @@ class Inventory extends InventoryTestCase
             'uptime' => '482 days, 05:42:18.50',
             'last_inventory_update' => $date_now,
             'snmpcredentials_id' => 4,
+            'remote_addr' => null,
         ];
         $this->array($equipment->fields)->isIdenticalTo($expected);
 
         //check network ports
-        $expected_count = 164;
+        $expected_count = 163;
         $iterator = $DB->request([
             'FROM'   => \NetworkPort::getTable(),
             'WHERE'  => [
@@ -1944,15 +1945,6 @@ class Inventory extends InventoryTestCase
             ],
         ]);
         $this->integer(count($iterator))->isIdenticalTo($expected_count);
-
-        $expecteds = [
-            ($expected_count - 1) => [
-                'logical_number' => 0,
-                'name' => 'Management',
-                'instantiation_type' => 'NetworkPortAggregate',
-                'mac' => '8c:60:4f:8d:ae:fc',
-            ],
-        ];
 
         $ips = [
             'Management' => [
@@ -1978,40 +1970,12 @@ class Inventory extends InventoryTestCase
             unset($port['date_mod']);
             unset($port['comment']);
 
-            if (isset($expecteds[$i])) {
-                $expected = $expecteds[$i];
-                $expected = $expected + [
-                    'items_id' => $equipments_id,
-                    'itemtype' => 'NetworkEquipment',
-                    'entities_id' => 0,
-                    'is_recursive' => 0,
-                    'is_deleted' => 0,
-                    'is_dynamic' => 1,
-                    'ifmtu' => 0,
-                    'ifspeed' => 0,
-                    'ifinternalstatus' => null,
-                    'ifconnectionstatus' => 0,
-                    'iflastchange' => null,
-                    'ifinbytes' => 0,
-                    'ifinerrors' => 0,
-                    'ifoutbytes' => 0,
-                    'ifouterrors' => 0,
-                    'ifstatus' => null,
-                    'ifdescr' => null,
-                    'ifalias' => null,
-                    'portduplex' => null,
-                    'trunk' => 0,
-                    'lastup' => null
-                ];
+            $this->string($port['itemtype'])->isIdenticalTo('NetworkEquipment');
+            $this->integer($port['items_id'])->isIdenticalTo($equipments_id);
+            $this->string($port['instantiation_type'])->isIdenticalTo('NetworkPortEthernet', print_r($port, true));
+            $this->string($port['mac'])->matches('/^(?:(?:[0-9a-f]{2}[\:]{1}){5}|(?:[0-9a-f]{2}[-]{1}){5}|(?:[0-9a-f]{2}){5})[0-9a-f]{2}$/i');
+            $this->integer($port['is_dynamic'])->isIdenticalTo(1);
 
-                $this->array($port)->isEqualTo($expected);
-            } else {
-                $this->string($port['itemtype'])->isIdenticalTo('NetworkEquipment');
-                $this->integer($port['items_id'])->isIdenticalTo($equipments_id);
-                $this->string($port['instantiation_type'])->isIdenticalTo('NetworkPortEthernet', print_r($port, true));
-                $this->string($port['mac'])->matches('/^(?:(?:[0-9a-f]{2}[\:]{1}){5}|(?:[0-9a-f]{2}[-]{1}){5}|(?:[0-9a-f]{2}){5})[0-9a-f]{2}$/i');
-                $this->integer($port['is_dynamic'])->isIdenticalTo(1);
-            }
             ++$i;
 
             //check for ips
@@ -2274,6 +2238,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
             'uptime' => '103 days, 13:53:28.28',
             'last_inventory_update' => $date_now,
             'snmpcredentials_id' => 0,
+            'remote_addr' => null,
         ];
 
         $stacks = [
@@ -2314,7 +2279,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
             $this->array($row)->isIdenticalTo($expected);
 
             //check network ports
-            $expected_count = 53;
+            $expected_count = 52;
             $ports_iterator = $DB->request([
                 'FROM'   => \NetworkPort::getTable(),
                 'WHERE'  => [
@@ -2331,15 +2296,6 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
                     $expected_count
                 )
             );
-
-            $expecteds = [
-                ($expected_count - 1) => [
-                    'logical_number' => 0,
-                    'name' => 'Management',
-                    'instantiation_type' => 'NetworkPortAggregate',
-                    'mac' => '00:23:ac:6a:01:00',
-                ],
-            ];
 
             $ips = [
                 'Management' => [
@@ -2394,40 +2350,11 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
                 unset($port['date_mod']);
                 unset($port['comment']);
 
-                if (isset($expecteds[$i])) {
-                    $expected = $expecteds[$i];
-                    $expected = $expected + [
-                        'items_id' => $equipments_id,
-                        'itemtype' => 'NetworkEquipment',
-                        'entities_id' => 0,
-                        'is_recursive' => 0,
-                        'is_deleted' => 0,
-                        'is_dynamic' => 1,
-                        'ifmtu' => 0,
-                        'ifspeed' => 0,
-                        'ifinternalstatus' => null,
-                        'ifconnectionstatus' => 0,
-                        'iflastchange' => null,
-                        'ifinbytes' => 0,
-                        'ifinerrors' => 0,
-                        'ifoutbytes' => 0,
-                        'ifouterrors' => 0,
-                        'ifstatus' => null,
-                        'ifdescr' => null,
-                        'ifalias' => null,
-                        'portduplex' => null,
-                        'trunk' => 0,
-                        'lastup' => null
-                    ];
-
-                    $this->array($port)->isEqualTo($expected);
-                } else {
-                    $this->string($port['itemtype'])->isIdenticalTo('NetworkEquipment');
-                    $this->integer($port['items_id'])->isIdenticalTo($equipments_id);
-                    $this->string($port['instantiation_type'])->isIdenticalTo('NetworkPortEthernet', print_r($port, true));
-                    $this->string($port['mac'])->matches('/^(?:(?:[0-9a-f]{2}[\:]{1}){5}|(?:[0-9a-f]{2}[-]{1}){5}|(?:[0-9a-f]{2}){5})[0-9a-f]{2}$/i');
-                    $this->integer($port['is_dynamic'])->isIdenticalTo(1);
-                }
+                $this->string($port['itemtype'])->isIdenticalTo('NetworkEquipment');
+                $this->integer($port['items_id'])->isIdenticalTo($equipments_id);
+                $this->string($port['instantiation_type'])->isIdenticalTo('NetworkPortEthernet', print_r($port, true));
+                $this->string($port['mac'])->matches('/^(?:(?:[0-9a-f]{2}[\:]{1}){5}|(?:[0-9a-f]{2}[-]{1}){5}|(?:[0-9a-f]{2}){5})[0-9a-f]{2}$/i');
+                $this->integer($port['is_dynamic'])->isIdenticalTo(1);
                 ++$i;
 
                 //check for ips
@@ -2558,10 +2485,10 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         }
 
         $db_ports = $DB->request(['FROM' => \NetworkPort::getTable()]);
-        $this->integer(count($db_ports))->isIdenticalTo(325);
+        $this->integer(count($db_ports))->isIdenticalTo(320);
 
         $db_neteq_ports = $DB->request(['FROM' => \NetworkPort::getTable(), 'WHERE' => ['itemtype' => 'NetworkEquipment']]);
-        $this->integer(count($db_neteq_ports))->isIdenticalTo(265);
+        $this->integer(count($db_neteq_ports))->isIdenticalTo(260);
 
         $db_connections = $DB->request(['FROM' => \NetworkPort_NetworkPort::getTable()]);
         $this->integer(count($db_connections))->isIdenticalTo(26);
@@ -2570,7 +2497,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         $this->integer(count($db_unmanageds))->isIdenticalTo(45);
 
         $db_ips = $DB->request(['FROM' => \IPAddress::getTable()]);
-        $this->integer(count($db_ips))->isIdenticalTo(150);
+        $this->integer(count($db_ips))->isIdenticalTo(5);
 
         $expected_names = [
             'san-replication',
@@ -2599,7 +2526,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         $this->integer(count($db_vlans_ports))->isIdenticalTo(219);
 
         $db_netnames = $DB->request(['FROM' => \NetworkName::getTable()]);
-        $this->integer(count($db_netnames))->isIdenticalTo(10);
+        $this->integer(count($db_netnames))->isIdenticalTo(5);
 
         $expecteds = [
             [
@@ -2759,6 +2686,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
             'uptime' => '(78894038) 9 days, 3:09:00.38',
             'last_inventory_update' => $date_now,
             'snmpcredentials_id' => 0,
+            'remote_addr' => null,
         ];
 
         foreach ($iterator as $row) {
@@ -2771,7 +2699,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
             $this->array($row)->isIdenticalTo($expected);
 
             //check network ports
-            $expected_count = 53;
+            $expected_count = 52;
             $ports_iterator = $DB->request([
                 'FROM'   => \NetworkPort::getTable(),
                 'WHERE'  => [
@@ -2788,15 +2716,6 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
                     $expected_count
                 )
             );
-
-            $expecteds = [
-                ($expected_count - 1) => [
-                    'logical_number' => 0,
-                    'name' => 'Management',
-                    'instantiation_type' => 'NetworkPortAggregate',
-                    'mac' => 'b0:5a:da:10:10:80',
-                ],
-            ];
 
             $ips = [
                 'Management' => [
@@ -2823,40 +2742,11 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
                 unset($port['date_mod']);
                 unset($port['comment']);
 
-                if (isset($expecteds[$i])) {
-                    $expected = $expecteds[$i];
-                    $expected = $expected + [
-                        'items_id' => $equipments_id,
-                        'itemtype' => 'NetworkEquipment',
-                        'entities_id' => 0,
-                        'is_recursive' => 0,
-                        'is_deleted' => 0,
-                        'is_dynamic' => 1,
-                        'ifmtu' => 0,
-                        'ifspeed' => 0,
-                        'ifinternalstatus' => null,
-                        'ifconnectionstatus' => 0,
-                        'iflastchange' => null,
-                        'ifinbytes' => 0,
-                        'ifinerrors' => 0,
-                        'ifoutbytes' => 0,
-                        'ifouterrors' => 0,
-                        'ifstatus' => null,
-                        'ifdescr' => null,
-                        'ifalias' => null,
-                        'portduplex' => null,
-                        'trunk' => 0,
-                        'lastup' => null
-                    ];
-
-                    $this->array($port)->isEqualTo($expected);
-                } else {
-                    $this->string($port['itemtype'])->isIdenticalTo('NetworkEquipment');
-                    $this->integer($port['items_id'])->isIdenticalTo($equipments_id);
-                    $this->string($port['instantiation_type'])->isIdenticalTo('NetworkPortEthernet', print_r($port, true));
-                    $this->string($port['mac'])->matches('/^(?:(?:[0-9a-f]{2}[\:]{1}){5}|(?:[0-9a-f]{2}[-]{1}){5}|(?:[0-9a-f]{2}){5})[0-9a-f]{2}$/i');
-                    $this->integer($port['is_dynamic'])->isIdenticalTo(1);
-                }
+                $this->string($port['itemtype'])->isIdenticalTo('NetworkEquipment');
+                $this->integer($port['items_id'])->isIdenticalTo($equipments_id);
+                $this->string($port['instantiation_type'])->isIdenticalTo('NetworkPortEthernet', print_r($port, true));
+                $this->string($port['mac'])->matches('/^(?:(?:[0-9a-f]{2}[\:]{1}){5}|(?:[0-9a-f]{2}[-]{1}){5}|(?:[0-9a-f]{2}){5})[0-9a-f]{2}$/i');
+                $this->integer($port['is_dynamic'])->isIdenticalTo(1);
                 ++$i;
 
                 //check for ips
@@ -3436,6 +3326,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
             'uptime' => '53 days, 4:19:42.16',
             'last_inventory_update' => $date_now,
             'snmpcredentials_id' => 0,
+            'remote_addr' => null,
         ];
 
         $first = true;
@@ -3457,7 +3348,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
             $this->array($row)->isIdenticalTo($expected_eq, print_r($row, true) . print_r($expected_eq, true));
 
            //check network ports
-            $expected_count = ($first ? 4 : 1);
+            $expected_count = ($first ? 3 : 1);
             $ports_iterator = $DB->request([
                 'FROM'   => \NetworkPort::getTable(),
                 'WHERE'  => [
@@ -3474,15 +3365,6 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
                     $expected_count
                 )
             );
-
-            $expecteds = [
-                'Management' => [
-                    'logical_number' => 0,
-                    'name' => 'Management',
-                    'instantiation_type' => 'NetworkPortAggregate',
-                    'mac' => '58:ac:78:59:45:fb',
-                ],
-            ];
 
             $ips = [
                 'Management' => [
@@ -3513,40 +3395,11 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
                 unset($port['date_mod']);
                 unset($port['comment']);
 
-                if ($port['mac'] == '58:ac:78:59:45:fb') {
-                    $expected = $expecteds['Management'];
-                    $expected = $expected + [
-                        'items_id' => $equipments_id,
-                        'itemtype' => 'NetworkEquipment',
-                        'entities_id' => 0,
-                        'is_recursive' => 0,
-                        'is_deleted' => 0,
-                        'is_dynamic' => 1,
-                        'ifmtu' => 0,
-                        'ifspeed' => 0,
-                        'ifinternalstatus' => null,
-                        'ifconnectionstatus' => 0,
-                        'iflastchange' => null,
-                        'ifinbytes' => 0,
-                        'ifinerrors' => 0,
-                        'ifoutbytes' => 0,
-                        'ifouterrors' => 0,
-                        'ifstatus' => null,
-                        'ifdescr' => null,
-                        'ifalias' => null,
-                        'portduplex' => null,
-                        'trunk' => 0,
-                        'lastup' => null
-                    ];
-
-                    $this->array($port)->isEqualTo($expected);
-                } else {
-                    $this->string($port['itemtype'])->isIdenticalTo('NetworkEquipment');
-                    $this->integer($port['items_id'])->isIdenticalTo($equipments_id);
-                   //$this->string($port['instantiation_type'])->isIdenticalTo('NetworkPortAggregate', print_r($port, true));
-                    $this->string($port['mac'])->matches('/^(?:(?:[0-9a-f]{2}[\:]{1}){5}|(?:[0-9a-f]{2}[-]{1}){5}|(?:[0-9a-f]{2}){5})[0-9a-f]{2}$/i');
-                    $this->integer($port['is_dynamic'])->isIdenticalTo(1);
-                }
+                $this->string($port['itemtype'])->isIdenticalTo('NetworkEquipment');
+                $this->integer($port['items_id'])->isIdenticalTo($equipments_id);
+                //$this->string($port['instantiation_type'])->isIdenticalTo('NetworkPortAggregate', print_r($port, true));
+                $this->string($port['mac'])->matches('/^(?:(?:[0-9a-f]{2}[\:]{1}){5}|(?:[0-9a-f]{2}[-]{1}){5}|(?:[0-9a-f]{2}){5})[0-9a-f]{2}$/i');
+                $this->integer($port['is_dynamic'])->isIdenticalTo(1);
                 ++$i;
 
                //check for ips
@@ -3815,11 +3668,12 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
             'uptime' => '65 days, 20:13:08.93',
             'last_inventory_update' => $date_now,
             'snmpcredentials_id' => 0,
+            'remote_addr' => null,
         ];
         $this->array($equipment->fields)->isIdenticalTo($expected);
 
         //check network ports
-        $expected_count = 53;
+        $expected_count = 52;
         $iterator = $DB->request([
             'FROM'   => \NetworkPort::getTable(),
             'WHERE'  => [
@@ -3845,13 +3699,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
                 'ifinbytes' => 1636476664,
                 'ifoutbytes' => 2829646176,
                 'portduplex' => 3
-            ],
-            ($expected_count - 1) => [
-                'logical_number' => 0,
-                'name' => 'Management',
-                'instantiation_type' => 'NetworkPortAggregate',
-                'mac' => 'ac:f1:df:8e:8e:00',
-            ],
+            ]
         ];
 
         $ips = [


### PR DESCRIPTION
This PR handle ```remote_addr``` to be managed  as unique source of ```Management NetworkPort```

Now (to prevent duplicate IP from management port)

```Management Port``` only take one ```IP``` (from ```remote_addr```)
```Management Port``` is only added / managed from ```discovery``` (on ```create```) because it use ```<IP>``` node that only available from ```discovery```



Fix too : FIX glpi-inventopry plugin TU https://github.com/glpi-project/glpi-inventory-plugin/actions/runs/4052704362/jobs/6972432429

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
