### PR TITLE
fix(savedsearch) : fix support of meta criteria

### DIFF
--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -565,7 +565,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
                     $available_meta = Search::getMetaItemtypeAvailable($this->fields['itemtype']);
 
                     $new_key = 0;
-                    foreach ($query_tab_save['criteria'] as $key => $val) {
+                    foreach ($query_tab_save['criteria'] as $val) {
                         // Get itemtype search options for current criterion
                         $opt = [];
                         if (!isset($val['meta'])) {
@@ -606,7 +606,8 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
                     $meta_ok = Search::getMetaItemtypeAvailable($query_tab['itemtype']);
                     unset($query_tab['metacriteria']);
                     $new_key = 0;
-                    foreach ($query_tab_save['metacriteria'] as $key => $val) {
+                    foreach ($query_tab_save['metacriteria'] as $val) {
+                        $opt = [];
                         if (isset($val['itemtype'])) {
                              $opt = Search::getCleanedOptions($val['itemtype']);
                         }

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -557,7 +557,6 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
                     $this->fields['itemtype'] => Search::getCleanedOptions($this->fields['itemtype'])
                 ];
 
-                $opt = [];
                 $query_tab_save = $query_tab;
                 $partial_load   = false;
                 // Standard search
@@ -566,6 +565,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
                     $new_key = 0;
                     foreach ($query_tab_save['criteria'] as $key => $val) {
                         //load searchoption if meta
+                        $opt = [];
                         if (!isset($val['meta'])) {
                             $opt = $itemtype_so[$this->fields['itemtype']];
                         } elseif (isset($val['itemtype'])) {

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -561,6 +561,9 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
                     unset($query_tab['criteria']);
                     $new_key = 0;
                     foreach ($query_tab_save['criteria'] as $key => $val) {
+                        if (isset($val['itemtype']) && isset($val['meta'])) {
+                            $opt = Search::getCleanedOptions($val['itemtype']);
+                        }
                         if (
                             isset($val['field'])
                             && $val['field'] != 'view'

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -553,7 +553,11 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
             case self::SEARCH:
             case self::ALERT:
                 // Check if all data are valid
-                $opt            = Search::getCleanedOptions($this->fields['itemtype']);
+                $itemtype_so = [
+                    $this->fields['itemtype'] => Search::getCleanedOptions($this->fields['itemtype'])
+                ];
+
+                $opt = [];
                 $query_tab_save = $query_tab;
                 $partial_load   = false;
                 // Standard search
@@ -561,8 +565,14 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
                     unset($query_tab['criteria']);
                     $new_key = 0;
                     foreach ($query_tab_save['criteria'] as $key => $val) {
-                        if (isset($val['itemtype']) && isset($val['meta'])) {
-                            $opt = Search::getCleanedOptions($val['itemtype']);
+                        //load searchoption if meta
+                        if (!isset($val['meta'])) {
+                            $opt = $itemtype_so[$this->fields['itemtype']];
+                        } elseif (isset($val['itemtype'])) {
+                            if (!array_key_exists($val['itemtype'], $itemtype_so)) {
+                                $itemtype_so[$val['itemtype']] = Search::getCleanedOptions($val['itemtype']);
+                            }
+                            $opt = $itemtype_so[$val['itemtype']];
                         }
                         if (
                             isset($val['field'])

--- a/templates/components/search/table.html.twig
+++ b/templates/components/search/table.html.twig
@@ -129,7 +129,11 @@
                   {% for col in data['data']['cols'] %}
                      {% set colkey = col['itemtype'] ~ '_' ~ col['id'] %}
                      {# showItem function returns "<td ...>...</td>" #}
-                     {{ showItem(0, row[colkey]['displayname'], 0, 0, call('Search::displayConfigItem', [itemtype, col['id'], row]))|raw }}
+                     {% if col['meta'] is defined %}
+                        {{ showItem(0, row[colkey]['displayname'], 0, 0,)|raw }}
+                     {% else %}
+                        {{ showItem(0, row[colkey]['displayname'], 0, 0, call('Search::displayConfigItem', [itemtype, col['id'], row]))|raw }}
+                     {% endif %}
                   {% endfor %}
 
                   {# display itemtype in AllAssets #}


### PR DESCRIPTION
1.  Fix warning about ``undefined array key`` when GLPI try to display data

![image](https://user-images.githubusercontent.com/7335054/217472588-45f6e715-94c2-41a4-8ac6-71627807b2f6.png)

```table.html.twig``` reproduces the logic of the function ```Search::outputData``` when GLPI display column


```twig
{% for col in data['data']['cols'] %}
   {% set colkey = col['itemtype'] ~ '_' ~ col['id'] %}
   {# showItem function returns "<td ...>...</td>" #}
   {{ showItem(0, row[colkey]['displayname'], 0, 0, call('Search::displayConfigItem', [itemtype, col['id'], row]))|raw }}
{% endfor %}
```

```php
            foreach ($data['data']['cols'] as $col) {
                $colkey = "{$col['itemtype']}_{$col['id']}";
                if (!$col['meta']) {
                    echo self::showItem(
                        $data['display_type'],
                        $row[$colkey]['displayname'],
                        $item_num,
                        $row_num,
                        self::displayConfigItem(
                            $data['itemtype'],
                            $col['id'],
                            $row
                        )
                    );
                } else { // META case
                    echo self::showItem(
                        $data['display_type'],
                        $row[$colkey]['displayname'],
                        $item_num,
                        $row_num
                    );
                }
            }
``` 

But TWIG template does not take into account the notion of ```meta``` like ```Search``` class.

This PR fix this.


2.  Fix ```Partial load of the saved search``` when filter use ```meta``` and ```fields``` added by plugin

To reproduce : 

- create container on ```Entity``` with ```fields```
- Add custom fields like ```Drodown```
- Do a search like this
![image](https://user-images.githubusercontent.com/7335054/217473801-79000948-c74b-4e58-b32e-5e26220c9539.png)
- Save search.
- Try to use it, you will see
![image](https://user-images.githubusercontent.com/7335054/217473976-0b6252fe-002d-4195-875f-90fd776dc93e.png)

It seems that now the ```metacriteria``` is transformed into ```criteria``` (with key ```meta```) by the ```Search``` class

```
// transform legacy meta-criteria in criteria (with flag meta=true)
// at the end of the array, as before there was only at the end of the query
if (
    isset($params["metacriteria"])
    && is_array($params["metacriteria"])
) {
    // as we will append meta to criteria, check the key exists
    if (!isset($params["criteria"])) {
        $params["criteria"] = [];
    }
    foreach ($params["metacriteria"] as $val) {
        $params["criteria"][] = $val + ['meta' => 1];
    }
    $params["metacriteria"] = [];
}
```

From database, no occurrence of ```metacriteria```

```
query: is_deleted=0&as_map=0&browse=0&criteria%5B0%5D%5Blink%5D=AND&criteria%5B0%5D%5Bfield%5D=14&criteria%5B0%5D%5Bsearchtype%5D=equals&criteria%5B0%5D%5Bvalue%5D=1&criteria%5B1%5D%5Blink%5D=AND&criteria%5B1%5D%5Bitemtype%5D=Entity&criteria%5B1%5D%5Bmeta%5D=1&criteria%5B1%5D%5Bfield%5D=76673&criteria%5B1%5D%5Bsearchtype%5D=equals&criteria%5B1%5D%5Bvalue%5D=1&itemtype=Ticket&sort%5B0%5D=19&order%5B0%5D=DESC
```

except if I missed something, when managing the criteria it is necessary to reload the ```SearchOption``` (with ```Search::getCleanedOptions```)  if it is a meta



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26643 #13457
