### PR TITLE
Fix PHP 8.2 dynamic property creation warning

### DIFF
--- a/src/HTMLTableSubHeader.php
+++ b/src/HTMLTableSubHeader.php
@@ -40,7 +40,7 @@ class HTMLTableSubHeader extends HTMLTableHeader
 {
    // The headers of each column
     private $header;
-
+    public $numberOfSubHeaders;
 
     /**
      * @param HTMLTableSuperHeader $header


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Fix `PHP Deprecated function (8192): Creation of dynamic property HTMLTableSubHeader::$numberOfSubHeaders is deprecated in /var/www/webapps/glpi/src/HTMLTableGroup.php at line 177` on computers components tab with PHP 8.2.