### PR TITLE
Improve kanban performances 2

### DIFF
--- a/ajax/getUserPicture.php
+++ b/ajax/getUserPicture.php
@@ -44,29 +44,29 @@ Html::header_nocache();
 
 Session::checkLoginUser();
 
-if (!isset($_GET['users_id'])) {
+if (!isset($_REQUEST['users_id'])) {
     Response::sendError(400, "Missing users_id parameter");
-} else if (!is_array($_GET['users_id'])) {
-    $_GET['users_id'] = [$_GET['users_id']];
+} else if (!is_array($_REQUEST['users_id'])) {
+    $_REQUEST['users_id'] = [$_REQUEST['users_id']];
 }
 
-$_GET['users_id'] = array_unique($_GET['users_id']);
+$_REQUEST['users_id'] = array_unique($_REQUEST['users_id']);
 
-if (!isset($_GET['size'])) {
-    $_GET['size'] = '100%';
+if (!isset($_REQUEST['size'])) {
+    $_REQUEST['size'] = '100%';
 }
 
-if (!isset($_GET['allow_blank'])) {
-    $_GET['allow_blank'] = false;
+if (!isset($_REQUEST['allow_blank'])) {
+    $_REQUEST['allow_blank'] = false;
 }
 
 $user = new User();
 $imgs = [];
 
-foreach ($_GET['users_id'] as $user_id) {
+foreach ($_REQUEST['users_id'] as $user_id) {
     if ($user->getFromDB($user_id)) {
-        if (!empty($user->fields['picture']) || $_GET['allow_blank']) {
-            if (isset($_GET['type']) && $_GET['type'] == 'thumbnail') {
+        if (!empty($user->fields['picture']) || $_REQUEST['allow_blank']) {
+            if (isset($_REQUEST['type']) && $_REQUEST['type'] == 'thumbnail') {
                 $path = User::getThumbnailURLForPicture($user->fields['picture']);
             } else {
                 $path = User::getURLForPicture($user->fields['picture']);
@@ -74,11 +74,11 @@ foreach ($_GET['users_id'] as $user_id) {
             $img = Html::image($path, [
                 'title'          => getUserName($user_id),
                 'data-bs-toggle' => 'tooltip',
-                'width'          => $_GET['size'],
-                'height'         => $_GET['size'],
-                'class'          => $_GET['class'] ?? ''
+                'width'          => $_REQUEST['size'],
+                'height'         => $_REQUEST['size'],
+                'class'          => $_REQUEST['class'] ?? ''
             ]);
-            if (isset($_GET['link']) && $_GET['link']) {
+            if (isset($_REQUEST['link']) && $_REQUEST['link']) {
                  $imgs[$user_id] = Html::link($img, User::getFormURLWithID($user_id));
             } else {
                 $imgs[$user_id] = $img;

--- a/js/modules/Kanban/Kanban.js
+++ b/js/modules/Kanban/Kanban.js
@@ -342,6 +342,11 @@ class GLPIKanbanRights {
 
         this.display_initials = true;
 
+        /**
+         * Keep track of users pictures that need to be loaded later on
+         *
+         * @type {Set}
+         */
         this.user_pictures_to_load = new Set([]);
 
         /**
@@ -1470,8 +1475,8 @@ class GLPIKanbanRights {
             self.user_pictures_to_load.clear();
 
             $.ajax({
+                type: 'POST', // Too much data may break GET limit
                 url: (self.ajax_root + "getUserPicture.php"),
-                async: false,
                 data: {
                     users_id: users_ids,
                     size: self.team_image_size,
@@ -1523,6 +1528,7 @@ class GLPIKanbanRights {
                 return;
             }
             $.ajax({
+                type: 'POST', // Too much data may break GET limit
                 url: (self.ajax_root + "getUserPicture.php"),
                 async: false,
                 data: {


### PR DESCRIPTION
https://github.com/glpi-project/glpi/pull/14525 was not enough to fix the internal ref issue.

Long story short, https://github.com/glpi-project/glpi/pull/14525 fixed the image picture cache that is built from the `cards` data returned by the `load_column_state` ajax request.

![image](https://user-images.githubusercontent.com/42734840/234811218-aefc12f8-eacd-4974-9e68-e9253304e4a2.png)

However, the `cards` entry returned in this request do not contain all displayed cards, it only contains cards that where moved in the kanban (thus saving their custom positions).
This mean that we may have 0 cards returned by this request, which make our cache far less useful.

To fix this specific point and improve the overall performances, I've applied the following fixes:

### 1\) Use user picture placeholder, load real pictures later

The kanban code is already able to display a fallback picture with the `generateUserBadge` function.

I've forced all users pictures to be displayed using this fallback method as a placeholder and kept track of their users id is a set.
After the kanban is fully displayed, I load the real images with a single ajax request and replace the placeholders.

This is similar to what the cache was doing but is done **after** the kanban is fully loaded (instead of before).
This mean we are sure to know all the users pictures that must be loaded and we wont impact the main loading process.

### 2\) Use `POST` requests

As we use a single query to load all the pictures, it could be possible to exceed the max `GET` size if too much users_id are specified.
Using a `POST` request avoid this potential issue.

### 3\) Remove the cache preload step

With this new system, we don't really need the cache preload step anymore so we can save a request by deleting it.

### 4\) Remove synchronous requests

I've removed the last remaining call to `$.ajax` which used `async: false` to avoid blocking the main thread.
I've replaced it by `async`/`await` and tried to group the columns loading requests into a single `await Promise.all`  to allow them to be executed concurrently.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27631
