### PR TITLE
Refresh plugin info when needing an update

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -599,6 +599,8 @@ class Plugin extends CommonDBTM
         ) {
             // Plugin known version differs from information or plugin has been renamed,
             // update information in database
+            $input              = $informations;
+            $input['directory'] = $plugin_key;
             if (!in_array($plugin->fields['state'], [self::ANEW, self::NOTINSTALLED, self::NOTUPDATED])) {
                 // mark it as 'updatable' unless it was not installed
                 trigger_error(
@@ -608,6 +610,8 @@ class Plugin extends CommonDBTM
                     ),
                     E_USER_WARNING
                 );
+
+                $input['state']     = self::NOTUPDATED;
 
                 Event::log(
                     '',
@@ -621,12 +625,12 @@ class Plugin extends CommonDBTM
                 );
             }
 
-            // Update status and all plugin info in case it was changed in a new update (like the license)
             $this->update(
-                [
+                $informations + [
                     'id'    => $plugin->fields['id'],
-                    'state' => self::NOTUPDATED,
-                ] + $informations
+                    'state' => $input['state'],
+                    'directory' => $input['directory'],
+                ]
             );
 
             $this->unload($plugin_key);

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -599,9 +599,6 @@ class Plugin extends CommonDBTM
         ) {
             // Plugin known version differs from information or plugin has been renamed,
             // update information in database
-            $input              = $informations;
-            $input['id']        = $plugin->fields['id'];
-            $input['directory'] = $plugin_key;
             if (!in_array($plugin->fields['state'], [self::ANEW, self::NOTINSTALLED, self::NOTUPDATED])) {
                 // mark it as 'updatable' unless it was not installed
                 trigger_error(
@@ -611,8 +608,6 @@ class Plugin extends CommonDBTM
                     ),
                     E_USER_WARNING
                 );
-
-                $input['state']     = self::NOTUPDATED;
 
                 Event::log(
                     '',
@@ -626,7 +621,13 @@ class Plugin extends CommonDBTM
                 );
             }
 
-            $this->update($input);
+            // Update status and all plugin info in case it was changed in a new update (like the license)
+            $this->update(
+                [
+                    'id'    => $plugin->fields['id'],
+                    'state' => self::NOTUPDATED,
+                ] + $informations
+            );
 
             $this->unload($plugin_key);
             // reset menu


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When a plugin changes some info like the license between versions, the new license information isn't being saved in the DB so the old license is still shown in the plugin list. This PR refreshes the plugin information at the time it detects that an update is needed.