### PR TITLE
fix link for notes in logs

### DIFF
--- a/front/notepad.form.php
+++ b/front/notepad.form.php
@@ -81,4 +81,12 @@ if (isset($_POST['add'])) {
     );
     Html::back();
 }
-Html::displayErrorAndDie("lost");
+
+if (isset($_GET['id']) && $note->getFromDB($_GET['id'])) {
+    /** @var class-string<CommonDBTM> $parent_itemtype */
+    $parent_itemtype = $note->fields['itemtype'];
+    $redirect = $parent_itemtype::getFormURLWithID($note->fields['items_id'], true) . "&forcetab=Notepad$1";
+    Html::redirect($redirect);
+} else {
+    Html::displayErrorAndDie("lost");
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Related post on the forum:
https://forum.glpi-project.org/viewtopic.php?id=286418

The note item link listed in Administration > Logs would always show a "Lost" error because the `notepad.form.php` front file never handled trying to get a note as they are always embedded in tabs of other items. This PR adds a redirect to the Notes tab of the parent item if you try to access the note via `notepad.form.php` without overriding the form URL which I think would break add, update and deletion.