### PR TITLE
fix(unicity): ability to test text fields

### DIFF
--- a/src/FieldUnicity.php
+++ b/src/FieldUnicity.php
@@ -294,7 +294,7 @@ class FieldUnicity extends CommonDropdown
        //Search option for this type
         if ($target = getItemForItemtype($itemtype)) {
            //Do not check unicity on fields in DB with theses types
-            $blacklisted_types = ['longtext', 'text'];
+            $blacklisted_types = ['longtext'];
 
            //Construct list
             $values = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A

I think this blacklist was originally done for performance reasons, but it blocks a cool feature.

When for example you want to find duplicate users who have the same "UserDN" (which is a text field).

On a database with 17K users, including a hundred duplicates on the UserDN, the query to find the duplications takes 0.153s