### PR TITLE
Fix tests on PHP 8.1

### DIFF
--- a/tests/units/Glpi/Application/ErrorHandler.php
+++ b/tests/units/Glpi/Application/ErrorHandler.php
@@ -35,6 +35,7 @@
 
 namespace tests\units\Glpi\Application;
 
+use Monolog\Handler\TestHandler;
 use Monolog\Level;
 
 class ErrorHandler extends \GLPITestCase
@@ -114,7 +115,7 @@ class ErrorHandler extends \GLPITestCase
         Level $expected_log_level,
         string $expected_msg_pattern
     ) {
-        $handler = $this->newMockInstance('Monolog\Handler\TestHandler');
+        $handler = new TestHandler();
         $logger = $this->newMockInstance('Monolog\\Logger', null, null, ['test-logger', [$handler]]);
 
        // Force session in debug mode (to get debug output)
@@ -243,7 +244,7 @@ class ErrorHandler extends \GLPITestCase
         string $expected_msg_pattern,
         bool $is_fatal_error = false
     ) {
-        $handler = $this->newMockInstance('Monolog\Handler\TestHandler');
+        $handler = new TestHandler();
         $logger = $this->newMockInstance('Monolog\\Logger', null, null, ['test-logger', [$handler]]);
 
        // Force session in debug mode (to get debug output)
@@ -293,7 +294,7 @@ class ErrorHandler extends \GLPITestCase
      */
     public function testHandleException()
     {
-        $handler = $this->newMockInstance('Monolog\Handler\TestHandler');
+        $handler = new TestHandler();
         $logger = $this->newMockInstance('Monolog\\Logger', null, null, ['test-logger', [$handler]]);
 
         $exception = new \RuntimeException('Something went wrong');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Looks like there is an issue in atoum mock generator on PHP 8.1. As we do not really use mock capability on this specific case, passing a real instance of `Monolog\Handler\TestHandler` is an acceptable quickfix.