### PR TITLE
Fix getItemTypeForTable when using namespace + item_xxx

### DIFF
--- a/tests/fixtures/another_test.php
+++ b/tests/fixtures/another_test.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi;
+
+class Another_Test extends \CommonDBTM
+{
+}

--- a/tests/fixtures/namespace_a_b.php
+++ b/tests/fixtures/namespace_a_b.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Namespace;
+
+class A_B extends \CommonDBTM
+{
+}

--- a/tests/fixtures/pluginfoo_search_a_b_c_d_e_f_g_bar.php
+++ b/tests/fixtures/pluginfoo_search_a_b_c_d_e_f_g_bar.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Foo\A\B\C\D\E\F\G;
+
+class Bar extends \CommonDBTM
+{
+}

--- a/tests/fixtures/pluginfoo_search_item_filter.php
+++ b/tests/fixtures/pluginfoo_search_item_filter.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Foo\Search;
+
+class Item_Filter extends \CommonDBTM
+{
+}

--- a/tests/fixtures/test_a_b.php
+++ b/tests/fixtures/test_a_b.php
@@ -33,7 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Namespace;
+namespace Glpi\Test;
 
 class A_B extends \CommonDBTM
 {

--- a/tests/functional/DbUtils.php
+++ b/tests/functional/DbUtils.php
@@ -147,7 +147,7 @@ class DbUtils extends DbTestCase
         require_once __DIR__ . '/../fixtures/pluginfooservice.php';
         require_once __DIR__ . '/../fixtures/pluginfoo_search_item_filter.php';
         require_once __DIR__ . '/../fixtures/pluginfoo_search_a_b_c_d_e_f_g_bar.php';
-        require_once __DIR__ . '/../fixtures/namespace_a_b.php';
+        require_once __DIR__ . '/../fixtures/test_a_b.php';
 
         return [
             ['glpi_dbmysqls', 'DBmysql', false], // not a CommonGLPI, should not be valid
@@ -162,7 +162,7 @@ class DbUtils extends DbTestCase
             ['glpi_plugin_foo_bazs', 'PluginFooBaz', false], // class not exists
             ['glpi_plugin_foo_services', 'PluginFooService', false], // not a CommonGLPI should not be valid
             ['glpi_plugin_foo_searches_items_filters', 'GlpiPlugin\Foo\Search\Item_Filter', true], // Namespace + CommonDBRelation
-            ['glpi_namespaces_as_bs', 'Glpi\Namespace\A_B', true], // Namespace + CommonDBRelation
+            ['glpi_tests_as_bs', 'Glpi\Test\A_B', true], // Namespace + CommonDBRelation
             ['glpi_plugin_foo_as_bs_cs_ds_es_fs_gs_bars', 'GlpiPlugin\Foo\A\B\C\D\E\F\G\Bar', true], // Long name space
         ];
     }

--- a/tests/functional/DbUtils.php
+++ b/tests/functional/DbUtils.php
@@ -145,6 +145,9 @@ class DbUtils extends DbTestCase
         require_once __DIR__ . '/../fixtures/pluginbarfoo.php';
         require_once __DIR__ . '/../fixtures/pluginfoobar.php';
         require_once __DIR__ . '/../fixtures/pluginfooservice.php';
+        require_once __DIR__ . '/../fixtures/pluginfoo_search_item_filter.php';
+        require_once __DIR__ . '/../fixtures/pluginfoo_search_a_b_c_d_e_f_g_bar.php';
+        require_once __DIR__ . '/../fixtures/namespace_a_b.php';
 
         return [
             ['glpi_dbmysqls', 'DBmysql', false], // not a CommonGLPI, should not be valid
@@ -158,6 +161,9 @@ class DbUtils extends DbTestCase
             ['glpi_plugin_foo_bars', 'PluginFooBar', true],
             ['glpi_plugin_foo_bazs', 'PluginFooBaz', false], // class not exists
             ['glpi_plugin_foo_services', 'PluginFooService', false], // not a CommonGLPI should not be valid
+            ['glpi_plugin_foo_searches_items_filters', 'GlpiPlugin\Foo\Search\Item_Filter', true], // Namespace + CommonDBRelation
+            ['glpi_namespaces_as_bs', 'Glpi\Namespace\A_B', true], // Namespace + CommonDBRelation
+            ['glpi_plugin_foo_as_bs_cs_ds_es_fs_gs_bars', 'GlpiPlugin\Foo\A\B\C\D\E\F\G\Bar', true], // Long name space
         ];
     }
 

--- a/tests/functional/DbUtils.php
+++ b/tests/functional/DbUtils.php
@@ -141,6 +141,7 @@ class DbUtils extends DbTestCase
     protected function dataTableType()
     {
        // Pseudo plugin class for test
+        require_once __DIR__ . '/../fixtures/another_test.php';
         require_once __DIR__ . '/../fixtures/pluginbarabstractstuff.php';
         require_once __DIR__ . '/../fixtures/pluginbarfoo.php';
         require_once __DIR__ . '/../fixtures/pluginfoobar.php';
@@ -161,9 +162,10 @@ class DbUtils extends DbTestCase
             ['glpi_plugin_foo_bars', 'PluginFooBar', true],
             ['glpi_plugin_foo_bazs', 'PluginFooBaz', false], // class not exists
             ['glpi_plugin_foo_services', 'PluginFooService', false], // not a CommonGLPI should not be valid
-            ['glpi_plugin_foo_searches_items_filters', 'GlpiPlugin\Foo\Search\Item_Filter', true], // Namespace + CommonDBRelation
-            ['glpi_tests_as_bs', 'Glpi\Test\A_B', true], // Namespace + CommonDBRelation
-            ['glpi_plugin_foo_as_bs_cs_ds_es_fs_gs_bars', 'GlpiPlugin\Foo\A\B\C\D\E\F\G\Bar', true], // Long name space
+            ['glpi_plugin_foo_searches_items_filters', 'GlpiPlugin\Foo\Search\Item_Filter', true], // Multi-level namespace + CommonDBRelation
+            ['glpi_anothers_tests', 'Glpi\Another_Test', true], // Single level namespace + CommonDBRelation
+            ['glpi_tests_as_bs', 'Glpi\Test\A_B', true], // Multi-level namespace + CommonDBRelation
+            ['glpi_plugin_foo_as_bs_cs_ds_es_fs_gs_bars', 'GlpiPlugin\Foo\A\B\C\D\E\F\G\Bar', true], // Long namespace
         ];
     }
 
@@ -1516,12 +1518,20 @@ class DbUtils extends DbTestCase
                 'expected' => 'Glpi\\Application\\Console\\MyCommand',
             ],
             [
+                'itemtype' => 'Glpi\\Something\\Item_filter',
+                'expected' => 'Glpi\\Something\\Item_Filter',
+            ],
+            [
                 'itemtype' => 'PluginFooBaritem',
                 'expected' => 'PluginFooBarItem',
             ],
             [
                 'itemtype' => 'GlpiPluGin\\Foo\\Namespacedbar',
                 'expected' => 'GlpiPlugin\\Foo\\NamespacedBar',
+            ],
+            [
+                'itemtype' => 'glpiplugin\\foo\\models\\foo\\bar_item',
+                'expected' => 'GlpiPlugin\\Foo\\Models\\Foo\\Bar_Item',
             ],
          // Good case (should not be altered)
             [
@@ -1566,12 +1576,20 @@ class DbUtils extends DbTestCase
                             'MyCommand.php' => '',
                         ],
                     ],
+                    'Something' => [
+                        'Item_Filter.php' => '',
+                    ],
                     'MyClass.php' => '',
                     'NamespacedClass.php' => '',
                 ],
                 'plugins' => [
                     'foo' => [
                         'src' => [
+                            'Models' => [
+                                'Foo' => [
+                                    'Bar_Item.php' => '',
+                                ],
+                            ],
                             'NamespacedBar.php' => '',
                             'PluginFooBarItem.php' => '',
                         ],


### PR DESCRIPTION
Handle namespace + item_xxx in `getItemTypeForTable `.

Before this change, when trying to get the itemtype of a  `glpi_namespace1_namespace2_items_filters` table, GLPI would try to load the `Glpi\Namespace1\Namespace2\Item\Filter` itemtype.

This itemtype is incorect as in the case of CommonDBRelation, we must keep the last '_' separator.
The correct itemtype would be lpi\Namespace1\Namespace2\Item_Filter`.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
