### PR TITLE
fix project auto percent toggle

### DIFF
--- a/src/Project.php
+++ b/src/Project.php
@@ -1635,7 +1635,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
             'type'      => 'checkbox',
             'name'      => 'auto_percent_done',
             'title'     => __('Automatically calculate'),
-            'onclick'   => "$(\"select[name='percent_done']\").prop('disabled', !$(\"input[name='auto_percent_done']\").prop('checked'));"
+            'onclick'   => "$(\"select[name='percent_done']\").prop('disabled', $(\"input[type='checkbox'][name='auto_percent_done']\").prop('checked'));"
         ];
         if ($this->fields['auto_percent_done']) {
             $auto_percent_done_params['checked'] = 'checked';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13899

`Html::showCheckbox` adds a hidden input with the same name which caused the onclick selector to target the wrong input. The Project Task form doesn't have this issue (uses Twig template).