### PR TITLE
Fix subquery search handling on PHP 7.4

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -5337,7 +5337,7 @@ JAVASCRIPT;
                 //     FROM `glpi_groups_tickets`
                 //     WHERE `groups_id` = '4' AND `glpi_groups_tickets`.`type` = '3'
                 // )
-                if ($val == 0) {
+                if (is_numeric($val) && (int)$val === 0) {
                     // Special case, search criteria is empty
                     $subquery_operator = $subquery_operator == "IN" ? "NOT IN" : "IN";
                     $out = " $link `$main_table`.`id` $subquery_operator (


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Loose comparison with 0 in PHP 7.4 is unsafe.
```
$ php -r 'var_dump("myself" == 0);'
bool(true)
```