### PR TITLE
Fix can_promote in twig

### DIFF
--- a/templates/components/itilobject/timeline/timeline_item_header.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header.html.twig
@@ -76,7 +76,7 @@
             </li>
          {% endset %}
          {% set actions = actions|merge({promoted_btn}) %}
-      {% elseif get_current_interface() == 'central' and item.getType() is same as 'Ticket' and item.canCreate() and (entry['type'] is same as 'ITILFollowup' or entry['type'] is same as 'TicketTask')  %}
+      {% elseif can_promote and get_current_interface() == 'central' and item.getType() is same as 'Ticket' and item.canCreate() and (entry['type'] is same as 'ITILFollowup' or entry['type'] is same as 'TicketTask')  %}
          {% set promote_url = '?_promoted_fup_id=' ~ entry_i['id'] %}
          {% if entry['type'] is same as 'TicketTask' %}
             {% set promote_url = '?_promoted_task_id=' ~ entry_i['id'] %}


### PR DESCRIPTION
Add "can_promote" test in a if on the creation of the button, for now when can_promote was false it do nothing, with this fix if we set can-promote at false the button on timeline object won't show up

<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
