### PR TITLE
Planning: fix datepicker input focus

### DIFF
--- a/js/glpi_dialog.js
+++ b/js/glpi_dialog.js
@@ -56,6 +56,7 @@
  *                                  }, {
  *                                     ...
  *                                  }]
+ * @param {boolean} dialog.bs_focus - Data-bs-focus value for the modal
  */
 var glpi_html_dialog = function({
     title       = "",
@@ -69,6 +70,7 @@ var glpi_html_dialog = function({
     show        = () => {},
     close       = () => {},
     buttons     = [],
+    bs_focus    = true,
 } = {}) {
     if (buttons.length > 0) {
         var buttons_html = "";
@@ -100,7 +102,9 @@ var glpi_html_dialog = function({
       </div>`;
     }
 
-    var modal = `<div class="modal fade ${modalclass}" id="${id}" role="dialog">';
+    const data_bs_focus = !bs_focus ? 'data-bs-focus="false"' : '';
+
+    var modal = `<div class="modal fade ${modalclass}" id="${id}" role="dialog" ${data_bs_focus}>
          <div class="modal-dialog ${dialogclass}">
             <div class="modal-content">
                <div class="modal-header">
@@ -175,6 +179,7 @@ var glpi_html_dialog = function({
  *                                  }, {
  *                                     ...
  *                                  }]
+ * @param {boolean} dialog.bs_focus - Data-bs-focus value for the modal
  */
 var glpi_ajax_dialog = function({
     url         = "",
@@ -192,6 +197,7 @@ var glpi_ajax_dialog = function({
     show        = () => {},
     close       = () => {},
     buttons     = [],
+    bs_focus    = true,
 } = {}) {
     if (url.length == 0) {
         return;
@@ -218,6 +224,7 @@ var glpi_ajax_dialog = function({
                 buttons: buttons,
                 show: show,
                 close: close,
+                bs_focus: bs_focus
             });
         }
     }).done(function(data) {

--- a/js/planning.js
+++ b/js/planning.js
@@ -556,6 +556,7 @@ var GLPIPlanning  = {
                         },
                         dialogclass: 'modal-lg',
                         title: __('Edit an event'),
+                        bs_focus: false
                     });
                 }
             },
@@ -599,6 +600,7 @@ var GLPIPlanning  = {
                     },
                     dialogclass: 'modal-lg',
                     title: __('Add an event'),
+                    bs_focus: false
                 });
 
                 GLPIPlanning.calendar.unselect();


### PR DESCRIPTION
Clicking on the hours/minutes/seconds inputs doesn't work on the planning page:

![image](https://user-images.githubusercontent.com/42734840/215813948-104b6e17-9cdc-4e39-9914-1c0bb42e5e08.png)

It's some kind of conflict with boostrap, setting `data-bs-focus` to `false` solve the issue.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !25165
