### PR TITLE
Make LDAP error message visible

### DIFF
--- a/templates/pages/setup/authentication.html.twig
+++ b/templates/pages/setup/authentication.html.twig
@@ -52,11 +52,9 @@
                      <span>{{ 'AuthLDAP'|itemtype_name }}</span>
                   </a>
                {% else %}
-                  <div class="list-group-item">
-                     <div class="list-group-item alert alert-important alert-warning m-3">
-                        <i class="fa-fw fa fa-exclamation-triangle me-2"></i>
-                        {{ __('The LDAP extension of your PHP parser isn’t installed') }}
-                     </div>
+                  <div class="alert alert-important alert-warning m-3">
+                    <i class="fa-fw fa fa-exclamation-triangle me-2"></i>
+                    {{ __('The LDAP extension of your PHP parser isn’t installed') }}
                   </div>
                {% endif %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Message was not correctly displayed. After the change:
![image](https://user-images.githubusercontent.com/224733/223422542-41094eec-d217-4ae3-b368-d81125135fc3.png)
