### PR TITLE
fix code comment typo

### DIFF
--- a/src/Notification_NotificationTemplate.php
+++ b/src/Notification_NotificationTemplate.php
@@ -389,7 +389,7 @@ class Notification_NotificationTemplate extends CommonDBRelation
      *
      * @param string $mode  Mode
      * @param string $label Mode's label
-     * @param strign $from  Plugin which registers the mode
+     * @param string $from  Plugin which registers the mode
      *
      * @return void
      */


### PR DESCRIPTION
noticed method parameter type mismatch warning in IDE, obviously typo in code comments:
![image](https://user-images.githubusercontent.com/322967/216002820-97c4f52e-1b7b-40d9-b069-266c1e0a19c3.png)

marking as bugfix, though importance is minor
Affects nothing except for developer's comfort.
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
