### PR TITLE
Fix service level form in ITIL items

### DIFF
--- a/templates/components/itilobject/service_levels.html.twig
+++ b/templates/components/itilobject/service_levels.html.twig
@@ -163,7 +163,7 @@
                {% endif %}
 
                {% if la_displayed %}
-                  <div class="{{ item.isNewItem ? '' : 'collapsed' }} w-100 mt-1" id="dropdown_{{ assign_la_id }}">
+                  <div class="{{ item.isNewItem ? '' : 'collapsed' }} w-100 mt-1 d-none" id="dropdown_{{ assign_la_id }}">
                      {{ fields.dropdownField(
                         la_field.la.getType(),
                         la_field.lafieldname,
@@ -206,6 +206,9 @@
 
                            // hide date field
                            $("#date_{{ assign_la_id }}").closest('.la_datefield').hide();
+
+                           // show dropdown field
+                           $('#dropdown_assign_la_{{ rand }}').removeClass('d-none');
 
                            // show level agreement dropdown
                            var myCollapse = new bootstrap.Collapse(document.getElementById('dropdown_{{ assign_la_id }}'));


### PR DESCRIPTION
Display of SLA form in ITIL items is not consistent with GLPI 9.5:

![image](https://user-images.githubusercontent.com/42734840/228847380-fb45ba01-4e48-43f1-990e-5c93cfe30917.png)

![image](https://user-images.githubusercontent.com/42734840/228847490-2d9d9e38-f3ea-4e7b-b935-b364fa9ebde2.png)

On GLPI 9.5, you can only see the date field until you click the "stopwatch" icon, which will replace the date field by a dropdown.

I think the dropdown is shown by mistake on GLPI 10, and the correct behavior would be this:

![image](https://user-images.githubusercontent.com/42734840/228847918-abd9e8a2-efcf-4166-a515-58cd39b8d4b9.png)

After clicking on the internal TTO "stopwatch":
![image](https://user-images.githubusercontent.com/42734840/228848019-b2ea5883-8627-42d7-a970-8e9d60509ee4.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27262
