### PR TITLE
fix(Entity): mishandling of the entity transfer option

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -1879,10 +1879,13 @@ class Entity extends CommonTreeDropdown
         $params = [
             'name'       => 'transfers_id',
             'value'      => $entity->fields['transfers_id'],
-            'emptylabel' => __('No automatic transfer')
+            'display_emptychoice' => false
         ];
         if ($entity->fields['id'] > 0) {
-            $params['toadd'] = [self::CONFIG_PARENT => __('Inheritance of the parent entity')];
+            $params['toadd'] = [
+                self::CONFIG_NEVER => __('No automatic transfer'),
+                self::CONFIG_PARENT => __('Inheritance of the parent entity')
+            ];
         }
         Dropdown::show('Transfer', $params);
         if ($entity->fields['transfers_strategy'] == self::CONFIG_PARENT) {


### PR DESCRIPTION
Actually ```'emptylabel' => __('No automatic transfer')``` is not considered as ```self::CONFIG_NEVER``` 

so when saving, the value ```"No automatic transfer"```  is never kept in databases 
and value ```-2 (inherited from a parent entity)``` is always here 

This PR fix this.



| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
