### PR TITLE
fix Dropdown depreciation for float values PHP8.1

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -1754,9 +1754,12 @@ JAVASCRIPT;
         }
 
         $field_id = Html::cleanId("dropdown_" . $myname . $p['rand']);
-        if (!isset($p['toadd'][$p['value']])) {
+        if(\is_float($p['value'])){
             $decimals = Toolbox::isFloat($p['value']) ? Toolbox::getDecimalNumbers($p['step']) : 0;
-            $valuename = self::getValueWithUnit($p['value'], $p['unit'], $decimals);
+            $p['value'] = self::getValueWithUnit($p['value'], $p['unit'], $decimals);
+        }
+        if (!isset($p['toadd'][$p['value']])) {
+            $valuename = $p['value'];
         } else {
             $valuename = $p['toadd'][$p['value']];
         }


### PR DESCRIPTION
This message appears when using `Dropdown::showNumber` with step parameter to 0.5 : `'step' => 0.5`

fix depreciation message 
`PHP Deprecated function (8192): Implicit conversion from float 5.5 to int loses precision in /var/www/html/src/Dropdown.php at line 1750`


<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
