### PR TITLE
fix(Massive actions) add status check before adding tasks/followups

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -3699,7 +3699,7 @@ abstract class CommonITILObject extends CommonDBTM
                             'state'             => $input['state'],
                             'content'           => $input['content']
                         ];
-                        if ($task->can(-1, CREATE, $input2)) {
+                        if ($task->can(-1, CREATE, $input2) && !in_array($item->fields['status'], array_merge($item->getSolvedStatusArray(), $item->getClosedStatusArray()))) {
                             if ($task->add($input2)) {
                                 $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
                             } else {

--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -840,7 +840,7 @@ class ITILFollowup extends CommonDBChild
                 $fup   = new self();
                 foreach ($ids as $id) {
                     if ($item->getFromDB($id)) {
-                        if (in_array($item->fields['status'], $item->getClosedStatusArray())) {
+                        if (in_array($item->fields['status'], array_merge($item->getSolvedStatusArray(), $item->getClosedStatusArray()))) {
                             $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                         } else {


### PR DESCRIPTION
_Rights uniformisation for twig and massive actions to add tasks and followups_

The timeline buttons at the bottom of Ticket or Change are displayed at this condition :
{% if item.**isNotSolved**() and default_action_data != false %}  (components/itilobjects/footer.html.twig)
==> Only displayed if item is not solved

If the specified item is solved, no possibility to add a new followup by this way.
But, it is always possible via massive actions because the condition is  :
if (in_array($item->fields['status'], $item->**getClosedStatusArray**())){

This PR uniformise the condition : allow to add followup or task only if item is not closed and is not solved.

<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
