### PR TITLE
Fix requirements messages on Windows env

### DIFF
--- a/src/System/Requirement/DataDirectoriesProtectedPath.php
+++ b/src/System/Requirement/DataDirectoriesProtectedPath.php
@@ -137,7 +137,7 @@ final class DataDirectoriesProtectedPath extends AbstractRequirement
             }
             $this->validation_messages[] = sprintf(
                 __('You can ignore this suggestion if your web server root directory is "%s".'),
-                sprintf('%s/public', $glpi_root_directory)
+                $glpi_root_directory . DIRECTORY_SEPARATOR . 'public'
             );
         }
     }

--- a/src/System/Requirement/SafeDocumentRoot.php
+++ b/src/System/Requirement/SafeDocumentRoot.php
@@ -45,7 +45,7 @@ final class SafeDocumentRoot extends AbstractRequirement
         $this->title = __('Safe configuration of web root directory');
         $this->description = sprintf(
             __('Web server root directory should be `%s` to ensure non-public files cannot be accessed.'),
-            sprintf('%s/public', realpath(GLPI_ROOT))
+            realpath(GLPI_ROOT) . DIRECTORY_SEPARATOR . 'public'
         );
         $this->optional = true;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Use correct directory separator on Windows env.

```diff
- Web server root directory should be `D:\Web\glpi/public` to ensure non-public files cannot be accessed.
+ Web server root directory should be `D:\Web\glpi\public` to ensure non-public files cannot be accessed.
```