### PR TITLE
fix(OS Rules): improvement of the REGEX

### DIFF
--- a/resources/Rules/RuleDictionnaryOperatingSystem.xml
+++ b/resources/Rules/RuleDictionnaryOperatingSystem.xml
@@ -8,7 +8,7 @@
         <description></description>
         <match>AND</match>
         <is_active>0</is_active>
-        <comment>/(SUSE|SunOS|Red Hat|CentOS|Ubuntu|Debian|Fedora|AlmaLinux|Oracle)(?:\D+|)([\d.]+) ?(?:\(?([\w ]+)\)?)?/
+        <comment>/(SUSE|SunOS|Red Hat|CentOS|Ubuntu|Debian|Fedora|AlmaLinux|Oracle)(?:\D+|)([\d.]*) ?(?:\(?([\w ]+)\)?)?/
 
             Example :
             Ubuntu 22.04.1 LTS -&amp;#62; #0 = Ubuntu
@@ -27,7 +27,7 @@
         <rulecriteria>
             <criteria>os_name</criteria>
             <condition>6</condition>
-            <pattern>/(SUSE|SunOS|Red Hat|CentOS|Ubuntu|Debian|Fedora|AlmaLinux|Oracle)(?:\D+|)([\d.]+) ?(?:\(?([\w ]+)\)?)?/</pattern>
+            <pattern>/(SUSE|SunOS|Red Hat|CentOS|Ubuntu|Debian|Fedora|AlmaLinux|Oracle)(?:\D+|)([\d.]*) ?(?:\(?([\w ]+)\)?)?/</pattern>
         </rulecriteria>
         <ruleaction>
             <action_type>append_regex_result</action_type>

--- a/tests/functionnal/Glpi/Inventory/Assets/OperatingSystem.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/OperatingSystem.php
@@ -165,6 +165,12 @@ class OperatingSystem extends AbstractInventoryAsset
                 "version" => "8.4",
                 "edition" => "Ootpa"
             ],
+            "redhat_03" => [
+                "full_name" => "Red Hat Enterprise Linux Server",
+                "name" => "Red Hat",
+                "version" => "",
+                "edition" => ""
+            ],
             "oracle_01" => [
                 "full_name" => "Oracle Linux Server release 7.3",
                 "name" => "Oracle",
@@ -396,6 +402,18 @@ class OperatingSystem extends AbstractInventoryAsset
             $tz->name = 'CEST';
             $tz->offset = '+0200';
             $object->timezone = $tz;
+        }
+
+        //replace missing properties by empty string
+        //see : assetCleanOsProvider -> redhat_03 example
+        if (!property_exists($result[0], 'version')) {
+            $result[0]->version = '';
+        }
+        if (!property_exists($result[0], 'operatingsystemversions_id')) {
+            $result[0]->operatingsystemversions_id = '';
+        }
+        if (!property_exists($result[0], 'operatingsystemeditions_id')) {
+            $result[0]->operatingsystemeditions_id = '';
         }
 
         $this->object($result[0])->isEqualTo($object);


### PR DESCRIPTION
REGEX improvement for ```OS Name```

current REGEX
```/(SUSE|SunOS|Red Hat|CentOS|Ubuntu|Debian|Fedora|AlmaLinux|Oracle)(?:\D+|)([\d.]+) ?(?:\(?([\w ]+)\)?)?/```

Not work with ```OS Name``` without ```version``` and ```edition```
Like : ```Red Hat Enterprise Linux Server```

Update ```REGEX``` to 
```/(SUSE|SunOS|Red Hat|CentOS|Ubuntu|Debian|Fedora|AlmaLinux|Oracle)(?:\D+|)([\d.]*) ?(?:\(?([\w ]+)\)?)?/```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
