### PR TITLE
Remove ability to change rules sortable state and sort field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ The present file will list all changes made to the project; according to the
 - `GLPIMailer` mailer class does not extends anymore `PHPMailer\PHPMailer\PHPMailer`.
   We added a compatibility layer to handle main usages found in plugins, but we cannot ensure compatibility with all properties and methods that were inherited from `PHPMailer\PHPMailer\PHPMailer`.
 - `CommonGLPI::createTabEntry()` signature changed.
+- All types of rules are now sortable and ordered by ranking.
 
 #### Deprecated
 - Usage of `GLPI_USE_CSRF_CHECK` constant.
@@ -124,6 +125,8 @@ The present file will list all changes made to the project; according to the
 - `Plugin::migrateItemType()`
 - `ProfileRight::updateProfileRightAsOtherRight()`
 - `ProfileRight::updateProfileRightsAsOtherRights()`
+- `Rule::$can_sort` property.
+- `Rule::$orderby` property.
 - `Search::computeTitle()`
 - `Search::csv_clean()`
 - `Search::findCriteriaInSession()`

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -53,10 +53,6 @@ class Rule extends CommonDBTM
     public $actions               = [];
    ///Criterias affected to this rule
     public $criterias             = [];
-   /// Rules can be sorted ?
-    public $can_sort              = false;
-   /// field used to order rules
-    public $orderby               = 'ranking';
 
    /// restrict matching to self::AND_MATCHING or self::OR_MATCHING : specify value to activate
     public $restrict_matching     = false;
@@ -608,20 +604,13 @@ class Rule extends CommonDBTM
         if (!$this->isEntityAssign()) {
             unset($actions[MassiveAction::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'add_transfer_list']);
         }
-        $collectiontype = $this->getCollectionClassName();
-        if ($collection = getItemForItemtype($collectiontype)) {
-            if (
-                $isadmin
-                && ($collection->orderby == "ranking")
-            ) {
-                $actions[__CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'move_rule']
-                = "<i class='fas fa-arrows-alt-v'></i>" .
-                 __('Move');
-            }
-            $actions[__CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'export']
-            = "<i class='fas fa-file-download'></i>" .
-              _x('button', 'Export');
+        if ($isadmin) {
+            $actions[__CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'move_rule'] = "<i class='fas fa-arrows-alt-v'></i>"
+                . __('Move');
         }
+        $actions[__CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'export'] = "<i class='fas fa-file-download'></i>"
+            . _x('button', 'Export');
+
         return $actions;
     }
 
@@ -2066,7 +2055,7 @@ class Rule extends CommonDBTM
             echo "<td>" . $entname . "</td>";
         }
 
-        if ($this->can_sort && $canedit) {
+        if ($canedit) {
             echo "<td colspan='2'><i class='fas fa-grip-horizontal grip-rule'></i></td>";
         }
         echo "</tr>";

--- a/src/RuleAsset.php
+++ b/src/RuleAsset.php
@@ -37,7 +37,6 @@ class RuleAsset extends Rule
 {
    // From Rule
     public static $rightname = 'rule_asset';
-    public $can_sort  = true;
 
     const ONADD    = 1;
     const ONUPDATE = 2;

--- a/src/RuleCommonITILObject.php
+++ b/src/RuleCommonITILObject.php
@@ -37,9 +37,6 @@ use Glpi\Toolbox\Sanitizer;
 
 abstract class RuleCommonITILObject extends Rule
 {
-    // From Rule
-    public $can_sort  = true;
-
     const PARENT  = 1024;
 
 

--- a/src/RuleDictionnaryDropdown.php
+++ b/src/RuleDictionnaryDropdown.php
@@ -35,9 +35,6 @@
 
 class RuleDictionnaryDropdown extends Rule
 {
-   // From Rule
-    public $can_sort      = true;
-
     public static $rightname     = 'rule_dictionnary_dropdown';
 
     /**

--- a/src/RuleDictionnaryPrinter.php
+++ b/src/RuleDictionnaryPrinter.php
@@ -41,9 +41,6 @@
  **/
 class RuleDictionnaryPrinter extends Rule
 {
-   // From Rule
-    public $can_sort  = true;
-
     public static $rightname = 'rule_dictionnary_printer';
 
 

--- a/src/RuleDictionnarySoftware.php
+++ b/src/RuleDictionnarySoftware.php
@@ -42,7 +42,6 @@
 class RuleDictionnarySoftware extends Rule
 {
     public $additional_fields_for_dictionnary = ['manufacturer'];
-    public $can_sort                          = true;
 
     public static $rightname                         = 'rule_dictionnary_software';
 

--- a/src/RuleImportAsset.php
+++ b/src/RuleImportAsset.php
@@ -49,7 +49,6 @@ class RuleImportAsset extends Rule
     const LINK_RESULT_LINK              = 2;
 
     public $restrict_matching = Rule::AND_MATCHING;
-    public $can_sort          = true;
 
     public static $rightname         = 'rule_import';
 

--- a/src/RuleImportComputer.php
+++ b/src/RuleImportComputer.php
@@ -43,7 +43,6 @@ class RuleImportComputer extends Rule
 
 
     public $restrict_matching = Rule::AND_MATCHING;
-    public $can_sort          = true;
 
     public static $rightname         = 'rule_import';
 

--- a/src/RuleImportEntity.php
+++ b/src/RuleImportEntity.php
@@ -40,7 +40,6 @@ class RuleImportEntity extends Rule
 {
    // From Rule
     public static $rightname = 'rule_import';
-    public $can_sort  = true;
 
     public function getTitle()
     {

--- a/src/RuleLocation.php
+++ b/src/RuleLocation.php
@@ -37,7 +37,6 @@
 class RuleLocation extends Rule
 {
     public static $rightname = 'rule_location';
-    public $can_sort  = true;
 
     public function getTitle()
     {

--- a/src/RuleMailCollector.php
+++ b/src/RuleMailCollector.php
@@ -38,8 +38,6 @@ class RuleMailCollector extends Rule
 {
    // From Rule
     public static $rightname = 'rule_mailcollector';
-    public $orderby   = "name";
-    public $can_sort  = true;
 
 
     /**

--- a/src/RuleRight.php
+++ b/src/RuleRight.php
@@ -44,7 +44,6 @@ class RuleRight extends Rule
 {
    // From Rule
     public static $rightname           = 'rule_ldap';
-    public $orderby             = "name";
     public $specific_parameters = true;
 
     /**

--- a/src/RuleSoftwareCategory.php
+++ b/src/RuleSoftwareCategory.php
@@ -44,7 +44,6 @@ class RuleSoftwareCategory extends Rule
 {
    // From Rule
     public static $rightname = 'rule_softwarecategories';
-    public $can_sort  = true;
 
 
     public function getTitle()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

It seems that `Rule::$can_sort` and `Rule::$orderby` properties are not working, or at least not on all contexts where they should. For instance, it seems that `RuleMailCollector` list is sorted and evaluated based on `ranking` field, while it is specified that it should be based on `name` field.

I propose to remove ability to override this, as it does not even seems to be used in plugins.

Now, all rule collections will be sortable and evaluated based on the way they are sorted.