### PR TITLE
fix(inventory): do not purge ComputerVirtualMachine

### DIFF
--- a/src/Inventory/Asset/VirtualMachine.php
+++ b/src/Inventory/Asset/VirtualMachine.php
@@ -260,7 +260,7 @@ class VirtualMachine extends InventoryAsset
                         }
                     }
                 }
-                $computerVirtualmachine->delete(['id' => $idtmp], true);
+                $computerVirtualmachine->delete(['id' => $idtmp]);
             }
         }
 

--- a/tests/functionnal/Glpi/Inventory/Inventory.php
+++ b/tests/functionnal/Glpi/Inventory/Inventory.php
@@ -4574,10 +4574,13 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
 
         $this->doInventory($json);
 
-        //check there is one less vm
-        $nb_vms--;
+        //check there are same count for computers and virtual machines
         $this->integer(countElementsInTable(\Computer::getTable()))->isIdenticalTo($nb_computers + $count_vms - 1);
-        $this->integer(countElementsInTable(\ComputerVirtualMachine::getTable()))->isIdenticalTo($nb_vms);
+        $this->integer(countElementsInTable(\ComputerVirtualMachine::getTable()))->isIdenticalTo($count_vms);
+        //check there is one less vm and computer not marked as deleted
+        $nb_vms--;
+        $this->integer(countElementsInTable(\Computer::getTable(), ['is_deleted' => 0]))->isIdenticalTo($nb_computers + $count_vms - 2);
+        $this->integer(countElementsInTable(\ComputerVirtualMachine::getTable(), ['is_deleted' => 0]))->isIdenticalTo($nb_vms);
 
         //check related computer has been put in trashbin
         $iterator = $DB->request([


### PR DESCRIPTION
When a ```VirtualMachine``` is missing from inventory file.

GLPI ```purge``` ```ComputerVirtualMachine``` and ```delete``` ```Computer```

it creates frustration among users (```Computer``` deleted, no info from ```ESX```` (```Virtualization``` tab)

I propose to only ```delete``` ```ComputerVirtualMachine```, 

The ```ComputerVirtualMachine``` will still be visible from the ```ESX``` (```Computer```) but marked as deleted (the code is already available)

![image](https://user-images.githubusercontent.com/7335054/217741353-67c3b4a8-373d-4f54-8821-b2f29852782b.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
