### PR TITLE
Fix warranty expiration in infocom report

### DIFF
--- a/front/report.infocom.php
+++ b/front/report.infocom.php
@@ -168,7 +168,8 @@ function display_infocoms_report($itemtype, $begin, $end)
 
         echo "<th>" . _x('price', 'Value') . "</th><th>" . __('ANV') . "</th>";
         echo "<th>" . __('TCO') . "</th><th>" . __('Date of purchase') . "</th>";
-        echo "<th>" . __('Startup date') . "</th><th>" . __('Warranty expiration date') . "</th></tr>";
+        echo "<th>" . __('Startup date') . "</th><th>" . __('Start date of warranty') . "</th>";
+        echo "<th>" . __('Warranty expiration date') . "</th></tr>";
 
         $valeursoustot      = 0;
         $valeurnettesoustot = 0;
@@ -244,7 +245,8 @@ function display_infocoms_report($itemtype, $begin, $end)
               "<td class='right'>" . Infocom::showTco($line["ticket_tco"], $line["value"]) . "</td>" .
               "<td>" . Html::convDate($line["buy_date"]) . "</td>" .
               "<td>" . Html::convDate($line["use_date"]) . "</td>" .
-              "<td>" . Infocom::getWarrantyExpir($line["buy_date"], $line["warranty_duration"]) .
+              "<td>" . Html::convDate($line["warranty_date"]) . "</td>" .
+              "<td>" . Infocom::getWarrantyExpir($line["warranty_date"], $line["warranty_duration"]) .
               "</td></tr>";
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Maybe #14031

Bug introduced back in 0.80 (2010) when the infocom form got a warranty start date. Prior to that, it assumed the purchase date was the start and the infocom report wasn't updated to reflect the change. This PR now calculates the expiration date based on the warranty date and not the purchase date. It also adds a column to show the warranty start date.