### PR TITLE
fix(inventory): remove management port for Printer on netinventory

### DIFF
--- a/src/Inventory/Asset/NetworkPort.php
+++ b/src/Inventory/Asset/NetworkPort.php
@@ -40,6 +40,7 @@ use Glpi\Inventory\Conf;
 use Glpi\Inventory\FilesToJSON;
 use Glpi\Toolbox\Sanitizer;
 use NetworkPort as GlobalNetworkPort;
+use NetworkPortAggregate;
 use NetworkPortType;
 use QueryParam;
 use RuleImportAssetCollection;
@@ -768,6 +769,21 @@ class NetworkPort extends InventoryAsset
     public function handlePorts($itemtype = null, $items_id = null)
     {
         $mainasset = $this->extra_data['\Glpi\Inventory\Asset\\' . $this->item->getType()];
+
+        //remove management port for Printer on netinventory
+        //to prevent twice IP (NetworkPortAggregate / NetworkPortEthernet)
+        if ($mainasset instanceof Printer && !$this->item->isNewItem()) {
+            if (empty($this->extra_data['\Glpi\Inventory\Asset\\' . $this->item->getType()]->getManagementPorts())) {
+                //remove all port management ports
+                $networkport = new GlobalNetworkPort();
+                $networkport->deleteByCriteria([
+                    "itemtype"           => $this->item->getType(),
+                    "items_id"           => $this->item->getID(),
+                    "instantiation_type" => NetworkPortAggregate::getType(),
+                    "name"               => "Management"
+                ], 1);
+            }
+        }
 
         //handle ports for stacked switches
         if ($mainasset->isStackedSwitch()) {


### PR DESCRIPTION
```Printer``` ```Network``` are now managed as ```NetworkEquipement``` ```Network```

See : https://github.com/glpi-project/glpi/pull/13894

But this feature => https://github.com/glpi-project/glpi/pull/12197

need to be adapt

Fix too : FIX glpi-inventopry plugin TU https://github.com/glpi-project/glpi-inventory-plugin/actions/runs/4052704362/jobs/6972432429


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
