### PR TITLE
feat(core): add user option to explicitly refuse all notifications

### DIFF
--- a/install/migrations/update_10.0.6_to_10.0.7/user.php
+++ b/install/migrations/update_10.0.6_to_10.0.7/user.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+
+if (!$DB->fieldExists(\User::getTable(), 'allow_notification')) {
+    $migration->addField(\User::getTable(), 'allow_notification', "tinyint NOT NULL DEFAULT '1'", ['value' => 1]);
+}

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -7634,6 +7634,7 @@ CREATE TABLE `glpi_users` (
   `nickname` varchar(255) DEFAULT NULL,
   `timeline_action_btn_layout` tinyint DEFAULT '0',
   `timeline_date_format` tinyint DEFAULT '0',
+  `allow_notification` tinyint NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicityloginauth` (`name`,`authtype`,`auths_id`),
   KEY `firstname` (`firstname`),

--- a/src/CommonITILActor.php
+++ b/src/CommonITILActor.php
@@ -361,6 +361,16 @@ abstract class CommonITILActor extends CommonDBRelation
             }
         }
 
+        //disable notification if explicitly refused by actor
+        if (isset($input['users_id']) && $input['users_id']) {
+            $user = new User();
+            if ($user->getFromDB($input['users_id'])) {
+                if (!$user->fields['allow_notification'] && $input['use_notification']) {
+                    $input['use_notification'] = false;
+                }
+            }
+        }
+
         if (!isset($input['alternative_email']) || is_null($input['alternative_email'])) {
             $input['alternative_email'] = '';
         } else if ($input['alternative_email'] != '' && !NotificationMailing::isUserAddressValid($input['alternative_email'])) {

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -188,12 +188,13 @@ abstract class CommonITILObject extends CommonDBTM
                         );
                         $email = UserEmail::getDefaultForUser($users_id_default);
                         $actors[] = [
-                            'items_id'          => $users_id_default,
-                            'itemtype'          => 'User',
-                            'text'              => $name,
-                            'title'             => $name,
-                            'use_notification'  => $email === '' ? false : $default_use_notif,
-                            'alternative_email' => $email,
+                            'items_id'              => $users_id_default,
+                            'itemtype'              => 'User',
+                            'text'                  => $name,
+                            'title'                 => $name,
+                            'use_notification'      => $email === '' || !$userobj->fields['allow_notification'] ? false : $default_use_notif,
+                            'allow_notification'    => $userobj->fields['allow_notification'],
+                            'alternative_email'     => $email,
                         ];
                     }
                 }
@@ -215,12 +216,13 @@ abstract class CommonITILObject extends CommonDBTM
                         );
                         $email = UserEmail::getDefaultForUser($users_id);
                         $actors[] = [
-                            'items_id'          => $users_id,
-                            'itemtype'          => 'User',
-                            'text'              => $name,
-                            'title'             => $name,
-                            'use_notification'  => $email === '' ? false : $default_use_notif,
-                            'alternative_email' => $email,
+                            'items_id'              => $users_id,
+                            'itemtype'              => 'User',
+                            'text'                  => $name,
+                            'title'                 => $name,
+                            'use_notification'      => $email === '' || $userobj->fields['allow_notification'] ? false : $default_use_notif,
+                            'allow_notification'    => $userobj->fields['allow_notification'],
+                            'alternative_email'     => $email,
                         ];
                     }
                 }
@@ -243,12 +245,13 @@ abstract class CommonITILObject extends CommonDBTM
                     $supplier_obj = new Supplier();
                     if ($supplier_obj->getFromDB($suppliers_id)) {
                         $actors[] = [
-                            'items_id'          => $supplier_obj->fields['id'],
-                            'itemtype'          => 'Supplier',
-                            'text'              => $supplier_obj->fields['name'],
-                            'title'             => $supplier_obj->fields['name'],
-                            'use_notification'  => $supplier_obj->fields['email'] === '' ? false : $default_use_notif,
-                            'alternative_email' => $supplier_obj->fields['email'],
+                            'items_id'              => $supplier_obj->fields['id'],
+                            'itemtype'              => 'Supplier',
+                            'text'                  => $supplier_obj->fields['name'],
+                            'title'                 => $supplier_obj->fields['name'],
+                            'use_notification'      => $supplier_obj->fields['email'] === '' || $userobj->fields['allow_notification'] ? false : $default_use_notif,
+                            'allow_notification'    => $supplier_obj->fields['allow_notification'],
+                            'alternative_email'     => $supplier_obj->fields['email'],
                         ];
                     }
                 }
@@ -308,15 +311,22 @@ abstract class CommonITILObject extends CommonDBTM
        // load existing actors (from existing itilobject)
         if (isset($this->users[$actortype])) {
             foreach ($this->users[$actortype] as $user) {
+                $allow_notification = true;
+                $user_obj = new User();
+                //check load user (for anonymous user)
+                if ($user_obj->getFromDB($user['users_id'])) {
+                    $allow_notification = $user_obj->fields['allow_notification'];
+                }
                 $name = getUserName($user['users_id']);
                 $actors[] = [
-                    'id'                => $user['id'],
-                    'items_id'          => $user['users_id'],
-                    'itemtype'          => 'User',
-                    'text'              => $name,
-                    'title'             => $name,
-                    'use_notification'  => $user['use_notification'],
-                    'alternative_email' => $user['alternative_email'],
+                    'id'                    => $user['id'],
+                    'items_id'              => $user['users_id'],
+                    'itemtype'              => 'User',
+                    'text'                  => $name,
+                    'title'                 => $name,
+                    'use_notification'      => $user['use_notification'],
+                    'allow_notification'    => $allow_notification,
+                    'alternative_email'     => $user['alternative_email'],
                 ];
             }
         }

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -544,6 +544,7 @@ class NotificationTarget extends CommonDBChild
             if (
                 !$user->getFromDB($data['users_id'])
                 || ($user->getField('is_deleted') == 1)
+                || ($user->getField('allow_notification') == 0) //notification explicitly refused bu yser
                 || ($user->getField('is_active') == 0)
                 || (!is_null($user->getField('begin_date'))
                   && ($user->getField('begin_date') > $_SESSION["glpi_currenttime"]))

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4104,15 +4104,22 @@ JAVASCRIPT;
     {
         global $CFG_GLPI;
 
+        $allow_notification = 1; //from user pref
         if (is_numeric(Session::getLoginUserID(false))) {
             $users_id_requester = Session::getLoginUserID();
             $users_id_assign    = Session::getLoginUserID();
+
+            $user = new User();
+            $user->getFromDB(Session::getLoginUserID());
+            $allow_notification = $user->fields['allow_notification'];
            // No default requester if own ticket right = tech and update_ticket right to update requester
             if (Session::haveRightsOr(self::$rightname, [UPDATE, self::OWN]) && !$_SESSION['glpiset_default_requester']) {
                 $users_id_requester = 0;
+                $allow_notification = 1; //reset to true
             }
             if (!Session::haveRight(self::$rightname, self::OWN) || !$_SESSION['glpiset_default_tech']) {
                 $users_id_assign = 0;
+                $allow_notification = 1; //reset to true
             }
             $entity      = $_SESSION['glpiactive_entity'];
             $requesttype = $_SESSION['glpidefault_requesttypes_id'];
@@ -4128,12 +4135,12 @@ JAVASCRIPT;
 
        // Set default values...
         return  ['_users_id_requester'       => $users_id_requester,
-            '_users_id_requester_notif' => ['use_notification'  => [$default_use_notif],
+            '_users_id_requester_notif' => ['use_notification'  => [(string) ($default_use_notif & $allow_notification)],
                 'alternative_email' => ['']
             ],
             '_groups_id_requester'      => 0,
             '_users_id_assign'          =>  $users_id_assign,
-            '_users_id_assign_notif'    => ['use_notification'  => [$default_use_notif],
+            '_users_id_assign_notif'    => ['use_notification'  => [(string) ($default_use_notif & $allow_notification)],
                 'alternative_email' => ['']
             ],
             '_groups_id_assign'         => 0,

--- a/src/User.php
+++ b/src/User.php
@@ -330,6 +330,8 @@ class User extends CommonDBTM
         } else {
             $this->fields['language'] = "en_GB";
         }
+
+        $this->fields['allow_notification'] = 1;
     }
 
 
@@ -2683,6 +2685,20 @@ HTML;
         echo "</tr>";
 
         if (empty($ID)) {
+            echo "<tr class='tab_bg_1'><th colspan='4'>" . _n('Notification', 'Notifications', Session::getPluralNumber()) . "</th></tr>";
+
+            echo "<tr class='tab_bg_1'><td>";
+            echo __("Receive notifications from GLPI");
+            echo "</td><td colspan='2'>";
+
+            echo "</td><td>";
+            Dropdown::showYesNo(
+                'allow_notification',
+                $this->fields['allow_notification'],
+            );
+
+            echo "</td></tr>";
+
             echo "<tr class='tab_bg_1'>";
             echo "<th colspan='2'>" . _n('Authorization', 'Authorizations', 1) . "</th>";
             $recurrand = mt_rand();
@@ -2786,6 +2802,21 @@ HTML;
                 echo "</td>";
                 echo "</tr>";
             }
+
+            echo "<tr class='tab_bg_1'><th colspan='4'>" . _n('Notification', 'Notifications', Session::getPluralNumber()) . "</th></tr>";
+
+            echo "<tr class='tab_bg_1'><td>";
+            echo __("Receive notifications from GLPI");
+            echo "</td><td colspan='2'>";
+
+            echo "</td><td>";
+            Dropdown::showYesNo(
+                'allow_notification',
+                $this->fields['allow_notification'],
+            );
+
+            echo "</td></tr>";
+
 
             if ($this->can($ID, UPDATE)) {
                 echo "<tr class='tab_bg_1'><th colspan='4'>" . __('Remote access keys') . "</th></tr>";
@@ -3197,6 +3228,20 @@ HTML;
                 echo "</td>";
                 echo "</tr>";
             }
+
+            echo "<tr class='tab_bg_1'><th colspan='4'>" . _n('Notification', 'Notifications', Session::getPluralNumber()) . "</th></tr>";
+
+            echo "<tr class='tab_bg_1'><td>";
+            echo __("Receive notifications from GLPI");
+            echo "</td><td colspan='2'>";
+
+            echo "</td><td>";
+            Dropdown::showYesNo(
+                'allow_notification',
+                $this->fields['allow_notification'],
+            );
+
+            echo "</td></tr>";
 
             echo "<tr class='tab_bg_1'><th colspan='4'>" . __('Remote access keys') . "</th></tr>";
 

--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -58,6 +58,7 @@
       <option selected="true" value="{{ actor['itemtype'] ~ '_' ~ actor['items_id'] }}"
             data-itemtype="{{ actor['itemtype'] }}" data-items-id="{{ actor['items_id'] }}"
             data-use-notification="{{ actor['use_notification'] }}"
+            data-allow-notification="{{ actor['allow_notification'] }}"
             data-alternative-email="{{ actor['alternative_email'] }}"
             {% if (actor['itemtype'] == 'User' and itiltemplate.isHiddenField('_users_id_' ~ actortype)) or (actor['itemtype'] == 'Group' and itiltemplate.isHiddenField('_groups_id_' ~ actortype)) %}
                disabled="disabled" style="display: none;"
@@ -84,6 +85,7 @@
          var text      = escapeMarkupText(element.data('text') ?? option.text ?? '');
          var title     = escapeMarkupText(element.data('title') ?? option.title ?? '');
          var use_notif = element.data('use-notification') ?? option.use_notification ?? 1;
+         var allow_notif = element.data('allow-notification') ?? option.allow_notification ?? 1;
          var alt_email = element.data('alternative-email') ?? option.alternative_email ?? '';
 
          var icon = "";
@@ -124,15 +126,23 @@
          {% if canupdate %}
          if (['User', 'Supplier', 'Email'].includes(itemtype)
             && is_selection) {
-            var fa_class = "far";
-            if (use_notif) {
-               fa_class = "fas";
+            var fa_class = "far fa-bell";
+
+            //notification allowed
+            if (use_notif && allow_notif) {
+               fa_class = "fas fa-bell";
             }
+
+            //notification explicitly refuse
+            if (!allow_notif) {
+               fa_class = "fas fa-bell-slash";
+            }
+
             actions = `<button class="btn btn-sm btn-ghost-secondary edit-notify-user"
                               data-bs-toggle="tooltip" data-bs-placement="top"
                               title="{{ __('Email followup') }}"
                               type="button">
-               <i class="${fa_class} fa-bell notify-icon"></i>
+               <i class="${fa_class} notify-icon"></i>
             </button>`;
          }
          {% endif %}

--- a/templates/components/itilobject/actors/main.html.twig
+++ b/templates/components/itilobject/actors/main.html.twig
@@ -163,6 +163,7 @@
             <div class="form-check form-switch">
                <input class="form-check-input" type="checkbox" id="use_notification" name="_notifications_use_notification" />
                <label class="form-check-label" for="use_notification">{{ __('Email followup') }}</label>
+               <label class="form-check-label center invisible text-danger" id="label_user_refuse_notification">{{ __('The user has explicitly refused the notifications') }}</label>
             </div>
             <input type="email" class="form-control" id="alternative_email" name="_notifications_alternative_email" />
          </div>
@@ -202,6 +203,7 @@
                itemtype: "{{ actor['itemtype'] }}",
                items_id: "{{ actor['items_id'] }}",
                use_notification: {{ actor['use_notification'] ? "1" : "0" }},
+               allow_notification: "{{ actor['allow_notification'] }}",
                {% if actor['alternative_email'] is defined %}
                   alternative_email: "{{ actor['alternative_email'] }}",
                {% endif %}
@@ -228,7 +230,19 @@
       modal.find("input[name=_notifications_actortype]").val(actortype);
       modal.find("input[name=_notifications_actorindex]").val(actorIndex);
       modal.find("input[name=_notifications_actorname]").removeAttr('readonly').val(text).attr('readonly', 'true');
-      modal.find("input[name=_notifications_use_notification]").prop('checked', parseInt(actor.use_notification));
+
+      if (parseInt(actor.use_notification) && parseInt(actor.allow_notification)) {
+         modal.find("input[name=_notifications_use_notification]").prop('checked', 1);
+      } else {
+         if (!parseInt(actor.allow_notification)) {
+            modal.find("#label_user_refuse_notification").removeClass('invisible');
+            modal.find("input[name=_notifications_use_notification]").prop('checked', 0);
+            modal.find("#use_notification").attr("disabled", true);
+            modal.find("#alternative_email").attr("disabled", true);
+            modal.find("#saveActorNotifySettings").addClass('invisible');
+         }
+      }
+
       modal.find("input[name=_notifications_alternative_email]").val(actor.alternative_email);
 
       editActorNotifySettings_modal.show();

--- a/tests/functionnal/NotificationMailing.php
+++ b/tests/functionnal/NotificationMailing.php
@@ -110,4 +110,36 @@ class NotificationMailing extends DbTestCase
              'mode'                     => 'mailing'
          ]);
     }
+
+    public function testAddRecipient()
+    {
+        //setup
+        $this->login();
+
+        $notification = new \NotificationTarget();
+        $notification->setEvent("NotificationEventMailing");
+        $notification->addToRecipientsList([
+            'users_id' => \Session::getLoginUserID()
+        ]);
+
+        $targets = $notification->getTargets();
+        $this->array($targets)->hasSize(1);
+
+
+        //update user to refuse explicitly notification
+        $user = new \User();
+        $this->boolean($user->update([
+            'id' => \Session::getLoginUserID(),
+            'allow_notification' => 0
+        ]))->isTrue();
+
+        $notification = new \NotificationTarget();
+        $notification->setEvent("NotificationEventMailing");
+        $notification->addToRecipientsList([
+            'users_id' => \Session::getLoginUserID()
+        ]);
+
+        $targets = $notification->getTargets();
+        $this->array($targets)->hasSize(0);
+    }
 }


### PR DESCRIPTION
Add new ```User``` option to explicitly refuse all notifications

From  ```Ticket``` configuration of the actors' notifications, the option is taken into account

![image](https://user-images.githubusercontent.com/7335054/222683065-c995a158-4fed-4c42-aeb5-461a84dd4896.png)

Icon are updated to represent the following cases

- Notification explicitly refused ![image](https://user-images.githubusercontent.com/7335054/222713201-e8206505-a902-4815-bf65-a5be0b43fb6c.png)

- Notification refused for this ticket (and actor type) ![image](https://user-images.githubusercontent.com/7335054/222713070-d469b6a5-0bab-4064-92f4-2edf0a90a60a.png)

- Notification allowed for this ticket (and actor type) ![image](https://user-images.githubusercontent.com/7335054/222713314-a7168cde-8c86-45db-b348-9eeb2dce44d1.png)

 
For other notifications (without configuration) ```addToRecipientsList``` check new option now.



| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26486
