### PR TITLE
Fix duplicated Entity search option ID

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -1250,7 +1250,7 @@ class Entity extends CommonTreeDropdown
         ];
 
         $tab[] = [
-            'id'                 => '71',
+            'id'                 => '75',
             'table'              => self::getTable(),
             'field'              => 'contracts_id_default',
             'name'               => __('Default contract'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Cannot merge 10.0/bugfixes branche into main due to SO ID duplication:
> Duplicate key 71 (Default contract/Satisfaction survey configuration (Change)) in Entity searchOptions!

Update search option was introduced a week ago in aba538ecd08f87879689e2912ea4f5015abb36b2 and was not part of a release, so changing it should not require a migration.