### PR TITLE
Fix parsing of `x-www-form-urlencoded` input in API

### DIFF
--- a/src/Api/APIRest.php
+++ b/src/Api/APIRest.php
@@ -518,6 +518,10 @@ class APIRest extends API
             /** @var array $postvars */
             parse_str($body, $postvars);
             foreach ($postvars as $field => $value) {
+                // $parameters['input'] needs to be an object when process API Request
+                if ($field === 'input') {
+                    $value = (object) $value;
+                }
                 $parameters[$field] = $value;
             }
             $this->format = "html";

--- a/tests/web/APIRest.php
+++ b/tests/web/APIRest.php
@@ -1385,7 +1385,10 @@ class APIRest extends APIBaseClass
     }
 
     /**
-     * @tags    api
+     * test update items endpoint
+     * using application/x-www-form-urlencoded
+     *
+     * @return void
      */
     public function testUpdateItemFormEncodedBody()
     {
@@ -1433,5 +1436,55 @@ class APIRest extends APIBaseClass
         $this->boolean((bool)$computer->getFromDB($computers_id))->isTrue();
         $this->string($computer->fields['serial'])->isIdenticalTo('abcdefg');
         $this->string($computer->fields['comment'])->isIdenticalTo('This computer has been updated.');
+    }
+
+    /**
+     * test delete items endpoint
+     * using application/x-www-form-urlencoded
+     *
+     * @return void
+     */
+    public function testDeleteItemFormEncodedBody()
+    {
+        $computer = $this->createComputer();
+        $computers_id = $computer->getID();
+
+        try {
+            $response = $this->http_client->delete(
+                $this->base_uri . 'Computer',
+                [
+                    'headers' => [
+                        'Session-Token' => $this->session_token,
+                        'Content-Type'  => 'application/x-www-form-urlencoded',
+                    ],
+                    'body' => http_build_query(
+                        [
+                            'input' => [
+                                'id' => $computers_id
+                            ]
+                        ]
+                    )
+                ]
+            );
+        } catch (\GuzzleHttp\Exception\RequestException $e) {
+            $response = $e->getResponse();
+        }
+
+        // Check response
+        $this->object($response)->isInstanceOf(\Psr\Http\Message\ResponseInterface::class);
+        $this->integer($response->getStatusCode())->isEqualTo(200);
+        $this->object($response)->isInstanceOf(\Psr\Http\Message\ResponseInterface::class);
+        $body = $response->getBody()->getContents();
+        $this->array(json_decode($body, true))->isEqualTo([
+            [
+                (string)$computers_id => true,
+                'message'             => '',
+            ]
+        ]);
+
+        // Check computer is updated
+        $computer = new \Computer();
+        $this->boolean((bool)$computer->getFromDB($computers_id))->isTrue();
+        $this->boolean((bool)$computer->getField('is_deleted'))->isTrue();
     }
 }


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

I found a bug that when calling GLPI Request using application/x-www-form-urlencoded content, glpi throw critical error
This error orrcurs on PHP >= 8
```
*** Uncaught Exception Error: Attempt to assign property "id" on array in \glpi\src\Api\APIRest.php at line 324
  Backtrace :
  apirest.php:57                                     Glpi\Api\APIRest->call()
```