### PR TITLE
fix(template): wrong tab after page reloading

### DIFF
--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -369,6 +369,7 @@ JAVASCRIPT;
                      itemtype: '" . addslashes($type) . "',
                      id: '$ID',
                      tab: index,
+                     withtemplate: " . ($_GET['withtemplate'] ?? 0) . "
                   }
                );
             }

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -3556,7 +3556,12 @@ HTML;
             $item->getFromDB($id);
         }
 
-        $tabs = $item->defineAllTabs();
+        $options = [];
+        if (isset($_GET['withtemplate'])) {
+            $options['withtemplate'] = $_GET['withtemplate'];
+        }
+
+        $tabs = $item->defineAllTabs($options);
         if (isset($tabs['no_all_tab'])) {
             unset($tabs['no_all_tab']);
         }


### PR DESCRIPTION
Example: on a computer template, by activating the "Management" tab, if you reload the page (after validation of the form) the page opens on the "Remote management" tab (which is the tab just before).

Same case with the other tabs, the reload is done on a previous tab.
The offset depends on the number of hidden tabs in the template.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27048
