### PR TITLE
Fix 2FA code autosubmit

### DIFF
--- a/templates/pages/2fa/macros.html.twig
+++ b/templates/pages/2fa/macros.html.twig
@@ -42,6 +42,18 @@
        $(document).ready(function() {
            const input_fields = $('input[name="totp_code[]"]');
            input_fields.first().focus();
+           input_fields.parent().on('keyup', 'input[name="totp_code[]"]', function(e) {
+               if (e.which === 8) {
+                   return;
+               }
+               if ($(this).val().length === 1) {
+                   const next = $(this).next();
+                   if (next.length === 0) {
+                       $(this).closest('form').submit();
+                       input_fields.prop('disabled', true);
+                   }
+               }
+           });
            input_fields.parent().on('keydown', 'input[name="totp_code[]"]', function(e) {
                if (e.which === 8) {
                    $(this).prev().focus();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Auto-submit when typing the 2FA code was incorrectly moved to the keydown event when I was improving the responsiveness of the field set, so autosubmit would not activate immediately after the last number was entered and would have required another key press.