### PR TITLE
fix(Device): enable history on update

### DIFF
--- a/src/Inventory/Asset/Device.php
+++ b/src/Inventory/Asset/Device.php
@@ -159,7 +159,7 @@ abstract class Device extends InventoryAsset
                             'items_id'           => $this->item->fields['id'],
                             'is_dynamic'         => 1
                         ] + $this->handleInput($val, $itemdevice);
-                        $itemdevice->update(Sanitizer::sanitize($itemdevice_data), false);
+                        $itemdevice->update(Sanitizer::sanitize($itemdevice_data), true);
                         unset($existing[$device_id][$key]);
                         break;
                     }


### PR DESCRIPTION
When a ```Item_DeviceXXX``` is updated by inventory, history is disabled.

So we do not have the history of what is updated.

this PR fix this.

![image](https://user-images.githubusercontent.com/7335054/217165531-dea3e94d-5389-4988-bfec-0c8622a0720e.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
