### PR TITLE
Misc marketplace updates/fixes

### DIFF
--- a/inc/based_config.php
+++ b/inc/based_config.php
@@ -94,7 +94,7 @@ include_once(GLPI_ROOT . "/inc/autoload.function.php");
         'GLPI_NETWORK_MAIL'                 => 'glpi@teclib.com',
         'GLPI_NETWORK_SERVICES'             => 'https://services.glpi-network.com', // GLPI Network services project URL
         'GLPI_NETWORK_REGISTRATION_API_URL' => '{GLPI_NETWORK_SERVICES}/api/registration/',
-        'GLPI_MARKETPLACE_PLUGINS_API_URI'  => '{GLPI_NETWORK_SERVICES}/api/glpi-plugins/',
+        'GLPI_MARKETPLACE_PLUGINS_API_URI'  => '{GLPI_NETWORK_SERVICES}/api/marketplace/',
         'GLPI_MARKETPLACE_ALLOW_OVERRIDE'   => true, // allow marketplace to override a plugin found outside GLPI_MARKETPLACE_DIR
         'GLPI_MARKETPLACE_MANUAL_DOWNLOADS' => true, // propose manual download link of plugins which cannot be installed/updated by marketplace
         'GLPI_USER_AGENT_EXTRA_COMMENTS'    => '', // Extra comment to add to GLPI User-Agent

--- a/src/Marketplace/Api/Plugins.php
+++ b/src/Marketplace/Api/Plugins.php
@@ -204,9 +204,11 @@ class Plugins
     ) {
         global $GLPI_CACHE;
 
+        $cache_key = self::getCacheKey('marketplace_all_plugins');
+
         if (self::$plugins === null) {
             $plugins_colct = !$force_refresh
-                ? $GLPI_CACHE->get('marketplace_all_plugins', null)
+                ? $GLPI_CACHE->get($cache_key, null)
                 : null;
 
             if ($plugins_colct === null) {
@@ -228,7 +230,7 @@ class Plugins
 
                 if ($this->last_error === null) {
                     // Cache result only if self::getPaginatedCollection() did not returned an incomplete result due to an error
-                    $GLPI_CACHE->set('marketplace_all_plugins', $plugins_colct, HOUR_TIMESTAMP);
+                    $GLPI_CACHE->set($cache_key, $plugins_colct, HOUR_TIMESTAMP);
                 }
             }
 
@@ -412,14 +414,16 @@ class Plugins
     {
         global $GLPI_CACHE;
 
-        $plugins_colct = !$force_refresh ? $GLPI_CACHE->get("marketplace_tag_$tag", []) : [];
+        $cache_key = self::getCacheKey("marketplace_tag_$tag");
+
+        $plugins_colct = !$force_refresh ? $GLPI_CACHE->get($cache_key, []) : [];
 
         if (!count($plugins_colct)) {
             $plugins_colct = $this->getPaginatedCollection("tags/{$tag}/plugin");
 
             if ($this->last_error === null) {
                 // Cache result only if self::getPaginatedCollection() did not returned an incomplete result due to an error
-                $GLPI_CACHE->set("marketplace_tag_$tag", $plugins_colct, HOUR_TIMESTAMP);
+                $GLPI_CACHE->set($cache_key, $plugins_colct, HOUR_TIMESTAMP);
             }
         }
 
@@ -501,5 +505,10 @@ class Plugins
     public function isListTruncated(): bool
     {
         return $this->is_list_truncated;
+    }
+
+    private static function getCacheKey(string $item_key): string
+    {
+        return $item_key . '_' . GLPINetwork::getRegistrationKey();
     }
 }

--- a/src/Marketplace/Controller.php
+++ b/src/Marketplace/Controller.php
@@ -405,7 +405,7 @@ class Controller extends CommonGLPI
     {
         $api_plugin = self::getAPI()->getPlugin($this->plugin_key);
 
-        if (!isset($api_plugin['required_offers'])) {
+        if (empty($api_plugin['required_offers'])) {
             return false;
         }
 

--- a/src/Marketplace/View.php
+++ b/src/Marketplace/View.php
@@ -733,7 +733,7 @@ HTML;
 
                     // Use "marketplace.download.php" proxy if archive is downloadable from GLPI marketplace plugins API
                     // as this API will refuse to serve the archive if registration key is not set in headers.
-                    $download_url = str_starts_with($plugin_data['installation_url'], GLPI_MARKETPLACE_PLUGINS_API_URI)
+                    $download_url = parse_url($plugin_data['installation_url'], PHP_URL_HOST) === parse_url(GLPI_MARKETPLACE_PLUGINS_API_URI, PHP_URL_HOST)
                         ? $CFG_GLPI['root_doc'] . '/front/marketplace.download.php?key=' . $plugin_key
                         : $plugin_data['installation_url'];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Use the new `/marketplace` endpoint.
On marketplace server side, endoints were a bit reorganized. Old endpoints are still supported, but the sooner we use the new ones in GLPI, the sooner aliases could be removed on marketplace server side.

2. Fix check on required offers in marketplace
GLPI expect `required_offer` key to be `null` when there is no required offer for a given plugin. When value is an array, it consider that an higher offer is required and prevent plugin to be downloaded. It requires a specific piece of code on marketplace server side, and I would like to remove it in the future.

3. Ensure marketplace cache is refreshed on registration key change
On some edge cases, marketplace server response may differ depending on used registration key, so when registration key changed, existing cache should not be reused.