### PR TITLE
Filtering on end warranty should also allow to search future dates

### DIFF
--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -1342,6 +1342,7 @@ class Infocom extends CommonDBChild
             ],
             'searchunit'         => 'MONTH',
             'delayunit'          => 'MONTH',
+            'maybefuture'        => true,
             'forcegroupby'       => true,
             'massiveaction'      => false,
             'joinparams'         => $joinparams

--- a/src/Search.php
+++ b/src/Search.php
@@ -3385,11 +3385,7 @@ JAVASCRIPT;
                                 ]
                             ];
                             break;
- 
-                        case "glpi_infocoms.end_warranty":
-                            $options2['with_future'] = true;
-                            break;
-                    }
+                     }
 
                     // Standard datatype usage
                     if (!$display && isset($searchopt['datatype'])) {

--- a/src/Search.php
+++ b/src/Search.php
@@ -3384,8 +3384,9 @@ JAVASCRIPT;
                                     'text'  => __('Myself'),
                                 ]
                             ];
+
                             break;
-                     }
+                    }
 
                     // Standard datatype usage
                     if (!$display && isset($searchopt['datatype'])) {

--- a/src/Search.php
+++ b/src/Search.php
@@ -3384,7 +3384,10 @@ JAVASCRIPT;
                                     'text'  => __('Myself'),
                                 ]
                             ];
-
+                            break;
+ 
+                        case "glpi_infocoms.end_warranty":
+                            $options2['with_future'] = true;
                             break;
                     }
 


### PR DESCRIPTION
Currently it is now possible to select future dates when wanting to see the warranty expiration dates of devices. This change helps to see which devices will need attention in the coming X time then.

