### PR TITLE
Do not load duplicated authorizations

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -65,6 +65,14 @@ class Entity extends CommonTreeDropdown
     const AUTO_ASSIGN_CATEGORY_HARDWARE  = 2;
 
     /**
+     * Possible relations between entities
+     */
+    public const RELATION_SELF      = 0;
+    public const RELATION_PARENT    = 1;
+    public const RELATION_CHILD     = 2;
+    public const RELATION_UNRELATED = 3;
+
+    /**
      * Possible values for "anonymize_support_agents" setting
      */
     const ANONYMIZE_DISABLED            = 0;
@@ -4054,5 +4062,38 @@ class Entity extends CommonTreeDropdown
             return self::badgeCompletenameLink($entity);
         }
         return null;
+    }
+
+    /**
+     * Compute the relation between two entities using their ids
+     * -> Entity 1 (is / is parent of / is a child of / is unrelated to) entity 2
+     *
+     * @param int $entity_1_id
+     * @param int $entity_2_id
+     *
+     * @return int Constant defining the relation (e.g. self::RELATION_SELF)
+     */
+    final public static function getRelationByIds(
+        int $entity_1_id,
+        int $entity_2_id,
+    ): int {
+        // Same entity
+        if ($entity_1_id == $entity_2_id) {
+            return self::RELATION_SELF;
+        }
+
+        $entity_1_sons = getSonsOf(self::getTable(), $entity_1_id);
+        $entity_1_parents = getAncestorsOf(self::getTable(), $entity_1_id);
+
+        if (in_array($entity_2_id, $entity_1_sons)) {
+            // Entity 1 is parent of entity 2
+            return self::RELATION_PARENT;
+        } elseif (in_array($entity_2_id, $entity_1_parents)) {
+            // Entity 1 is a child of entity 2
+            return self::RELATION_CHILD;
+        } else {
+            // No relation between these entities
+            return self::RELATION_UNRELATED;
+        }
     }
 }

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -4075,7 +4075,7 @@ class Entity extends CommonTreeDropdown
      */
     final public static function getRelationByIds(
         int $entity_1_id,
-        int $entity_2_id,
+        int $entity_2_id
     ): int {
         // Same entity
         if ($entity_1_id == $entity_2_id) {

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -1116,4 +1116,63 @@ class Entity extends DbTestCase
         $this->integer(getItemByTypeName('Entity', 'test clone entity (copy 3)', true))->isGreaterThan(0);
         $this->integer(getItemByTypeName('Entity', 'test clone entity (copy 4)', true))->isGreaterThan(0);
     }
+
+    /**
+     * Data provider for testGetRelationByIds
+     *
+     * return iterable
+     */
+    protected function testGetRelationByIdsProvider(): iterable
+    {
+        $root = getItemByTypeName("Entity", "Root entity", true);
+        $test_root = getItemByTypeName("Entity", "_test_root_entity", true);
+        $test_child_1 = getItemByTypeName("Entity", "_test_child_1", true);
+        $test_child_2 = getItemByTypeName("Entity", "_test_child_2", true);
+
+        return [
+            // Same entities
+            [$root, $root, \Entity::RELATION_SELF],
+            [$test_root, $test_root, \Entity::RELATION_SELF],
+            [$test_child_1, $test_child_1, \Entity::RELATION_SELF],
+            [$test_child_2, $test_child_2, \Entity::RELATION_SELF],
+
+            // Parent entities
+            [$root, $test_root, \Entity::RELATION_PARENT],
+            [$root, $test_child_1, \Entity::RELATION_PARENT],
+            [$root, $test_child_2, \Entity::RELATION_PARENT],
+            [$test_root, $test_child_1, \Entity::RELATION_PARENT],
+            [$test_root, $test_child_2, \Entity::RELATION_PARENT],
+
+            // Children entities
+            [$test_root, $root, \Entity::RELATION_CHILD],
+            [$test_child_1, $root, \Entity::RELATION_CHILD],
+            [$test_child_2, $root, \Entity::RELATION_CHILD],
+            [$test_child_1, $test_root, \Entity::RELATION_CHILD],
+            [$test_child_2, $test_root, \Entity::RELATION_CHILD],
+
+            // Unrelated entities
+            [$test_child_1, $test_child_2, \Entity::RELATION_UNRELATED],
+        ];
+    }
+
+    /**
+     * Tests for Entity::getRelationByIds
+     *
+     * @dataprovider testGetRelationByIdsProvider
+     *
+     * @param int $entity_1 First entity id
+     * @param int $entity_2 Second entity id
+     * @param int $expected Expected relation
+     *
+     * @return void
+     */
+    public function testGetRelationByIds(
+        int $entity_1,
+        int $entity_2,
+        int $expected
+    ): void {
+        $this->integer(
+            \Entity::getRelationByIds($entity_1, $entity_2)
+        )->isEqualTo($expected);
+    }
 }

--- a/tests/functionnal/Session.php
+++ b/tests/functionnal/Session.php
@@ -638,7 +638,7 @@ class Session extends \DbTestCase
     public function testInitEntityProfiles(
         int $users_id,
         string $profile,
-        array $expected,
+        array $expected
     ): void {
         \Session::initEntityProfiles($users_id);
 


### PR DESCRIPTION
Users may have "obsolete" authorizations:

![image](https://user-images.githubusercontent.com/42734840/226584258-dec92d79-f56a-404d-8ee5-f6c455e8d8a6.png)

For example in the image above I already have a recursive authorization on the Root entity but I also have two distinct authorizations on sub entities.
These authorizations are useless as I can already see any data in entities below root but they are still loaded into GLPI's session, causing some displays issues in the entity selector:

![image](https://user-images.githubusercontent.com/42734840/226584984-c3e2771a-b572-4930-aef3-b2c223911513.png)

To fix this I'm doing some safety checks before setting the session data, clearing obsolete authorizations as needed.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
