### PR TITLE
fix(inventory): manage UUID format changed

### DIFF
--- a/src/Inventory/Asset/VirtualMachine.php
+++ b/src/Inventory/Asset/VirtualMachine.php
@@ -238,7 +238,7 @@ class VirtualMachine extends InventoryAsset
                     if ($sinput == $arraydb) {
                         $input = [
                             'id'           => $keydb,
-                            'uuid'         => strtolower($handled_input['uuid']) ?? '', //strtolower
+                            'uuid'         => strtolower($handled_input['uuid'] ?? ''),
                             'is_dynamic'   => 1
                         ];
 

--- a/src/Inventory/Asset/VirtualMachine.php
+++ b/src/Inventory/Asset/VirtualMachine.php
@@ -42,6 +42,7 @@ use ComputerVirtualMachine;
 use Glpi\Inventory\Conf;
 use Glpi\Toolbox\Sanitizer;
 use RuleImportAssetCollection;
+use Toolbox;
 
 class VirtualMachine extends InventoryAsset
 {
@@ -222,26 +223,33 @@ class VirtualMachine extends InventoryAsset
             $computerVirtualmachine->getFromDB($keydb);
             foreach ($value as $key => $val) {
                 $handled_input = $this->handleInput($val, $computerVirtualmachine);
-                $sinput = [
-                    'name'                     => $handled_input['name'] ?? '',
-                    'uuid'                     => $handled_input['uuid'] ?? '',
-                    'virtualmachinesystems_id' => $handled_input['virtualmachinesystems_id'] ?? 0
-                ];
-                if ($sinput == $arraydb) {
-                    $input = [
-                        'id'           => $keydb,
-                        'is_dynamic'   => 1
+
+                //search ComputervirtualMachine on cleaned UUID if it changed
+                foreach (ComputerVirtualMachine::getUUIDRestrictCriteria($handled_input['uuid']) as $cleaned_uuid) {
+                    $sinput = [
+                        'name'                     => $handled_input['name'] ?? '',
+                        'uuid'                     => $cleaned_uuid ?? '',
+                        'virtualmachinesystems_id' => $handled_input['virtualmachinesystems_id'] ?? 0
                     ];
 
-                    foreach (['vcpu', 'ram', 'virtualmachinetypes_id', 'virtualmachinestates_id'] as $prop) {
-                        if (property_exists($val, $prop)) {
-                            $input[$prop] = $handled_input[$prop];
+                    if ($sinput == $arraydb) {
+                        $input = [
+                            'id'           => $keydb,
+                            'uuid'         => $handled_input['uuid'] ?? '',
+                            'is_dynamic'   => 1
+                        ];
+
+                        foreach (['vcpu', 'ram', 'virtualmachinetypes_id', 'virtualmachinestates_id'] as $prop) {
+                            if (property_exists($val, $prop)) {
+                                $input[$prop] = $handled_input[$prop];
+                            }
                         }
+
+                        $computerVirtualmachine->update(Sanitizer::sanitize($input));
+                        unset($value[$key]);
+                        unset($db_vms[$keydb]);
+                        break 2;
                     }
-                    $computerVirtualmachine->update(Sanitizer::sanitize($input));
-                    unset($value[$key]);
-                    unset($db_vms[$keydb]);
-                    break;
                 }
             }
         }

--- a/src/Inventory/Asset/VirtualMachine.php
+++ b/src/Inventory/Asset/VirtualMachine.php
@@ -232,10 +232,13 @@ class VirtualMachine extends InventoryAsset
                         'virtualmachinesystems_id' => $handled_input['virtualmachinesystems_id'] ?? 0
                     ];
 
+                    //strtolower to be the same as getUUIDRestrictCriteria()
+                    $arraydb['uuid'] = strtolower($arraydb['uuid']);
+
                     if ($sinput == $arraydb) {
                         $input = [
                             'id'           => $keydb,
-                            'uuid'         => $handled_input['uuid'] ?? '',
+                            'uuid'         => strtolower($handled_input['uuid']) ?? '', //strtolower
                             'is_dynamic'   => 1
                         ];
 

--- a/src/Inventory/Asset/VirtualMachine.php
+++ b/src/Inventory/Asset/VirtualMachine.php
@@ -225,7 +225,7 @@ class VirtualMachine extends InventoryAsset
                 $handled_input = $this->handleInput($val, $computerVirtualmachine);
 
                 //search ComputervirtualMachine on cleaned UUID if it changed
-                foreach (ComputerVirtualMachine::getUUIDRestrictCriteria($handled_input['uuid']) as $cleaned_uuid) {
+                foreach (ComputerVirtualMachine::getUUIDRestrictCriteria($handled_input['uuid'] ?? '') as $cleaned_uuid) {
                     $sinput = [
                         'name'                     => $handled_input['name'] ?? '',
                         'uuid'                     => $cleaned_uuid ?? '',

--- a/tests/functionnal/Glpi/Inventory/Assets/VirtualMachine.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/VirtualMachine.php
@@ -166,4 +166,198 @@ class VirtualMachine extends AbstractInventoryAsset
         $this->boolean($cvm->getFromDbByCrit(['computers_id' => $computer->fields['id']]))
            ->isTrue('Virtual machine has not been linked to computer :(');
     }
+
+    public function testImportVirtualMachine()
+    {
+
+        $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+        <REQUEST>
+          <CONTENT>
+            <BIOS>
+              <ASSETTAG></ASSETTAG>
+              <BDATE>2018-02-08T00:00:00Z</BDATE>
+              <BVERSION>1.3.7</BVERSION>
+              <MSN>2YR88P2</MSN>
+              <SMANUFACTURER>Dell Inc.</SMANUFACTURER>
+              <SMODEL>PowerEdge R640</SMODEL>
+              <SSN>2YR88P2</SSN>
+            </BIOS>
+            <CPUS>
+              <CORE>10</CORE>
+              <MANUFACTURER>Intel</MANUFACTURER>
+              <NAME>Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz</NAME>
+              <SPEED>2394</SPEED>
+              <THREAD>2</THREAD>
+            </CPUS>
+            <HARDWARE>
+              <DNS>10.100.230.2/10.100.230.4</DNS>
+              <MEMORY>130625</MEMORY>
+              <NAME>ESX-03-DMZ</NAME>
+              <UUID>8c8c8944-0074-5632-7452-b2c04f564712</UUID>
+              <VMSYSTEM>Physical</VMSYSTEM>
+              <WORKGROUP>teclib.fr</WORKGROUP>
+            </HARDWARE>
+            <NETWORKS>
+              <DESCRIPTION>vmk0</DESCRIPTION>
+              <IPADDRESS>10.100.240.66</IPADDRESS>
+              <IPMASK>255.255.255.192</IPMASK>
+              <MACADDR>80:18:44:f0:47:33</MACADDR>
+              <MTU>1500</MTU>
+              <STATUS>Up</STATUS>
+              <VIRTUALDEV>1</VIRTUALDEV>
+            </NETWORKS>
+            <OPERATINGSYSTEM>
+              <BOOT_TIME>2022-08-06 15:40:56</BOOT_TIME>
+              <DNS_DOMAIN>insep.fr</DNS_DOMAIN>
+              <FQDN>esx-03-dmz.teclib.fr</FQDN>
+              <FULL_NAME>VMware ESXi 6.7.0 build-19195723</FULL_NAME>
+              <NAME>VMware ESXi</NAME>
+              <TIMEZONE>
+                <NAME>UTC</NAME>
+                <OFFSET>+0000</OFFSET>
+              </TIMEZONE>
+              <VERSION>6.7.0</VERSION>
+            </OPERATINGSYSTEM>
+            <VERSIONCLIENT>GLPI-Agent_v1.4-1</VERSIONCLIENT>
+            <VIRTUALMACHINES>
+              <COMMENT>Computer VM</COMMENT>
+              <MAC>00:50:56:90:43:42</MAC>
+              <MEMORY>1024</MEMORY>
+              <NAME>SRV-DMZ-EZ</NAME>
+              <STATUS>running</STATUS>
+              <UUID>420904fe-6a92-95e8-13f9-a37fc3607c14</UUID>
+              <VCPU>1</VCPU>
+              <VMTYPE>VMware</VMTYPE>
+            </VIRTUALMACHINES>
+          </CONTENT>
+          <DEVICEID>ESX-03-DMZ.insep.fr-2023-02-02-11-34-53</DEVICEID>
+          <QUERY>INVENTORY</QUERY>
+        </REQUEST>
+        ";
+
+          //change config to import vms as computers
+          $this->login();
+          $conf = new \Glpi\Inventory\Conf();
+          $this->boolean($conf->saveConf(['vm_as_computer' => 1]))->isTrue();
+          $this->logout();
+
+          //computer inventory knows bios
+          $inventory = $this->doInventory($xml_source, true);
+
+          $esx_id_first = $inventory->getItem()->fields['id'];
+          $this->integer($esx_id_first)->isGreaterThan(0);
+
+          //always one VM
+          $vm = new \ComputerVirtualMachine();
+          $this->array($vm->find())->hasSize(1);
+
+          //get ComputervirtualMachine
+          $vm_first = new \ComputerVirtualMachine();
+          $this->boolean($vm_first->getFromDBByCrit([
+              'uuid' => '420904fe-6a92-95e8-13f9-a37fc3607c14',
+              'computers_id' => $esx_id_first
+          ]))->isTrue();
+
+
+          //get Computer
+          $computer_linked_first = new \Computer();
+          $this->boolean($computer_linked_first->getFromDBByCrit([
+              'uuid' => '420904fe-6a92-95e8-13f9-a37fc3607c14',
+          ]))->isTrue();
+
+          $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+          <REQUEST>
+            <CONTENT>
+              <BIOS>
+                <ASSETTAG></ASSETTAG>
+                <BDATE>2018-02-08T00:00:00Z</BDATE>
+                <BVERSION>1.3.7</BVERSION>
+                <MSN>2YR88P2</MSN>
+                <SMANUFACTURER>Dell Inc.</SMANUFACTURER>
+                <SMODEL>PowerEdge R640</SMODEL>
+                <SSN>2YR88P2</SSN>
+              </BIOS>
+              <CPUS>
+                <CORE>10</CORE>
+                <MANUFACTURER>Intel</MANUFACTURER>
+                <NAME>Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz</NAME>
+                <SPEED>2394</SPEED>
+                <THREAD>2</THREAD>
+              </CPUS>
+              <HARDWARE>
+                <DNS>10.100.230.2/10.100.230.4</DNS>
+                <MEMORY>130625</MEMORY>
+                <NAME>ESX-03-DMZ</NAME>
+                <UUID>8c8c8944-0074-5632-7452-b2c04f564712</UUID>
+                <VMSYSTEM>Physical</VMSYSTEM>
+                <WORKGROUP>teclib.fr</WORKGROUP>
+              </HARDWARE>
+              <NETWORKS>
+                <DESCRIPTION>vmk0</DESCRIPTION>
+                <IPADDRESS>10.100.240.66</IPADDRESS>
+                <IPMASK>255.255.255.192</IPMASK>
+                <MACADDR>80:18:44:f0:47:33</MACADDR>
+                <MTU>1500</MTU>
+                <STATUS>Up</STATUS>
+                <VIRTUALDEV>1</VIRTUALDEV>
+              </NETWORKS>
+              <OPERATINGSYSTEM>
+                <BOOT_TIME>2022-08-06 15:40:56</BOOT_TIME>
+                <DNS_DOMAIN>insep.fr</DNS_DOMAIN>
+                <FQDN>esx-03-dmz.teclib.fr</FQDN>
+                <FULL_NAME>VMware ESXi 6.7.0 build-19195723</FULL_NAME>
+                <NAME>VMware ESXi</NAME>
+                <TIMEZONE>
+                  <NAME>UTC</NAME>
+                  <OFFSET>+0000</OFFSET>
+                </TIMEZONE>
+                <VERSION>6.7.0</VERSION>
+              </OPERATINGSYSTEM>
+              <VERSIONCLIENT>GLPI-Agent_v1.4-1</VERSIONCLIENT>
+              <VIRTUALMACHINES>
+                <COMMENT>Computer VM</COMMENT>
+                <MAC>00:50:56:90:43:42</MAC>
+                <MEMORY>1024</MEMORY>
+                <NAME>SRV-DMZ-EZ</NAME>
+                <STATUS>running</STATUS>
+                <UUID>fe040942-926a-e895-13f9-a37fc3607c14</UUID>
+                <VCPU>1</VCPU>
+                <VMTYPE>VMware</VMTYPE>
+              </VIRTUALMACHINES>
+            </CONTENT>
+            <DEVICEID>ESX-03-DMZ.insep.fr-2023-02-02-11-34-53</DEVICEID>
+            <QUERY>INVENTORY</QUERY>
+          </REQUEST>
+          ";
+
+
+          //redo inventory with different formatted UUID fe040942-926a-e895-13f9-a37fc3607c14
+          $inventory = $this->doInventory($xml_source, true);
+
+          $esx_id_second = $inventory->getItem()->fields['id'];
+          $this->integer($esx_id_second)->isGreaterThan(0);
+
+          $this->integer($esx_id_first)->isEqualTo($esx_id_second);
+
+          //always one VM
+          $vm = new \ComputerVirtualMachine();
+          $this->array($vm->find())->hasSize(1);
+
+          //get ComputervirtualMachine
+          $vm_second = new \ComputerVirtualMachine();
+          $this->boolean($vm_second->getFromDBByCrit([
+              'uuid' => 'fe040942-926a-e895-13f9-a37fc3607c14',
+              'computers_id' => $esx_id_second
+          ]))->isTrue();
+
+          //get Computer
+          $computer_linked_second = new \Computer();
+          $this->boolean($computer_linked_second->getFromDBByCrit([
+              'uuid' => 'fe040942-926a-e895-13f9-a37fc3607c14',
+          ]))->isTrue();
+
+          //same VM and Computer
+          $this->integer($vm_first->fields['id'])->isEqualTo($vm_second->fields['id']);
+          $this->integer($computer_linked_first->fields['id'])->isEqualTo($computer_linked_second->fields['id']);
+    }
 }

--- a/tests/functionnal/Glpi/Inventory/Assets/VirtualMachine.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/VirtualMachine.php
@@ -225,7 +225,7 @@ class VirtualMachine extends AbstractInventoryAsset
               <MEMORY>1024</MEMORY>
               <NAME>SRV-DMZ-EZ</NAME>
               <STATUS>running</STATUS>
-              <UUID>420904fe-6a92-95e8-13f9-a37fc3607c14</UUID>
+              <UUID>420904FE-6a92-95e8-13f9-a37fc3607c14</UUID>
               <VCPU>1</VCPU>
               <VMTYPE>VMware</VMTYPE>
             </VIRTUALMACHINES>


### PR DESCRIPTION
Actually ```inventory``` can manage handle ```Computer``` even if  ```uuid``` change
from this ```420904fe-6a92-95e8-13f9-a37fc3607c14``` to this ```fe040942-926a-e895-13f9-a37fc3607c14```

See ```ComputerVirtualMachine::getUUIDRestrictCriteria```
https://github.com/glpi-project/glpi/blob/40cf35f66efb3840e6b6fe426589526a2df37149/src/ComputerVirtualMachine.php#L368-L401

But, this behavior is not done for ```ComputerVirtualMachine``` it self.

The link between ```ESX``` and ```Computer``` is then deleted and recreated at each inventory if ```UUID``` changed.

This Pr fix this

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26226
