### PR TITLE
Handle LDAP_NO_SUCH_OBJECT error response from LDAP

### DIFF
--- a/src/RuleRightCollection.php
+++ b/src/RuleRightCollection.php
@@ -255,6 +255,17 @@ class RuleRightCollection extends RuleCollection
                 "objectClass=*",
                 $rule_fields
             );
+            if ($sz === false) {
+                $errno = ldap_errno($params_lower["connection"]);
+                // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
+                if ($errno !== 32) {
+                    trigger_error(
+                        sprintf('LDAP search failed with error (%s) %s', $errno, ldap_error($params_lower["connection"])),
+                        E_USER_WARNING
+                    );
+                }
+                return $rule_parameters;
+            }
             $rule_input = AuthLDAP::get_entries_clean($params_lower["connection"], $sz);
 
             if (count($rule_input)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | maybe #14556 #14075

I made some tests locally and I was not able to connect due to a `LDAP_NO_SUCH_OBJECT` error in `ldap_search`/`ldap_read` calls. This is a bit weird, but these methods are returning an error instead of an empty result when nothing matches the search criteria.

Such a case was not triggering a fatal error before PHP 8.1 (behaviour change is due to https://php.watch/versions/8.1/LDAP-resource). I guess people had logs full of warning but never noticed it.