### PR TITLE
fix(ui): fix thumbnail background color

### DIFF
--- a/src/KnowbaseItem_Comment.php
+++ b/src/KnowbaseItem_Comment.php
@@ -281,7 +281,7 @@ class KnowbaseItem_Comment extends CommonDBTM
             $html .= "<div class='h_date'>" . Html::convDateTime($comment['date_creation']) . "</div>";
             $html .= "<div class='h_user'>";
             $thumbnail_url = User::getThumbnailURLForPicture($user->fields['picture']);
-            $style = !empty($thumbnail_url) ? "background-image: url(\"$thumbnail_url\")" : ("background-color: " . $user->getUserInitialsBgColor());
+            $style = !empty($thumbnail_url) ? "background-image: url(\"$thumbnail_url\"); background-color: inherit;" : ("background-color: " . $user->getUserInitialsBgColor());
             $html .= '<a href="' . $user->getLinkURL() . '">';
             $html .= "<span class='avatar avatar-md rounded' style='{$style}'>";
             if (empty($thumbnail_url)) {

--- a/src/Notepad.php
+++ b/src/Notepad.php
@@ -329,7 +329,7 @@ class Notepad extends CommonDBChild
                 $thumbnail_url = User::getThumbnailURLForPicture($note['picture']);
                 $user = new User();
                 $user->getFromDB($note['users_id_lastupdater']);
-                $style = !empty($thumbnail_url) ? "background-image: url('$thumbnail_url')" : ("background-color: " . $user->getUserInitialsBgColor());
+                $style = !empty($thumbnail_url) ? "background-image: url('$thumbnail_url'); background-color: inherit;" : ("background-color: " . $user->getUserInitialsBgColor());
                 echo '<a href="' . $user->getLinkURL() . '">';
                 $user_name = formatUserName(
                     $user->getID(),

--- a/templates/components/user/picture.html.twig
+++ b/templates/components/user/picture.html.twig
@@ -46,7 +46,7 @@
 {% endif %}
 
 <span class="avatar {{ avatar_size }} rounded"
-      style="{% if user_thumbnail is not null %}background-image: url({{ user_thumbnail }}); {% endif %}background-color: {{ user.getUserInitialsBgColor() }}">
+      style="{% if user_thumbnail is not null %}background-image: url({{ user_thumbnail }}); background-color: inherit; {% else %} background-color: {{ user.getUserInitialsBgColor() }}{% endif %}">
    {% if user_thumbnail is null %}
          {{ user.getUserInitials(enable_anonymization) }}
    {% endif %}


### PR DESCRIPTION
I user upload thumbnail with transparent background

background color from users initial is still display.

Before : 
![image](https://user-images.githubusercontent.com/7335054/219667190-3a457a7b-1a0a-447b-8616-bff47cfb96c7.png)


After : 
![image](https://user-images.githubusercontent.com/7335054/219667207-1b677db5-abd7-4db3-9e88-0886d63d4b9d.png)


Fix ```KnownBaseItem_Comment``` comment and ```NotePad``` too.

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
