### PR TITLE
Fix getAllDasboardCards cache

### DIFF
--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -1112,14 +1112,14 @@ HTML;
             // Keep a log trace in case of unexpected session value
             // This may help with debugging in the future
             trigger_error(
-                "Unable to get current language, will default to 'getAllDasboardCards' key",
+                "Unable to get current language, will default to 'getAllDashboardCards' key",
                 E_USER_WARNING
             );
 
-            return "getAllDasboardCards";
+            return "getAllDashboardCards";
         }
 
-        return "getAllDasboardCards_$language";
+        return "getAllDashboardCards_$language";
     }
 
     /**

--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -280,7 +280,7 @@ HTML;
 
         // Force clear the cards cache in debug mode
         if ($_SESSION['glpi_use_mode'] === Session::DEBUG_MODE) {
-            $GLPI_CACHE->delete('getAllDasboardCards');
+            $GLPI_CACHE->delete(self::getAllDashboardCardsCacheKey());
         }
 
         // prepare all available cards
@@ -1098,6 +1098,31 @@ HTML;
     }
 
     /**
+     * Get cache key for the "getAllDasboardCards" function data.
+     * The data will contain some translated strings and thus must be kept in a
+     * separate cache entry for each languages
+     *
+     * @return string
+     */
+    public static function getAllDashboardCardsCacheKey(): string
+    {
+        $language = Session::getLanguage();
+
+        if (!$language) {
+            // Keep a log trace in case of unexpected session value
+            // This may help with debugging in the future
+            trigger_error(
+                "Unable to get current language, will default to 'getAllDasboardCards' key",
+                E_USER_WARNING
+            );
+
+            return "getAllDasboardCards";
+        }
+
+        return "getAllDasboardCards_$language";
+    }
+
+    /**
      * Construct catalog of all possible cards addable in a dashboard.
      *
      * @param bool $force Force rebuild the catalog of cards
@@ -1108,7 +1133,7 @@ HTML;
     {
         global $CFG_GLPI, $GLPI_CACHE;
 
-        $cards = $GLPI_CACHE->get('getAllDasboardCards');
+        $cards = $GLPI_CACHE->get(self::getAllDashboardCardsCacheKey());
 
         if ($cards === null || $force) {
             // anonymous fct for adding relevant filters to cards
@@ -1449,7 +1474,7 @@ HTML;
                     'content' => __("Toggle edit mode to edit content"),
                 ]
             ];
-            $GLPI_CACHE->set('getAllDasboardCards', $cards);
+            $GLPI_CACHE->set(self::getAllDashboardCardsCacheKey(), $cards);
         }
 
         $more_cards = Plugin::doHookFunction(Hooks::DASHBOARD_CARDS);

--- a/src/Session.php
+++ b/src/Session.php
@@ -1922,4 +1922,14 @@ class Session
         //Remove cookie to allow new login
         Auth::setRememberMeCookie('');
     }
+
+    /**
+     * Get the current language
+     *
+     * @return null|string
+     */
+    public static function getLanguage(): ?string
+    {
+        return $_SESSION['glpilanguage'] ?? null;
+    }
 }


### PR DESCRIPTION
The `getAllDasboardCards` cache entry will contain translated content and thus must be cached independently for each languages.

![image](https://user-images.githubusercontent.com/42734840/224337542-0e20e17c-683f-42b7-a12d-840ec32c08d4.png)

A better solution would be to not include translated content in the `getAllDasboardCards`  function, but it would require a lot more changes and probably some breaking changes regarding plugins like Advanced Dashboards.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26769
