### PR TITLE
Do not show create button for entities if no recursion

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -195,7 +195,6 @@ class Entity extends CommonTreeDropdown
     {
         // Do not show the create button if no recusive access on current entity
         return parent::canCreate() && Session::haveRecursiveAccessToEntity(Session::getActiveEntity());
-
     }
 
     public function canCreateItem()

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -191,6 +191,12 @@ class Entity extends CommonTreeDropdown
         return _n('Entity', 'Entities', $nb);
     }
 
+    public static function canCreate()
+    {
+        // Do not show the create button if no recusive access on current entity
+        return parent::canCreate() && Session::haveRecursiveAccessToEntity(Session::getActiveEntity());
+
+    }
 
     public function canCreateItem()
     {


### PR DESCRIPTION
User that have no recursive access to the current entity can't create any new entity (as the new entity would become a child of the current entity, which they would not be able to see).

Currently users stills have access to the create button in this case, which lead them to an empty page:

![image](https://user-images.githubusercontent.com/42734840/236486721-66c3130e-01de-4c06-8173-3d43865bcf7f.png)

These changes prevent the create button to be displayed for these users (this also cover the "add child" action in the "Entities" tab of an already existing entity).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27898
