### PR TITLE
feat(global search): sort items by number of results

### DIFF
--- a/front/search.php
+++ b/front/search.php
@@ -43,7 +43,7 @@ if (!$CFG_GLPI['allow_search_global']) {
 }
 if (isset($_GET["globalsearch"])) {
     $searchtext = trim($_GET["globalsearch"]);
-    $all_data = [];
+    $no_result = [];
 
     echo "<div class='search_page search_page_global flex-row flex-wrap'>";
     foreach ($CFG_GLPI["globalsearch_types"] as $itemtype) {
@@ -62,20 +62,31 @@ if (isset($_GET["globalsearch"])) {
             $params["criteria"][$count]["searchtype"]  = 'contains';
             $params["criteria"][$count]["value"]       = $searchtext;
 
-            $all_data[] = Search::getDatas($itemtype, $params);
+            $data = Search::getDatas($itemtype, $params);
+            if ($data['data']['count'] > 0) {
+                echo "<div class='search-container w-100 disable-overflow-y' counter='" . $data['data']['count'] . "'>";
+                Search::displayData($data);
+                echo "</div>";
+            } else {
+                $no_result[] = $itemtype::getTypeName(1);
+            }
         }
     }
-    uasort(
-        $all_data,
-        function ($a, $b) {
-            return $b['data']['count'] - $a['data']['count'];
-        }
-    );
-    foreach ($all_data as $data) {
-        echo "<div class='search-container w-100 disable-overflow-y' counter='" . $data['data']['count'] . "'>";
-        Search::displayData($data);
-        echo "</div>";
+
+    echo "<div class='search-container w-100 disable-overflow-y' counter='" . $data['data']['count'] . "'>";
+    echo "<div class='ajax-container search-display-data'>";
+    echo "<div class='card card-sm mt-0 search-card'>";
+    echo "<div class='card-header d-flex justify-content-between search-header pe-0'>";
+    echo "<h2>" . __('Other searches with no item found') . "</h2>";
+    echo "</div>";
+    echo '<ul>';
+    foreach ($no_result as $itemtype) {
+        echo "<li>" . $itemtype . "</li>";
     }
+    echo '</ul>';
+    echo "</div>";
+    echo "</div>";
+    echo "</div>";
     echo "</div>";
 }
 

--- a/front/search.php
+++ b/front/search.php
@@ -43,6 +43,7 @@ if (!$CFG_GLPI['allow_search_global']) {
 }
 if (isset($_GET["globalsearch"])) {
     $searchtext = trim($_GET["globalsearch"]);
+    $all_data = [];
 
     echo "<div class='search_page search_page_global flex-row flex-wrap'>";
     foreach ($CFG_GLPI["globalsearch_types"] as $itemtype) {
@@ -61,10 +62,19 @@ if (isset($_GET["globalsearch"])) {
             $params["criteria"][$count]["searchtype"]  = 'contains';
             $params["criteria"][$count]["value"]       = $searchtext;
 
-            echo "<div class='search-container w-100 disable-overflow-y'>";
-            Search::showList($itemtype, $params);
-            echo "</div>";
+            $all_data[] = Search::getDatas($itemtype, $params);
         }
+    }
+    uasort(
+        $all_data,
+        function ($a, $b) {
+            return $b['data']['count'] - $a['data']['count'];
+        }
+    );
+    foreach ($all_data as $data) {
+        echo "<div class='search-container w-100 disable-overflow-y' counter='" . $data['data']['count'] . "'>";
+        Search::displayData($data);
+        echo "</div>";
     }
     echo "</div>";
 }


### PR DESCRIPTION
Sort items in the global search results by number of results

Before:
![image](https://user-images.githubusercontent.com/8530352/222424420-3997abbe-8164-49f2-b3b9-7c662ef80ebf.png)

After:
![image](https://user-images.githubusercontent.com/8530352/222424280-fabc59ab-ab05-4a84-a1aa-983137f1431e.png)



| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26078
