### PR TITLE
Fix color field null value handling

### DIFF
--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -393,7 +393,7 @@
             preferredFormat: "hex",
             type: "text",
             change: function(color) {
-                if (color.getAlpha() !== 1) {
+                if (color !== null && color.getAlpha() !== 1) {
                     let hex = color.toHexString();
                     hex += ("0" + Math.round(parseFloat(color.getAlpha()) * 255).toString(16)).slice(-2);
                     this.value = hex;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

A JavaScript error is thrown if the color in a Spectrum color input is set to null, causing the control to stop working properly.