### PR TITLE
Improve Kanban performances when loading user pictures

### DIFF
--- a/js/modules/Kanban/Kanban.js
+++ b/js/modules/Kanban/Kanban.js
@@ -1432,7 +1432,6 @@ class GLPIKanbanRights {
                     let user_img = null;
                     $.ajax({
                         url: (self.ajax_root + "getUserPicture.php"),
-                        async: false,
                         data: {
                             users_id: [items_id],
                             size: self.team_image_size,

--- a/js/modules/Kanban/Kanban.js
+++ b/js/modules/Kanban/Kanban.js
@@ -1432,6 +1432,7 @@ class GLPIKanbanRights {
                     let user_img = null;
                     $.ajax({
                         url: (self.ajax_root + "getUserPicture.php"),
+                        async: false,
                         data: {
                             users_id: [items_id],
                             size: self.team_image_size,
@@ -1978,11 +1979,11 @@ class GLPIKanbanRights {
                         column_field: self.column_field.id
                     }
                 }).done(function(columns, textStatus, jqXHR) {
+                    clearColumns();
+                    self.columns = columns;
                     preloadBadgeCache({
                         trim_cache: true
                     });
-                    clearColumns();
-                    self.columns = columns;
                     fillColumns();
                     // Re-filter kanban
                     self.filter();


### PR DESCRIPTION
Kanban load each users pictures to display using **synchronous** ajax requests.

This is problematic when you have a lot of tickets with 100+ different user pictures to load.
There is a gif example in the internal ref where the page takes 55 seconds to load because of this, as each images must be loaded one by one while the execution of the page is paused.

@cconard96 Can you confirm that this change (setting the request as asynchronous) is safe ? I see a few more `async: false` parameters in the same file, can they be removed as well ?

An even better improvement would be to get the picture directly from the main `action=refresh` ajax request:

![image](https://user-images.githubusercontent.com/42734840/232070668-70ce6343-87f6-4d18-a541-d34a1d0e5283.png)

It seems we already have all information needed in this endpoint, this would help reduce the amount of ajax requests by loading all the data at once.

Is this something you could look into if you have some time ?

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27631
