### PR TITLE
Disable richtext for blacklistmail content

### DIFF
--- a/src/BlacklistedMailContent.php
+++ b/src/BlacklistedMailContent.php
@@ -73,7 +73,8 @@ class BlacklistedMailContent extends CommonDropdown
             'label' => __('Content'),
             'type'  => 'textarea',
             'rows'  => 20,
-            'list'  => true
+            'list'  => true,
+            'enable_richtext' => false
         ]
         ];
     }

--- a/templates/dropdown_form.html.twig
+++ b/templates/dropdown_form.html.twig
@@ -86,7 +86,7 @@
                             full_width: true,
                             full_width_adapt_column: false,
                             is_horizontal: false,
-                            enable_richtext: true,
+                            enable_richtext: field['enable_richtext'] is defined ? field['enable_richtext'] : true,
                             enable_images: false,
                         }
                     ) }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13276

This field was not rich text enabled prior to 10.0 and having it reformat text that is inputted can cause issues since it is supposed to be directly compared to mail content.