### PR TITLE
feat(saved search): restore the ability to order the list

### DIFF
--- a/ajax/savedsearch.php
+++ b/ajax/savedsearch.php
@@ -92,7 +92,7 @@ if ($action == 'display_mine') {
 }
 
 if ($action == 'reorder') {
-    $savedsearch->saveOrder($_GET['ids']);
+    $savedsearch->saveOrder($_POST['ids']);
     header("Content-Type: application/json; charset=UTF-8");
     echo json_encode(['res' => true]);
 }

--- a/css/includes/components/_saved-searches.scss
+++ b/css/includes/components/_saved-searches.scss
@@ -187,7 +187,7 @@ body.horizontal-layout {
 
         &::before {
             content: "\ec01";
-            font-family: "tabler-icons";
+            font-family: tabler-icons;
             font-weight: 900;
             color: $secondary;
             margin-left: -1rem;

--- a/css/includes/components/_saved-searches.scss
+++ b/css/includes/components/_saved-searches.scss
@@ -167,3 +167,24 @@ body.horizontal-layout {
         min-width: 200px;
     }
 }
+
+.sortable-savedsearches {
+    .sortable-placeholder {
+        background: #e7f06367;
+        border: 1px dashed #ccc;
+        min-height: 80px;
+        min-width: 50px;
+        padding: 10px;
+        margin: 10px;
+        opacity: 0.5;
+    }
+
+    .grip-savedsearch {
+        cursor: pointer;
+        cursor: grab;
+
+        &:active {
+            cursor: grabbing;
+        }
+    }
+}

--- a/css/includes/components/_saved-searches.scss
+++ b/css/includes/components/_saved-searches.scss
@@ -172,8 +172,6 @@ body.horizontal-layout {
     .sortable-placeholder {
         background: #e7f06367;
         border: 1px dashed #ccc;
-        min-height: 80px;
-        min-width: 50px;
         padding: 10px;
         margin: 10px;
         opacity: 0.5;
@@ -182,6 +180,7 @@ body.horizontal-layout {
     .grip-savedsearch {
         cursor: pointer;
         cursor: grab;
+        padding-right: 10px;
 
         &:active {
             cursor: grabbing;

--- a/css/includes/components/_saved-searches.scss
+++ b/css/includes/components/_saved-searches.scss
@@ -180,10 +180,18 @@ body.horizontal-layout {
     .grip-savedsearch {
         cursor: pointer;
         cursor: grab;
-        padding-right: 10px;
 
         &:active {
             cursor: grabbing;
+        }
+
+        &::before {
+            content: "\ec01";
+            font-family: "tabler-icons";
+            font-weight: 900;
+            color: $secondary;
+            margin-left: -1rem;
+            width: 1rem;
         }
     }
 }

--- a/css/includes/components/_saved-searches.scss
+++ b/css/includes/components/_saved-searches.scss
@@ -185,7 +185,7 @@ body.horizontal-layout {
             cursor: grabbing;
         }
 
-        &::before {
+        &:hover::before {
             content: "\ec01";
             font-family: tabler-icons;
             font-weight: 900;

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -874,7 +874,37 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
             $searches[$data['id']] = $data;
         }
 
-        return $searches;
+        // get personal order
+        $user               = new User();
+        $personalorderfield = $this->getPersonalOrderField();
+        $ordered            = [];
+
+        $personalorder = [];
+        if ($user->getFromDB(Session::getLoginUserID())) {
+            $personalorder = importArrayFromDB($user->fields[$personalorderfield]);
+        }
+        if (!is_array($personalorder)) {
+            $personalorder = [];
+        }
+
+        // Add on personal order
+        if (count($personalorder)) {
+            foreach ($personalorder as $id) {
+                if (isset($searches[$id])) {
+                    $ordered[$id] = $searches[$id];
+                    unset($searches[$id]);
+                }
+            }
+        }
+
+        // Add unsaved in order
+        if (count($searches)) {
+            foreach ($searches as $id => $val) {
+                $ordered[$id] = $val;
+            }
+        }
+
+        return $ordered;
     }
 
     /**

--- a/templates/layout/parts/saved_searches.html.twig
+++ b/templates/layout/parts/saved_searches.html.twig
@@ -45,6 +45,15 @@
       </span>
 
       <li class="ms-auto btn-list me-1 flex-nowrap">
+         <label class="form-check form-switch btn btn-sm btn-ghost-secondary me-0 me-sm-1 px-1 mb-0 flex-column-reverse flex-sm-row"
+               data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-trigger="hover"
+               title="{{ __('Toggle sorting mode') }}">
+            <input type="checkbox" class="form-check-input ms-0 me-1 mt-0 sorting-mode" role="button"
+                  {{ session('glpisorting_mode') ? 'checked' : '' }} autocomplete="off" />
+            <span class="form-check-label mb-1 mb-sm-0">
+               <i class="fa-solid fa-sort"></i>
+            </span>
+         </label>
          <a href="{{ path('front/savedsearch.php') }}" class="btn btn-sm btn-icon btn-ghost-secondary"
             data-bs-toggle="tooltip" data-bs-placement="bottom"
             title="{{ __('Manage all saved searches') }}">

--- a/templates/layout/parts/saved_searches.html.twig
+++ b/templates/layout/parts/saved_searches.html.twig
@@ -51,7 +51,7 @@
             <input type="checkbox" class="form-check-input ms-0 me-1 mt-0 sorting-mode" role="button"
                   {{ session('glpisorting_mode') ? 'checked' : '' }} autocomplete="off" />
             <span class="form-check-label mb-1 mb-sm-0">
-               <i class="fa-solid fa-sort"></i>
+               <i class="ti ti-menu-order"></i>
             </span>
          </label>
          <a href="{{ path('front/savedsearch.php') }}" class="btn btn-sm btn-icon btn-ghost-secondary"

--- a/templates/layout/parts/saved_searches.html.twig
+++ b/templates/layout/parts/saved_searches.html.twig
@@ -45,15 +45,6 @@
       </span>
 
       <li class="ms-auto btn-list me-1 flex-nowrap">
-         <label class="form-check form-switch btn btn-sm btn-ghost-secondary me-0 me-sm-1 px-1 mb-0 flex-column-reverse flex-sm-row"
-               data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-trigger="hover"
-               title="{{ __('Toggle sorting mode') }}">
-            <input type="checkbox" class="form-check-input ms-0 me-1 mt-0 sorting-mode" role="button"
-                  {{ session('glpisorting_mode') ? 'checked' : '' }} autocomplete="off" />
-            <span class="form-check-label mb-1 mb-sm-0">
-               <i class="ti ti-menu-order"></i>
-            </span>
-         </label>
          <a href="{{ path('front/savedsearch.php') }}" class="btn btn-sm btn-icon btn-ghost-secondary"
             data-bs-toggle="tooltip" data-bs-placement="bottom"
             title="{{ __('Manage all saved searches') }}">

--- a/templates/layout/parts/saved_searches_list.html.twig
+++ b/templates/layout/parts/saved_searches_list.html.twig
@@ -37,27 +37,55 @@
    </div>
 {% endif %}
 
+<table class='table table-striped table-hover card-table'>
+<tbody class='sortable-savedsearches'>
 {% for search in saved_searches %}
-   <div class="savedsearches-item list-group-item search-line d-flex align-items-center pe-1 {{ active == search['id'] ? 'active' : '' }}"
-         data-id="{{ search['id'] }}">
-      <a href="{{ 'SavedSearch'|itemtype_search_path }}?action=load&amp;id={{ search['id'] }}"
-         class="d-block saved-searches-link text-truncate">
-         {{ search['name']|verbatim_value }}
-      </a>
-      <div class="{{ search['is_default'] > 0 ? '' : 'list-group-item-actions' }} ms-auto default-ctrl">
-         <i class="{{ search['is_default'] > 0 ? 'fas' : 'far' }} fa-star fa-xs mark-default me-1"
-            title="{{ search['is_default'] > 0 ? __('Default search') : __('mark as default') }}"
-            data-bs-toggle="tooltip" data-bs-placement="right"
-            role="button"></i>
-      </div>
-      <div class="d-flex flex-nowrap align-items-center">
-         {% if search['is_private'] == 1 %}
-         <i class="ti ti-lock fa-xs text-muted me-1" title="{{ __('private') }}"
-            data-bs-toggle="tooltip" data-bs-placement="right"></i>
-         {% endif %}
-         <span class="badge">
-            {{ search['count']|raw }}
-         </span>
-      </div>
-   </div>
+   <tr class='tab_bg_1 savedsearch' data-id="{{ search['id'] }}">
+      <td><i class='fas fa-grip-horizontal grip-savedsearch'></i></td>
+      <td class="savedsearches-item list-group-item search-line d-flex align-items-center pe-1 {{ active == search['id'] ? 'active' : '' }}"
+            data-id="{{ search['id'] }}">
+         <a href="{{ 'SavedSearch'|itemtype_search_path }}?action=load&amp;id={{ search['id'] }}"
+            class="d-block saved-searches-link text-truncate">
+            {{ search['name']|verbatim_value }}
+         </a>
+         <div class="{{ search['is_default'] > 0 ? '' : 'list-group-item-actions' }} ms-auto default-ctrl">
+            <i class="{{ search['is_default'] > 0 ? 'fas' : 'far' }} fa-star fa-xs mark-default me-1"
+               title="{{ search['is_default'] > 0 ? __('Default search') : __('mark as default') }}"
+               data-bs-toggle="tooltip" data-bs-placement="right"
+               role="button"></i>
+         </div>
+         <div class="d-flex flex-nowrap align-items-center">
+            {% if search['is_private'] == 1 %}
+            <i class="ti ti-lock fa-xs text-muted me-1" title="{{ __('private') }}"
+               data-bs-toggle="tooltip" data-bs-placement="right"></i>
+            {% endif %}
+            <span class="badge">
+               {{ search['count']|raw }}
+            </span>
+         </div>
+      </td>
+   </tr>
 {% endfor %}
+</tbody>
+</table>
+
+<script type="text/javascript">
+$(function() {
+   sortable('.sortable-savedsearches', {
+      handle: '.grip-savedsearch',
+      placeholder: '<tr><td class="sortable-placeholder">&nbsp;</td></tr>'
+   })
+   $('.sortable-savedsearches').on('sortupdate', function(e) {
+      var _ids = $('tr.savedsearch').map(function(idx, ele) {
+         return $(ele).data('id');
+      }).get();
+
+      $.post(CFG_GLPI['root_doc']+'/ajax/savedsearch.php', {
+         'action': 'reorder',
+         'ids': _ids,
+      });
+
+      displayAjaxMessageAfterRedirect();
+   });
+});
+</script>

--- a/templates/layout/parts/saved_searches_list.html.twig
+++ b/templates/layout/parts/saved_searches_list.html.twig
@@ -39,29 +39,26 @@
 
 <div class='sortable-savedsearches'>
 {% for search in saved_searches %}
-   <div class='savedsearch' data-id="{{ search['id'] }}">
-      <div class="savedsearches-item list-group-item search-line d-flex align-items-center pe-1 {{ active == search['id'] ? 'active' : '' }}"
-            data-id="{{ search['id'] }}">
-         <i class='fas fa-grip-horizontal grip-savedsearch' style="display: none;"></i>
-         <a href="{{ 'SavedSearch'|itemtype_search_path }}?action=load&amp;id={{ search['id'] }}"
-            class="d-block saved-searches-link text-truncate">
-            {{ search['name']|verbatim_value }}
-         </a>
-         <div class="{{ search['is_default'] > 0 ? '' : 'list-group-item-actions' }} ms-auto default-ctrl">
-            <i class="{{ search['is_default'] > 0 ? 'fas' : 'far' }} fa-star fa-xs mark-default me-1"
-               title="{{ search['is_default'] > 0 ? __('Default search') : __('mark as default') }}"
-               data-bs-toggle="tooltip" data-bs-placement="right"
-               role="button"></i>
-         </div>
-         <div class="d-flex flex-nowrap align-items-center">
-            {% if search['is_private'] == 1 %}
-            <i class="ti ti-lock fa-xs text-muted me-1" title="{{ __('private') }}"
-               data-bs-toggle="tooltip" data-bs-placement="right"></i>
-            {% endif %}
-            <span class="badge">
-               {{ search['count']|raw }}
-            </span>
-         </div>
+   <div class="savedsearches-item list-group-item search-line d-flex align-items-center pe-1 {{ active == search['id'] ? 'active' : '' }}"
+         data-id="{{ search['id'] }}">
+      <a href="{{ 'SavedSearch'|itemtype_search_path }}?action=load&amp;id={{ search['id'] }}"
+         class="d-block saved-searches-link text-truncate">
+         {{ search['name']|verbatim_value }}
+      </a>
+      <div class="{{ search['is_default'] > 0 ? '' : 'list-group-item-actions' }} ms-auto default-ctrl">
+         <i class="{{ search['is_default'] > 0 ? 'fas' : 'far' }} fa-star fa-xs mark-default me-1"
+            title="{{ search['is_default'] > 0 ? __('Default search') : __('mark as default') }}"
+            data-bs-toggle="tooltip" data-bs-placement="right"
+            role="button"></i>
+      </div>
+      <div class="d-flex flex-nowrap align-items-center">
+         {% if search['is_private'] == 1 %}
+         <i class="ti ti-lock fa-xs text-muted me-1" title="{{ __('private') }}"
+            data-bs-toggle="tooltip" data-bs-placement="right"></i>
+         {% endif %}
+         <span class="badge">
+            {{ search['count']|raw }}
+         </span>
       </div>
    </div>
 {% endfor %}
@@ -70,11 +67,10 @@
 <script type="text/javascript">
 $(function() {
    sortable('.sortable-savedsearches', {
-      handle: '.grip-savedsearch',
-      placeholder: '<div class="sortable-placeholder">&nbsp;</div>'
+      placeholder: '<div class="sortable-placeholder">&nbsp;</div>',
    })
    $('.sortable-savedsearches').on('sortupdate', function(e) {
-      var _ids = $('.savedsearch').map(function(idx, ele) {
+      var _ids = $('.savedsearches-item').map(function(idx, ele) {
          return $(ele).data('id');
       }).get();
 
@@ -86,10 +82,12 @@ $(function() {
       displayAjaxMessageAfterRedirect();
    });
    var sorting_mode = function() {
-      if ($('.sorting-mode').is(":checked")) {
-         $('.grip-savedsearch').show();
+      var _mode = $('.sorting-mode').is(":checked");
+      $('.savedsearches-item').toggleClass('grip-savedsearch', _mode);
+      if (_mode) {
+         sortable('.sortable-savedsearches', 'enable');
       } else {
-         $('.grip-savedsearch').hide();
+         sortable('.sortable-savedsearches', 'disable');
       }
    };
    $('.sorting-mode').on('change', function(e) {

--- a/templates/layout/parts/saved_searches_list.html.twig
+++ b/templates/layout/parts/saved_searches_list.html.twig
@@ -37,13 +37,12 @@
    </div>
 {% endif %}
 
-<table class='table table-striped table-hover card-table' style='table-layout:fixed;'>
-<tbody class='sortable-savedsearches'>
+<div class='sortable-savedsearches'>
 {% for search in saved_searches %}
-   <tr class='tab_bg_1 savedsearch' data-id="{{ search['id'] }}">
-      <td class="col-2"><i class='fas fa-grip-horizontal grip-savedsearch'></i></td>
-      <td class="col-12 savedsearches-item list-group-item search-line d-flex align-items-center pe-1 {{ active == search['id'] ? 'active' : '' }}"
+   <div class='savedsearch' data-id="{{ search['id'] }}">
+      <div class="savedsearches-item list-group-item search-line d-flex align-items-center pe-1 {{ active == search['id'] ? 'active' : '' }}"
             data-id="{{ search['id'] }}">
+         <i class='fas fa-grip-horizontal grip-savedsearch' style="display: none;"></i>
          <a href="{{ 'SavedSearch'|itemtype_search_path }}?action=load&amp;id={{ search['id'] }}"
             class="d-block saved-searches-link text-truncate">
             {{ search['name']|verbatim_value }}
@@ -63,20 +62,19 @@
                {{ search['count']|raw }}
             </span>
          </div>
-      </td>
-   </tr>
+      </div>
+   </div>
 {% endfor %}
-</tbody>
-</table>
+</div>
 
 <script type="text/javascript">
 $(function() {
    sortable('.sortable-savedsearches', {
       handle: '.grip-savedsearch',
-      placeholder: '<tr><td colspan="2" class="sortable-placeholder">&nbsp;</td></tr>'
+      placeholder: '<div class="sortable-placeholder">&nbsp;</div>'
    })
    $('.sortable-savedsearches').on('sortupdate', function(e) {
-      var _ids = $('tr.savedsearch').map(function(idx, ele) {
+      var _ids = $('.savedsearch').map(function(idx, ele) {
          return $(ele).data('id');
       }).get();
 
@@ -87,5 +85,16 @@ $(function() {
 
       displayAjaxMessageAfterRedirect();
    });
+   var sorting_mode = function() {
+      if ($('.sorting-mode').is(":checked")) {
+         $('.grip-savedsearch').show();
+      } else {
+         $('.grip-savedsearch').hide();
+      }
+   };
+   $('.sorting-mode').on('change', function(e) {
+      sorting_mode();
+   });
+   sorting_mode();
 });
 </script>

--- a/templates/layout/parts/saved_searches_list.html.twig
+++ b/templates/layout/parts/saved_searches_list.html.twig
@@ -37,12 +37,12 @@
    </div>
 {% endif %}
 
-<table class='table table-striped table-hover card-table'>
+<table class='table table-striped table-hover card-table' style='table-layout:fixed;'>
 <tbody class='sortable-savedsearches'>
 {% for search in saved_searches %}
    <tr class='tab_bg_1 savedsearch' data-id="{{ search['id'] }}">
-      <td><i class='fas fa-grip-horizontal grip-savedsearch'></i></td>
-      <td class="savedsearches-item list-group-item search-line d-flex align-items-center pe-1 {{ active == search['id'] ? 'active' : '' }}"
+      <td class="col-2"><i class='fas fa-grip-horizontal grip-savedsearch'></i></td>
+      <td class="col-12 savedsearches-item list-group-item search-line d-flex align-items-center pe-1 {{ active == search['id'] ? 'active' : '' }}"
             data-id="{{ search['id'] }}">
          <a href="{{ 'SavedSearch'|itemtype_search_path }}?action=load&amp;id={{ search['id'] }}"
             class="d-block saved-searches-link text-truncate">
@@ -73,7 +73,7 @@
 $(function() {
    sortable('.sortable-savedsearches', {
       handle: '.grip-savedsearch',
-      placeholder: '<tr><td class="sortable-placeholder">&nbsp;</td></tr>'
+      placeholder: '<tr><td colspan="2" class="sortable-placeholder">&nbsp;</td></tr>'
    })
    $('.sortable-savedsearches').on('sortupdate', function(e) {
       var _ids = $('tr.savedsearch').map(function(idx, ele) {

--- a/templates/layout/parts/saved_searches_list.html.twig
+++ b/templates/layout/parts/saved_searches_list.html.twig
@@ -39,7 +39,7 @@
 
 <div class='sortable-savedsearches'>
 {% for search in saved_searches %}
-   <div class="savedsearches-item list-group-item search-line d-flex align-items-center pe-1 {{ active == search['id'] ? 'active' : '' }}"
+   <div class="savedsearches-item grip-savedsearch list-group-item search-line d-flex align-items-center pe-1 {{ active == search['id'] ? 'active' : '' }}"
          data-id="{{ search['id'] }}">
       <a href="{{ 'SavedSearch'|itemtype_search_path }}?action=load&amp;id={{ search['id'] }}"
          class="d-block saved-searches-link text-truncate">
@@ -81,18 +81,5 @@ $(function() {
 
       displayAjaxMessageAfterRedirect();
    });
-   var sorting_mode = function() {
-      var _mode = $('.sorting-mode').is(":checked");
-      $('.savedsearches-item').toggleClass('grip-savedsearch', _mode);
-      if (_mode) {
-         sortable('.sortable-savedsearches', 'enable');
-      } else {
-         sortable('.sortable-savedsearches', 'disable');
-      }
-   };
-   $('.sorting-mode').on('change', function(e) {
-      sorting_mode();
-   });
-   sorting_mode();
 });
 </script>


### PR DESCRIPTION
In 9.5 it was possible to manually order the list of saved searches, which was not possible since 10.0.


Before:

![image](https://user-images.githubusercontent.com/8530352/231761554-6e2fd386-9ddf-42cf-85e6-15f7ef1ee1cd.png)

After:

![image](https://user-images.githubusercontent.com/8530352/231761262-288bbab3-ad88-4f98-9a9c-26a033d57cae.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27549
