### PR TITLE
Fix JS toast style

### DIFF
--- a/js/glpi_dialog.js
+++ b/js/glpi_dialog.js
@@ -341,10 +341,10 @@ const glpi_toast = (title, message, css_class, options = {}) => {
         animation_extra_classes: 'animate__delay-2s animate__slow'
     }, options);
 
-    const animation_classes = options.animated ? `animate_animated ${options.animation} ${options.animation_extra_classes}` : '';
+    const animation_classes = options.animated ? `animate__animated ${options.animation} ${options.animation_extra_classes}` : '';
     const html = `<div class='toast-container bottom-0 end-0 p-3 messages_after_redirect'>
-      <div id='toast_js_${toast_id}' class='toast ${css_class} ${animation_classes}' role='alert' aria-live='assertive' aria-atomic='true'>
-         <div class='toast-header'>
+      <div id='toast_js_${toast_id}' class='toast ${animation_classes}' role='alert' aria-live='assertive' aria-atomic='true'>
+         <div class='toast-header ${css_class}'>
             <strong class='me-auto'>${title}</strong>
             <button type='button' class='btn-close' data-bs-dismiss='toast' aria-label='${__('Close')}'></button>
          </div>


### PR DESCRIPTION
Toasts created by the `glpi_toast` javascript function are not identical to their `Session::addMessageAfterRedirect` PHP counterparts.

PHP toast:

![image](https://user-images.githubusercontent.com/42734840/231768289-b3344dad-e7e6-46c6-aa9b-da0ebd748aa8.png)

JS toast:

![image](https://user-images.githubusercontent.com/42734840/231768165-bf689f20-34ef-4122-bc8b-2f4c14148825.png)

JS toast after changes:

![image](https://user-images.githubusercontent.com/42734840/231768399-5dec28df-16ed-425e-b878-aeb368ec7f9c.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
