### PR TITLE
fix(notification): missing tags for contracts

### DIFF
--- a/src/NotificationTargetContract.php
+++ b/src/NotificationTargetContract.php
@@ -66,6 +66,8 @@ class NotificationTargetContract extends NotificationTarget
             $tmp                        = [];
             $tmp['##contract.name##']   = $contract['name'];
             $tmp['##contract.number##'] = $contract['num'];
+            $tmp['##contract.comment##'] = $contract['comment'];
+            $tmp['##contract.account##'] = $contract['account_number'];
 
             if ($contract['contracttypes_id']) {
                 $tmp['##contract.type##'] = Dropdown::getDropdownName(
@@ -171,6 +173,8 @@ class NotificationTargetContract extends NotificationTarget
         $tags = ['contract.action'       => _n('Event', 'Events', 1),
             'contract.name'         => __('Name'),
             'contract.number'       => _x('phone', 'Number'),
+            'contract.comment'      => __('Comments'),
+            'contract.account'      => __('Account number'),
             'contract.items.number' => _x('quantity', 'Number of items'),
             'contract.items'        => __('Device list'),
             'contract.type'         => _n('Type', 'Types', 1),


### PR DESCRIPTION
Adding the tags `##contract.comment##` and `##contract.account##`

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26795
