### PR TITLE
Add 64 bits integer support as optional requirement

### DIFF
--- a/src/System/Requirement/IntegerSize.php
+++ b/src/System/Requirement/IntegerSize.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\System\Requirement;
+
+final class IntegerSize extends AbstractRequirement
+{
+    public function __construct()
+    {
+        $this->title = __('PHP maximal integer size');
+        $this->description = __('Support of 64 bits integers is required for IP addresses related operations (network inventory, API clients IP filtering, ...).');
+        $this->optional = true;
+    }
+
+    protected function check()
+    {
+        if (PHP_INT_SIZE < 8) {
+            $this->validated = false;
+            $this->validation_messages[] = __('OS or PHP is not relying on 64 bits integers, operations on IP addresses may produce unexpected results.');
+        } else {
+            $this->validated = true;
+            $this->validation_messages[] = __('OS and PHP are relying on 64 bits integers.');
+        }
+    }
+}

--- a/src/System/RequirementsManager.php
+++ b/src/System/RequirementsManager.php
@@ -44,6 +44,7 @@ use Glpi\System\Requirement\Extension;
 use Glpi\System\Requirement\ExtensionConstant;
 use Glpi\System\Requirement\ExtensionGroup;
 use Glpi\System\Requirement\InstallationNotOverriden;
+use Glpi\System\Requirement\IntegerSize;
 use Glpi\System\Requirement\LogsWriteAccess;
 use Glpi\System\Requirement\MemoryLimit;
 use Glpi\System\Requirement\MysqliMysqlnd;
@@ -138,6 +139,7 @@ class RequirementsManager
        // Below requirements are optionals
 
         $requirements[] = new SessionsSecurityConfiguration();
+        $requirements[] = new IntegerSize();
         $requirements[] = new Extension(
             'exif',
             true,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

See #13980. `ip2long` produces unexpected result on 32 bits OS (see https://www.php.net/manual/fr/function.ip2long.php#refsect1-function.ip2long-notes). It may be possible to fix this, but I am not sure it is worth the cost, especially if we have to maintain a 32 bits environment in our test suite just for this.

I think we could move this requirement from optional to mandatory in next GLPI major version, but we have to do some checks on Windows platforms first. Indeed, on [this thread](https://stackoverflow.com/a/27865372), someone says that PHP on Windows is always using 32 bits integers, but I do not know if it is a fact on all Windows platforms (including Windows server and Windows Professional version) or only on some limited plaforms (e.g. Windows Family versions).