### PR TITLE
Display whole matching branches on entity tree filtering

### DIFF
--- a/templates/layout/parts/profile_selector.html.twig
+++ b/templates/layout/parts/profile_selector.html.twig
@@ -169,6 +169,7 @@
             autoExpand: true, // if results found in children, auto-expand parent
             nodata: '{{ __("No entity found") }}', // message when no data found
             highlight: false, // do not highlight matches by wrapping inside tags (when true, this strip the a tag)
+            counter: false, // do not show counters when filtering entity tree
          },
 
          // load 3rd party scrollbar extension for viewport mode
@@ -209,7 +210,7 @@
 
       var searchTree = function() {
          var search_text = $("#entsearchtext{{ rand }}").val();
-         $.ui.fancytree.getTree("#tree_entity{{ rand }}").filterNodes(search_text);
+         $.ui.fancytree.getTree("#tree_entity{{ rand }}").filterBranches(search_text);
       }
 
       $('#entsearchform{{ rand }}').submit(function(event) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14317

Entity tree filtering was done at node level, meaning that child of matching entities were filtered, as they were not matching the search term themselves.
Filtering at branch level fixes this.

Before
![image](https://user-images.githubusercontent.com/33253653/227159810-6ababb97-2695-499d-be6f-ba4936a98412.png)

After
![image](https://user-images.githubusercontent.com/33253653/227159671-982259ae-112f-4c62-8460-7ea29c36d759.png)
