### PR TITLE
fix(NetworkPort): fix display of delete non dynamic NetworkPort

### DIFF
--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -656,14 +656,18 @@ class NetworkPort extends CommonDBChild
         $itemtype = $item->getType();
         $items_id = $item->getField('id');
 
-        //from dynamic asset, deleted items are displayed from lock tab
-        //from manual asset, deleted items are always displayed (with is_deleted column)
-        $deleted_criteria = [];
-        if ($item->isDynamic()) {
-            $deleted_criteria = [
-                "is_deleted" => 0
-            ];
-        }
+        //no matter if the main item is dynamic,
+        //deleted and dynamic networkport are displayed from lock tab
+        //deleted and non dynamic networkport are always displayed (with is_deleted column)
+        $deleted_criteria = [
+            'OR'  => [
+                'AND' => [
+                    "is_deleted" => 0,
+                    "is_dynamic" => 1
+                ],
+                "is_dynamic" => 0
+            ]
+        ];
 
         if (
             !NetworkEquipment::canView()


### PR DESCRIPTION
The display of ```NetworkPort``` should not depend on the is_dynamic property of the parent asset, but it should depend on the is_dynamic property of the ```NetworkPort```  (a dynamic asset can have dynamic and non dynamic ```NetworkPort```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26491
