### PR TITLE
fix(inventory): do not lock networkport when handle metrics

### DIFF
--- a/src/Inventory/Asset/NetworkPort.php
+++ b/src/Inventory/Asset/NetworkPort.php
@@ -543,6 +543,7 @@ class NetworkPort extends InventoryAsset
             $input_db['ifoutbytes']  = $input['ifoutbytes'];
             $input_db['ifinerrors']  = $input['ifinerrors'];
             $input_db['ifouterrors'] = $input['ifouterrors'];
+            $input_db['is_dynamic'] = true;
             $netport->update($input_db);
         }
     }

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -483,6 +483,7 @@ class NetworkPort extends CommonDBChild
                 'ifoutbytes'      => $this->fields['ifoutbytes'] ?? 0,
                 'ifinerrors'      => $this->fields['ifinerrors'] ?? 0,
                 'ifouterrors'     => $this->fields['ifouterrors'] ?? 0,
+                'is_dynamic'     =>  $this->fields['is_dynamic'] ?? 0,
             ],
             $unicity_input
         );

--- a/tests/functionnal/Glpi/Inventory/Assets/NetworkPort.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/NetworkPort.php
@@ -479,6 +479,11 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         ];
         $this->array($db_input)->isIdenticalTo($expected_input);
 
+        //no lock
+        $lockedfield = new \Lockedfield();
+        $this->boolean($lockedfield->isHandled($networkport))->isTrue();
+        $this->array($lockedfield->getLockedValues($networkport->getType(), $networkport->fields['id']))->isEmpty();
+
         //change 'date' to yesterday to get new metric after reimport (2nd step)
         $currentDate = new DateTime(date('Y-m-d'));
         $yesterdayTime = $currentDate->sub(new DateInterval('P1D'));
@@ -533,6 +538,11 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         ];
         $this->array($db_input)->isIdenticalTo($expected_input);
 
+        //no lock
+        $lockedfield = new \Lockedfield();
+        $this->boolean($lockedfield->isHandled($networkport))->isTrue();
+        $this->array($lockedfield->getLockedValues($networkport->getType(), $networkport->fields['id']))->isEmpty();
+
         //Third step : import NetworkEquipement again but with new metrics
         //check that the previous data are updated
 
@@ -579,5 +589,10 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
             "networkports_id" => $networkport->fields['id'],
         ];
         $this->array($db_input)->isIdenticalTo($expected_input);
+
+        //no lock
+        $lockedfield = new \Lockedfield();
+        $this->boolean($lockedfield->isHandled($networkport))->isTrue();
+        $this->array($lockedfield->getLockedValues($networkport->getType(), $networkport->fields['id']))->isEmpty();
     }
 }


### PR DESCRIPTION
Do not lock ```networkport```  when handle metrics

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14063
