### PR TITLE
Do not derogate to `utf8mb4` and `unsigned` keys migrations warnings

### DIFF
--- a/src/Central.php
+++ b/src/Central.php
@@ -494,22 +494,12 @@ class Central extends CommonGLPI
                 . ' '
                 . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:timestamps');
             }
-            /*
-             * FIXME: Remove `$exclude_plugins = true` condition in GLPI 10.1.
-             * This condition is here only to prevent having this message displayed after installation of plugins that
-             * may not have yet handle the switch to utf8mb4.
-             */
-            if (($non_utf8mb4_count = $DB->getNonUtf8mb4Tables(true)->count()) > 0) {
+            if (($non_utf8mb4_count = $DB->getNonUtf8mb4Tables()->count()) > 0) {
                 $messages['warnings'][] = sprintf(__('%1$s tables are using the deprecated utf8mb3 storage charset.'), $non_utf8mb4_count)
                 . ' '
                 . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:utf8mb4');
             }
-            /*
-             * FIXME: Remove `$exclude_plugins = true` condition in GLPI 10.1.
-             * This condition is here only to prevent having this message displayed after installation of plugins that
-             * may not have yet handle the switch to unsigned keys.
-             */
-            if (($signed_keys_col_count = $DB->getSignedKeysColumns(true)->count()) > 0) {
+            if (($signed_keys_col_count = $DB->getSignedKeysColumns()->count()) > 0) {
                 $messages['warnings'][] = sprintf(__('%d primary or foreign keys columns are using signed integers.'), $signed_keys_col_count)
                 . ' '
                 . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:unsigned_keys');

--- a/src/Update.php
+++ b/src/Update.php
@@ -300,27 +300,13 @@ class Update
                 . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:timestamps');
             $this->migration->displayError($message);
         }
-        /*
-         * FIXME: Remove `$DB->use_utf8mb4` and `$exclude_plugins = true` conditions in GLPI 10.1.
-         * These conditions are here only to prevent having this message on every migration to GLPI 10.0.x.
-         * Indeed, as migration command was not available in previous versions, users may not understand
-         * why this is considered as an error.
-         * Also, some plugins may not have yet handle the switch to utf8mb4.
-         */
-        if ($DB->use_utf8mb4 && ($non_utf8mb4_count = $DB->getNonUtf8mb4Tables(true)->count()) > 0) {
+        if (($non_utf8mb4_count = $DB->getNonUtf8mb4Tables()->count()) > 0) {
             $message = sprintf(__('%1$s tables are using the deprecated utf8mb3 storage charset.'), $non_utf8mb4_count)
                 . ' '
                 . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:utf8mb4');
             $this->migration->displayError($message);
         }
-        /*
-         * FIXME: Remove `!$DB->allow_signed_keys` and `$exclude_plugins = true` conditions in GLPI 10.1.
-         * These conditions are here only to prevent having this message on every migration to GLPI 10.0.x.
-         * Indeed, as migration command was not available in previous versions, users may not understand
-         * why this is considered as an error.
-         * Also, some plugins may not have yet handle the switch to unsigned keys.
-         */
-        if (!$DB->allow_signed_keys && ($signed_keys_col_count = $DB->getSignedKeysColumns(true)->count()) > 0) {
+        if (($signed_keys_col_count = $DB->getSignedKeysColumns()->count()) > 0) {
             $message = sprintf(__('%d primary or foreign keys columns are using signed integers.'), $signed_keys_col_count)
                 . ' '
                 . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:unsigned_keys');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In GLPI 10.0, warnings related `utf8mb4` and `unsigned` keys migrations where ignoring plugins tables. This was done to avoid rushing plugin developers on this point.
Also, these warnings were not shown during update process, unless on GLPI instances on which the `utf8mb4` and/or `unsigned` keys migrations were already executed once.

With proposed change:
1. Plugins tables will also be checked.
2. Warning at the end of the update process will not be condition to a previous execution of the corresponding migration.