### PR TITLE
feat: add deleted status on items header

### DIFF
--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -1077,14 +1077,13 @@ class CommonGLPI implements CommonGLPIInterface
                     'forceid' => $this instanceof CommonITILObject
                 ]);
                 if ($this->isField('is_deleted') && $this->fields['is_deleted']) {
-                    echo "<span class='mx-2 bg-danger status rounded-1' title=\"" . __s('This item is deleted!') . "\"
+                    $title = $this->isField('date_mod')
+                                ? sprintf(__s('Item has been deleted on %1$s'), Html::convDateTime($this->fields['date_mod']))
+                                : __s('Deleted');
+                    echo "<span class='mx-2 bg-danger status rounded-1' title=\"" . $title . "\"
                         data-bs-toggle='tooltip'>
                         <i class='ti ti-trash'></i>";
-                    if ($this->isField('date_mod')) {
-                        echo sprintf(__s('Deleted on %1$s'), Html::convDateTime($this->fields['date_mod']));
-                    } else {
-                        echo __s('This item is deleted!');
-                    }
+                        echo __s('Deleted');
                     echo "</span>";
                 }
                 echo "</h3>";

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -1076,6 +1076,17 @@ class CommonGLPI implements CommonGLPIInterface
                 echo $this->getNameID([
                     'forceid' => $this instanceof CommonITILObject
                 ]);
+                if ($this->isField('is_deleted') && $this->fields['is_deleted']) {
+                    echo "<span class='mx-2 bg-danger status rounded-1' title=\"" . __s('This item is deleted!') . "\"
+                        data-bs-toggle='tooltip'>
+                        <i class='ti ti-trash'></i>";
+                    if ($this->isField('date_mod')) {
+                        echo sprintf(('Deleted on %1$s'), Html::convDateTime($this->fields['date_mod']));
+                    } else {
+                        echo __s('This item is deleted!');
+                    }
+                    echo "</span>";
+                }
                 echo "</h3>";
             } else {
                 echo TemplateRenderer::getInstance()->render('components/form/header_content.html.twig', [

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -1081,7 +1081,7 @@ class CommonGLPI implements CommonGLPIInterface
                         data-bs-toggle='tooltip'>
                         <i class='ti ti-trash'></i>";
                     if ($this->isField('date_mod')) {
-                        echo sprintf(('Deleted on %1$s'), Html::convDateTime($this->fields['date_mod']));
+                        echo sprintf(__s('Deleted on %1$s'), Html::convDateTime($this->fields['date_mod']));
                     } else {
                         echo __s('This item is deleted!');
                     }

--- a/templates/components/form/header_content.html.twig
+++ b/templates/components/form/header_content.html.twig
@@ -107,6 +107,16 @@
          <i class="{{ call('Agent::getIcon') }}"></i>
       </span>
       {% endif %}
+      {% if in_navheader and item.isField('is_deleted') and item.fields['is_deleted'] %}
+      <span class="mx-1 bg-danger status rounded-1" title="{{ __('This item is deleted!') }}" data-bs-toggle="tooltip">
+         <i class="ti ti-trash"></i>
+         {% if item.isField('date_mod') and item.fields['date_mod'] != 'NULL' %}
+            {{ __('Deleted on %s')|format(item.fields['date_mod']) }}
+         {% else %}
+            {{ __('This item is deleted!') }}
+         {% endif %}
+      </span>
+      {% endif %}
 
       {% if header_toolbar %}
          <div class="d-inline-block toolbar ms-2">

--- a/templates/components/form/header_content.html.twig
+++ b/templates/components/form/header_content.html.twig
@@ -108,13 +108,10 @@
       </span>
       {% endif %}
       {% if in_navheader and item.isField('is_deleted') and item.fields['is_deleted'] %}
-      <span class="mx-1 bg-danger status rounded-1" title="{{ __('This item is deleted!') }}" data-bs-toggle="tooltip">
+      {% set title = item.isField('date_mod') ? __('Item has been deleted on %s')|format(item.fields['date_mod']) : __('Deleted') %}
+      <span class="mx-1 bg-danger status rounded-1" title="{{ title }}" data-bs-toggle="tooltip">
          <i class="ti ti-trash"></i>
-         {% if item.isField('date_mod') and item.fields['date_mod'] != 'NULL' %}
-            {{ __('Deleted on %s')|format(item.fields['date_mod']) }}
-         {% else %}
-            {{ __('This item is deleted!') }}
-         {% endif %}
+         {{ __('Deleted') }}
       </span>
       {% endif %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A

Apart from the "Restore" or "Delete permanently" button, the fact that an item is deleted is not currently UI impactful.

This proposal to further highlight this deleted status (an add deletion date).

Ticket header
![image](https://user-images.githubusercontent.com/470612/227514262-922f54aa-a6a6-4de2-9912-ee8da3070c05.png)

Computer header
![image](https://user-images.githubusercontent.com/470612/227514300-bd52fb66-aff4-4b71-8175-9923868630b1.png)

User header
![image](https://user-images.githubusercontent.com/470612/227514322-e88e85cc-9e11-4124-b8af-4520f53851b9.png)
