### PR TITLE
fix(rule ticket): drop itilcategories_id_cn

### DIFF
--- a/install/migrations/update_10.0.6_to_10.0.7/ruleticket.php
+++ b/install/migrations/update_10.0.6_to_10.0.7/ruleticket.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+// Replace old rule criteria itilcategories_id_cn
+$DB->updateOrDie(
+    'glpi_rulecriterias',
+    [
+        'criteria' => 'itilcategories_id'
+    ],
+    [
+        'criteria' => 'itilcategories_id_cn'
+    ],
+    '10.0.7 replace old rule criteria itilcategories_id_cn'
+);

--- a/src/RuleTicket.php
+++ b/src/RuleTicket.php
@@ -496,16 +496,10 @@ class RuleTicket extends Rule
         $criterias['date_mod']['linkfield']                   = 'date_mod';
 
         $criterias['itilcategories_id']['table']              = 'glpi_itilcategories';
-        $criterias['itilcategories_id']['field']              = 'name';
-        $criterias['itilcategories_id']['name']               = _n('Category', 'Categories', 1) . " - " . __('Name');
+        $criterias['itilcategories_id']['field']              = 'completename';
+        $criterias['itilcategories_id']['name']               = _n('Category', 'Categories', 1);
         $criterias['itilcategories_id']['linkfield']          = 'itilcategories_id';
         $criterias['itilcategories_id']['type']               = 'dropdown';
-
-        $criterias['itilcategories_id_cn']['table']           = 'glpi_itilcategories';
-        $criterias['itilcategories_id_cn']['field']           = 'completename';
-        $criterias['itilcategories_id_cn']['name']            = _n('Category', 'Categories', 1) . ' - ' . __('Complete name');
-        $criterias['itilcategories_id_cn']['linkfield']       = 'itilcategories_id';
-        $criterias['itilcategories_id_cn']['type']            = 'dropdown';
 
         $criterias['itilcategories_id_code']['table']              = 'glpi_itilcategories';
         $criterias['itilcategories_id_code']['field']              = 'code';

--- a/src/RuleTicketCollection.php
+++ b/src/RuleTicketCollection.php
@@ -153,9 +153,6 @@ class RuleTicketCollection extends RuleCollection
             }
         }
 
-        if (isset($input['itilcategories_id'])) {
-            $input['itilcategories_id_cn'] = $input['itilcategories_id'];
-        }
         return $input;
     }
 }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1256,11 +1256,6 @@ class Ticket extends CommonITILObject
                 $changes[]                             = '_groups_id_of_requester';
             }
 
-           // Special case to make sure rule depending on category completename are also executed
-            if (in_array('itilcategories_id', $changes)) {
-                $changes[] = 'itilcategories_id_cn';
-            }
-
             $input = $rules->processAllRules(
                 $input,
                 $input,


### PR DESCRIPTION
`itilcategories_id_cn` and `itilcategories_id` seem redundant.
IMO, the category criterion should work as it does with locations or entity.

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25374
