### PR TITLE
fix(Inventory): search Domain with asset entities_id

### DIFF
--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -713,7 +713,7 @@ abstract class MainAsset extends InventoryAsset
             $matching_domains = $DB->request([
                 'FROM' => $domain->getTable(),
                 'WHERE' => [
-                    'name' => $val->domains_id,
+                    'name' => Sanitizer::sanitize($val->domains_id),
                     'is_deleted' => 0,
                 ] + getEntitiesRestrictCriteria($domain->getTable(), '', $entities_id, true),
                 'LIMIT' => 1, // Get the first domain, as we assume that a domain should not be declared multiple times in the same entity scope

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -711,12 +711,15 @@ abstract class MainAsset extends InventoryAsset
         if (property_exists($val, 'domains_id')) {
             $domain = new \Domain();
             $matching_domains = $DB->request([
-                'name' => $val->domains_id,
-                'is_deleted' => 0,
-                'entities_id' => getEntitiesRestrictCriteria($domain->getTable(), '', $entities_id, true),
+                'FROM' => $domain->getTable(),
+                'WHERE' => [
+                    'name' => $val->domains_id,
+                    'is_deleted' => 0,
+                    'entities_id' => getEntitiesRestrictCriteria($domain->getTable(), '', $entities_id, true),
+                ],
+                'LIMIT' => 1, // Get the first domain, as we assume that a domain should not be declared multiple times in the same entity scope
             ]);
             if ($matching_domains->count() > 0) {
-                // Get the first domain, as we assume that a domain should not be declared multiple times in the same entity scope.
                 $domain->getFromResultSet($matching_domains->current());
             } else {
                 $domain->add(

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -710,7 +710,15 @@ abstract class MainAsset extends InventoryAsset
         //handle domains
         if (property_exists($val, 'domains_id')) {
             $domain = new \Domain();
-            if (!$domain->getFromDBByCrit(Sanitizer::sanitize(['name' => $val->domains_id]))) {
+            if (
+                !$domain->getFromDBByCrit(Sanitizer::sanitize(
+                    [
+                        'name' => $val->domains_id,
+                        'is_deleted' => 0,
+                        'entities_id' => $entities_id,
+                    ]
+                ))
+            ) {
                 $domain->add(
                     Sanitizer::sanitize([
                         'name' => $val->domains_id,

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -715,8 +715,7 @@ abstract class MainAsset extends InventoryAsset
                 'WHERE' => [
                     'name' => $val->domains_id,
                     'is_deleted' => 0,
-                    'entities_id' => getEntitiesRestrictCriteria($domain->getTable(), '', $entities_id, true),
-                ],
+                ] + getEntitiesRestrictCriteria($domain->getTable(), '', $entities_id, true),
                 'LIMIT' => 1, // Get the first domain, as we assume that a domain should not be declared multiple times in the same entity scope
             ]);
             if ($matching_domains->count() > 0) {


### PR DESCRIPTION
Like ```Software```, ```Domain``` must follow the asset entity

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
