### PR TITLE
fix(UI): Display missing object header from template

### DIFF
--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -958,6 +958,9 @@ class CommonGLPI implements CommonGLPIInterface
 
         if (is_array($options) && count($options)) {
             $cleanoptions = $options;
+            if (isset($options['withtemplate'])) {
+                unset($cleanoptions['withtemplate']);
+            }
             foreach (array_keys($cleanoptions) as $key) {
                // Do not include id options
                 if (($key[0] == '_') || ($key == 'id')) {

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -955,14 +955,9 @@ class CommonGLPI implements CommonGLPIInterface
         }
         $target         = $_SERVER['PHP_SELF'];
         $extraparamhtml = "";
-        $withtemplate   = "";
 
         if (is_array($options) && count($options)) {
             $cleanoptions = $options;
-            if (isset($options['withtemplate'])) {
-                $withtemplate = $options['withtemplate'];
-                unset($cleanoptions['withtemplate']);
-            }
             foreach (array_keys($cleanoptions) as $key) {
                // Do not include id options
                 if (($key[0] == '_') || ($key == 'id')) {
@@ -973,8 +968,7 @@ class CommonGLPI implements CommonGLPIInterface
         }
 
         if (
-            empty($withtemplate)
-            && !$this->isNewID($ID)
+            !$this->isNewID($ID)
             && $this->getType()
             && $this->displaylist
         ) {

--- a/templates/components/form/header_content.html.twig
+++ b/templates/components/form/header_content.html.twig
@@ -78,7 +78,7 @@
 
 <div id="header_{{ rand }}"
      class="card-header main-header d-flex flex-wrap mx-n2 mt-n2 align-items-stretch {% if in_navheader %} align-self-end {% endif %} flex-grow-1">
-   {% if withtemplate == 1 %}
+   {% if withtemplate == 1 and item.isNewItem() %}
       <input type="text" class="form-control ms-4 mb-2" placeholder="{{ __('Template name') }}"
              name="template_name" id="textfield_template_name{{ rand }}"
              value="{{ template_name }}" />
@@ -94,7 +94,9 @@
          {% if in_navheader %}
             <i class="{{ icon }}"></i>
          {% endif %}
-         {% if item.id > 0 %}
+         {% if withtemplate == 1 and item.id > 0 %}
+            {{ __('Template') }} - {{ nametype }} - {{ template_name }}
+         {% elseif item.id > 0 %}
             {{ nametype }} - {{ friendlyname }}
          {% else %}
             {{ nametype }}

--- a/templates/components/form/header_content.html.twig
+++ b/templates/components/form/header_content.html.twig
@@ -95,7 +95,7 @@
             <i class="{{ icon }}"></i>
          {% endif %}
          {% if withtemplate == 1 and item.id > 0 %}
-            {{ __('Template') }} - {{ nametype }} - {{ template_name }}
+            {{ _n('Template', 'Templates', 1) }} - {{ nametype }} - {{ template_name }}
          {% elseif item.id > 0 %}
             {{ nametype }} - {{ friendlyname }}
          {% else %}


### PR DESCRIPTION
Display missing object header from template


Before : 

![image](https://user-images.githubusercontent.com/7335054/222451456-248d7e09-2307-45ce-82b3-648a10c36946.png)


After : 

![image](https://user-images.githubusercontent.com/7335054/222451133-eab09076-ea16-41c5-bcb3-d24848ae0783.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
