### PR TITLE
Fix skipping 2FA setup in grace period

### DIFF
--- a/index.php
+++ b/index.php
@@ -131,6 +131,9 @@ if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
         Toolbox::manageRedirect($redirect);
     }
 
+    if (isset($_SESSION['mfa_pre_auth'], $_POST['skip_mfa'])) {
+        Html::redirect($CFG_GLPI['root_doc'] . '/front/login.php?skip_mfa=1');
+    }
     if (isset($_SESSION['mfa_pre_auth'])) {
         if (isset($_GET['mfa_setup'])) {
             if (isset($_POST['secret'], $_POST['totp_code'])) {

--- a/templates/pages/2fa/macros.html.twig
+++ b/templates/pages/2fa/macros.html.twig
@@ -129,9 +129,9 @@
             {% endif %}
             <div class="ms-auto">
                {% if enforced and in_grace_period %}
-                  <button type="submit" class="btn btn-outline-secondary" name="skip_mfa">{{ __('Skip') }}</button>
+                  <button type="submit" formnovalidate class="btn btn-outline-secondary" name="skip_mfa">{{ __('Skip') }}</button>
                {% endif %}
-               <button type="submit" formnovalidate name="continue" class="btn btn-primary ms-1">{{ __('Verify') }}</button>
+               <button type="submit" name="continue" class="btn btn-primary ms-1">{{ __('Verify') }}</button>
             </div>
          </div>
       </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The code is validated on the server side so having the code input labeled as required isn't needed. This fixes the issue with skipping the 2FA setup when in a grace period.