### PR TITLE
IITLTimeline: hide "answer" button if not allowed to add followups

### DIFF
--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -45,21 +45,27 @@
    <div class="buttons-bar d-flex py-2">
       <div class="col {{ timeline_btns_cls }} ps-3 timeline-buttons d-flex">
          {% if not item.isNewItem() %}
-            {% set default_action_data = timeline_itemtypes|first %}
+            {% set main_actions_itemtypes = timeline_itemtypes|filter((v, k) => v.hide_in_menu is not defined or v.hide_in_menu != true) %}
+
+            {% set default_action_data = main_actions_itemtypes|first %}
+            {% set default_action = main_actions_itemtypes|keys|first %}
             {% if item.isNotSolved() and default_action_data != false %}
-               {% if timeline_itemtypes|length > 1 %}
+               {% if main_actions_itemtypes|length > 1 %}
                   {% set btn_class = timeline_btn_layout == constant('Config::TIMELINE_ACTION_BTN_SPLITTED') ? "" : "btn-group" %}
                   <div class="{{ btn_class }} me-2 main-actions" style="{{ load_kb_sol > 0 ? 'display:none;' : '' }}">
                {% else %}
                   {# Don't use d-inline-flex class as it add an '!important' tag that mess with our javascript that will hide this div #}
                   <div class="main-actions" style="display:inline-flex">
                {% endif %}
-                  <button class="btn btn-primary answer-action mb-2" data-bs-toggle="collapse" data-bs-target="#new-{{ default_action_data.class }}-block">
+                  <button
+                     class="btn btn-primary answer-action mb-2 {{ default_action != "answer" ? "action-" ~ default_action : "" }}"
+                     data-bs-toggle="collapse"
+                     data-bs-target="#new-{{ default_action_data.class }}-block"
+                  >
                      <i class="{{ default_action_data.icon }}"></i>
                      <span>{{ default_action_data.label }}</span>
                   </button>
 
-                  {% set main_actions_itemtypes = timeline_itemtypes|filter((v, k) => v.hide_in_menu is not defined or v.hide_in_menu != true) %}
                   {% if main_actions_itemtypes|length > 1 %}
                      {% if timeline_btn_layout == constant('Config::TIMELINE_ACTION_BTN_SPLITTED') %}
                         {% for action, timeline_itemtype in main_actions_itemtypes %}
@@ -71,7 +77,12 @@
                               {% endif %}
                         {% endfor %}
                      {% else %}
-                        <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split mb-2" data-bs-toggle="dropdown" aria-expanded="false">
+                        <button
+                           type="button"
+                           class="btn btn-primary dropdown-toggle dropdown-toggle-split mb-2 {{ default_action != "answer" ? "action-" ~ default_action : "" }}"
+                           data-bs-toggle="dropdown"
+                           aria-expanded="false"
+                        >
                            <span class="visually-hidden">{{ __('View other actions') }}</span>
                         </button>
                         <ul class="dropdown-menu">


### PR DESCRIPTION
User that aren't allowed to add followups still have the "answer" button in the ITIL timeline.

Rights:

![image](https://user-images.githubusercontent.com/42734840/221830668-bcca174e-2b55-4bf4-b1a6-249817d69764.png)

Before:

![image](https://user-images.githubusercontent.com/42734840/221830849-87686b14-1d39-44eb-b902-169c75090b45.png)

Note that "answer" is shown but not "add task" despite the user rights indicating the opposite.

After:

![image](https://user-images.githubusercontent.com/42734840/221830185-cc1396d9-ecb6-49ec-baa8-b25628822673.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26945
