### PR TITLE
Enhance locales requests response time

### DIFF
--- a/front/locale.php
+++ b/front/locale.php
@@ -40,6 +40,8 @@ $dont_check_maintenance_mode = true;
 
 include('../inc/includes.php');
 
+session_write_close(); // Unlocks session to permit concurrent calls
+
 header("Content-Type: application/json; charset=UTF-8");
 
 $is_cacheable = !isset($_GET['debug']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When there are many plugins locales to load, it can take a long time due to the PHP session locking mechanism. Indeed, each request must wait for the previous one to be finished to be able to "open" the session and process the request.

![image](https://user-images.githubusercontent.com/33253653/235868158-0bb6d338-183d-4a46-a53b-1748c68a3c30.png)
