### PR TITLE
fix(rule ticket): triggering action on actor update

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1190,6 +1190,9 @@ class Ticket extends CommonITILObject
                 $input_key = '_' . $field . '_' . $t;
                 $deleted_key = $input_key . '_deleted';
                 $deleted_actors = array_key_exists($deleted_key, $input) && is_array($input[$deleted_key]) ? array_column($input[$deleted_key], 'items_id') : [];
+                if (!is_array($input[$input_key] ?? [])) {
+                    $input[$input_key] = [$input[$input_key]];
+                }
                 $added_actors = array_diff($input[$input_key] ?? [], array_column($actors, $field));
                 if (empty($added_actors) && empty($deleted_actors)) {
                     $unchanged[] = $input_key;

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1190,10 +1190,11 @@ class Ticket extends CommonITILObject
                 $input_key = '_' . $field . '_' . $t;
                 $deleted_key = $input_key . '_deleted';
                 $deleted_actors = array_key_exists($deleted_key, $input) && is_array($input[$deleted_key]) ? array_column($input[$deleted_key], 'items_id') : [];
-                if (!is_array($input[$input_key] ?? [])) {
-                    $input[$input_key] = [$input[$input_key]];
+                $tmp_input = $input[$input_key] ?? [];
+                if (!is_array($tmp_input)) {
+                    $tmp_input = [$input[$input_key]];
                 }
-                $added_actors = array_diff($input[$input_key] ?? [], array_column($actors, $field));
+                $added_actors = array_diff($tmp_input, array_column($actors, $field));
                 if (empty($added_actors) && empty($deleted_actors)) {
                     $unchanged[] = $input_key;
                 }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1192,7 +1192,7 @@ class Ticket extends CommonITILObject
                 $deleted_actors = array_key_exists($deleted_key, $input) && is_array($input[$deleted_key]) ? array_column($input[$deleted_key], 'items_id') : [];
                 $tmp_input = $input[$input_key] ?? [];
                 if (!is_array($tmp_input)) {
-                    $tmp_input = [$input[$input_key]];
+                    $tmp_input = [$tmp_input];
                 }
                 $added_actors = array_diff($tmp_input, array_column($actors, $field));
                 if (empty($added_actors) && empty($deleted_actors)) {

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1152,6 +1152,7 @@ class Ticket extends CommonITILObject
         $rules               = new RuleTicketCollection($entid);
         $rule                = $rules->getRuleClass();
         $changes             = [];
+        $unchanged           = [];
         $post_added          = [];
         $tocleanafterrules   = [];
         $usertypes           = [
@@ -1187,7 +1188,32 @@ class Ticket extends CommonITILObject
             foreach ($existing_actors as $actor_itemtype => $actors) {
                 $field = getForeignKeyFieldForItemType($actor_itemtype);
                 $input_key = '_' . $field . '_' . $t;
-                $input[$input_key] = array_diff($input[$input_key] ?? [], array_column($actors, $field));
+                $deleted_key = $input_key . '_deleted';
+                $deleted_actors = array_key_exists($deleted_key, $input) && is_array($input[$deleted_key]) ? array_column($input[$deleted_key], 'items_id') : [];
+                $added_actors = array_diff($input[$input_key] ?? [], array_column($actors, $field));
+                if (empty($added_actors) && empty($deleted_actors)) {
+                    $unchanged[] = $input_key;
+                }
+                foreach ($actors as $actor) {
+                    if (
+                        !isset($input[$input_key])
+                        || (is_array($input[$input_key]) && !in_array($actor[$field], $input[$input_key]))
+                        || (is_numeric($input[$input_key]) && $actor[$field] !== $input[$input_key])
+                    ) {
+                        if (
+                            !array_key_exists($input_key, $input)
+                            || (!is_array($input[$input_key]) && !is_numeric($input[$input_key]) && empty($input[$input_key]))
+                        ) {
+                            $input[$input_key] = [];
+                        } elseif (!is_array($input[$input_key])) {
+                            $input[$input_key] = [$input[$input_key]];
+                        }
+                        if (!in_array($actor[$field], $deleted_actors)) {
+                            $input[$input_key][]             = $actor[$field];
+                            $tocleanafterrules[$input_key][] = $actor[$field];
+                        }
+                    }
+                }
             }
         }
 
@@ -1197,8 +1223,9 @@ class Ticket extends CommonITILObject
                 && !array_key_exists($key, $post_added)
             ) {
                 if (
-                    !isset($this->fields[$key])
-                    || ($DB->escape($this->fields[$key]) != $input[$key])
+                    (!isset($this->fields[$key])
+                    || ($DB->escape($this->fields[$key]) != $input[$key]))
+                    && !in_array($key, $unchanged)
                 ) {
                     $changes[] = $key;
                 }
@@ -1249,6 +1276,25 @@ class Ticket extends CommonITILObject
                 ]
             );
             $input = Toolbox::stripslashes_deep($input);
+        }
+
+       // Clean actors fields added for rules
+        foreach ($tocleanafterrules as $key => $values_to_drop) {
+            if (!array_key_exists($key, $input) || !is_array($input[$key])) {
+                // Assign rules may remove input key or replace array by a single value.
+                // In such case, as values were completely redefined by rules, there is no need to filter them.
+                continue;
+            }
+
+            $input[$key] = array_filter(
+                $input[$key],
+                function ($value) use ($values_to_drop) {
+                    return !in_array($value, $values_to_drop);
+                }
+            );
+            if (in_array($key, $post_added) && empty($input[$key])) {
+                unset($input[$key]);
+            }
         }
 
         if (isset($input['_link'])) {

--- a/tests/functional/RuleTicket.php
+++ b/tests/functional/RuleTicket.php
@@ -2965,4 +2965,137 @@ class RuleTicket extends DbTestCase
             ]
         ))->isEqualTo(1);
     }
+
+    public function testFollowupTemplateAssignFromGroup()
+    {
+        $this->login();
+
+        // Create rule
+        $rule_ticket = new \RuleTicket();
+        $rule_ticket_id = $rule_ticket->add([
+            'name'         => 'test group requester criterion',
+            'match'        => 'AND',
+            'is_active'    => 1,
+            'sub_type'     => 'RuleTicket',
+            'condition'    => \RuleTicket::ONADD + \RuleTicket::ONUPDATE,
+            'is_recursive' => 1,
+        ]);
+        $this->integer($rule_ticket_id)->isGreaterThan(0);
+
+        //create group that matches the rule
+        $group = new \Group();
+        $group_id1 = $group->add($group_input = [
+            "name"         => "group1",
+            "is_requester" => true
+        ]);
+        $this->checkInput($group, $group_id1, $group_input);
+
+        //create group that doesn't match the rule
+        $group_id2 = $group->add($group_input = [
+            "name"         => "group2",
+            "is_requester" => true
+        ]);
+        $this->checkInput($group, $group_id2, $group_input);
+
+        // Create criteria to check if requester group is group1
+        $rule_criteria = new \RuleCriteria();
+        $rule_criteria_id = $rule_criteria->add([
+            'rules_id'  => $rule_ticket_id,
+            'criteria'  => '_groups_id_requester',
+            'condition' => \Rule::PATTERN_IS,
+            'pattern'   => $group_id1,
+        ]);
+        $this->integer($rule_criteria_id)->isGreaterThan(0);
+
+        // Create followup template
+        $followup_template = new ITILFollowupTemplate();
+        $followup_template_id = $followup_template->add([
+            'content' => "<p>test testFollowupTemplateAssignFromGroup</p>",
+        ]);
+        $this->integer($followup_template_id)->isGreaterThan(0);
+
+        // Add action to rule
+        $rule_action = new RuleAction();
+        $rule_action_id = $rule_action->add([
+            'rules_id'    => $rule_ticket_id,
+            'action_type' => 'append',
+            'field'       => 'itilfollowup_template',
+            'value'       => $followup_template_id,
+        ]);
+        $this->integer($rule_action_id)->isGreaterThan(0);
+
+        // Create ticket
+        $ticket = new \Ticket();
+        $ticket_id = $ticket->add([
+            'name'              => 'test',
+            'content'           => 'test',
+            '_groups_id_requester' => [$group_id1],
+        ]);
+        $this->integer($ticket_id)->isGreaterThan(0);
+
+        //link between group1 and ticket will exist
+        $ticketGroup = new \Group_Ticket();
+        $this->boolean(
+            $ticketGroup->getFromDBByCrit([
+                'tickets_id'         => $ticket_id,
+                'groups_id'          => $group_id1,
+                'type'               => \CommonITILActor::REQUESTER
+            ])
+        )->isTrue();
+
+        // Check that followup was added
+        $this->integer(countElementsInTable(
+            ITILFollowup::getTable(),
+            ['itemtype' => \Ticket::getType(), 'items_id' => $ticket_id]
+        ))->isEqualTo(1);
+
+        // Add group2 to ticket
+        $ticket->update([
+            'id'                  => $ticket_id,
+            '_groups_id_requester' => [$group_id1, $group_id2],
+        ]);
+
+        //link between group2 and ticket will exist
+        $this->boolean(
+            $ticketGroup->getFromDBByCrit([
+                'tickets_id'         => $ticket_id,
+                'groups_id'          => $group_id2,
+                'type'               => \CommonITILActor::REQUESTER
+            ])
+        )->isTrue();
+
+        // Check that followup was added
+        $this->integer(countElementsInTable(
+            ITILFollowup::getTable(),
+            ['itemtype' => \Ticket::getType(), 'items_id' => $ticket_id]
+        ))->isEqualTo(2);
+
+        // Add user to ticket
+        $user = new \User();
+        $user_id = $user->add([
+            'name' => 'test',
+        ]);
+        $this->integer($user_id)->isGreaterThan(0);
+
+        $ticket->update([
+            'id'                  => $ticket_id,
+            '_users_id_requester' => [$user_id],
+        ]);
+
+        //link between user and ticket will exist
+        $ticketUser = new \Ticket_User();
+        $this->boolean(
+            $ticketUser->getFromDBByCrit([
+                'tickets_id'         => $ticket_id,
+                'users_id'           => $user_id,
+                'type'               => \CommonITILActor::REQUESTER
+            ])
+        )->isTrue();
+
+        // Check that followup was NOT added
+        $this->integer(countElementsInTable(
+            ITILFollowup::getTable(),
+            ['itemtype' => \Ticket::getType(), 'items_id' => $ticket_id]
+        ))->isEqualTo(2);
+    }
 }


### PR DESCRIPTION
When you have a rule whose criterion is the assignment of a group "XXX", the rule is triggered when you change the "assigned" field. If the value contains the group "XXX", the action is applied, even if this group was already present before the current update.

IMHO, the rule should only apply at the time of adding the group and not if you add more actors afterwards.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27454
