### PR TITLE
Prevent searched text to be twice escaped

### DIFF
--- a/src/Search/Provider/SQLProvider.php
+++ b/src/Search/Provider/SQLProvider.php
@@ -4471,13 +4471,8 @@ final class SQLProvider implements SearchProviderInterface
      **/
     public static function makeTextSearchValue($val)
     {
-        global $DB;
-
-        // Escape raw value to protect SQL special chars.
-        $val = $DB->escape($val);
-
         // escape _ char used as wildcard in mysql likes
-        $val = str_replace('_', '\\_', $val);
+        $val = str_replace('_', '\_', $val);
 
         if ($val === 'NULL' || $val === 'null') {
             return null;

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -1689,9 +1689,8 @@ class Search extends DbTestCase
             ['rtim this   $', '%rtim this'],
             ['  extra spaces ', '%extra spaces%'],
             ['^ exactval $', 'exactval'],
-            ['snake_case', '%snake\\_case%'], // _ is a wildcard that must be escaped
-            ['quot\'ed', '%quot\\\'ed%'],
-            ['quot\\\'ed', '%quot\\\\\\\'ed%'], // already escaped value should produce double escaping
+            ['snake_case', '%snake\_case%'], // _ is a wildcard that must be escaped
+            ['quot\'ed', '%quot\'ed%'], // quotes should not be escaped by this method
             ['<PROD-15>$', '%<PROD-15>'],
             ['A&B', '%A&B%'],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`makeTextSearchValue()` method result is used either in raw queries via `DBmysql::quoteValue($search_val)` that is already escaping values, either in `DBmysql::request()` params, that are now automatically escaped.