### PR TITLE
Prevent users from deleting the super admin profile

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -170,6 +170,10 @@ class User extends CommonDBTM
 
     public function canDeleteItem()
     {
+        if ($this->isLastSuperAdminUser()) {
+            return false;
+        }
+
         if (
             Session::canViewAllEntities()
             || Session::haveAccessToAllOfEntities($this->getEntities())
@@ -1028,6 +1032,20 @@ class User extends CommonDBTM
 
         if (array_key_exists('timezone', $input) && empty($input['timezone'])) {
             $input['timezone'] = 'NULL';
+        }
+
+        if (
+            $this->fields['is_active'] == true
+            && isset($input['is_active'])
+            && $input['is_active'] == false // User is no longer active
+            && $this->isLastSuperAdminUser()
+        ) {
+            unset($input['is_active']);
+            Session::addMessageAfterRedirect(
+                __("Can't set user as inactive as it is the only remaining super administrator."),
+                false,
+                ERROR
+            );
         }
 
         return $input;
@@ -6557,5 +6575,30 @@ HTML;
         }
 
         return __('Unknown user');
+    }
+
+    /**
+     * Check if this User is the last super-admin user.
+     * A "super-admin user" is a user that can edit GLPI's profiles.
+     *
+     * @return bool
+     */
+    protected function isLastSuperAdminUser(): bool
+    {
+        // Find all active authorizations for the super admins
+        $super_admin_authorizations = (new Profile_User())->find([
+            'profiles_id' => Profile::getSuperAdminProfilesId(),
+            'users_id' => new QuerySubQuery([
+                'SELECT' => 'id',
+                'FROM'   => 'glpi_users',
+                'WHERE'  => ['is_active' => 1, 'is_deleted' => 0],
+            ])
+        ]);
+        $authorizations_ids = array_column($super_admin_authorizations, 'users_id');
+
+        return
+            count($authorizations_ids) == 1 // Only one super admin auth
+            && $authorizations_ids[0] == $this->fields['id'] // Id match our user
+        ;
     }
 }

--- a/tests/functionnal/Profile.php
+++ b/tests/functionnal/Profile.php
@@ -194,4 +194,49 @@ class Profile extends DbTestCase
             $this->integer(($profile->fields['ticket'] & $right))->isEqualTo($right);
         }
     }
+
+    /**
+     * Tests for Profile->canPurgeItem()
+     *
+     * @return void
+     */
+    public function testCanPurgeItem(): void
+    {
+        // Default: only one super admin account, can't be deleted
+        $super_admin = getItemByTypeName('Profile', 'Super-Admin');
+        $this->boolean($super_admin->isLastSuperAdminProfile())->isTrue();
+        $this->boolean($super_admin->canPurgeItem())->isEqualTo(false);
+
+        $super_admin_2 = $this->createItem("Profile", [
+            "name" => "Super-Admin 2"
+        ]);
+        $this->boolean($super_admin->isLastSuperAdminProfile())->isTrue();
+        $this->boolean($super_admin_2->isLastSuperAdminProfile())->isFalse();
+
+        // Two super admin account, both can be deleted
+        $this->updateItem("Profile", $super_admin_2->getID(), [
+            '_profile' => [UPDATE . "_0" => true]
+        ]);
+        $this->boolean($super_admin->isLastSuperAdminProfile())->isFalse();
+        $this->boolean($super_admin_2->isLastSuperAdminProfile())->isFalse();
+    }
+
+    /**
+     * Tests for Profile->prepareInputForUpdate()
+     *
+     * @return void
+     */
+    public function testprepareInputForUpdate(): void
+    {
+        // Default: only one super admin account, can't remove update rights
+        $super_admin = getItemByTypeName('Profile', 'Super-Admin');
+        $this->boolean($super_admin->isLastSuperAdminProfile())->isTrue();
+        $this->boolean($super_admin->update([
+            'id' => $super_admin->getId(),
+            '_profile' => [UPDATE . "_0" => false]
+        ]))->isEqualTo(true);
+        $this->hasSessionMessages(ERROR, [
+            "Can't remove update right on this profile as it is the only remaining profile with this right."
+        ]);
+    }
 }

--- a/tests/functionnal/Profile_User.php
+++ b/tests/functionnal/Profile_User.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use DbTestCase;
+
+/**
+ * Tests for Profile_User class
+ */
+class Profile_User extends DbTestCase
+{
+    /**
+     * Tests for Profile_User->canPurgeItem()
+     *
+     * @return void
+     */
+    public function testCanPurgeItem(): void
+    {
+        // Default: only one super admin account
+        $super_admin = getItemByTypeName('Profile', 'Super-Admin');
+        $this->boolean($super_admin->isLastSuperAdminProfile())->isTrue();
+
+        // Default: 3 super admin account authorizations
+        $authorizations = (new \Profile_User())->find([
+            'profiles_id' => $super_admin->fields['id']
+        ]);
+        $this->array($authorizations)->hasSize(3);
+        $this->array(array_column($authorizations, 'id'))->isEqualTo([
+            2, // glpi
+            6, // TU_USER
+            7, // jsmith123
+        ]);
+
+        // Delete 2 authorizations
+        $this->login('glpi', 'glpi');
+        $this->boolean(\Profile_User::getById(6)->canPurgeItem())->isTrue();
+        $this->boolean((new \Profile_User())->delete(['id' => 6], 1))->isTrue();
+        $this->boolean(\Profile_User::getById(7)->canPurgeItem())->isTrue();
+        $this->boolean((new \Profile_User())->delete(['id' => 7], 1))->isTrue();
+
+        // Last user, can't be purged
+        $this->boolean(\Profile_User::getById(2)->canPurgeItem())->isFalse();
+        // Can still be purged by calling delete, maybe it should not be possible ?
+        $this->boolean((new \Profile_User())->delete(['id' => 2], 1))->isTrue();
+    }
+}


### PR DESCRIPTION
We are having semi-frequent issues with users that delete the super-admin account or profile.
As a reminder, a "super-admin" profile is a profile that have the rights to edit GLPI's profiles.

To prevent this, I've made the following changes:
* Prevent last super-admin user from being deleted or disabled
* Prevent last super-admin profile from being deleted
* Prevent last super-admin profile authorization from being deleted
* Prevent "profile" update rights from being removed from the last-super admin profile (there was some existing code to handle this case but it wasn't working)

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
