### PR TITLE
Fix missing history entry when adding a user to a group

### DIFF
--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -918,6 +918,8 @@ class Group_User extends CommonDBRelation
     {
         global $DB;
 
+        parent::post_purgeItem();
+
        // remove user from plannings
         $groups_id  = $this->fields['groups_id'];
         $planning_k = 'group_' . $groups_id . '_users';

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -857,6 +857,8 @@ class Group_User extends CommonDBRelation
     {
         global $DB;
 
+        parent::post_addItem();
+
        // add new user to plannings
         $groups_id  = $this->fields['groups_id'];
         $planning_k = 'group_' . $groups_id . '_users';


### PR DESCRIPTION
New `Group_User` relations are not shown in GLPI history.

These history entries are handled automatically by `CommonDBRelation::post_addItem()` and the `Group_User` class was overriding the function without calling the parent method.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27336
