### PR TITLE
fix(inventory): fix restore / purge lock for Domain_Item

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -492,7 +492,7 @@ $CFG_GLPI['inventory_lockable_objects'] = ['Computer_Item',  'Item_SoftwareLicen
     'Item_DeviceControl', 'Item_DeviceDrive', 'Item_DeviceFirmware', 'Item_DeviceGeneric', 'Item_DeviceGraphicCard',
     'Item_DeviceHardDrive', 'Item_DeviceMemory', 'Item_DeviceMotherboard', 'Item_DeviceNetworkCard', 'Item_DevicePci',
     'Item_DevicePowerSupply', 'Item_DeviceProcessor', 'Item_DeviceSensor', 'Item_DeviceSimcard', 'Item_DeviceSoundCard',
-    'DatabaseInstance', 'Item_RemoteManagement','Monitor'
+    'DatabaseInstance', 'Item_RemoteManagement','Monitor', 'Domain_Item'
 ];
 
 $CFG_GLPI["kb_types"]              = ['Budget', 'Change', 'Computer',


### PR DESCRIPTION
Fix restore / purge lock for Domain_Item

```Domain_Item``` need to be set in ```$CFG_GLPI['inventory_lockable_objects'] ```

See ```glpi/front/lock.form.php```

https://github.com/glpi-project/glpi/blob/2b3f5440bd8d175d4eb5b0b70399607b4b36ecf0/front/lock.form.php#L47-L51

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
