### PR TITLE
fix(NetworkPort): fix 'restore' action

### DIFF
--- a/front/networkport.form.php
+++ b/front/networkport.form.php
@@ -153,6 +153,20 @@ if (isset($_POST["add"])) {
         $nn->delete($_POST);
     }
     Html::back();
+} else if (isset($_POST["restore"])) {
+    $np->check($_POST["id"], DELETE);
+
+    if ($np->restore($_POST)) {
+        Event::log(
+            $_POST["id"],
+            "networkport",
+            4,
+            "inventory",
+            //TRANS: %s is the user login
+            sprintf(__('%s restores an item'), $_SESSION["glpiname"])
+        );
+    }
+    Html::back();
 } else {
     if (empty($_GET["items_id"])) {
         $_GET["items_id"] = "";


### PR DESCRIPTION
Fix missing 'restore' action from ```NetworkPort```


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26491