### PR TITLE
fix: no rights for personal reminders and RSS feeds

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -5054,11 +5054,11 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_SELF_SERVICE,
                 'name' => 'reminder_public',
-                'rights' => READ | Reminder::PERSONAL,
+                'rights' => READ,
             ], [
                 'profiles_id' => self::PROFILE_SELF_SERVICE,
                 'name' => 'rssfeed_public',
-                'rights' => READ | RSSFeed::PERSONAL,
+                'rights' => READ,
             ], [
                 'profiles_id' => self::PROFILE_SELF_SERVICE,
                 'name' => 'bookmark_public',

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -5054,11 +5054,11 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_SELF_SERVICE,
                 'name' => 'reminder_public',
-                'rights' => READ,
+                'rights' => READ | Reminder::PERSONAL,
             ], [
                 'profiles_id' => self::PROFILE_SELF_SERVICE,
                 'name' => 'rssfeed_public',
-                'rights' => READ,
+                'rights' => READ | RSSFeed::PERSONAL,
             ], [
                 'profiles_id' => self::PROFILE_SELF_SERVICE,
                 'name' => 'bookmark_public',
@@ -5330,11 +5330,11 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'reminder_public',
-                'rights' => READ,
+                'rights' => READ | Reminder::PERSONAL,
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'rssfeed_public',
-                'rights' => READ,
+                'rights' => READ | RSSFeed::PERSONAL,
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'bookmark_public',
@@ -5626,11 +5626,11 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'reminder_public',
-                'rights' => READ | UPDATE | CREATE | PURGE,
+                'rights' => READ | UPDATE | CREATE | PURGE | Reminder::PERSONAL,
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'rssfeed_public',
-                'rights' => READ | UPDATE | CREATE | PURGE,
+                'rights' => READ | UPDATE | CREATE | PURGE | RSSFeed::PERSONAL,
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'bookmark_public',
@@ -5923,11 +5923,11 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'reminder_public',
-                'rights' => ALLSTANDARDRIGHT | UNLOCK,
+                'rights' => ALLSTANDARDRIGHT | UNLOCK | Reminder::PERSONAL,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'rssfeed_public',
-                'rights' => ALLSTANDARDRIGHT | UNLOCK,
+                'rights' => ALLSTANDARDRIGHT | UNLOCK | RSSFeed::PERSONAL,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'bookmark_public',
@@ -6222,11 +6222,11 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_HOTLINER,
                 'name' => 'reminder_public',
-                'rights' => self::RIGHT_NONE,
+                'rights' => self::RIGHT_NONE | Reminder::PERSONAL,
             ], [
                 'profiles_id' => self::PROFILE_HOTLINER,
                 'name' => 'rssfeed_public',
-                'rights' => self::RIGHT_NONE,
+                'rights' => self::RIGHT_NONE | RSSFeed::PERSONAL,
             ], [
                 'profiles_id' => self::PROFILE_HOTLINER,
                 'name' => 'bookmark_public',
@@ -6507,11 +6507,11 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'reminder_public',
-                'rights' => READ | UPDATE | CREATE | PURGE,
+                'rights' => READ | UPDATE | CREATE | PURGE | Reminder::PERSONAL,
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'rssfeed_public',
-                'rights' => READ | UPDATE | CREATE | PURGE,
+                'rights' => READ | UPDATE | CREATE | PURGE | RSSFeed::PERSONAL,
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'bookmark_public',
@@ -6798,11 +6798,11 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'reminder_public',
-                'rights' => READ | UPDATE | CREATE | PURGE,
+                'rights' => READ | UPDATE | CREATE | PURGE | Reminder::PERSONAL,
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'rssfeed_public',
-                'rights' => READ | UPDATE | CREATE | PURGE,
+                'rights' => READ | UPDATE | CREATE | PURGE | RSSFeed::PERSONAL,
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'bookmark_public',
@@ -7113,11 +7113,11 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'reservation',
-                'rights' => READ,
+                'rights' => READ | Reminder::PERSONAL,
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'rssfeed_public',
-                'rights' => READ,
+                'rights' => READ | RSSFeed::PERSONAL,
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'rule_dictionnary_dropdown',

--- a/install/migrations/update_10.0.6_to_10.0.7/profils.php
+++ b/install/migrations/update_10.0.6_to_10.0.7/profils.php
@@ -37,5 +37,5 @@
  * @var DB $DB
  * @var Migration $migration
  */
-$migration->updateRight('reminder_public', Reminder::PERSONAL, ['reminder_public' => 0]);
-$migration->updateRight('rssfeed_public', RSSFeed::PERSONAL, ['rssfeed_public' => 0]);
+$migration->addRightByInterface('reminder_public', Reminder::PERSONAL, 'central');
+$migration->addRightByInterface('rssfeed_public', RSSFeed::PERSONAL, 'central');

--- a/install/migrations/update_10.0.6_to_10.0.7/profils.php
+++ b/install/migrations/update_10.0.6_to_10.0.7/profils.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+$migration->updateRight('reminder_public', Reminder::PERSONAL, ['reminder_public' => 0]);
+$migration->updateRight('rssfeed_public', RSSFeed::PERSONAL, ['rssfeed_public' => 0]);

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -1232,6 +1232,61 @@ class Migration
     }
 
     /**
+     * Add specific right to profiles that match interface
+     *
+     * @param string  $name      Right name
+     * @param integer $right     Right to add
+     * @param string  $interface Interface to set (defaults to central)
+     *
+     * @return void
+     */
+    public function addRightByInterface($name, $right, $interface = 'central')
+    {
+        global $DB;
+
+        $prof_iterator = $DB->request([
+            'SELECT'    => [
+                'glpi_profiles.id',
+                'glpi_profilerights.rights',
+            ],
+            'FROM'      => 'glpi_profiles',
+            'JOIN'      => [
+                'glpi_profilerights' => [
+                    'FKEY' => [
+                        'glpi_profilerights'      => 'profiles_id',
+                        'glpi_profiles'           => 'id',
+                        [
+                            'AND' => [
+                                'glpi_profilerights.name' => $name
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            'WHERE'     => [
+                'interface' => $interface,
+            ]
+        ]);
+
+        foreach ($prof_iterator as $profile) {
+            if (intval($profile['rights']) & $right) {
+                continue;
+            }
+            $DB->updateOrInsert(
+                'glpi_profilerights',
+                [
+                    'rights'       => $profile['rights'] | $right,
+                ],
+                [
+                    'profiles_id'  => $profile['id'],
+                    'name'         => $name
+                ],
+                sprintf('%1$s update right for %2$s', $this->version, $name)
+            );
+        }
+    }
+
+    /**
      * Update right to profiles that match rights requirements
      *    Default is to update rights of profiles with READ and UPDATE rights on config
      *

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -1284,6 +1284,14 @@ class Migration
                 sprintf('%1$s update right for %2$s', $this->version, $name)
             );
         }
+
+        $this->displayWarning(
+            sprintf(
+                'Rights has been updated for %1$s, you should review ACLs after update',
+                $name
+            ),
+            true
+        );
     }
 
     /**

--- a/src/RSSFeed.php
+++ b/src/RSSFeed.php
@@ -87,7 +87,8 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria
     {
 
         return (Session::haveRight(self::$rightname, CREATE)
-              || Session::getCurrentInterface() != 'helpdesk');
+              || Session::haveRight(self::$rightname, self::PERSONAL)
+              && Session::getCurrentInterface() != 'helpdesk');
     }
 
 
@@ -132,7 +133,9 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria
      **/
     public static function canUpdate()
     {
-        return (Session::getCurrentInterface() != 'helpdesk');
+        return (Session::haveRight(self::$rightname, UPDATE)
+              || Session::haveRight(self::$rightname, self::PERSONAL)
+              && Session::getCurrentInterface() != 'helpdesk');
     }
 
 
@@ -142,7 +145,9 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria
      **/
     public static function canPurge()
     {
-        return (Session::getCurrentInterface() != 'helpdesk');
+        return (Session::haveRight(self::$rightname, PURGE)
+              || Session::haveRight(self::$rightname, self::PERSONAL)
+              && Session::getCurrentInterface() != 'helpdesk');
     }
 
 

--- a/src/RSSFeed.php
+++ b/src/RSSFeed.php
@@ -86,18 +86,14 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria
     public static function canCreate()
     {
 
-        return (Session::haveRight(self::$rightname, CREATE)
-              || Session::haveRight(self::$rightname, self::PERSONAL)
-              && Session::getCurrentInterface() != 'helpdesk');
+        return (Session::haveRightsOr(self::$rightname, [CREATE, self::PERSONAL]));
     }
 
 
     public static function canView()
     {
 
-        return (Session::haveRight('rssfeed_public', READ)
-              || Session::haveRight(self::$rightname, self::PERSONAL)
-              && Session::getCurrentInterface() != 'helpdesk');
+        return (Session::haveRightsOr(self::$rightname, [READ, self::PERSONAL]));
     }
 
 
@@ -133,9 +129,7 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria
      **/
     public static function canUpdate()
     {
-        return (Session::haveRight(self::$rightname, UPDATE)
-              || Session::haveRight(self::$rightname, self::PERSONAL)
-              && Session::getCurrentInterface() != 'helpdesk');
+        return (Session::haveRightsOr(self::$rightname, [UPDATE, self::PERSONAL]));
     }
 
 
@@ -145,9 +139,7 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria
      **/
     public static function canPurge()
     {
-        return (Session::haveRight(self::$rightname, PURGE)
-              || Session::haveRight(self::$rightname, self::PERSONAL)
-              && Session::getCurrentInterface() != 'helpdesk');
+        return (Session::haveRightsOr(self::$rightname, [PURGE, self::PERSONAL]));
     }
 
 
@@ -1124,7 +1116,7 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria
             $values = [READ => __('Read')];
         } else {
             $values = parent::getRights();
-            $values[self::PERSONAL] = __('Show personal when no public rights');
+            $values[self::PERSONAL] = __('Manage personal');
         }
         return $values;
     }

--- a/src/RSSFeed.php
+++ b/src/RSSFeed.php
@@ -71,7 +71,7 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria
 
     public static $rightname    = 'rssfeed_public';
 
-
+    const PERSONAL = 128;
 
     public static function getTypeName($nb = 0)
     {
@@ -95,7 +95,8 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria
     {
 
         return (Session::haveRight('rssfeed_public', READ)
-              || Session::getCurrentInterface() != 'helpdesk');
+              || Session::haveRight(self::$rightname, self::PERSONAL)
+              && Session::getCurrentInterface() != 'helpdesk');
     }
 
 
@@ -1118,6 +1119,7 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria
             $values = [READ => __('Read')];
         } else {
             $values = parent::getRights();
+            $values[self::PERSONAL] = __('Show personal when no public rights');
         }
         return $values;
     }

--- a/src/Reminder.php
+++ b/src/Reminder.php
@@ -73,7 +73,8 @@ class Reminder extends CommonDBVisible implements
     {
 
         return (Session::haveRight(self::$rightname, CREATE)
-              || Session::getCurrentInterface() != 'helpdesk');
+              || Session::haveRight(self::$rightname, self::PERSONAL)
+              && Session::getCurrentInterface() != 'helpdesk');
     }
 
 
@@ -132,7 +133,9 @@ class Reminder extends CommonDBVisible implements
      **/
     public static function canUpdate()
     {
-        return (Session::getCurrentInterface() != 'helpdesk');
+        return (Session::haveRight(self::$rightname, UPDATE)
+              || Session::haveRight(self::$rightname, self::PERSONAL)
+              && Session::getCurrentInterface() != 'helpdesk');
     }
 
 
@@ -142,7 +145,9 @@ class Reminder extends CommonDBVisible implements
      **/
     public static function canPurge()
     {
-        return (Session::getCurrentInterface() != 'helpdesk');
+        return (Session::haveRight(self::$rightname, PURGE)
+              || Session::haveRight(self::$rightname, self::PERSONAL)
+              && Session::getCurrentInterface() != 'helpdesk');
     }
 
 

--- a/src/Reminder.php
+++ b/src/Reminder.php
@@ -57,7 +57,7 @@ class Reminder extends CommonDBVisible implements
 
     public static $rightname    = 'reminder_public';
 
-
+    const PERSONAL = 128;
 
     public static function getTypeName($nb = 0)
     {
@@ -81,7 +81,8 @@ class Reminder extends CommonDBVisible implements
     {
 
         return (Session::haveRight(self::$rightname, READ)
-              || Session::getCurrentInterface() != 'helpdesk');
+              || Session::haveRight(self::$rightname, self::PERSONAL)
+              && Session::getCurrentInterface() != 'helpdesk');
     }
 
 
@@ -1035,6 +1036,7 @@ class Reminder extends CommonDBVisible implements
             $values = [READ => __('Read')];
         } else {
             $values = parent::getRights();
+            $values[self::PERSONAL] = __('Show personal when no public rights');
         }
         return $values;
     }

--- a/src/Reminder.php
+++ b/src/Reminder.php
@@ -72,18 +72,14 @@ class Reminder extends CommonDBVisible implements
     public static function canCreate()
     {
 
-        return (Session::haveRight(self::$rightname, CREATE)
-              || Session::haveRight(self::$rightname, self::PERSONAL)
-              && Session::getCurrentInterface() != 'helpdesk');
+        return (Session::haveRightsOr(self::$rightname, [CREATE, self::PERSONAL]));
     }
 
 
     public static function canView()
     {
 
-        return (Session::haveRight(self::$rightname, READ)
-              || Session::haveRight(self::$rightname, self::PERSONAL)
-              && Session::getCurrentInterface() != 'helpdesk');
+        return (Session::haveRightsOr(self::$rightname, [READ, self::PERSONAL]));
     }
 
 
@@ -133,9 +129,7 @@ class Reminder extends CommonDBVisible implements
      **/
     public static function canUpdate()
     {
-        return (Session::haveRight(self::$rightname, UPDATE)
-              || Session::haveRight(self::$rightname, self::PERSONAL)
-              && Session::getCurrentInterface() != 'helpdesk');
+        return (Session::haveRightsOr(self::$rightname, [UPDATE, self::PERSONAL]));
     }
 
 
@@ -145,9 +139,7 @@ class Reminder extends CommonDBVisible implements
      **/
     public static function canPurge()
     {
-        return (Session::haveRight(self::$rightname, PURGE)
-              || Session::haveRight(self::$rightname, self::PERSONAL)
-              && Session::getCurrentInterface() != 'helpdesk');
+        return (Session::haveRightsOr(self::$rightname, [PURGE, self::PERSONAL]));
     }
 
 
@@ -1041,7 +1033,7 @@ class Reminder extends CommonDBVisible implements
             $values = [READ => __('Read')];
         } else {
             $values = parent::getRights();
-            $values[self::PERSONAL] = __('Show personal when no public rights');
+            $values[self::PERSONAL] = __('Manage personal');
         }
         return $values;
     }

--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -769,6 +769,49 @@ class Migration extends \GLPITestCase
         $this->integer(count($right4))->isEqualTo(4);
     }
 
+    public function testAddRightByInterface()
+    {
+        global $DB;
+
+        $DB->delete('glpi_profilerights', [
+            'name' => [
+                'testright1', 'testright2', 'testright3', 'testright4'
+            ]
+        ]);
+        //Test adding a READ right on central interface
+        $this->output(
+            function () {
+                $this->migration->addRightByInterface('testright1', READ, ['interface' => 'central']);
+            }
+        )->isEqualTo('Rights has been updated for testright1, you should review ACLs after update');
+
+        //Test adding a READ right on helpdesk interface
+        $this->output(
+            function () {
+                $this->migration->addRightByInterface('testright2', READ, ['interface' => 'helpdesk']);
+            }
+        )->isEqualTo('Rights has been updated for testright2, you should review ACLs after update');
+
+        //Check if rights have been added
+        $right1 = $DB->request([
+            'FROM' => 'glpi_profilerights',
+            'WHERE'  => [
+                'name'   => 'testright1',
+                'rights' => READ
+            ]
+        ]);
+        $this->integer(count($right1))->isEqualTo(7);
+
+        $right2 = $DB->request([
+            'FROM' => 'glpi_profilerights',
+            'WHERE'  => [
+                'name'   => 'testright2',
+                'rights' => READ
+            ]
+        ]);
+        $this->integer(count($right2))->isEqualTo(1);
+    }
+
     public function testRenameTable()
     {
 


### PR DESCRIPTION
When a profile did not have access to `public reminders`, GLPI replaced the menu with `personal reminders`, so the menu was not removed completely.

This PR adds rights to hide menus completely

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26786
