### PR TITLE
Ensure rights have search options to allow historical logging

### DIFF
--- a/src/Cartridge.php
+++ b/src/Cartridge.php
@@ -48,6 +48,8 @@ class Cartridge extends CommonDBRelation
     public $dohistory                   = true;
     public $no_form_page                = true;
 
+    public static $rightname = 'cartridge';
+
     public static $itemtype_1 = 'CartridgeItem';
     public static $items_id_1 = 'cartridgeitems_id';
 

--- a/src/DisplayPreference.php
+++ b/src/DisplayPreference.php
@@ -50,7 +50,10 @@ class DisplayPreference extends CommonDBTM
     const PERSONAL = 1024;
     const GENERAL  = 2048;
 
-
+    public static function getTypeName($nb = 0)
+    {
+        return __('Search result display');
+    }
 
     public function prepareInputForAdd($input)
     {

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -864,9 +864,15 @@ class Profile extends CommonDBTM
                     ],
                     'tools' => [
                         'general' => [
-                            $fn_get_rights(Reminder::class, 'central'),
-                            $fn_get_rights(RSSFeed::class, 'central'),
-                            $fn_get_rights(SavedSearch::class, 'central'),
+                            $fn_get_rights(Reminder::class, 'central', [
+                                'label' => _n('Public reminder', 'Public reminders', Session::getPluralNumber())
+                            ]),
+                            $fn_get_rights(RSSFeed::class, 'central', [
+                                'label' => _n('Public RSS feed', 'Public RSS feeds', Session::getPluralNumber())
+                            ]),
+                            $fn_get_rights(SavedSearch::class, 'central', [
+                                'label' => _n('Public saved search', 'Public saved searches', Session::getPluralNumber())
+                            ]),
                             $fn_get_rights(Report::class, 'central'),
                             $fn_get_rights(KnowbaseItem::class, 'central'),
                             $fn_get_rights(ReservationItem::class, 'central'),
@@ -887,8 +893,13 @@ class Profile extends CommonDBTM
                             $fn_get_rights(Consumable::class, 'central'),
                             $fn_get_rights(Phone::class, 'central'),
                             $fn_get_rights(Peripheral::class, 'central'),
-                            $fn_get_rights(NetworkName::class, 'central'),
-                            $fn_get_rights(DeviceSimcard::class, 'central', ['field' => 'devicesimcard_pinpuk']),
+                            $fn_get_rights(NetworkName::class, 'central', [
+                                'label' => __('Internet')
+                            ]),
+                            $fn_get_rights(DeviceSimcard::class, 'central', [
+                                'label' => __('Simcard PIN/PUK'),
+                                'field' => 'devicesimcard_pinpuk'
+                            ]),
                         ],
                     ],
                     'management' => [

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -793,19 +793,18 @@ class Profile extends CommonDBTM
      * }>
      * @internal BC not guaranteed. Only public so it can be used in tests to ensure search options are made for all rights.
      */
-    public static function getRightsForForm(string $form, string $interface): array
+    public static function getRightsForForm(string $interface = 'all', string $form = 'all', string $group = 'all'): array
     {
-        // Helper function to streamline rights definition
         /**
+         * Helper function to streamline rights definition
          * @param class-string<CommonDBTM> $itemtype
-         * @param string|array $interface
+         * @param string $interface
          * @param string $field
          * @param array $options
          * @return array
          */
-        $fn_get_rights = static function (string $itemtype, $interface, string $field = null, array $options = []) {
+        $fn_get_rights = static function (string $itemtype, string $interface, string $field = null, array $options = []) {
             $options = array_replace([
-                'group' => null,
                 'scope' => 'entity'
             ], $options);
             $rights = Profile::getRightsFor($itemtype, $interface);
@@ -816,8 +815,6 @@ class Profile extends CommonDBTM
                 'rights' => $rights,
                 'label'  => $itemtype::getTypeName(Session::getPluralNumber()),
                 'field'  => $field,
-                'interface' => !is_array($interface) ? [$interface] : $interface,
-                'group' => $options['group'],
                 'scope' => $options['scope']
             ];
         };
@@ -825,315 +822,339 @@ class Profile extends CommonDBTM
         static $all_rights = null;
 
         if ($all_rights === null) {
-            $all_rights['tracking'] = [
-                $fn_get_rights(Ticket::class, 'helpdesk'),
-                $fn_get_rights(ITILFollowup::class, 'helpdesk'),
-                $fn_get_rights(TicketTask::class, 'helpdesk'),
-                $fn_get_rights(TicketValidation::class, 'helpdesk'),
-                [
-                    'itemtype'  => 'TicketTemplate',
-                    'label'     => _n('Template', 'Templates', Session::getPluralNumber()),
-                    'field'     => 'itiltemplate',
-                    'interface' => 'central',
-                    'group'     => 'itilobjects',
-                    'scope'     => 'entity'
-                ],
-                $fn_get_rights(PendingReason::class, 'central', null, ['group' => 'itilobjects']),
-                $fn_get_rights(Ticket::class, 'central', null, ['group' => 'tickets']),
-                $fn_get_rights(TicketCost::class, 'central', null, ['group' => 'tickets']),
-                $fn_get_rights(TicketRecurrent::class, 'central', null, ['group' => 'tickets']),
-                $fn_get_rights(ITILFollowup::class, 'central', null, ['group' => 'followups_tasks']),
-                $fn_get_rights(TicketTask::class, 'central', null, ['group' => 'followups_tasks']),
-                $fn_get_rights(TicketValidation::class, 'central', null, ['group' => 'validations']),
-                $fn_get_rights(Stat::class, 'central', null, ['group' => 'visiblity']),
-                $fn_get_rights(Planning::class, 'central', null, ['group' => 'visiblity']),
-                $fn_get_rights(PlanningExternalEvent::class, 'central', null, ['group' => 'planning']),
-                $fn_get_rights(Problem::class, 'central', null, ['group' => 'problems']),
-                $fn_get_rights(Change::class, 'central', null, ['group' => 'changes']),
-                $fn_get_rights(ChangeValidation::class, 'central', null, ['group' => 'changes']),
-                $fn_get_rights(RecurrentChange::class, 'central', null, ['group' => 'changes']),
-            ];
-            $all_rights['tools'] = [
-                $fn_get_rights(KnowbaseItem::class, 'helpdesk'),
-                $fn_get_rights(ReservationItem::class, 'helpdesk'),
-                $fn_get_rights(Reminder::class, 'helpdesk'),
-                $fn_get_rights(RSSFeed::class, 'helpdesk'),
-                $fn_get_rights(Reminder::class, 'central'),
-                $fn_get_rights(RSSFeed::class, 'central'),
-                $fn_get_rights(SavedSearch::class, 'central'),
-                $fn_get_rights(Report::class, 'central'),
-                $fn_get_rights(KnowbaseItem::class, 'central'),
-                $fn_get_rights(ReservationItem::class, 'central'),
-                $fn_get_rights(Project::class, 'central', null, ['group' => 'projects']),
-                $fn_get_rights(ProjectTask::class, 'central', null, ['group' => 'projects']),
-            ];
-            $all_rights['assets'] = [
-                $fn_get_rights(Computer::class, 'central'),
-                $fn_get_rights(Monitor::class, 'central'),
-                $fn_get_rights(Software::class, 'central'),
-                $fn_get_rights(NetworkEquipment::class, 'central'),
-                $fn_get_rights(Printer::class, 'central'),
-                $fn_get_rights(Cartridge::class, 'central'),
-                $fn_get_rights(Consumable::class, 'central'),
-                $fn_get_rights(Phone::class, 'central'),
-                $fn_get_rights(Peripheral::class, 'central'),
-                $fn_get_rights(NetworkName::class, 'central'),
-                $fn_get_rights(DeviceSimcard::class, 'central', 'devicesimcard_pinpuk'),
-            ];
-            $all_rights['management'] = [
-                $fn_get_rights(SoftwareLicense::class, 'central'),
-                [
-                    'itemtype'  => 'Contact',
-                    'label'     => _n('Contact', 'Contacts', Session::getPluralNumber()) . " / " .
-                        _n('Supplier', 'Suppliers', Session::getPluralNumber()),
-                    'field'     => 'contact_enterprise',
-                    'interface' => 'central',
-                    'group'     => null,
-                    'scope'     => 'entity'
-                ],
-                $fn_get_rights(Document::class, 'central'),
-                $fn_get_rights(Contract::class, 'central'),
-                $fn_get_rights(Infocom::class, 'central'),
-                $fn_get_rights(Budget::class, 'central'),
-                $fn_get_rights(Line::class, 'central'),
-                $fn_get_rights(Certificate::class, 'central'),
-                $fn_get_rights(Datacenter::class, 'central'),
-                $fn_get_rights(Cluster::class, 'central'),
-                $fn_get_rights(Domain::class, 'central'),
-                $fn_get_rights(Appliance::class, 'central'),
-                $fn_get_rights(DatabaseInstance::class, 'central'),
-                $fn_get_rights(Cable::class, 'central'),
-            ];
-            $all_rights['admin'] = [
-                $fn_get_rights(User::class, 'central', null, ['group' => 'admin']),
-                $fn_get_rights(Entity::class, 'central', null, ['group' => 'admin', 'scope' => 'global']),
-                $fn_get_rights(Group::class, 'central', null, ['group' => 'admin', 'scope' => 'global']),
-                $fn_get_rights(__CLASS__, 'central', null, ['group' => 'admin', 'scope' => 'global']),
-                $fn_get_rights(QueuedNotification::class, 'central', null, ['group' => 'admin', 'scope' => 'global']),
-                $fn_get_rights(Log::class, 'central', null, ['group' => 'admin', 'scope' => 'global']),
-                [
-                    'itemtype'  => 'Glpi\Inventory\Conf',
-                    'label'     => __('Inventory'),
-                    'field'     => 'inventory',
-                    'interface' => 'central',
-                    'group'     => 'inventory',
-                    'scope'     => 'global'
-                ],
-                [
-                    'itemtype'  => 'LockedField',
-                    'label'     => Lockedfield::getTypeName(Session::getPluralNumber()),
-                    'field'     => 'locked_field',
-                    'rights'  => [
-                        CREATE => __('Create'), // For READ / CREATE
-                        UPDATE => __('Update'), //for CREATE / PURGE global lock
-                    ],
-                    'interface' => 'central',
-                    'group'     => 'inventory',
-                    'scope'     => 'global'
-                ],
-                $fn_get_rights(SNMPCredential::class, 'central', null, ['group' => 'inventory', 'scope' => 'global']),
-                [
-                    'itemtype'  => 'RefusedEquipment',
-                    'label'     => RefusedEquipment::getTypeName(Session::getPluralNumber()),
-                    'field'     => 'refusedequipment',
-                    'rights'  => [
-                        READ  => __('Read'),
-                        UPDATE  => __('Update'),
-                        PURGE   => ['short' => __('Purge'),
-                            'long'  => _x('button', 'Delete permanently')
-                        ]
-                    ],
-                    'interface' => 'central',
-                    'group'     => 'inventory',
-                    'scope'     => 'global'
-                ],
-                [
-                    'itemtype'  => 'Unmanaged',
-                    'label'     => Unmanaged::getTypeName(Session::getPluralNumber()),
-                    'field'     => 'unmanaged',
-                    'rights'  => [
-                        READ  => __('Read'),
-                        UPDATE  => __('Update'),
-                        DELETE => __('Delete'),
-                        PURGE   => ['short' => __('Purge'),
-                            'long'  => _x('button', 'Delete permanently')
-                        ]
-                    ],
-                    'interface' => 'central',
-                    'group'     => 'inventory',
-                    'scope'     => 'global'
-                ],
-                [
-                    'itemtype'  => 'Agent',
-                    'label'     => Agent::getTypeName(Session::getPluralNumber()),
-                    'field'     => 'agent',
-                    'rights'  => [
-                        READ    => __('Read'),
-                        UPDATE  => __('Update'),
-                        PURGE   => ['short' => __('Purge'),
-                            'long'  => _x('button', 'Delete permanently')
-                        ]
-                    ],
-                    'interface' => 'central',
-                    'group'     => 'inventory',
-                    'scope'     => 'global'
-                ],
-                [
-                    'itemtype'  => 'Rule', //FIXME Why not RuleRight?
-                    'label'     => __('Authorizations assignment rules'),
-                    'field'     => 'rule_ldap',
-                    'interface' => 'central',
-                    'group'     => 'rules',
-                    'scope'     => 'global'
-                ],
-                ['itemtype'  => 'RuleImportAsset',
-                    'label'     => __('Rules for assigning a computer to an entity'),
-                    'field'     => 'rule_import',
-                    'interface' => 'central',
-                    'group'     => 'rules',
-                    'scope'     => 'global'
-                ],
-                ['itemtype'  => 'RuleLocation',
-                    'label'     => __('Rules for assigning a computer to a location'),
-                    'field'     => 'rule_location',
-                    'interface' => 'central',
-                    'group'     => 'rules',
-                    'scope'     => 'global'
-                ],
-                ['itemtype'  => 'RuleMailCollector',
-                    'label'     => __('Rules for assigning a ticket created through a mails receiver'),
-                    'field'     => 'rule_mailcollector',
-                    'interface' => 'central',
-                    'group'     => 'rules',
-                    'scope'     => 'global'
-                ],
-                ['itemtype'  => 'RuleSoftwareCategory',
-                    'label'     => __('Rules for assigning a category to a software'),
-                    'field'     => 'rule_softwarecategories',
-                    'interface' => 'central',
-                    'group'     => 'rules',
-                    'scope'     => 'global'
-                ],
-                ['itemtype'  => 'RuleTicket',
-                    'label'     => __('Business rules for tickets (entity)'),
-                    'field'     => 'rule_ticket',
-                    'interface' => 'central',
-                    'group'     => 'rules',
-                    'scope'     => 'entity'
-                ],
-                ['itemtype'  => 'RuleAsset',
-                    'label'     => __('Business rules for assets'),
-                    'field'     => 'rule_asset',
-                    'interface' => 'central',
-                    'group'     => 'rules',
-                    'scope'     => 'entity'
-                ],
-                ['itemtype'  => 'Transfer',
-                    'label'     => __('Transfer'),
-                    'field'     => 'transfer',
-                    'interface' => 'central',
-                    'group'     => 'rules',
-                    'scope'     => 'global'
-                ],
-                [
-                    'itemtype'  => 'RuleDictionnaryDropdown',
-                    'label'     => __('Dropdowns dictionary'),
-                    'field'     => 'rule_dictionnary_dropdown',
-                    'interface' => 'central',
-                    'group'     => 'dictionaries',
-                    'scope'     => 'global'
-                ],
-                [
-                    'itemtype'  => 'RuleDictionnarySoftware',
-                    'label'     => __('Software dictionary'),
-                    'field'     => 'rule_dictionnary_software',
-                    'interface' => 'central',
-                    'group'     => 'dictionaries',
-                    'scope'     => 'global'
-                ],
-                [
-                    'itemtype'  => 'RuleDictionnaryPrinter',
-                    'label'     => __('Printers dictionnary'),
-                    'field'     => 'rule_dictionnary_printer',
-                    'interface' => 'central',
-                    'group'     => 'dictionaries',
-                    'scope'     => 'global'
-                ]
-            ];
-
             $dropdown_rights = (new Profile())->getRights();
             unset($dropdown_rights[DELETE]);
             unset($dropdown_rights[UNLOCK]);
 
-            $all_rights['setup'] = [
-                $fn_get_rights(Config::class, 'central', null, ['scope' => 'entity']),
-                [
-                    'rights'  => [
-                        READ    => __('Read'),
-                        UPDATE  => __('Update')
+            $all_rights = [
+                'central' => [
+                    'tracking' => [
+                        'itilobjects' => [
+                            [
+                                'itemtype'  => 'TicketTemplate',
+                                'label'     => _n('Template', 'Templates', Session::getPluralNumber()),
+                                'field'     => 'itiltemplate',
+                                'scope'     => 'entity'
+                            ],
+                            $fn_get_rights(PendingReason::class, 'central'),
+                        ],
+                        'tickets' => [
+                            $fn_get_rights(Ticket::class, 'central'),
+                            $fn_get_rights(TicketCost::class, 'central'),
+                            $fn_get_rights(TicketRecurrent::class, 'central'),
+                        ],
+                        'followups_tasks' => [
+                            $fn_get_rights(ITILFollowup::class, 'central'),
+                            $fn_get_rights(TicketTask::class, 'central'),
+                        ],
+                        'validations' => [
+                            $fn_get_rights(TicketValidation::class, 'central'),
+                        ],
+                        'visibility' => [
+                            $fn_get_rights(Stat::class, 'central'),
+                            $fn_get_rights(Planning::class, 'central'),
+                        ],
+                        'planning' => [
+                            $fn_get_rights(PlanningExternalEvent::class, 'central'),
+                        ],
+                        'problems' => [
+                            $fn_get_rights(Problem::class, 'central'),
+                        ],
+                        'changes' => [
+                            $fn_get_rights(Change::class, 'central'),
+                            $fn_get_rights(ChangeValidation::class, 'central'),
+                            $fn_get_rights(RecurrentChange::class, 'central'),
+                        ],
                     ],
-                    'label'  => __('Personalization'),
-                    'field'  => 'personalization',
-                    'interface' => ['central', 'helpdesk'],
-                    'group'     => null,
-                    'scope'     => 'entity'
+                    'tools' => [
+                        'general' => [
+                            $fn_get_rights(Reminder::class, 'central'),
+                            $fn_get_rights(RSSFeed::class, 'central'),
+                            $fn_get_rights(SavedSearch::class, 'central'),
+                            $fn_get_rights(Report::class, 'central'),
+                            $fn_get_rights(KnowbaseItem::class, 'central'),
+                            $fn_get_rights(ReservationItem::class, 'central'),
+                        ],
+                        'projects' => [
+                            $fn_get_rights(Project::class, 'central'),
+                            $fn_get_rights(ProjectTask::class, 'central'),
+                        ]
+                    ],
+                    'assets' => [
+                        'general' => [
+                            $fn_get_rights(Computer::class, 'central'),
+                            $fn_get_rights(Monitor::class, 'central'),
+                            $fn_get_rights(Software::class, 'central'),
+                            $fn_get_rights(NetworkEquipment::class, 'central'),
+                            $fn_get_rights(Printer::class, 'central'),
+                            $fn_get_rights(Cartridge::class, 'central'),
+                            $fn_get_rights(Consumable::class, 'central'),
+                            $fn_get_rights(Phone::class, 'central'),
+                            $fn_get_rights(Peripheral::class, 'central'),
+                            $fn_get_rights(NetworkName::class, 'central'),
+                            $fn_get_rights(DeviceSimcard::class, 'central', 'devicesimcard_pinpuk'),
+                        ],
+                    ],
+                    'management' => [
+                        'general' => [
+                            $fn_get_rights(SoftwareLicense::class, 'central'),
+                            [
+                                'itemtype'  => 'Contact',
+                                'label'     => _n('Contact', 'Contacts', Session::getPluralNumber()) . " / " .
+                                    _n('Supplier', 'Suppliers', Session::getPluralNumber()),
+                                'field'     => 'contact_enterprise',
+                                'scope'     => 'entity'
+                            ],
+                            $fn_get_rights(Document::class, 'central'),
+                            $fn_get_rights(Contract::class, 'central'),
+                            $fn_get_rights(Infocom::class, 'central'),
+                            $fn_get_rights(Budget::class, 'central'),
+                            $fn_get_rights(Line::class, 'central'),
+                            $fn_get_rights(Certificate::class, 'central'),
+                            $fn_get_rights(Datacenter::class, 'central'),
+                            $fn_get_rights(Cluster::class, 'central'),
+                            $fn_get_rights(Domain::class, 'central'),
+                            $fn_get_rights(Appliance::class, 'central'),
+                            $fn_get_rights(DatabaseInstance::class, 'central'),
+                            $fn_get_rights(Cable::class, 'central'),
+                        ],
+                    ],
+                    'admin' => [
+                        'general' => [
+                            $fn_get_rights(User::class, 'central'),
+                            $fn_get_rights(Entity::class, 'central', null, ['scope' => 'global']),
+                            $fn_get_rights(Group::class, 'central', null, ['scope' => 'global']),
+                            $fn_get_rights(__CLASS__, 'central', null, ['scope' => 'global']),
+                            $fn_get_rights(QueuedNotification::class, 'central', null, ['scope' => 'global']),
+                            $fn_get_rights(Log::class, 'central', null, ['scope' => 'global']),
+                        ],
+                        'inventory' => [
+                            [
+                                'itemtype'  => 'Glpi\Inventory\Conf',
+                                'label'     => __('Inventory'),
+                                'field'     => 'inventory',
+                                'scope'     => 'global'
+                            ],
+                            [
+                                'itemtype'  => 'LockedField',
+                                'label'     => Lockedfield::getTypeName(Session::getPluralNumber()),
+                                'field'     => 'locked_field',
+                                'rights'  => [
+                                    CREATE => __('Create'), // For READ / CREATE
+                                    UPDATE => __('Update'), //for CREATE / PURGE global lock
+                                ],
+                                'scope'     => 'global'
+                            ],
+                            $fn_get_rights(SNMPCredential::class, 'central', null, ['scope' => 'global']),
+                            [
+                                'itemtype'  => 'RefusedEquipment',
+                                'label'     => RefusedEquipment::getTypeName(Session::getPluralNumber()),
+                                'field'     => 'refusedequipment',
+                                'rights'  => [
+                                    READ  => __('Read'),
+                                    UPDATE  => __('Update'),
+                                    PURGE   => ['short' => __('Purge'),
+                                        'long'  => _x('button', 'Delete permanently')
+                                    ]
+                                ],
+                                'scope'     => 'global'
+                            ],
+                            [
+                                'itemtype'  => 'Unmanaged',
+                                'label'     => Unmanaged::getTypeName(Session::getPluralNumber()),
+                                'field'     => 'unmanaged',
+                                'rights'  => [
+                                    READ  => __('Read'),
+                                    UPDATE  => __('Update'),
+                                    DELETE => __('Delete'),
+                                    PURGE   => ['short' => __('Purge'),
+                                        'long'  => _x('button', 'Delete permanently')
+                                    ]
+                                ],
+                                'scope'     => 'global'
+                            ],
+                            [
+                                'itemtype'  => 'Agent',
+                                'label'     => Agent::getTypeName(Session::getPluralNumber()),
+                                'field'     => 'agent',
+                                'rights'  => [
+                                    READ    => __('Read'),
+                                    UPDATE  => __('Update'),
+                                    PURGE   => ['short' => __('Purge'),
+                                        'long'  => _x('button', 'Delete permanently')
+                                    ]
+                                ],
+                                'scope'     => 'global'
+                            ],
+                        ],
+                        'rules' => [
+                            [
+                                'itemtype'  => 'Rule', //FIXME Why not RuleRight?
+                                'label'     => __('Authorizations assignment rules'),
+                                'field'     => 'rule_ldap',
+                                'scope'     => 'global'
+                            ],
+                            [
+                                'itemtype'  => 'RuleImportAsset',
+                                'label'     => __('Rules for assigning a computer to an entity'),
+                                'field'     => 'rule_import',
+                                'scope'     => 'global'
+                            ],
+                            [
+                                'itemtype'  => 'RuleLocation',
+                                'label'     => __('Rules for assigning a computer to a location'),
+                                'field'     => 'rule_location',
+                                'scope'     => 'global'
+                            ],
+                            [
+                                'itemtype'  => 'RuleMailCollector',
+                                'label'     => __('Rules for assigning a ticket created through a mails receiver'),
+                                'field'     => 'rule_mailcollector',
+                                'scope'     => 'global'
+                            ],
+                            [
+                                'itemtype'  => 'RuleSoftwareCategory',
+                                'label'     => __('Rules for assigning a category to a software'),
+                                'field'     => 'rule_softwarecategories',
+                                'scope'     => 'global'
+                            ],
+                            [
+                                'itemtype'  => 'RuleTicket',
+                                'label'     => __('Business rules for tickets (entity)'),
+                                'field'     => 'rule_ticket',
+                                'scope'     => 'entity'
+                            ],
+                            [
+                                'itemtype'  => 'RuleAsset',
+                                'label'     => __('Business rules for assets'),
+                                'field'     => 'rule_asset',
+                                'scope'     => 'entity'
+                            ],
+                            [
+                                'itemtype'  => 'Transfer',
+                                'label'     => __('Transfer'),
+                                'field'     => 'transfer',
+                                'scope'     => 'global'
+                            ],
+                        ],
+                        'dictionaries' => [
+                            [
+                                'itemtype'  => 'RuleDictionnaryDropdown',
+                                'label'     => __('Dropdowns dictionary'),
+                                'field'     => 'rule_dictionnary_dropdown',
+                                'scope'     => 'global'
+                            ],
+                            [
+                                'itemtype'  => 'RuleDictionnarySoftware',
+                                'label'     => __('Software dictionary'),
+                                'field'     => 'rule_dictionnary_software',
+                                'scope'     => 'global'
+                            ],
+                            [
+                                'itemtype'  => 'RuleDictionnaryPrinter',
+                                'label'     => __('Printers dictionnary'),
+                                'field'     => 'rule_dictionnary_printer',
+                                'scope'     => 'global'
+                            ]
+                        ]
+                    ],
+                    'setup' => [
+                        'general' => [
+                            $fn_get_rights(Config::class, 'central', null, ['scope' => 'entity']),
+                            [
+                                'rights'  => [
+                                    READ    => __('Read'),
+                                    UPDATE  => __('Update')
+                                ],
+                                'label'  => __('Personalization'),
+                                'field'  => 'personalization',
+                                'scope'     => 'entity'
+                            ],
+                            [
+                                'itemtype'  => 'Glpi\Dashboard\Grid',
+                                'label'     => __('All dashboards'),
+                                'field'     => 'dashboard',
+                                'scope'     => 'entity'
+                            ],
+                            $fn_get_rights(DisplayPreference::class, 'central', null, ['scope' => 'entity']),
+                            [
+                                'itemtype'  => 'Item_Devices',
+                                'label'     => _n('Component', 'Components', Session::getPluralNumber()),
+                                'field'     => 'device',
+                                'scope'     => 'entity'
+                            ],
+                            [
+                                'rights'    => $dropdown_rights,
+                                'label'     => _n('Global dropdown', 'Global dropdowns', Session::getPluralNumber()),
+                                'field'     => 'dropdown',
+                                'scope'     => 'global'
+                            ],
+                            $fn_get_rights(Location::class, 'central', null, ['scope' => 'entity']),
+                            $fn_get_rights(ITILCategory::class, 'central', null, ['scope' => 'entity']),
+                            $fn_get_rights(KnowbaseItemCategory::class, 'central', null, ['scope' => 'entity']),
+                            $fn_get_rights(TaskCategory::class, 'central', null, ['scope' => 'entity']),
+                            $fn_get_rights(State::class, 'central', null, ['scope' => 'entity']),
+                            $fn_get_rights(ITILFollowupTemplate::class, 'central', null, ['scope' => 'entity']),
+                            $fn_get_rights(SolutionTemplate::class, 'central', null, ['scope' => 'entity']),
+                            $fn_get_rights(Calendar::class, 'central', null, ['scope' => 'entity']),
+                            $fn_get_rights(DocumentType::class, 'central', null, ['scope' => 'entity']),
+                            $fn_get_rights(Link::class, 'central', null, ['scope' => 'entity']),
+                            $fn_get_rights(Notification::class, 'central', null, ['scope' => 'entity']),
+                            [
+                                'itemtype'  => 'SLM',
+                                'label'     => __('SLM'),
+                                'field'     => 'slm',
+                                'scope'     => 'entity'
+                            ],
+                        ],
+                    ]
                 ],
-                [
-                    'itemtype'  => 'Glpi\Dashboard\Grid',
-                    'label'     => __('All dashboards'),
-                    'field'     => 'dashboard',
-                    'interface' => 'central',
-                    'group'     => null,
-                    'scope'     => 'entity'
-                ],
-                $fn_get_rights(DisplayPreference::class, 'central', null, ['scope' => 'entity']),
-                [
-                    'itemtype'  => 'Item_Devices',
-                    'label'     => _n('Component', 'Components', Session::getPluralNumber()),
-                    'field'     => 'device',
-                    'interface' => 'central',
-                    'group'     => null,
-                    'scope'     => 'entity'
-                ],
-                [
-                    'rights'    => $dropdown_rights,
-                    'label'     => _n('Global dropdown', 'Global dropdowns', Session::getPluralNumber()),
-                    'field'     => 'dropdown',
-                    'interface' => 'central',
-                    'group'     => null,
-                    'scope'     => 'global'
-                ],
-                $fn_get_rights(Location::class, 'central', null, ['scope' => 'entity']),
-                $fn_get_rights(ITILCategory::class, 'central', null, ['scope' => 'entity']),
-                $fn_get_rights(KnowbaseItemCategory::class, 'central', null, ['scope' => 'entity']),
-                $fn_get_rights(TaskCategory::class, 'central', null, ['scope' => 'entity']),
-                $fn_get_rights(State::class, 'central', null, ['scope' => 'entity']),
-                $fn_get_rights(ITILFollowupTemplate::class, 'central', null, ['scope' => 'entity']),
-                $fn_get_rights(SolutionTemplate::class, 'central', null, ['scope' => 'entity']),
-                $fn_get_rights(Calendar::class, 'central', null, ['scope' => 'entity']),
-                $fn_get_rights(DocumentType::class, 'central', null, ['scope' => 'entity']),
-                $fn_get_rights(Link::class, 'central', null, ['scope' => 'entity']),
-                $fn_get_rights(Notification::class, 'central', null, ['scope' => 'entity']),
-                [
-                    'itemtype'  => 'SLM',
-                    'label'     => __('SLM'),
-                    'field'     => 'slm',
-                    'interface' => 'central',
-                    'group'     => null,
-                    'scope'     => 'entity'
-                ],
+                'helpdesk' => [
+                    'tracking' => [
+                        'general' => [
+                            $fn_get_rights(Ticket::class, 'helpdesk'),
+                            $fn_get_rights(ITILFollowup::class, 'helpdesk'),
+                            $fn_get_rights(TicketTask::class, 'helpdesk'),
+                            $fn_get_rights(TicketValidation::class, 'helpdesk'),
+                        ],
+                    ],
+                    'tools' => [
+                        'general' => [
+                            $fn_get_rights(KnowbaseItem::class, 'helpdesk'),
+                            $fn_get_rights(ReservationItem::class, 'helpdesk'),
+                            $fn_get_rights(Reminder::class, 'helpdesk'),
+                            $fn_get_rights(RSSFeed::class, 'helpdesk'),
+                        ],
+                    ],
+                    'setup' => [
+                        'general' => [
+                            $fn_get_rights(Config::class, 'central', null, ['scope' => 'entity']),
+                            [
+                                'rights'  => [
+                                    READ    => __('Read'),
+                                    UPDATE  => __('Update')
+                                ],
+                                'label'  => __('Personalization'),
+                                'field'  => 'personalization',
+                                'scope'     => 'entity'
+                            ],
+                        ],
+                    ]
+                ]
             ];
         }
 
-        $form_rights = $all_rights[$form] ?? [];
-        $form_rights = array_filter($form_rights, static function (array $rights) use ($interface): bool {
-            return is_array($rights['interface']) ? in_array($interface, $rights['interface'], true) : ($rights['interface'] === $interface);
-        });
-        // Remove 'interface' key from each definition
-        foreach ($form_rights as &$rights) {
-            unset($rights['interface']);
+        $result = $all_rights;
+        if ($interface !== 'all') {
+            $result = $all_rights[$interface] ?? [];
         }
-        return $form_rights;
+        if ($form !== 'all') {
+            $result = $all_rights[$interface][$form] ?? [];
+        }
+        if ($group !== 'all') {
+            $result = $all_rights[$interface][$form][$group] ?? [];
+        }
+        return $result;
     }
 
     /**
@@ -1156,10 +1177,8 @@ class Profile extends CommonDBTM
             'default_class' => 'tab_bg_2'
         ];
 
-        $rights = self::getRightsForForm('tracking', 'helpdesk');
-
         $matrix_options['title'] = __('Assistance');
-        $this->displayRightsChoiceMatrix($rights, $matrix_options);
+        $this->displayRightsChoiceMatrix(self::getRightsForForm('helpdesk', 'tracking', 'general'), $matrix_options);
 
         echo "<div class='mt-4 mx-n2'>";
         echo "<table class='table table-hover card-table'>";
@@ -1290,10 +1309,8 @@ class Profile extends CommonDBTM
             'default_class' => 'tab_bg_2'
         ];
 
-        $rights = self::getRightsForForm('tools', 'helpdesk');
-
         $matrix_options['title'] = __('Tools');
-        $this->displayRightsChoiceMatrix($rights, $matrix_options);
+        $this->displayRightsChoiceMatrix(self::getRightsForForm('helpdesk', 'tools', 'general'), $matrix_options);
 
         if ($canedit) {
             echo "<div class='center'>";
@@ -1334,9 +1351,8 @@ class Profile extends CommonDBTM
             echo "<form method='post' action='" . $this->getFormURL() . "' data-track-changes='true'>";
         }
 
-        $rights = self::getRightsForForm('assets', 'central');
-
-        $this->displayRightsChoiceMatrix($rights, ['canedit'       => $canedit,
+        $this->displayRightsChoiceMatrix(self::getRightsForForm('central', 'assets', 'general'), [
+            'canedit'       => $canedit,
             'default_class' => 'tab_bg_2',
             'title'         => _n('Asset', 'Assets', Session::getPluralNumber())
         ]);
@@ -1387,9 +1403,8 @@ class Profile extends CommonDBTM
             'default_class' => 'tab_bg_2'
         ];
 
-        $rights = self::getRightsForForm('management', 'central');
         $matrix_options['title'] = __('Management');
-        $this->displayRightsChoiceMatrix($rights, $matrix_options);
+        $this->displayRightsChoiceMatrix(self::getRightsForForm('central', 'management', 'general'), $matrix_options);
 
         echo "<div class='tab_cadre_fixehov mx-n2'>";
         echo "<input type='hidden' name='_managed_domainrecordtypes' value='1'>";
@@ -1455,18 +1470,11 @@ class Profile extends CommonDBTM
             'default_class' => 'tab_bg_2'
         ];
 
-        $rights = self::getRightsForForm('tools', 'central');
-        $general_rights = array_filter($rights, static function ($right) {
-            return $right['group'] === null;
-        });
-        $project_rights = array_filter($rights, static function ($right) {
-            return $right['group'] === 'projects';
-        });
         $matrix_options['title'] = __('Tools');
-        $this->displayRightsChoiceMatrix($general_rights, $matrix_options);
+        $this->displayRightsChoiceMatrix(self::getRightsForForm('central', 'tools', 'general'), $matrix_options);
 
         $matrix_options['title'] = _n('Project', 'Projects', Session::getPluralNumber());
-        $this->displayRightsChoiceMatrix($project_rights, $matrix_options);
+        $this->displayRightsChoiceMatrix(self::getRightsForForm('central', 'tools', 'projects'), $matrix_options);
 
         if (
             $canedit
@@ -1543,30 +1551,17 @@ class Profile extends CommonDBTM
             'default_class' => 'tab_bg_2'
         ];
 
-        $rights = self::getRightsForForm('tracking', 'central');
-        $itilobject_rights = array_filter($rights, static function ($right) {
-            return $right['group'] === 'itilobjects';
-        });
         $matrix_options['title'] = _n('ITIL object', 'ITIL objects', Session::getPluralNumber());
-        $this->displayRightsChoiceMatrix($itilobject_rights, $matrix_options);
+        $this->displayRightsChoiceMatrix(self::getRightsForForm('central', 'tracking', 'itilobjects'), $matrix_options);
 
-        $ticket_rights = array_filter($rights, static function ($right) {
-            return $right['group'] === 'tickets';
-        });
         $matrix_options['title'] = _n('Ticket', 'Tickets', Session::getPluralNumber());
-        $this->displayRightsChoiceMatrix($ticket_rights, $matrix_options);
+        $this->displayRightsChoiceMatrix(self::getRightsForForm('central', 'tracking', 'tickets'), $matrix_options);
 
-        $fup_task_rights = array_filter($rights, static function ($right) {
-            return $right['group'] === 'followups_tasks';
-        });
         $matrix_options['title'] = _n('Followup', 'Followups', Session::getPluralNumber()) . " / " . _n('Task', 'Tasks', Session::getPluralNumber());
-        $this->displayRightsChoiceMatrix($fup_task_rights, $matrix_options);
+        $this->displayRightsChoiceMatrix(self::getRightsForForm('central', 'tracking', 'followups_tasks'), $matrix_options);
 
-        $validation_rights = array_filter($rights, static function ($right) {
-            return $right['group'] === 'validations';
-        });
         $matrix_options['title'] = _n('Validation', 'Validations', Session::getPluralNumber());
-        $this->displayRightsChoiceMatrix($validation_rights, $matrix_options);
+        $this->displayRightsChoiceMatrix(self::getRightsForForm('central', 'tracking', 'validations'), $matrix_options);
 
         echo "<div class='mx-n2 my-4'>";
         echo "<table class='table table-hover card-table'>";
@@ -1603,30 +1598,17 @@ class Profile extends CommonDBTM
         echo "</table>";
         echo "</div>";
 
-        $visibility_rights = array_filter($rights, static function ($right) {
-            return $right['group'] === 'visibility';
-        });
         $matrix_options['title'] = __('Visibility');
-        $this->displayRightsChoiceMatrix($visibility_rights, $matrix_options);
-
-        $planning_rights = array_filter($rights, static function ($right) {
-            return $right['group'] === 'planning';
-        });
+        $this->displayRightsChoiceMatrix(self::getRightsForForm('central', 'tracking', 'visibility'), $matrix_options);
 
         $matrix_options['title'] = __('Planning');
-        $this->displayRightsChoiceMatrix($planning_rights, $matrix_options);
+        $this->displayRightsChoiceMatrix(self::getRightsForForm('central', 'tracking', 'planning'), $matrix_options);
 
-        $problem_rights = array_filter($rights, static function ($right) {
-            return $right['group'] === 'problems';
-        });
         $matrix_options['title'] = Problem::getTypeName(Session::getPluralNumber());
-        $this->displayRightsChoiceMatrix($problem_rights, $matrix_options);
+        $this->displayRightsChoiceMatrix(self::getRightsForForm('central', 'tracking', 'problems'), $matrix_options);
 
-        $change_rights = array_filter($rights, static function ($right) {
-            return $right['group'] === 'changes';
-        });
         $matrix_options['title'] = _n('Change', 'Changes', Session::getPluralNumber());
-        $this->displayRightsChoiceMatrix($change_rights, $matrix_options);
+        $this->displayRightsChoiceMatrix(self::getRightsForForm('central', 'tracking', 'changes'), $matrix_options);
 
         if (
             $canedit
@@ -1899,30 +1881,17 @@ class Profile extends CommonDBTM
             'canedit'       => $canedit,
         ];
 
-        $rights = self::getRightsForForm('admin', 'central');
-        $admin_rights = array_filter($rights, static function ($right) {
-            return $right['group'] === 'admin';
-        });
         $matrix_options['title'] = __('Administration');
-        $this->displayRightsChoiceMatrix($admin_rights, $matrix_options);
+        $this->displayRightsChoiceMatrix(self::getRightsForForm('central', 'admin', 'general'), $matrix_options);
 
-        $inv_rights = array_filter($rights, static function ($right) {
-            return $right['group'] === 'inventory';
-        });
         $matrix_options['title'] = __('Inventory');
-        $this->displayRightsChoiceMatrix($inv_rights, $matrix_options);
+        $this->displayRightsChoiceMatrix(self::getRightsForForm('central', 'admin', 'inventory'), $matrix_options);
 
-        $rule_rights = array_filter($rights, static function ($right) {
-            return $right['group'] === 'rules';
-        });
         $matrix_options['title'] = _n('Rule', 'Rules', Session::getPluralNumber());
-        $this->displayRightsChoiceMatrix($rule_rights, $matrix_options);
+        $this->displayRightsChoiceMatrix(self::getRightsForForm('central', 'admin', 'rules'), $matrix_options);
 
-        $dictionary_rights = array_filter($rights, static function ($right) {
-            return $right['group'] === 'dictionaries';
-        });
         $matrix_options['title'] = __('Dropdowns dictionary');
-        $this->displayRightsChoiceMatrix($dictionary_rights, $matrix_options);
+        $this->displayRightsChoiceMatrix(self::getRightsForForm('central', 'admin', 'dictionaries'), $matrix_options);
 
         if (
             $canedit
@@ -1963,9 +1932,8 @@ class Profile extends CommonDBTM
             echo "<form method='post' action='" . $this->getFormURL() . "' data-track-changes='true'>";
         }
 
-        $rights = self::getRightsForForm('setup', 'central');
-
-        $this->displayRightsChoiceMatrix($rights, ['canedit'       => $canedit,
+        $this->displayRightsChoiceMatrix(self::getRightsForForm('central', 'setup', 'general'), [
+            'canedit'       => $canedit,
             'title'         => __('Setup')
         ]);
 
@@ -2014,9 +1982,8 @@ class Profile extends CommonDBTM
             echo "<form method='post' action='" . $this->getFormURL() . "' data-track-changes='true'>";
         }
 
-        $rights = self::getRightsForForm('setup', 'helpdesk');
-
-        $this->displayRightsChoiceMatrix($rights, ['canedit'       => $canedit,
+        $this->displayRightsChoiceMatrix(self::getRightsForForm('helpdesk', 'setup', 'general'), [
+            'canedit'       => $canedit,
             'title'         => __('Setup')
         ]);
 

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -911,7 +911,14 @@ class Profile extends CommonDBTM
                 $fn_get_rights(__CLASS__, 'central', null, ['group' => 'admin', 'scope' => 'global']),
                 $fn_get_rights(QueuedNotification::class, 'central', null, ['group' => 'admin', 'scope' => 'global']),
                 $fn_get_rights(Log::class, 'central', null, ['group' => 'admin', 'scope' => 'global']),
-                $fn_get_rights(\Glpi\Inventory\Conf::class, 'central', null, ['group' => 'inventory', 'scope' => 'global']),
+                [
+                    'itemtype'  => 'Glpi\Inventory\Conf',
+                    'label'     => __('Inventory'),
+                    'field'     => 'inventory',
+                    'interface' => 'central',
+                    'group'     => 'inventory',
+                    'scope'     => 'global'
+                ],
                 [
                     'itemtype'  => 'LockedField',
                     'label'     => Lockedfield::getTypeName(Session::getPluralNumber()),
@@ -1054,7 +1061,7 @@ class Profile extends CommonDBTM
                 ]
             ];
 
-            $dropdown_rights = (new Profile)->getRights();
+            $dropdown_rights = (new Profile())->getRights();
             unset($dropdown_rights[DELETE]);
             unset($dropdown_rights[UNLOCK]);
 
@@ -2350,6 +2357,147 @@ class Profile extends CommonDBTM
         ];
 
         $tab[] = [
+            'id'                 => '142',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => SoftwareLicense::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => SoftwareLicense::class,
+            'rightname'          => SoftwareLicense::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => SoftwareLicense::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '143',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => _n('Contact', 'Contacts', Session::getPluralNumber()) . " / " .
+                _n('Supplier', 'Suppliers', Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => Contact::class,
+            'rightname'          => 'contact_enterprise',
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => 'contact_enterprise']
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '144',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => Line::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => Line::class,
+            'rightname'          => Line::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => Line::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '145',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => Certificate::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => Certificate::class,
+            'rightname'          => Certificate::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => Certificate::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '146',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => Datacenter::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => Datacenter::class,
+            'rightname'          => Datacenter::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => Datacenter::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '147',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => Cluster::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => Cluster::class,
+            'rightname'          => Cluster::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => Cluster::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '148',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => Domain::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => Domain::class,
+            'rightname'          => Domain::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => Domain::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '149',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => Appliance::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => Appliance::class,
+            'rightname'          => Appliance::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => Appliance::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '150',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => DatabaseInstance::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => DatabaseInstance::class,
+            'rightname'          => DatabaseInstance::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => DatabaseInstance::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '151',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => Cable::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => Cable::class,
+            'rightname'          => Cable::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => Cable::$rightname]
+            ]
+        ];
+
+        $tab[] = [
             'id'                 => 'tools',
             'name'               => __('Tools')
         ];
@@ -2394,6 +2542,34 @@ class Profile extends CommonDBTM
             'joinparams'         => [
                 'jointype'           => 'child',
                 'condition'          => ['NEWTABLE.name' => 'reports']
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '140',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => Project::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => Project::class,
+            'rightname'          => Project::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => Project::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '141',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => ProjectTask::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => ProjectTask::class,
+            'rightname'          => ProjectTask::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => ProjectTask::$rightname]
             ]
         ];
 
@@ -2533,6 +2709,132 @@ class Profile extends CommonDBTM
         ];
 
         $tab[] = [
+            'id'                 => '162',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => __('All dashboards'),
+            'datatype'           => 'right',
+            'rightclass'         => Glpi\Dashboard\Grid::class,
+            'rightname'          => 'dashboard',
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => 'dashboard']
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '163',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => Location::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => Location::class,
+            'rightname'          => Location::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => Location::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '164',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => ITILCategory::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => ITILCategory::class,
+            'rightname'          => ITILCategory::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => ITILCategory::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '165',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => KnowbaseItemCategory::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => KnowbaseItemCategory::class,
+            'rightname'          => KnowbaseItemCategory::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => KnowbaseItemCategory::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '166',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => TaskCategory::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => TaskCategory::class,
+            'rightname'          => TaskCategory::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => TaskCategory::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '167',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => State::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => State::class,
+            'rightname'          => State::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => State::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '168',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => ITILFollowupTemplate::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => ITILFollowupTemplate::class,
+            'rightname'          => ITILFollowupTemplate::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => ITILFollowupTemplate::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '169',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => SolutionTemplate::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => SolutionTemplate::class,
+            'rightname'          => SolutionTemplate::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => SolutionTemplate::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '170',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => __('SLM'),
+            'datatype'           => 'right',
+            'rightclass'         => SLM::class,
+            'rightname'          => 'slm',
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => 'slm']
+            ]
+        ];
+
+        $tab[] = [
             'id'                 => 'admin',
             'name'               => __('Administration')
         ];
@@ -2609,6 +2911,34 @@ class Profile extends CommonDBTM
         ];
 
         $tab[] = [
+            'id'                 => '159',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => RuleLocation::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => RuleLocation::class,
+            'rightname'          => RuleLocation::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => RuleLocation::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '160',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => RuleAsset::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => RuleAsset::class,
+            'rightname'          => RuleAsset::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => RuleAsset::$rightname]
+            ]
+        ];
+
+        $tab[] = [
             'id'                 => '90',
             'table'              => 'glpi_profilerights',
             'field'              => 'rights',
@@ -2633,6 +2963,20 @@ class Profile extends CommonDBTM
             'joinparams'         => [
                 'jointype'           => 'child',
                 'condition'          => ['NEWTABLE.name' => 'rule_dictionnary_dropdown']
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '161',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => RuleDictionnaryPrinter::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => RuleDictionnaryPrinter::class,
+            'rightname'          => RuleDictionnaryPrinter::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => RuleDictionnaryPrinter::$rightname]
             ]
         ];
 
@@ -2718,6 +3062,104 @@ class Profile extends CommonDBTM
             'joinparams'         => [
                 'jointype'           => 'child',
                 'condition'          => ['NEWTABLE.name' => 'logs']
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '152',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => QueuedNotification::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => QueuedNotification::class,
+            'rightname'          => QueuedNotification::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => QueuedNotification::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '153',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => __('Inventory'),
+            'datatype'           => 'right',
+            'rightclass'         => \Glpi\Inventory\Conf::class,
+            'rightname'          => \Glpi\Inventory\Conf::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => \Glpi\Inventory\Conf::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '154',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => Lockedfield::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => Lockedfield::class,
+            'rightname'          => Lockedfield::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => Lockedfield::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '155',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => SNMPCredential::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => SNMPCredential::class,
+            'rightname'          => SNMPCredential::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => SNMPCredential::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '156',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => RefusedEquipment::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => RefusedEquipment::class,
+            'rightname'          => RefusedEquipment::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => RefusedEquipment::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '157',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => Unmanaged::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => Unmanaged::class,
+            'rightname'          => Unmanaged::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => Unmanaged::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '158',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => Agent::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => Agent::class,
+            'rightname'          => Agent::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => Agent::$rightname]
             ]
         ];
 
@@ -2904,6 +3346,132 @@ class Profile extends CommonDBTM
             'joinparams'         => [
                 'jointype'           => 'child',
                 'condition'          => ['NEWTABLE.name' => 'change']
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '131',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => ITILFollowup::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => ITILFollowup::class,
+            'rightname'          => ITILFollowup::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => ITILFollowup::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '132',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => TicketTask::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => TicketTask::class,
+            'rightname'          => TicketTask::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => TicketTask::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '133',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => TicketValidation::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => TicketValidation::class,
+            'rightname'          => TicketValidation::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => TicketValidation::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '134',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => _n('Template', 'Templates', Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => TicketTemplate::class,
+            'rightname'          => 'itiltemplate',
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => 'itiltemplate']
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '135',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => PendingReason::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => PendingReason::class,
+            'rightname'          => PendingReason::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => PendingReason::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '136',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => TicketRecurrent::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => TicketRecurrent::class,
+            'rightname'          => TicketRecurrent::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => TicketRecurrent::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '137',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => PlanningExternalEvent::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => PlanningExternalEvent::class,
+            'rightname'          => PlanningExternalEvent::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => PlanningExternalEvent::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '138',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => ChangeValidation::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => ChangeValidation::class,
+            'rightname'          => ChangeValidation::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => ChangeValidation::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '139',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => RecurrentChange::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => RecurrentChange::class,
+            'rightname'          => RecurrentChange::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => RecurrentChange::$rightname]
             ]
         ];
 

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -1056,7 +1056,8 @@ class Profile extends CommonDBTM
                             $fn_get_rights(DocumentType::class, 'central'),
                             $fn_get_rights(Link::class, 'central'),
                             $fn_get_rights(Notification::class, 'central'),
-                            $fn_get_rights(SLM::class, 'central', ['label' => __('SLM')])
+                            $fn_get_rights(SLM::class, 'central', ['label' => __('SLM')]),                            
+                            $fn_get_rights(LineOperator::class, 'central'),
                         ],
                     ]
                 ],
@@ -1079,7 +1080,6 @@ class Profile extends CommonDBTM
                     ],
                     'setup' => [
                         'general' => [
-                            $fn_get_rights(Config::class, 'central', ['scope' => 'entity']),
                             $fn_get_rights(null, 'helpdesk', [
                                 'rights'  => [
                                     READ    => __('Read'),

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -1067,7 +1067,7 @@ class Profile extends CommonDBTM
                             $fn_get_rights(DocumentType::class, 'central'),
                             $fn_get_rights(Link::class, 'central'),
                             $fn_get_rights(Notification::class, 'central'),
-                            $fn_get_rights(SLM::class, 'central', ['label' => __('SLM')]),                            
+                            $fn_get_rights(SLM::class, 'central', ['label' => __('SLM')]),
                             $fn_get_rights(LineOperator::class, 'central'),
                         ],
                     ]
@@ -2759,6 +2759,20 @@ class Profile extends CommonDBTM
             'joinparams'         => [
                 'jointype'           => 'child',
                 'condition'          => ['NEWTABLE.name' => 'slm']
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '171',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => LineOperator::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => LineOperator::class,
+            'rightname'          => LineOperator::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => LineOperator::$rightname]
             ]
         ];
 

--- a/tests/functional/Profile.php
+++ b/tests/functional/Profile.php
@@ -247,35 +247,40 @@ class Profile extends DbTestCase
      */
     public function testProfileRightsHaveSearchOptions()
     {
-        $forms = ['tracking', 'tools', 'assets', 'management', 'admin', 'setup'];
-        $interfaces = ['helpdesk', 'central'];
-
         $search_opts = \Search::getOptions(\Profile::class);
         // We can keep only the options that have 'right' as the field
         $search_opts = array_filter($search_opts, static function ($opt) {
             return is_array($opt) && isset($opt['field']) && $opt['field'] === 'rights';
         });
         $failures = [];
-        foreach ($forms as $form) {
-            foreach ($interfaces as $interface) {
-                $rights = \Profile::getRightsForForm($form, $interface);
-                $previous_right = null;
-                foreach ($rights as $right) {
-                    if (empty($right['field'])) {
-                        echo 'A right is missing a field name. Please check that the class has the rightname property set or the right is otherwise defined with the field property in the array';
-                        echo 'The previous right was: ' . print_r($previous_right, true);
-                        continue;
+        $all_rights = \Profile::getRightsForForm();
+
+        foreach ($all_rights as $interface => $forms) {
+            foreach ($forms as $form => $groups) {
+                foreach ($groups as $group => $rights) {
+                    $previous_right = null;
+                    foreach ($rights as $right) {
+                        if (empty($right['field'])) {
+                            echo 'A right is missing a field name. Please check that the class has the rightname property set or the right is otherwise defined with the field property in the array';
+                            if ($previous_right) {
+                                echo 'The previous right was: ' . print_r($previous_right, true) . " in ${$interface}/${$form}/${$group}";
+                            } else {
+                                echo "The right was the first one in ${$interface}/${$form}/${$group}";
+                            }
+                            continue;
+                        }
+                        $search_opt_matches = array_filter($search_opts, static function ($opt) use ($right) {
+                            return array_key_exists('rightname', $opt) && $opt['rightname'] === $right['field'];
+                        });
+                        if (!count($search_opt_matches)) {
+                            $failures[] = $right['field'];
+                        }
+                        $previous_right = $right;
                     }
-                    $search_opt_matches = array_filter($search_opts, static function ($opt) use ($right) {
-                        return array_key_exists('rightname', $opt) && $opt['rightname'] === $right['field'];
-                    });
-                    if (!count($search_opt_matches)) {
-                        $failures[] = $right['field'];
-                    }
-                    $previous_right = $right;
                 }
             }
         }
+
         $failures = array_unique($failures);
         if (count($failures)) {
             echo sprintf('The following rights do not have a search option: %s', implode(', ', $failures));

--- a/tests/functional/Profile.php
+++ b/tests/functional/Profile.php
@@ -259,20 +259,26 @@ class Profile extends DbTestCase
         foreach ($forms as $form) {
             foreach ($interfaces as $interface) {
                 $rights = \Profile::getRightsForForm($form, $interface);
+                $previous_right = null;
                 foreach ($rights as $right) {
+                    if (empty($right['field'])) {
+                        echo 'A right is missing a field name. Please check that the class has the rightname property set or the right is otherwise defined with the field property in the array';
+                        echo 'The previous right was: ' . print_r($previous_right, true);
+                        continue;
+                    }
                     $search_opt_matches = array_filter($search_opts, static function ($opt) use ($right) {
-                        return $opt['rightname'] === $right['field'];
+                        return array_key_exists('rightname', $opt) && $opt['rightname'] === $right['field'];
                     });
                     if (!count($search_opt_matches)) {
                         $failures[] = $right['field'];
                     }
+                    $previous_right = $right;
                 }
             }
         }
         $failures = array_unique($failures);
         if (count($failures)) {
             echo sprintf('The following rights do not have a search option: %s', implode(', ', $failures));
-            ob_flush();
         }
         $this->array($failures)->isEmpty();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14481

Only some permission changes in profiles are being logged in the historical data. Rights must have a search option for their changes to be logged. This PR adds a test to ensure a search option exists for at least the basic rights that are displayed as a checkbox matrix. Most of this PR is moving the rights arrays from each `showForm*` method into a single, separate method so they would be known by the test.