### PR TITLE
Allow sending of multiple notifications for a same recipient

### DIFF
--- a/src/Notification.php
+++ b/src/Notification.php
@@ -644,17 +644,29 @@ class Notification extends CommonDBTM
      * @param string $itemtype Item type
      * @param int    $entity   Restrict to entity
      *
-     * @return ResultSet
-     **/
+     * @return array
+     */
     public static function getNotificationsByEventAndType($event, $itemtype, $entity)
     {
         global $DB, $CFG_GLPI;
+
+        $modes = Notification_NotificationTemplate::getModes();
+        $restrict_modes = [];
+        foreach (array_keys($modes) as $mode) {
+            if ($CFG_GLPI['notifications_' . $mode]) {
+                $restrict_modes[] = $mode;
+            }
+        }
+        if (count($restrict_modes) === 0) {
+            return [];
+        }
 
         $criteria = [
             'SELECT'    => [
                 Notification::getTable() . '.*',
                 Notification_NotificationTemplate::getTable() . '.mode',
-                Notification_NotificationTemplate::getTable() . '.notificationtemplates_id'
+                Notification_NotificationTemplate::getTable() . '.notificationtemplates_id',
+                Entity::getTable() . '.level',
             ],
             'FROM'      => Notification::getTable(),
             'LEFT JOIN' => [
@@ -672,8 +684,9 @@ class Notification extends CommonDBTM
                 ]
             ],
             'WHERE'     => [
-                Notification::getTable() . '.itemtype' => $itemtype,
-                Notification::getTable() . '.event'    => $event,
+                Notification_NotificationTemplate::getTable() . '.mode' => $restrict_modes,
+                Notification::getTable() . '.itemtype'  => $itemtype,
+                Notification::getTable() . '.event'     => $event,
                 Notification::getTable() . '.is_active' => 1,
             ] + getEntitiesRestrictCriteria(
                 Notification::getTable(),
@@ -684,18 +697,17 @@ class Notification extends CommonDBTM
             'ORDER'     => Entity::getTable() . '.level DESC'
         ];
 
-        $modes = Notification_NotificationTemplate::getModes();
-        $restrict_modes = [];
-        foreach ($modes as $mode => $conf) {
-            if ($CFG_GLPI['notifications_' . $mode]) {
-                $restrict_modes[] = $mode;
-            }
-        }
-        if (count($restrict_modes)) {
-            $criteria['WHERE'][Notification_NotificationTemplate::getTable() . '.mode'] = $restrict_modes;
+        $result = $DB->request($criteria);
+        if ($result->count() === 0) {
+            return [];
         }
 
-        return $DB->request($criteria);
+        $notifications = iterator_to_array($result);
+        $max_level = max(array_column($notifications, 'level'));
+        return array_filter(
+            $notifications,
+            fn($notification) => $notification['level'] === $max_level
+        );
     }
 
 

--- a/tests/functionnal/Glpi/RichText/UserMention.php
+++ b/tests/functionnal/Glpi/RichText/UserMention.php
@@ -56,9 +56,9 @@ class UserMention extends DbTestCase
         $tech_id = getItemByTypeName('User', 'tech', true);
         $normal_id = getItemByTypeName('User', 'normal', true);
 
-       // Delete existing notifications targets (to prevent sending of notifications not related to user_mention)
-        $notification_targets = new NotificationTarget();
-        $notification_targets->deleteByCriteria(['NOT' => ['items_id' => Notification::MENTIONNED_USER]]);
+        // Disable default notifications
+        global $DB;
+        $DB->update(\Notification::getTable(), ['is_active' => 0], ['is_active' => '1']);
 
        // Add email to users for notifications
         $user = new User();
@@ -297,9 +297,12 @@ HTML
         $tech_id = getItemByTypeName('User', 'tech', true);
         $normal_id = getItemByTypeName('User', 'normal', true);
 
-       // Delete existing notifications targets (to prevent sending of notifications not related to user_mention)
-        $notification_targets = new NotificationTarget();
-        $notification_targets->deleteByCriteria(['NOT' => ['items_id' => Notification::MENTIONNED_USER]]);
+        // Disable default notifications
+        global $DB;
+        $DB->update(\Notification::getTable(), ['is_active' => 0], ['is_active' => '1']);
+
+        // Create test notification
+        $this->createNotification(\Ticket::class);
 
        // Add email to users for notifications
         $user = new User();

--- a/tests/functionnal/NotificationEvent.php
+++ b/tests/functionnal/NotificationEvent.php
@@ -1,0 +1,334 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use DbTestCase;
+
+class NotificationEvent extends DbTestCase
+{
+    protected function raiseEventProvider(): iterable
+    {
+        global $DB, $CFG_GLPI;
+
+        $this->login();
+
+        $entity_id_root       = getItemByTypeName(\Entity::class, '_test_root_entity', true);
+        $entity_id_child1     = getItemByTypeName(\Entity::class, '_test_child_1', true);
+        $entity_id_subchild11 = $this->createItem(\Entity::class, ['name' => '_test_subchild_1.1', 'entities_id' => $entity_id_child1])->getID();
+        $entity_id_child2     = getItemByTypeName(\Entity::class, '_test_child_2', true);
+        $tech_user_id         = getItemByTypeName(\User::class, 'tech', true);
+
+        // Ensure notifications are sent
+        $CFG_GLPI['use_notifications']     = true;
+        $CFG_GLPI['notifications_mailing'] = true;
+
+        // Disable base notification
+        $DB->update(\Notification::getTable(), ['is_active' => 0], ['is_active' => 1]);
+
+        // Create notifications templates
+        $new_ticket_template = $this->createItem(
+            \NotificationTemplate::class,
+            [
+                'name'     => $this->getUniqueString(),
+                'itemtype' => \Ticket::class,
+            ]
+        );
+        $this->createItem(
+            \NotificationTemplateTranslation::class,
+            [
+                'notificationtemplates_id' => $new_ticket_template->getID(),
+                'language'                 => '',
+                'subject'                  => 'Ticket created',
+                'content_text'             => '...',
+                'content_html'             => '...',
+            ]
+        );
+        $assigned_template = $this->createItem(
+            \NotificationTemplate::class,
+            [
+                'name'     => $this->getUniqueString(),
+                'itemtype' => \Ticket::class,
+            ]
+        );
+        $this->createItem(
+            \NotificationTemplateTranslation::class,
+            [
+                'notificationtemplates_id' => $assigned_template->getID(),
+                'language'                 => '',
+                'subject'                  => 'You are assigned!',
+                'content_text'             => '...',
+                'content_html'             => '...',
+            ]
+        );
+        $new_project_template = $this->createItem(
+            \NotificationTemplate::class,
+            [
+                'name'     => $this->getUniqueString(),
+                'itemtype' => \Project::class,
+            ]
+        );
+        $this->createItem(
+            \NotificationTemplateTranslation::class,
+            [
+                'notificationtemplates_id' => $new_project_template->getID(),
+                'language'                 => '',
+                'subject'                  => 'Project created',
+                'content_text'             => '...',
+                'content_html'             => '...',
+            ]
+        );
+
+        // Create notifications for assigned user at different entity level
+        $notifications_specs = [
+            // Notifications on '_test_root_entity'
+            [
+                // Keep this one to check that notification is sent only on matching itemtype
+                'name'         => 'Project created in _test_root_entity + child entities',
+                'entities_id'  => $entity_id_root,
+                'is_recursive' => 1,
+                'is_active'    => 1,
+                'itemtype'     => \Project::class,
+                'event'        => 'new',
+                '_notificationtemplates_id' => $new_project_template->getID(),
+            ],
+            [
+                'name'         => 'Ticket created in _test_root_entity + child entities',
+                'entities_id'  => $entity_id_root,
+                'is_recursive' => 1,
+                'is_active'    => 1,
+                'itemtype'     => \Ticket::class,
+                'event'        => 'new',
+                '_notificationtemplates_id' => $new_ticket_template->getID(),
+            ],
+            [
+                'name'         => 'Ticket created in _test_root_entity + child entities (duplicate that should be ignored)',
+                'entities_id'  => $entity_id_root,
+                'is_recursive' => 1,
+                'is_active'    => 1,
+                'itemtype'     => \Ticket::class,
+                'event'        => 'new',
+                '_notificationtemplates_id' => $new_ticket_template->getID(),
+            ],
+            [
+                'name'         => 'You are assigned in _test_root_entity',
+                'entities_id'  => $entity_id_root,
+                'is_recursive' => 0,
+                'is_active'    => 1,
+                'itemtype'     => \Ticket::class,
+                'event'        => 'new',
+                '_notificationtemplates_id' => $assigned_template->getID(),
+            ],
+
+            // Notifications on '_test_child_1'
+            [
+                // Active, so should override parent entities config
+                'name'         => 'You are assigned in _test_child_1',
+                'entities_id'  => $entity_id_child1,
+                'is_recursive' => 0,
+                'is_active'    => 1,
+                'itemtype'     => \Ticket::class,
+                'event'        => 'new',
+                '_notificationtemplates_id' => $assigned_template->getID(),
+            ],
+
+            // Notifications on '_test_child_2'
+            // Not active, so should not override parent entities config
+            [
+                'name'         => 'You are assigned in _test_child_2',
+                'entities_id'  => $entity_id_child2,
+                'is_recursive' => 0,
+                'is_active'    => 0,
+                'itemtype'     => \Ticket::class,
+                'event'        => 'new',
+                '_notificationtemplates_id' => $assigned_template->getID(),
+            ],
+        ];
+        foreach ($notifications_specs as $notification_specs) {
+            $notification = $this->createItem(
+                \Notification::class,
+                $notification_specs
+            );
+            $this->createItem(
+                \Notification_NotificationTemplate::class,
+                [
+                    'notifications_id'         => $notification->getID(),
+                    'mode'                     => \Notification_NotificationTemplate::MODE_MAIL,
+                    'notificationtemplates_id' => $notification_specs['_notificationtemplates_id'],
+                ]
+            );
+            $this->createItem(
+                \NotificationTarget::class,
+                [
+                    'notifications_id' => $notification->getID(),
+                    'items_id'         => \Notification::ASSIGN_TECH,
+                    'type'             => 1,
+                ]
+            );
+        }
+
+        $common_input = [
+            'name'          => $this->getUniqueString(),
+            'content'       => $this->getUniqueString(),
+            '_disablenotif' => true, // disable notifications, will be raised manually
+        ];
+
+        // When ticket is created on '_test_root_entity' entity, assignee will receive 2 notifications
+        // -> 'Ticket created in _test_root_entity + child entities'
+        // -> 'You are assigned in _test_root_entity'
+        yield [
+            'event'    => 'new',
+            'item'     => $this->createItem(
+                \Ticket::class,
+                $common_input + [
+                    'entities_id'            => $entity_id_root,
+                    '_users_id_assign'       => ["$tech_user_id"],
+                    '_users_id_assign_notif' => [
+                        'use_notification'   => ['1'],
+                        'alternative_email'  => ['tech@domain.tld'],
+                    ],
+                ]
+            ),
+            'expected' => [
+                [
+                    'notificationtemplates_id' => $new_ticket_template->getID(),
+                    'recipientname'            => 'tech',
+                ],
+                [
+                    'notificationtemplates_id' => $assigned_template->getID(),
+                    'recipientname'            => 'tech',
+                ],
+            ],
+        ];
+
+        // When ticket is created on '_test_child_1' entity, assignee will only receive notifications defined
+        // in '_test_child_1' entity, but not those defined in '_test_root_entity' entity + child entities
+        // as we consider that defining an active notification in one entity overrides the whole configuration of parent entities
+        // -> 'You are assigned in _test_child_1'
+        yield [
+            'event'    => 'new',
+            'item'     => $this->createItem(
+                \Ticket::class,
+                $common_input + [
+                    'entities_id'            => $entity_id_child1,
+                    '_users_id_assign'       => ["$tech_user_id"],
+                    '_users_id_assign_notif' => [
+                        'use_notification'   => ['1'],
+                        'alternative_email'  => ['tech@domain.tld'],
+                    ],
+                ]
+            ),
+            'expected' => [
+                [
+                    'notificationtemplates_id' => $assigned_template->getID(),
+                    'recipientname'            => 'tech',
+                ],
+            ],
+        ];
+
+        // When ticket is created on '_test_subchild_1.1' entity, assignee will receive notifications defined in
+        // '_test_root_entity' entity + child entities because notifications defined on closest level are not visible
+        // from '_test_subchild_1.1' entity
+        // -> 'Ticket created in _test_root_entity + child entities'
+        yield [
+            'event'    => 'new',
+            'item'     => $this->createItem(
+                \Ticket::class,
+                $common_input + [
+                    'entities_id'            => $entity_id_subchild11,
+                    '_users_id_assign'       => ["$tech_user_id"],
+                    '_users_id_assign_notif' => [
+                        'use_notification'   => ['1'],
+                        'alternative_email'  => ['tech@domain.tld'],
+                    ],
+                ]
+            ),
+            'expected' => [
+                [
+                    'notificationtemplates_id' => $new_ticket_template->getID(),
+                    'recipientname'            => 'tech',
+                ],
+            ],
+        ];
+
+        // When ticket is created on '_test_child_2' entity, assignee will receive notifications defined
+        // in '_test_root_entity' entity + child entities, because notification defined in '_test_child_2' is inactive
+        // and therefore is ignored
+        // -> 'You are assigned in _test_root_entity'
+        yield [
+            'event'    => 'new',
+            'item'     => $this->createItem(
+                \Ticket::class,
+                $common_input + [
+                    'entities_id'            => $entity_id_child2,
+                    '_users_id_assign'       => ["$tech_user_id"],
+                    '_users_id_assign_notif' => [
+                        'use_notification'   => ['1'],
+                        'alternative_email'  => ['tech@domain.tld'],
+                    ],
+                ]
+            ),
+            'expected' => [
+                [
+                    'notificationtemplates_id' => $new_ticket_template->getID(),
+                    'recipientname'            => 'tech',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataprovider raiseEventProvider
+     */
+    public function testRaiseEvent(string $event, \CommonDBTM $item, array $expected): void
+    {
+        global $DB;
+
+        // Clean queued notifications
+        $DB->update(\QueuedNotification::getTable(), ['is_deleted' => 1], ['is_deleted' => 0]);
+
+        // Raise event
+        $this->boolean(\NotificationEvent::raiseEvent('new', $item))->isTrue();
+
+        // Check created notifications
+        $notifications = getAllDataFromTable(\QueuedNotification::getTable(), ['is_deleted' => 0]);
+        $this->array($notifications)->hasSize(count($expected));
+
+        foreach ($expected as $criteria) {
+            $found = getAllDataFromTable(\QueuedNotification::getTable(), $criteria + ['is_deleted' => 0]);
+            $this->array($found)->hasSize(1);
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26290

Currently, if a user is the recipient of multiple distincts notifications generated by the same event, he will only receive one. 

Current filtering logic has been done to fix a usecase explained in #5702, considering that a notification defined in a sub-entity overrides notifications defined in parent entities. This seems a legitimate usecase. The problem is that there is a limit in the implementation and only one notification is sent.

User may be recipient of multiple distinct notifications that are not using the same template and, therefore, are not providing the same message. For instance:
 - notification 1 is sent to requester and observer of a new ticket and contains the full ticket information with a generic "A new ticket has been created" subject;
 - notification 2 is sent to assignee of a new ticket and contains a summary of ticket with SLA information and a "You have been assigned to a ticket" subject.

When user is both in observers (someone mentionned him using the `@username` feature) and in assignee (a rule assigned him), he should receive both notifications.

Proposed change tries to combine both of usecase:
 - only notifications defined at higher level are sent (to match usecase explained in #5702);
 - multiple notifications can be sent to the same recipient (to match usecase explained in !26290).

There is still a filtering to not send multiple notifications to the same user if they were generated using the same template.

TODO:
- [ ] When a notification overrides a notification configured in a parent entity, indicates it with a clear information message.
- [ ] When a notification is overriden by a notification configured in a child entity, indicates it with a clear information message.