### PR TITLE
Add users_id_tech for unmanaged devices

### DIFF
--- a/install/migrations/update_10.0.6_to_10.0.7/unmanageds.php
+++ b/install/migrations/update_10.0.6_to_10.0.7/unmanageds.php
@@ -60,6 +60,7 @@ if ($DB->fieldExists(\Unmanaged::getTable(), 'domains_id')) {
 
 if (!$DB->fieldExists(\Unmanaged::getTable(), 'users_id_tech')) {
     $migration->addField(\Unmanaged::getTable(), 'users_id_tech', "int {$default_key_sign} NOT NULL DEFAULT '0'", ['after' => 'states_id']);
+    $migration->addKey(\Unmanaged::getTable(), 'users_id_tech');
 }
 
 //new right value for unmanageds (previously based on config UPDATE)

--- a/install/migrations/update_10.0.6_to_10.0.7/unmanageds.php
+++ b/install/migrations/update_10.0.6_to_10.0.7/unmanageds.php
@@ -38,6 +38,8 @@
  * @var Migration $migration
  */
 
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
+
 if ($DB->fieldExists(\Unmanaged::getTable(), 'domains_id')) {
     $iterator = $DB->request([
         'SELECT' => ['id', 'domains_id'],
@@ -54,6 +56,10 @@ if ($DB->fieldExists(\Unmanaged::getTable(), 'domains_id')) {
         }
     }
     $migration->dropField(\Unmanaged::getTable(), 'domains_id');
+}
+
+if (!$DB->fieldExists(\Unmanaged::getTable(), 'users_id_tech')) {
+    $migration->addField(\Unmanaged::getTable(), 'users_id_tech', "int {$default_key_sign} NOT NULL DEFAULT '0'", ['after' => 'states_id']);
 }
 
 //new right value for unmanageds (previously based on config UPDATE)

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -8872,7 +8872,8 @@ CREATE TABLE `glpi_unmanageds` (
   KEY `date_creation` (`date_creation`),
   KEY `autoupdatesystems_id` (`autoupdatesystems_id`),
   KEY `agents_id` (`agents_id`),
-  KEY `snmpcredentials_id` (`snmpcredentials_id`)
+  KEY `snmpcredentials_id` (`snmpcredentials_id`),
+  KEY `users_id_tech` (`users_id_tech`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_networkporttypes`;

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -8840,6 +8840,7 @@ CREATE TABLE `glpi_unmanageds` (
   `users_id` int unsigned NOT NULL DEFAULT '0',
   `groups_id` int unsigned NOT NULL DEFAULT '0',
   `states_id` int unsigned NOT NULL DEFAULT '0',
+  `users_id_tech` int unsigned NOT NULL DEFAULT '0',
   `groups_id_tech` int unsigned NOT NULL DEFAULT '0',
   `is_dynamic` tinyint NOT NULL DEFAULT '0',
   `date_creation` timestamp NULL DEFAULT NULL,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fixes All Assets view as `users_id_tech` field is expected for all assets but was missing for Unmanaged which was added to this list in #13326.