### PR TITLE
Enhance unmet prerequisites message in `migration:timestamps` command

### DIFF
--- a/src/Console/Migration/TimestampsCommand.php
+++ b/src/Console/Migration/TimestampsCommand.php
@@ -203,25 +203,19 @@ class TimestampsCommand extends AbstractCommand
             DBConnection::PROPERTY_ALLOW_DATETIME => false,
         ];
 
-        $timezones_requirement = new DbTimezones($this->db);
-        if ($timezones_requirement->isValidated()) {
-            $properties_to_update[DBConnection::PROPERTY_USE_TIMEZONES] = true;
-        } else {
-            $output->writeln(
-                '<error>' . __('Timezones usage cannot be activated due to following errors:') . '</error>',
-                OutputInterface::VERBOSITY_QUIET
-            );
-            foreach ($timezones_requirement->getValidationMessages() as $validation_message) {
+        if ($this->db->use_timezones !== true) {
+            $timezones_requirement = new DbTimezones($this->db);
+            if ($timezones_requirement->isValidated()) {
+                $properties_to_update[DBConnection::PROPERTY_USE_TIMEZONES] = true;
+            } else {
                 $output->writeln(
-                    '<error> - ' . $validation_message . '</error>',
+                    [
+                        '<comment>' . __('Timezones usage cannot be activated due to missing requirements.') . '</comment>',
+                        '<comment>' . sprintf(__('Run the "%1$s" command for more details.'), 'php bin/console database:enable_timezones') . '</comment>',
+                    ],
                     OutputInterface::VERBOSITY_QUIET
                 );
             }
-            $message = sprintf(
-                __('Fix them and run the "%1$s" command to enable timezones.'),
-                'php bin/console database:enable_timezones'
-            );
-            $output->writeln('<error>' . $message . '</error>', OutputInterface::VERBOSITY_QUIET);
         }
 
         if (!DBConnection::updateConfigProperties($properties_to_update)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

`migration:timestamps` command is responsible to migrate database data. When timezones usages cannot be enabled, command do not fail though.

Replace the error message
![image](https://user-images.githubusercontent.com/33253653/228850361-b8cc57ce-beba-4f0e-887d-82814d2d0190.png)

by a warning
![image](https://user-images.githubusercontent.com/33253653/228848999-184e778b-8404-4d1c-93be-ffa0cd5fb233.png)
