### PR TITLE
drop global var for uploads indexation

### DIFF
--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -130,8 +130,8 @@ var handleUploadedFile = function (files, files_data, input_name, container, edi
  * @param      {String}  input_name    Name of generated input hidden (default filename)
  * @param      {Object}  container     The fileinfo container
  */
-var fileindex = 0;
 var displayUploadedFile = function(file, tag, editor, input_name, filecontainer) {
+    var fileindex = $('input[name^="_'+input_name+'["]').length;
     var ext = file.name.split('.').pop();
 
     var p = $('<p></p>')
@@ -169,8 +169,6 @@ var displayUploadedFile = function(file, tag, editor, input_name, filecontainer)
     $('<span class="ti ti-circle-x pointer"></span>').click(function() {
         deleteImagePasted(elementsIdToRemove, tag.tag, editor);
     }).appendTo(p);
-
-    fileindex++;
 };
 
 /**


### PR DESCRIPTION
This change is required to allow a user to add files to a file field which is rendered with pre-uploaded files.

This use case may happen in Formcreator when a validator validates answers containing a file question. This PR is required for https://github.com/pluginsGLPI/formcreator/pull/3226

The goal is to not start the uploads index from zero, but counts the existing inputs related to a file upload field instead.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
