### PR TITLE
fix(run_tests): remove lint_X tests when --all option

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -105,13 +105,10 @@ elif [[ "$ALL" = true ]]; then
   TESTS_TO_RUN=("${TESTS_SUITES[@]}")
 
   # Remove specific lint test, because of global "lint" test suite
-  DO_NOT_RUN=("lint_php" "lint_js" "lint_scss" "lint_twig")
-  for TEST_SUITE in "${DO_NOT_RUN[@]}"; do
-    for TEST in "${!TESTS_TO_RUN[@]}"; do
-      if [[ ${TESTS_TO_RUN[TEST]} = $TEST_SUITE ]]; then
-        unset 'TESTS_TO_RUN[TEST]'
-      fi
-    done
+  for TEST in "${!TESTS_TO_RUN[@]}"; do
+    if [[ "${TESTS_TO_RUN[TEST]}" =~ ^lint_.+ ]]; then
+      unset 'TESTS_TO_RUN[TEST]'
+    fi
   done
 
   USE_SERVICES_CONTAINERS=1

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -103,6 +103,17 @@ if [[ $# -gt 0 ]]; then
   done
 elif [[ "$ALL" = true ]]; then
   TESTS_TO_RUN=("${TESTS_SUITES[@]}")
+
+  # Remove specific lint test, because of global "lint" test suite
+  DO_NOT_RUN=("lint_php" "lint_js" "lint_scss" "lint_twig")
+  for TEST_SUITE in "${DO_NOT_RUN[@]}"; do
+    for TEST in "${!TESTS_TO_RUN[@]}"; do
+      if [[ ${TESTS_TO_RUN[TEST]} = $TEST_SUITE ]]; then
+        unset 'TESTS_TO_RUN[TEST]'
+      fi
+    done
+  done
+
   USE_SERVICES_CONTAINERS=1
 fi
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A

As a result of this change (https://github.com/glpi-project/glpi/pull/14159), if the "--all" option is used, the lint tests are run twice.