### PR TITLE
select2 dropdownAutowidth workaround for webkit

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -37,6 +37,21 @@
 
 var timeoutglobalvar;
 
+if (navigator.userAgent.indexOf('AppleWebKit') !== -1) {
+    // Workaround for select2 dropdownAutowidth not applying until the second time the dropdown is opened
+    // See: https://github.com/glpi-project/glpi/issues/13433 and https://github.com/select2/select2/issues/4678
+    const original_select2_fn = $.fn.select2;
+    $.fn.select2 = function (options) {
+        const result = original_select2_fn.apply(this, arguments);
+        if (typeof options === 'object') {
+            // open and close the dropdown after initialization
+            this.select2('open');
+            this.select2('close');
+        }
+        return result;
+    };
+}
+
 /**
  * modifier la propriete display d'un element
  *

--- a/js/common.js
+++ b/js/common.js
@@ -37,28 +37,6 @@
 
 var timeoutglobalvar;
 
-if (navigator.userAgent.indexOf('AppleWebKit') !== -1 && navigator.vendor.indexOf('Apple') !== -1) {
-    // Workaround for select2 dropdownAutowidth not applying until the second time the dropdown is opened
-    // See: https://github.com/glpi-project/glpi/issues/13433 and https://github.com/select2/select2/issues/4678
-    const original_select2_fn = $.fn.select2;
-    $.fn.select2 = function (options) {
-        const result = original_select2_fn.apply(this, arguments);
-        if (typeof options === 'object') {
-            // open and close the dropdown after initialization
-            result.on('select2:open', function () {
-                const el = $(this);
-                if (el.data('opened-before') === undefined) {
-                    el.data('opened-before', true);
-                    el.select2('close');
-                    el.select2('open');
-                }
-            });
-        }
-        return result;
-    };
-    $.fn.select2.defaults = original_select2_fn.defaults;
-}
-
 /**
  * modifier la propriete display d'un element
  *

--- a/js/common.js
+++ b/js/common.js
@@ -37,7 +37,7 @@
 
 var timeoutglobalvar;
 
-if (navigator.userAgent.indexOf('AppleWebKit') !== -1) {
+if (navigator.userAgent.indexOf('AppleWebKit') !== -1 && navigator.vendor.indexOf('Apple') !== -1) {
     // Workaround for select2 dropdownAutowidth not applying until the second time the dropdown is opened
     // See: https://github.com/glpi-project/glpi/issues/13433 and https://github.com/select2/select2/issues/4678
     const original_select2_fn = $.fn.select2;
@@ -45,11 +45,18 @@ if (navigator.userAgent.indexOf('AppleWebKit') !== -1) {
         const result = original_select2_fn.apply(this, arguments);
         if (typeof options === 'object') {
             // open and close the dropdown after initialization
-            this.select2('open');
-            this.select2('close');
+            result.on('select2:open', function () {
+                const el = $(this);
+                if (el.data('opened-before') === undefined) {
+                    el.data('opened-before', true);
+                    el.select2('close');
+                    el.select2('open');
+                }
+            });
         }
         return result;
     };
+    $.fn.select2.defaults = original_select2_fn.defaults;
 }
 
 /**

--- a/js/webkit_fix.js
+++ b/js/webkit_fix.js
@@ -1,0 +1,54 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+if (navigator.userAgent.indexOf('AppleWebKit') !== -1 && navigator.vendor.indexOf('Apple') !== -1) {
+    // Workaround for select2 dropdownAutowidth not applying until the second time the dropdown is opened
+    // See: https://github.com/glpi-project/glpi/issues/13433 and https://github.com/select2/select2/issues/4678
+    const original_select2_fn = $.fn.select2;
+    $.fn.select2 = function (options) {
+        const result = original_select2_fn.apply(this, arguments);
+        if (typeof options === 'object') {
+            // open and close the dropdown after initialization
+            result.on('select2:open', function () {
+                const el = $(this);
+                if (el.data('opened-before') === undefined) {
+                    el.data('opened-before', true);
+                    el.select2('close');
+                    el.select2('open');
+                }
+            });
+        }
+        return result;
+    };
+    $.fn.select2.defaults = original_select2_fn.defaults;
+}

--- a/src/Html.php
+++ b/src/Html.php
@@ -1340,6 +1340,7 @@ HTML;
         $tpl_vars['css_files'][] = ['path' => 'css/palettes/' . $theme . '.scss'];
 
         $tpl_vars['js_files'][] = ['path' => 'public/lib/base.js'];
+        $tpl_vars['js_files'][] = ['path' => 'js/webkit_fix.js'];
         $tpl_vars['js_files'][] = ['path' => 'js/common.js'];
 
        // Search

--- a/tests/js/bootstrap.mjs
+++ b/tests/js/bootstrap.mjs
@@ -37,6 +37,9 @@ await import('jquery').then((jquery) => {
     window.$ = window.jQuery = jquery.default;
 });
 await import('@tabler/core');
+await import('select2/dist/js/select2.full').then((select2) => {
+    $.fn.select2 = select2;
+});
 
 // Add a flag variable to know in other scripts if they are run in tests. Should not affect how they behave, just how functions/vars in non-modules are bound.
 window.GLPI_TEST_ENV = true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13433

When using a browser running Webkit, the first time you open a select2 dropdown the auto width does not apply. This seems like a bug in the Webkit engine. This PR adds a workaround when it detects an AppleWebKit user agent to close and then reopen the dropdown when the user tries opening it the first time.

Since this only happens for WebKit, I had to test this using Cypress with the experimental Webkit support. You should be able to test this fix using this branch which includes this fix along with a Cypress + Webkit setup:
https://github.com/cconard96/glpi/tree/fix/13433

1. Start Cypress with `npm run test:e2e`
2. Select E2E Testing option
3. Select Webkit and then click "Start E2E Testing in WebKit"
4. Select the "test.cy.js" spec. After it is finished, you should be able to use GLPI manually to test the fix.
Since manual interactions seem to glitch out sometimes, the quickest/easiest way to test is to check the language dropdown.