### PR TITLE
Fix entry_i variable in timeline twig template

### DIFF
--- a/src/Application/View/Extension/ItemtypeExtension.php
+++ b/src/Application/View/Extension/ItemtypeExtension.php
@@ -68,6 +68,7 @@ class ItemtypeExtension extends AbstractExtension
     {
         return [
             new TwigFunction('get_item', [$this, 'getItem']),
+            new TwigFunction('set_item_attribute', [$this, 'setItemAttribute']),
             new TwigFunction('get_item_comment', [$this, 'getItemComment']),
             new TwigFunction('get_item_link', [$this, 'getItemLink'], ['is_safe' => ['html']]),
             new TwigFunction('get_item_name', [$this, 'getItemName']),
@@ -274,4 +275,24 @@ class ItemtypeExtension extends AbstractExtension
         }
         return null;
     }
+    
+    /**
+     * Return Object with modified property given
+     * 
+     * @param object $item 
+     * @param string $attribute 
+     * @param mixed $value 
+     * 
+     * @return object
+     */
+    public function setItemAttribute(object $item, string $attribute, $value) 
+    {
+        if (is_array($item->$attribute) || is_array($value) ) {
+            $item->$attribute = array_merge($item->$attribute, $value);
+        } else {
+           $item->$attribute = $value;
+        }
+        return $item;
+    }
+
 }

--- a/src/Application/View/Extension/ItemtypeExtension.php
+++ b/src/Application/View/Extension/ItemtypeExtension.php
@@ -275,24 +275,23 @@ class ItemtypeExtension extends AbstractExtension
         }
         return null;
     }
-    
+
     /**
      * Return Object with modified property given
-     * 
-     * @param object $item 
-     * @param string $attribute 
-     * @param mixed $value 
-     * 
+     *
+     * @param object $item
+     * @param string $attribute
+     * @param mixed $value
+     *
      * @return object
      */
-    public function setItemAttribute(object $item, string $attribute, $value) 
+    public function setItemAttribute(object $item, string $attribute, $value)
     {
-        if (is_array($item->$attribute) || is_array($value) ) {
+        if (is_array($item->$attribute) || is_array($value)) {
             $item->$attribute = array_merge($item->$attribute, $value);
         } else {
-           $item->$attribute = $value;
+            $item->$attribute = $value;
         }
         return $item;
     }
-
 }

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -45,11 +45,20 @@
    {% for entry in timeline %}
       {% set entry_i = entry['item'] %}
       {% set entry_object = get_item(entry['type'], entry_i['id']) %}
+      {% set entry_rand = random() %}
+      
+      <div class="timeline-item mb-3 {{ itiltype }} {{ state_class }} {{ entry['class'] }} {{ 'right' in item_position ? 'ms-auto' : '' }}"
+            data-itemtype="{{ entry['type'] }}" data-items-id="{{ entry_i['id'] }}"
+            {% if entry['item_action'] is defined %}data-item-action="{{ entry['item_action'] }}"{% endif %}>
+            
+      {% set entry_object = set_item_attribute(entry_object, "fields", entry_i) %}
+      {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::PRE_SHOW_ITEM'), {'item': entry_object, 'options': {'parent': item, 'rand': entry_rand}}) }}
+      {% set entry_i = entry_object.fields %}
+      
       {% set users_id = entry_i['users_id'] %}
       {% set is_private = entry_i['is_private'] ?? false %}
       {% set date_creation = entry_i['date_creation'] ?? entry_i['date'] %}
       {% set date_mod = entry_i['date_mod'] %}
-      {% set entry_rand = random() %}
       {% set is_current_user = users_id == session('glpiID') %}
       {% set anonym_user = (get_current_interface() == 'helpdesk' and not is_current_user and entity_config('anonymize_support_agents', session('glpiactive_entity')) != constant('Entity::ANONYMIZE_DISABLED')) %}
 
@@ -95,12 +104,6 @@
             {% set solution_class = 'refused' %}
          {% endif %}
       {% endif %}
-
-      <div class="timeline-item mb-3 {{ itiltype }} {{ state_class }} {{ entry['class'] }} {{ 'right' in item_position ? 'ms-auto' : '' }}"
-            data-itemtype="{{ entry['type'] }}" data-items-id="{{ entry_i['id'] }}"
-            {% if entry['item_action'] is defined %}data-item-action="{{ entry['item_action'] }}"{% endif %}>
-
-         {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::PRE_SHOW_ITEM'), {'item': entry_object, 'options': {'parent': item, 'rand': entry_rand}}) }}
 
          <div class="row">
             <div class="col-auto todo-list-state {{ 'left' in item_position ? 'ms-auto ms-0 order-sm-last' : '' }}">
@@ -179,7 +182,9 @@
             </div>
          </div>
 
+         {% set entry_object = set_item_attribute(entry_object, "fields", entry_i) %}
          {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::POST_SHOW_ITEM'), {'item': entry_object, 'options': {'parent': item, 'rand': entry_rand}}) }}
+         {% set entry_i = entry_object.fields %}
       </div>
    {% endfor %}
 

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -46,15 +46,15 @@
       {% set entry_i = entry['item'] %}
       {% set entry_object = get_item(entry['type'], entry_i['id']) %}
       {% set entry_rand = random() %}
-      
+
       <div class="timeline-item mb-3 {{ itiltype }} {{ state_class }} {{ entry['class'] }} {{ 'right' in item_position ? 'ms-auto' : '' }}"
             data-itemtype="{{ entry['type'] }}" data-items-id="{{ entry_i['id'] }}"
             {% if entry['item_action'] is defined %}data-item-action="{{ entry['item_action'] }}"{% endif %}>
-            
+
       {% set entry_object = set_item_attribute(entry_object, "fields", entry_i) %}
       {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::PRE_SHOW_ITEM'), {'item': entry_object, 'options': {'parent': item, 'rand': entry_rand}}) }}
       {% set entry_i = entry_object.fields %}
-      
+
       {% set users_id = entry_i['users_id'] %}
       {% set is_private = entry_i['is_private'] ?? false %}
       {% set date_creation = entry_i['date_creation'] ?? entry_i['date'] %}


### PR DESCRIPTION
My issue was I can't modify attribute of a timeline object in hook because it didn't have any incidence in this twig template and I need to update property of this object before hook for having all correct datas

Add set attribute function (after research it is impossible to set or update an object attribute in twig template)

I have moved div declaration because if I modified something in my hook I want to update all variables

Update "entry_object" fields attribute for use it in an hook (in timeline twig template if "entry_i" (array fields of and timeline object) is modified before the hook we didn't have correct object) for example on this template I want to update data of timeline object field attribute and I didn't have "can_edit" in my array because "entry_object" in an new object created in twig template

After the hook, make an update of "entry_i" variable with data modified in the hook (for example in this twig template if I modified "can_edit" field in the array it does nothing because "entry_object" is not used in the template)

<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
