### PR TITLE
fix(logs): 404 error on delete

### DIFF
--- a/front/logviewer.php
+++ b/front/logviewer.php
@@ -43,7 +43,11 @@ Session::checkRight("logs", READ);
 
 $filepath = $_REQUEST['filepath'] ?? null;
 
-if ($filepath === null || !file_exists(GLPI_LOG_DIR . '/' . $filepath) || is_dir(GLPI_LOG_DIR . '/' . $filepath)) {
+if ($filepath === null) {
+    Html::redirect($CFG_GLPI["root_doc"] . "/front/logs.php");
+}
+
+if (!file_exists(GLPI_LOG_DIR . '/' . $filepath) || is_dir(GLPI_LOG_DIR . '/' . $filepath)) {
     Response::sendError(404, 'Not found', Response::CONTENT_TYPE_TEXT_HTML);
 }
 
@@ -59,7 +63,7 @@ if (($_GET['action'] ?? '') === 'download') {
     Session::checkRight('config', UPDATE);
     $logparser = new LogParser();
     $logparser->delete($filepath);
-    Html::back();
+    Html::redirect($CFG_GLPI["root_doc"] . "/front/logs.php");
 } else {
     Html::header(
         LogViewer::getTypeName(Session::getPluralNumber()),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A

- fix 404 error when deleting a log file
- fix 404 error when click on the breadcrumb entry "Log file" (so with an empty "filepath" )