### PR TITLE
fix missed rand reuse for itil link tabs

### DIFF
--- a/templates/components/form/link_existing_or_new.html.twig
+++ b/templates/components/form/link_existing_or_new.html.twig
@@ -45,7 +45,8 @@
          <div class="col-auto">
             {{ fields.dropdownField(primary_dropdown_itemtype, primary_dropdown_itemtype|itemtype_foreign_key, '', '', {
                no_label: true,
-               field_class: ''
+               field_class: '',
+               rand: rand
             }|merge(dropdown_options)) }}
             {% if ajax_dropdown is defined %}
                {% do call('Ajax::updateItemOnSelectEvent', [
@@ -59,7 +60,8 @@
                <span id="{{ ajax_dropdown['toupdate']['id'] }}">
                   {{ fields.dropdownField(ajax_dropdown['toupdate']['itemtype'], (ajax_dropdown['toupdate']['itemtype'])|itemtype_foreign_key, '', '', {
                      no_label: true,
-                     field_class: ''
+                     field_class: '',
+                     rand: rand
                   }|merge(ajax_dropdown['toupdate']['params'])) }}
                </span>
             {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14065

The predetermined random value for form field IDs wasn't being reused in all fields so changing the AJAX dropdowns like when you change the Project in the Project Tasks tab of a Ticket wasn't working.