### PR TITLE
Fix pending reason wrapping

### DIFF
--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -213,7 +213,7 @@
             </div>
 
             {{ call_plugin_hook('post_item_form', {"item": subitem, 'options': params}) }}
-            <div class="d-flex card-footer mx-n3 mb-n3">
+            <div class="d-flex card-footer mx-n3 mb-n3 flex-wrap" style="row-gap: 10px;">
                {% set pending_reasons %}
                   {% set show_pending_reasons_actions = item.fields['status'] == constant('CommonITILObject::WAITING') and not has_pending_reason and not add_reopen %}
                   {% if get_current_interface() == 'central' and item.isAllowedStatus(item.fields['status'], constant('CommonITILObject::WAITING')) %}

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -421,7 +421,7 @@
             {% endset %}
 
             {{ call_plugin_hook('post_item_form', {"item": subitem, 'options': params}) }}
-            <div class="d-flex card-footer mx-n3 mb-n3">
+            <div class="d-flex card-footer mx-n3 mb-n3 flex-wrap" style="row-gap: 10px;">
                {% if subitem.fields['id'] <= 0 %}
                   <div class="input-group">
                      <button class="btn btn-primary" type="submit" name="add">

--- a/templates/components/itilobject/timeline/pending_reasons.html.twig
+++ b/templates/components/itilobject/timeline/pending_reasons.html.twig
@@ -66,7 +66,7 @@
                'addicon': false,
                'comments': false,
                'width': '95%',
-               'field_class': '',
+               'field_class': 'flex-nowrap',
                'add_field_html': pending_reasons_id_script
             }
          ) }}


### PR DESCRIPTION
There is some issues with the display of pending reasons depending on your screen size and the pending reason name length.

Issue 1:

![image](https://user-images.githubusercontent.com/42734840/236250068-caee478d-a673-484b-aa30-feebf24291be.png)

Issue 2:

![image](https://user-images.githubusercontent.com/42734840/236250148-7496cdeb-1d3f-4c5d-974a-3f8c2d9e1eb1.png)

After changes:

Disable wrapping for the pending reason + pending toggle div:

![image](https://user-images.githubusercontent.com/42734840/236250277-c1a60bd8-a093-4a1c-87cc-53e2c10b8429.png)

Enable wrapping for the parent container div + some row-gap padding:

![image](https://user-images.githubusercontent.com/42734840/236250562-129dd509-f7a0-4997-9eb9-834efd2a14b8.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27887
