### PR TITLE
feat(Cost): increase action time from CommonITILCost

### DIFF
--- a/src/CommonITILCost.php
+++ b/src/CommonITILCost.php
@@ -438,8 +438,17 @@ abstract class CommonITILCost extends CommonDBChild
         echo "<tr class='tab_bg_1'>";
         echo "<td>" . __('Duration') . "</td>";
         echo "<td>";
+
+        $toadd = [];
+        $max = max(DAY_TIMESTAMP, 10 * MINUTE_TIMESTAMP);
+        for ($i = MINUTE_TIMESTAMP; $i < $max; $i += MINUTE_TIMESTAMP) {
+            $toadd[] = $i;
+        }
         Dropdown::showTimeStamp('actiontime', ['value'           => $this->fields['actiontime'],
-            'addfirstminutes' => true
+            'min'                  => DAY_TIMESTAMP,
+            'max'                  => DAY_TIMESTAMP * 50,
+            'step'                 => DAY_TIMESTAMP,
+            'toadd'                => $toadd
         ]);
         echo "</td>";
         echo "<td>" . __('End date') . "</td>";

--- a/src/CommonITILCost.php
+++ b/src/CommonITILCost.php
@@ -438,17 +438,11 @@ abstract class CommonITILCost extends CommonDBChild
         echo "<tr class='tab_bg_1'>";
         echo "<td>" . __('Duration') . "</td>";
         echo "<td>";
-
-        $toadd = [];
-        $max = max(DAY_TIMESTAMP, 10 * MINUTE_TIMESTAMP);
-        for ($i = MINUTE_TIMESTAMP; $i < $max; $i += MINUTE_TIMESTAMP) {
-            $toadd[] = $i;
-        }
         Dropdown::showTimeStamp('actiontime', ['value'           => $this->fields['actiontime'],
+            'addfirstminutes'      => true,
             'min'                  => DAY_TIMESTAMP,
             'max'                  => DAY_TIMESTAMP * 50,
             'step'                 => DAY_TIMESTAMP,
-            'toadd'                => $toadd
         ]);
         echo "</td>";
         echo "<td>" . __('End date') . "</td>";


### PR DESCRIPTION

Actually ```actiontime``` for ```CommonITILCost``` is a maximum of 1 day

Increase days to 50.

replace ```addfirstminutes``` by ```toadd``` to prevent countdown by minute for each hour of each day

![image](https://user-images.githubusercontent.com/7335054/233399347-e287a9f4-354b-4f91-953c-608e2dde7483.png)


 


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27218