### PR TITLE
set timeline default positition when answering a itilobject where use…

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -6483,6 +6483,7 @@ abstract class CommonITILObject extends CommonDBTM
        // 1) rule for followups, documents, tasks and validations:
        //    Matrix for position of timeline objects
        //    R O A (R=Requester, O=Observer, A=AssignedTo)
+       //    0 0 0 -> depending on the interface: central -> right, helpdesk -> left
        //    0 0 1 -> Right
        //    0 1 0 -> Left
        //    0 1 1 -> R
@@ -6497,6 +6498,9 @@ abstract class CommonITILObject extends CommonDBTM
         $pos = self::TIMELINE_LEFT;
 
         $pos_matrix = [];
+        $pos_matrix[0][0][0] = Session::getCurrentInterface() == "central"
+            ? self::TIMELINE_RIGHT
+            : self::TIMELINE_LEFT;
         $pos_matrix[0][0][1] = self::TIMELINE_RIGHT;
         $pos_matrix[0][1][1] = self::TIMELINE_RIGHT;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Use case: you answering a ticket, but your forgot to assign it to yourself.
So you're not actor of this ticket.

Proposition to change the default position of the followup in the timeline, if you are in standard interface, in this use case, your followup will be placed at right.
