### PR TITLE
fix(core): add missing saved search for dropdown

### DIFF
--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -122,6 +122,9 @@ abstract class CommonDropdown extends CommonDBTM
                         $menu['options'][$key]['page']            = $tmp->getSearchURL(false);
                         $menu['options'][$key]['icon']            = $tmp->getIcon();
                         $menu['options'][$key]['links']['search'] = $tmp->getSearchURL(false);
+                        //saved search list
+                        $menu['options'][$key]['links']['lists']  = "";
+                        $menu['options'][$key]['lists_itemtype']  = $tmp::getType();
                         if ($tmp->canCreate()) {
                             $menu['options'][$key]['links']['add'] = $tmp->getFormURL(false);
                         }


### PR DESCRIPTION
add missing saved search list from all ```dropdown``` item (like ```ITILCategory```)

![image](https://user-images.githubusercontent.com/7335054/221517872-a047fed0-17e6-4584-9e4d-13af084a6ea2.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26918
