### PR TITLE
Remove move action from single action list

### DIFF
--- a/src/Rule.php
+++ b/src/Rule.php
@@ -713,9 +713,9 @@ class Rule extends CommonDBTM
 
     public function getForbiddenSingleMassiveActions()
     {
-        $exlcuded = parent::getForbiddenSingleMassiveActions();
-        $exlcuded[] = __CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'move_rule';
-        return $exlcuded;
+        $excluded = parent::getForbiddenSingleMassiveActions();
+        $excluded[] = __CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'move_rule';
+        return $excluded;
     }
 
     public function rawSearchOptions()

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -711,6 +711,12 @@ class Rule extends CommonDBTM
         parent::processMassiveActionsForOneItemtype($ma, $item, $ids);
     }
 
+    public function getForbiddenSingleMassiveActions()
+    {
+        $exlcuded = parent::getForbiddenSingleMassiveActions();
+        $exlcuded[] = __CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'move_rule';
+        return $exlcuded;
+    }
 
     public function rawSearchOptions()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14306

I'm not sure that this action should be available in the single action list since it relies on knowing where in the list the rule is currently, which you cannot see from the rule itself