### PR TITLE
Fix OLA escalation date calculation

### DIFF
--- a/install/migrations/update_10.0.6_to_10.0.7/ticket_fix_internal_tto_escalation.php
+++ b/install/migrations/update_10.0.6_to_10.0.7/ticket_fix_internal_tto_escalation.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+$migration->addField("glpi_tickets", "ola_tto_begin_date", "datetime");

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -7149,6 +7149,7 @@ CREATE TABLE `glpi_tickets` (
   `olas_id_tto` int unsigned NOT NULL DEFAULT '0',
   `olas_id_ttr` int unsigned NOT NULL DEFAULT '0',
   `olalevels_id_ttr` int unsigned NOT NULL DEFAULT '0',
+  `ola_tto_begin_date` timestamp NULL DEFAULT NULL,
   `ola_ttr_begin_date` timestamp NULL DEFAULT NULL,
   `internal_time_to_resolve` timestamp NULL DEFAULT NULL,
   `internal_time_to_own` timestamp NULL DEFAULT NULL,

--- a/src/LevelAgreement.php
+++ b/src/LevelAgreement.php
@@ -1013,8 +1013,33 @@ abstract class LevelAgreement extends CommonDBChild
 
         if ($levels_id) {
             $toadd = [];
+
+            // Compute start date
+            if ($pre == "ola") {
+                // OLA have their own start date which is set when the OLA is added to the ticket
+                if (
+                    $this->fields['type'] == SLM::TTO
+                    && !is_null($ticket->fields['ola_tto_begin_date'])
+                ) {
+                    $date_field = "ola_tto_begin_date";
+                } elseif (
+                    $this->fields['type'] == SLM::TTR
+                    && !is_null($ticket->fields['ola_ttr_begin_date'])
+                ) {
+                    $date_field = "ola_ttr_begin_date";
+                } else {
+                    // Fall back to default date in case the specific date fields
+                    // are not set (which may be the case for tickets created
+                    // before their addition)
+                    $date_field = 'date';
+                }
+            } else {
+                // SLA are based on the ticket opening date
+                $date_field = 'date';
+            }
+
             $date = $this->computeExecutionDate(
-                $ticket->fields['date'],
+                $ticket->fields[$date_field],
                 $levels_id,
                 $ticket->fields[$pre . '_waiting_duration']
             );

--- a/src/LevelAgreement.php
+++ b/src/LevelAgreement.php
@@ -1015,16 +1015,16 @@ abstract class LevelAgreement extends CommonDBChild
             $toadd = [];
 
             // Compute start date
-            if ($pre == "ola") {
+            if ($pre === "ola") {
                 // OLA have their own start date which is set when the OLA is added to the ticket
                 if (
-                    $this->fields['type'] == SLM::TTO
-                    && !is_null($ticket->fields['ola_tto_begin_date'])
+                    (int) $this->fields['type'] === SLM::TTO
+                    && $ticket->fields['ola_tto_begin_date'] !== null
                 ) {
                     $date_field = "ola_tto_begin_date";
                 } elseif (
-                    $this->fields['type'] == SLM::TTR
-                    && !is_null($ticket->fields['ola_ttr_begin_date'])
+                    (int) $this->fields['type'] === SLM::TTR
+                    && $ticket->fields['ola_ttr_begin_date'] !== null
                 ) {
                     $date_field = "ola_ttr_begin_date";
                 } else {

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -485,6 +485,8 @@ class Ticket extends CommonITILObject
             if ($ola->fields['type'] == SLM::TTR) {
                 $data["olalevels_id_ttr"] = OlaLevel::getFirstOlaLevel($olas_id);
                 $data['ola_ttr_begin_date'] = $date;
+            } elseif ($ola->fields['type'] == SLM::TTO) {
+                $data['ola_tto_begin_date'] = $date;
             }
            // Compute time_to_resolve
             $data[$dateField]             = $ola->computeDate($date);

--- a/tests/DbTestCase.php
+++ b/tests/DbTestCase.php
@@ -257,4 +257,20 @@ class DbTestCase extends \GLPITestCase
             $this->createItem($itemtype, $input);
         }
     }
+
+    /**
+     * Compare two date with an acceptable detla (to account for tests execution
+     * times that may push a date one second later than expected)
+     *
+     * @param string $date1                    Any format supported by strtotime
+     * @param string $date2                    Any format supported by strtotime
+     * @param int    $acceptable_seconds_delta 1 second by fault
+     */
+    protected function areDateEquals(
+        string $date1,
+        string $date2,
+        int $acceptable_seconds_delta = 1
+    ): bool {
+        return abs(strtotime($date1) - strtotime($date2)) <= $acceptable_seconds_delta;
+    }
 }

--- a/tests/DbTestCase.php
+++ b/tests/DbTestCase.php
@@ -257,20 +257,4 @@ class DbTestCase extends \GLPITestCase
             $this->createItem($itemtype, $input);
         }
     }
-
-    /**
-     * Compare two date with an acceptable detla (to account for tests execution
-     * times that may push a date one second later than expected)
-     *
-     * @param string $date1                    Any format supported by strtotime
-     * @param string $date2                    Any format supported by strtotime
-     * @param int    $acceptable_seconds_delta 1 second by fault
-     */
-    protected function areDateEquals(
-        string $date1,
-        string $date2,
-        int $acceptable_seconds_delta = 1
-    ): bool {
-        return abs(strtotime($date1) - strtotime($date2)) <= $acceptable_seconds_delta;
-    }
 }

--- a/tests/functional/SLM.php
+++ b/tests/functional/SLM.php
@@ -899,8 +899,18 @@ class SLM extends DbTestCase
         // Check SLA, must be calculated from the ticket start date
         $tto_expected_date = date('Y-m-d H:i:s', strtotime($date_1_hour_ago) + 3600 * 4); // 4 hours TTO
         $ttr_expected_date = date('Y-m-d H:i:s', strtotime($date_1_hour_ago) + 3600 * 12); // 12 hours TTR
-        $this->string($ticket->fields['time_to_own'])->isEqualTo($tto_expected_date);
-        $this->string($ticket->fields['time_to_resolve'])->isEqualTo($ttr_expected_date);
+        $this->boolean(
+            $this->areDateEquals(
+                $ticket->fields['time_to_own'],
+                $tto_expected_date,
+            )
+        )->isTrue();
+        $this->boolean(
+            $this->areDateEquals(
+                $ticket->fields['time_to_resolve'],
+                $ttr_expected_date,
+            )
+        )->isTrue();
 
         // Check escalation levels
         $sla_levels = (new SlaLevel_Ticket())->find([
@@ -911,14 +921,34 @@ class SLM extends DbTestCase
         $ttr_level = array_shift($sla_levels);
         $tto_level_expected_date = date('Y-m-d H:i:s', strtotime($tto_expected_date) - 900); // 15 minutes escalation level
         $ttr_level_expected_date = date('Y-m-d H:i:s', strtotime($ttr_expected_date) - 1800); // 30 minutes escalation level
-        $this->string($tto_level['date'])->isEqualTo($tto_level_expected_date);
-        $this->string($ttr_level['date'])->isEqualTo($ttr_level_expected_date);
+        $this->boolean(
+            $this->areDateEquals(
+                $tto_level['date'],
+                $tto_level_expected_date,
+            )
+        )->isTrue();
+        $this->boolean(
+            $this->areDateEquals(
+                $ttr_level['date'],
+                $ttr_level_expected_date,
+            )
+        )->isTrue();
 
         // Check OLA, must be calculated from the date at which it was added to the ticket
         $tto_expected_date = date('Y-m-d H:i:s', strtotime($now) + 3600 * 2); // 2 hours TTO
         $ttr_expected_date = date('Y-m-d H:i:s', strtotime($now) + 3600 * 8); // 8 hours TTR
-        $this->string($ticket->fields['internal_time_to_own'])->isEqualTo($tto_expected_date);
-        $this->string($ticket->fields['internal_time_to_resolve'])->isEqualTo($ttr_expected_date);
+        $this->boolean(
+            $this->areDateEquals(
+                $ticket->fields['internal_time_to_own'],
+                $tto_expected_date,
+            )
+        )->isTrue();
+        $this->boolean(
+            $this->areDateEquals(
+                $ticket->fields['internal_time_to_resolve'],
+                $ttr_expected_date,
+            )
+        )->isTrue();
 
         // Check escalation levels
         $ola_levels = (new OlaLevel_Ticket())->find([
@@ -929,7 +959,17 @@ class SLM extends DbTestCase
         $ttr_level = array_shift($ola_levels);
         $tto_level_expected_date = date('Y-m-d H:i:s', strtotime($tto_expected_date) - 2700); // 45 minutes escalation level
         $ttr_level_expected_date = date('Y-m-d H:i:s', strtotime($ttr_expected_date) - 3600); // 60 minutes escalation level
-        $this->string($tto_level['date'])->isEqualTo($tto_level_expected_date);
-        $this->string($ttr_level['date'])->isEqualTo($ttr_level_expected_date);
+        $this->boolean(
+            $this->areDateEquals(
+                $tto_level['date'],
+                $tto_level_expected_date,
+            )
+        )->isTrue();
+        $this->boolean(
+            $this->areDateEquals(
+                $ttr_level['date'],
+                $ttr_level_expected_date,
+            )
+        )->isTrue();
     }
 }

--- a/tests/functional/SLM.php
+++ b/tests/functional/SLM.php
@@ -909,8 +909,8 @@ class SLM extends DbTestCase
         $this->array($sla_levels)->hasSize(2);
         $tto_level = array_shift($sla_levels);
         $ttr_level = array_shift($sla_levels);
-        $tto_level_expected_date = date('Y-m-d H:i:s', strtotime($tto_expected_date) - 900); // 1 hour escalation level
-        $ttr_level_expected_date = date('Y-m-d H:i:s', strtotime($ttr_expected_date) - 1800); // 1 hour escalation level
+        $tto_level_expected_date = date('Y-m-d H:i:s', strtotime($tto_expected_date) - 900); // 15 minutes escalation level
+        $ttr_level_expected_date = date('Y-m-d H:i:s', strtotime($ttr_expected_date) - 1800); // 30 minutes escalation level
         $this->string($tto_level['date'])->isEqualTo($tto_level_expected_date);
         $this->string($ttr_level['date'])->isEqualTo($ttr_level_expected_date);
 
@@ -927,8 +927,8 @@ class SLM extends DbTestCase
         $this->array($ola_levels)->hasSize(2);
         $tto_level = array_shift($ola_levels);
         $ttr_level = array_shift($ola_levels);
-        $tto_level_expected_date = date('Y-m-d H:i:s', strtotime($tto_expected_date) - 2700); // 1 hour escalation level
-        $ttr_level_expected_date = date('Y-m-d H:i:s', strtotime($ttr_expected_date) - 3600); // 1 hour escalation level
+        $tto_level_expected_date = date('Y-m-d H:i:s', strtotime($tto_expected_date) - 2700); // 45 minutes escalation level
+        $ttr_level_expected_date = date('Y-m-d H:i:s', strtotime($ttr_expected_date) - 3600); // 60 minutes escalation level
         $this->string($tto_level['date'])->isEqualTo($tto_level_expected_date);
         $this->string($ttr_level['date'])->isEqualTo($ttr_level_expected_date);
     }

--- a/tests/functional/SLM.php
+++ b/tests/functional/SLM.php
@@ -899,18 +899,8 @@ class SLM extends DbTestCase
         // Check SLA, must be calculated from the ticket start date
         $tto_expected_date = date('Y-m-d H:i:s', strtotime($date_1_hour_ago) + 3600 * 4); // 4 hours TTO
         $ttr_expected_date = date('Y-m-d H:i:s', strtotime($date_1_hour_ago) + 3600 * 12); // 12 hours TTR
-        $this->boolean(
-            $this->areDateEquals(
-                $ticket->fields['time_to_own'],
-                $tto_expected_date,
-            )
-        )->isTrue();
-        $this->boolean(
-            $this->areDateEquals(
-                $ticket->fields['time_to_resolve'],
-                $ttr_expected_date,
-            )
-        )->isTrue();
+        $this->string($ticket->fields['time_to_own'])->isEqualTo($tto_expected_date);
+        $this->string($ticket->fields['time_to_resolve'])->isEqualTo($ttr_expected_date);
 
         // Check escalation levels
         $sla_levels = (new SlaLevel_Ticket())->find([
@@ -921,34 +911,14 @@ class SLM extends DbTestCase
         $ttr_level = array_shift($sla_levels);
         $tto_level_expected_date = date('Y-m-d H:i:s', strtotime($tto_expected_date) - 900); // 15 minutes escalation level
         $ttr_level_expected_date = date('Y-m-d H:i:s', strtotime($ttr_expected_date) - 1800); // 30 minutes escalation level
-        $this->boolean(
-            $this->areDateEquals(
-                $tto_level['date'],
-                $tto_level_expected_date,
-            )
-        )->isTrue();
-        $this->boolean(
-            $this->areDateEquals(
-                $ttr_level['date'],
-                $ttr_level_expected_date,
-            )
-        )->isTrue();
+        $this->string($tto_level['date'])->isEqualTo($tto_level_expected_date);
+        $this->string($ttr_level['date'])->isEqualTo($ttr_level_expected_date);
 
         // Check OLA, must be calculated from the date at which it was added to the ticket
         $tto_expected_date = date('Y-m-d H:i:s', strtotime($now) + 3600 * 2); // 2 hours TTO
         $ttr_expected_date = date('Y-m-d H:i:s', strtotime($now) + 3600 * 8); // 8 hours TTR
-        $this->boolean(
-            $this->areDateEquals(
-                $ticket->fields['internal_time_to_own'],
-                $tto_expected_date,
-            )
-        )->isTrue();
-        $this->boolean(
-            $this->areDateEquals(
-                $ticket->fields['internal_time_to_resolve'],
-                $ttr_expected_date,
-            )
-        )->isTrue();
+        $this->string($ticket->fields['internal_time_to_own'])->isEqualTo($tto_expected_date);
+        $this->string($ticket->fields['internal_time_to_resolve'])->isEqualTo($ttr_expected_date);
 
         // Check escalation levels
         $ola_levels = (new OlaLevel_Ticket())->find([
@@ -959,17 +929,7 @@ class SLM extends DbTestCase
         $ttr_level = array_shift($ola_levels);
         $tto_level_expected_date = date('Y-m-d H:i:s', strtotime($tto_expected_date) - 2700); // 45 minutes escalation level
         $ttr_level_expected_date = date('Y-m-d H:i:s', strtotime($ttr_expected_date) - 3600); // 60 minutes escalation level
-        $this->boolean(
-            $this->areDateEquals(
-                $tto_level['date'],
-                $tto_level_expected_date,
-            )
-        )->isTrue();
-        $this->boolean(
-            $this->areDateEquals(
-                $ttr_level['date'],
-                $ttr_level_expected_date,
-            )
-        )->isTrue();
+        $this->string($tto_level['date'])->isEqualTo($tto_level_expected_date);
+        $this->string($ttr_level['date'])->isEqualTo($ttr_level_expected_date);
     }
 }

--- a/tests/functional/SLM.php
+++ b/tests/functional/SLM.php
@@ -878,7 +878,7 @@ class SLM extends DbTestCase
         ]);
 
         // Create a ticket 1 hour ago without any SLA
-        $date_1_hour_ago = date('Y-m-d H:i:s', strtotime('-1 hour'));
+        $date_1_hour_ago = date('Y-m-d H:i:s', strtotime('-1 hour', strtotime($_SESSION['glpi_currenttime'])));
         $ticket = $this->createItem("Ticket", [
             "name"        => "Test ticket",
             "content"     => "Test ticket",
@@ -887,7 +887,7 @@ class SLM extends DbTestCase
         ]);
 
         // Add SLA and OLA to the ticket
-        $now = date('Y-m-d H:i:s'); // Keep track of when the OLA where set
+        $now = $_SESSION['glpi_currenttime']; // Keep track of when the OLA where set
         $this->updateItem("Ticket", $ticket->getID(), [
             "slas_id_tto" => $sla_tto->getID(),
             "slas_id_ttr" => $sla_ttr->getID(),

--- a/tests/functional/SLM.php
+++ b/tests/functional/SLM.php
@@ -843,17 +843,39 @@ class SLM extends DbTestCase
             "definition_time" => "hour",
         ]);
 
-        // Create one escalation level for each SLA and OLA (1 hour before)
-        foreach ([$sla_tto, $sla_ttr, $ola_tto, $ola_ttr] as $la) {
-            $class = $la instanceof \SLA ? "SlaLevel" : "OlaLevel";
-            $this->createItem($class, [
-                $la->getForeignKeyField() => $la->getID(),
-                "name"                    => "Test escalation level",
-                "entities_id"             => $entity,
-                "execution_time"          => -3600,
-                "is_active"               => true,
-            ]);
-        }
+        // Create one escalation level for each SLA and OLA
+        $this->createItems("SlaLevel", [
+            [
+                "slas_id"        => $sla_tto->getID(),
+                "name"           => "Test escalation level (SLA/TTO)",
+                "entities_id"    => $entity,
+                "execution_time" => -900, // 15 minutes
+                "is_active"      => true,
+            ],
+            [
+                "slas_id"        => $sla_ttr->getID(),
+                "name"           => "Test escalation level (SLA/TTR)",
+                "entities_id"    => $entity,
+                "execution_time" => -1800, // 30 minutes
+                "is_active"      => true,
+            ],
+        ]);
+        $this->createItems("OlaLevel", [
+            [
+                "olas_id"        => $ola_tto->getID(),
+                "name"           => "Test escalation level (OLA/TTO)",
+                "entities_id"    => $entity,
+                "execution_time" => -2700, // 45 minutes
+                "is_active"      => true,
+            ],
+            [
+                "olas_id"        => $ola_ttr->getID(),
+                "name"           => "Test escalation level (OLA/TTR)",
+                "entities_id"    => $entity,
+                "execution_time" => -3600, // 60 minutes
+                "is_active"      => true,
+            ],
+        ]);
 
         // Create a ticket 1 hour ago without any SLA
         $date_1_hour_ago = date('Y-m-d H:i:s', strtotime('-1 hour'));
@@ -887,8 +909,8 @@ class SLM extends DbTestCase
         $this->array($sla_levels)->hasSize(2);
         $tto_level = array_shift($sla_levels);
         $ttr_level = array_shift($sla_levels);
-        $tto_level_expected_date = date('Y-m-d H:i:s', strtotime($tto_expected_date) - 3600); // 1 hour escalation level
-        $ttr_level_expected_date = date('Y-m-d H:i:s', strtotime($ttr_expected_date) - 3600); // 1 hour escalation level
+        $tto_level_expected_date = date('Y-m-d H:i:s', strtotime($tto_expected_date) - 900); // 1 hour escalation level
+        $ttr_level_expected_date = date('Y-m-d H:i:s', strtotime($ttr_expected_date) - 1800); // 1 hour escalation level
         $this->string($tto_level['date'])->isEqualTo($tto_level_expected_date);
         $this->string($ttr_level['date'])->isEqualTo($ttr_level_expected_date);
 
@@ -905,7 +927,7 @@ class SLM extends DbTestCase
         $this->array($ola_levels)->hasSize(2);
         $tto_level = array_shift($ola_levels);
         $ttr_level = array_shift($ola_levels);
-        $tto_level_expected_date = date('Y-m-d H:i:s', strtotime($tto_expected_date) - 3600); // 1 hour escalation level
+        $tto_level_expected_date = date('Y-m-d H:i:s', strtotime($tto_expected_date) - 2700); // 1 hour escalation level
         $ttr_level_expected_date = date('Y-m-d H:i:s', strtotime($ttr_expected_date) - 3600); // 1 hour escalation level
         $this->string($tto_level['date'])->isEqualTo($tto_level_expected_date);
         $this->string($ttr_level['date'])->isEqualTo($ttr_level_expected_date);


### PR DESCRIPTION
TTO/TTR for OLA are calculated from the date at which the OLA were added to the ticket.
However, their escalation dates are currently calculated incorrectly (using the ticket opening date instead).

Ticket created at 12:00:
![image](https://user-images.githubusercontent.com/42734840/229096284-e83f4c66-d54c-44d3-a5a2-9c5afe8c8116.png)

OLA added at 12:25:
![image](https://user-images.githubusercontent.com/42734840/229096366-87fb2113-4d41-44dc-9cb8-78cbc51763dc.png)

The TTO/TTR are correct:
![image](https://user-images.githubusercontent.com/42734840/229096495-c9d65df0-0a33-49b0-a997-1940e6be302a.png)

The escalation dates are incorrect:
![image](https://user-images.githubusercontent.com/42734840/229096557-f97ac2e6-a621-4d9a-9d6d-1159b717ecc9.png)
![image](https://user-images.githubusercontent.com/42734840/229096667-6d6f5834-6717-40c4-bc62-c02b38989114.png)

Fixed by storing the date at which the OLA were set (new `ola_tto_begin_date` field for TTO, the `ola_ttr_begin_date` field for TTR already existed) and using it in calculations.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27262
