### PR TITLE
Alter handing of required Dropdowns

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -183,6 +183,14 @@ class Dropdown
             }
         }
 
+        if(isset($params['specific_tags']['required'])){
+                if($params['value'] == 0 && $name == $params['emptylabel']){
+                        $params['value'] = "";
+                        $params['placeholder'] = $params['emptylabel'];
+                }
+                $params['display_emptychoice'] = false;
+        }
+
         if ($params['readonly']) {
             $output = '';
             if ($params["multiple"]) {


### PR DESCRIPTION
Alter behavior of Dropdown::show in case it is marked as required, for better user experience. 
Currently value is evaluated just after form submission, with error message and not on browser side as empty value is 0 and not null.  
Alter it in this way: In case current value is 0, display placeholder with emptylabel instead.

Not sure whether this should belong directly to Dropdown code or rather it should be in twig template. 
Also I am not sure whether it can introduce some compatibility issues.. 
Maybe overriding should happen just if parameters display_emptychoice and placeholder were not passed to function.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | NA
