### PR TITLE
fix(user): auth EXTERNAL mode even without LDAP

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -1099,7 +1099,8 @@ class Auth extends CommonGLPI
         }
 
         $methods = [
-            self::DB_GLPI => __('Authentication on GLPI database'),
+            self::DB_GLPI  => __('Authentication on GLPI database'),
+            self::EXTERNAL => __('External authentications'),
         ];
 
         $result = $DB->request([
@@ -1111,8 +1112,7 @@ class Auth extends CommonGLPI
         ])->current();
 
         if ($result['cpt'] > 0) {
-            $methods[self::LDAP]     = __('Authentication on a LDAP directory');
-            $methods[self::EXTERNAL] = __('External authentications');
+            $methods[self::LDAP] = __('Authentication on a LDAP directory');
         }
 
         $result = $DB->request([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26150

Allows administrators to select "EXTERNAL" authentication mode, even when there is no LDAP directory configured.

This does not change the behavior that follows this first dropdown choice, if LDAP directories are available he can always choose it in the next dropdown (auth mode = external + ldap), or leave it empty (auth mode = external).
