### PR TITLE
feat(ruleaction): Assign a contract to ticket through regular expression or direct selection

### DIFF
--- a/tests/functionnal/Rule.php
+++ b/tests/functionnal/Rule.php
@@ -258,7 +258,7 @@ class Rule extends DbTestCase
         $this->integer($rule->maxActionsCount())->isIdenticalTo(1);
 
         $rule = new \RuleTicket();
-        $this->integer($rule->maxActionsCount())->isIdenticalTo(34);
+        $this->integer($rule->maxActionsCount())->isIdenticalTo(35);
 
         $rule = new \RuleDictionnarySoftware();
         $this->integer($rule->maxActionsCount())->isIdenticalTo(4);


### PR DESCRIPTION
Currently, it is required that there be criteria for the selection of the contract that applies to the particular tickets.

The objective is to be able to open a ticket and that by means of rules, there is a way to assign a contract to it given that the work orders represent different priority levels, for each contract that has been contracted by the final customer.

In some cases, such as this one, the end user should be able to select which contract he wants to use and immediately, this will represent the level of service that the ticket will take.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 42
