### PR TITLE
fix: The last update user not updated with anonymous users

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -4912,7 +4912,7 @@ abstract class CommonITILObject extends CommonDBTM
            // set last updater if interactive user
             if (!Session::isCron()) {
                 $update['users_id_lastupdater'] = Session::getLoginUserID();
-            } else if ($users_id_lastupdater > 0) {
+            } else {
                 $update['users_id_lastupdater'] = $users_id_lastupdater;
             }
 

--- a/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
@@ -65,7 +65,7 @@
    {% endif %}
 </span>
 
-{% if users_id_editor > 0 and date_creation != date_mod %}
+{% if date_creation != date_mod %}
    <span class="badge user-select-auto text-wrap ms-1 d-none d-md-block">
       {% set date_span %}
          <span
@@ -83,15 +83,19 @@
          </span>
       {% endset %}
 
-      {% set is_current_editor = (users_id_editor == session('glpiID')) %}
-      {% set anonym_editor = (get_current_interface() == 'helpdesk' and not is_current_editor and entity_config('anonymize_support_agents', session('glpiactive_entity')) != constant('Entity::ANONYMIZE_DISABLED')) %}
-      {% set editor_span %}
-         {{ include('components/user/link_with_tooltip.html.twig', {
-            'users_id': users_id_editor,
-            'enable_anonymization': anonym_editor
-         }, with_context = false) }}
-      {% endset %}
+      {% if users_id_editor > 0 %}
+         {% set is_current_editor = (users_id_editor == session('glpiID')) %}
+         {% set anonym_editor = (get_current_interface() == 'helpdesk' and not is_current_editor and entity_config('anonymize_support_agents', session('glpiactive_entity')) != constant('Entity::ANONYMIZE_DISABLED')) %}
+         {% set editor_span %}
+            {{ include('components/user/link_with_tooltip.html.twig', {
+               'users_id': users_id_editor,
+               'enable_anonymization': anonym_editor
+            }, with_context = false) }}
+         {% endset %}
 
-      {{ __('Last update: %1$s by %2$s')|format(date_span, editor_span)|raw }}
+         {{ __('Last update: %1$s by %2$s')|format(date_span, editor_span)|raw }}
+      {% else %}
+         {{ __('Last update: %1$s by anonymous user')|format(date_span)|raw }}
+      {% endif %}
    </span>
 {% endif %}


### PR DESCRIPTION
When an anonymous user answers on a ticket the field corresponding to the last author of update (users_id_lastupdater) does not change and keeps the value of the last GLPI user, which is false.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27829
