### PR TITLE
fix(ui): add missing saved search list from Notification

### DIFF
--- a/src/Notification.php
+++ b/src/Notification.php
@@ -168,7 +168,7 @@ class Notification extends CommonDBTM
             $menu['options']['notification']['links']['search'] = Notification::getSearchURL(false);
             //saved search list
             $menu['options']['notification']['links']['lists']  = "";
-            $menu['options']['notification']['option']['lists_itemtype']  = Notification::getType();
+            $menu['options']['notification']['lists_itemtype']  = Notification::getType();
 
             $menu['options']['notificationtemplate']['title']
                         = _n('Notification template', 'Notification templates', Session::getPluralNumber());
@@ -180,7 +180,7 @@ class Notification extends CommonDBTM
                         = NotificationTemplate::getSearchURL(false);
             //saved search list
             $menu['options']['notificationtemplate']['links']['lists']  = "";
-            $menu['options']['notificationtemplate']['option']['lists_itemtype']  = NotificationTemplate::getType();
+            $menu['options']['notificationtemplate']['lists_itemtype']  = NotificationTemplate::getType();
         }
         if (count($menu)) {
             return $menu;

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -167,6 +167,10 @@ class Notification extends CommonDBTM
             $menu['options']['notification']['links']['add']    = Notification::getFormURL(false);
             $menu['options']['notification']['links']['search'] = Notification::getSearchURL(false);
 
+            //saved search list
+            $menu['options']['notification']['links']['lists']  = "";
+            $menu['options']['notification']['option']['lists_itemtype']  = Notification::getType();
+
             $menu['options']['notificationtemplate']['title']
                         = _n('Notification template', 'Notification templates', Session::getPluralNumber());
             $menu['options']['notificationtemplate']['page']

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -166,7 +166,6 @@ class Notification extends CommonDBTM
             $menu['options']['notification']['page']            = Notification::getSearchURL(false);
             $menu['options']['notification']['links']['add']    = Notification::getFormURL(false);
             $menu['options']['notification']['links']['search'] = Notification::getSearchURL(false);
-
             //saved search list
             $menu['options']['notification']['links']['lists']  = "";
             $menu['options']['notification']['option']['lists_itemtype']  = Notification::getType();
@@ -179,6 +178,9 @@ class Notification extends CommonDBTM
                         = NotificationTemplate::getFormURL(false);
             $menu['options']['notificationtemplate']['links']['search']
                         = NotificationTemplate::getSearchURL(false);
+            //saved search list
+            $menu['options']['notificationtemplate']['links']['lists']  = "";
+            $menu['options']['notificationtemplate']['option']['lists_itemtype']  = NotificationTemplate::getType();
         }
         if (count($menu)) {
             return $menu;


### PR DESCRIPTION
add missing saved search list from ```Notification```

![image](https://user-images.githubusercontent.com/7335054/221213722-8825f6a2-02c2-457e-8fba-6dcda68c0b8f.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26926
