### PR TITLE
fix(inventory): set last inventory update date to related computer

### DIFF
--- a/src/Inventory/Asset/VirtualMachine.php
+++ b/src/Inventory/Asset/VirtualMachine.php
@@ -294,6 +294,7 @@ class VirtualMachine extends InventoryAsset
             }
             // Define location of physical computer (host)
             $vm->locations_id = $this->item->fields['locations_id'];
+            $vm->last_inventory_update = $_SESSION["glpi_currenttime"];
             $vm->autoupdatesystems_id = $this->item->fields['autoupdatesystems_id'];
             $vm->is_dynamic = 1;
 


### PR DESCRIPTION
Handle ```last_inventory_update``` for ```Computer``` linked to ```VirtualMachine```


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26406
