### PR TITLE
fix(search): satisfaction column empty in search result

### DIFF
--- a/js/modules/Search/Table.js
+++ b/js/modules/Search/Table.js
@@ -199,6 +199,7 @@ window.GLPI.Search.Table = class Table extends GenericView {
                 this.getElement().trigger('search_refresh', [this.getElement()]);
                 this.hideLoadingSpinner();
                 this.shiftSelectAllCheckbox();
+                this.reloadJS('rateit');
             }, () => {
                 handle_search_failure();
             });
@@ -210,6 +211,14 @@ window.GLPI.Search.Table = class Table extends GenericView {
     // permit to [shift] select checkboxes
     shiftSelectAllCheckbox() {
         $('#'+this.element_id+' tbody input[type="checkbox"]').shiftSelectable();
+    }
+
+    reloadJS(script) {
+        $.each($('script:empty[type="text/javascript"][src*="'+script+'"]'), function(index, el) {
+            var clone = el.cloneNode(true);
+            $(el).remove();
+            $(clone).appendTo('body');
+        });
     }
 
     registerListeners() {


### PR DESCRIPTION
In the ticket search, the satisfaction column was empty after a search, but complete when reloading the whole page.

The star rating depends on the JS lib "rateit" which only applies to its loading. However, when we refresh only the results table, the JS was not reloaded and therefore the stars do not appear.

Before:
![image](https://user-images.githubusercontent.com/8530352/219394939-5eed0f23-7b18-4144-aba9-dc361b835000.png)

After:
![image](https://user-images.githubusercontent.com/8530352/219394766-7a7636c4-8163-4659-b8ad-530c8206052f.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26728
