### PR TITLE
fix kb comment tab visibility

### DIFF
--- a/src/KnowbaseItem_Comment.php
+++ b/src/KnowbaseItem_Comment.php
@@ -44,7 +44,7 @@ class KnowbaseItem_Comment extends CommonDBTM
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        if (!$item->canUpdateItem()) {
+        if (!($item instanceof KnowbaseItem) || !$item->canComment()) {
             return '';
         }
 

--- a/tests/functionnal/KnowbaseItem_Comment.php
+++ b/tests/functionnal/KnowbaseItem_Comment.php
@@ -150,6 +150,16 @@ class KnowbaseItem_Comment extends DbTestCase
         $_SESSION['glpishow_count_on_tabs'] = 0;
         $name = $kbcom->getTabNameForItem($kb1);
         $this->string($name)->isIdenticalTo('Comments');
+
+        // Change knowbase rights to be empty
+        $_SESSION['glpiactiveprofile']['knowbase'] = 0;
+        // Tab name should be empty
+        $this->string($kbcom->getTabNameForItem($kb1))->isEmpty();
+
+        // Add comment and read right
+        $_SESSION['glpiactiveprofile']['knowbase'] = READ | \KnowbaseItem::COMMENTS;
+        // Tab name should be filled (start with "Comments")
+        $this->string($kbcom->getTabNameForItem($kb1))->matches('/^Comments/');
     }
 
     public function testDisplayComments()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14348

Visibility of the comments tab should depend on the comment right and not update rights.