### PR TITLE
fix(ticket): use default entity of requester

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -636,7 +636,7 @@ abstract class CommonITILObject extends CommonDBTM
         $entities = $_SESSION['glpiactiveentities'] ?? [];
         foreach ($requesters as $users_id) {
             $user_entities = Profile_User::getUserEntities($users_id, true, true);
-            $entities = array_intersect($entities, $user_entities);
+            $entities = array_intersect($user_entities, $entities);
         }
 
         $entities = array_values($entities); // Ensure keys are starting at 0


### PR DESCRIPTION
When creating a ticket for another requester, and the requester has multiple entities in its permissions, the ticket entity was the one with the lowest ID instead of using the user's default entity.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27319
