### PR TITLE
Remove usage of `#[ReturnTypeWillChange]` attribute

### DIFF
--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -744,8 +744,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
      *
      * @return mixed
      */
-    #[ReturnTypeWillChange]
-    public function current()
+    public function current(): mixed
     {
         return $this->row;
     }
@@ -755,8 +754,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
      *
      * @return mixed
      */
-    #[ReturnTypeWillChange]
-    public function key()
+    public function key(): mixed
     {
         return $this->row !== null ? ($this->row["id"] ?? $this->position) : null;
     }

--- a/src/Search/SearchOption.php
+++ b/src/Search/SearchOption.php
@@ -77,8 +77,7 @@ final class SearchOption implements \ArrayAccess
         return isset($this->search_opt_array[$offset]);
     }
 
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->search_opt_array[$offset];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

As we no longer support PHP < 8.0 on main branch, `mixed` type could be used now.