### PR TITLE
Fix planning widget rendering

### DIFF
--- a/js/planning.js
+++ b/js/planning.js
@@ -83,6 +83,7 @@ var GLPIPlanning  = {
         var all_days = [0, 1, 2, 3, 4, 5, 6];
         var enabled_days = CFG_GLPI.planning_work_days;
         var hidden_days = all_days.filter(day => !enabled_days.some(n => n == day));
+        var loadedLocales = Object.keys(FullCalendarLocales);
 
         this.calendar = new FullCalendar.Calendar(document.getElementById(GLPIPlanning.dom_id), {
             plugins:     options.plugins,
@@ -105,6 +106,7 @@ var GLPIPlanning  = {
             agendaEventMinHeight: 13,
             header: options.header,
             hiddenDays: hidden_days,
+            locale: loadedLocales.length === 1 ? loadedLocales[0] : undefined,
             //resources: options.resources,
             resources: function(fetchInfo, successCallback) {
             // Filter resources by whether their id is in visible_res.
@@ -604,11 +606,6 @@ var GLPIPlanning  = {
                 GLPIPlanning.calendar.unselect();
             }
         });
-
-        var loadedLocales = Object.keys(FullCalendarLocales);
-        if (loadedLocales.length === 1) {
-            GLPIPlanning.calendar.setOption('locale', loadedLocales[0]);
-        }
 
         $('.planning_on_central a')
             .mousedown(function() {


### PR DESCRIPTION
After 10.0.6, the planning widget have some rendering issue on chromium based browser (but it works fine on firefox):

![image](https://user-images.githubusercontent.com/42734840/215766972-e0638813-4bfa-4ff1-879f-c11f2e6fd13a.png)

It seems to be an indirect consequence of the switch to 2 columns layout.
On the previous layout, the issue still existed but wasn't noticed on bigger screens because with 3 columns the planning widget ended up perfectly at the end of a column, so there was no content underneath to mess up his it's rendering.

The issue is kinda hard to explain (I'm still not sure I really understand it) but the basis is that we have these ajax requests:

![image](https://user-images.githubusercontent.com/42734840/215768590-5b382067-51ad-4590-a4eb-03ba05b6d50a.png)

The data in rendered by request 1 & 2.
GLPI tell gridstack to recompute the grid after the request 3 is done.
On firefox 1 & 2 always end before 3.
On chromium based browsers, 2 always end **after** 3, which created our issue.

I did find weird that we have two requests to load the data instead of one so I tried to investigate where they came from.
Request 1 is triggered by full calendar constructor - seems normal to me.
Request 2 is triggered by `GLPIPlanning.calendar.setOption('locale', loadedLocales[0]);` - which is (maybe ?) a bug fixed in fullcalendar 5 (see https://github.com/fullcalendar/fullcalendar/issues/5155).

So I've removed the `setOption('locale'`...) and instead set it directly in the constructor, which indeed remove request 2 from the equation - which fix our rendering issue as request 3 can finally end last on chromium based browsers.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26487 #13938
