### PR TITLE
Rework of pending reasons

### DIFF
--- a/css/includes/components/itilobject/_timeline.scss
+++ b/css/includes/components/itilobject/_timeline.scss
@@ -287,7 +287,8 @@
         }
     }
 
-    &.Log {
+    &.Log,
+    &.ITILAutoBump {
         width: 100%;
 
         .user-part {

--- a/css/includes/components/itilobject/_timeline.scss
+++ b/css/includes/components/itilobject/_timeline.scss
@@ -288,7 +288,7 @@
     }
 
     &.Log,
-    &.ITILAutoBump {
+    &.ITILReminder {
         width: 100%;
 
         .user-part {
@@ -316,6 +316,7 @@
                     .timeline-header {
                         margin-left: 1rem;
                         margin-top: 0;
+                        margin-bottom: 0;
                     }
                 }
             }

--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -1069,7 +1069,7 @@ $RELATION = [
 
     'glpi_pendingreasons' => [
         '_glpi_pendingreasons_items' => 'pendingreasons_id',
-        '_glpi_itilautobumps' => 'pendingreasons_id',
+        '_glpi_itilreminders' => 'pendingreasons_id',
     ],
 
     'glpi_pdumodels' => [

--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -163,7 +163,7 @@ $RELATION = [
         'glpi_slms'                => 'calendars_id',
         'glpi_recurrentchanges'    => 'calendars_id',
         'glpi_ticketrecurrents'    => 'calendars_id',
-        '_glpi_pendingreasons'     => 'calendars_id',
+        'glpi_pendingreasons'     => 'calendars_id',
     ],
 
     'glpi_cartridgeitems' => [
@@ -1069,7 +1069,7 @@ $RELATION = [
 
     'glpi_pendingreasons' => [
         '_glpi_pendingreasons_items' => 'pendingreasons_id',
-        '_glpi_itilreminders' => 'pendingreasons_id',
+        'glpi_itilreminders' => 'pendingreasons_id',
     ],
 
     'glpi_pdumodels' => [

--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -163,6 +163,7 @@ $RELATION = [
         'glpi_slms'                => 'calendars_id',
         'glpi_recurrentchanges'    => 'calendars_id',
         'glpi_ticketrecurrents'    => 'calendars_id',
+        '_glpi_pendingreasons'     => 'calendars_id',
     ],
 
     'glpi_cartridgeitems' => [
@@ -1068,6 +1069,7 @@ $RELATION = [
 
     'glpi_pendingreasons' => [
         '_glpi_pendingreasons_items' => 'pendingreasons_id',
+        '_glpi_itilautobumps' => 'pendingreasons_id',
     ],
 
     'glpi_pdumodels' => [

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -3064,7 +3064,7 @@ $empty_data_builder = new class
                 'id'           => 76,
                 'name'         => 'Automatic reminder',
                 'itemtype'     => 'Ticket',
-                'event'        => 'auto_bump',
+                'event'        => 'auto_reminder',
                 'is_recursive' => 0,
                 'is_active'    => 0,
             ]
@@ -5197,8 +5197,8 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
                 'notificationtemplates_id' => '31',
                 'language'                 => '',
                 'subject'                  => '##ticket.action## ##ticket.title##',
-                'content_text'             => '##ticket.autobump.bumptext##',
-                'content_html'             => '&lt;p&gt;##ticket.autobump.bumptext##&lt;/p&gt;',
+                'content_text'             => '##ticket.reminder.bumptext##',
+                'content_html'             => '&lt;p&gt;##ticket.reminder.bumptext##&lt;/p&gt;',
             ]
         ];
 

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -5196,9 +5196,21 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
                 'id'                       => '31',
                 'notificationtemplates_id' => '31',
                 'language'                 => '',
-                'subject'                  => '##ticket.action## ##ticket.title##',
-                'content_text'             => '##ticket.reminder.bumptext##',
-                'content_html'             => '&lt;p&gt;##ticket.reminder.bumptext##&lt;/p&gt;',
+                'subject'                  => '##ticket.action## ##ticket.name##',
+                'content_text'             => '##lang.ticket.title##: ##ticket.title##
+
+##lang.ticket.reminder.bumpcounter##: ##ticket.reminder.bumpcounter##
+##lang.ticket.reminder.bumpremaining##: ##ticket.reminder.bumpremaining##
+##lang.ticket.reminder.bumptotal##: ##ticket.reminder.bumptotal##
+##lang.ticket.reminder.deadline##: ##ticket.reminder.deadline##
+
+##lang.ticket.reminder.text##: ##ticket.reminder.text##',
+                'content_html'             => '&lt;p&gt;##lang.ticket.title##: ##ticket.title##&lt;/p&gt;
+                    &lt;p&gt;##lang.ticket.reminder.bumpcounter##: ##ticket.reminder.bumpcounter##&lt;/a&gt;&lt;br /&gt;
+                    ##lang.ticket.reminder.bumpremaining##: ##ticket.reminder.bumpremaining##&lt;/a&gt;&lt;br /&gt;
+                    ##lang.ticket.reminder.bumptotal##: ##ticket.reminder.bumptotal##&lt;/a&gt;&lt;br /&gt;
+                    ##lang.ticket.reminder.deadline##: ##ticket.reminder.deadline##&lt;/p&gt;
+                    &lt;p&gt;##lang.ticket.reminder.text##: ##ticket.reminder.text##&lt;/p&gt;',
             ]
         ];
 

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -3060,7 +3060,14 @@ $empty_data_builder = new class
                 'event'        => 'replysatisfaction',
                 'is_recursive' => 1,
                 'is_active'    => 1,
-            ],
+            ], [
+                'id'           => 76,
+                'name'         => 'Automatic reminder',
+                'itemtype'     => 'Ticket',
+                'event'        => 'auto_bump',
+                'is_recursive' => 0,
+                'is_active'    => 0,
+            ]
         ];
 
         $tables['glpi_notifications_notificationtemplates'] = [
@@ -3439,7 +3446,12 @@ $empty_data_builder = new class
                 'notifications_id'         => '75',
                 'mode'                     => 'mailing',
                 'notificationtemplates_id' => 30,
-            ],
+            ], [
+                'id'                       => 76,
+                'notifications_id'         => '76',
+                'mode'                     => 'mailing',
+                'notificationtemplates_id' => 31,
+            ]
         ];
 
         $tables['glpi_notificationtargets'] = [
@@ -4153,7 +4165,22 @@ $empty_data_builder = new class
                 'items_id'         => '2',
                 'type'             => '1',
                 'notifications_id' => '75',
-            ],
+            ], [
+                'id'               => '145',
+                'items_id'         => '3',
+                'type'             => '1',
+                'notifications_id' => '76',
+            ], [
+                'id'               => '146',
+                'items_id'         => '1',
+                'type'             => '1',
+                'notifications_id' => '76',
+            ], [
+                'id'               => '147',
+                'items_id'         => '21',
+                'type'             => '1',
+                'notifications_id' => '76',
+            ]
         ];
 
         $tables['glpi_notificationtemplates'] = [
@@ -4277,7 +4304,11 @@ $empty_data_builder = new class
                 'id'       => '30',
                 'name'     => 'Change Satisfaction',
                 'itemtype' => 'Change',
-            ],
+            ], [
+                'id'       => '31',
+                'name'     => 'Automatic reminder',
+                'itemtype' => 'Ticket',
+            ]
         ];
 
         $tables['glpi_notificationtemplatetranslations'] = [
@@ -5161,7 +5192,27 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
                 'content_html'             => '&lt;p&gt;##lang.change.title## : ##change.title##&lt;/p&gt;
 &lt;p&gt;##lang.change.closedate## : ##change.closedate##&lt;/p&gt;
 &lt;p&gt;##lang.satisfaction.text## &lt;a href="##change.urlsatisfaction##"&gt;##change.urlsatisfaction##&lt;/a&gt;&lt;/p&gt;',
-            ],
+            ], [
+                'id'                       => '31',
+                'notificationtemplates_id' => '31',
+                'language'                 => '',
+                'subject'                  => '##ticket.action## ##ticket.entity##',
+                'content_text'             => '##lang.ticket.title##: ##ticket.title##
+
+##lang.ticket.autobump.bumpcounter##: ##ticket.autobump.bumpcounter##
+##lang.ticket.autobump.bumpremaining##: ##ticket.autobump.bumpremaining##
+##lang.ticket.autobump.bumptotal##: ##ticket.autobump.bumptotal##
+##lang.ticket.autobump.deadline##: ##ticket.autobump.deadline##
+
+##lang.ticket.autobump.bumptext##: ##ticket.autobump.bumptext##',
+                'content_html'             => '&lt;p&gt;##lang.ticket.title##: ##ticket.title##&lt;/p&gt;
+&lt;p&gt;##lang.ticket.autobump.bumpcounter##: ##ticket.autobump.bumpcounter##
+##lang.ticket.autobump.bumpremaining##: ##ticket.autobump.bumpremaining##
+##lang.ticket.autobump.bumptotal##: ##ticket.autobump.bumptotal##
+##lang.ticket.autobump.deadline##: ##ticket.autobump.deadline##&lt;/p&gt;
+&lt;p&gt;
+##lang.ticket.autobump.bumptext##: ##ticket.autobump.bumptext##&lt;/p&gt;',
+            ]
         ];
 
         $tables['glpi_profilerights'] = [

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -5196,22 +5196,9 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
                 'id'                       => '31',
                 'notificationtemplates_id' => '31',
                 'language'                 => '',
-                'subject'                  => '##ticket.action## ##ticket.entity##',
-                'content_text'             => '##lang.ticket.title##: ##ticket.title##
-
-##lang.ticket.autobump.bumpcounter##: ##ticket.autobump.bumpcounter##
-##lang.ticket.autobump.bumpremaining##: ##ticket.autobump.bumpremaining##
-##lang.ticket.autobump.bumptotal##: ##ticket.autobump.bumptotal##
-##lang.ticket.autobump.deadline##: ##ticket.autobump.deadline##
-
-##lang.ticket.autobump.bumptext##: ##ticket.autobump.bumptext##',
-                'content_html'             => '&lt;p&gt;##lang.ticket.title##: ##ticket.title##&lt;/p&gt;
-&lt;p&gt;##lang.ticket.autobump.bumpcounter##: ##ticket.autobump.bumpcounter##
-##lang.ticket.autobump.bumpremaining##: ##ticket.autobump.bumpremaining##
-##lang.ticket.autobump.bumptotal##: ##ticket.autobump.bumptotal##
-##lang.ticket.autobump.deadline##: ##ticket.autobump.deadline##&lt;/p&gt;
-&lt;p&gt;
-##lang.ticket.autobump.bumptext##: ##ticket.autobump.bumptext##&lt;/p&gt;',
+                'subject'                  => '##ticket.action## ##ticket.title##',
+                'content_text'             => '##ticket.autobump.bumptext##',
+                'content_html'             => '&lt;p&gt;##ticket.autobump.bumptext##&lt;/p&gt;',
             ]
         ];
 

--- a/install/migrations/update_10.0.x_to_10.1.0/itilautobumps.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/itilautobumps.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+$default_charset = DBConnection::getDefaultCharset();
+$default_collation = DBConnection::getDefaultCollation();
+
+// Add ITILAutoBump table
+if (!$DB->tableExists('glpi_itilautobumps')) {
+    $query = "CREATE TABLE `glpi_itilautobumps` (
+        `id` int unsigned NOT NULL AUTO_INCREMENT,
+        `itemtype` varchar(100) NOT NULL,
+        `items_id` int unsigned NOT NULL DEFAULT '0',
+        `pendingreasons_id` int unsigned NOT NULL DEFAULT '0',
+        `date_mod` timestamp NULL DEFAULT NULL,
+        `date_creation` timestamp NULL DEFAULT NULL,
+        PRIMARY KEY (`id`),
+        KEY `item` (`itemtype`,`items_id`),
+        KEY `date_mod` (`date_mod`),
+        KEY `date_creation` (`date_creation`),
+        KEY `pendingreasons_id` (`pendingreasons_id`)
+      ) ENGINE=InnoDB DEFAULT CHARSET=$default_charset COLLATE=$default_collation ROW_FORMAT=DYNAMIC;";
+    $DB->queryOrDie($query, 'x.x add table glpi_itilautobumps');
+}

--- a/install/migrations/update_10.0.x_to_10.1.0/itilautobumps.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/itilautobumps.php
@@ -40,14 +40,15 @@
 
 $default_charset = DBConnection::getDefaultCharset();
 $default_collation = DBConnection::getDefaultCollation();
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
 // Add ITILAutoBump table
 if (!$DB->tableExists('glpi_itilautobumps')) {
     $query = "CREATE TABLE `glpi_itilautobumps` (
-        `id` int unsigned NOT NULL AUTO_INCREMENT,
+        `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
         `itemtype` varchar(100) NOT NULL,
-        `items_id` int unsigned NOT NULL DEFAULT '0',
-        `pendingreasons_id` int unsigned NOT NULL DEFAULT '0',
+        `items_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+        `pendingreasons_id` int {$default_key_sign} NOT NULL DEFAULT '0',
         `date_mod` timestamp NULL DEFAULT NULL,
         `date_creation` timestamp NULL DEFAULT NULL,
         PRIMARY KEY (`id`),
@@ -55,6 +56,6 @@ if (!$DB->tableExists('glpi_itilautobumps')) {
         KEY `date_mod` (`date_mod`),
         KEY `date_creation` (`date_creation`),
         KEY `pendingreasons_id` (`pendingreasons_id`)
-      ) ENGINE=InnoDB DEFAULT CHARSET=$default_charset COLLATE=$default_collation ROW_FORMAT=DYNAMIC;";
+    ) ENGINE=InnoDB DEFAULT CHARSET=$default_charset COLLATE=$default_collation ROW_FORMAT=DYNAMIC;";
     $DB->queryOrDie($query, 'x.x add table glpi_itilautobumps');
 }

--- a/install/migrations/update_10.0.x_to_10.1.0/itilreminders.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/itilreminders.php
@@ -57,5 +57,5 @@ if (!$DB->tableExists('glpi_itilreminders')) {
         KEY `date_creation` (`date_creation`),
         KEY `pendingreasons_id` (`pendingreasons_id`)
     ) ENGINE=InnoDB DEFAULT CHARSET=$default_charset COLLATE=$default_collation ROW_FORMAT=DYNAMIC;";
-    $DB->queryOrDie($query, 'x.x add table glpi_itilreminders');
+    $DB->queryOrDie($query, '10.1 add table glpi_itilreminders');
 }

--- a/install/migrations/update_10.0.x_to_10.1.0/itilreminders.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/itilreminders.php
@@ -59,3 +59,6 @@ if (!$DB->tableExists('glpi_itilreminders')) {
     ) ENGINE=InnoDB DEFAULT CHARSET=$default_charset COLLATE=$default_collation ROW_FORMAT=DYNAMIC;";
     $DB->queryOrDie($query, '10.1 add table glpi_itilreminders');
 }
+
+$migration->addField('glpi_itilreminders', 'name', 'varchar(255) DEFAULT NULL');
+$migration->addField('glpi_itilreminders', 'content', 'text');

--- a/install/migrations/update_10.0.x_to_10.1.0/itilreminders.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/itilreminders.php
@@ -49,16 +49,20 @@ if (!$DB->tableExists('glpi_itilreminders')) {
         `itemtype` varchar(100) NOT NULL,
         `items_id` int {$default_key_sign} NOT NULL DEFAULT '0',
         `pendingreasons_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+        `name` varchar(255) DEFAULT NULL,
+        `content` text,
         `date_mod` timestamp NULL DEFAULT NULL,
         `date_creation` timestamp NULL DEFAULT NULL,
         PRIMARY KEY (`id`),
         KEY `item` (`itemtype`,`items_id`),
+        KEY `name` (`name`),
         KEY `date_mod` (`date_mod`),
         KEY `date_creation` (`date_creation`),
         KEY `pendingreasons_id` (`pendingreasons_id`)
     ) ENGINE=InnoDB DEFAULT CHARSET=$default_charset COLLATE=$default_collation ROW_FORMAT=DYNAMIC;";
     $DB->queryOrDie($query, '10.1 add table glpi_itilreminders');
+} else {
+    $migration->addField('glpi_itilreminders', 'name', 'varchar(255) DEFAULT NULL');
+    $migration->addField('glpi_itilreminders', 'content', 'text');
+    $migration->addKey('glpi_itilreminders', 'name', 'name');
 }
-
-$migration->addField('glpi_itilreminders', 'name', 'varchar(255) DEFAULT NULL');
-$migration->addField('glpi_itilreminders', 'content', 'text');

--- a/install/migrations/update_10.0.x_to_10.1.0/itilreminders.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/itilreminders.php
@@ -42,9 +42,9 @@ $default_charset = DBConnection::getDefaultCharset();
 $default_collation = DBConnection::getDefaultCollation();
 $default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
-// Add ITILAutoBump table
-if (!$DB->tableExists('glpi_itilautobumps')) {
-    $query = "CREATE TABLE `glpi_itilautobumps` (
+// Add ITILReminder table
+if (!$DB->tableExists('glpi_itilreminders')) {
+    $query = "CREATE TABLE `glpi_itilreminders` (
         `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
         `itemtype` varchar(100) NOT NULL,
         `items_id` int {$default_key_sign} NOT NULL DEFAULT '0',
@@ -57,5 +57,5 @@ if (!$DB->tableExists('glpi_itilautobumps')) {
         KEY `date_creation` (`date_creation`),
         KEY `pendingreasons_id` (`pendingreasons_id`)
     ) ENGINE=InnoDB DEFAULT CHARSET=$default_charset COLLATE=$default_collation ROW_FORMAT=DYNAMIC;";
-    $DB->queryOrDie($query, 'x.x add table glpi_itilautobumps');
+    $DB->queryOrDie($query, 'x.x add table glpi_itilreminders');
 }

--- a/install/migrations/update_10.0.x_to_10.1.0/notifications.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/notifications.php
@@ -236,7 +236,7 @@ if (countElementsInTable('glpi_notifications', ['itemtype' => 'Ticket', 'event' 
 ##lang.ticket.reminder.bumptotal##: ##ticket.reminder.bumptotal##
 ##lang.ticket.reminder.deadline##: ##ticket.reminder.deadline##
 
-##lang.ticket.reminder.bumptext##: ##ticket.reminder.bumptext##
+##lang.ticket.reminder.text##: ##ticket.reminder.text##
 PLAINTEXT,
         'content_html' => <<<HTML
         &lt;p&gt;##lang.ticket.title##: ##ticket.title##&lt;/p&gt;
@@ -245,7 +245,7 @@ PLAINTEXT,
 ##lang.ticket.reminder.bumptotal##: ##ticket.reminder.bumptotal##
 ##lang.ticket.reminder.deadline##: ##ticket.reminder.deadline##&lt;/p&gt;
 &lt;p&gt;
-##lang.ticket.reminder.bumptext##: ##ticket.reminder.bumptext##&lt;/p&gt;
+##lang.ticket.reminder.text##: ##ticket.reminder.text##&lt;/p&gt;
 HTML
     ]);
 

--- a/install/migrations/update_10.0.x_to_10.1.0/notifications.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/notifications.php
@@ -216,7 +216,7 @@ HTML,
 /** /Change Satisfaction notification */
 
 /** Add new notification for AutoBump */
-if (countElementsInTable('glpi_notifications', ['itemtype' => 'Ticket', 'event' => 'auto_bump']) === 0) {
+if (countElementsInTable('glpi_notifications', ['itemtype' => 'Ticket', 'event' => 'auto_reminder']) === 0) {
     $DB->insertOrDie('glpi_notificationtemplates', [
         'name' => 'Automatic reminder',
         'itemtype' => 'Ticket'
@@ -231,21 +231,21 @@ if (countElementsInTable('glpi_notifications', ['itemtype' => 'Ticket', 'event' 
         'content_text' => <<<PLAINTEXT
         ##lang.ticket.title##: ##ticket.title##
 
-##lang.ticket.autobump.bumpcounter##: ##ticket.autobump.bumpcounter##
-##lang.ticket.autobump.bumpremaining##: ##ticket.autobump.bumpremaining##
-##lang.ticket.autobump.bumptotal##: ##ticket.autobump.bumptotal##
-##lang.ticket.autobump.deadline##: ##ticket.autobump.deadline##
+##lang.ticket.reminder.bumpcounter##: ##ticket.reminder.bumpcounter##
+##lang.ticket.reminder.bumpremaining##: ##ticket.reminder.bumpremaining##
+##lang.ticket.reminder.bumptotal##: ##ticket.reminder.bumptotal##
+##lang.ticket.reminder.deadline##: ##ticket.reminder.deadline##
 
-##lang.ticket.autobump.bumptext##: ##ticket.autobump.bumptext##
+##lang.ticket.reminder.bumptext##: ##ticket.reminder.bumptext##
 PLAINTEXT,
         'content_html' => <<<HTML
         &lt;p&gt;##lang.ticket.title##: ##ticket.title##&lt;/p&gt;
-&lt;p&gt;##lang.ticket.autobump.bumpcounter##: ##ticket.autobump.bumpcounter##
-##lang.ticket.autobump.bumpremaining##: ##ticket.autobump.bumpremaining##
-##lang.ticket.autobump.bumptotal##: ##ticket.autobump.bumptotal##
-##lang.ticket.autobump.deadline##: ##ticket.autobump.deadline##&lt;/p&gt;
+&lt;p&gt;##lang.ticket.reminder.bumpcounter##: ##ticket.reminder.bumpcounter##
+##lang.ticket.reminder.bumpremaining##: ##ticket.reminder.bumpremaining##
+##lang.ticket.reminder.bumptotal##: ##ticket.reminder.bumptotal##
+##lang.ticket.reminder.deadline##: ##ticket.reminder.deadline##&lt;/p&gt;
 &lt;p&gt;
-##lang.ticket.autobump.bumptext##: ##ticket.autobump.bumptext##&lt;/p&gt;
+##lang.ticket.reminder.bumptext##: ##ticket.reminder.bumptext##&lt;/p&gt;
 HTML
     ]);
 
@@ -254,7 +254,7 @@ HTML
         [
             'name'            => 'Automatic reminder',
             'itemtype'        => 'Ticket',
-            'event'           => 'auto_bump',
+            'event'           => 'auto_reminder',
             'comment'         => null,
             'is_recursive'    => 0,
             'is_active'       => 0,

--- a/install/migrations/update_10.0.x_to_10.1.0/notifications.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/notifications.php
@@ -228,25 +228,20 @@ if (countElementsInTable('glpi_notifications', ['itemtype' => 'Ticket', 'event' 
         'notificationtemplates_id' => $notificationtemplate_id,
         'language' => '',
         'subject' => '##ticket.action## ##ticket.name##',
-        'content_text' => <<<PLAINTEXT
-        ##lang.ticket.title##: ##ticket.title##
+        'content_text' => '##lang.ticket.title##: ##ticket.title##
 
 ##lang.ticket.reminder.bumpcounter##: ##ticket.reminder.bumpcounter##
 ##lang.ticket.reminder.bumpremaining##: ##ticket.reminder.bumpremaining##
 ##lang.ticket.reminder.bumptotal##: ##ticket.reminder.bumptotal##
 ##lang.ticket.reminder.deadline##: ##ticket.reminder.deadline##
 
-##lang.ticket.reminder.text##: ##ticket.reminder.text##
-PLAINTEXT,
-        'content_html' => <<<HTML
-        &lt;p&gt;##lang.ticket.title##: ##ticket.title##&lt;/p&gt;
-&lt;p&gt;##lang.ticket.reminder.bumpcounter##: ##ticket.reminder.bumpcounter##
-##lang.ticket.reminder.bumpremaining##: ##ticket.reminder.bumpremaining##
-##lang.ticket.reminder.bumptotal##: ##ticket.reminder.bumptotal##
-##lang.ticket.reminder.deadline##: ##ticket.reminder.deadline##&lt;/p&gt;
-&lt;p&gt;
-##lang.ticket.reminder.text##: ##ticket.reminder.text##&lt;/p&gt;
-HTML
+##lang.ticket.reminder.text##: ##ticket.reminder.text##',
+        'content_html' => '&lt;p&gt;##lang.ticket.title##: ##ticket.title##&lt;/p&gt;
+            &lt;p&gt;##lang.ticket.reminder.bumpcounter##: ##ticket.reminder.bumpcounter##&lt;/a&gt;&lt;br /&gt;
+            ##lang.ticket.reminder.bumpremaining##: ##ticket.reminder.bumpremaining##&lt;/a&gt;&lt;br /&gt;
+            ##lang.ticket.reminder.bumptotal##: ##ticket.reminder.bumptotal##&lt;/a&gt;&lt;br /&gt;
+            ##lang.ticket.reminder.deadline##: ##ticket.reminder.deadline##&lt;/p&gt;
+            &lt;p&gt;##lang.ticket.reminder.text##: ##ticket.reminder.text##&lt;/p&gt;',
     ]);
 
     $DB->insertOrDie(

--- a/install/migrations/update_10.0.x_to_10.1.0/notifications.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/notifications.php
@@ -80,18 +80,16 @@ if (!$notification_exists) {
             'subject' => '##user.action##',
             'content_text' => <<<PLAINTEXT
     ##user.realname## ##user.firstname##
-    
+
     ##lang.passwordinit.information##
-    
+
     ##lang.passwordinit.link## ##user.passwordiniturl##
-    PLAINTEXT
-            ,
+    PLAINTEXT,
             'content_html' => <<<HTML
     &lt;p&gt;&lt;strong&gt;##user.realname## ##user.firstname##&lt;/strong&gt;&lt;/p&gt;
     &lt;p&gt;##lang.passwordinit.information##&lt;/p&gt;
     &lt;p&gt;##lang.passwordinit.link## &lt;a title="##user.passwordiniturl##" href="##user.passwordiniturl##"&gt;##user.passwordiniturl##&lt;/a&gt;&lt;/p&gt;
-    HTML
-            ,
+    HTML,
         ],
         '10.1 Add password initialization notification template translations'
     );
@@ -144,14 +142,12 @@ if (countElementsInTable('glpi_notifications', ['itemtype' => 'Change', 'event' 
 ##lang.change.closedate## : ##change.closedate##
 
 ##lang.satisfaction.text## ##change.urlsatisfaction##
-PLAINTEXT
-            ,
+PLAINTEXT,
             'content_html'             => <<<HTML
 &lt;p&gt;##lang.change.title## : ##change.title##&lt;/p&gt;
 &lt;p&gt;##lang.change.closedate## : ##change.closedate##&lt;/p&gt;
 &lt;p&gt;##lang.satisfaction.text## &lt;a href="##change.urlsatisfaction##"&gt;##change.urlsatisfaction##&lt;/a&gt;&lt;/p&gt;
-HTML
-            ,
+HTML,
         ],
         'Add change satisfaction survey notification template translations'
     );
@@ -218,3 +214,82 @@ HTML
     }
 }
 /** /Change Satisfaction notification */
+
+/** Add new notification for AutoBump */
+if (countElementsInTable('glpi_notifications', ['itemtype' => 'Ticket', 'event' => 'auto_bump']) === 0) {
+    $DB->insertOrDie('glpi_notificationtemplates', [
+        'name' => 'Automatic reminder',
+        'itemtype' => 'Ticket'
+    ]);
+
+    $notificationtemplate_id = $DB->insertId();
+
+    $DB->insertOrDie('glpi_notificationtemplatetranslations', [
+        'notificationtemplates_id' => $notificationtemplate_id,
+        'language' => '',
+        'subject' => '##ticket.action## ##ticket.name##',
+        'content_text' => <<<PLAINTEXT
+        ##lang.ticket.title##: ##ticket.title##
+
+##lang.ticket.autobump.bumpcounter##: ##ticket.autobump.bumpcounter##
+##lang.ticket.autobump.bumpremaining##: ##ticket.autobump.bumpremaining##
+##lang.ticket.autobump.bumptotal##: ##ticket.autobump.bumptotal##
+##lang.ticket.autobump.deadline##: ##ticket.autobump.deadline##
+
+##lang.ticket.autobump.bumptext##: ##ticket.autobump.bumptext##
+PLAINTEXT,
+        'content_html' => <<<HTML
+        &lt;p&gt;##lang.ticket.title##: ##ticket.title##&lt;/p&gt;
+&lt;p&gt;##lang.ticket.autobump.bumpcounter##: ##ticket.autobump.bumpcounter##
+##lang.ticket.autobump.bumpremaining##: ##ticket.autobump.bumpremaining##
+##lang.ticket.autobump.bumptotal##: ##ticket.autobump.bumptotal##
+##lang.ticket.autobump.deadline##: ##ticket.autobump.deadline##&lt;/p&gt;
+&lt;p&gt;
+##lang.ticket.autobump.bumptext##: ##ticket.autobump.bumptext##&lt;/p&gt;
+HTML
+    ]);
+
+    $DB->insertOrDie(
+        'glpi_notifications',
+        [
+            'name'            => 'Automatic reminder',
+            'itemtype'        => 'Ticket',
+            'event'           => 'auto_bump',
+            'comment'         => null,
+            'is_recursive'    => 0,
+            'is_active'       => 0,
+        ],
+        'Add automatic reminder notification'
+    );
+    $notification_id = $DB->insertId();
+
+    $targets = [
+        [
+            'items_id' => 3,
+            'type' => 1,
+        ],
+        [
+            'items_id' => 1,
+            'type' => 1,
+        ],
+        [
+            'items_id' => 21,
+            'type' => 1,
+        ],
+    ];
+
+    foreach ($targets as $target) {
+        $DB->insertOrDie('glpi_notificationtargets', [
+            'items_id'         => $target['items_id'],
+            'type'             => $target['type'],
+            'notifications_id' => $notification_id,
+        ]);
+    }
+
+    $DB->insertOrDie('glpi_notifications_notificationtemplates', [
+        'notifications_id'         => $notification_id,
+        'mode'                     => Notification_NotificationTemplate::MODE_MAIL,
+        'notificationtemplates_id' => $notificationtemplate_id,
+    ]);
+}
+/** /Add new notification for AutoBump */

--- a/install/migrations/update_10.0.x_to_10.1.0/pendingreason.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/pendingreason.php
@@ -43,17 +43,17 @@ $default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 $table = 'glpi_pendingreasons';
 // Add new "is_default" field on pendingreasons table
 if (!$DB->fieldExists($table, 'is_default')) {
-    $migration->addField($table, 'is_default', "tinyint NOT NULL DEFAULT '0'");
+    $migration->addField($table, 'is_default', 'bool', ['value' => 0]);
 }
 
 // Add new "is_pending_per_default" field on pendingreasons table
 if (!$DB->fieldExists($table, 'is_pending_per_default')) {
-    $migration->addField($table, 'is_pending_per_default', "tinyint NOT NULL DEFAULT '0'");
+    $migration->addField($table, 'is_pending_per_default', 'bool', ['value' => 0]);
 }
 
 // Add new "calendars_id" field on pendingreasons table
 $fkey_to_add = 'calendars_id';
 if (!$DB->fieldExists($table, $fkey_to_add)) {
-    $migration->addField($table, $fkey_to_add, "int {$default_key_sign} NOT NULL DEFAULT '0'");
+    $migration->addField($table, $fkey_to_add, 'fkey');
     $migration->addKey($table, $fkey_to_add);
 }

--- a/install/migrations/update_10.0.x_to_10.1.0/pendingreason.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/pendingreason.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
+
+$table = 'glpi_pendingreasons';
+// Add new "is_default" field on pendingreasons table
+if (!$DB->fieldExists($table, 'is_default')) {
+    $migration->addField($table, 'is_default', "tinyint NOT NULL DEFAULT '0'");
+}
+
+// Add new "is_pending_per_default" field on pendingreasons table
+if (!$DB->fieldExists($table, 'is_pending_per_default')) {
+    $migration->addField($table, 'is_pending_per_default', "tinyint NOT NULL DEFAULT '0'");
+}
+
+// Add new "calendars_id" field on pendingreasons table
+$fkey_to_add = 'calendars_id';
+if (!$DB->fieldExists($table, $fkey_to_add)) {
+    $migration->addField($table, $fkey_to_add, "int {$default_key_sign} NOT NULL DEFAULT '0'");
+    $migration->addKey($table, $fkey_to_add);
+}

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9554,8 +9554,8 @@ CREATE TABLE `glpi_searches_criteriafilters` (
   KEY `search_itemtype` (`search_itemtype`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
-DROP TABLE IF EXISTS `glpi_itilautobumps`;
-CREATE TABLE `glpi_itilautobumps` (
+DROP TABLE IF EXISTS `glpi_itilreminders`;
+CREATE TABLE `glpi_itilreminders` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `itemtype` varchar(100) NOT NULL,
   `items_id` int unsigned NOT NULL DEFAULT '0',

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9234,18 +9234,22 @@ CREATE TABLE `glpi_pendingreasons` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `entities_id` int unsigned NOT NULL DEFAULT '0',
   `is_recursive` tinyint NOT NULL DEFAULT '0',
+  `is_default` tinyint NOT NULL DEFAULT '0',
+  `is_pending_per_default` tinyint NOT NULL DEFAULT '0',
   `name` varchar(255) DEFAULT NULL,
   `followup_frequency` int NOT NULL DEFAULT '0',
   `followups_before_resolution` int NOT NULL DEFAULT '0',
   `itilfollowuptemplates_id` int unsigned NOT NULL DEFAULT '0',
   `solutiontemplates_id` int unsigned NOT NULL DEFAULT '0',
+  `calendars_id` int unsigned NOT NULL DEFAULT '0',
   `comment` text,
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `itilfollowuptemplates_id` (`itilfollowuptemplates_id`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
-  KEY `solutiontemplates_id` (`solutiontemplates_id`)
+  KEY `solutiontemplates_id` (`solutiontemplates_id`),
+  KEY `calendars_id` (`calendars_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_pendingreasons_items`;
@@ -9548,6 +9552,21 @@ CREATE TABLE `glpi_searches_criteriafilters` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `item` (`itemtype`, `items_id`),
   KEY `search_itemtype` (`search_itemtype`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+
+DROP TABLE IF EXISTS `glpi_itilautobumps`;
+CREATE TABLE `glpi_itilautobumps` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `itemtype` varchar(100) NOT NULL,
+  `items_id` int unsigned NOT NULL DEFAULT '0',
+  `pendingreasons_id` int unsigned NOT NULL DEFAULT '0',
+  `date_mod` timestamp NULL DEFAULT NULL,
+  `date_creation` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `item` (`itemtype`,`items_id`),
+  KEY `date_mod` (`date_mod`),
+  KEY `date_creation` (`date_creation`),
+  KEY `pendingreasons_id` (`pendingreasons_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 SET FOREIGN_KEY_CHECKS=1;

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9560,6 +9560,8 @@ CREATE TABLE `glpi_itilreminders` (
   `itemtype` varchar(100) NOT NULL,
   `items_id` int unsigned NOT NULL DEFAULT '0',
   `pendingreasons_id` int unsigned NOT NULL DEFAULT '0',
+  `name` varchar(255) DEFAULT NULL,
+  `content` text,
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9566,6 +9566,7 @@ CREATE TABLE `glpi_itilreminders` (
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `item` (`itemtype`,`items_id`),
+  KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `pendingreasons_id` (`pendingreasons_id`)

--- a/src/Central.php
+++ b/src/Central.php
@@ -515,7 +515,7 @@ class Central extends CommonGLPI
                 && countElementsInTable('glpi_pendingreasons_items') > 0
                 && !count($notification->find([
                     'itemtype' => 'Ticket',
-                    'event'     => 'auto_bump',
+                    'event'     => 'auto_reminder',
                     'is_active'  => true,
                 ]))
             ) {
@@ -525,7 +525,7 @@ class Central extends CommonGLPI
                             'link' => 'AND',
                             'field' => 2,
                             'searchtype' => 'equals',
-                            'value' => 'Ticket$#$auto_bump'
+                            'value' => 'Ticket$#$auto_reminder'
                         ]
                     ]
                 ];

--- a/src/Central.php
+++ b/src/Central.php
@@ -513,10 +513,11 @@ class Central extends CommonGLPI
             if (
                 \Config::getConfigurationValue('core', 'use_notifications')
                 && countElementsInTable('glpi_pendingreasons_items') > 0
-                && $notification->getFromDBByCrit([
+                && !count($notification->find([
                     'itemtype' => 'Ticket',
-                    'event'     => 'auto_bump'
-                ]) && !$notification->getField('is_active')
+                    'event'     => 'auto_bump',
+                    'is_active'  => true,
+                ]))
             ) {
                 $criteria = [
                     'criteria' => [

--- a/src/Central.php
+++ b/src/Central.php
@@ -506,12 +506,13 @@ class Central extends CommonGLPI
             }
 
             /*
-            * Check if there are pending reasons items and the notification is not active
-            * If so, display a warning message
-            */
+             * Check if there are pending reasons items and the notification is not active
+             * If so, display a warning message
+             */
             $notification = new \Notification();
             if (
-                countElementsInTable('glpi_pendingreasons_items') > 0
+                \Config::getConfigurationValue('core', 'use_notifications')
+                && countElementsInTable('glpi_pendingreasons_items') > 0
                 && $notification->getFromDBByCrit([
                     'itemtype' => 'Ticket',
                     'event'     => 'auto_bump'
@@ -527,14 +528,12 @@ class Central extends CommonGLPI
                         ]
                     ]
                 ];
-                $link = '<a href="' . Notification::getSearchURL() . '?' . Toolbox::append_params($criteria) . '">' . __('Show notification') . '</a>';
+                $link = '<a href="' . Notification::getSearchURL() . '?' . Toolbox::append_params($criteria) . '">' . __('notification') . '</a>';
 
                 $messages['warnings'][] = sprintf(
-                    __('There are %1$s pending reasons items and the notification is not active.'),
-                    countElementsInTable('glpi_pendingreasons_items')
-                )
-                    . ' '
-                    . $link;
+                    __('You have defined pending reasons without any respective active %s.'),
+                    $link
+                );
             }
         }
 

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7301,7 +7301,7 @@ abstract class CommonITILObject extends CommonDBTM
                 '<span>%1$s%2$s (<span data-bs-toggle="popover" data-bs-html="true" data-bs-sanitize="true" data-bs-content="%3$s"><u>%4$s</u></span>)</span>',
                 '<i class="ti ti-refresh-alert text-warning me-1"></i>',
                 __('Auto bump'),
-                htmlspecialchars($followup_template->fields['content']),
+                $followup_template->fields['content'],
                 $autobump_obj->getPendingReason()->fields['name']
             );
 

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7294,7 +7294,7 @@ abstract class CommonITILObject extends CommonDBTM
         $autobump_obj = new ITILAutoBump();
         $autobumps = $autobump_obj->find(['items_id'  => $this->getID()]);
         foreach ($autobumps as $autobump_id => $autobump) {
-            $autobump_obj->getFromDB($autobump_id);
+            $autobump_obj = ITILAutoBump::getByID($autobump_id);
             $pending_reason = $autobump_obj->getPendingReason();
             $followup_template = ITILFollowupTemplate::getById($pending_reason->fields['itilfollowuptemplates_id']);
             $content = sprintf(

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7295,14 +7295,14 @@ abstract class CommonITILObject extends CommonDBTM
         $autobumps = $autobump_obj->find(['items_id'  => $this->getID()]);
         foreach ($autobumps as $autobump_id => $autobump) {
             $autobump_obj->getFromDB($autobump_id);
-            $pending_reason = $autobump_obj->getPendinReason();
+            $pending_reason = $autobump_obj->getPendingReason();
             $followup_template = ITILFollowupTemplate::getById($pending_reason->fields['itilfollowuptemplates_id']);
             $content = sprintf(
                 '<span>%1$s%2$s (<span data-bs-toggle="popover" data-bs-html="true" data-bs-sanitize="true" data-bs-content="%3$s"><u>%4$s</u></span>)</span>',
                 '<i class="ti ti-refresh-alert text-warning me-1"></i>',
                 __('Auto bump'),
                 htmlspecialchars($followup_template->fields['content']),
-                $autobump_obj->getPendinReason()->fields['name']
+                $autobump_obj->getPendingReason()->fields['name']
             );
 
             $timeline["ITILAutoBump_" . $autobump_id] = [

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7301,8 +7301,8 @@ abstract class CommonITILObject extends CommonDBTM
                 '<span>%1$s%2$s (<span data-bs-toggle="popover" data-bs-html="true" data-bs-sanitize="true" data-bs-content="%3$s"><u>%4$s</u></span>)</span>',
                 '<i class="ti ti-refresh-alert text-warning me-1"></i>',
                 ITILReminder::getTypeName(1),
-                $followup_template !== false ? $followup_template->getRenderedContent($this) : '',
-                $pending_reason->fields['name']
+                $autoreminder_obj->fields['content'] ?? '',
+                $autoreminder_obj->fields['name']
             );
 
             $timeline["ITILReminder_" . $autoreminder_id] = [

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7299,7 +7299,7 @@ abstract class CommonITILObject extends CommonDBTM
             $followup_template = ITILFollowupTemplate::getById($pending_reason->fields['itilfollowuptemplates_id']);
             $content = sprintf(
                 '<span>%1$s%2$s (<span data-bs-toggle="popover" data-bs-html="true" data-bs-sanitize="true" data-bs-content="%3$s"><u>%4$s</u></span>)</span>',
-                '<i id="aaaa" class="ti ti-reload text-primary me-1"></i>',
+                '<i class="ti ti-reload text-primary me-1"></i>',
                 __('Auto bump'),
                 htmlspecialchars($followup_template->fields['content']),
                 $autobump_obj->getPendinReason()->fields['name']

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7290,27 +7290,28 @@ abstract class CommonITILObject extends CommonDBTM
             }
         }
 
-        // add autobumps to timeline
-        $autobump_obj = new ITILAutoBump();
-        $autobumps = $autobump_obj->find(['items_id'  => $this->getID()]);
-        foreach ($autobumps as $autobump_id => $autobump) {
-            $autobump_obj = ITILAutoBump::getByID($autobump_id);
-            $pending_reason = $autobump_obj->getPendingReason();
+        // add autoreminders to timeline
+        $autoreminder_obj = new ITILReminder();
+        $autoreminders = $autoreminder_obj->find(['items_id'  => $this->getID()]);
+        foreach ($autoreminders as $autoreminder_id => $autoreminder) {
+            $autoreminder_obj = ITILReminder::getByID($autoreminder_id);
+            $pending_reason = $autoreminder_obj->getPendingReason();
             $followup_template = ITILFollowupTemplate::getById($pending_reason->fields['itilfollowuptemplates_id']);
             $content = sprintf(
                 '<span>%1$s%2$s (<span data-bs-toggle="popover" data-bs-html="true" data-bs-sanitize="true" data-bs-content="%3$s"><u>%4$s</u></span>)</span>',
                 '<i class="ti ti-refresh-alert text-warning me-1"></i>',
-                __('Auto bump'),
-                $followup_template->fields['content'],
-                $autobump_obj->getPendingReason()->fields['name']
+                __('Auto reminder'),
+                $followup_template->fields['content'] ?? '',
+                $autoreminder_obj->getPendingReason()->fields['name']
             );
 
-            $timeline["ITILAutoBump_" . $autobump_id] = [
-                'type' => ITILAutoBump::class,
+            $timeline["ITILReminder_" . $autoreminder_id] = [
+                'type' => ITILReminder::class,
                 'item' => [
-                    'id' => $autobump_id,
+                    'id' => $autoreminder_id,
                     'content' => $content,
-                    'date' => $autobump['date_creation'],
+                    'is_content_safe'    => true,
+                    'date' => $autoreminder['date_creation'],
                     'users_id' => 0,
                     'can_edit' => false,
                     'timeline_position' => self::TIMELINE_LEFT,

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7290,6 +7290,34 @@ abstract class CommonITILObject extends CommonDBTM
             }
         }
 
+        // add autobumps to timeline
+        $autobump_obj = new ITILAutoBump();
+        $autobumps = $autobump_obj->find(['items_id'  => $this->getID()]);
+        foreach ($autobumps as $autobump_id => $autobump) {
+            $autobump_obj->getFromDB($autobump_id);
+            $pending_reason = $autobump_obj->getPendinReason();
+            $followup_template = ITILFollowupTemplate::getById($pending_reason->fields['itilfollowuptemplates_id']);
+            $content = sprintf(
+                '<span>%1$s%2$s (<span data-bs-toggle="popover" data-bs-html="true" data-bs-sanitize="true" data-bs-content="%3$s"><u>%4$s</u></span>)</span>',
+                '<i id="aaaa" class="ti ti-reload text-primary me-1"></i>',
+                __('Auto bump'),
+                htmlspecialchars($followup_template->fields['content']),
+                $autobump_obj->getPendinReason()->fields['name']
+            );
+
+            $timeline["ITILAutoBump_" . $autobump_id] = [
+                'type' => ITILAutoBump::class,
+                'item' => [
+                    'id' => $autobump_id,
+                    'content' => $content,
+                    'date' => $autobump['date_creation'],
+                    'users_id' => 0,
+                    'can_edit' => false,
+                    'timeline_position' => self::TIMELINE_LEFT,
+                ]
+            ];
+        }
+
         Plugin::doHook(Hooks::SHOW_IN_TIMELINE, ['item' => $this, 'timeline' => &$timeline]);
 
        //sort timeline items by date

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7299,7 +7299,7 @@ abstract class CommonITILObject extends CommonDBTM
             $followup_template = ITILFollowupTemplate::getById($pending_reason->fields['itilfollowuptemplates_id']);
             $content = sprintf(
                 '<span>%1$s%2$s (<span data-bs-toggle="popover" data-bs-html="true" data-bs-sanitize="true" data-bs-content="%3$s"><u>%4$s</u></span>)</span>',
-                '<i class="ti ti-reload text-primary me-1"></i>',
+                '<i class="ti ti-refresh-alert text-warning me-1"></i>',
                 __('Auto bump'),
                 htmlspecialchars($followup_template->fields['content']),
                 $autobump_obj->getPendinReason()->fields['name']

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7300,9 +7300,9 @@ abstract class CommonITILObject extends CommonDBTM
             $content = sprintf(
                 '<span>%1$s%2$s (<span data-bs-toggle="popover" data-bs-html="true" data-bs-sanitize="true" data-bs-content="%3$s"><u>%4$s</u></span>)</span>',
                 '<i class="ti ti-refresh-alert text-warning me-1"></i>',
-                __('Auto reminder'),
-                $followup_template->fields['content'] ?? '',
-                $autoreminder_obj->getPendingReason()->fields['name']
+                ITILReminder::getTypeName(1),
+                $followup_template !== false ? $followup_template->getRenderedContent($this) : '',
+                $pending_reason->fields['name']
             );
 
             $timeline["ITILReminder_" . $autoreminder_id] = [

--- a/src/ITILAutoBump.php
+++ b/src/ITILAutoBump.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+class ITILAutoBump extends CommonDBChild
+{
+    // From CommonDBTM
+    public $dohistory = true;
+
+    public static $itemtype = 'itemtype'; // Class name or field name (start with itemtype) for link to Parent
+    public static $items_id = 'items_id'; // Field name
+
+    public static function getTypeName($nb = 0)
+    {
+        return _n('Auto Bump', 'Auto Bumps', $nb);
+    }
+
+    public function getPendinReason()
+    {
+        $pending_reason = new PendingReason();
+        $pending_reason->getFromDB($this->fields['pendingreasons_id']);
+        return $pending_reason;
+    }
+
+    public static function getIcon()
+    {
+        return "ti ti-reload";
+    }
+}

--- a/src/ITILAutoBump.php
+++ b/src/ITILAutoBump.php
@@ -46,7 +46,7 @@ class ITILAutoBump extends CommonDBChild
         return _n('Auto Bump', 'Auto Bumps', $nb);
     }
 
-    public function getPendinReason()
+    public function getPendingReason()
     {
         $pending_reason = new PendingReason();
         $pending_reason->getFromDB($this->fields['pendingreasons_id']);

--- a/src/ITILAutoBump.php
+++ b/src/ITILAutoBump.php
@@ -55,6 +55,6 @@ class ITILAutoBump extends CommonDBChild
 
     public static function getIcon()
     {
-        return "ti ti-reload";
+        return "ti ti-refresh-alert";
     }
 }

--- a/src/ITILReminder.php
+++ b/src/ITILReminder.php
@@ -43,10 +43,10 @@ class ITILReminder extends CommonDBChild
 
     public static function getTypeName($nb = 0)
     {
-        return _n('Auto Bump', 'Auto Bumps', $nb);
+        return _n('Automatic reminder', 'Automatic reminders', $nb);
     }
 
-    public function getPendingReason()
+    public function getPendingReason(): PendingReason
     {
         $pending_reason = new PendingReason();
         $pending_reason->getFromDB($this->fields['pendingreasons_id']);

--- a/src/ITILReminder.php
+++ b/src/ITILReminder.php
@@ -33,7 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
-class ITILAutoBump extends CommonDBChild
+class ITILReminder extends CommonDBChild
 {
     // From CommonDBTM
     public $dohistory = true;

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -327,7 +327,7 @@ class ITILSolution extends CommonDBChild
         if (
             $this->input["itemtype"] == 'Ticket'
             && $_SESSION['glpiset_solution_tech']
-            && $this->input["users_id"] != $config['system_user']
+            && ($this->input['_disable_auto_assign'] ?? false) === true
         ) {
             Ticket::assignToMe($this->input["items_id"], $this->input["users_id"]);
         }

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -326,7 +326,7 @@ class ITILSolution extends CommonDBChild
         if (
             $this->input["itemtype"] == 'Ticket'
             && $_SESSION['glpiset_solution_tech']
-            && ($this->input['_disable_auto_assign'] ?? true) === true
+            && ($this->input['_disable_auto_assign'] ?? false) === false
         ) {
             Ticket::assignToMe($this->input["items_id"], $this->input["users_id"]);
         }

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -278,6 +278,7 @@ class ITILSolution extends CommonDBChild
 
     public function post_addItem()
     {
+        $config = Config::getConfigurationValues('core', ['system_user']);
 
        //adding a solution mean the ITIL object is now solved
        //and maybe closed (according to entitiy configuration)
@@ -323,7 +324,11 @@ class ITILSolution extends CommonDBChild
             ]);
         }
 
-        if ($this->input["itemtype"] == 'Ticket' && $_SESSION['glpiset_solution_tech']) {
+        if (
+            $this->input["itemtype"] == 'Ticket'
+            && $_SESSION['glpiset_solution_tech']
+            && $this->input["users_id"] != $config['system_user']
+        ) {
             Ticket::assignToMe($this->input["items_id"], $this->input["users_id"]);
         }
 

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -327,7 +327,7 @@ class ITILSolution extends CommonDBChild
         if (
             $this->input["itemtype"] == 'Ticket'
             && $_SESSION['glpiset_solution_tech']
-            && ($this->input['_disable_auto_assign'] ?? false) === true
+            && ($this->input['_disable_auto_assign'] ?? true) === true
         ) {
             Ticket::assignToMe($this->input["items_id"], $this->input["users_id"]);
         }

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -278,7 +278,6 @@ class ITILSolution extends CommonDBChild
 
     public function post_addItem()
     {
-        $config = Config::getConfigurationValues('core', ['system_user']);
 
        //adding a solution mean the ITIL object is now solved
        //and maybe closed (according to entitiy configuration)

--- a/src/NotificationTargetCommonITILObject.php
+++ b/src/NotificationTargetCommonITILObject.php
@@ -2113,10 +2113,10 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
             $objettype . '.numberoflinkedtickets' => _x('quantity', 'Number of linked tickets'),
             $objettype . '.numberoflinkedchanges' => _x('quantity', 'Number of linked changes'),
             $objettype . '.numberoflinkedproblems' => _x('quantity', 'Number of linked problems'),
-            $objettype . '.autobump.bumpcounter' => __('Number of bumps'),
+            $objettype . '.autobump.bumpcounter' => __('Number of sent bumps'),
             $objettype . '.autobump.bumpremaining' => __('Number of remaining bumps'),
-            $objettype . '.autobump.bumptotal'  => __('Total number of bumps'),
-            $objettype . '.autobump.deadline'   => __('Deadline'),
+            $objettype . '.autobump.bumptotal'  => __('Total number of bumps before auto resolution'),
+            $objettype . '.autobump.deadline'   => __('Auto resolution deadline'),
             $objettype . '.autobump.bumptext'   => __('Bump text'),
         ];
 

--- a/src/NotificationTargetCommonITILObject.php
+++ b/src/NotificationTargetCommonITILObject.php
@@ -1408,8 +1408,8 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                 $data["##$objettype.reminder.bumpremaining##"] = $pending_reason_item->getField('followups_before_resolution') - $pending_reason_item->getField('bump_count');
                 $data["##$objettype.reminder.bumptotal##"]     = $pending_reason_item->getField('followups_before_resolution');
                 $data["##$objettype.reminder.deadline##"]      = $pending_reason_item->getAutoResolvedate();
-                $data["##$objettype.reminder.text##"]      = $followup_template !== false ? $followup_template->getRenderedContent($item) : '',
-                $data["##$objettype.reminder.name##"] = $pending_reason->getField('name');
+                $data["##$objettype.reminder.text##"]          = $followup_template !== false ? $followup_template->getRenderedContent($item) : '';
+                $data["##$objettype.reminder.name##"]          = $pending_reason->getField('name');
             }
         }
 

--- a/src/NotificationTargetCommonITILObject.php
+++ b/src/NotificationTargetCommonITILObject.php
@@ -2119,7 +2119,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
             $objettype . '.reminder.bumptotal'  => __('Total number of reminders before automatic resolution'),
             $objettype . '.reminder.deadline'   => __('Auto resolution deadline'),
             $objettype . '.reminder.bumptext'   => __('Reminder text'),
-             $objettype . '.reminder.name' => __('Pending reason name'),
+            $objettype . '.reminder.name' => __('Pending reason name'),
         ];
 
         foreach ($tags as $tag => $label) {

--- a/src/NotificationTargetCommonITILObject.php
+++ b/src/NotificationTargetCommonITILObject.php
@@ -142,7 +142,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
             'update_followup'   => __('Update of a followup'),
             'delete_followup'   => __('Deletion of a followup'),
             'user_mention'      => __('User mentionned'),
-            'auto_bump'         => __('Automatic reminder'),
+            'auto_reminder'         => __('Automatic reminder'),
         ];
 
         asort($events);
@@ -1379,9 +1379,9 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
             $data["##$objettype.solution.description##"] = $itilsolution->getField('content');
         }
 
-        $itilautobump = new ITILAutoBump();
+        $itilreminder = new ITILReminder();
         if (
-            $itilautobump->getFromDBByRequest([
+            $itilreminder->getFromDBByRequest([
                 'WHERE'  => [
                     'itemtype'  => $objettype,
                     'items_id'  => $item->fields['id'],
@@ -1390,7 +1390,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                 'LIMIT'  => 1
             ])
         ) {
-            $pending_reason = PendingReason::getById($itilautobump->getField('pendingreasons_id'));
+            $pending_reason = PendingReason::getById($itilreminder->getField('pendingreasons_id'));
             $pending_reason_item = new PendingReason_Item();
             $followup_template = ITILFollowupTemplate::getById($pending_reason->getField('itilfollowuptemplates_id'));
             if (
@@ -1404,11 +1404,11 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                     'LIMIT'  => 1
                 ])
             ) {
-                $data["##$objettype.autobump.bumpcounter##"]   = $pending_reason_item->getField('bump_count');
-                $data["##$objettype.autobump.bumpremaining##"] = $pending_reason_item->getField('followups_before_resolution') - $pending_reason_item->getField('bump_count');
-                $data["##$objettype.autobump.bumptotal##"]     = $pending_reason_item->getField('followups_before_resolution');
-                $data["##$objettype.autobump.deadline##"]      = $pending_reason_item->getAutoResolvedate();
-                $data["##$objettype.autobump.bumptext##"]      = $followup_template->getField('content');
+                $data["##$objettype.reminder.bumpcounter##"]   = $pending_reason_item->getField('bump_count');
+                $data["##$objettype.reminder.bumpremaining##"] = $pending_reason_item->getField('followups_before_resolution') - $pending_reason_item->getField('bump_count');
+                $data["##$objettype.reminder.bumptotal##"]     = $pending_reason_item->getField('followups_before_resolution');
+                $data["##$objettype.reminder.deadline##"]      = $pending_reason_item->getAutoResolvedate();
+                $data["##$objettype.reminder.bumptext##"]      = $followup_template->getField('content');
             }
         }
 
@@ -2113,11 +2113,11 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
             $objettype . '.numberoflinkedtickets' => _x('quantity', 'Number of linked tickets'),
             $objettype . '.numberoflinkedchanges' => _x('quantity', 'Number of linked changes'),
             $objettype . '.numberoflinkedproblems' => _x('quantity', 'Number of linked problems'),
-            $objettype . '.autobump.bumpcounter' => __('Number of sent bumps'),
-            $objettype . '.autobump.bumpremaining' => __('Number of remaining bumps'),
-            $objettype . '.autobump.bumptotal'  => __('Total number of bumps before automatic resolution'),
-            $objettype . '.autobump.deadline'   => __('Auto resolution deadline'),
-            $objettype . '.autobump.bumptext'   => __('Bump text'),
+            $objettype . '.reminder.bumpcounter' => __('Number of sent bumps since status is pending'),
+            $objettype . '.reminder.bumpremaining' => __('Number of remaining bumps before automatic resolution'),
+            $objettype . '.reminder.bumptotal'  => __('Total number of bumps before automatic resolution'),
+            $objettype . '.reminder.deadline'   => __('Auto resolution deadline'),
+            $objettype . '.reminder.bumptext'   => __('Bump text'),
         ];
 
         foreach ($tags as $tag => $label) {

--- a/src/NotificationTargetCommonITILObject.php
+++ b/src/NotificationTargetCommonITILObject.php
@@ -142,7 +142,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
             'update_followup'   => __('Update of a followup'),
             'delete_followup'   => __('Deletion of a followup'),
             'user_mention'      => __('User mentionned'),
-            'auto_reminder'         => __('Automatic reminder'),
+            'auto_reminder'    => ITILReminder::getTypeName(1),
         ];
 
         asort($events);
@@ -1390,11 +1390,11 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                 'LIMIT'  => 1
             ])
         ) {
-            $pending_reason = PendingReason::getById($itilreminder->getField('pendingreasons_id'));
+            $pending_reason = $itilreminder->getPendingReason();
             $pending_reason_item = new PendingReason_Item();
-            $followup_template = ITILFollowupTemplate::getById($pending_reason->getField('itilfollowuptemplates_id'));
+            $followup_template = ITILFollowupTemplate::getById($pending_reason->fields['itilfollowuptemplates_id']);
             if (
-                $pending_reason && $followup_template && $pending_reason_item->getFromDBByRequest([
+                $pending_reason && $pending_reason_item->getFromDBByRequest([
                     'WHERE'  => [
                         'itemtype'  => $objettype,
                         'items_id'  => $item->fields['id'],
@@ -1408,7 +1408,8 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                 $data["##$objettype.reminder.bumpremaining##"] = $pending_reason_item->getField('followups_before_resolution') - $pending_reason_item->getField('bump_count');
                 $data["##$objettype.reminder.bumptotal##"]     = $pending_reason_item->getField('followups_before_resolution');
                 $data["##$objettype.reminder.deadline##"]      = $pending_reason_item->getAutoResolvedate();
-                $data["##$objettype.reminder.bumptext##"]      = $followup_template->getField('content');
+                $data["##$objettype.reminder.text##"]      = $followup_template !== false ? $followup_template->getRenderedContent($item) : '',
+                $data["##$objettype.reminder.name##"] = $pending_reason->getField('name');
             }
         }
 
@@ -2113,11 +2114,12 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
             $objettype . '.numberoflinkedtickets' => _x('quantity', 'Number of linked tickets'),
             $objettype . '.numberoflinkedchanges' => _x('quantity', 'Number of linked changes'),
             $objettype . '.numberoflinkedproblems' => _x('quantity', 'Number of linked problems'),
-            $objettype . '.reminder.bumpcounter' => __('Number of sent bumps since status is pending'),
-            $objettype . '.reminder.bumpremaining' => __('Number of remaining bumps before automatic resolution'),
-            $objettype . '.reminder.bumptotal'  => __('Total number of bumps before automatic resolution'),
+            $objettype . '.reminder.bumpcounter' => __('Number of sent reminders since status is pending'),
+            $objettype . '.reminder.bumpremaining' => __('Number of remaining reminders before automatic resolution'),
+            $objettype . '.reminder.bumptotal'  => __('Total number of reminders before automatic resolution'),
             $objettype . '.reminder.deadline'   => __('Auto resolution deadline'),
-            $objettype . '.reminder.bumptext'   => __('Bump text'),
+            $objettype . '.reminder.bumptext'   => __('Reminder text'),
+             $objettype . '.reminder.name' => __('Pending reason name'),
         ];
 
         foreach ($tags as $tag => $label) {

--- a/src/NotificationTargetCommonITILObject.php
+++ b/src/NotificationTargetCommonITILObject.php
@@ -2115,7 +2115,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
             $objettype . '.numberoflinkedproblems' => _x('quantity', 'Number of linked problems'),
             $objettype . '.autobump.bumpcounter' => __('Number of sent bumps'),
             $objettype . '.autobump.bumpremaining' => __('Number of remaining bumps'),
-            $objettype . '.autobump.bumptotal'  => __('Total number of bumps before auto resolution'),
+            $objettype . '.autobump.bumptotal'  => __('Total number of bumps before automatic resolution'),
             $objettype . '.autobump.deadline'   => __('Auto resolution deadline'),
             $objettype . '.autobump.bumptext'   => __('Bump text'),
         ];

--- a/src/NotificationTargetCommonITILObject.php
+++ b/src/NotificationTargetCommonITILObject.php
@@ -2118,7 +2118,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
             $objettype . '.reminder.bumpremaining' => __('Number of remaining reminders before automatic resolution'),
             $objettype . '.reminder.bumptotal'  => __('Total number of reminders before automatic resolution'),
             $objettype . '.reminder.deadline'   => __('Auto resolution deadline'),
-            $objettype . '.reminder.bumptext'   => __('Reminder text'),
+            $objettype . '.reminder.text'   => __('Reminder text'),
             $objettype . '.reminder.name' => __('Pending reason name'),
         ];
 

--- a/src/PendingReason.php
+++ b/src/PendingReason.php
@@ -68,7 +68,7 @@ class PendingReason extends CommonDropdown
                         'show_warning' => $defaultPendingReason && $defaultPendingReason->getID() != $this->getID(),
                         'tooltip' => $defaultPendingReason ? \Html::showToolTip(
                             sprintf(
-                                __('If you set this as the default pending reason, the previous default pending reason (%s) will no longer default.'),
+                                __('If you set this as the default pending reason, the previous default pending reason (%s) will no longer be the default value.'),
                                 '<a href="' . PendingReason::getFormURLWithID($defaultPendingReason->getID()) . '">' . $defaultPendingReason->fields['name'] . '</a>'
                             ),
                             [
@@ -379,13 +379,13 @@ class PendingReason extends CommonDropdown
         return $input;
     }
 
-    public function add(array $input, $options = [], $history = true)
+    public function prepareInputForAdd($input)
     {
-        return parent::add($this->prepareInput($input), $options, $history);
+        return $this->prepareInput($input);
     }
 
-    public function update(array $input, $options = [], $history = true)
+    public function prepareInputForUpdate($input)
     {
-        return parent::update($this->prepareInput($input), $options, $history);
+        return $this->prepareInput($input);
     }
 }

--- a/src/PendingReason.php
+++ b/src/PendingReason.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\View\TemplateRenderer;
+
 /**
  * ITILCategory class
  **/
@@ -62,9 +64,9 @@ class PendingReason extends CommonDropdown
                 'label' => __('Default pending reason'),
                 'type' => 'bool',
                 'params' => [
-                    'add_field_html' => ($defaultPendingReason && $defaultPendingReason->getID() != $this->getID() ?
-                        '<span id="is_default_warning" class="text-warning d-none">'
-                        . \Html::showToolTip(
+                    'add_field_html' => TemplateRenderer::getInstance()->render('components/form/pending_reason_is_default.html.twig', [
+                        'show_warning' => $defaultPendingReason && $defaultPendingReason->getID() != $this->getID(),
+                        'tooltip' => $defaultPendingReason ? \Html::showToolTip(
                             sprintf(
                                 __('If you set this as the default pending reason, the previous default pending reason (%s) will no longer default.'),
                                 '<a href="' . PendingReason::getFormURLWithID($defaultPendingReason->getID()) . '">' . $defaultPendingReason->fields['name'] . '</a>'
@@ -73,20 +75,8 @@ class PendingReason extends CommonDropdown
                                 'display' => false,
                                 'awesome-class' => 'fa fa-exclamation-triangle fa-lg',
                             ]
-                        )
-                        . '</span>'
-                        : '')
-                        . '<script>'
-                        . '$("select[name=\'is_default\']").on("change", function() {'
-                        . 'if ($(this).val() == 1) {'
-                        . '$("#is_default_warning").removeClass("d-none");'
-                        . '$("select[name=\'is_pending_per_default\']").prop("disabled", false);'
-                        . '} else {'
-                        . '$("#is_default_warning").addClass("d-none");'
-                        . '$("select[name=\'is_pending_per_default\']").prop("disabled", true);'
-                        . '}'
-                        . '});'
-                        . '</script>',
+                        ) : '',
+                    ]),
                 ],
             ],
             [

--- a/src/PendingReason.php
+++ b/src/PendingReason.php
@@ -353,7 +353,7 @@ class PendingReason extends CommonDropdown
         );
     }
 
-    private static function getDefault(): ?PendingReason
+    public static function getDefault(): ?PendingReason
     {
         $pending_reason = new PendingReason();
         if (

--- a/src/PendingReason.php
+++ b/src/PendingReason.php
@@ -80,10 +80,10 @@ class PendingReason extends CommonDropdown
                         . '$("select[name=\'is_default\']").on("change", function() {'
                         . 'if ($(this).val() == 1) {'
                         . '$("#is_default_warning").removeClass("d-none");'
-                        . '$("select[name=\'is_pending_per_default\']").parent().parent().removeClass("d-none");'
+                        . '$("select[name=\'is_pending_per_default\']").prop("disabled", false);'
                         . '} else {'
                         . '$("#is_default_warning").addClass("d-none");'
-                        . '$("select[name=\'is_pending_per_default\']").parent().parent().addClass("d-none");'
+                        . '$("select[name=\'is_pending_per_default\']").prop("disabled", true);'
                         . '}'
                         . '});'
                         . '</script>',
@@ -94,7 +94,7 @@ class PendingReason extends CommonDropdown
                 'label' => __('Pending per default'),
                 'type' => 'bool',
                 'params' => [
-                    'add_field_class' => $this->fields['is_default'] ? '' : 'd-none',
+                    'disabled' => !$this->fields['is_default'],
                 ],
             ],
             [
@@ -105,7 +105,7 @@ class PendingReason extends CommonDropdown
             ],
             [
                 'name'  => 'followup_frequency',
-                'label' => __('Automatic follow-up frequency'),
+                'label' => __('Automatic follow-up/solution frequency'),
                 'type'  => '',
                 'list'  => true
             ],

--- a/src/PendingReason.php
+++ b/src/PendingReason.php
@@ -370,18 +370,30 @@ class PendingReason extends CommonDropdown
         return $default_pending && $default_pending->fields['is_pending_per_default'];
     }
 
-    public function prepareInput(array $input)
+    public function updateDefaultPendingReason()
     {
-        if (isset($input['is_default']) && $input['is_default']) {
+        if (isset($this->input['is_default']) && $this->input['is_default']) {
             $previous_default = self::getDefault();
             if ($previous_default !== null) {
-                 $previous_default->update(['id' => $previous_default->getId()] + ['is_default' => 0]);
+                $previous_default->update(['id' => $previous_default->getId()] + ['is_default' => 0]);
             }
         }
+    }
 
-        if (isset($input['is_pending_per_default']) && $input['is_pending_per_default']) {
-            $input['is_pending_per_default'] = $input['is_default'] ?? 0;
-        }
+    public function pre_addInDB()
+    {
+        $this->updateDefaultPendingReason();
+    }
+
+    public function pre_updateInDB()
+    {
+        $this->updateDefaultPendingReason();
+    }
+
+    public function prepareInput($input)
+    {
+        $input['is_pending_per_default'] = isset($input['is_default']) && $input['is_default'] ?
+            ($input['is_pending_per_default'] ?? 0) : 0;
 
         return $input;
     }

--- a/src/PendingReason.php
+++ b/src/PendingReason.php
@@ -263,11 +263,7 @@ class PendingReason extends CommonDropdown
      * @param $name
      * @param $options
      */
-    public function displayIsDefaultPendingReasonField(
-        $value = null,
-        $name = "",
-        $options = [],
-    ) {
+    private function displayIsDefaultPendingReasonField(bool $value): string {
         if (empty($name)) {
             $name = "is_default";
         }
@@ -275,7 +271,7 @@ class PendingReason extends CommonDropdown
         $options['display'] = false;
         $defaultPendingReason = self::getDefault();
 
-        $out = Dropdown::showYesNo($name, $value, params: $options);
+        $out = Dropdown::showYesNo($name, $value, params: ['display' => false]);
         $out .= TemplateRenderer::getInstance()->render('components/form/pending_reason_is_default.html.twig', [
             'show_warning' => $defaultPendingReason && $defaultPendingReason->getID() != $this->getID(),
             'tooltip' => $defaultPendingReason ? \Html::showToolTip(
@@ -315,7 +311,7 @@ class PendingReason extends CommonDropdown
         } else if ($field['name'] == 'followups_before_resolution') {
             echo self::displayFollowupsNumberBeforeResolutionField($this->fields['followups_before_resolution']);
         } else if ($field['name'] == 'is_default') {
-            echo self::displayIsDefaultPendingReasonField($this->fields['is_default']);
+            echo self::displayIsDefaultPendingReasonField((bool)$this->fields['is_default']);
         }
     }
 
@@ -357,7 +353,7 @@ class PendingReason extends CommonDropdown
         );
     }
 
-    public static function getDefault()
+    private static function getDefault(): ?PendingReason
     {
         $pending_reason = new PendingReason();
         if (
@@ -381,17 +377,10 @@ class PendingReason extends CommonDropdown
     public function prepareInput(array $input)
     {
         if (isset($input['is_default']) && $input['is_default']) {
-            global $DB;
-
-            $DB->update(
-                $this->getTable(),
-                [
-                    'is_default' => 0,
-                ],
-                [
-                    'is_default' => 1,
-                ]
-            );
+            $previous_default = self::getDefault();
+            if ($previous_default !== null) {
+                 $previous_default->update(['id' => $previous_default->getId()] + ['is_default' => 0]);
+            }
         }
 
         if (isset($input['is_pending_per_default']) && $input['is_pending_per_default']) {

--- a/src/PendingReason.php
+++ b/src/PendingReason.php
@@ -56,28 +56,11 @@ class PendingReason extends CommonDropdown
 
     public function getAdditionalFields()
     {
-        $defaultPendingReason = self::getDefault();
-
         return [
             [
                 'name' => 'is_default',
                 'label' => __('Default pending reason'),
-                'type' => 'bool',
-                'params' => [
-                    'add_field_html' => TemplateRenderer::getInstance()->render('components/form/pending_reason_is_default.html.twig', [
-                        'show_warning' => $defaultPendingReason && $defaultPendingReason->getID() != $this->getID(),
-                        'tooltip' => $defaultPendingReason ? \Html::showToolTip(
-                            sprintf(
-                                __('If you set this as the default pending reason, the previous default pending reason (%s) will no longer be the default value.'),
-                                '<a href="' . PendingReason::getFormURLWithID($defaultPendingReason->getID()) . '">' . $defaultPendingReason->fields['name'] . '</a>'
-                            ),
-                            [
-                                'display' => false,
-                                'awesome-class' => 'fa fa-exclamation-triangle fa-lg',
-                            ]
-                        ) : '',
-                    ]),
-                ],
+                'type' => '',
             ],
             [
                 'name' => 'is_pending_per_default',
@@ -274,6 +257,43 @@ class PendingReason extends CommonDropdown
     }
 
     /**
+     * Display specific "is_default" field
+     *
+     * @param $value
+     * @param $name
+     * @param $options
+     */
+    public function displayIsDefaultPendingReasonField(
+        $value = null,
+        $name = "",
+        $options = [],
+    ) {
+        if (empty($name)) {
+            $name = "is_default";
+        }
+
+        $options['display'] = false;
+        $defaultPendingReason = self::getDefault();
+
+        $out = Dropdown::showYesNo($name, $value, params: $options);
+        $out .= TemplateRenderer::getInstance()->render('components/form/pending_reason_is_default.html.twig', [
+            'show_warning' => $defaultPendingReason && $defaultPendingReason->getID() != $this->getID(),
+            'tooltip' => $defaultPendingReason ? \Html::showToolTip(
+                sprintf(
+                    __('If you set this as the default pending reason, the previous default pending reason (%s) will no longer be the default value.'),
+                    '<a href="' . PendingReason::getFormURLWithID($defaultPendingReason->getID()) . '">' . $defaultPendingReason->fields['name'] . '</a>'
+                ),
+                [
+                    'display' => false,
+                    'awesome-class' => 'fa fa-exclamation-triangle fa-lg',
+                ]
+            ) : '',
+        ]);
+
+        return $out;
+    }
+
+    /**
      * Get possibles values for 'followups_before_resolution' field of pending reasons
      * @return array number of bump before resolution => label
      */
@@ -291,9 +311,11 @@ class PendingReason extends CommonDropdown
     {
 
         if ($field['name'] == 'followup_frequency') {
-            echo self::displayFollowupFrequencyfield($this->fields['followup_frequency'], "", [], false);
+            echo self::displayFollowupFrequencyfield($this->fields['followup_frequency']);
         } else if ($field['name'] == 'followups_before_resolution') {
-            echo self::displayFollowupsNumberBeforeResolutionField($this->fields['followups_before_resolution'], "", [], false);
+            echo self::displayFollowupsNumberBeforeResolutionField($this->fields['followups_before_resolution']);
+        } else if ($field['name'] == 'is_default') {
+            echo self::displayIsDefaultPendingReasonField($this->fields['is_default']);
         }
     }
 

--- a/src/PendingReason.php
+++ b/src/PendingReason.php
@@ -263,7 +263,8 @@ class PendingReason extends CommonDropdown
      * @param $name
      * @param $options
      */
-    private function displayIsDefaultPendingReasonField(bool $value): string {
+    private function displayIsDefaultPendingReasonField(bool $value): string
+    {
         if (empty($name)) {
             $name = "is_default";
         }

--- a/src/PendingReason.php
+++ b/src/PendingReason.php
@@ -265,14 +265,9 @@ class PendingReason extends CommonDropdown
      */
     private function displayIsDefaultPendingReasonField(bool $value): string
     {
-        if (empty($name)) {
-            $name = "is_default";
-        }
-
-        $options['display'] = false;
         $defaultPendingReason = self::getDefault();
 
-        $out = Dropdown::showYesNo($name, $value, params: ['display' => false]);
+        $out = Dropdown::showYesNo('is_default', $value, params: ['display' => false]);
         $out .= TemplateRenderer::getInstance()->render('components/form/pending_reason_is_default.html.twig', [
             'show_warning' => $defaultPendingReason && $defaultPendingReason->getID() != $this->getID(),
             'tooltip' => $defaultPendingReason ? \Html::showToolTip(

--- a/src/PendingReasonCron.php
+++ b/src/PendingReasonCron.php
@@ -142,9 +142,9 @@ class PendingReasonCron extends CommonDBTM
                     continue;
                 }
 
-                // Add bump (new ITILAutoBump)
-                $autoBump = new ITILAutoBump();
-                $autoBump->add([
+                // Add bump (new ITILReminder)
+                $autoReminder = new ITILReminder();
+                $autoReminder->add([
                     'itemtype' => $item::getType(),
                     'items_id' => $item->getID(),
                     'pendingreasons_id' => $pending_reason->getID(),
@@ -152,7 +152,7 @@ class PendingReasonCron extends CommonDBTM
                 $task->addVolume(1);
 
                 // Send notification
-                \NotificationEvent::raiseEvent('auto_bump', $item);
+                \NotificationEvent::raiseEvent('auto_reminder', $item);
             } else if ($resolve && $now > $resolve) {
                 // Load solution template
                 $solution_template = SolutionTemplate::getById($pending_reason->fields['solutiontemplates_id']);

--- a/src/PendingReasonCron.php
+++ b/src/PendingReasonCron.php
@@ -142,12 +142,16 @@ class PendingReasonCron extends CommonDBTM
                     continue;
                 }
 
-                // Add bump (new ITILReminder)
-                $autoReminder = new ITILReminder();
-                $autoReminder->add([
+                // Add reminder (new ITILReminder)
+                $reminder = new ITILReminder();
+                $reminder->add([
                     'itemtype' => $item::getType(),
                     'items_id' => $item->getID(),
                     'pendingreasons_id' => $pending_reason->getID(),
+                    'name' => $pending_reason->fields['name'],
+                    'content' => ITILFollowupTemplate::getById(
+                        $pending_reason->fields['itilfollowuptemplates_id']
+                    )->getRenderedContent($item),
                 ]);
                 $task->addVolume(1);
 

--- a/src/PendingReasonCron.php
+++ b/src/PendingReasonCron.php
@@ -120,12 +120,6 @@ class PendingReasonCron extends CommonDBTM
                 continue;
             }
 
-            // Skip if the day is a non-working day or a holliday
-            $calendar = Calendar::getById($pending_reason->fields['calendars_id']);
-            if ($calendar && ($calendar->isHoliday($now) || !$calendar->isAWorkingDay(time()))) {
-                continue;
-            }
-
             $next_bump = $pending_item->getNextFollowupDate();
             $resolve = $pending_item->getAutoResolvedate();
 

--- a/src/PendingReasonCron.php
+++ b/src/PendingReasonCron.php
@@ -164,11 +164,12 @@ class PendingReasonCron extends CommonDBTM
                 // Add solution
                 $solution = new ITILSolution();
                 $solution->add([
-                    'itemtype'         => $item::getType(),
-                    'items_id'         => $item->getID(),
-                    'solutiontypes_id' => $solution_template->fields['solutiontypes_id'],
-                    'content'          => $solution_template->getRenderedContent($item),
-                    'users_id'         => $config['system_user'],
+                    'itemtype'             => $item::getType(),
+                    'items_id'             => $item->getID(),
+                    'solutiontypes_id'     => $solution_template->fields['solutiontypes_id'],
+                    'content'              => $solution_template->getRenderedContent($item),
+                    'users_id'             => $config['system_user'],
+                    '_disable_auto_assign' => true,
                 ]);
                 $task->addVolume(1);
             }

--- a/src/PendingReason_Item.php
+++ b/src/PendingReason_Item.php
@@ -187,13 +187,24 @@ class PendingReason_Item extends CommonDBRelation
             return false;
         }
 
-        $calendar = Calendar::getById(PendingReason::getById($this->fields['pendingreasons_id'])->fields['calendars_id']);
-        return $calendar->computeEndDate(
-            $this->fields['last_bump_date'],
-            $this->fields['followup_frequency'],
-            0,
-            true
+        $calendar = Calendar::getById(
+            PendingReason::getById($this->fields['pendingreasons_id'])->fields['calendars_id']
         );
+        $lastBumpDate = new DateTime($this->fields['last_bump_date']);
+        $lastBumpDate->add(DateInterval::createFromDateString(
+            $this->fields['followup_frequency'] . ' seconds'
+        ));
+
+        if ($calendar) {
+            return $calendar->computeEndDate(
+                $this->fields['last_bump_date'],
+                $this->fields['followup_frequency'],
+                0,
+                true
+            );
+        }
+
+        return $lastBumpDate->format('Y-m-d H:i:s');
     }
 
     /**
@@ -211,13 +222,24 @@ class PendingReason_Item extends CommonDBRelation
             $this->fields['followups_before_resolution'] : 0)
             - $this->fields['bump_count'] + 1;
 
-        $calendar = Calendar::getById(PendingReason::getById($this->fields['pendingreasons_id'])->fields['calendars_id']);
-        return $calendar->computeEndDate(
-            $this->fields['last_bump_date'],
-            $this->fields['followup_frequency'] * $remaining_bumps,
-            0,
-            true
+        $calendar = Calendar::getById(
+            PendingReason::getById($this->fields['pendingreasons_id'])->fields['calendars_id']
         );
+        $lastBumpDate = new DateTime($this->fields['last_bump_date']);
+        $lastBumpDate->add(DateInterval::createFromDateString(
+            $this->fields['followup_frequency'] * $remaining_bumps . ' seconds'
+        ));
+
+        if ($calendar) {
+            return $calendar->computeEndDate(
+                $this->fields['last_bump_date'],
+                $this->fields['followup_frequency'] * $remaining_bumps,
+                0,
+                true
+            );
+        }
+
+        return $lastBumpDate->format('Y-m-d H:i:s');
     }
 
     /**

--- a/src/PendingReason_Item.php
+++ b/src/PendingReason_Item.php
@@ -187,13 +187,13 @@ class PendingReason_Item extends CommonDBRelation
             return false;
         }
 
-        $last_bump_date = new DateTime($this->fields['last_bump_date']);
-
-        return $this->skipNonWorkingDays(
-            Calendar::getById(PendingReason::getById($this->fields['pendingreasons_id'])->fields['calendars_id']),
-            $last_bump_date,
-            (new DateTime())->setTimestamp($last_bump_date->getTimestamp() + $this->fields['followup_frequency'])
-        )->format("Y-m-d H:i:s");
+        $calendar = Calendar::getById(PendingReason::getById($this->fields['pendingreasons_id'])->fields['calendars_id']);
+        return $calendar->computeEndDate(
+            $this->fields['last_bump_date'],
+            $this->fields['followup_frequency'],
+            0,
+            true
+        );
     }
 
     /**
@@ -210,15 +210,14 @@ class PendingReason_Item extends CommonDBRelation
         $remaining_bumps = ($this->fields['followups_before_resolution'] > 0 ?
             $this->fields['followups_before_resolution'] : 0)
             - $this->fields['bump_count'] + 1;
-        $last_bump_date = new DateTime($this->fields['last_bump_date']);
 
-        return $this->skipNonWorkingDays(
-            Calendar::getById(PendingReason::getById($this->fields['pendingreasons_id'])->fields['calendars_id']),
-            $last_bump_date,
-            (new DateTime())->setTimestamp(
-                $last_bump_date->getTimestamp() + ($this->fields['followup_frequency'] * $remaining_bumps)
-            ),
-        )->format("Y-m-d H:i:s");
+        $calendar = Calendar::getById(PendingReason::getById($this->fields['pendingreasons_id'])->fields['calendars_id']);
+        return $calendar->computeEndDate(
+            $this->fields['last_bump_date'],
+            $this->fields['followup_frequency'] * $remaining_bumps,
+            0,
+            true
+        );
     }
 
     /**

--- a/src/PendingReason_Item.php
+++ b/src/PendingReason_Item.php
@@ -190,10 +190,6 @@ class PendingReason_Item extends CommonDBRelation
         $calendar = Calendar::getById(
             PendingReason::getById($this->fields['pendingreasons_id'])->fields['calendars_id']
         );
-        $lastBumpDate = new DateTime($this->fields['last_bump_date']);
-        $lastBumpDate->add(DateInterval::createFromDateString(
-            $this->fields['followup_frequency'] . ' seconds'
-        ));
 
         if ($calendar) {
             return $calendar->computeEndDate(
@@ -203,6 +199,11 @@ class PendingReason_Item extends CommonDBRelation
                 true
             );
         }
+
+        $lastBumpDate = new DateTime($this->fields['last_bump_date']);
+        $lastBumpDate->add(DateInterval::createFromDateString(
+            $this->fields['followup_frequency'] . ' seconds'
+        ));
 
         return $lastBumpDate->format('Y-m-d H:i:s');
     }
@@ -218,17 +219,13 @@ class PendingReason_Item extends CommonDBRelation
             return false;
         }
 
-        $remaining_bumps = ($this->fields['followups_before_resolution'] > 0 ?
-            $this->fields['followups_before_resolution'] : 0)
-            - $this->fields['bump_count'] + 1;
+        // -1 = auto resolution without bumps
+        $expected_bumps = max($this->fields['followups_before_resolution'], 0);
+        $remaining_bumps = $expected_bumps - $this->fields['bump_count'] + 1;
 
         $calendar = Calendar::getById(
             PendingReason::getById($this->fields['pendingreasons_id'])->fields['calendars_id']
         );
-        $lastBumpDate = new DateTime($this->fields['last_bump_date']);
-        $lastBumpDate->add(DateInterval::createFromDateString(
-            $this->fields['followup_frequency'] * $remaining_bumps . ' seconds'
-        ));
 
         if ($calendar) {
             return $calendar->computeEndDate(
@@ -238,6 +235,11 @@ class PendingReason_Item extends CommonDBRelation
                 true
             );
         }
+
+        $lastBumpDate = new DateTime($this->fields['last_bump_date']);
+        $lastBumpDate->add(DateInterval::createFromDateString(
+            $this->fields['followup_frequency'] * $remaining_bumps . ' seconds'
+        ));
 
         return $lastBumpDate->format('Y-m-d H:i:s');
     }

--- a/src/PendingReason_Item.php
+++ b/src/PendingReason_Item.php
@@ -245,29 +245,6 @@ class PendingReason_Item extends CommonDBRelation
     }
 
     /**
-     * Skip non working days in the date range
-     *
-     * @param Calendar $calendar
-     * @param DateTime $start
-     * @param DateTime $end
-     * @return DateTime
-     */
-    public function skipNonWorkingDays(Calendar $calendar, DateTime $start, DateTime $end)
-    {
-        for ($i = 1; $i < $end->diff($start)->format('%a') + 1; $i++) {
-            $date = (new DateTime())->setTimestamp($start->getTimestamp() + (DAY_TIMESTAMP * $i));
-            if (
-                $calendar && ($calendar->isHoliday($date->format('Y-m-d H:i:s'))
-                    || !$calendar->isAWorkingDay($date->getTimestamp()))
-            ) {
-                $end->setTimestamp($end->getTimestamp() + DAY_TIMESTAMP);
-            }
-        }
-
-        return $end;
-    }
-
-    /**
      * Check that the given timeline event is the lastest "pending" action for
      * the given item
      *

--- a/templates/components/form/pending_reason_is_default.html.twig
+++ b/templates/components/form/pending_reason_is_default.html.twig
@@ -1,0 +1,50 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2023 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% if show_warning %}
+    <span id="is_default_warning" class="text-warning d-none">
+        {{ tooltip|raw }}
+    </span>
+{% endif %}
+
+<script>
+    $("select[name=\'is_default\']").on("change", function () {
+        if ($(this).val() == 1) {
+            $("#is_default_warning").removeClass("d-none");
+            $("select[name=\'is_pending_per_default\']").prop("disabled", false);
+        } else {
+            $("#is_default_warning").addClass("d-none");
+            $("select[name=\'is_pending_per_default\']").prop("disabled", true);
+        }
+    });
+</script>

--- a/templates/components/form/pending_reason_is_default.html.twig
+++ b/templates/components/form/pending_reason_is_default.html.twig
@@ -41,11 +41,11 @@
     $('select[name="is_default"]').on("change", function () {
         if ($(this).val() == 1) {
             $("#is_default_warning").removeClass("d-none");
-            $("select[name=\'is_pending_per_default\']").prop("disabled", false);
+            $('select[name="is_pending_per_default"]').prop("disabled", false);
         } else {
             $("#is_default_warning").addClass("d-none");
-            $("select[name=\'is_pending_per_default\']").prop("disabled", true);
-            $("select[name=\'is_pending_per_default\']").trigger('setValue', 0);
+            $('select[name="is_pending_per_default"]').prop("disabled", true);
+            $('select[name="is_pending_per_default"]').trigger('setValue', 0);
         }
     });
 </script>

--- a/templates/components/form/pending_reason_is_default.html.twig
+++ b/templates/components/form/pending_reason_is_default.html.twig
@@ -45,6 +45,7 @@
         } else {
             $("#is_default_warning").addClass("d-none");
             $("select[name=\'is_pending_per_default\']").prop("disabled", true);
+            $("select[name=\'is_pending_per_default\']").trigger('setValue', 0);
         }
     });
 </script>

--- a/templates/components/form/pending_reason_is_default.html.twig
+++ b/templates/components/form/pending_reason_is_default.html.twig
@@ -38,7 +38,7 @@
 {% endif %}
 
 <script>
-    $("select[name=\'is_default\']").on("change", function () {
+    $('select[name="is_default"]').on("change", function () {
         if ($(this).val() == 1) {
             $("#is_default_warning").removeClass("d-none");
             $("select[name=\'is_pending_per_default\']").prop("disabled", false);

--- a/templates/components/itilobject/timeline/filter_timeline.html.twig
+++ b/templates/components/itilobject/timeline/filter_timeline.html.twig
@@ -69,7 +69,7 @@
       'checked': true,
    },
    'autoreminder': {
-      'title': _n('Reminder', 'Reminders', get_plural_number()),
+      'title': 'ITILReminder'|itemtype_name(get_plural_number()),
       'icon': 'ITILReminder'|itemtype_icon,
       'itemtype': 'ITILReminder',
       'checked': true,

--- a/templates/components/itilobject/timeline/filter_timeline.html.twig
+++ b/templates/components/itilobject/timeline/filter_timeline.html.twig
@@ -68,6 +68,12 @@
       'itemtype': 'ITILSolution',
       'checked': true,
    },
+   'autobump': {
+      'title': _n('AutoBump', 'AutoBumps', get_plural_number()),
+      'icon': 'ITILAutoBump'|itemtype_icon,
+      'itemtype': 'ITILAutoBump',
+      'checked': true,
+   }
 } %}
 
 {% if get_current_interface() == 'central' %}

--- a/templates/components/itilobject/timeline/filter_timeline.html.twig
+++ b/templates/components/itilobject/timeline/filter_timeline.html.twig
@@ -68,10 +68,10 @@
       'itemtype': 'ITILSolution',
       'checked': true,
    },
-   'autobump': {
-      'title': _n('AutoBump', 'AutoBumps', get_plural_number()),
-      'icon': 'ITILAutoBump'|itemtype_icon,
-      'itemtype': 'ITILAutoBump',
+   'autoreminder': {
+      'title': _n('Reminder', 'Reminders', get_plural_number()),
+      'icon': 'ITILReminder'|itemtype_icon,
+      'itemtype': 'ITILReminder',
       'checked': true,
    }
 } %}

--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -41,6 +41,7 @@
 {% set can_update_kb = has_profile_right('knowbase', constant('UPDATE')) %}
 {% set nokb = params['nokb'] is defined or params['nokb'] == true %}
 {% set rand = random() %}
+{% set is_default_pending = call('PendingReason::isDefaultPending') %}
 
 {% block timeline_card %}
    {% if form_mode == 'view' %}
@@ -216,7 +217,7 @@
             {# Fixed min-height ensure no height increase when toggling the pending reason button, as select 2 dropdown are a bit higher than the default footer height #}
             <div class="d-flex card-footer mx-n3 mb-n3 flex-wrap" style="row-gap: 10px; min-height: 79px">
                {% set pending_reasons %}
-                  {% set show_pending_reasons_actions = item.fields['status'] == constant('CommonITILObject::WAITING') and not has_pending_reason and not add_reopen %}
+                  {% set show_pending_reasons_actions = (item.fields['status'] == constant('CommonITILObject::WAITING') or is_default_pending) and not has_pending_reason and not add_reopen %}
                   {% if get_current_interface() == 'central' and item.isAllowedStatus(item.fields['status'], constant('CommonITILObject::WAITING')) %}
                      <span
                         class="input-group-text bg-yellow-lt py-0 pe-0 {{ show_pending_reasons_actions ? 'flex-fill' : '' }}"
@@ -230,7 +231,7 @@
                               <input type="checkbox" name="pending" value="1" class="form-check-input"
                                     id="enable-pending-reasons-{{ rand }}"
                                     role="button"
-                                    {{ item.fields['status'] == constant('CommonITILObject::WAITING') and not add_reopen ? 'checked' : '' }}
+                                    {{ (item.fields['status'] == constant('CommonITILObject::WAITING') or is_default_pending) and not add_reopen ? 'checked' : '' }}
                                     data-bs-toggle="collapse" data-bs-target="#pending-reasons-setup-{{ rand }}" />
                            </label>
                         </span>

--- a/templates/components/itilobject/timeline/pending_reasons.html.twig
+++ b/templates/components/itilobject/timeline/pending_reasons.html.twig
@@ -33,8 +33,9 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
+{% set default_pending = call('PendingReason::getDefault') %}
 {% set pending_item = call('PendingReason_Item::getForItem', [subitem, true]) %}
-{% if subitem.isNewItem() or pending_item or call('PendingReason_Item::isLastTimelineItem', [subitem])  %}
+{% if subitem.isNewItem() or pending_item or call('PendingReason_Item::isLastTimelineItem', [subitem]) %}
    <div class="row">
       <div class="col-12 col-sm-4" title="{{ "PendingReason"|itemtype_name }}"
            data-bs-toggle="tooltip" data-bs-placement="top">
@@ -55,7 +56,7 @@
          {{ fields.dropdownField(
             'PendingReason',
             'pendingreasons_id',
-            subitem.fields['pendingreasons_id'],
+            subitem.fields['pendingreasons_id'] ?? default_pending.fields['id'],
             pendingreasons_lbl,
             {
                'label_class': 'col-1',
@@ -93,6 +94,8 @@
                   $('#pending-reasons-more_options_{{ rand }}').removeClass('show');
                }
             });
+
+            $('#dropdown_pendingreasons_id{{ rand }}').trigger('change');
          </script>
       </div>
 

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -245,4 +245,21 @@ $(function() {
       $("#itil-footer .main-actions").show();
    });
 });
+
+// Align ITILAutoBump
+let result = document.evaluate(
+   '//div[contains(@class, "timeline-header")][contains(@id, "ITILAutoBump_")]',
+   document,
+   null,
+   XPathResult.ORDERED_NODE_SNAPSHOT_TYPE,
+   null
+);
+
+for (let i = 0; i < result.snapshotLength; i++) {
+   let node = result.snapshotItem(i);
+   let width = (i > 0 ? Math.max(result.snapshotItem(i - 1).offsetWidth, node.offsetWidth) : node.offsetWidth) + 1;
+   node.style.setProperty('width', 'var(--itilautobump-header-badge-width)');
+   node.style.setProperty('flex-direction', 'row-reverse');
+   document.documentElement.style.setProperty('--itilautobump-header-badge-width', width + 'px');
+}
 </script>

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -246,9 +246,9 @@ $(function() {
    });
 });
 
-// Align ITILAutoBump
+// Align ITILReminder
 let result = document.evaluate(
-   '//div[contains(@class, "timeline-header")][contains(@id, "ITILAutoBump_")]',
+   '//div[contains(@class, "timeline-header")][contains(@id, "ITILReminder_")]',
    document,
    null,
    XPathResult.ORDERED_NODE_SNAPSHOT_TYPE,

--- a/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
@@ -69,6 +69,8 @@
       {% endset %}
 
       {{ __('Created: %1$s by %2$s for the group %3$s')|format(date_span, creator_span, group_span)|raw }}
+   {% elseif entry['type'] == 'ITILAutoBump' %}
+      {{ __('%1$s')|format(date_span)|raw }}
    {% else %}
       {% if users_id > 0 %}
          {% set creator_span %}

--- a/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
@@ -70,7 +70,7 @@
 
       {{ __('Created: %1$s by %2$s for the group %3$s')|format(date_span, creator_span, group_span)|raw }}
    {% elseif entry['type'] == 'ITILReminder' %}
-      {{ __('%1$s')|format(date_span)|raw }}
+      {{ date_span|raw }}
    {% else %}
       {% if users_id > 0 %}
          {% set creator_span %}

--- a/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
@@ -69,7 +69,7 @@
       {% endset %}
 
       {{ __('Created: %1$s by %2$s for the group %3$s')|format(date_span, creator_span, group_span)|raw }}
-   {% elseif entry['type'] == 'ITILAutoBump' %}
+   {% elseif entry['type'] == 'ITILReminder' %}
       {{ __('%1$s')|format(date_span)|raw }}
    {% else %}
       {% if users_id > 0 %}

--- a/templates/dropdown_form.html.twig
+++ b/templates/dropdown_form.html.twig
@@ -64,7 +64,7 @@
 
             {# Dynamically show additional fields unique to certain dropdowns #}
             {% for field in additional_fields %}
-                {% set fields_params = base_fields_params %}
+                {% set fields_params = base_fields_params|merge(field['params'] ?? []) %}
                 {% set type = field['type']|default('') %}
                 {% set show_field = true %}
                 {% if field['name'] == 'entities_id' and (type != 'parent' or item.fields['id'] == 0) %}

--- a/tests/functional/PendingReason.class.php
+++ b/tests/functional/PendingReason.class.php
@@ -108,7 +108,7 @@ class PendingReason extends DbTestCase
                 'expected' => '2021-02-25 13:01:00'
             ],
             [
-            // Case 6: first with weekend
+            // Case 5: first with weekend
                 'fields' => [
                     'pendingreason' => [
                         'calendars_id' => 1,

--- a/tests/functional/PendingReason.class.php
+++ b/tests/functional/PendingReason.class.php
@@ -54,38 +54,92 @@ class PendingReason extends DbTestCase
             [
             // Case 1: no auto bump
                 'fields' => [
-                    'followup_frequency'          => 0,
+                    'pendingreason' => [
+                        'calendars_id' => 1,
+                    ],
+                    'pendingreason_item' => [
+                        'followup_frequency' => 0,
+                    ],
                 ],
                 'expected' => false
             ],
             [
             // Case 2: max bump reached
                 'fields' => [
-                    'followup_frequency'          => 60,
-                    'followups_before_resolution' => 2,
-                    'bump_count'                  => 2,
+                    'pendingreason' => [
+                        'calendars_id' => 1,
+                    ],
+                    'pendingreason_item' => [
+                        'followup_frequency'          => 60,
+                        'followups_before_resolution' => 2,
+                        'bump_count'                  => 2,
+                    ]
                 ],
                 'expected' => false
             ],
             [
             // Case 3: first bump
                 'fields' => [
-                    'followup_frequency'          => 60,
-                    'followups_before_resolution' => 2,
-                    'bump_count'                  => 0,
-                    'last_bump_date'              => '2021-02-25 12:00:00',
+                    'pendingreason' => [
+                        'calendars_id' => 1,
+                    ],
+                    'pendingreason_item' => [
+                        'followup_frequency'          => 60,
+                        'followups_before_resolution' => 2,
+                        'bump_count'                  => 0,
+                        'last_bump_date'              => '2021-02-25 12:00:00',
+                    ]
                 ],
                 'expected' => date('2021-02-25 12:01:00')
             ],
             [
             // Case 4: second or more bump
                 'fields' => [
-                    'followup_frequency'          => 60,
-                    'followups_before_resolution' => 7,
-                    'bump_count'                  => 5,
-                    'last_bump_date'              => '2021-02-25 13:00:00',
+                    'pendingreason' => [
+                        'calendars_id' => 1,
+                    ],
+                    'pendingreason_item' => [
+                        'followup_frequency'          => 60,
+                        'followups_before_resolution' => 7,
+                        'bump_count'                  => 5,
+                        'last_bump_date'              => '2021-02-25 13:00:00',
+                    ]
                 ],
                 'expected' => '2021-02-25 13:01:00'
+            ],
+            [
+            // Case 6: first with weekend
+                'fields' => [
+                    'pendingreason' => [
+                        'calendars_id' => 1,
+                    ],
+                    'pendingreason_item' => [
+                        'followup_frequency'          => 86400,
+                        'followups_before_resolution' => 7,
+                        'bump_count'                  => 0,
+                        'last_bump_date'              => '2023-04-07 13:00:00',
+                    ]
+                ],
+                'expected' => '2023-04-10 13:00:00'
+            ],
+            [
+            // Case 6: first with xmas holidays
+                'fields' => [
+                    'calendar_holiday' => [
+                        'calendars_id' => 1,
+                        'holidays_id'  => 1,
+                    ],
+                    'pendingreason' => [
+                        'calendars_id' => 1,
+                    ],
+                    'pendingreason_item' => [
+                        'followup_frequency'          => 86400,
+                        'followups_before_resolution' => 7,
+                        'bump_count'                  => 0,
+                        'last_bump_date'              => '2018-12-28 13:00:00',
+                    ]
+                ],
+                'expected' => '2019-01-07 13:00:00',
             ],
         ];
     }
@@ -95,8 +149,15 @@ class PendingReason extends DbTestCase
      */
     public function testGetNextFollowupDate(array $fields, $expected)
     {
+        if (isset($fields['calendar_holiday'])) {
+            $this->createItem('Calendar_Holiday', $fields['calendar_holiday']);
+        }
+
+        $pending_reason = $this->createItem('PendingReason', $fields['pendingreason']);
+        $fields['pendingreason_item']['pendingreasons_id'] = $pending_reason->getID();
+
         $pending_reason_item = new \PendingReason_Item();
-        $pending_reason_item->fields = $fields;
+        $pending_reason_item->fields = $fields['pendingreason_item'];
 
         $this->variable($expected)->isEqualTo($pending_reason_item->getNextFollowupDate());
     }
@@ -107,78 +168,152 @@ class PendingReason extends DbTestCase
             [
             // Case 1: no auto bump
                 'fields' => [
-                    'followup_frequency'          => 0,
-                    'followups_before_resolution' => 2,
+                    'pendingreason' => [
+                        'calendars_id' => 1,
+                    ],
+                    'pendingreason_item' => [
+                        'followup_frequency'          => 0,
+                        'followups_before_resolution' => 2,
+                    ]
                 ],
                 'expected' => false
             ],
             [
             // Case 2: no auto solve
                 'fields' => [
-                    'followup_frequency'          => 60,
-                    'followups_before_resolution' => 0,
+                    'pendingreason' => [
+                        'calendars_id' => 1,
+                    ],
+                    'pendingreason_item' => [
+                        'followup_frequency'          => 60,
+                        'followups_before_resolution' => 0,
+                    ]
                 ],
                 'expected' => false
             ],
             [
             // Case 3: 0/5 bump occurred yet
                 'fields' => [
-                    'followup_frequency'          => 60,
-                    'followups_before_resolution' => 5,
-                    'bump_count'                  => 0,
-                    'last_bump_date'              => '2021-02-25 14:00:00',
+                    'pendingreason' => [
+                        'calendars_id' => 1,
+                    ],
+                    'pendingreason_item' => [
+                        'followup_frequency'          => 60,
+                        'followups_before_resolution' => 5,
+                        'bump_count'                  => 0,
+                        'last_bump_date'              => '2021-02-25 14:00:00',
+                    ]
                 ],
                 'expected' => '2021-02-25 14:06:00'
             ],
             [
             // Case 4: 1/5 bump occurred
                 'fields' => [
-                    'followup_frequency'          => 60,
-                    'followups_before_resolution' => 5,
-                    'bump_count'                  => 1,
-                    'last_bump_date'              => '2021-02-25 15:00:00',
+                    'pendingreason' => [
+                        'calendars_id' => 1,
+                    ],
+                    'pendingreason_item' => [
+                        'followup_frequency'          => 60,
+                        'followups_before_resolution' => 5,
+                        'bump_count'                  => 1,
+                        'last_bump_date'              => '2021-02-25 15:00:00',
+                    ]
                 ],
                 'expected' => '2021-02-25 15:05:00'
             ],
             [
             // Case 5: 2/5 bump occurred
                 'fields' => [
-                    'followup_frequency'          => 60,
-                    'followups_before_resolution' => 5,
-                    'bump_count'                  => 2,
-                    'last_bump_date'              => '2021-02-25 16:00:00',
+                    'pendingreason' => [
+                        'calendars_id' => 1,
+                    ],
+                    'pendingreason_item' => [
+                        'followup_frequency'          => 60,
+                        'followups_before_resolution' => 5,
+                        'bump_count'                  => 2,
+                        'last_bump_date'              => '2021-02-25 16:00:00',
+                    ]
                 ],
                 'expected' => '2021-02-25 16:04:00'
             ],
             [
             // Case 5: 3/5 bump occurred
                 'fields' => [
-                    'followup_frequency'          => 60,
-                    'followups_before_resolution' => 5,
-                    'bump_count'                  => 3,
-                    'last_bump_date'              => '2021-02-25 17:00:00',
+                    'pendingreason' => [
+                        'calendars_id' => 1,
+                    ],
+                    'pendingreason_item' => [
+                        'followup_frequency'          => 60,
+                        'followups_before_resolution' => 5,
+                        'bump_count'                  => 3,
+                        'last_bump_date'              => '2021-02-25 17:00:00',
+                    ]
                 ],
                 'expected' => '2021-02-25 17:03:00'
             ],
             [
             // Case 5: 4/5 bump occurred
                 'fields' => [
-                    'followup_frequency'          => 60,
-                    'followups_before_resolution' => 5,
-                    'bump_count'                  => 4,
-                    'last_bump_date'              => '2021-02-25 18:00:00',
+                    'pendingreason' => [
+                        'calendars_id' => 1,
+                    ],
+                    'pendingreason_item' => [
+                        'followup_frequency'          => 60,
+                        'followups_before_resolution' => 5,
+                        'bump_count'                  => 4,
+                        'last_bump_date'              => '2021-02-25 18:00:00',
+                    ]
                 ],
                 'expected' => '2021-02-25 18:02:00'
             ],
             [
             // Case 5: 5/5 bump occurred
                 'fields' => [
-                    'followup_frequency'          => 60,
-                    'followups_before_resolution' => 5,
-                    'bump_count'                  => 5,
-                    'last_bump_date'              => '2021-02-25 19:00:00',
+                    'pendingreason' => [
+                        'calendars_id' => 1,
+                    ],
+                    'pendingreason_item' => [
+                        'followup_frequency'          => 60,
+                        'followups_before_resolution' => 5,
+                        'bump_count'                  => 5,
+                        'last_bump_date'              => '2021-02-25 19:00:00',
+                    ]
                 ],
                 'expected' => '2021-02-25 19:01:00'
+            ],
+            [
+            // Case 6: 0/8 bump occured with weekend between
+                'fields' => [
+                    'pendingreason' => [
+                        'calendars_id' => 1,
+                    ],
+                    'pendingreason_item' => [
+                        'followup_frequency'          => 86400,
+                        'followups_before_resolution' => 8,
+                        'bump_count'                  => 0,
+                        'last_bump_date'              => '2023-04-07 13:00:00',
+                    ]
+                ],
+                'expected' => '2023-04-20 13:00:00'
+            ],
+            // Case 7: 0/8 bump occured with xmas holidays between
+            [
+                'fields' => [
+                    'calendar_holiday' => [
+                        'calendars_id' => 1,
+                        'holidays_id'  => 1,
+                    ],
+                    'pendingreason' => [
+                        'calendars_id' => 1,
+                    ],
+                    'pendingreason_item' => [
+                        'followup_frequency'          => 86400,
+                        'followups_before_resolution' => 8,
+                        'bump_count'                  => 0,
+                        'last_bump_date'              => '2018-12-21 13:00:00',
+                    ]
+                ],
+                'expected' => '2019-01-10 13:00:00',
             ],
         ];
     }
@@ -188,8 +323,15 @@ class PendingReason extends DbTestCase
      */
     public function testGetAutoResolvedate(array $fields, $expected)
     {
+        if (isset($fields['calendar_holiday'])) {
+            $this->createItem('Calendar_Holiday', $fields['calendar_holiday']);
+        }
+
+        $pending_reason = $this->createItem('PendingReason', $fields['pendingreason']);
+        $fields['pendingreason_item']['pendingreasons_id'] = $pending_reason->getID();
+
         $pending_reason_item = new \PendingReason_Item();
-        $pending_reason_item->fields = $fields;
+        $pending_reason_item->fields = $fields['pendingreason_item'];
 
         $this->variable($expected)->isEqualTo($pending_reason_item->getAutoResolvedate());
     }

--- a/tests/functional/PendingReason.class.php
+++ b/tests/functional/PendingReason.class.php
@@ -141,6 +141,21 @@ class PendingReason extends DbTestCase
                 ],
                 'expected' => '2019-01-07 13:00:00',
             ],
+            [
+            // Case 7: no followup
+                'fields' => [
+                    'pendingreason' => [
+                        'calendars_id' => 1,
+                    ],
+                    'pendingreason_item' => [
+                        'followup_frequency'          => 86400,
+                        'followups_before_resolution' => -1,
+                        'bump_count'                  => 0,
+                        'last_bump_date'              => '2018-12-28 13:00:00',
+                    ]
+                ],
+                'expected' => false,
+            ]
         ];
     }
 
@@ -314,6 +329,21 @@ class PendingReason extends DbTestCase
                     ]
                 ],
                 'expected' => '2019-01-10 13:00:00',
+            ],
+            [
+            // Case 8: no bumps before resolution
+                'fields' => [
+                    'pendingreason' => [
+                        'calendars_id' => 1,
+                    ],
+                    'pendingreason_item' => [
+                        'followup_frequency'          => 86400,
+                        'followups_before_resolution' => -1,
+                        'bump_count'                  => 0,
+                        'last_bump_date'              => '2023-05-12 19:00:00',
+                    ],
+                ],
+                'expected' => '2023-05-15 19:00:00',
             ],
         ];
     }


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The main idea is to remove the reminder follow-up and introduce a new, more discreet element to replace them.
In addition, there are several minor changes.

**1. Rework of pending reasons**
* Use a new distinct type ITILAutoBump in ITIL objects timeline
* Add new table structure for glpi_itilautobumps
* Display information concisely in timeline format
* Add new filters and notification events

**2. Miscellaneous changes**
* Taking into account the calendar to avoid reminders on non-working days
* Define a default pending reason that is automatically pre-selected in follow-ups
* Resolution without follow-up