### PR TITLE
fix(ticket): filtering the dropdown of changes

### DIFF
--- a/src/Change_Problem.php
+++ b/src/Change_Problem.php
@@ -170,7 +170,8 @@ class Change_Problem extends CommonDBRelation
                     'entity'      => $problem->getEntityID(),
                     'entity_sons' => $problem->isRecursive(),
                     'used'        => $used,
-                    'displaywith' => ['id']
+                    'displaywith' => ['id'],
+                    'condition'   => Change::getOpenCriteria(),
                 ],
                 'create_link' => Session::haveRight(Change::$rightname, CREATE)
             ]);
@@ -280,7 +281,8 @@ class Change_Problem extends CommonDBRelation
                     'entity'      => $change->getEntityID(),
                     'entity_sons' => $change->isRecursive(),
                     'used'        => $used,
-                    'displaywith' => ['id']
+                    'displaywith' => ['id'],
+                    'condition'   => Problem::getOpenCriteria(),
                 ],
                 'create_link' => false
             ]);

--- a/src/Change_Problem.php
+++ b/src/Change_Problem.php
@@ -281,8 +281,7 @@ class Change_Problem extends CommonDBRelation
                     'entity'      => $change->getEntityID(),
                     'entity_sons' => $change->isRecursive(),
                     'used'        => $used,
-                    'displaywith' => ['id'],
-                    'condition'   => Problem::getOpenCriteria(),
+                    'displaywith' => ['id']
                 ],
                 'create_link' => false
             ]);

--- a/src/Change_Ticket.php
+++ b/src/Change_Ticket.php
@@ -279,7 +279,8 @@ class Change_Ticket extends CommonDBRelation
                     'entity'      => $change->getEntityID(),
                     'entity_sons' => $change->isRecursive(),
                     'used'        => $used,
-                    'displaywith' => ['id']
+                    'displaywith' => ['id'],
+                    'condition'   => Ticket::getOpenCriteria(),
                 ],
                 'create_link' => false
             ]);
@@ -405,7 +406,8 @@ class Change_Ticket extends CommonDBRelation
                     'entity'      => $ticket->getEntityID(),
                     'entity_sons' => $ticket->isRecursive(),
                     'used'        => $used,
-                    'displaywith' => ['id']
+                    'displaywith' => ['id'],
+                    'condition'   => Change::getOpenCriteria(),
                 ],
                 'create_link' => Session::haveRight(Change::$rightname, CREATE)
             ]);

--- a/src/Change_Ticket.php
+++ b/src/Change_Ticket.php
@@ -279,8 +279,7 @@ class Change_Ticket extends CommonDBRelation
                     'entity'      => $change->getEntityID(),
                     'entity_sons' => $change->isRecursive(),
                     'used'        => $used,
-                    'displaywith' => ['id'],
-                    'condition'   => Ticket::getOpenCriteria(),
+                    'displaywith' => ['id']
                 ],
                 'create_link' => false
             ]);

--- a/src/Problem_Ticket.php
+++ b/src/Problem_Ticket.php
@@ -308,7 +308,6 @@ class Problem_Ticket extends CommonDBRelation
                     'entity_sons' => $problem->isRecursive(),
                     'used'        => $used,
                     'displaywith' => ['id'],
-                    'condition'   => Ticket::getOpenCriteria(),
                 ],
                 'create_link' => false
             ]);

--- a/src/Problem_Ticket.php
+++ b/src/Problem_Ticket.php
@@ -308,6 +308,7 @@ class Problem_Ticket extends CommonDBRelation
                     'entity_sons' => $problem->isRecursive(),
                     'used'        => $used,
                     'displaywith' => ['id'],
+                    'condition'   => Ticket::getOpenCriteria(),
                 ],
                 'create_link' => false
             ]);


### PR DESCRIPTION
The dropdown to link a change to a ticket did not filter out resolved and closed statuses.

![image](https://user-images.githubusercontent.com/8530352/217206441-13ae95e4-5871-45bd-971f-9e44336bdcc7.png)

_Same thing between change/problem and problem/ticket_

Considering the `Ticket` < `Problem` < `Change` hierarchy, we can associate a closed element when going down the hierarchy, but not when going up.
Example: We can associate a closed ticket from a change, but we cannot associate a closed change from a ticket.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26630
