### PR TITLE
ITIL Kanban: Fix error for empties columns

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8850,7 +8850,7 @@ abstract class CommonITILObject extends CommonDBTM
 
         // Replace category ids with category names in items metadata
         foreach ($columns as &$column) {
-            foreach ($column['items'] as &$item) {
+            foreach (($column['items'] ?? []) as &$item) {
                 $item['_metadata']['category'] = $categories[$item['_metadata']['category']] ?? '';
             }
         }


### PR DESCRIPTION
Kanban page fails completely if one of the defined columns does not contains any tickets.

>[2023-03-13 11:17:29] glpiphplog.WARNING:   *** PHP Warning (2): foreach() argument must be of type array|object, null given in /home/aclai/localhost/glpi/10.0-bugfixes/src/CommonITILObject.php at line 8853
  Backtrace :
  ajax/kanban.php:247                                CommonITILObject::getKanbanColumns()

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26997
