### PR TITLE
Fix bulk create and update of some items via api

### DIFF
--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -1805,7 +1805,6 @@ abstract class API
         $itemtype = $this->handleDepreciation($itemtype);
 
         $input    = isset($params['input']) ? $params["input"] : null;
-        $item     = new $itemtype();
 
         if (is_object($input)) {
             $input = [$input];
@@ -1825,6 +1824,8 @@ abstract class API
             $failed       = 0;
             $index        = 0;
             foreach ($input as $object) {
+                // Use a new instance each time to avoid side effects with data from a previous item (See #14490)
+                $item     = new $itemtype();
                 $object      = $this->inputObjectToArray($object);
                 $current_res = [];
 
@@ -1933,9 +1934,7 @@ abstract class API
     protected function updateItems($itemtype, $params = [])
     {
         $itemtype = $this->handleDepreciation($itemtype);
-
         $input    = isset($params['input']) ? $params["input"] : null;
-        $item     = new $itemtype();
 
         if (is_object($input)) {
             $input = [$input];
@@ -1955,6 +1954,8 @@ abstract class API
             $failed       = 0;
             $index        = 0;
             foreach ($input as $object) {
+                // Use a new instance each time to avoid side effects with data from a previous item (See #14490)
+                $item     = new $itemtype();
                 $current_res = [];
                 if (isset($object->id)) {
                     if (!$item->getFromDB($object->id)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14490 

IPNetwork at least uses some class properties that interfere with adding/updating multiple items using the same instance. For safety, I think the API should always use a new instance for each item being created/updated.