### PR TITLE
fix(ticket): wrong content when create from project task

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4251,7 +4251,7 @@ JAVASCRIPT;
                 $pt = new ProjectTask();
                 if ($pt->getFromDB($options['_projecttasks_id'])) {
                     $options['name'] = $pt->getField('name');
-                    $options['content'] = $pt->getField('name');
+                    $options['content'] = $pt->getField('content');
                 }
             }
             // Override defaut values from followup if needed


### PR DESCRIPTION
When a ticket was created from a project task, the title AND the description of the ticket were identical, in both fields, it was the title of the task.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27264
