### PR TITLE
Stricter reopen rules for self-services users

### DIFF
--- a/src/Features/ParentStatus.php
+++ b/src/Features/ParentStatus.php
@@ -39,6 +39,7 @@ use CommonITILActor;
 use CommonITILObject;
 use PendingReason_Item;
 use Session;
+use Toolbox;
 
 /**
  * ParentStatus
@@ -90,11 +91,19 @@ trait ParentStatus
             $parentitem->update($update);
         }
 
-       // Set parent status to pending
-        if ($input['pending'] ?? 0) {
-            $input['_status'] = CommonITILObject::WAITING;
-        } elseif (!isset($input['_no_reopen']) && $parentitem->needReopen()) {
-            $input["_reopen"] = true;
+        if (isset($input['pending'])) {
+            // Pending toggle was explicitly enabled or disabled
+            if ($input['pending']) {
+                $input['_status'] = CommonITILObject::WAITING;
+            } else {
+                $input["_reopen"] = true;
+            }
+        } else {
+            // Pending toggle isn't set (self-service, API, ...)
+            // Try to compute whether or not we need te reopen the ticket or not
+            if (isset($input['_no_reopen']) && $parentitem->needReopen()) {
+                $input["_reopen"] = true;
+            }
         }
 
        //manage reopening of ITILObject

--- a/src/Features/ParentStatus.php
+++ b/src/Features/ParentStatus.php
@@ -93,7 +93,7 @@ trait ParentStatus
        // Set parent status to pending
         if ($input['pending'] ?? 0) {
             $input['_status'] = CommonITILObject::WAITING;
-        } elseif (!isset($input['_no_reopen']) && $parentitem->fields["status"] == CommonITILObject::WAITING) {
+        } elseif (!isset($input['_no_reopen']) && $parentitem->needReopen()) {
             $input["_reopen"] = true;
         }
 

--- a/src/Features/ParentStatus.php
+++ b/src/Features/ParentStatus.php
@@ -100,7 +100,7 @@ trait ParentStatus
             }
         } else {
             // Pending toggle isn't set (self-service, API, ...)
-            // Try to compute whether or not we need te reopen the ticket or not
+            // Try to compute whether or not we need te reopen the ticket
             if (isset($input['_no_reopen']) && $parentitem->needReopen()) {
                 $input["_reopen"] = true;
             }

--- a/src/Features/ParentStatus.php
+++ b/src/Features/ParentStatus.php
@@ -39,7 +39,6 @@ use CommonITILActor;
 use CommonITILObject;
 use PendingReason_Item;
 use Session;
-use Toolbox;
 
 /**
  * ParentStatus
@@ -101,7 +100,7 @@ trait ParentStatus
         } else {
             // Pending toggle isn't set (self-service, API, ...)
             // Try to compute whether or not we need te reopen the ticket
-            if (isset($input['_no_reopen']) && $parentitem->needReopen()) {
+            if (!isset($input['_no_reopen']) && $parentitem->needReopen()) {
                 $input["_reopen"] = true;
             }
         }


### PR DESCRIPTION
Some code that only trigger for self-service users was not strict enough.
The code is checking the status instead of calling `needReopen` which has additional checks.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26763
