### PR TITLE
feat(notification template): add missing location tags

### DIFF
--- a/src/NotificationTargetTicket.php
+++ b/src/NotificationTargetTicket.php
@@ -697,7 +697,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
             'ticket.item.locationstate'    => sprintf(
                 __('%1$s: %2$s'),
                 _n('Associated element', 'Associated elements', Session::getPluralNumber()),
-                __('State')
+                _x('location', 'State')
             ),
             'ticket.item.locationcountry'  => sprintf(
                 __('%1$s: %2$s'),

--- a/src/NotificationTargetTicket.php
+++ b/src/NotificationTargetTicket.php
@@ -256,6 +256,21 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
             if ($locations->getField('altitude')) {
                 $data['##ticket.location.altitude##'] = $locations->getField('altitude');
             }
+            if ($locations->getField('address')) {
+                $data['##ticket.location.address##'] = $locations->getField('address');
+            }
+            if ($locations->getField('postcode')) {
+                $data['##ticket.location.postcode##'] = $locations->getField('postcode');
+            }
+            if ($locations->getField('town')) {
+                $data['##ticket.location.town##'] = $locations->getField('town');
+            }
+            if ($locations->getField('state')) {
+                $data['##ticket.location.state##'] = $locations->getField('state');
+            }
+            if ($locations->getField('country')) {
+                $data['##ticket.location.country##'] = $locations->getField('country');
+            }
         }
 
        // is ticket deleted
@@ -273,6 +288,11 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
         $data['##ticket.item.locationlatitude##']    = '';
         $data['##ticket.item.locationlongitude##']   = '';
         $data['##ticket.item.locationaltitude##']    = '';
+        $data['##ticket.item.locationaddress##']     = '';
+        $data['##ticket.item.locationpostcode##']    = '';
+        $data['##ticket.item.locationtown##']        = '';
+        $data['##ticket.item.locationstate##']       = '';
+        $data['##ticket.item.locationcountry##']     = '';
         $data['##ticket.item.contact##']             = '';
         $data['##ticket.item.contactnumber##']       = '';
         $data['##ticket.item.user##']                = '';
@@ -343,6 +363,21 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
                         }
                         if ($hardware->getField('altitude')) {
                             $data['##ticket.item.locationaltitude##'] = $locations->getField('altitude');
+                        }
+                        if ($hardware->getField('address')) {
+                            $data['##ticket.item.locationaddress##'] = $locations->getField('address');
+                        }
+                        if ($hardware->getField('postcode')) {
+                            $data['##ticket.item.locationpostcode##'] = $locations->getField('postcode');
+                        }
+                        if ($hardware->getField('town')) {
+                            $data['##ticket.item.locationtown##'] = $locations->getField('town');
+                        }
+                        if ($hardware->getField('state')) {
+                            $data['##ticket.item.locationstate##'] = $locations->getField('state');
+                        }
+                        if ($hardware->getField('country')) {
+                            $data['##ticket.item.locationcountry##'] = $locations->getField('country');
                         }
                     }
 
@@ -643,6 +678,31 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
                 __('%1$s: %2$s'),
                 _n('Associated element', 'Associated elements', Session::getPluralNumber()),
                 __('Altitude')
+            ),
+            'ticket.item.locationaddress'  => sprintf(
+                __('%1$s: %2$s'),
+                _n('Associated element', 'Associated elements', Session::getPluralNumber()),
+                __('Address')
+            ),
+            'ticket.item.locationpostcode' => sprintf(
+                __('%1$s: %2$s'),
+                _n('Associated element', 'Associated elements', Session::getPluralNumber()),
+                __('Postal code')
+            ),
+            'ticket.item.locationcity'     => sprintf(
+                __('%1$s: %2$s'),
+                _n('Associated element', 'Associated elements', Session::getPluralNumber()),
+                __('City')
+            ),
+            'ticket.item.locationstate'    => sprintf(
+                __('%1$s: %2$s'),
+                _n('Associated element', 'Associated elements', Session::getPluralNumber()),
+                __('State')
+            ),
+            'ticket.item.locationcountry'  => sprintf(
+                __('%1$s: %2$s'),
+                _n('Associated element', 'Associated elements', Session::getPluralNumber()),
+                __('Country')
             ),
             'ticket.item.model'            => _n('Model', 'Models', 1),
             'ticket.item.contact'          => __('Alternate username'),


### PR DESCRIPTION
In ticket notifications, some location fields were missing in the tags:

- Address
- Postal code
- Town
- State
- Country


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26381
