### PR TITLE
Fix: Cannot export item_devicetype (item_devicesimcard, etc...)

### DIFF
--- a/front/report.dynamic.php
+++ b/front/report.dynamic.php
@@ -43,7 +43,11 @@ $itemtype = $_GET['item_type'];
 if ($itemtype === 'AllAssets') {
     Session::checkCentralAccess();
 } else {
-    Session::checkRight($itemtype::$rightname, READ);
+    Session::checkValidSessionId();
+    $item = new $itemtype();
+    if (!$item->canView()) {
+        Html::displayRightError();
+    }
 }
 
 if (isset($_GET["display_type"])) {


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

I found a bug that cannot export simcard (Item_DeviceSimcard) because Item_DeviceSimcard doesn't have $rightname and will be failed when exporting in report.dynamic.php

<pre>
$itemtype = $_GET['item_type'];
if ($itemtype === 'AllAssets') {
    Session::checkCentralAccess();
} else {
    <b>Session::checkRight($itemtype::$rightname, READ);</b>
}
</pre>