### PR TITLE
fix(notification template): error message in debug

### DIFF
--- a/front/notificationtemplatetranslation.form.php
+++ b/front/notificationtemplatetranslation.form.php
@@ -46,6 +46,10 @@ if (!isset($_GET["id"])) {
 $language = new NotificationTemplateTranslation();
 
 $template = new NotificationTemplate();
+if (!isset($_GET["notificationtemplates_id"]) && $_GET["id"] != '') {
+    $language->getFromDB($_GET["id"]);
+    $_GET["notificationtemplates_id"] = $language->fields["notificationtemplates_id"];
+}
 $template->getFromDB($_GET["notificationtemplates_id"]);
 $_SESSION['glpilisturl'][NotificationTemplateTranslation::getType()] = $template->getLinkURL();
 

--- a/front/notificationtemplatetranslation.form.php
+++ b/front/notificationtemplatetranslation.form.php
@@ -45,14 +45,6 @@ if (!isset($_GET["id"])) {
 
 $language = new NotificationTemplateTranslation();
 
-$template = new NotificationTemplate();
-if (!isset($_GET["notificationtemplates_id"]) && $_GET["id"] != '') {
-    $language->getFromDB($_GET["id"]);
-    $_GET["notificationtemplates_id"] = $language->fields["notificationtemplates_id"];
-}
-$template->getFromDB($_GET["notificationtemplates_id"]);
-$_SESSION['glpilisturl'][NotificationTemplateTranslation::getType()] = $template->getLinkURL();
-
 if (isset($_POST["add"])) {
     $language->check(-1, CREATE, $_POST);
     $newID = $language->add($_POST);
@@ -91,6 +83,14 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
+    $template = new NotificationTemplate();
+    if (!isset($_GET["notificationtemplates_id"]) && $_GET["id"] != '') {
+        $language->getFromDB($_GET["id"]);
+        $_GET["notificationtemplates_id"] = $language->fields["notificationtemplates_id"];
+    }
+    $template->getFromDB($_GET["notificationtemplates_id"]);
+    $_SESSION['glpilisturl'][NotificationTemplateTranslation::getType()] = $template->getLinkURL();
+
     if ($_GET["id"] == '') {
         $options = [
             "notificationtemplates_id" => $_GET["notificationtemplates_id"]


### PR DESCRIPTION
Prevent this error message in debug mode : `PHP Warning (2): Undefined array key "notificationtemplates_id" in /home/teclib/Dev/GLPI/10.0-bugfixes/front/notificationtemplatetranslation.form.php at line 49`

![image](https://user-images.githubusercontent.com/8530352/217750585-64637f33-a0fc-47c6-8183-fb55a9e9fae0.png)

_The error did not appear to have any functional impact_

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
