### PR TITLE
Fix forcetab parameter for namespaces

### DIFF
--- a/inc/includes.php
+++ b/inc/includes.php
@@ -115,19 +115,19 @@ if (!isset($_SESSION["MESSAGE_AFTER_REDIRECT"])) {
 }
 
 // Manage force tab
-if (isset($_REQUEST['forcetab'])) {
+if (isset($_UREQUEST['forcetab'])) {
     if (preg_match('/\/plugins\/([a-zA-Z]+)\/front\/([a-zA-Z]+).form.php/', $_SERVER['PHP_SELF'], $matches)) {
         $itemtype = 'plugin' . $matches[1] . $matches[2];
-        Session::setActiveTab($itemtype, $_REQUEST['forcetab']);
+        Session::setActiveTab($itemtype, $_UREQUEST['forcetab']);
     } else if (preg_match('/([a-zA-Z]+).form.php/', $_SERVER['PHP_SELF'], $matches)) {
         $itemtype = $matches[1];
-        Session::setActiveTab($itemtype, $_REQUEST['forcetab']);
+        Session::setActiveTab($itemtype, $_UREQUEST['forcetab']);
     } else if (preg_match('/\/plugins\/([a-zA-Z]+)\/front\/([a-zA-Z]+).php/', $_SERVER['PHP_SELF'], $matches)) {
         $itemtype = 'plugin' . $matches[1] . $matches[2];
-        Session::setActiveTab($itemtype, $_REQUEST['forcetab']);
+        Session::setActiveTab($itemtype, $_UREQUEST['forcetab']);
     } else if (preg_match('/([a-zA-Z]+).php/', $_SERVER['PHP_SELF'], $matches)) {
         $itemtype = $matches[1];
-        Session::setActiveTab($itemtype, $_REQUEST['forcetab']);
+        Session::setActiveTab($itemtype, $_UREQUEST['forcetab']);
     }
 }
 // Manage tabs

--- a/inc/includes.php
+++ b/inc/includes.php
@@ -115,19 +115,19 @@ if (!isset($_SESSION["MESSAGE_AFTER_REDIRECT"])) {
 }
 
 // Manage force tab
-if (isset($_UREQUEST['forcetab'])) {
+if (isset($_REQUEST['forcetab'])) {
     if (preg_match('/\/plugins\/([a-zA-Z]+)\/front\/([a-zA-Z]+).form.php/', $_SERVER['PHP_SELF'], $matches)) {
         $itemtype = 'plugin' . $matches[1] . $matches[2];
-        Session::setActiveTab($itemtype, $_UREQUEST['forcetab']);
+        Session::setActiveTab($itemtype, $_REQUEST['forcetab']);
     } else if (preg_match('/([a-zA-Z]+).form.php/', $_SERVER['PHP_SELF'], $matches)) {
         $itemtype = $matches[1];
-        Session::setActiveTab($itemtype, $_UREQUEST['forcetab']);
+        Session::setActiveTab($itemtype, $_REQUEST['forcetab']);
     } else if (preg_match('/\/plugins\/([a-zA-Z]+)\/front\/([a-zA-Z]+).php/', $_SERVER['PHP_SELF'], $matches)) {
         $itemtype = 'plugin' . $matches[1] . $matches[2];
-        Session::setActiveTab($itemtype, $_UREQUEST['forcetab']);
+        Session::setActiveTab($itemtype, $_REQUEST['forcetab']);
     } else if (preg_match('/([a-zA-Z]+).php/', $_SERVER['PHP_SELF'], $matches)) {
         $itemtype = $matches[1];
-        Session::setActiveTab($itemtype, $_UREQUEST['forcetab']);
+        Session::setActiveTab($itemtype, $_REQUEST['forcetab']);
     }
 }
 // Manage tabs

--- a/src/Toolbox/Sanitizer.php
+++ b/src/Toolbox/Sanitizer.php
@@ -230,7 +230,7 @@ class Sanitizer
         $class_match = [];
 
         return preg_match(
-            '/^(?<class>(([a-zA-Z0-9_]+\\\)+[a-zA-Z0-9_]+))(:?:[a-zA-Z0-9_]+)?(\$[0-9]+)*$/',
+            '/^(?<class>(([a-zA-Z0-9_]+\\\)+[a-zA-Z0-9_]+))(:?:[a-zA-Z0-9_]+)?(\$[0-9]+)?$/',
             $value,
             $class_match
         ) && class_exists($class_match['class']);

--- a/src/Toolbox/Sanitizer.php
+++ b/src/Toolbox/Sanitizer.php
@@ -219,6 +219,7 @@ class Sanitizer
 
     /**
      * Check wether the value correspond to a valid namespaced class (or a callable identifier related to a valid class).
+     * Note: also support the {namespace}${tab number} format used for tab identifications
      *
      * @param string $value
      *
@@ -227,8 +228,12 @@ class Sanitizer
     public static function isNsClassOrCallableIdentifier(string $value): bool
     {
         $class_match = [];
-        return preg_match('/^(?<class>(([a-zA-Z0-9_]+\\\)+[a-zA-Z0-9_]+))(:?:[a-zA-Z0-9_]+)?$/', $value, $class_match)
-            && class_exists($class_match['class']);
+
+        return preg_match(
+            '/^(?<class>(([a-zA-Z0-9_]+\\\)+[a-zA-Z0-9_]+))(:?:[a-zA-Z0-9_]+)?(\$[0-9]+)*$/',
+            $value,
+            $class_match
+        ) && class_exists($class_match['class']);
     }
 
     /**

--- a/tests/units/Glpi/Toolbox/Sanitizer.php
+++ b/tests/units/Glpi/Toolbox/Sanitizer.php
@@ -618,6 +618,10 @@ TXT;
             'value'    => 'Glpi\\\\Socket',
             'is_class' => false, // namespace separator are escaped, so it is not considered as a valid classname
         ];
+        yield [
+            'value'    => 'Glpi\Dashboard\Dashboard$1',
+            'is_class' => true, // special format for tab names
+        ];
     }
 
     /**


### PR DESCRIPTION
Tab names that contains name space (e.g. `GlpiPlugin\MyPlugin\Config`) can't be used with the `forcetab` query parameter as `\` are converted into `\\` by our processing of `$_REQUEST`.

Fixed by using `$_UREQUEST` instead (but maybe doing an str_replace on `$_REQUEST` instead would be safer ?).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
