### PR TITLE
API: Do not render progress bars when executing massive actions

### DIFF
--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -1323,6 +1323,10 @@ class MassiveAction
      **/
     public function updateProgressBars()
     {
+        if (isAPI()) {
+            // No progress bar on API
+            return;
+        }
 
         if ($this->timer->getTime() > 1) {
            // If the action's delay is more than one second, the display progress bars


### PR DESCRIPTION
Fix this issue with the API trying to render some progress bars in its output:

![image](https://user-images.githubusercontent.com/42734840/234299992-a517083f-88c3-4068-acf3-af0d2fd2df9c.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27735