### PR TITLE
fix(Approval): ##object.urlvalidation## return bad redirect

### DIFF
--- a/src/NotificationTargetChange.php
+++ b/src/NotificationTargetChange.php
@@ -72,7 +72,7 @@ class NotificationTargetChange extends NotificationTargetCommonITILObject
         $data['##change.urlvalidation##']
                      = $this->formatURL(
                          $options['additionnaloption']['usertype'],
-                         "change_" . $item->getField("id") . "_ChangeValidation$1"
+                         "change_" . $item->getField("id") . '_Change$main'
                      );
         $data['##change.globalvalidation##']
                      = ChangeValidation::getStatus($item->getField('global_validation'));

--- a/src/NotificationTargetTicket.php
+++ b/src/NotificationTargetTicket.php
@@ -165,7 +165,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
         $data['##ticket.urlvalidation##']
                         = $this->formatURL(
                             $options['additionnaloption']['usertype'],
-                            "ticket_" . $item->getField("id") . "_TicketValidation$1"
+                            "ticket_" . $item->getField("id") . '_Ticket$main'
                         );
         $data['##ticket.globalvalidation##']
                         = TicketValidation::getStatus($item->getField('global_validation'));


### PR DESCRIPTION
```##ticket.urlvalidation##``` and ```##change.urlvalidation##``` generate a bad redirection

The approval or refusal is no longer done in the ```Validation``` tab but in the ```Timeline (main)``` tab

We need to generate this : 
```
http://127.0.0.1/GLPI/10.0-bugfixes/ajax/common.tabs.php?_target=/GLPI/10.0-bugfixes/front/ticket.form.php&_itemtype=Ticket&_glpi_tab=Ticket$main&id=1
```

instead of 
```
http://127.0.0.1/GLPI/10.0-bugfixes/ajax/common.tabs.php?_target=/GLPI/10.0-bugfixes/front/ticket.form.php&_itemtype=Ticket&_glpi_tab=TicketValidation$1&id=1
```




| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27061
