### PR TITLE
fix(Widget): prevent undefined array key from 'multipleNumber'

### DIFF
--- a/src/Dashboard/Widget.php
+++ b/src/Dashboard/Widget.php
@@ -392,7 +392,6 @@ HTML;
         $class = $p['class'];
         $class .= count($p['filters']) > 0 ? " filter-" . implode(' filter-', $p['filters']) : "";
 
-        $alphabet = range('a', 'z');
         $numbers_html = "";
         $i = 0;
         foreach ($p['data'] as $entry) {
@@ -416,7 +415,7 @@ HTML;
             $formatted_number = Toolbox::shortenNumber($entry['number']);
 
             $numbers_html .= <<<HTML
-            <a {$href} class="line line-{$alphabet[$i]}">
+            <a {$href} class="line line-{$i}">
                <span class="content" {$color}>$formatted_number</span>
                <i class="icon {$entry['icon']}" {$color2}></i>
                <span class="label" {$color2}>{$entry['label']}</span>
@@ -2011,7 +2010,6 @@ JAVASCRIPT;
             ];
         }
 
-        $alphabet = range('a', 'z');
         $min_l = 20; // min for luminosity
         $max_l = 20; // max ...
         $min_s = 30; // min for saturation
@@ -2026,7 +2024,7 @@ JAVASCRIPT;
         $colors = [];
 
         for ($i = 1; $i <= $nb_series; $i++) {
-            $names[$i - 1] = $alphabet[$i - 1];
+            $names[$i - 1] = $i - 1;
 
            // adjust luminosity
             $i_l_step = $i * $step_l + $min_l / 100;

--- a/tests/units/Glpi/Dashboard/Widget.php
+++ b/tests/units/Glpi/Dashboard/Widget.php
@@ -61,7 +61,7 @@ class Widget extends DbTestCase
                 'nb_series' => 4,
                 'revert'    => true,
                 'expected'  => [
-                    'names'  => ['a', 'b', 'c', 'd'],
+                    'names'  => [0, 1, 2, 3],
                     'colors' => [
                         '#a6a6a6',
                         '#808080',
@@ -74,7 +74,7 @@ class Widget extends DbTestCase
                 'nb_series' => 4,
                 'revert'    => false,
                 'expected'  => [
-                    'names'  => ['a', 'b', 'c', 'd'],
+                    'names'  => [0, 1, 2, 3],
                     'colors' => [
                         '#595959',
                         '#808080',


### PR DESCRIPTION
Prevent PHP warning

```
Warning: Undefined array key 26 in /mnt/diskhome/home///htdocs/src/Dashboard/Widget.php on line 419
Warning: Undefined array key 27 in /mnt/diskhome/home///htdocs/src/Dashboard/Widget.php on line 419
Warning: Undefined array key 28 in /mnt/diskhome/home///htdocs/src/Dashboard/Widget.php on line 419
Warning: Undefined array key 29 in /mnt/diskhome/home///htdocs/src/Dashboard/Widget.php on line 419
Warning: Undefined array key 30 in /mnt/diskhome/home///htdocs/src/Dashboard/Widget.php on line 419
```
Because ```multipleNumber``` can display can display as many lines as the user wants

![image](https://user-images.githubusercontent.com/7335054/227533649-28bb0e5e-f31f-4937-9212-bd356c8a1746.png)

but technically ```multipleNumber``` is limited to the number of characters in the alphabet (26)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
