### PR TITLE
Add ability to bypass right checks

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -2437,9 +2437,7 @@ class Session
         } finally {
             self::$bypass_right_checks = false;
         }
-        if ($caught_throwable !== null) {
-            throw $caught_throwable;
-        }
+        throw $caught_throwable;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

A plugin I'm working on requires some actions to take place regardless of the current user's permissions and having a static property to indicate that right checks should be skipped seems like the best solution available at the moment.