### PR TITLE
permit to query Lockedfield with api

### DIFF
--- a/src/Lockedfield.php
+++ b/src/Lockedfield.php
@@ -53,6 +53,11 @@ class Lockedfield extends CommonDBTM
         return _n('Locked field', 'Locked fields', $nb);
     }
 
+    public static function canView()
+    {
+        return self::canUpdate();
+    }
+
     public static function canPurge()
     {
         return Session::haveRight(self::$rightname, UPDATE);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

There is no READ flag in profiles for this right, so api return an ERROR_RIGHT_MISSING
