### PR TITLE
Fix promote button state/visibility

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -6752,6 +6752,7 @@ abstract class CommonITILObject extends CommonDBTM
                 $followup_obj->getFromDB($followups_id);
                 if ($followup_obj->canViewItem() || $params['bypass_rights']) {
                     $followup['can_edit'] = $followup_obj->canUpdateItem();
+                    $followup['can_promote'] = Session::getCurrentInterface() === 'central' && $this instanceof Ticket && Ticket::canCreate();
                     $timeline["ITILFollowup_" . $followups_id] = [
                         'type' => ITILFollowup::class,
                         'item' => $followup,
@@ -6768,6 +6769,7 @@ abstract class CommonITILObject extends CommonDBTM
                 $task_obj->getFromDB($tasks_id);
                 if ($task_obj->canViewItem() || $params['bypass_rights']) {
                     $task['can_edit'] = $task_obj->canUpdateItem();
+                    $task['can_promote'] = Session::getCurrentInterface() === 'central' && $this instanceof Ticket && Ticket::canCreate();
                     $timeline[$task_obj::getType() . "_" . $tasks_id] = [
                         'type' => $taskClass,
                         'item' => $task,

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -54,8 +54,6 @@
       {% set anonym_user = (get_current_interface() == 'helpdesk' and not is_current_user and entity_config('anonymize_support_agents', session('glpiactive_entity')) != constant('Entity::ANONYMIZE_DISABLED')) %}
 
       {% set can_edit_i  = entry_i['can_edit'] %}
-      {% set can_promote = (entry['type'] == 'ITILFollowup' or entry['type'] == 'TicketTask') and can_edit_i and not status_closed %}
-      {% set is_promoted = can_promote and entry_i['sourceof_items_id'] > 0 %}
 
       {% set timeline_position = entry_i['timeline_position'] %}
       {% set item_position = 't-left' %}

--- a/templates/components/itilobject/timeline/timeline_item_header.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header.html.twig
@@ -66,31 +66,33 @@
          </span>
       {% endif %}
 
-      {% if is_promoted %}
-         {% set promoted_btn %}
-            <li>
-               <a class="dropdown-item text-warning" href="{{ 'Ticket'|itemtype_form_path(entry_i['sourceof_items_id']) }}">
-                  <i class="fa-fw ti ti-git-branch"></i>
-                  <span>{{ __('%s was already promoted')|format(entry['type']|itemtype_name) }}</span>
-               </a>
-            </li>
-         {% endset %}
-         {% set actions = actions|merge({promoted_btn}) %}
-      {% elseif get_current_interface() == 'central' and item.getType() is same as 'Ticket' and item.canCreate() and (entry['type'] is same as 'ITILFollowup' or entry['type'] is same as 'TicketTask')  %}
-         {% set promote_url = '?_promoted_fup_id=' ~ entry_i['id'] %}
-         {% if entry['type'] is same as 'TicketTask' %}
-            {% set promote_url = '?_promoted_task_id=' ~ entry_i['id'] %}
-         {% endif %}
+      {% if get_current_interface() == 'central' and item.getType() is same as 'Ticket' and item.canCreate() and (entry['type'] is same as 'ITILFollowup' or entry['type'] is same as 'TicketTask') %}
+         {% if entry_i['sourceof_items_id'] > 0 %}
+            {% set promoted_btn %}
+               <li>
+                  <a class="dropdown-item text-warning" href="{{ 'Ticket'|itemtype_form_path(entry_i['sourceof_items_id']) }}">
+                     <i class="fa-fw ti ti-git-branch"></i>
+                     <span>{{ __('%s was already promoted')|format(entry['type']|itemtype_name) }}</span>
+                  </a>
+               </li>
+            {% endset %}
+            {% set actions = actions|merge({promoted_btn}) %}
+         {% else %}
+            {% set promote_url = '?_promoted_fup_id=' ~ entry_i['id'] %}
+            {% if entry['type'] is same as 'TicketTask' %}
+               {% set promote_url = '?_promoted_task_id=' ~ entry_i['id'] %}
+            {% endif %}
 
-         {% set promote_btn %}
-            <li>
-               <a class="dropdown-item" href="{{ 'Ticket'|itemtype_form_path ~ promote_url }}">
-                  <i class="fa-fw ti ti-git-branch"></i>
-                  <span>{{ __('Promote to Ticket') }}</span>
-               </a>
-            </li>
-         {% endset %}
-         {% set actions = actions|merge({promote_btn}) %}
+            {% set promote_btn %}
+               <li>
+                  <a class="dropdown-item" href="{{ 'Ticket'|itemtype_form_path ~ promote_url }}">
+                     <i class="fa-fw ti ti-git-branch"></i>
+                     <span>{{ __('Promote to Ticket') }}</span>
+                  </a>
+               </li>
+            {% endset %}
+            {% set actions = actions|merge({promote_btn}) %}
+         {% endif %}
       {% endif %}
 
       {% if actions|length %}

--- a/templates/components/itilobject/timeline/timeline_item_header.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header.html.twig
@@ -66,7 +66,7 @@
          </span>
       {% endif %}
 
-      {% if get_current_interface() == 'central' and item.getType() is same as 'Ticket' and item.canCreate() and (entry['type'] is same as 'ITILFollowup' or entry['type'] is same as 'TicketTask') %}
+      {% if entry_i['can_promote'] %}
          {% if entry_i['sourceof_items_id'] > 0 %}
             {% set promoted_btn %}
                <li>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

The `item was already promoted` entry was only displayed when Ticket was editable and not closed. This condition does not make sense. Indeed, when an item was already promoted, we should display this information whenever the parent status is.
Thus, it was resulting in proposing the promotion of an item that was already promoted.

Before fix:
![image](https://user-images.githubusercontent.com/33253653/231396960-89dae0a9-4444-4346-995d-d25607b9f55d.png)

After fix:
![image](https://user-images.githubusercontent.com/33253653/231397208-b735618e-186e-4824-ac62-111cd92e9abd.png)

I also reviewed the conditions to ensure that the `item was already promoted` entry is only visible for user that would have rights to promote the item if it was not already promoted.

Replace #14475