### PR TITLE
fix(document): entry name in database

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -241,21 +241,6 @@ class Document extends CommonDBTM
             && ($item = getItemForItemtype($input["itemtype"]))
             && ($input["items_id"] > 0)
         ) {
-            $typename = $item->getTypeName(1);
-            $name     = NOT_AVAILABLE;
-
-            if ($item->getFromDB($input["items_id"])) {
-                $name = $item->getNameID();
-            }
-           //TRANS: %1$s is Document, %2$s is item type, %3$s is item name
-            $input["name"] = addslashes(Html::resume_text(
-                sprintf(
-                    __('%1$s: %2$s'),
-                    Document::getTypeName(1),
-                    sprintf(__('%1$s - %2$s'), $typename, $name)
-                ),
-                200
-            ));
             $create_from_item = true;
         }
 

--- a/tests/functionnal/Document.php
+++ b/tests/functionnal/Document.php
@@ -149,7 +149,7 @@ class Document extends DbTestCase
          ->variable['users_id']->isEqualTo($uid)
          ->string['itemtype']->isIdenticalTo('Computer')
          ->variable['items_id']->isEqualTo($cid)
-         ->string['name']->isIdenticalTo('Document: Computer - Documented Computer');
+         ->string['name']->isIdenticalTo('A_name.pdf');
     }
 
     /** Cannot work without a real document uploaded.


### PR DESCRIPTION
The name of the document in the database loaded from a ticket was not determined in the same way:

- If the document was loaded directly (Action: `Add a document`), the ticket name was used
- If it is in a followup, the file name was used.

_IMO, users look at documents more from a ticket than from the document menu, so the name based on the source is less relevant than the original file._


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26561
