### PR TITLE
fix(document): show filename in timeline

### DIFF
--- a/templates/components/itilobject/timeline/form_document_item.html.twig
+++ b/templates/components/itilobject/timeline/form_document_item.html.twig
@@ -44,9 +44,9 @@
          {% if entry_i['filename'] %}
             {% set docpath = path('front/document.send.php?docid=' ~ entry_i['id'] ~ "&" ~ fk ~ "=" ~ item.fields["id"]) %}
             <div class="col text-truncate">
-               <a href="{{ docpath }}" target="_blank" title="{{ filename }}">
+               <a href="{{ docpath }}" target="_blank" title="{{ name }}">
                   <img src="{{ filename|document_icon }}" alt="{{ __('File extension') }}" />
-                  {{ name }}
+                  {{ filename }}
                </a>
             </div>
          {% endif %}


### PR DESCRIPTION
As discussed : https://github.com/glpi-project/glpi/pull/13986
Display the filename instead of the document name in the timeline.

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26561
