### PR TITLE
Upgrade tabler icons to v2.2

### DIFF
--- a/css/includes/_fonts.scss
+++ b/css/includes/_fonts.scss
@@ -46,6 +46,6 @@ $fontDir: "../css/lib/fontsource/inter/files";
 @include fontFace($weight: 900);
 
 $font-family-sans-serif: inter, -apple-system, blinkmacsystemfont, san francisco, segoe ui, roboto, helvetica neue, sans-serif !default;
-$ti-font-path: "../css/lib/tabler/icons/iconfont/fonts";
+$ti-font-path: "../css/lib/tabler/icons-webfont/fonts";
 
-@import "~@tabler/icons/iconfont/tabler-icons";
+@import "~@tabler/icons-webfont/tabler-icons";

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@fullcalendar/rrule": "^4.4.0",
                 "@fullcalendar/timegrid": "^4.4.0",
                 "@tabler/core": "^1.0.0-beta9",
-                "@tabler/icons": "^1.68.0",
+                "@tabler/icons-webfont": "^2.2.0",
                 "animate.css": "^4.1.1",
                 "bootstrap": "^5.1.1",
                 "chartist": "^0.11.4",
@@ -1778,17 +1778,17 @@
                 }
             }
         },
-        "node_modules/@tabler/icons": {
-            "version": "1.68.0",
-            "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-1.68.0.tgz",
-            "integrity": "sha512-UseBEEhv7r+Drl3iZih7rkwqkfJJZscjd5ZvK1WdIIulQsBa+qE8WBDGdAO0RtjkCclEK88z9kC0s5wiVPIvkw==",
+        "node_modules/@tabler/core/node_modules/@tabler/icons": {
+            "version": "1.119.0",
+            "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-1.119.0.tgz",
+            "integrity": "sha512-Fk3Qq4w2SXcTjc/n1cuL5bccPkylrOMo7cYpQIf/yw6zP76LQV9dtLcHQUjFiUnaYuswR645CnURIhlafyAh9g==",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/codecalm"
             },
             "peerDependencies": {
-                "react": "^16.x || 17.x",
-                "react-dom": "^16.x || 17.x"
+                "react": "^16.x || 17.x || 18.x",
+                "react-dom": "^16.x || 17.x || 18.x"
             },
             "peerDependenciesMeta": {
                 "react": {
@@ -1797,6 +1797,27 @@
                 "react-dom": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@tabler/icons": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-2.2.0.tgz",
+            "integrity": "sha512-s2mm+7JqmLObKdU89Dtiy+USmUpOlACsoXZZPykjAJZC4pK3wMYxLsclJxViWLeLTb6Bc0oga92V7R+9nrj1ZQ==",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/codecalm"
+            }
+        },
+        "node_modules/@tabler/icons-webfont": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@tabler/icons-webfont/-/icons-webfont-2.2.0.tgz",
+            "integrity": "sha512-rAok1gpbi3XzsgyXGAg1jNueXm1L5YGR2ab0RWMR8T8W8x6Kl2IlCOPZ5mHTJoac+2BA3s9dAPRsMM47nfPMYw==",
+            "dependencies": {
+                "@tabler/icons": "2.2.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/codecalm"
             }
         },
         "node_modules/@testing-library/jest-dom": {
@@ -7817,7 +7838,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/js-yaml": {
             "version": "3.14.1",
@@ -8078,19 +8099,6 @@
             "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
             "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
             "dev": true
-        },
-        "node_modules/loose-envify": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-            },
-            "bin": {
-                "loose-envify": "cli.js"
-            }
         },
         "node_modules/lru-cache": {
             "version": "6.0.0",
@@ -8440,7 +8448,7 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -9046,35 +9054,6 @@
             "integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao=",
             "dev": true
         },
-        "node_modules/react": {
-            "version": "17.0.2",
-            "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-            "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/react-dom": {
-            "version": "17.0.2",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-            "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "scheduler": "^0.20.2"
-            },
-            "peerDependencies": {
-                "react": "17.0.2"
-            }
-        },
         "node_modules/react-is": {
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -9380,17 +9359,6 @@
             },
             "engines": {
                 "node": ">=v12.22.7"
-            }
-        },
-        "node_modules/scheduler": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-            "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1"
             }
         },
         "node_modules/schema-utils": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "@fullcalendar/rrule": "^4.4.0",
         "@fullcalendar/timegrid": "^4.4.0",
         "@tabler/core": "^1.0.0-beta9",
-        "@tabler/icons": "^1.68.0",
+        "@tabler/icons-webfont": "^2.2.0",
         "animate.css": "^4.1.1",
         "bootstrap": "^5.1.1",
         "chartist": "^0.11.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -190,8 +190,8 @@ var filesToCopy = [
         to: scssOutputPath,
     },
     {
-        package: '@tabler/icons',
-        from: '{iconfont/fonts/*,iconfont/tabler-icons.scss}',
+        package: '@tabler/icons-webfont',
+        from: '{fonts/*,tabler-icons.scss}',
         to: scssOutputPath,
     },
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Based on the changelogs, no icon was removed and the icons that had been renamed don't seem to be used by GLPI or any of the plugins I have downloaded. There have been hundreds of new icons added since 1.68 and many of them are useful for a plugin I am working on.

If BC is still a concern, I guess CSS rules could be added so that the old names of any renamed icons that exist in 1.68 can still work.