### PR TITLE
feat(VirtualMachine): display deleted link when needed

### DIFF
--- a/src/ComputerVirtualMachine.php
+++ b/src/ComputerVirtualMachine.php
@@ -198,7 +198,8 @@ class ComputerVirtualMachine extends CommonDBChild
 
                 $computer = new Computer();
                 foreach ($hosts as $host) {
-                    echo "<tr class='tab_bg_2'>";
+                    $class = $host['is_deleted'] ? "deleted" : "";
+                    echo "<tr class='tab_bg_2 $class' >";
                     echo "<td>";
                     if ($computer->can($host['computers_id'], READ)) {
                         echo "<a href='" . Computer::getFormURLWithID($computer->fields['id']) . "'>";


### PR DESCRIPTION
From a host, GLPI adds a CSS class for VMs that have been deleted.

![image](https://user-images.githubusercontent.com/7335054/236151222-8d9a370c-f4a3-472e-97ca-a2fb76a15ff6.png)

do the same from ```Computer```  when it changes ESX  (the link to the first one is deleted and a new one is created)

![image](https://user-images.githubusercontent.com/7335054/236151411-ca6cb35b-82e5-4384-a664-6616bb73514b.png)



| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
