### PR TITLE
fix(ticket): check user exist before link

### DIFF
--- a/src/CommonITILActor.php
+++ b/src/CommonITILActor.php
@@ -354,7 +354,8 @@ abstract class CommonITILActor extends CommonDBRelation
             $actor_id        = $input[$fk_field];
 
             // check if the actor exists in database
-            $actor = new $input['itemtype']();
+            $itemtype = getItemtypeForForeignKeyField($fk_field);
+            $actor = new $itemtype();
             if (!$actor->getFromDB($actor_id)) {
                 return false;
             }

--- a/src/CommonITILActor.php
+++ b/src/CommonITILActor.php
@@ -352,6 +352,13 @@ abstract class CommonITILActor extends CommonDBRelation
         if (isset($input[$fk_field]) && $input[$fk_field] > 0) {
             $current_type    = $input['type'] ?? 0;
             $actor_id        = $input[$fk_field];
+
+            // check if the actor exists in database
+            $actor = new User();
+            if (!$actor->getFromDB($actor_id)) {
+                return false;
+            }
+
             $existing_actors = $this->getActors($input[static::getItilObjectForeignKey()] ?? 0);
             $existing_ids    = array_column($existing_actors[$current_type] ?? [], $fk_field);
 

--- a/src/CommonITILActor.php
+++ b/src/CommonITILActor.php
@@ -354,7 +354,7 @@ abstract class CommonITILActor extends CommonDBRelation
             $actor_id        = $input[$fk_field];
 
             // check if the actor exists in database
-            $actor = new User();
+            $actor = new $input['itemtype']();
             if (!$actor->getFromDB($actor_id)) {
                 return false;
             }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -109,7 +109,7 @@ function loadDataset()
    // Unit test data definition
     $data = [
       // bump this version to force reload of the full dataset, when content change
-        '_version' => '4.9',
+        '_version' => '4.10',
 
       // Type => array of entries
         'Entity' => [
@@ -351,6 +351,14 @@ function loadDataset()
                 'fax'          => '0123456787',
                 'email'        => 'info@_supplier01_name.com',
                 'comment'      => 'Comment for supplier _suplier01_name',
+                'entities_id'  => '_test_root_entity'
+            ],
+            [
+                'name'         => '_suplier02_name',
+                'phonenumber'  => '0123456788',
+                'fax'          => '0123456786',
+                'email'        => 'info@_supplier02_name.com',
+                'comment'      => 'Comment for supplier _suplier02_name',
                 'entities_id'  => '_test_root_entity'
             ]
         ], 'Location' => [

--- a/tests/functionnal/Project.php
+++ b/tests/functionnal/Project.php
@@ -283,7 +283,7 @@ class Project extends DbTestCase
         $this->array($team)->isEmpty();
 
        // Add team members
-        $this->boolean($project->addTeamMember(\User::class, 1, ['role' => Team::ROLE_MEMBER]))->isTrue();
+        $this->boolean($project->addTeamMember(\User::class, 4, ['role' => Team::ROLE_MEMBER]))->isTrue();
 
        // Reload from DB
         $project->getFromDB($projects_id);
@@ -293,11 +293,11 @@ class Project extends DbTestCase
         $this->array($team)->hasSize(1);
         $this->array($team[0])->hasKeys(['itemtype', 'items_id', 'role']);
         $this->string($team[0]['itemtype'])->isEqualTo(\User::class);
-        $this->integer($team[0]['items_id'])->isEqualTo(1);
+        $this->integer($team[0]['items_id'])->isEqualTo(4);
         $this->integer($team[0]['role'])->isEqualTo(Team::ROLE_MEMBER);
 
        // Delete team members
-        $this->boolean($project->deleteTeamMember(\User::class, 1, ['role' => Team::ROLE_MEMBER]))->isTrue();
+        $this->boolean($project->deleteTeamMember(\User::class, 4, ['role' => Team::ROLE_MEMBER]))->isTrue();
 
        //Reload ticket from DB
         $project->getFromDB($projects_id);

--- a/tests/functionnal/ProjectTask.php
+++ b/tests/functionnal/ProjectTask.php
@@ -231,7 +231,7 @@ class ProjectTask extends DbTestCase
         $this->array($team)->isEmpty();
 
        // Add team members
-        $this->boolean($project_task->addTeamMember(\User::class, 1, ['role' => Team::ROLE_MEMBER]))->isTrue();
+        $this->boolean($project_task->addTeamMember(\User::class, 4, ['role' => Team::ROLE_MEMBER]))->isTrue();
 
        // Reload ticket from DB
         $project_task->getFromDB($projecttasks_id);
@@ -241,11 +241,11 @@ class ProjectTask extends DbTestCase
         $this->array($team)->hasSize(1);
         $this->array($team[0])->hasKeys(['itemtype', 'items_id', 'role']);
         $this->string($team[0]['itemtype'])->isEqualTo(\User::class);
-        $this->integer($team[0]['items_id'])->isEqualTo(1);
+        $this->integer($team[0]['items_id'])->isEqualTo(4);
         $this->integer($team[0]['role'])->isEqualTo(Team::ROLE_MEMBER);
 
        // Delete team members
-        $this->boolean($project_task->deleteTeamMember(\User::class, 1, ['role' => Team::ROLE_MEMBER]))->isTrue();
+        $this->boolean($project_task->deleteTeamMember(\User::class, 4, ['role' => Team::ROLE_MEMBER]))->isTrue();
 
        //Reload ticket from DB
         $project_task->getFromDB($projecttasks_id);

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -4250,7 +4250,7 @@ HTML
         $this->array($team)->isEmpty();
 
        // Add team members
-        $this->boolean($ticket->addTeamMember(\User::class, 1, ['role' => Team::ROLE_ASSIGNED]))->isTrue();
+        $this->boolean($ticket->addTeamMember(\User::class, 4, ['role' => Team::ROLE_ASSIGNED]))->isTrue();
 
        // Reload ticket from DB
         $ticket->getFromDB($tickets_id);
@@ -4260,11 +4260,11 @@ HTML
         $this->array($team)->hasSize(1);
         $this->array($team[0])->hasKeys(['itemtype', 'items_id', 'role']);
         $this->string($team[0]['itemtype'])->isEqualTo(\User::class);
-        $this->integer($team[0]['items_id'])->isEqualTo(1);
+        $this->integer($team[0]['items_id'])->isEqualTo(4);
         $this->integer($team[0]['role'])->isEqualTo(Team::ROLE_ASSIGNED);
 
        // Delete team members
-        $this->boolean($ticket->deleteTeamMember(\User::class, 1, ['role' => Team::ROLE_ASSIGNED]))->isTrue();
+        $this->boolean($ticket->deleteTeamMember(\User::class, 4, ['role' => Team::ROLE_ASSIGNED]))->isTrue();
 
        //Reload ticket from DB
         $ticket->getFromDB($tickets_id);

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -4273,7 +4273,7 @@ HTML
         $this->array($team)->isEmpty();
 
        // Add team members
-        $this->boolean($ticket->addTeamMember(\Group::class, 5, ['role' => Team::ROLE_ASSIGNED]))->isTrue();
+        $this->boolean($ticket->addTeamMember(\Group::class, 2, ['role' => Team::ROLE_ASSIGNED]))->isTrue();
 
        // Reload ticket from DB
         $ticket->getFromDB($tickets_id);
@@ -4283,7 +4283,7 @@ HTML
         $this->array($team)->hasSize(1);
         $this->array($team[0])->hasKeys(['itemtype', 'items_id', 'role']);
         $this->string($team[0]['itemtype'])->isEqualTo(\Group::class);
-        $this->integer($team[0]['items_id'])->isEqualTo(5);
+        $this->integer($team[0]['items_id'])->isEqualTo(2);
         $this->integer($team[0]['role'])->isEqualTo(Team::ROLE_ASSIGNED);
     }
 


### PR DESCRIPTION
Check that the actor exists in the database before adding it to the ticket (change, problem).

_Case observed at a customer: the user with ID = 1 (not existing in the database) was added to all tickets created via the FormCreator plugin and when the Behaviors plugin is active._

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26985
