### PR TITLE
Memory optimization for glpi:diagnostic:check_documents_integrity

### DIFF
--- a/src/Console/AbstractCommand.php
+++ b/src/Console/AbstractCommand.php
@@ -278,11 +278,15 @@ abstract class AbstractCommand extends Command implements GlpiCommandInterface
      *
      * @param iterable $iterable
      * @param callable $message_callback
+     * @param int|null $count
      *
      * @return iterable
      */
-    final protected function iterate(iterable $iterable, ?callable $message_callback = null): iterable
-    {
+    final protected function iterate(
+        iterable $iterable,
+        ?callable $message_callback = null,
+        ?int $count = null
+    ): iterable {
         // Redefine formats
         $formats = [
             ProgressBar::FORMAT_NORMAL,
@@ -309,7 +313,11 @@ abstract class AbstractCommand extends Command implements GlpiCommandInterface
         // Init progress bar
         $this->progress_bar = new ProgressBar($this->output);
         $this->progress_bar->setMessage(''); // Empty message on iteration start
-        $this->progress_bar->start(is_countable($iterable) ? \count($iterable) : 0);
+        $this->progress_bar->start(
+            !is_null($count) ?
+            $count :
+            (is_countable($iterable) ? \count($iterable) : 0)
+        );
 
         // Iterate on items
         foreach ($iterable as $key => $value) {


### PR DESCRIPTION
I've had some issues with the `php bin/console glpi:diagnostic:check_documents_integrity` command as it would go over the allowed memory limit.

With a test database of 638015 documents, the command would reach around 141MB of memory.
After optimization, the command do not got over 20MB.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
