### PR TITLE
Fix showing closed column ITIL kanban

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8730,6 +8730,10 @@ abstract class CommonITILObject extends CommonDBTM
         if (empty($column_ids)) {
             return [];
         }
+        // Fill columns with empty arrays for each column id to avoid missing columns in the kanban
+        foreach ($column_ids as $column_id) {
+            $columns[$column_id] = [];
+        }
         // Never try getting cards in drop-only columns
         $columns_defined = self::getAllKanbanColumns('status');
         $statuses_from_db = array_filter($column_ids, static function ($id) use ($columns_defined) {
@@ -8741,11 +8745,14 @@ abstract class CommonITILObject extends CommonDBTM
                 'status' => $statuses_from_db
             ];
         }
-        if (!isset($criteria['status'])) {
-            // Avoid fetching everything when nothing is needed
-            return [];
+
+        // Avoid fetching everything when nothing is needed
+        if (isset($criteria['status'])) {
+            $items = self::getDataToDisplayOnKanban($ID, $criteria);
+        } else {
+            $items = [];
         }
-        $items      = self::getDataToDisplayOnKanban($ID, $criteria);
+
 
         $extracolumns = self::getAllKanbanColumns($column_field, $column_ids, $get_default);
         foreach ($extracolumns as $column_id => $column) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Since the closed column for ITIL Kanbans are "drop only", the `getKanbanColumns` method was exiting early with an empty array which results in the JS code not adding any new columns. This meant that to see the column after selecting it under "Add Column", you had to refresh the page.