### PR TITLE
feat(inventory): improve file upload

### DIFF
--- a/src/Inventory/Conf.php
+++ b/src/Inventory/Conf.php
@@ -286,6 +286,10 @@ class Conf extends CommonGLPI
         TemplateRenderer::getInstance()->display('pages/admin/inventory/upload_result.html.twig', [
             'imported_files' => $this->importFiles($to_import)
         ]);
+
+        TemplateRenderer::getInstance()->display('components/messages_after_redirect_toasts.html.twig', [
+            'display_container' => true
+        ]);
     }
 
     /**

--- a/templates/pages/admin/inventory/upload_result.html.twig
+++ b/templates/pages/admin/inventory/upload_result.html.twig
@@ -63,15 +63,19 @@
                                     {% if result['items'] is array %}
                                         {% for item in result['items'] %}
                                             {% if item is object %}
+                                             <div>
                                                 <span>
                                                 <i class="{{ item.getIcon() }}"></i>
                                                 {{ get_item_link(item) }}
                                                 </span>
+                                            </div>
                                             {% else %}
-                                                <span class="alert-sucess">
-                                                <i class="fas fa-check"></i>
-                                                {{ result['message'] }}
-                                                </span>
+                                                <div>
+                                                    <span class="alert-sucess">
+                                                    <i class="fas fa-check"></i>
+                                                    {{ result['message'] }}
+                                                    </span>
+                                                </div>
                                             {% endif %}
                                         {% endfor %}
                                     {% else %}


### PR DESCRIPTION
If more than one asset are created / updated (like stacked swtich), they are displayed on a line

![image](https://user-images.githubusercontent.com/7335054/223762467-5a5a8719-4272-44b3-9bb1-b34ed0ae6f90.png)

More readable on several lines

![image](https://user-images.githubusercontent.com/7335054/223762524-de55b1b2-10b4-4a58-b522-76f1dd8d64b1.png)


If a (non-critical) error occurs you have to go back to the previous page to see the popup

![image](https://user-images.githubusercontent.com/7335054/223762802-6892fe1f-b7b5-4d14-b314-6f4603d954f8.png)

Fix this to get popup from upload result

![image](https://user-images.githubusercontent.com/7335054/223762873-d0e07c09-5cd7-41d0-8166-595d110d37fe.png)





| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
