### PR TITLE
Fix enable_images option handling in textarea fields

### DIFF
--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -227,7 +227,8 @@
          id,
          options.rand,
          true,
-         options.disabled|default(false)
+         options.disabled|default(false),
+         options.enable_images
       ]) %}
    {% endif %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26857

Adding images in solution, followup or task templates is not supported. However, pasting images was not disabled due to the fact that argument was not correctly passed to the rich text editor initialization method.