### PR TITLE
Normalize console command namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ The present file will list all changes made to the project; according to the
   We added a compatibility layer to handle main usages found in plugins, but we cannot ensure compatibility with all properties and methods that were inherited from `PHPMailer\PHPMailer\PHPMailer`.
 - `CommonGLPI::createTabEntry()` signature changed.
 - All types of rules are now sortable and ordered by ranking.
+- Plugins console commands must now use the normalized prefix `plugins:XXX` where `XXX` is the plugin key.
 
 #### Deprecated
 - Usage of `GLPI_USE_CSRF_CHECK` constant.

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -518,4 +518,16 @@ class Application extends BaseApplication
 
         return true;
     }
+
+    public function extractNamespace(string $name, ?int $limit = null): string
+    {
+        $parts = explode(':', $name);
+
+        if ($limit === 1 && count($parts) >= 2 && $parts[0] === 'plugins') {
+            // Force grouping plugin commands
+            $limit = 2;
+        }
+
+        return implode(':', null === $limit ? $parts : \array_slice($parts, 0, $limit));
+    }
 }

--- a/src/Console/CommandLoader.php
+++ b/src/Console/CommandLoader.php
@@ -169,17 +169,35 @@ class CommandLoader implements CommandLoaderInterface
                 continue;
             }
 
-            $class = $this->getCommandClassnameFromFile(
+            $command = $this->getCommandFromFile(
                 $file,
                 $basedir,
                 ['', NS_GLPI]
             );
 
-            if (null === $class) {
+            if (null === $command) {
                  continue;
             }
 
-            $this->registerCommand(new $class());
+            $names = [$command->getName(), ...$command->getAliases()];
+            foreach ($names as $name) {
+                foreach (['tools', 'plugins'] as $protected_namespaces) {
+                    if (preg_match('/^' . $protected_namespaces . ':/', $name) === 1) {
+                        // Do not register commands that are using a protected pattern
+                        trigger_error(
+                            sprintf(
+                                'GLPI command `%s` must be moved outside the protected `%s` namespace.',
+                                $name,
+                                $protected_namespaces
+                            ),
+                            E_USER_WARNING
+                        );
+                        continue 2;
+                    }
+                }
+            }
+
+            $this->registerCommand($command);
         }
     }
 
@@ -225,6 +243,8 @@ class CommandLoader implements CommandLoaderInterface
                     continue;
                 }
 
+                $plugin_dirname = $plugin_directory->getFilename();
+
                 $plugin_files = new RecursiveIteratorIterator(
                     new RecursiveDirectoryIterator($plugin_basedir),
                     RecursiveIteratorIterator::SELF_FIRST
@@ -236,25 +256,46 @@ class CommandLoader implements CommandLoaderInterface
                         continue;
                     }
 
-                     // Prefixes can be:
-                     // - GlpiPlugin\Myplugin if class is namespaced
-                     // - PluginMyplugin if class is not namespaced nor PSR-4 compliant
-                     // - empty if class is not namespaced but PSR-4 compliant
-                     $class = $this->getCommandClassnameFromFile(
-                         $file,
-                         $plugin_basedir,
-                         [
-                             NS_PLUG . ucfirst($plugin_directory->getFilename()) . '\\',
-                             'Plugin' . ucfirst($plugin_directory->getFilename()),
-                             '',
-                         ]
-                     );
+                    // Prefixes can be:
+                    // - GlpiPlugin\Myplugin if class is namespaced
+                    // - PluginMyplugin if class is not namespaced nor PSR-4 compliant
+                    // - empty if class is not namespaced but PSR-4 compliant
+                    $command = $this->getCommandFromFile(
+                        $file,
+                        $plugin_basedir,
+                        [
+                            NS_PLUG . ucfirst($plugin_dirname) . '\\',
+                            'Plugin' . ucfirst($plugin_dirname),
+                            '',
+                        ]
+                    );
 
-                    if (null === $class) {
-                          continue;
+                    if (null === $command) {
+                         continue;
                     }
 
-                     $this->registerCommand(new $class());
+                    $expected_pattern = '/^'
+                        . 'plugins:'            // starts with `plugins:` prefix
+                        . $plugin_dirname       // followed by plugin key (directory name)
+                        . '(:[^:]+)+'           // followed by, at least, another command name part
+                        . '$/';
+                    $names = [$command->getName(), ...$command->getAliases()];
+                    foreach ($names as $name) {
+                        if (preg_match($expected_pattern, $name) !== 1) {
+                            // Do not register commands that are not using the expected prefix
+                            trigger_error(
+                                sprintf(
+                                    'Plugin command `%s` must be moved in the `plugins:%s` namespace.',
+                                    $name,
+                                    $plugin_dirname
+                                ),
+                                E_USER_WARNING
+                            );
+                            continue 2;
+                        }
+                    }
+
+                    $this->registerCommand($command);
                 }
             }
 
@@ -283,16 +324,35 @@ class CommandLoader implements CommandLoaderInterface
                 continue;
             }
 
-            $class = $this->getCommandClassnameFromFile(
+            $command = $this->getCommandFromFile(
                 $file,
                 $basedir
             );
 
-            if (null === $class) {
-                continue;
+            if (null === $command) {
+                 continue;
             }
 
-            $this->registerCommand(new $class());
+            $expected_pattern = '/^'
+                . 'tools'               // starts with `tools:` prefix
+                . '(:[^:]+)+'           // followed by, at least, another command name part
+                . '$/';
+            $names = [$command->getName(), ...$command->getAliases()];
+            foreach ($names as $name) {
+                if (preg_match($expected_pattern, $name) !== 1) {
+                    // Do not register commands that are not using the expected prefix
+                    trigger_error(
+                        sprintf(
+                            'Tools command `%s` must be moved in the `tools` namespace.',
+                            $name
+                        ),
+                        E_USER_WARNING
+                    );
+                    continue 2;
+                }
+            }
+
+            $this->registerCommand($command);
         }
     }
 
@@ -315,15 +375,15 @@ class CommandLoader implements CommandLoaderInterface
     }
 
     /**
-     * Return classname of command contained in file, if file contains one.
+     * Return class instance of command contained in file, if file contains one.
      *
      * @param SplFileInfo $file      File to inspect
      * @param string      $basedir   Directory containing classes (eg GLPI_ROOT . '/inc')
      * @param array       $prefixes  Possible prefixes to add to classname (eg 'PluginExample', 'GlpiPlugin\Example')
      *
-     * @return null|string
+     * @return null|Command
      */
-    private function getCommandClassnameFromFile(SplFileInfo $file, $basedir, array $prefixes = [])
+    private function getCommandFromFile(SplFileInfo $file, $basedir, array $prefixes = []): ?Command
     {
 
        // Check if file is readable
@@ -362,7 +422,7 @@ class CommandLoader implements CommandLoaderInterface
 
             $reflectionClass = new ReflectionClass($classname_to_check);
             if ($reflectionClass->isInstantiable() && $reflectionClass->isSubclassOf(Command::class)) {
-                return $classname_to_check;
+                return new $classname_to_check();
             }
         }
 

--- a/src/Console/Plugin/ListCommand.php
+++ b/src/Console/Plugin/ListCommand.php
@@ -51,8 +51,7 @@ class ListCommand extends AbstractCommand implements ForceNoPluginsOptionCommand
     {
         parent::configure();
 
-        $this->setName('glpi:plugin:list');
-        $this->setAliases(['plugin:list']);
+        $this->setName('plugin:list');
         $this->setDescription('List all plugins present in the plugins directory or from the marketplace');
 
         // Add option to change output format

--- a/tests/units/Glpi/Console/CommandLoader.php
+++ b/tests/units/Glpi/Console/CommandLoader.php
@@ -46,14 +46,13 @@ class CommandLoader extends \GLPITestCase
 
         $structure = [
             'src' => [
-            // Not instanciable case
+                // Not instanciable case
                 'AbstractCommand.php' => <<<PHP
 <?php
 abstract class AbstractCommand extends \\Symfony\\Component\\Console\\Command\\Command { }
-PHP
-            ,
+PHP,
 
-            // Base command case with alias
+                // Base command case with alias
                 'InstallCommand.php' => <<<PHP
 <?php
 class InstallCommand extends \\Symfony\\Component\\Console\\Command\\Command {
@@ -62,10 +61,9 @@ class InstallCommand extends \\Symfony\\Component\\Console\\Command\\Command {
       \$this->setAliases(['db:install']);
    }
 }
-PHP
-            ,
+PHP,
 
-            // Namespaced command case located in root of source dir
+                // Namespaced command case located in root of source dir
                 'ValidateCommand.php' => <<<PHP
 <?php
 namespace Glpi;
@@ -74,14 +72,13 @@ class ValidateCommand extends \\Symfony\\Component\\Console\\Command\\Command {
       \$this->setName('validate');
    }
 }
-PHP
-            ,
+PHP,
 
-            // Not a command case
+                // Not a command case
                 'SomeName.php' => '<?php class SomeName {}',
 
                 'Console' => [
-               // Namespaced command case
+                    // Namespaced command case
                     'TestCommand.php' => <<<PHP
 <?php
 namespace Glpi\\Console;
@@ -90,11 +87,11 @@ class TestCommand extends \\Symfony\\Component\\Console\\Command\\Command {
       \$this->setName('test');
    }
 }
-PHP
+PHP,
                 ],
             ],
             'tools' => [
-            // Base command case with alias
+                // Base command case with alias
                 'DebugCommand.php' => <<<PHP
 <?php
 class DebugCommand extends \\Symfony\\Component\\Console\\Command\\Command {
@@ -102,91 +99,108 @@ class DebugCommand extends \\Symfony\\Component\\Console\\Command\\Command {
       \$this->setName('tools:debug');
    }
 }
-PHP
-            ,
+PHP,
 
-            // Not a command case
+                // Not a command case
                 'oldscript.php' => '<?php echo("Hi!");',
             ],
             'plugins' => [
                 'awesome' => [
                     'inc' => [
-                  // Not recognized due to bad filename pattern
+                        // Not recognized due to bad filename pattern
                         'basecmd.class.php' => <<<PHP
 <?php
 class PluginAwesomeBaseCmd extends \\Symfony\\Component\\Console\\Command\\Command {
    protected function configure() {
-      \$this->setName('plugin_awesome:base');
+      \$this->setName('plugins:awesome:base');
    }
 }
-PHP
-                  ,
+PHP,
 
-                  // Plugin command case
+                        // Plugin command case
                         'updatecommand.class.php' => <<<PHP
 <?php
 class PluginAwesomeUpdateCommand extends \\Symfony\\Component\\Console\\Command\\Command {
    protected function configure() {
-      \$this->setName('plugin_awesome:update');
+      \$this->setName('plugins:awesome:update');
    }
 }
-PHP
-                  ,
+PHP,
 
-                  // Plugin namespaced command case (inside "inc" dir)
+                        // Plugin namespaced command case (inside "inc" dir)
                         'namespacedcommand.class.php' => <<<PHP
 <?php
 namespace GlpiPlugin\\Awesome;
 class NamespacedCommand extends \\Symfony\\Component\\Console\\Command\\Command {
    protected function configure() {
-      \$this->setName('plugin_awesome:namespaced');
+      \$this->setName('plugins:awesome:namespaced');
    }
 }
-PHP
-                  ,
+PHP,
 
                         'console' => [
-                     // Plugin namespaced command case (inside a sub dir)
+                            // Plugin namespaced command case (inside a sub dir)
                             'anothercommand.class.php' => <<<PHP
 <?php
 namespace GlpiPlugin\\Awesome\\Console;
 class AnotherCommand extends \\Symfony\\Component\\Console\\Command\\Command {
    protected function configure() {
-      \$this->setName('plugin_awesome:another');
+      \$this->setName('plugins:awesome:another');
    }
 }
-PHP
+PHP,
                         ],
                     ],
                     'src' => [
-                  // Plugin PSR-4 compliant with namespace command case
+                        // Plugin PSR-4 compliant with namespace command case
                         'PluginAwesomePsr4Command.php' => <<<PHP
 <?php
 class PluginAwesomePsr4Command extends \\Symfony\\Component\\Console\\Command\\Command {
    protected function configure() {
-      \$this->setName('plugin_awesome:psr4');
+      \$this->setName('plugins:awesome:psr4');
    }
 }
-PHP
-                  ,
+PHP,
 
                         'Console' => [
-                     // Plugin PSR-4 compliant without namespace command case
+                            // Plugin PSR-4 compliant without namespace command case
                             'YetAnotherCommand.php' => <<<PHP
 <?php
 namespace GlpiPlugin\\Awesome\\Console;
 class YetAnotherCommand extends \\Symfony\\Component\\Console\\Command\\Command {
    protected function configure() {
-      \$this->setName('plugin_awesome:yetanother');
+      \$this->setName('plugins:awesome:yetanother');
    }
 }
-PHP
+PHP,
+
+                            // Misnamed command
+                            'MisnamedCommand.php' => <<<PHP
+<?php
+namespace GlpiPlugin\\Awesome\\Console;
+class MisnamedCommand extends \\Symfony\\Component\\Console\\Command\\Command {
+   protected function configure() {
+      \$this->setName('awesome:misnamed');
+   }
+}
+PHP,
+
+                            // Command located in another plugin namespace
+                            'FooBarCommand.php' => <<<PHP
+<?php
+namespace GlpiPlugin\\Awesome\\Console;
+class FooBarCommand extends \\Symfony\\Component\\Console\\Command\\Command {
+   protected function configure() {
+      \$this->setName('plugins:anotherplugin:foobar');
+   }
+}
+PHP,
                         ],
                     ],
                 ],
                 'misc' => [
                     'inc' => [
-                  // Not a command case
+                        // Not a command case
                         'misc.class.php' => '<?php class PluginMiscMisc {}',
                     ]
                 ],
@@ -196,57 +210,54 @@ PHP
                     'plugins' => [
                         'random' => [
                             'inc' => [
-                        // Not recognized due to bad filename pattern
+                                // Not recognized due to bad filename pattern
                                 'testcmd.class.php' => <<<PHP
 <?php
 class PluginRandomTestCmd extends \\Symfony\\Component\\Console\\Command\\Command {
    protected function configure() {
-      \$this->setName('plugin_random:test');
+      \$this->setName('plugins:random:test');
    }
 }
-PHP
-                        ,
+PHP,
 
-                        // Plugin command case
+                                // Plugin command case
                                 'randomcommand.class.php' => <<<PHP
 <?php
 class PluginRandomRandomCommand extends \\Symfony\\Component\\Console\\Command\\Command {
    protected function configure() {
-      \$this->setName('plugin_random:random');
+      \$this->setName('plugins:random:random');
    }
 }
-PHP
-                        ,
+PHP,
 
-                        // Plugin namespaced command case (inside "inc" dir)
+                                // Plugin namespaced command case (inside "inc" dir)
                                 'checkcommand.class.php' => <<<PHP
 <?php
 namespace GlpiPlugin\\Random;
 class CheckCommand extends \\Symfony\\Component\\Console\\Command\\Command {
    protected function configure() {
-      \$this->setName('plugin_random:check');
+      \$this->setName('plugins:random:check');
    }
 }
-PHP
-                        ,
+PHP,
 
                                 'console' => [
-                           // Plugin namespaced command case (inside a sub dir)
+                                    // Plugin namespaced command case (inside a sub dir)
                                     'foocommand.class.php' => <<<PHP
 <?php
 namespace GlpiPlugin\\Random\\Console;
 class FooCommand extends \\Symfony\\Component\\Console\\Command\\Command {
    protected function configure() {
-      \$this->setName('plugin_random:foo');
+      \$this->setName('plugins:random:foo');
    }
 }
-PHP
+PHP,
                                 ],
                             ],
                         ],
                         'misc' => [
                             'inc' => [
-                        // Not a command case
+                                // Not a command case
                                 'something.class.php' => '<?php class PluginRandomSomething {}',
                             ]
                         ],
@@ -265,31 +276,42 @@ PHP
         ];
 
         $plugins_names_to_class = [
-            'plugin_awesome:update'     => 'PluginAwesomeUpdateCommand',
-            'plugin_awesome:namespaced' => 'GlpiPlugin\\Awesome\\NamespacedCommand',
-            'plugin_awesome:another'    => 'GlpiPlugin\\Awesome\\Console\\AnotherCommand',
-            'plugin_awesome:psr4'       => 'PluginAwesomePsr4Command',
-            'plugin_awesome:yetanother' => 'GlpiPlugin\\Awesome\\Console\\YetAnotherCommand',
-            'plugin_random:random'      => 'PluginRandomRandomCommand',
-            'plugin_random:check'       => 'GlpiPlugin\\Random\\CheckCommand',
-            'plugin_random:foo'         => 'GlpiPlugin\\Random\\Console\\FooCommand',
+            'plugins:awesome:update'     => 'PluginAwesomeUpdateCommand',
+            'plugins:awesome:namespaced' => 'GlpiPlugin\\Awesome\\NamespacedCommand',
+            'plugins:awesome:another'    => 'GlpiPlugin\\Awesome\\Console\\AnotherCommand',
+            'plugins:awesome:psr4'       => 'PluginAwesomePsr4Command',
+            'plugins:awesome:yetanother' => 'GlpiPlugin\\Awesome\\Console\\YetAnotherCommand',
+            'plugins:random:random'      => 'PluginRandomRandomCommand',
+            'plugins:random:check'       => 'GlpiPlugin\\Random\\CheckCommand',
+            'plugins:random:foo'         => 'GlpiPlugin\\Random\\Console\\FooCommand',
         ];
 
         $all_names_to_class = array_merge($core_names_to_class, $plugins_names_to_class);
 
-       // Mock plugin
+        // Mock plugin
         $plugin = $this->newMockInstance('Plugin');
         $this->calling($plugin)->isActivated = true;
 
-       // Check with plugins
-        $command_loader = new \Glpi\Console\CommandLoader(true, vfsStream::url('glpi'), $plugin);
-        $this->array($command_loader->getNames())->isIdenticalTo(array_keys($all_names_to_class));
-        foreach ($all_names_to_class as $name => $classname) {
-            $this->boolean($command_loader->has($name))->isTrue();
-            $this->object($command_loader->get($name))->isInstanceOf($classname);
-        }
+        // Check with plugins
+        $this->when(
+            function () use ($plugin, $all_names_to_class) {
+                $command_loader = new \Glpi\Console\CommandLoader(true, vfsStream::url('glpi'), $plugin);
+                $this->array($command_loader->getNames())->isIdenticalTo(array_keys($all_names_to_class));
+                foreach ($all_names_to_class as $name => $classname) {
+                    $this->boolean($command_loader->has($name))->isTrue();
+                    $this->object($command_loader->get($name))->isInstanceOf($classname);
+                }
+            }
+        )->error()
+            ->withType(E_USER_WARNING)
+            ->withMessage('Plugin command `awesome:misnamed` must be moved in the `plugins:awesome` namespace.')
+            ->exists()
+         ->error()
+            ->withType(E_USER_WARNING)
+            ->withMessage('Plugin command `plugins:anotherplugin:foobar` must be moved in the `plugins:awesome` namespace.')
+            ->exists();
 
-       // Check without plugins
+        // Check without plugins
         $command_loader = new \Glpi\Console\CommandLoader(false, vfsStream::url('glpi'), $plugin);
         $this->array($command_loader->getNames())->isIdenticalTo(array_keys($core_names_to_class));
         foreach ($core_names_to_class as $name => $classname) {
@@ -297,12 +319,24 @@ PHP
             $this->object($command_loader->get($name))->isInstanceOf($classname);
         }
 
-       // Check async plugin registration
-        $command_loader->setIncludePlugins(true);
-        $this->array($command_loader->getNames())->isIdenticalTo(array_keys($all_names_to_class));
-        foreach ($all_names_to_class as $name => $classname) {
-            $this->boolean($command_loader->has($name))->isTrue();
-            $this->object($command_loader->get($name))->isInstanceOf($classname);
-        }
+        // Check async plugin registration
+        $this->when(
+            function () use ($plugin, $all_names_to_class) {
+                $command_loader = new \Glpi\Console\CommandLoader(false, vfsStream::url('glpi'), $plugin);
+                $command_loader->setIncludePlugins(true);
+                $this->array($command_loader->getNames())->isIdenticalTo(array_keys($all_names_to_class));
+                foreach ($all_names_to_class as $name => $classname) {
+                    $this->boolean($command_loader->has($name))->isTrue();
+                    $this->object($command_loader->get($name))->isInstanceOf($classname);
+                }
+            }
+        )->error()
+            ->withType(E_USER_WARNING)
+            ->withMessage('Plugin command `awesome:misnamed` must be moved in the `plugins:awesome` namespace.')
+            ->exists()
+         ->error()
+            ->withType(E_USER_WARNING)
+            ->withMessage('Plugin command `plugins:anotherplugin:foobar` must be moved in the `plugins:awesome` namespace.')
+            ->exists();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Purpose of this PR is to:
1. ensure plugins commands are grouped in their own namespace (see image below);
2. prevent conflics between GLPI base commands, GLPI tools commands and plugins commands, each having their own reserved namespace.

![image](https://user-images.githubusercontent.com/33253653/216932316-de9446f8-bea1-471a-bb82-e76ccb4cf210.png)

EDIT: To be reviewed without whitespace changes.