### PR TITLE
Add 'tag' and 'otherserial' to RuleAsset

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5677,6 +5677,14 @@ class CommonDBTM extends CommonGLPI
                 $input['_auto'] = 0;
             }
 
+            //if agent exist pass the 'tag' to RuleAssetCollection
+            if (Toolbox::hasTrait($this, \Glpi\Features\Inventoriable::class)) {
+                $agent = $this->getInventoryAgent();
+                if ($agent !== null) {
+                    $input['tag'] = $agent->fields['tag'];
+                }
+            }
+
             // Set the condition (add or update)
             $output = $ruleasset->processAllRules($input, [], [], [
                 'condition' => $condition

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5678,7 +5678,10 @@ class CommonDBTM extends CommonGLPI
             }
 
             //if agent exist pass the 'tag' to RuleAssetCollection
-            if (Toolbox::hasTrait($this, \Glpi\Features\Inventoriable::class)) {
+            if (
+                Toolbox::hasTrait($this, \Glpi\Features\Inventoriable::class)
+                && method_exists($this, 'getInventoryAgent')
+            ) {
                 $agent = $this->getInventoryAgent();
                 if ($agent !== null) {
                     $input['tag'] = $agent->fields['tag'];

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5684,7 +5684,7 @@ class CommonDBTM extends CommonGLPI
             ) {
                 $agent = $this->getInventoryAgent();
                 if ($agent !== null) {
-                    $input['tag'] = $agent->fields['tag'];
+                    $input['_tag'] = $agent->fields['tag'];
                 }
             }
 

--- a/src/RuleAsset.php
+++ b/src/RuleAsset.php
@@ -136,7 +136,7 @@ class RuleAsset extends Rule
         $criterias['users_id']['type']            = 'dropdown_users';
         $criterias['users_id']['table']           = 'glpi_users';
 
-        $criterias['tag']['name']            = sprintf('%s > %s', Agent::getTypeName(1), __('Inventory tag'));
+        $criterias['_tag']['name']            = sprintf('%s > %s', Agent::getTypeName(1), __('Inventory tag'));
 
         $criterias['_locations_id_of_user']['table']     = 'glpi_locations';
         $criterias['_locations_id_of_user']['field']     = 'completename';

--- a/src/RuleAsset.php
+++ b/src/RuleAsset.php
@@ -136,6 +136,8 @@ class RuleAsset extends Rule
         $criterias['users_id']['type']            = 'dropdown_users';
         $criterias['users_id']['table']           = 'glpi_users';
 
+        $criterias['tag']['name']            = sprintf('%s > %s', Agent::getTypeName(1), __('Inventory tag'));
+
         $criterias['_locations_id_of_user']['table']     = 'glpi_locations';
         $criterias['_locations_id_of_user']['field']     = 'completename';
         $criterias['_locations_id_of_user']['name']      = __('User location');
@@ -193,6 +195,10 @@ class RuleAsset extends Rule
         $actions['comment']['table']            = '';
         $actions['comment']['field']            = 'comment';
         $actions['comment']['name']             = __('Comments');
+
+        $actions['otherserial']['name']              = __('Inventory number');
+        $actions['otherserial']['type']              = 'text';
+        $actions['otherserial']['force_actions']     = ['regex_result'];
 
         return $actions;
     }

--- a/tests/functional/Glpi/Inventory/Inventory.php
+++ b/tests/functional/Glpi/Inventory/Inventory.php
@@ -42,6 +42,7 @@ use OperatingSystem;
 use OperatingSystemArchitecture;
 use OperatingSystemServicePack;
 use OperatingSystemVersion;
+use RuleCriteria;
 use wapmorgan\UnifiedArchive\UnifiedArchive;
 
 class Inventory extends InventoryTestCase
@@ -6080,5 +6081,112 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         $this->boolean($computer->getFromDB($computers_id))->isTrue();
         //check is same on update
         $this->integer($computer->fields['states_id'])->isIdenticalTo($other_states_id);
+    }
+
+
+    public function testOrgerSerialFromTag()
+    {
+        global $DB;
+
+        //create rule
+        $input_rule = [
+            'is_active' => 1,
+            'name'      => 'use TAG as otherserial',
+            'match'     => 'AND',
+            'sub_type'  => 'RuleAsset',
+            'condition' => \RuleAsset::ONUPDATE
+        ];
+
+        $rule = new \Rule();
+        $rules_id = $rule->add($input_rule);
+        $this->integer($rules_id)->isGreaterThan(0);
+
+        //create criteria
+        $input_criteria = [
+            'rules_id'  => $rules_id,
+            'criteria'      => 'tag',
+            'condition' => \Rule::REGEX_MATCH,
+            'pattern' => '/(.*)/'
+        ];
+        $rule_criteria = new \RuleCriteria();
+        $rule_criteria_id = $rule_criteria->add($input_criteria);
+        $this->integer($rule_criteria_id)->isGreaterThan(0);
+
+        //create action
+        $input_action = [
+            'rules_id'  => $rules_id,
+            'action_type' => 'regex_result',
+            'field' => 'otherserial',
+            'value' => '#0'
+        ];
+        $rule_action = new \RuleAction();
+        $rule_action_id = $rule_action->add($input_action);
+        $this->integer($rule_action_id)->isGreaterThan(0);
+
+        $tag = 'a_tag';
+        $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+        <REQUEST>
+        <CONTENT>
+          <HARDWARE>
+            <NAME>glpixps</NAME>
+            <UUID>25C1BB60-5BCB-11D9-B18F-5404A6A534C4</UUID>
+          </HARDWARE>
+          <BIOS>
+            <MSN>640HP72</MSN>
+          </BIOS>
+          <VERSIONCLIENT>FusionInventory-Inventory_v2.4.1-2.fc28</VERSIONCLIENT>
+        </CONTENT>
+        <DEVICEID>test_otherserial_from_tag</DEVICEID>
+        <QUERY>INVENTORY</QUERY>
+        <TAG>" . $tag . "</TAG>
+        </REQUEST>";
+
+        $this->doInventory($xml_source, true);
+
+
+        //check created agent
+        $agents = $DB->request(['FROM' => \Agent::getTable(), "WHERE" => ['deviceid' => 'test_otherserial_from_tag']]);
+        $this->integer(count($agents))->isIdenticalTo(1);
+        $agent = $agents->current();
+        $this->string($agent['tag'])->isIdenticalTo($tag);
+
+        //check created computer
+        $computer = new \Computer();
+        $this->boolean($computer->getFromDB($agent['items_id']))->isTrue();
+        $this->string($computer->fields['otherserial'])->isIdenticalTo($tag);
+
+
+        //redo inventory by updating tag
+        $tag = 'other_tag';
+        $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+        <REQUEST>
+        <CONTENT>
+          <HARDWARE>
+            <NAME>glpixps</NAME>
+            <UUID>25C1BB60-5BCB-11D9-B18F-5404A6A534C4</UUID>
+          </HARDWARE>
+          <BIOS>
+            <MSN>640HP72</MSN>
+          </BIOS>
+          <VERSIONCLIENT>FusionInventory-Inventory_v2.4.1-2.fc28</VERSIONCLIENT>
+        </CONTENT>
+        <DEVICEID>test_otherserial_from_tag</DEVICEID>
+        <QUERY>INVENTORY</QUERY>
+        <TAG>" . $tag . "</TAG>
+        </REQUEST>";
+
+        $this->doInventory($xml_source, true);
+
+
+        //check agent
+        $agents = $DB->request(['FROM' => \Agent::getTable(), "WHERE" => ['deviceid' => 'test_otherserial_from_tag']]);
+        $this->integer(count($agents))->isIdenticalTo(1);
+        $agent = $agents->current();
+        $this->string($agent['tag'])->isIdenticalTo($tag);
+
+        //check created computer
+        $computer = new \Computer();
+        $this->boolean($computer->getFromDB($agent['items_id']))->isTrue();
+        $this->string($computer->fields['otherserial'])->isIdenticalTo($tag);
     }
 }

--- a/tests/functional/Glpi/Inventory/Inventory.php
+++ b/tests/functional/Glpi/Inventory/Inventory.php
@@ -6084,7 +6084,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
     }
 
 
-    public function testOrgerSerialFromTag()
+    public function testOtherSerialFromTag()
     {
         global $DB;
 

--- a/tests/functional/Glpi/Inventory/Inventory.php
+++ b/tests/functional/Glpi/Inventory/Inventory.php
@@ -6104,7 +6104,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         //create criteria
         $input_criteria = [
             'rules_id'  => $rules_id,
-            'criteria'      => 'tag',
+            'criteria'      => '_tag',
             'condition' => \Rule::REGEX_MATCH,
             'pattern' => '/(.*)/'
         ];


### PR DESCRIPTION
Add 'tag' as criteria to ```RuleAsset``` engine

Add 'otherserial' action (```regex_result```) to ```RuleAsset``` engine

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27588
