### PR TITLE
fix(inventory): revert old entities_id for agent too

### DIFF
--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -696,23 +696,6 @@ abstract class MainAsset extends InventoryAsset
             $this->setNew();
         }
 
-        if (in_array($itemtype, $CFG_GLPI['agent_types'])) {
-            $this->agent->update(['id' => $this->agent->fields['id'], 'items_id' => $items_id, 'entities_id' => $entities_id]);
-        } else {
-            $this->agent->fields['items_id'] = $items_id;
-            $this->agent->fields['entities_id'] = $entities_id;
-        }
-
-        //check for any old agent to remove
-        $agent = new \Agent();
-        $agent->deleteByCriteria([
-            'itemtype' => $this->item->getType(),
-            'items_id' => $items_id,
-            'NOT' => [
-                'id' => $this->agent->fields['id']
-            ]
-        ]);
-
         $val->id = $this->item->fields['id'];
 
         if ($entities_id == -1) {
@@ -734,8 +717,26 @@ abstract class MainAsset extends InventoryAsset
             } else {
                 //no transfert so revert to old entities_id
                 $val->entities_id = $this->item->fields['entities_id'];
+                $this->agent->fields['entities_id'] = $this->item->fields['entities_id'];
             }
         }
+
+        if (in_array($itemtype, $CFG_GLPI['agent_types'])) {
+            $this->agent->update(['id' => $this->agent->fields['id'], 'items_id' => $items_id, 'entities_id' => $val->entities_id]);
+        } else {
+            $this->agent->fields['items_id'] = $items_id;
+            $this->agent->fields['entities_id'] = $entities_id;
+        }
+
+        //check for any old agent to remove
+        $agent = new \Agent();
+        $agent->deleteByCriteria([
+            'itemtype' => $this->item->getType(),
+            'items_id' => $items_id,
+            'NOT' => [
+                'id' => $this->agent->fields['id']
+            ]
+        ]);
 
         if ($this->is_discovery === true && !$this->isNew()) {
             //if NetworkEquipement

--- a/tests/functionnal/Glpi/Inventory/Assets/Computer.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Computer.php
@@ -35,8 +35,6 @@
 
 namespace tests\units\Glpi\Inventory\Asset;
 
-use Agent;
-
 include_once __DIR__ . '/../../../../abstracts/AbstractInventoryAsset.php';
 
 /* Test for inc/inventory/asset/computer.class.php */

--- a/tests/functionnal/Glpi/Inventory/Assets/Computer.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Computer.php
@@ -1142,7 +1142,7 @@ class Computer extends AbstractInventoryAsset
         $this->integer($computer->fields['entities_id'])->isEqualTo(0);
 
 
-        //transer to another entity
+        //transfer to another entity
         $doTransfer = \Entity::getUsedConfig('transfers_strategy', $computer->fields['entities_id'], 'transfers_id', 0);
         $transfer = new \Transfer();
         $transfer->getFromDB($doTransfer);


### PR DESCRIPTION
Like https://github.com/glpi-project/glpi/pull/12891

When ```transfer_strategy``` does not allow the automatic transfer

the inventory does not put the old entities_id to ```Agent``` -> so the ```Agent``` changes entity.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27014
