### PR TITLE
Ensure user is logged when accessing saved searches

### DIFF
--- a/front/savedsearch.php
+++ b/front/savedsearch.php
@@ -33,9 +33,9 @@
  * ---------------------------------------------------------------------
  */
 
-if (!defined('GLPI_ROOT')) {
-    include('../inc/includes.php');
-}
+include('../inc/includes.php');
+
+Session::checkLoginUser();
 
 if (Session::getCurrentInterface() == "helpdesk") {
     Html::helpHeader(SavedSearch::getTypeName(Session::getPluralNumber()));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14529

`front/savedsearch.php` file was probably included by another front script in previous GLPI versions. This is no longer the case.

When accessing this page without an active session, it triggers an error. Checking session state fixes this.