### PR TITLE
Fix redirect URL parameters

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -573,7 +573,7 @@ class Html
         }
 
         if (!empty($params)) {
-            if (str_contains('?', $dest)) {
+            if (str_contains($dest, '?')) {
                 $dest .= '&' . $params;
             } else {
                 $dest .= '?' . $params;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14138

`str_contains` params were inverted.