### PR TITLE
Do not check HTTP_REFERER value on POST requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The present file will list all changes made to the project; according to the
 #### Changes
 
 #### Deprecated
+- `Toolbox::checkValidReferer()`
 
 #### Removed
 

--- a/apirest.php
+++ b/apirest.php
@@ -40,7 +40,6 @@
 use Glpi\Cache\CacheManager;
 
 define('GLPI_ROOT', __DIR__);
-define('DO_NOT_CHECK_HTTP_REFERER', 1);
 ini_set('session.use_cookies', 0);
 
 include_once(GLPI_ROOT . "/inc/based_config.php");

--- a/apixmlrpc.php
+++ b/apixmlrpc.php
@@ -40,7 +40,6 @@
 use Glpi\Cache\CacheManager;
 
 define('GLPI_ROOT', __DIR__);
-define('DO_NOT_CHECK_HTTP_REFERER', 1);
 
 include_once(GLPI_ROOT . "/inc/based_config.php");
 

--- a/caldav.php
+++ b/caldav.php
@@ -38,7 +38,6 @@
  */
 
 define('GLPI_ROOT', __DIR__);
-define('DO_NOT_CHECK_HTTP_REFERER', 1);
 ini_set('session.use_cookies', 0);
 
 include_once(GLPI_ROOT . '/inc/includes.php');

--- a/front/cron.php
+++ b/front/cron.php
@@ -37,7 +37,6 @@
 chdir(__DIR__);
 
 
-define('DO_NOT_CHECK_HTTP_REFERER', 1);
 include('../inc/includes.php');
 
 if (!is_writable(GLPI_LOCK_DIR)) {

--- a/inc/includes.php
+++ b/inc/includes.php
@@ -139,15 +139,6 @@ if (isset($_REQUEST['glpilist_limit'])) {
     $_SESSION['glpilist_limit'] = $_REQUEST['glpilist_limit'];
 }
 
-// Security : Check HTTP_REFERRER : need to be in GLPI.
-if (
-    !defined('DO_NOT_CHECK_HTTP_REFERER')
-    && !isCommandLine()
-    && isset($_POST) && is_array($_POST) && count($_POST)
-) {
-    Toolbox::checkValidReferer();
-}
-
 // Security : check CSRF token
 if (
     GLPI_USE_CSRF_CHECK

--- a/index.php
+++ b/index.php
@@ -50,8 +50,6 @@ use Glpi\Toolbox\Sanitizer;
 define('GLPI_ROOT', __DIR__);
 include(GLPI_ROOT . "/inc/based_config.php");
 
-define('DO_NOT_CHECK_HTTP_REFERER', 1);
-
 // If config_db doesn't exist -> start installation
 if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
     if (file_exists(GLPI_ROOT . '/install/install.php')) {

--- a/install/install.php
+++ b/install/install.php
@@ -540,8 +540,6 @@ if (!isset($_SESSION['can_process_install']) || !isset($_POST["install"])) {
     header_html(__("Select your language"));
     choose_language();
 } else {
-   // Check valid Referer :
-    Toolbox::checkValidReferer();
    // Check CSRF: ensure nobody strap first page that checks if config file exists ...
     Session::checkCSRF($_POST);
 

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2492,9 +2492,13 @@ class Toolbox
      * @since 0.84.2
      *
      * @return void  display error if not permit
+     *
+     * @deprecated 10.0.7
      **/
     public static function checkValidReferer()
     {
+        Toolbox::deprecated('Checking `HTTP_REFERER` does not provide any security.');
+
         global $CFG_GLPI;
 
         $isvalidReferer = true;

--- a/status.php
+++ b/status.php
@@ -35,7 +35,6 @@
 
 use Glpi\System\Status\StatusChecker;
 
-define('DO_NOT_CHECK_HTTP_REFERER', 1);
 include('./inc/includes.php');
 
 // Force in normal mode

--- a/tools/getsearchoptions.php
+++ b/tools/getsearchoptions.php
@@ -33,8 +33,6 @@
  * ---------------------------------------------------------------------
  */
 
-define('DO_NOT_CHECK_HTTP_REFERER', 1);
-
 // Ensure current directory when run from crontab
 chdir(__DIR__);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. `HTTP_REFERER` value cannot be trusted, so checking it does not really enforce security.
2. There is now a CSRF token check on all POST request (except for API), so checking `HTTP_REFERER` seems not relevant anymore.
3. Default behaviour of browsers is to not send cookies on `POST` requests (`SameSite: Lax` policy on cookies), so result will be that GLPI will not be able to retrieve session and will therefore not be able to validate CSRF token, so request will anyway be invalidated. Thus, since GLPI 10.0.3 ((see #12302), we added a warning on install/update to indicate when `SameSite` session cookie policy is not at least `Lax`, to ensure that sysadmins are fixing potential unsecure web server configuration.
