### PR TITLE
fix(ticket): improve KB display

### DIFF
--- a/css/legacy/includes/_styles.scss
+++ b/css/legacy/includes/_styles.scss
@@ -656,7 +656,7 @@
       padding: 5px;
       width: 420px;
       height: 40vh;
-      right: -5px;
+      right: -25px;
       z-index: 1000;
       margin-top: 20px;
       border-radius: 2px;
@@ -677,7 +677,7 @@
          border-width: 0 10px 17.3px 10px;
          border-color: transparent transparent #CCC transparent;
          top: -18px;
-         right: 5px;
+         right: 25px;
          position: absolute;
       }
 
@@ -690,7 +690,7 @@
          border-width: 0 10px 18.3px 10px;
          border-color: transparent transparent #ffffff transparent;
          top: -16px;
-         right: 5px;
+         right: 25px;
          position: absolute;
       }
    }

--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -975,16 +975,22 @@ abstract class CommonDropdown extends CommonDBTM
                     $ret .= "</div>"; // .faqadd_block_content
                 } else {
                     $ret .= Html::scriptBlock("
-                  var getKnowbaseItemAnswer$rand = function() {
-                     var knowbaseitems_id = $('#dropdown_knowbaseitems_id$rand').val();
-                     $('#faqadd_block_content$rand').load(
-                        '" . $CFG_GLPI['root_doc'] . "/ajax/getKnowbaseItemAnswer.php',
-                        {
-                           'knowbaseitems_id': knowbaseitems_id
+                        var getKnowbaseItemAnswer$rand = function() {
+                            var knowbaseitems_id = $('#dropdown_knowbaseitems_id$rand').val();
+                            $('#faqadd_block_content$rand').load(
+                                '" . $CFG_GLPI['root_doc'] . "/ajax/getKnowbaseItemAnswer.php',
+                                {
+                                    'knowbaseitems_id': knowbaseitems_id
+                                }
+                            );
+                        };
+                        var setMaxWidth = function() {
+                            var maxWidth = $('#faqadd_block_content$rand').closest('.form-field').width();
+                            $('.faqadd_entries').css('max-width', maxWidth);
                         }
-                     );
-                  };
-               ");
+                        $(window).resize(setMaxWidth);
+                        setMaxWidth();
+                    ");
                     $ret .= "<label for='dropdown_knowbaseitems_id$rand'>" .
                     KnowbaseItem::getTypeName() . "</label>&nbsp;";
                     $ret .= KnowbaseItem::dropdown([


### PR DESCRIPTION
On small screen resolutions, when you display the KB, its rendering is cut.

Before:

![image](https://user-images.githubusercontent.com/8530352/230624620-2ce6b228-4ff1-4514-88e9-5e4fabe399fe.png)


After:

![image](https://user-images.githubusercontent.com/8530352/230624366-55889722-b0dc-4c53-b7d0-85bb277eabeb.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27550
