### PR TITLE
add missing softwarelicense cache fields

### DIFF
--- a/install/migrations/update_10.0.6_to_10.0.7/softwarelicense.php
+++ b/install/migrations/update_10.0.6_to_10.0.7/softwarelicense.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+if (!$DB->fieldExists('glpi_softwarelicenses', 'ancestors_cache')) {
+    $migration->addField('glpi_softwarelicenses', 'ancestors_cache', 'longtext');
+}
+
+if (!$DB->fieldExists('glpi_softwarelicenses', 'sons_cache')) {
+    $migration->addField('glpi_softwarelicenses', 'sons_cache', 'longtext');
+}

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -6582,6 +6582,8 @@ CREATE TABLE `glpi_softwarelicenses` (
   `softwarelicenses_id` int unsigned NOT NULL DEFAULT '0',
   `completename` text,
   `level` int NOT NULL DEFAULT '0',
+  `ancestors_cache` longtext,
+  `sons_cache` longtext,
   `entities_id` int unsigned NOT NULL DEFAULT '0',
   `is_recursive` tinyint NOT NULL DEFAULT '0',
   `number` int NOT NULL DEFAULT '0',

--- a/src/System/Diagnostic/DatabaseSchemaConsistencyChecker.php
+++ b/src/System/Diagnostic/DatabaseSchemaConsistencyChecker.php
@@ -52,6 +52,15 @@ class DatabaseSchemaConsistencyChecker extends AbstractDatabaseChecker
         $missing_columns = [];
 
         $columns = $this->getColumnsNames($table_name);
+        $itemtype = getItemTypeForTable($table_name);
+
+        if (is_subclass_of($itemtype, \CommonTreeDropdown::class)) {
+            foreach (['level', 'ancestors_cache', 'sons_cache'] as $expected_col) {
+                if (!in_array($expected_col, $columns)) {
+                    $missing_columns[] = $expected_col;
+                }
+            }
+        }
         foreach ($columns as $column_name) {
             switch ($column_name) {
                 case 'date_creation':


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

SoftwareLicense is a CommonTreeDropdown class and there are two cache fields that are expected to be present for all those classes, but are missing here. A SQL error is thrown after purging a Software because of these missing fields.