### PR TITLE
Improve plugins init performances

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -550,7 +550,11 @@ class Plugin extends CommonDBTM
         $this->loadPluginInformations();
         $plugin = new self();
 
-        $informations = $this->plugins_information[$plugin_key] ?? [];
+        // Fallback on $this->getInformationsFromDirectory is needed for unit
+        // tests with fake "tester" plugin, as the plugin does not have a real
+        // directory so $this->loadPluginInformations wont be able to find it
+        // by iterating on /plugins and /marketplace
+        $informations = $this->plugins_information[$plugin_key] ?? $this->getInformationsFromDirectory($plugin_key);
         $new_specs    = $this->getNewInfoAndDirBasedOnOldName($plugin_key);
         $is_already_known = $plugin->getFromDBByCrit(['directory' => $plugin_key]);
         $is_loadable      = !empty($informations);

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -505,7 +505,6 @@ class Plugin extends CommonDBTM
                 in_array($plugin_name, ['.svn', '.', '..'])
                 || !is_dir($plugin_directory->getRealPath())
             ) {
-
                 continue;
             }
 
@@ -513,6 +512,7 @@ class Plugin extends CommonDBTM
             $plugins_informations[$plugin_name] = $info;
         }
         $this->plugins_informations = $plugins_informations;
+
         // Check all directories from the checklist
         foreach ($directories as $directory) {
             if (in_array($directory, $excluded_plugins)) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -511,7 +511,7 @@ class Plugin extends CommonDBTM
      *
      * @return void
      */
-    private function loadPluginInformations(): void
+    private function loadPluginInformation(): void
     {
         // Run once
         if ($this->plugins_information !== null) {
@@ -547,14 +547,14 @@ class Plugin extends CommonDBTM
      */
     public function checkPluginState($plugin_key)
     {
-        $this->loadPluginInformations();
+        $this->loadPluginInformation();
         $plugin = new self();
 
         // Fallback on $this->getInformationsFromDirectory is needed for unit
         // tests with fake "tester" plugin, as the plugin does not have a real
-        // directory so $this->loadPluginInformations wont be able to find it
+        // directory so $this->loadPluginInformation wont be able to find it
         // by iterating on /plugins and /marketplace
-        $informations = $this->plugins_information[$plugin_key] ?? $this->getInformationsFromDirectory($plugin_key);
+        $information = $this->plugins_information[$plugin_key] ?? $this->getInformationsFromDirectory($plugin_key);
         $new_specs    = $this->getNewInfoAndDirBasedOnOldName($plugin_key);
         $is_already_known = $plugin->getFromDBByCrit(['directory' => $plugin_key]);
         $is_loadable      = !empty($informations);
@@ -772,8 +772,8 @@ class Plugin extends CommonDBTM
      */
     private function getNewInfoAndDirBasedOnOldName($oldname)
     {
-        foreach ($this->plugins_information as $plugin_name => $informations) {
-            if (array_key_exists('oldname', $informations) && $informations['oldname'] === $oldname) {
+        foreach ($this->plugins_information as $plugin_name => $information) {
+            if (array_key_exists('oldname', $information) && $information['oldname'] === $oldname) {
                // Return information if oldname specified in parsed directory matches passed value
                 return [
                     'directory'    => $plugin_name,

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -557,7 +557,7 @@ class Plugin extends CommonDBTM
         $information = $this->plugins_information[$plugin_key] ?? $this->getInformationsFromDirectory($plugin_key);
         $new_specs    = $this->getNewInfoAndDirBasedOnOldName($plugin_key);
         $is_already_known = $plugin->getFromDBByCrit(['directory' => $plugin_key]);
-        $is_loadable      = !empty($informations);
+        $is_loadable      = !empty($information);
         $is_replaced      = $new_specs !== null;
 
         if (!$is_already_known && !$is_loadable) {
@@ -581,7 +581,7 @@ class Plugin extends CommonDBTM
                     [
                         'id'    => $plugin->fields['id'],
                         'state' => self::REPLACED,
-                    ] + $informations
+                    ] + $information
                 );
 
                 $this->unload($plugin_key);
@@ -623,7 +623,7 @@ class Plugin extends CommonDBTM
             // Plugin not known, add it in DB
             $this->add(
                 array_merge(
-                    $informations,
+                    $information,
                     [
                         'state'     => $is_replaced ? self::REPLACED : self::NOTINSTALLED,
                         'directory' => $plugin_key,
@@ -634,12 +634,12 @@ class Plugin extends CommonDBTM
         }
 
         if (
-            $informations['version'] != $plugin->fields['version']
+            $information['version'] != $plugin->fields['version']
             || $plugin_key != $plugin->fields['directory']
         ) {
             // Plugin known version differs from information or plugin has been renamed,
             // update information in database
-            $input              = $informations;
+            $input              = $information;
             $input['id']        = $plugin->fields['id'];
             $input['directory'] = $plugin_key;
             if (!in_array($plugin->fields['state'], [self::ANEW, self::NOTINSTALLED, self::NOTUPDATED])) {
@@ -768,7 +768,7 @@ class Plugin extends CommonDBTM
      *
      * @param string $oldname
      *
-     * @return null|array If a new directory is found, returns an array containing 'directory' and 'informations' keys.
+     * @return null|array If a new directory is found, returns an array containing 'directory' and 'information' keys.
      */
     private function getNewInfoAndDirBasedOnOldName($oldname)
     {
@@ -777,7 +777,7 @@ class Plugin extends CommonDBTM
                // Return information if oldname specified in parsed directory matches passed value
                 return [
                     'directory'    => $plugin_name,
-                    'informations' => $informations,
+                    'information' => $information,
                 ];
             }
         }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -129,7 +129,7 @@ class Plugin extends CommonDBTM
      *
      * @var array
      */
-    private ?array $plugins_informations = null;
+    private ?array $plugins_information = null;
 
     public static function getTypeName($nb = 0)
     {
@@ -514,11 +514,11 @@ class Plugin extends CommonDBTM
     private function loadPluginInformations(): void
     {
         // Run once
-        if ($this->plugins_informations !== null) {
+        if ($this->plugins_information !== null) {
             return;
         }
 
-        $plugins_informations = [];
+        $plugins_information = [];
         $plugins_directories = new AppendIterator();
         $plugins_directories->append(new DirectoryIterator(GLPI_ROOT . '/plugins'));
         $plugins_directories->append(new DirectoryIterator(GLPI_ROOT . '/marketplace'));
@@ -533,9 +533,9 @@ class Plugin extends CommonDBTM
             }
 
             $info = $this->getInformationsFromDirectory($plugin_name);
-            $plugins_informations[$plugin_name] = $info;
+            $plugins_information[$plugin_name] = $info;
         }
-        $this->plugins_informations = $plugins_informations;
+        $this->plugins_information = $plugins_information;
     }
 
     /**
@@ -550,7 +550,7 @@ class Plugin extends CommonDBTM
         $this->loadPluginInformations();
         $plugin = new self();
 
-        $informations = $this->plugins_informations[$plugin_key] ?? [];
+        $informations = $this->plugins_information[$plugin_key] ?? [];
         $new_specs    = $this->getNewInfoAndDirBasedOnOldName($plugin_key);
         $is_already_known = $plugin->getFromDBByCrit(['directory' => $plugin_key]);
         $is_loadable      = !empty($informations);
@@ -768,7 +768,7 @@ class Plugin extends CommonDBTM
      */
     private function getNewInfoAndDirBasedOnOldName($oldname)
     {
-        foreach ($this->plugins_informations as $plugin_name => $informations) {
+        foreach ($this->plugins_information as $plugin_name => $informations) {
             if (array_key_exists('oldname', $informations) && $informations['oldname'] === $oldname) {
                // Return information if oldname specified in parsed directory matches passed value
                 return [

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -519,7 +519,9 @@ class Plugin extends CommonDBTM
         }
 
         $plugins_informations = [];
-        $plugins_directories = new DirectoryIterator(GLPI_ROOT . '/plugins');
+        $plugins_directories = new AppendIterator();
+        $plugins_directories->append(new DirectoryIterator(GLPI_ROOT . '/plugins'));
+        $plugins_directories->append(new DirectoryIterator(GLPI_ROOT . '/marketplace'));
         foreach ($plugins_directories as $plugin_directory) {
             $plugin_name = $plugin_directory->getFilename();
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -507,11 +507,11 @@ class Plugin extends CommonDBTM
     }
 
     /**
-     * Build plugin info data once to save performances
+     * Get information for all plugins found on filesystem.
      *
      * @return array
      */
-    private function getPluginInformation(): array
+    private function getPluginsInformation(): array
     {
         // Run once
         if ($this->plugins_information !== null) {
@@ -552,7 +552,7 @@ class Plugin extends CommonDBTM
     {
         $plugin = new self();
 
-        $information = $this->getPluginInformation()[$plugin_key];
+        $information = $this->getPluginsInformation()[$plugin_key] ?? [];
         $new_specs    = $this->getNewInfoAndDirBasedOnOldName($plugin_key);
         $is_already_known = $plugin->getFromDBByCrit(['directory' => $plugin_key]);
         $is_loadable      = !empty($information);
@@ -770,7 +770,7 @@ class Plugin extends CommonDBTM
      */
     private function getNewInfoAndDirBasedOnOldName($oldname)
     {
-        foreach ($this->plugins_information as $plugin_name => $information) {
+        foreach ($this->getPluginsInformation() as $plugin_name => $information) {
             if (array_key_exists('oldname', $information) && $information['oldname'] === $oldname) {
                // Return information if oldname specified in parsed directory matches passed value
                 return [


### PR DESCRIPTION
I've noticed a while ago that the performances cost of plugins seemed to be a bit too high.
I can't tell if it was an exponential scale or not but the more plugins you had the slower GLPI would get.

I've decided to take a quick look at it today and managed to cut the plugins initialization process time by half.
There may be more optimizations to be found but it's a good first step.

This was done by moving some repetitive code that would be run multiple time with the same input into class properties that are only loaded once.

To benchmark the performances on my side, I've enabled about 20 plugins and added the code below to time the `plugin::init()` function, which is called once per page or ajax request and will load all the plugins.
```diff
diff --git a/src/Plugin.php b/src/Plugin.php
index 5ee1f541b1..d2592d808c 100644
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -229,6 +229,7 @@ class Plugin extends CommonDBTM
     public function init(bool $load_plugins = false, array $excluded_plugins = [])
     {
         global $DB;
+        $start_time = microtime(true);

         self::$plugins_state_checked = false;
         self::$activated_plugins = [];
@@ -270,6 +271,9 @@ class Plugin extends CommonDBTM
             // For plugins which require action after all plugin init
             Plugin::doHook(Hooks::POST_INIT);
         }
+
+        $end_time = microtime(true);
+        Toolbox::logDebug($end_time - $start_time);
     }

```

Then I went on the plugin page (could be any other page), pressed F5 and saved the logs.
Each logs seems to contain 4 entries, which would mean we have 1 page being loaded + 3 ajax requests.

First, here are the executions time in `10.0/bugfixes`:

![image](https://user-images.githubusercontent.com/42734840/231420853-e5cedf46-d663-4907-b637-046d58422d65.png)

The average time seems to be 0.1s second which is quite big as the total load time of the page is about 0.27ms (so plugins init account for almost half my execution time in a localhost environnement). 

And here are the exections time after applying the optimizations found in this PR:

![image](https://user-images.githubusercontent.com/42734840/231420762-8e4876a7-f0b3-4076-a488-acaa132f67bd.png)

We are down to around 0.05s which is a great improvement for instances with a lot of plugins, especially for things like loading dashboards where there may be a 20+ ajax requests at the same time,.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
