### PR TITLE
Fix full screen mode of rich text editor

### DIFF
--- a/css/legacy/includes/_styles.scss
+++ b/css/legacy/includes/_styles.scss
@@ -177,10 +177,6 @@
      margin-left: .5em;
    }
 
-   .tox-tinymce.tox-fullscreen {
-      top: 105px !important;
-   }
-
    .pointer {
       opacity: .7;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14184

Removed rule was initially made to keep the header displayed when full screen mode was active on rich text.
There are many problems with that:
 - 105 latest pixels of the content are hidden and unreachable;
 - it does not handle ability to choose page layout (header has not the same height when menu is on top or on sidebar);
 - it does not handle responsiveness of layout;
 - it does not handle custome CSS rules that can be made in entity configuration or by a plugin.

So, I propose to remove this rule, and let the fullscreen mode take all available space on the screen.