### PR TITLE
Enhance handling of LDAP errors

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -277,7 +277,7 @@ class Auth extends CommonGLPI
 
             $dn = $infos['dn'];
             $this->user_found = $dn != '';
-            if ($this->user_found && @ldap_bind($this->ldap_connection, $dn, $password)) {
+            if ($this->user_found && ldap_bind($this->ldap_connection, $dn, $password)) {
                //Hook to implement to restrict access by checking the ldap directory
                 if (Plugin::doHookFunction(Hooks::RESTRICT_LDAP_AUTH, $infos)) {
                     return $infos;

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -2517,7 +2517,7 @@ class AuthLDAP extends CommonDBTM
     public static function getGroupCNByDn($ldap_connection, $group_dn)
     {
 
-        $sr = @ ldap_read($ldap_connection, $group_dn, "objectClass=*", ["cn"]);
+        $sr = ldap_read($ldap_connection, $group_dn, "objectClass=*", ["cn"]);
         if ($sr === false) {
            //group does not exists
             return false;
@@ -3005,32 +3005,32 @@ class AuthLDAP extends CommonDBTM
         $timeout = 0
     ) {
 
-        $ds = @ldap_connect($host, intval($port));
+        $ds = ldap_connect($host, intval($port));
         if ($ds) {
-            @ldap_set_option($ds, LDAP_OPT_PROTOCOL_VERSION, 3);
-            @ldap_set_option($ds, LDAP_OPT_REFERRALS, 0);
-            @ldap_set_option($ds, LDAP_OPT_DEREF, $deref_options);
-            @ldap_set_option($ds, LDAP_OPT_NETWORK_TIMEOUT, $timeout);
+            ldap_set_option($ds, LDAP_OPT_PROTOCOL_VERSION, 3);
+            ldap_set_option($ds, LDAP_OPT_REFERRALS, 0);
+            ldap_set_option($ds, LDAP_OPT_DEREF, $deref_options);
+            ldap_set_option($ds, LDAP_OPT_NETWORK_TIMEOUT, $timeout);
 
             if (!empty($tls_certfile) && file_exists($tls_certfile)) {
-                @ldap_set_option(null, LDAP_OPT_X_TLS_CERTFILE, $tls_certfile);
+                ldap_set_option(null, LDAP_OPT_X_TLS_CERTFILE, $tls_certfile);
             }
 
             if (!empty($tls_keyfile) && file_exists($tls_keyfile)) {
-                @ldap_set_option(null, LDAP_OPT_X_TLS_KEYFILE, $tls_keyfile);
+                ldap_set_option(null, LDAP_OPT_X_TLS_KEYFILE, $tls_keyfile);
             }
 
             if ($use_tls) {
-                if (!@ldap_start_tls($ds)) {
+                if (!ldap_start_tls($ds)) {
                     return false;
                 }
             }
            // Auth bind
             if ($use_bind) {
                 if ($login != '') {
-                    $b = @ldap_bind($ds, $login, $password);
+                    $b = ldap_bind($ds, $login, $password);
                 } else { // Anonymous bind
-                    $b = @ldap_bind($ds);
+                    $b = ldap_bind($ds);
                 }
             } else {
                 $b = true;
@@ -3453,7 +3453,7 @@ class AuthLDAP extends CommonDBTM
      */
     public static function getObjectByDn($ds, $condition, $dn, $attrs = [], $clean = true)
     {
-        if ($result = @ ldap_read($ds, $dn, $condition, $attrs)) {
+        if ($result = ldap_read($ds, $dn, $condition, $attrs)) {
             if ($clean) {
                 $info = self::get_entries_clean($ds, $result);
             } else {

--- a/src/RuleRightCollection.php
+++ b/src/RuleRightCollection.php
@@ -249,7 +249,7 @@ class RuleRightCollection extends RuleCollection
             $rule_fields = $this->getFieldsToLookFor();
 
            //Get all the datas we need from ldap to process the rules
-            $sz         = @ldap_read(
+            $sz         = ldap_read(
                 $params_lower["connection"],
                 $params_lower["userdn"],
                 "objectClass=*",

--- a/src/User.php
+++ b/src/User.php
@@ -1639,7 +1639,7 @@ class User extends CommonDBTM
             sort($group_fields);
 
            // If the groups must be retrieve from the ldap user object
-            $sr = @ ldap_read($ldap_connection, $userdn, "objectClass=*", $group_fields);
+            $sr = ldap_read($ldap_connection, $userdn, "objectClass=*", $group_fields);
             $v  = AuthLDAP::get_entries_clean($ldap_connection, $sr);
 
             for ($i = 0; $i < $v['count']; $i++) {
@@ -1797,7 +1797,7 @@ class User extends CommonDBTM
             $fields  = array_filter($fields);
             $f       = self::getLdapFieldNames($fields);
 
-            $sr      = @ ldap_read($ldap_connection, $userdn, "objectClass=*", $f);
+            $sr      = ldap_read($ldap_connection, $userdn, "objectClass=*", $f);
             $v       = AuthLDAP::get_entries_clean($ldap_connection, $sr);
 
             if (


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Many calls to `ldap` methods are currently made using the `@` operator, that is silenting errors. Thus, some parts of the code are not handling error cases, so process often fails many lines later, without a clear stack trace of the initial error (the one that was silented).

We should handle errors as early as possible and remove errors litenting to improve ability to debug issues.

TODO:
- [x] remove `@` operators
- [ ] handle errors on each `ldap` methods (i.e. adapt code if error is blocking)