### PR TITLE
Reapply filters after showing Kanban column

### DIFF
--- a/js/modules/Kanban/Kanban.js
+++ b/js/modules/Kanban/Kanban.js
@@ -2111,6 +2111,7 @@ class GLPIKanbanRights {
             }
 
             refreshSortables();
+            self.filter();
         };
 
         /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Kanban filters were not reapplied after adding a new column. Newly shown columns would be unfiltered until the next background refresh or the filters were changed. Now, the filters are immediately re-applied after the new column is shown.