### PR TITLE
fix marketplace link

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -176,7 +176,7 @@ class Plugin extends CommonDBTM
             $classic     => Plugin::getSearchURL(false),
         ];
         if (MarketplaceController::isWebAllowed()) {
-            $links[$marketplace] = MarketplaceController::getSearchURL(false);
+            $links[$marketplace] = MarketplaceView::getSearchURL(false);
         }
         return $links;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This only affects the main branch as the bug was introduced with the feature to control Marketplace availability. The wrong class was being used to get the URL so the button would redirect you to a non-existent URL `/front/marketplace/controller.php`.