### PR TITLE
add key on level column for CommonTreeDropdowns

### DIFF
--- a/install/migrations/update_10.0.6_to_10.0.7/indexes.php
+++ b/install/migrations/update_10.0.6_to_10.0.7/indexes.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+// Add index on level on all TreeDropdown tables
+$tables = [
+    'glpi_businesscriticities',
+    'glpi_documentcategories',
+    'glpi_entities',
+    'glpi_groups',
+    'glpi_ipnetworks',
+    'glpi_itilcategories',
+    'glpi_knowbaseitemcategories',
+    'glpi_locations',
+    'glpi_softwarecategories',
+    'glpi_softwarelicenses',
+    'glpi_softwarelicensetypes',
+    'glpi_states',
+    'glpi_taskcategories',
+];
+
+foreach ($tables as $table) {
+    $migration->addKey($table, 'level');
+}

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -362,7 +362,8 @@ CREATE TABLE `glpi_businesscriticities` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `entities_id` (`entities_id`),
-  KEY `is_recursive` (`is_recursive`)
+  KEY `is_recursive` (`is_recursive`),
+  KEY `level` (`level`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -2543,7 +2544,8 @@ CREATE TABLE `glpi_documentcategories` (
   UNIQUE KEY `unicity` (`documentcategories_id`,`name`),
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
-  KEY `date_creation` (`date_creation`)
+  KEY `date_creation` (`date_creation`),
+  KEY `level` (`level`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -2799,7 +2801,8 @@ CREATE TABLE `glpi_entities` (
   KEY `authldaps_id` (`authldaps_id`),
   KEY `calendars_id` (`calendars_id`),
   KEY `entities_id_software` (`entities_id_software`),
-  KEY `contracts_id_default` (`contracts_id_default`)
+  KEY `contracts_id_default` (`contracts_id_default`),
+  KEY `level` (`level`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -2996,7 +2999,8 @@ CREATE TABLE `glpi_groups` (
   KEY `is_itemgroup` (`is_itemgroup`),
   KEY `is_usergroup` (`is_usergroup`),
   KEY `is_manager` (`is_manager`),
-  KEY `date_creation` (`date_creation`)
+  KEY `date_creation` (`date_creation`),
+  KEY `level` (`level`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -3275,7 +3279,8 @@ CREATE TABLE `glpi_ipnetworks` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
-  KEY `ipnetworks_id` (`ipnetworks_id`)
+  KEY `ipnetworks_id` (`ipnetworks_id`),
+  KEY `level` (`level`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -3833,7 +3838,8 @@ CREATE TABLE `glpi_itilcategories` (
   KEY `is_problem` (`is_problem`),
   KEY `is_change` (`is_change`),
   KEY `date_mod` (`date_mod`),
-  KEY `date_creation` (`date_creation`)
+  KEY `date_creation` (`date_creation`),
+  KEY `level` (`level`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -3873,7 +3879,8 @@ CREATE TABLE `glpi_knowbaseitemcategories` (
   KEY `is_recursive` (`is_recursive`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
-  KEY `knowbaseitemcategories_id` (`knowbaseitemcategories_id`)
+  KEY `knowbaseitemcategories_id` (`knowbaseitemcategories_id`),
+  KEY `level` (`level`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -4110,7 +4117,8 @@ CREATE TABLE `glpi_locations` (
   KEY `name` (`name`),
   KEY `is_recursive` (`is_recursive`),
   KEY `date_mod` (`date_mod`),
-  KEY `date_creation` (`date_creation`)
+  KEY `date_creation` (`date_creation`),
+  KEY `level` (`level`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -6560,7 +6568,8 @@ CREATE TABLE `glpi_softwarecategories` (
   `sons_cache` longtext,
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
-  KEY `softwarecategories_id` (`softwarecategories_id`)
+  KEY `softwarecategories_id` (`softwarecategories_id`),
+  KEY `level` (`level`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -6626,7 +6635,8 @@ CREATE TABLE `glpi_softwarelicenses` (
   KEY `manufacturers_id` (`manufacturers_id`),
   KEY `states_id` (`states_id`),
   KEY `allow_overquota` (`allow_overquota`),
-  KEY `softwarelicenses_id` (`softwarelicenses_id`)
+  KEY `softwarelicenses_id` (`softwarelicenses_id`),
+  KEY `level` (`level`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -6652,7 +6662,8 @@ CREATE TABLE `glpi_softwarelicensetypes` (
   KEY `is_recursive` (`is_recursive`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
-  KEY `softwarelicensetypes_id` (`softwarelicensetypes_id`)
+  KEY `softwarelicensetypes_id` (`softwarelicensetypes_id`),
+  KEY `level` (`level`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -6883,7 +6894,8 @@ CREATE TABLE `glpi_states` (
   KEY `is_visible_databaseinstance` (`is_visible_databaseinstance`),
   KEY `is_visible_cable` (`is_visible_cable`),
   KEY `date_mod` (`date_mod`),
-  KEY `date_creation` (`date_creation`)
+  KEY `date_creation` (`date_creation`),
+  KEY `level` (`level`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -6984,7 +6996,8 @@ CREATE TABLE `glpi_taskcategories` (
   KEY `is_helpdeskvisible` (`is_helpdeskvisible`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
-  KEY `knowbaseitemcategories_id` (`knowbaseitemcategories_id`)
+  KEY `knowbaseitemcategories_id` (`knowbaseitemcategories_id`),
+  KEY `level` (`level`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 

--- a/src/System/Diagnostic/DatabaseKeysChecker.php
+++ b/src/System/Diagnostic/DatabaseKeysChecker.php
@@ -36,6 +36,7 @@
 namespace Glpi\System\Diagnostic;
 
 use CommonDBTM;
+use CommonTreeDropdown;
 
 /**
  * @since 10.0.0
@@ -59,9 +60,10 @@ class DatabaseKeysChecker extends AbstractDatabaseChecker
 
         $columns = $this->getColumnsNames($table_name);
         foreach ($columns as $column_name) {
+            $itemtype = getItemTypeForTable($table_name);
             $column_name_matches = [];
             if (
-                is_a($itemtype = getItemTypeForTable($table_name), CommonDBTM::class, true)
+                is_a($itemtype, CommonDBTM::class, true)
                 && $column_name === $itemtype::getNameField()
                 && preg_match('/text$/', $this->getColumnType($table_name, $column_name)) !== 1
             ) {
@@ -82,8 +84,9 @@ class DatabaseKeysChecker extends AbstractDatabaseChecker
                 }
             } else if (
                 isForeignKeyField($column_name)
-                    || preg_match('/^date(_(mod|creation))$/', $column_name)
-                    || preg_match('/^is_(active|deleted|dynamic|recursive|template)$/', $column_name)
+                || preg_match('/^date(_(mod|creation))$/', $column_name)
+                || preg_match('/^is_(active|deleted|dynamic|recursive|template)$/', $column_name)
+                || (is_a($itemtype, CommonTreeDropdown::class, true) && $column_name === 'level')
             ) {
                 $ignored_fields = [
                     'glpi_ipaddresses.mainitems_id', // FIXME Should be renamed to glpi_ipaddresses.items_id_main to fit naming conventions.


### PR DESCRIPTION
For itemtypes using commontreedropdown items may show very slowly because of unoptimized SQL queries. 

This may happen with Formcreator, when a question is designed to show only a subtree of existing items, and when there are a thousand of items in the database.

Adding an index on level columns shows a speed gain of 50%.

internal ref !26669

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #
