### PR TITLE
Planning: fix task edition

### DIFF
--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -1418,6 +1418,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             'item'               => $options['parent'],
             'subitem'            => $this,
             'has_pending_reason' => PendingReason_Item::getForItem($options['parent']) !== false,
+            'params'             => $options,
         ]);
 
         return true;

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -1278,7 +1278,8 @@ class Planning extends CommonGLPI
 
     public static function editEventForm($params = [])
     {
-        if (!$params['itemtype'] instanceof CommonDBTM) {
+        $item = getItemForItemtype($params['itemtype']);
+        if ($item instanceof CommonDBTM) {
             echo "<div class='center'>";
             echo "<a href='" . $params['url'] . "' class='btn btn-outline-secondary'>" .
                 "<i class='ti ti-eye'></i>" .
@@ -1296,7 +1297,6 @@ class Planning extends CommonGLPI
                 $options['parent'] = getItemForItemtype($params['parentitemtype']);
                 $options['parent']->getFromDB($params['parentid']);
             }
-            $item = getItemForItemtype($params['itemtype']);
             $item->getFromDB((int) $params['id']);
             $item->showForm((int)$params['id'], $options);
             $callback = "glpi_close_all_dialogs();

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -41,6 +41,7 @@
 {% set can_update_kb = has_profile_right('knowbase', constant('UPDATE')) %}
 {% set nokb = params['nokb'] is defined or params['nokb'] == true %}
 {% set rand = random() %}
+{% set formoptions  = params['formoptions'] ?? '' %}
 
 {% block timeline_card %}
    {% if form_mode == 'view' %}
@@ -154,7 +155,7 @@
    {% else %}
       <div class="itiltask">
          <form name="asset_form" style="width: 100%;" class="d-flex flex-column" method="post"
-               action="{{ subitem.getFormURL() }}" enctype="multipart/form-data" data-track-changes="true" data-submit-once>
+               action="{{ subitem.getFormURL() }}"  enctype="multipart/form-data" data-track-changes="true" data-submit-once {{ formoptions|raw }}>
             <input type="hidden" name="itemtype" value="{{ item.getType() }}" />
             <input type="hidden" name="{{ item.getForeignKeyField() }}" value="{{ item.fields['id'] }}" />
             {{ call_plugin_hook('pre_item_form', {"item": subitem, 'options': params}) }}


### PR DESCRIPTION
When editing a task on the planning, clicking the "save" button should save the content using AJAX and close the modal:

![image](https://user-images.githubusercontent.com/42734840/216989086-4b0becc8-38aa-4835-8130-0784965d6a11.png)

On GLPI 10, the form is POSTed instead and we are redirected to the parent ticket/change/problem page.

After inspecting the code, we do specify correctly that the form should be handled through AJAX:

![image](https://user-images.githubusercontent.com/42734840/216989959-33921d67-3a08-4f1f-bb33-2590c76f84c2.png)

Note the `'formoptions' => "id='edit_event_form$rand'",` above that must match the ID passed to `Html::ajaxForm()`.
This is needed as the ID will be used to bind to the submit event.

This `formoptions` is handled correctly in the `generic_show_form` template but not in the specific template for tasks (which create our issue).

Fixed in 695117262103f865f46e9b125a5c0f1c667540bc by handling the option the same way it is done in `generic_show_form.html.twig`

I've also noticed the condition at the start doesn't make sense:

![image](https://user-images.githubusercontent.com/42734840/216991175-6a8db4d5-96c5-4866-8a33-96425fb44978.png)

1) `$params['itemtype']` is a string, it will never be a CommonDBTM instance (condition is always true)
2) The code below seems to be made to handle CommonDBTM so the condition should in fact validate that the item **is** a CommonDBTM (the current code would check the opposite *if it was working properly*).

Fixed in  https://github.com/glpi-project/glpi/commit/d63eda06799f8fc377be2fb702820d9923e92284

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26393
