### PR TITLE
Use filters for new dashboard cards

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -549,6 +549,7 @@ class GLPIDashboard {
 
         var args = form_data.card_options;
         args.force = true;
+        args.apply_filters = this.getFiltersFromDB();
 
         // add the new widget
         var widget = this.addWidget(form_data);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

New cards added to a dashboard didn't use the existing filters until the page was refreshed.