### PR TITLE
Set max size for 'alt' property (images)

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -5003,7 +5003,7 @@ JAVASCRIPT
         }
 
         if (!isset($options['alt'])) {
-            $options['alt'] = $options['title'];
+            $options['alt'] = Html::resume_text($options['title'], 30);
         }
 
         if (


### PR DESCRIPTION
Images tag generated by `ajax/getUserPicture.php` contains the user's full name in the `alt` property so it can be displayed in case the image fail to load.

![image](https://user-images.githubusercontent.com/42734840/233972453-7776e593-750a-48d7-8063-5704c462eac8.png)

It may cause some display issues for users with very long names:

![image](https://user-images.githubusercontent.com/42734840/233972833-fb2c5391-3a50-4e2a-9ddf-370fbacd45db.png)

To prevent this, I've added an hardcoded limit to 30 chars:

![image](https://user-images.githubusercontent.com/42734840/233973019-037ebdb5-4dfa-45f7-b2a5-4998b5d3114d.png)

The full value is still available in the `title` attribute.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
