### PR TITLE
fix(ola): missing value in dropdown

### DIFF
--- a/src/OlaLevel.php
+++ b/src/OlaLevel.php
@@ -112,7 +112,8 @@ class OlaLevel extends LevelAgreementLevel
             self::dropdownExecutionTime(
                 'execution_time',
                 ['max_time' => $delay,
-                    'used'     => self::getAlreadyUsedExecutionTime($ola->fields['id'])
+                    'used'     => self::getAlreadyUsedExecutionTime($ola->fields['id']),
+                    'type'     => $ola->fields['type'],
                 ]
             );
 

--- a/src/OlaLevel.php
+++ b/src/OlaLevel.php
@@ -263,6 +263,7 @@ class OlaLevel extends LevelAgreementLevel
             'execution_time',
             ['max_time'  => $delay,
                 'used'      => self::getAlreadyUsedExecutionTime($ola->fields['id']),
+                'type'      => $ola->fields['type'],
                 'value'     => $this->fields['execution_time']
             ]
         );


### PR DESCRIPTION
In the OLA, the option `Time to own` or `Time to resolve` was missing, whereas they are proposed in the SLA

![image](https://user-images.githubusercontent.com/8530352/232793097-7cbbcef5-ff71-4ec3-81a9-1b4e27deb6b3.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27667
