### PR TITLE
fix(authldap): LDAP date value

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -4642,10 +4642,12 @@ class AuthLDAP extends CommonDBTM
             // See https://learn.microsoft.com/en-us/windows/win32/sysinfo/converting-a-time-t-value-to-a-file-time?redirectedfrom=MSDN
             $time = intval($date) / (10000000) - 11644473600;
             return $time > 0 ? date('Y-m-d H:i:s', $time) : '';
-        } else {
+        } elseif (preg_match('/^(\d{14})\.0Z$/', $date, $matches)) {
             // Ymdhis.0Z LDAP timestamps
-            $date = DateTime::createFromFormat('Ymdhis.0Z', $date);
+            $date = DateTime::createFromFormat('YmdHis', $matches[1]);
             return $date ? $date->format('Y-m-d H:i:s') : '';
+        } else {
+            return '';
         }
     }
 }

--- a/tests/LDAP/AuthLdap.php
+++ b/tests/LDAP/AuthLdap.php
@@ -2380,6 +2380,6 @@ class AuthLDAP extends DbTestCase
     {
         $auth = new \AuthLDAP();
         $this->string($auth->getLdapDateValue('20230224150800.0Z'))->isIdenticalTo('2023-02-24 15:08:00');
-        $this->string($auth->getLdapDateValue('133217216420000000'))->isIdenticalTo('2023-02-24 15:14:02');
+        $this->string($auth->getLdapDateValue('133217216420000000'))->isIdenticalTo('2023-02-24 14:14:02');
     }
 }

--- a/tests/LDAP/AuthLdap.php
+++ b/tests/LDAP/AuthLdap.php
@@ -2375,4 +2375,11 @@ class AuthLDAP extends DbTestCase
         ]);
         $this->array($uts)->hasSize(0);
     }
+
+    public function testGetLdapDateValue()
+    {
+        $auth = new \AuthLDAP();
+        $this->string($auth->getLdapDateValue('20230224150800.0Z'))->isIdenticalTo('2023-02-24 15:08:00');
+        $this->string($auth->getLdapDateValue('133217216420000000'))->isIdenticalTo('2023-02-24 15:14:02');
+    }
 }


### PR DESCRIPTION
The LDAP `Ymdhis.0Z` timestamp format was not always converted, so the `valid from` and `valid to` fields were not always synchronized.

https://github.com/glpi-project/glpi/pull/14032

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 26853
