### PR TITLE
fix(license template): missing relations

### DIFF
--- a/src/SoftwareLicense.php
+++ b/src/SoftwareLicense.php
@@ -56,7 +56,13 @@ class SoftwareLicense extends CommonTreeDropdown
 
     public function getCloneRelations(): array
     {
-        return [];
+        return [
+            Infocom::class,
+            Contract_Item::class,
+            Document_Item::class,
+            KnowbaseItem_Item::class,
+            Notepad::class
+        ];
     }
 
     public static function getTypeName($nb = 0)


### PR DESCRIPTION
When creating a license from template, linked items (as contract) were not copied on the created license.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27043
