### PR TITLE
Fix invalid cache after moving entity under root

### DIFF
--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -403,7 +403,7 @@ abstract class CommonTreeDropdown extends CommonDropdown
             $newParentNameID = '';
 
             $parent = clone $this;
-            if ($oldParentID > 0) {
+            if (!$this->isNewID($oldParentID)) {
                 $this->cleanParentsSons($oldParentID);
                 if ($history) {
                     if ($parent->getFromDB($oldParentID)) {
@@ -424,7 +424,7 @@ abstract class CommonTreeDropdown extends CommonDropdown
                 }
             }
 
-            if ($newParentID > 0) {
+            if (!$this->isNewID($newParentID)) {
                 $this->cleanParentsSons(null, false);
                 $this->addSonInParents();
                 if ($history) {

--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -403,12 +403,10 @@ abstract class CommonTreeDropdown extends CommonDropdown
             $newParentNameID = '';
 
             $parent = clone $this;
-            if (!$this->isNewID($oldParentID)) {
+            if ($parent->getFromDB($oldParentID)) {
                 $this->cleanParentsSons($oldParentID);
                 if ($history) {
-                    if ($parent->getFromDB($oldParentID)) {
-                        $oldParentNameID = $parent->getNameID(['forceid' => true]);
-                    }
+                    $oldParentNameID = $parent->getNameID(['forceid' => true]);
                     $changes = [
                         '0',
                         addslashes($this->getNameID(['forceid' => true])),
@@ -424,13 +422,11 @@ abstract class CommonTreeDropdown extends CommonDropdown
                 }
             }
 
-            if (!$this->isNewID($newParentID)) {
+            if ($parent->getFromDB($newParentID)) {
                 $this->cleanParentsSons(null, false);
                 $this->addSonInParents();
                 if ($history) {
-                    if ($parent->getFromDB($newParentID)) {
-                        $newParentNameID = $parent->getNameID(['forceid' => true]);
-                    }
+                    $newParentNameID = $parent->getNameID(['forceid' => true]);
                     $changes = [
                         '0',
                         '',


### PR DESCRIPTION
Moving an entity under root result in an invalid `sons_cache`.

This is caused by check done on IDs that rely on 0 meaning that the item doesn't have any parent, which is false for entities (0 = root entity's id).

If you are affected by this issue, clearing GLPI's cache then logging off/on should restore access to the "lost" entity (and applying the patch before moving another entity).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27259 #14095 #14179 #14180
