### PR TITLE
Fix missing rateit lib for stats

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -565,7 +565,7 @@ $CFG_GLPI['javascript'] = [
         'ticket'    => ['rateit', 'tinymce', 'kanban', 'dashboard'],
         'problem'   => ['tinymce', 'kanban', 'sortable'],
         'change'    => ['tinymce', 'kanban', 'sortable'],
-        'stat'      => ['charts']
+        'stat'      => ['charts', 'rateit']
     ],
     'tools'     => [
         'project'                 => ['kanban', 'tinymce', 'sortable'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Assistance > Statistics page tries using the rateit library but it is not included for these pages.