### PR TITLE
fix(massive action): check all

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -155,9 +155,9 @@ function displayOtherSelectOptions(select_object, other_option_name) {
  * @param {HTMLElement} reference
  * @param {string} container_id
 **/
-function checkAsCheckboxes(reference, container_id) {
+function checkAsCheckboxes(reference, container_id, checkboxes_selector = 'input[type="checkbox"]') {
     reference = typeof(reference) === 'string' ? document.getElementById(reference) : reference;
-    $('#' + container_id + ' input.' + reference.className + '[type="checkbox"]:enabled')
+    $('#' + container_id + ' ' + checkboxes_selector + ':enabled')
         .prop('checked', $(reference).is(':checked'));
 
     return true;

--- a/js/common.js
+++ b/js/common.js
@@ -157,7 +157,7 @@ function displayOtherSelectOptions(select_object, other_option_name) {
 **/
 function checkAsCheckboxes(reference, container_id) {
     reference = typeof(reference) === 'string' ? document.getElementById(reference) : reference;
-    $('#' + container_id + ' input[type="checkbox"]:enabled')
+    $('#' + container_id + ' input.' + reference.className + '[type="checkbox"]:enabled')
         .prop('checked', $(reference).is(':checked'));
 
     return true;

--- a/src/Html.php
+++ b/src/Html.php
@@ -2315,10 +2315,10 @@ HTML;
             $rand = mt_rand();
         }
 
-        $out  = "<input title='" . __s('Check all as') . "' type='checkbox' class='form-check-input'
+        $out  = "<input title='" . __s('Check all as') . "' type='checkbox' class='form-check-input massive_action_checkbox'
                       title='" . __s('Check all as') . "'
                       name='_checkall_$rand' id='checkall_$rand'
-                      onclick= \"if ( checkAsCheckboxes(this, '$container_id')) {return true;}\">";
+                      onclick= \"if ( checkAsCheckboxes(this, '$container_id', '.massive_action_checkbox')) {return true;}\">";
 
        // permit to shift select checkboxes
         $out .= Html::scriptBlock("\$(function() {\$('#$container_id input[type=\"checkbox\"]').shiftSelectable();});");
@@ -2417,6 +2417,7 @@ HTML;
         $params['zero_on_empty']   = true;
         $params['specific_tags']   = [];
         $params['criterion']       = [];
+        $params['class']           = '';
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {
@@ -2430,7 +2431,7 @@ HTML;
             $out .= '<input type="hidden" name="' . $params['name'] . '" value="0" />';
         }
 
-        $out .= "<input type='checkbox' class='form-check-input' title=\"" . $params['title'] . "\" ";
+        $out .= "<input type='checkbox' class='form-check-input " . $params['class'] . "' title=\"" . $params['title'] . "\" ";
         if (isset($params['onclick'])) {
             $params['onclick'] = htmlspecialchars($params['onclick'], ENT_QUOTES);
             $out .= " onclick='{$params['onclick']}'";
@@ -2520,6 +2521,7 @@ HTML;
             $options['name'] = "item[$itemtype][" . $id . "]";
         }
 
+        $options['class']         = 'massive_action_checkbox';
         $options['zero_on_empty'] = false;
 
         return self::getCheckbox($options);

--- a/templates/components/search/table.html.twig
+++ b/templates/components/search/table.html.twig
@@ -41,9 +41,9 @@
             {% if showmassiveactions %}
             <th style="width: 30px;">
                <div>
-                  <input class="form-check-input" type="checkbox" id="checkall_{{ rand }}"
+                  <input class="form-check-input massive_action_checkbox" type="checkbox" id="checkall_{{ rand }}"
                         value="" aria-label="{{ __('Check all as') }}"
-                        onclick="checkAsCheckboxes(this, '{{ searchform_id }}');" />
+                        onclick="checkAsCheckboxes(this, '{{ searchform_id }}', '.massive_action_checkbox');" />
                </div>
             </th>
             {% endif %}

--- a/templates/components/search/table.html.twig
+++ b/templates/components/search/table.html.twig
@@ -120,7 +120,7 @@
 
                            {% if item is instanceof('CommonDBTM') and call(itemtype ~ '::isMassiveActionAllowed', [row['id']])  %}
                               {% set checked = session('glpimassiveactionselected')[itemtype][row['id']] ?? false %}
-                              <input class="form-check-input" type="checkbox" data-glpicore-ma-tags="common"
+                              <input class="form-check-input massive_action_checkbox" type="checkbox" data-glpicore-ma-tags="common"
                                  value="1" aria-label="" {% if checked %}checked="checked"{% endif %}
                                  name="item[{{ row['TYPE'] ?? itemtype }}][{{ row['id'] }}]" />
                            {% endif %}


### PR DESCRIPTION
In the ticket items tab, the KB entries unfolded when selecting all for massive actions and conversely, folded when unchecking all.

_I think it's more general, when there is a checkbox in the table data, but I don't know any other case._

Before:

![image](https://user-images.githubusercontent.com/8530352/228746464-27138b9f-9be5-4731-8c10-7e13f2f6ddec.png)

After:

![image](https://user-images.githubusercontent.com/8530352/228746527-a69551ae-56d3-43fe-8dc0-68e5d079750d.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
