### PR TITLE
Rework All Tab

### DIFF
--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -360,7 +360,7 @@ JAVASCRIPT;
             }
             echo  "</div>"; // .tab-content
             echo "</div>"; // .container-fluid
-            $js = "
+            $js = <<<JS
          var loadTabContents = function (tablink, force_reload = false) {
             var url = tablink.attr('href');
             var target = tablink.attr('data-bs-target');
@@ -418,7 +418,7 @@ JAVASCRIPT;
                $('#$tabdiv_id li a').eq($(this).val()).tab('show');
             });
          });
-         ";
+JS;
 
             echo Html::scriptBlock($js);
         }

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -337,16 +337,30 @@ JAVASCRIPT;
                 $display_class = "d-none";
             }
 
-            foreach ($tabs as $val) {
+            foreach ($tabs as $tab_key => $val) {
                 $target = str_replace('\\', '_', $val['id']);
-                $html_tabs .= "<li class='nav-item $navitemml'>
-               <a class='nav-link justify-content-between $navlinkp $display_class' data-bs-toggle='tab' title='" . strip_tags($val['title']) . "' ";
-                $html_tabs .= " href='" . $val['url'] . (isset($val['params']) ? '?' . $val['params'] : '') . "' data-bs-target='#{$target}'>";
-                $html_tabs .= $val['title'] . "</a></li>";
-
-                $html_sele .= "<option value='$i' " . ($active_id == $target ? "selected" : "") . ">
-               {$val['title']}
-            </option>";
+                $href = $val['url'] . (isset($val['params']) ? '?' . $val['params'] : '');
+                $selected = $active_id == $target ? 'selected' : '';
+                $title = $val['title'];
+                $title_clean = strip_tags($title);
+                if ($tab_key !== -1) {
+                    $html_tabs .= <<<HTML
+                        <li class='nav-item $navitemml'>
+                            <a class='nav-link justify-content-between $navlinkp $display_class' data-bs-toggle='tab'
+                                title='{$title_clean}' href='{$href}' data-bs-target='#{$target}'>{$title}</a>
+                        </li>
+HTML;
+                    $html_sele .= "<option value='$i' {$selected}>{$val['title']}</option>";
+                } else {
+                    // All tabs
+                    $html_tabs .= <<<HTML
+                        <li class='nav-item $navitemml'>
+                            <a class='nav-link justify-content-between $navlinkp $display_class' data-bs-toggle='tab'
+                                title='{$title_clean}' href='#' data-show-all-tabs="true">{$title}</a>
+                        </li>
+HTML;
+                    $html_sele .= "<option value='$i' {$selected}>{$val['title']}</option>";
+                }
                 $i++;
             }
             echo $html_tabs;
@@ -361,7 +375,7 @@ JAVASCRIPT;
             echo  "</div>"; // .tab-content
             echo "</div>"; // .container-fluid
             $js = <<<JS
-         var loadTabContents = function (tablink, force_reload = false) {
+         var loadTabContents = function (tablink, force_reload = false, update_current_tab = true) {
             var url = tablink.attr('href');
             var target = tablink.attr('data-bs-target');
             var index = tablink.closest('.nav-item').index();
@@ -377,7 +391,7 @@ JAVASCRIPT;
                   }
                );
             }
-            if ($(target).html() && !force_reload) {
+            if (update_current_tab && $(target).html() && !force_reload) {
                 updateCurrentTab();
                 return;
             }
@@ -403,11 +417,27 @@ JAVASCRIPT;
             // Restore href
             active_link.attr('href', currenthref);
          };
+         
+         const loadAllTabs = () => {
+             const tabs = $('#$tabdiv_id a[data-bs-toggle=\"tab\"]');
+             tabs.each((index, tab) => {
+                loadTabContents($(tab));
+             });
+         }
 
          $(function() {
             $('a[data-bs-toggle=\"tab\"]').on('shown.bs.tab', function(e) {
                e.preventDefault();
-               loadTabContents($(this));
+               if ($(this).attr('data-show-all-tabs') === 'true') {
+                  loadAllTabs();
+                  // show all tabs by adding active and show classes to all tabs
+                  $('#$tabdiv_id').parent().find('.tab-pane').addClass('active show');
+               } else {
+                  // Remove active and show classes from all tabs except the one that is clicked
+                  let clicked_tab = $(this).attr('data-bs-target');
+                  $('#$tabdiv_id').parent().find('.tab-pane:not(' + clicked_tab + ')').removeClass('active show');
+                  loadTabContents($(this));
+               }
             });
 
             // load initial tab

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -374,6 +374,9 @@ HTML;
             }
             echo  "</div>"; // .tab-content
             echo "</div>"; // .container-fluid
+
+            $json_type = json_encode($type);
+            $withtemplate = (int)($_GET['withtemplate'] ?? 0);
             $js = <<<JS
          var loadTabContents = function (tablink, force_reload = false, update_current_tab = true) {
             var url = tablink.attr('href');
@@ -384,10 +387,10 @@ HTML;
                 $.get(
                   '{$CFG_GLPI['root_doc']}/ajax/updatecurrenttab.php',
                   {
-                     itemtype: " . json_encode($type) . ",
+                     itemtype: $json_type,
                      id: '$ID',
                      tab: index,
-                     withtemplate: " . (int)($_GET['withtemplate'] ?? 0) . "
+                     withtemplate: $withtemplate
                   }
                );
             }
@@ -431,7 +434,7 @@ HTML;
                if ($(this).attr('data-show-all-tabs') === 'true') {
                   loadAllTabs();
                   // show all tabs by adding active and show classes to all tabs
-                  $('#$tabdiv_id').parent().find('.tab-pane').addClass('active show');
+                  $('#$tabdiv_id').parent().find('.tab-pane').addClass('active show').removeClass('fade');
                } else {
                   // Remove active and show classes from all tabs except the one that is clicked
                   let clicked_tab = $(this).attr('data-bs-target');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Proof of concept to utilize the tab content already loaded instead of forcibly getting the content of every tab again for the All tab. This should eliminate all issues with duplicate IDs and duplicate initialization of JavaScript components, and simplify the server-side handling of this tab. This also allows the user to start filling a form in a tab, and finish it in the All tab. The downside is that loading the All tab may take longer because the loading of previously unloaded tabs would be done in individual requests.

New functionality when the All tab is selected:
1. Load the content of every other tab without forcing a reload so that only the unloaded tabs are retrieved from the server
2. Manually add the `active` and `show` classes to the tab panels to show all the tabs
When selecting a tab other than the All tab, the superfluous `active` and `show` classes are removed.

In some cases, there seems to be some race conditions where the classes are not set as expected. This PR is just a proof of concept and would require some additional work for a proper implementation.