### PR TITLE
fix(core): globally prohibit massive action if necessary

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -6151,7 +6151,7 @@ class CommonDBTM extends CommonGLPI
         return new MassiveAction($params, [], 'initial', $this->getID());
     }
 
-    public function isMassiveActionAllowed(int $items_id): bool
+    public static function isMassiveActionAllowed(int $items_id): bool
     {
         return true;
     }

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -6151,6 +6151,11 @@ class CommonDBTM extends CommonGLPI
         return new MassiveAction($params, [], 'initial', $this->getID());
     }
 
+    public function isMassiveActionAllowed(int $items_id): bool
+    {
+        return true;
+    }
+
     /**
      * Automatically update 1-N links tables for the current item.
      *

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -6150,6 +6150,7 @@ class CommonDBTM extends CommonGLPI
 
         return new MassiveAction($params, [], 'initial', $this->getID());
     }
+
     /**
      * Check whether actions are allowed for given item.
      */

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -6150,7 +6150,9 @@ class CommonDBTM extends CommonGLPI
 
         return new MassiveAction($params, [], 'initial', $this->getID());
     }
-
+    /**
+     * Check whether actions are allowed for given item.
+     */
     public static function isMassiveActionAllowed(int $items_id): bool
     {
         return true;

--- a/src/User.php
+++ b/src/User.php
@@ -197,7 +197,7 @@ class User extends CommonDBTM
     }
 
 
-    public function isMassiveActionAllowed(int $items_id): bool
+    public static function isMassiveActionAllowed(int $items_id): bool
     {
         $config = Config::getConfigurationValues('core', ['system_user']);
         return !($config['system_user'] == $items_id);

--- a/src/User.php
+++ b/src/User.php
@@ -204,8 +204,8 @@ class User extends CommonDBTM
 
     public static function isMassiveActionAllowed(int $items_id): bool
     {
-        $config = Config::getConfigurationValues('core', ['system_user']);
-        return !($config['system_user'] == $items_id);
+        global $CFG_GLPI;
+        return !($CFG_GLPI['system_user'] == $items_id);
     }
 
 

--- a/src/User.php
+++ b/src/User.php
@@ -175,7 +175,8 @@ class User extends CommonDBTM
         }
 
         //prevent delete / purge from API
-        if (!self::isMassiveActionAllowed($this->fields['id'])) {
+        global $CFG_GLPI;
+        if ($this->fields['id'] == $CFG_GLPI['system_user']) {
             return false;
         }
 

--- a/src/User.php
+++ b/src/User.php
@@ -174,6 +174,11 @@ class User extends CommonDBTM
             return false;
         }
 
+        //prevent delete / purge from API
+        if (!self::isMassiveActionAllowed($this->fields['id'])) {
+            return false;
+        }
+
         if (
             Session::canViewAllEntities()
             || Session::haveAccessToAllOfEntities($this->getEntities())

--- a/src/User.php
+++ b/src/User.php
@@ -197,6 +197,13 @@ class User extends CommonDBTM
     }
 
 
+    public function isMassiveActionAllowed(int $items_id): bool
+    {
+        $config = Config::getConfigurationValues('core', ['system_user']);
+        return !($config['system_user'] == $items_id);
+    }
+
+
     /**
      * Compute preferences for the current user mixing config and user data.
      *

--- a/templates/components/form/single-action.html.twig
+++ b/templates/components/form/single-action.html.twig
@@ -35,7 +35,7 @@
    {% set onlyicon = false %}
 {% endif %}
 
-{% if not(item.isNewItem()) and item.isMassiveActionAllowed(item.fields['id'])%}
+{% if not(item.isNewItem()) and call(item.getType() ~ '::isMassiveActionAllowed', [item.fields['id']])%}
    {% set input = item.getMassiveActionsForItem().getInput() %}
    {% if input['actions']|length > 0 %}
    {% set ms_auto = single_actions_ms_auto ? 'ms-auto' : '' %}

--- a/templates/components/form/single-action.html.twig
+++ b/templates/components/form/single-action.html.twig
@@ -35,7 +35,7 @@
    {% set onlyicon = false %}
 {% endif %}
 
-{% if not(item.isNewItem()) %}
+{% if not(item.isNewItem()) and item.isMassiveActionAllowed(item.fields['id'])%}
    {% set input = item.getMassiveActionsForItem().getInput() %}
    {% if input['actions']|length > 0 %}
    {% set ms_auto = single_actions_ms_auto ? 'ms-auto' : '' %}

--- a/templates/components/search/table.html.twig
+++ b/templates/components/search/table.html.twig
@@ -117,10 +117,13 @@
                         {% elseif itemtype == 'User' and not can_view_all_entities() and not has_access_to_user_entities(row['id']) %}
                         {% elseif item is instanceof('CommonDBTM') and item.maybeRecursive() and not has_access_to_entity(row['entities_id'])  %}
                         {% else %}
-                           {% set checked = session('glpimassiveactionselected')[itemtype][row['id']] ?? false %}
-                           <input class="form-check-input" type="checkbox" data-glpicore-ma-tags="common"
-                              value="1" aria-label="" {% if checked %}checked="checked"{% endif %}
-                              name="item[{{ row['TYPE'] ?? itemtype }}][{{ row['id'] }}]" />
+
+                           {% if item is instanceof('CommonDBTM') and item.isMassiveActionAllowed(row['id'])  %}
+                              {% set checked = session('glpimassiveactionselected')[itemtype][row['id']] ?? false %}
+                              <input class="form-check-input" type="checkbox" data-glpicore-ma-tags="common"
+                                 value="1" aria-label="" {% if checked %}checked="checked"{% endif %}
+                                 name="item[{{ row['TYPE'] ?? itemtype }}][{{ row['id'] }}]" />
+                           {% endif %}
                         {% endif %}
                      </div>
                   </td>

--- a/templates/components/search/table.html.twig
+++ b/templates/components/search/table.html.twig
@@ -118,7 +118,7 @@
                         {% elseif item is instanceof('CommonDBTM') and item.maybeRecursive() and not has_access_to_entity(row['entities_id'])  %}
                         {% else %}
 
-                           {% if item is instanceof('CommonDBTM') and item.isMassiveActionAllowed(row['id'])  %}
+                           {% if item is instanceof('CommonDBTM') and call(itemtype ~ '::isMassiveActionAllowed', [row['id']])  %}
                               {% set checked = session('glpimassiveactionselected')[itemtype][row['id']] ?? false %}
                               <input class="form-check-input" type="checkbox" data-glpicore-ma-tags="common"
                                  value="1" aria-label="" {% if checked %}checked="checked"{% endif %}


### PR DESCRIPTION
Even if  system user ```glpi-user``` can't be deleted from his form

```MassiveAction``` are available (with ```trashbin``` and ```purge```)

![image](https://user-images.githubusercontent.com/7335054/222099008-0ddfb74f-b289-4b6e-98f9-6e4dbb43ae2a.png)

![image](https://user-images.githubusercontent.com/7335054/222099017-be356a68-f3c7-4088-a5cd-8ea19cc87a33.png)

Add ```CommonDBTM``` function to prohibit massive action (```bulk``` or ```single```) if necessary

![image](https://user-images.githubusercontent.com/7335054/222099705-fd37bb10-6ae9-411b-97bb-fde3a04d7cfd.png)

![image](https://user-images.githubusercontent.com/7335054/222099721-d0224307-3bf6-4609-87f3-783158a5f263.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
