### PR TITLE
fix(savedsearch): incorrect is_default query

### DIFF
--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -788,7 +788,9 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
         $criteria = [
             'SELECT'    => [
                 "$table.*",
-                "$utable.id AS is_default"
+                new \QueryExpression(
+                    "IF($utable.users_id = " . Session::getLoginUserID() . ", $utable.id, NULL) AS is_default"
+                ),
             ],
             'FROM'      => $table,
             'LEFT JOIN' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13577
