### PR TITLE
fix deprecation warning (found in 10.0.7)

### DIFF
--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -1606,10 +1606,10 @@ final class DbUtils
             $id_visible = $_SESSION["glpiis_ids_visible"];
         }
 
-        if ($realname !== null && strlen($realname) > 0) {
+        if (strlen($realname ?? '') > 0) {
             $formatted = $realname;
 
-            if ($firstname !== null && strlen($firstname) > 0) {
+            if (strlen($firstname ?? '') > 0) {
                 if ($order == User::FIRSTNAME_BEFORE) {
                     $formatted = $firstname . " " . $formatted;
                 } else {

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -1609,7 +1609,7 @@ final class DbUtils
         if ($realname !== null && strlen($realname) > 0) {
             $formatted = $realname;
 
-            if (strlen($firstname) > 0) {
+            if ($firstname !== null && strlen($firstname) > 0) {
                 if ($order == User::FIRSTNAME_BEFORE) {
                     $formatted = $firstname . " " . $formatted;
                 } else {


### PR DESCRIPTION
When viewing a list of tickets, debug mode enabled, I may get several errors:

```PHP Deprecated function (8192): strlen(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/glpi/src/DbUtils.php at line 1580```

I don't have access to backtrace, but the fix seems obvious.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
