### PR TITLE
Workaround for mandatory file upload check

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -5643,6 +5643,8 @@ HTML;
                   $('#{$p['filecontainer']}'),
                   '{$p['editor_id']}'
                );
+               // remove required
+                $('#fileupload{$p['rand']}').removeAttr('required');
             },
             fail: function (e, data) {
                const err = 'responseText' in data.jqXHR && data.jqXHR.responseText.length > 0


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14161

The automatic upload of files seems to interfere with the `required` attribute on the file upload input. As a workaround, the required attribute is removed when a file is automatically uploaded. All cases that expects a mandatory file upload should verify it on the server side anyways (Tickets do if mandatory through a template), so it seems like a low risk to remove the client-side check after the first auto-upload.