### PR TITLE
fix: missing category when change created from ticket

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -483,12 +483,21 @@ abstract class CommonITILObject extends CommonDBTM
         if (in_array($this->getType(), ['Change', 'Problem']) && $tickets_id) {
             $ticket->getFromDB($tickets_id);
 
-            $options['content']             = $ticket->fields['content'];
-            $options['name']                = $ticket->fields['name'];
-            $options['impact']              = $ticket->fields['impact'];
-            $options['urgency']             = $ticket->fields['urgency'];
-            $options['priority']            = $ticket->fields['priority'];
-            if (isset($options['_tickets_id']) && !isset($options['_saved']['itilcategories_id'])) {
+            foreach ([
+                'content',
+                'name',
+                'impact',
+                'urgency',
+                'priority',
+                'time_to_resolve',
+                'entities_id',
+            ] as $field) {
+                if (!isset($options['_saved'][$field])) {
+                    $options[$field] = $ticket->fields[$field];
+                }
+            }
+
+            if (!isset($options['_saved']['itilcategories_id'])) {
                 //page is reloaded on category change, we only want category on the very first load
                 $category = new ITILCategory();
                 $options['itilcategories_id'] = 0;
@@ -502,8 +511,6 @@ abstract class CommonITILObject extends CommonDBTM
                     $options['itilcategories_id'] = $ticket->fields['itilcategories_id'];
                 }
             }
-            $options['time_to_resolve']     = $ticket->fields['time_to_resolve'];
-            $options['entities_id']         = $ticket->fields['entities_id'];
         }
 
         // check original problem for change

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -483,7 +483,7 @@ abstract class CommonITILObject extends CommonDBTM
         if (in_array($this->getType(), ['Change', 'Problem']) && $tickets_id) {
             $ticket->getFromDB($tickets_id);
 
-            foreach ([
+            $fields = [
                 'content',
                 'name',
                 'impact',
@@ -491,7 +491,8 @@ abstract class CommonITILObject extends CommonDBTM
                 'priority',
                 'time_to_resolve',
                 'entities_id',
-            ] as $field) {
+            ];
+            foreach ($fields as $field) {
                 if (!isset($options['_saved'][$field])) {
                     $options[$field] = $ticket->fields[$field];
                 }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -488,7 +488,7 @@ abstract class CommonITILObject extends CommonDBTM
             $options['impact']              = $ticket->fields['impact'];
             $options['urgency']             = $ticket->fields['urgency'];
             $options['priority']            = $ticket->fields['priority'];
-            if (isset($options['tickets_id'])) {
+            if (isset($options['_tickets_id']) && !isset($options['_saved']['itilcategories_id'])) {
                 //page is reloaded on category change, we only want category on the very first load
                 $category = new ITILCategory();
                 $options['itilcategories_id'] = 0;

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -483,6 +483,7 @@ abstract class CommonITILObject extends CommonDBTM
         if (in_array($this->getType(), ['Change', 'Problem']) && $tickets_id) {
             $ticket->getFromDB($tickets_id);
 
+            // copy fields from original ticket, only when fields are not already set by the user (contained in _saved array)
             $fields = [
                 'content',
                 'name',

--- a/templates/components/form/link_existing_or_new.html.twig
+++ b/templates/components/form/link_existing_or_new.html.twig
@@ -74,7 +74,7 @@
          </div>
          <div class="col-auto ms-4">
             {% if create_link %}
-               {% set target_form_path = (target_itemtype|itemtype_form_path ~ "?_" ~ source_itemtype|itemtype_foreign_key ~ "=" ~ source_items_id) %}
+               {% set target_form_path = (target_itemtype|itemtype_form_path ~ "?" ~ source_itemtype|itemtype_foreign_key ~ "=" ~ source_items_id) %}
                {% set create_url = create_link['url'] is defined ? create_link['url'] : target_form_path %}
                <a href="{{ create_url }}" class="btn btn-primary">
                   <i class="ti ti-plus"></i>

--- a/templates/components/form/link_existing_or_new.html.twig
+++ b/templates/components/form/link_existing_or_new.html.twig
@@ -74,7 +74,7 @@
          </div>
          <div class="col-auto ms-4">
             {% if create_link %}
-               {% set target_form_path = (target_itemtype|itemtype_form_path ~ "?" ~ source_itemtype|itemtype_foreign_key ~ "=" ~ source_items_id) %}
+               {% set target_form_path = (target_itemtype|itemtype_form_path ~ "?_" ~ source_itemtype|itemtype_foreign_key ~ "=" ~ source_items_id) %}
                {% set create_url = create_link['url'] is defined ? create_link['url'] : target_form_path %}
                <a href="{{ create_url }}" class="btn btn-primary">
                   <i class="ti ti-plus"></i>


### PR DESCRIPTION
When creating a change from a ticket, the category of the original ticket was not automatically included in the new change.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27779
