### PR TITLE
Fix user dropdown filtering on helpdesk interface

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -4070,6 +4070,8 @@ HTML;
 
                 if (count($users)) {
                     $WHERE = ['glpi_users.id' => $users];
+                } else {
+                    $WHERE = ['0'];
                 }
                 break;
 
@@ -4107,6 +4109,8 @@ HTML;
 
                 if (count($users)) {
                     $WHERE = ['glpi_users.id' => $users];
+                } else {
+                    $WHERE = ['0'];
                 }
 
                 break;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The `User::getSqlSearchResult()` could return list of all users when used with `$right='groups'` or `$right='delegate'` from helpdesk interface.
Indeed, in this case, if there is no matching user found in current user groups, the where clause on `users_id` will not b applied due to https://github.com/glpi-project/glpi/blob/66691c1b2f029ae103fb6f79f6d4a7d3b246c91e/src/User.php#L4071-L4073.

It only affects helpdesk interface, as current user is added to users list on central interface: https://github.com/glpi-project/glpi/blob/66691c1b2f029ae103fb6f79f6d4a7d3b246c91e/src/User.php#L4067-L4069

Bug was introduced when code was refactored. Previously, the `0` condition was applied; https://github.com/glpi-project/glpi/blob/2142546026ad405550e2f9e2b8bf4643dc017a68/inc/user.class.php#L3348-L3352

I guess it is really an edge case, as this bug was introduced in GLPI 9.4.0.