### PR TITLE
Make 64bits integers requirement mandatory

### DIFF
--- a/src/System/Requirement/IntegerSize.php
+++ b/src/System/Requirement/IntegerSize.php
@@ -41,14 +41,13 @@ final class IntegerSize extends AbstractRequirement
     {
         $this->title = __('PHP maximal integer size');
         $this->description = __('Support of 64 bits integers is required for IP addresses related operations (network inventory, API clients IP filtering, ...).');
-        $this->optional = true;
     }
 
     protected function check()
     {
         if (PHP_INT_SIZE < 8) {
             $this->validated = false;
-            $this->validation_messages[] = __('OS or PHP is not relying on 64 bits integers, operations on IP addresses may produce unexpected results.');
+            $this->validation_messages[] = __('OS or PHP is not relying on 64 bits integers.');
         } else {
             $this->validated = true;
             $this->validation_messages[] = __('OS and PHP are relying on 64 bits integers.');

--- a/src/System/RequirementsManager.php
+++ b/src/System/RequirementsManager.php
@@ -70,6 +70,7 @@ class RequirementsManager
         $requirements = [];
 
         $requirements[] = new PhpVersion(GLPI_MIN_PHP, GLPI_MAX_PHP);
+        $requirements[] = new IntegerSize();
 
         $requirements[] = new SessionsConfiguration();
 
@@ -139,7 +140,6 @@ class RequirementsManager
        // Below requirements are optionals
 
         $requirements[] = new SessionsSecurityConfiguration();
-        $requirements[] = new IntegerSize();
         $requirements[] = new Extension(
             'exif',
             true,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

As discussed previously, this requirement should be mandatory on next major GLPI version.