### PR TITLE
Fix dashboard fitler css conflict

### DIFF
--- a/css/standalone/dashboard.scss
+++ b/css/standalone/dashboard.scss
@@ -212,7 +212,7 @@ $break_tablet: 1400px;
                     }
 
                     .delete-filter {
-                        display: inline-block;
+                        display: inline-block !important;
                     }
 
                     legend {


### PR DESCRIPTION
The dashboards have some css code to hide the extra dropdown buttons like "+" in the filter area.
It seems to be a bit too aggressive and in the case of dropdown built from `Dropdown::FromArray`, which do not have these buttons, will end up targeting the delete filter button instead ("trash" icon).

![image](https://user-images.githubusercontent.com/42734840/229121772-20cf1fc1-193a-493b-bf1b-eec522453152.png)

Setting the delete filter button display's style as important avoid this issue.

Note: we do not have any filter that use this kind of dropdown yet so the issue does not affect anyone at this moment (but it could be an issue for future filters).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27440
