### PR TITLE
Allow End of month/year for future date selections

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -3409,7 +3409,7 @@ JS;
             }
 
             if ($params['with_days']) {
-                    $dates['ENDMONTH']  = __('End of the month');
+                $dates['ENDMONTH']  = __('End of the month');
             }
 
             for ($i = 1; $i <= 12; $i++) {
@@ -3417,7 +3417,7 @@ JS;
             }
 
             if ($params['with_days']) {
-                    $dates['ENDYEAR']  = __('End of the year');
+                $dates['ENDYEAR']  = __('End of the year');
             }
 
             for ($i = 1; $i <= 10; $i++) {
@@ -3461,8 +3461,8 @@ JS;
                 return date("Y-m-d", $specifictime);
         }
 
-       // Search on begin of month / year
-        if (strstr($val, 'BEGIN')) {
+       // Search on begin /end of month / year
+        if (strstr($val, 'BEGIN') || strstr($val, 'END')) {
             $hour   = 0;
             $minute = 0;
             $second = 0;
@@ -3477,21 +3477,7 @@ JS;
 
                 case "BEGINMONTH":
                     break;
-            }
 
-            return date($format_use, mktime($hour, $minute, $second, $month, $day, $year));
-        }
-
-       // Search on begin of month / year
-        if (strstr($val, 'END')) {
-            $hour   = 0;
-            $minute = 0;
-            $second = 0;
-            $month  = date("n", $specifictime);
-            $day    = 1;
-            $year   = date("Y", $specifictime);
-
-            switch ($val) {
                 case "ENDYEAR":
                     $month = 12;
                     $day = 31;

--- a/src/Html.php
+++ b/src/Html.php
@@ -3408,8 +3408,16 @@ JS;
                 $dates[$i . 'WEEK'] = sprintf(_n('+ %d week', '+ %d weeks', $i), $i);
             }
 
+            if ($params['with_days']) {
+                    $dates['ENDMONTH']  = __('End of the month');
+            }
+
             for ($i = 1; $i <= 12; $i++) {
                 $dates[$i . 'MONTH'] = sprintf(_n('+ %d month', '+ %d months', $i), $i);
+            }
+
+            if ($params['with_days']) {
+                    $dates['ENDYEAR']  = __('End of the year');
             }
 
             for ($i = 1; $i <= 10; $i++) {
@@ -3468,6 +3476,29 @@ JS;
                     break;
 
                 case "BEGINMONTH":
+                    break;
+            }
+
+            return date($format_use, mktime($hour, $minute, $second, $month, $day, $year));
+        }
+
+       // Search on begin of month / year
+        if (strstr($val, 'END')) {
+            $hour   = 0;
+            $minute = 0;
+            $second = 0;
+            $month  = date("n", $specifictime);
+            $day    = 1;
+            $year   = date("Y", $specifictime);
+
+            switch ($val) {
+                case "ENDYEAR":
+                    $month = 12;
+                    $day = 31;
+                    break;
+
+                case "ENDMONTH":
+                    $day = date("t", $specifictime);
                     break;
             }
 


### PR DESCRIPTION
This change allows a new selection "End of month" and "End of year" (like "Beginning of month" and "Beginning of year" already exist).


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
