### PR TITLE
fix(ticket): display of actor names too long

### DIFF
--- a/css/includes/components/_select2.scss
+++ b/css/includes/components/_select2.scss
@@ -149,6 +149,8 @@
 
                     padding: 1px 3px;
                     margin: 3px 3px 0 0;
+                    max-width: 100%;
+                    white-space: normal;
 
                     @include dark-mode {
                         & {


### PR DESCRIPTION
When an actor's name is too long, it is truncated and the icons that follow are not visible.

Before:

![image](https://user-images.githubusercontent.com/8530352/229112278-2fcda337-d052-42c9-9df9-cc43a178549c.png)

After:
![image](https://user-images.githubusercontent.com/8530352/229112055-b6131148-f8c1-431d-90de-98008302019b.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27445
