### PR TITLE
fix(core): display checkbox for allasset view

### DIFF
--- a/templates/components/search/table.html.twig
+++ b/templates/components/search/table.html.twig
@@ -117,8 +117,8 @@
                         {% elseif itemtype == 'User' and not can_view_all_entities() and not has_access_to_user_entities(row['id']) %}
                         {% elseif item is instanceof('CommonDBTM') and item.maybeRecursive() and not has_access_to_entity(row['entities_id'])  %}
                         {% else %}
-
-                           {% if item is instanceof('CommonDBTM') and call(itemtype ~ '::isMassiveActionAllowed', [row['id']])  %}
+                           {# item is null from global asset view #}
+                           {% if item is null or item is instanceof('CommonDBTM') and call(itemtype ~ '::isMassiveActionAllowed', [row['id']])  %}
                               {% set checked = session('glpimassiveactionselected')[itemtype][row['id']] ?? false %}
                               <input class="form-check-input massive_action_checkbox" type="checkbox" data-glpicore-ma-tags="common"
                                  value="1" aria-label="" {% if checked %}checked="checked"{% endif %}

--- a/templates/components/search/table.html.twig
+++ b/templates/components/search/table.html.twig
@@ -117,8 +117,8 @@
                         {% elseif itemtype == 'User' and not can_view_all_entities() and not has_access_to_user_entities(row['id']) %}
                         {% elseif item is instanceof('CommonDBTM') and item.maybeRecursive() and not has_access_to_entity(row['entities_id'])  %}
                         {% else %}
-                           {# item is null from global asset view #}
-                           {% if item is null or item is instanceof('CommonDBTM') and call(itemtype ~ '::isMassiveActionAllowed', [row['id']])  %}
+                           {% set row_itemtype = row['TYPE'] ?? itemtype %}
+                           {% if call(row_itemtype ~ '::isMassiveActionAllowed', [row['id']]) %}
                               {% set checked = session('glpimassiveactionselected')[itemtype][row['id']] ?? false %}
                               <input class="form-check-input massive_action_checkbox" type="checkbox" data-glpicore-ma-tags="common"
                                  value="1" aria-label="" {% if checked %}checked="checked"{% endif %}

--- a/templates/components/search/table.html.twig
+++ b/templates/components/search/table.html.twig
@@ -119,7 +119,7 @@
                         {% else %}
                            {% set row_itemtype = row['TYPE'] ?? itemtype %}
                            {% if call(row_itemtype ~ '::isMassiveActionAllowed', [row['id']]) %}
-                              {% set checked = session('glpimassiveactionselected')[itemtype][row['id']] ?? false %}
+                              {% set checked = session('glpimassiveactionselected')[row_itemtype][row['id']] ?? false %}
                               <input class="form-check-input massive_action_checkbox" type="checkbox" data-glpicore-ma-tags="common"
                                  value="1" aria-label="" {% if checked %}checked="checked"{% endif %}
                                  name="item[{{ row['TYPE'] ?? itemtype }}][{{ row['id'] }}]" />


### PR DESCRIPTION
```checkbox```  from ```allasset (global)``` view is not available because

```item``` from ```allasset (global)``` view is ```null```

This PR handle this case


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14684
