### PR TITLE
fix(Session) PHP operator correction

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -1233,7 +1233,7 @@ class Session
         }
 
         if (isset($_SESSION["glpiactiveprofile"][$module])) {
-            return intval($_SESSION["glpiactiveprofile"][$module]) & $right;
+            return intval($_SESSION["glpiactiveprofile"][$module]) && $right;
         }
 
         return false;


### PR DESCRIPTION
Correct the error message when saving plugin config form :

`Uncaught Exception TypeError: Unsupported operand types: string & int in /var/www/html/src/Session.php at line 1236`

<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
