### PR TITLE
fix(ldap): missing preconfig fields

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -517,7 +517,9 @@ class AuthLDAP extends CommonDBTM
                     'group_field', 'group_member_field', 'group_search_type',
                     'mobile_field', 'phone_field', 'phone2_field',
                     'realname_field', 'registration_number_field', 'title_field',
-                    'use_dn', 'use_tls', 'responsible_field'
+                    'use_dn', 'use_tls', 'picture_field', 'responsible_field',
+                    'category_field', 'language_field', 'location_field',
+                    'can_support_pagesize', 'pagesize',
                 ];
 
                 foreach ($hidden_fields as $hidden_field) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A

Even if values are pre-configured in "preconfig", they are not taken into account when submit add form, the following lines are ignored:
https://github.com/glpi-project/glpi/blob/94fa6fe3d58e366bedbc8ddf222a10efc61d1236/src/AuthLDAP.php#L220-L223

This PR fixes that problem (and adds a few more fields).