### PR TITLE
Task Status is changed when update fails in timeline

### DIFF
--- a/ajax/timeline.php
+++ b/ajax/timeline.php
@@ -56,18 +56,18 @@ if (($_POST['action'] ?? null) === 'change_task_state') {
         $new_state = ($task->fields['state'] == Planning::DONE)
                         ? Planning::TODO
                         : Planning::DONE;
-        $new_label = Planning::getState($new_state);
-        echo json_encode([
-            'state'  => $new_state,
-            'label'  => $new_label
-        ]);
-
         $foreignKey = $parent->getForeignKeyField();
         $task->update([
             'id'        => intval($_POST['tasks_id']),
             $foreignKey => intval($_POST[$foreignKey]),
             'state'     => $new_state,
             'users_id_editor' => Session::getLoginUserID()
+        ]);
+        $task->getFromDB(intval($_POST['tasks_id']));
+        $new_label = Planning::getState($new_state);
+        echo json_encode([
+            'state'  => $task->fields['state'],
+            'label'  => $new_label
         ]);
     }
 } else if (($_REQUEST['action'] ?? null) === 'viewsubitem') {

--- a/ajax/timeline.php
+++ b/ajax/timeline.php
@@ -63,7 +63,6 @@ if (($_POST['action'] ?? null) === 'change_task_state') {
             'state'     => $new_state,
             'users_id_editor' => Session::getLoginUserID()
         ]);
-        $task->getFromDB(intval($_POST['tasks_id']));
         $new_label = Planning::getState($new_state);
         echo json_encode([
             'state'  => $task->fields['state'],


### PR DESCRIPTION
When changing status of a task in the timeline by checking its box, the status is changed even if update function hasn't changed it.
Example:  - update fails 
                - plugin [hooks](https://glpi-developer-documentation.readthedocs.io/en/master/plugins/hooks.html) interrupts it (I'm using behaviors plugin to control that fields are filled). 
I propose to recall the status from DB after the update of the task to be sure of its value.


