### PR TITLE
Fix missing KB revision right

### DIFF
--- a/src/KnowbaseItem_Revision.php
+++ b/src/KnowbaseItem_Revision.php
@@ -37,6 +37,8 @@
 /// since version 9.2
 class KnowbaseItem_Revision extends CommonDBTM
 {
+    public static $rightname   = 'knowbase';
+
     public static function getTypeName($nb = 0)
     {
         return _n('Revision', 'Revisions', $nb);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13786

KnowbaseItem_Revision was missing a right name so API access was impossible.