### PR TITLE
fix(search): toggle is_deleted,as_map not working

### DIFF
--- a/src/Search/Input/QueryBuilder.php
+++ b/src/Search/Input/QueryBuilder.php
@@ -400,6 +400,7 @@ final class QueryBuilder implements SearchInputInterface
             : "";
 
         TemplateRenderer::getInstance()->display('components/search/query_builder/criteria.html.twig', [
+            'mainform'    => $p['mainform'],
             'from_meta'   => $from_meta,
             'meta'        => $criteria['meta'] ?? false,
             'sess_itemtype' => $sess_itemtype,

--- a/templates/components/search/query_builder/criteria.html.twig
+++ b/templates/components/search/query_builder/criteria.html.twig
@@ -53,7 +53,7 @@
       <div class="row g-1">
          {% if not from_meta %}
             {% if num == 0 and mainform is defined and mainform %}
-               {% set item = itemtype != 'AllAssets' ? call('getItemFromItemtype', [itemtype]) : null %}
+               {% set item = itemtype != 'AllAssets' ? call('getItemForItemtype', [itemtype]) : null %}
                {% if item is not null and item.maybeDeleted() %}
                   <input type="hidden" id="is_deleted" name="is_deleted" value="{{ p['is_deleted'] }}">
                {% endif %}


### PR DESCRIPTION
Toggle `is_deleted` or `as_map` did nothing on search page

![image](https://user-images.githubusercontent.com/8530352/216612165-1be0f756-beb2-4ae4-ae7f-7bc41126ac7d.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
