### PR TITLE
Handle missing itemtype on log display

### DIFF
--- a/src/Log.php
+++ b/src/Log.php
@@ -578,7 +578,7 @@ class Log extends CommonDBTM
                         $tmp['field']   = NOT_AVAILABLE;
                         if ($linktype_field = explode('#', $data["itemtype_link"])) {
                             $linktype     = $linktype_field[0];
-                            $tmp['field'] = $linktype::getTypeName();
+                            $tmp['field'] = is_a($linktype, CommonGLPI::class, true) ? $linktype::getTypeName() : $linktype;
                         }
                         $tmp['change'] = sprintf(
                             __('%1$s: %2$s'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Sometimes, log can contain an entry related to an itemtype that is no longer available. In my case, it was an entry containing `itemtype_link='PluginFieldsProfile#right'`, but the `fields` plugin was inactive.

Following error was triggered:
```
glpiphplog.CRITICAL:   *** Uncaught Exception Error: Class "PluginFieldsProfile" not found in /var/www/glpi/src/Log.php at line 581
  Backtrace :
  src/Log.php:316                                    Log::getHistoryData()
  src/Log.php:107                                    Log::showForItem()
  src/CommonGLPI.php:689                             Log::displayTabContentForItem()
  ajax/common.tabs.php:116                           CommonGLPI::displayStandardTab()
```