### PR TITLE
Fix DB creation at install on PHP 8.1+

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -267,6 +267,7 @@ function step4($databasename, $newdatabasename)
 
    //Check if the port is in url
     $hostport = explode(":", $host);
+    mysqli_report(MYSQLI_REPORT_OFF);
     if (count($hostport) < 2) {
         $link = new mysqli($hostport[0], $user, $password);
     } else {

--- a/src/Console/Database/InstallCommand.php
+++ b/src/Console/Database/InstallCommand.php
@@ -224,6 +224,7 @@ class InstallCommand extends AbstractConfigureCommand
             return self::ERROR_CANNOT_CREATE_ENCRYPTION_KEY_FILE;
         }
 
+        mysqli_report(MYSQLI_REPORT_OFF);
         $mysqli = new \mysqli();
         if (intval($db_port) > 0) {
            // Network port


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

Since PHP 8.1, `mysqli` errors are triggering errors instead of warnings (see https://php.watch/versions/8.1/mysqli-error-mode).

We already fixed some cases, but not all. For instance, creating a new DB from install process was not working anymore, due to following error:
```
glpiphplog.CRITICAL:   *** Uncaught Exception mysqli_sql_exception: Unknown database 'test' in /var/www/glpi/install/install.php at line 319
  Backtrace :
  install/install.php:319                            mysqli->select_db()
  install/install.php:598                            step4()
```