### PR TITLE
Fix error on network port form

### DIFF
--- a/src/CommonDBChild.php
+++ b/src/CommonDBChild.php
@@ -923,11 +923,6 @@ abstract class CommonDBChild extends CommonDBConnexity
         $lower_name = strtolower(get_called_class());
         $div_id     = "add_" . $lower_name . "_to_" . $item->getType() . "_" . $items_id;
 
-       // To be sure not to load bad datas from this table
-        if ($items_id == 0) {
-            $items_id = -99;
-        }
-
         $query = [
             'FROM'   => static::getTable(),
             'WHERE'  => [

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -453,7 +453,7 @@ class CommonDBTM extends CommonGLPI
     {
 
         if (isset($this->fields[static::getIndexName()])) {
-            return $this->fields[static::getIndexName()];
+            return (int)$this->fields[static::getIndexName()];
         }
         return -1;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

to fix:
```
[2023-02-22 11:07:54] glpisqllog.WARNING: DBmysql::query() in /var/www/webapps/glpi/src/DBmysql.php line 404
  *** MySQL query warnings:
  SQL: SELECT * FROM `glpi_ipaddresses` WHERE `items_id` = '' AND `itemtype` = 'NetworkName' AND `is_deleted` = '0'
  Warnings: 
1292: Truncated incorrect DECIMAL value: ''
  Backtrace :
  src/DBmysqlIterator.php:112                        
  src/DBmysql.php:1056                               DBmysqlIterator->execute()
  src/CommonDBChild.php:948                          DBmysql->request()
  src/NetworkName.php:478                            CommonDBChild::showChildsForItemForm()
  src/NetworkPort.php:1399                           NetworkName::showFormForNetworkPort()
  src/CommonGLPI.php:676                             NetworkPort->showForm()
  ajax/common.tabs.php:116                           CommonGLPI::displayStandardTab()
```