### PR TITLE
Prevent dates migration to fail when DB contains views

### DIFF
--- a/install/migrations/update_10.0.1_to_10.0.2/dates.php
+++ b/install/migrations/update_10.0.1_to_10.0.2/dates.php
@@ -53,6 +53,7 @@ $columns_iterator = $DB->request(
         'FROM'   => 'information_schema.columns',
         'WHERE'  => [
             'table_schema' => $DB->dbdefault,
+            'table_type'   => 'BASE TABLE',
             'data_type'    => ['timestamp', 'datetime', 'date'],
         ],
         'ORDER'  => ['TABLE_NAME', 'COLUMN_NAME'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27884

Some plugins may use SQL views that have date fields. In such case, the migration to GLPI 10.0.2 is failing with following error: `The target table XXX of the UPDATE is not updatable`.