### PR TITLE
WIP fix(disconnect): propage is_dynamic value if needed to prevent locked fields

### DIFF
--- a/src/Computer_Item.php
+++ b/src/Computer_Item.php
@@ -227,6 +227,11 @@ class Computer_Item extends CommonDBRelation
 
                         if (count($updates)) {
                             $updates['id'] = $this->fields['items_id'];
+                            //propage is_dynamic value if needed to prevent locked fields
+                            if (isset($device->fields['is_dynamic'])) {
+                                $updates['is_dynamic'] = $device->fields['is_dynamic'];
+                            }
+
                             $device->update($updates);
                         }
                     }

--- a/tests/functionnal/Glpi/Inventory/Assets/Computer.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Computer.php
@@ -348,6 +348,155 @@ class Computer extends AbstractInventoryAsset
         $this->integer(count($locks))->isIdenticalTo(0);
     }
 
+
+    public function testAutoUpdateOnDisconnectWithoutLockedField()
+    {
+        global $DB, $CFG_GLPI;
+        $item_monitor = new \Computer_Item();
+
+        $xml =  "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<REQUEST>
+  <CONTENT>
+    <HARDWARE>
+      <NAME>glpixps</NAME>
+      <UUID>25C1BB60-5BCB-11D9-B18F-5404A6A534C4</UUID>
+      <LASTLOGGEDUSER>glpi</LASTLOGGEDUSER>
+    </HARDWARE>
+    <BIOS>
+      <ASSETTAG>SER1234</ASSETTAG>
+      <BDATE>06/02/2016</BDATE>
+      <BMANUFACTURER>Dell Inc.</BMANUFACTURER>
+      <BVERSION>1.4.3</BVERSION>
+      <MMANUFACTURER>Dell Inc.</MMANUFACTURER>
+      <MMODEL>07TYC2</MMODEL>
+      <MSN>/640HP72/CN129636460078/</MSN>
+      <SKUNUMBER>0704</SKUNUMBER>
+      <SMANUFACTURER>Dell Inc.</SMANUFACTURER>
+      <SMODEL>XPS 13 9350</SMODEL>
+      <SSN>640HP72</SSN>
+    </BIOS>
+    <MONITORS>
+          <BASE64>AP///////wBNEEkUAAAAACAZAQSlHRF4Dt5Qo1RMmSYPUFQAAAABAQEBAQEBAQEBAQEBAQEBGjaAoHA4H0AwIDUAJqUQAAAYAAAAEAAAAAAAAAAAAAAAAAAAAAAA/gBESkNQNoBMUTEzM00xAAAAAAACQQMoABIAAAsBCiAgAGY=</BASE64>
+          <CAPTION>DJCP6</CAPTION>
+          <DESCRIPTION>32/2015</DESCRIPTION>
+          <MANUFACTURER>Sharp Corporation</MANUFACTURER>
+          <SERIAL>AFGHHDR0</SERIAL>
+        </MONITORS>
+    <VERSIONCLIENT>FusionInventory-Inventory_v2.4.1-2.fc28</VERSIONCLIENT>
+  </CONTENT>
+  <DEVICEID>glpixps.teclib.infra-2018-10-03-08-42-36</DEVICEID>
+  <QUERY>INVENTORY</QUERY>
+</REQUEST>";
+
+        $converter = new \Glpi\Inventory\Converter();
+        $data = $converter->convert($xml);
+        $json = json_decode($data);
+
+        $this->doInventory($json);
+
+        //check created agent
+        $agents = $DB->request(['FROM' => \Agent::getTable()]);
+        $this->integer(count($agents))->isIdenticalTo(1);
+        $agent = $agents->current();
+        $this->array($agent)
+            ->string['deviceid']->isIdenticalTo('glpixps.teclib.infra-2018-10-03-08-42-36')
+            ->string['itemtype']->isIdenticalTo('Computer');
+
+        //check created computer
+        $computers_id = $agent['items_id'];
+
+        $this->integer($computers_id)->isGreaterThan(0);
+        $computer = new \Computer();
+        $this->boolean($computer->getFromDB($computers_id))->isTrue();
+
+        $this->integer($computer->fields['users_id'])->isGreaterThan(0);
+
+        //one dynamic monitor linked
+        $monitors = $item_monitor->find(['itemtype' => 'Monitor', 'computers_id' => $computers_id, 'is_dynamic' => 1]);
+        $this->integer(count($monitors))->isIdenticalTo(1);
+
+        //load monitor
+        $monitor = new \Monitor();
+        $monitor_id = reset($monitors)['items_id'];
+        $this->boolean($monitor->getFromDB($monitor_id))->isTrue();
+        //check same users
+        $this->integer($monitor->fields['users_id'])->isIdenticalTo($computer->fields['users_id']);
+
+        //Enable option to clean users_id on disconnect
+        $CFG_GLPI['is_user_autoclean']     = 1;
+
+        //change user from XML file
+        $xml =  "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+        <REQUEST>
+          <CONTENT>
+            <HARDWARE>
+              <NAME>glpixps</NAME>
+              <UUID>25C1BB60-5BCB-11D9-B18F-5404A6A534C4</UUID>
+              <LASTLOGGEDUSER>tech</LASTLOGGEDUSER>
+            </HARDWARE>
+            <BIOS>
+              <ASSETTAG>SER1234</ASSETTAG>
+              <BDATE>06/02/2016</BDATE>
+              <BMANUFACTURER>Dell Inc.</BMANUFACTURER>
+              <BVERSION>1.4.3</BVERSION>
+              <MMANUFACTURER>Dell Inc.</MMANUFACTURER>
+              <MMODEL>07TYC2</MMODEL>
+              <MSN>/640HP72/CN129636460078/</MSN>
+              <SKUNUMBER>0704</SKUNUMBER>
+              <SMANUFACTURER>Dell Inc.</SMANUFACTURER>
+              <SMODEL>XPS 13 9350</SMODEL>
+              <SSN>640HP72</SSN>
+            </BIOS>
+            <VERSIONCLIENT>FusionInventory-Inventory_v2.4.1-2.fc28</VERSIONCLIENT>
+          </CONTENT>
+          <DEVICEID>glpixps.teclib.infra-2018-10-03-08-42-36</DEVICEID>
+          <QUERY>INVENTORY</QUERY>
+        </REQUEST>";
+
+        $converter = new \Glpi\Inventory\Converter();
+        $data = $converter->convert($xml);
+        $json = json_decode($data);
+
+        $this->doInventory($json);
+
+        //check agent
+        $agents = $DB->request(['FROM' => \Agent::getTable()]);
+        $this->integer(count($agents))->isIdenticalTo(1);
+        $agent = $agents->current();
+        $this->array($agent)
+            ->string['deviceid']->isIdenticalTo('glpixps.teclib.infra-2018-10-03-08-42-36')
+            ->string['itemtype']->isIdenticalTo('Computer');
+
+        //check computer
+        $computers_id = $agent['items_id'];
+
+        $this->integer($computers_id)->isGreaterThan(0);
+        $computer = new \Computer();
+        $this->boolean($computer->getFromDB($computers_id))->isTrue();
+
+        $this->integer($computer->fields['users_id'])->isGreaterThan(0);
+
+        //always one monitor linked but deleted
+        $monitors = $item_monitor->find(['itemtype' => 'Monitor', 'computers_id' => $computers_id, 'is_dynamic' => 1]);
+        $this->integer(count($monitors))->isIdenticalTo(0);
+
+        //reload monitor
+        $monitor = new \Monitor();
+        $this->boolean($monitor->getFromDB($monitor_id))->isTrue();
+        //check same users
+        $this->integer($monitor->fields['users_id'])->isIdenticalTo(0);
+
+
+        $locked_field = new \Lockedfield();
+        //no lock from computer
+        $locks = $locked_field->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
+        $this->integer(count($locks))->isIdenticalTo(0);
+
+        //no lock from computer
+        $locks = $locked_field->find(['itemtype' => 'Monitor', 'items_id' => $monitor_id]);
+        $this->integer(count($locks))->isIdenticalTo(0);
+    }
+
     public function testHandle()
     {
         $json_str = file_get_contents(self::INV_FIXTURES . 'computer_1.json');


### PR DESCRIPTION
Like https://github.com/glpi-project/glpi/pull/13309
but for ```disconnect``` step


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27194
