### PR TITLE
fix(search): query search with backslash

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -9089,6 +9089,12 @@ HTML;
         // 2. Escape raw value to protect SQL special chars.
         $val = Sanitizer::dbEscape(Sanitizer::unsanitize($val));
 
+        // Backslashes must be doubled in LIKE clause, according to MySQL documentation:
+        // https://dev.mysql.com/doc/refman/8.0/en/string-comparison-functions.html
+        // > To search for \, specify it as \\\\; this is because the backslashes are stripped once by the parser
+        // > and again when the pattern match is made, leaving a single backslash to be matched against.
+        //
+        // At this point, backslashes are already escaped, so escaped backslashes (\\) have to be transformed to \\\\.
         $val = str_replace('\\\\', '\\\\\\\\', $val);
 
        // escape _ char used as wildcard in mysql likes

--- a/src/Search.php
+++ b/src/Search.php
@@ -9089,6 +9089,8 @@ HTML;
         // 2. Escape raw value to protect SQL special chars.
         $val = Sanitizer::dbEscape(Sanitizer::unsanitize($val));
 
+        $val = str_replace('\\\\', '\\\\\\\\', $val);
+
        // escape _ char used as wildcard in mysql likes
         $val = str_replace('_', '\\_', $val);
 

--- a/tests/functional/Search.php
+++ b/tests/functional/Search.php
@@ -1666,6 +1666,7 @@ class Search extends DbTestCase
             ['<PROD-15>$', '%<PROD-15>'],
             ['A&#38;B', '%A&B%'],
             ['A&B', '%A&B%'],
+            ["backslashes \\ \\\\ are twice escaped when not used in ', \n, \r, ... ", "%backslashes \\\\\\\\ \\\\\\\\\\\\\\\\ are twice escaped when not used in \', \\n, \\r, ...%"],
         ];
     }
 


### PR DESCRIPTION
When we made a search with a text containing a backslash, GLPI never found a result

Before:

![image](https://user-images.githubusercontent.com/8530352/231161736-83036dd4-0544-4bd0-97bf-7e9d5b417915.png)

After : 

![image](https://user-images.githubusercontent.com/8530352/231161654-9d297e3d-4ac9-4bd7-b531-d5dab56d33f0.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27408
