### PR TITLE
Fix pending reasons wrap 2

### DIFF
--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -213,7 +213,8 @@
             </div>
 
             {{ call_plugin_hook('post_item_form', {"item": subitem, 'options': params}) }}
-            <div class="d-flex card-footer mx-n3 mb-n3 flex-wrap" style="row-gap: 10px;">
+            {# Fixed min-height ensure no height increase when toggling the pending reason button, as select 2 dropdown are a bit higher than the default footer height #}
+            <div class="d-flex card-footer mx-n3 mb-n3 flex-wrap" style="row-gap: 10px; min-height: 79px">
                {% set pending_reasons %}
                   {% set show_pending_reasons_actions = item.fields['status'] == constant('CommonITILObject::WAITING') and not has_pending_reason and not add_reopen %}
                   {% if get_current_interface() == 'central' and item.isAllowedStatus(item.fields['status'], constant('CommonITILObject::WAITING')) %}
@@ -248,7 +249,8 @@
                {% endset %}
 
                {% if subitem.fields['id'] <= 0 %}
-                  <div class="input-group">
+                  {# Do not enable flex wrapping when creating a new item as the pending form will be merged with the add button in an input group #}
+                  <div class="input-group flex-nowrap">
                      <button class="btn btn-primary" type="submit" name="add">
                         <i class="fas fa-plus"></i>
                         <span>{{ _x('button', 'Add') }}</span>

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -421,9 +421,11 @@
             {% endset %}
 
             {{ call_plugin_hook('post_item_form', {"item": subitem, 'options': params}) }}
-            <div class="d-flex card-footer mx-n3 mb-n3 flex-wrap" style="row-gap: 10px;">
+            {# Fixed min-height ensure no height increase when toggling the pending reason button, as select 2 dropdown are a bit higher than the default footer height #}
+            <div class="d-flex card-footer mx-n3 mb-n3 flex-wrap" style="row-gap: 10px; min-height: 79px">
                {% if subitem.fields['id'] <= 0 %}
-                  <div class="input-group">
+                  {# Do not enable flex wrapping when creating a new item as the pending form will be merged with the add button in an input group #}
+                  <div class="input-group flex-nowrap">
                      <button class="btn btn-primary" type="submit" name="add">
                         <i class="fas fa-plus"></i>
                         <span>{{ _x('button', 'Add') }}</span>


### PR DESCRIPTION
#14660 fix some overflow issue by using wrapping and work great on followup edition:

![image](https://github.com/glpi-project/glpi/assets/42734840/fd631957-0cda-42f3-a0e8-66fb3d48bb52)

However it's not great for followup **creation** as we have a grouped input with the "Add" button in this case so wrapping is not ideal:

![image](https://github.com/glpi-project/glpi/assets/42734840/5ed4dc05-1334-4319-bb1c-d13bfb544fd4)

I've fixed it by preventing wrapping in this case, as we have enough space here to display the full form in one line:

![image](https://github.com/glpi-project/glpi/assets/42734840/e457026e-30a0-427c-abd0-d8465638866a)

Edition mode is still using the wrapped version.

@orthagh I didn't forget our discussion about shortening the form by hiding/restricting the followup frequency dropdowns, still something I want to do but maybe later as this solution was a lot simpler for now.

We've also had some complains that the form footer change height when toggling the pending reason button.
This is because select2 dropdowns are a bit higher than our buttons, so displaying/hiding the dropdowns change the height.

I've added a fixed min-height to the button to prevent this, not sure if it can be done better (maybe the dropdown should be smaller instead) ?
Its not that important anyway so the current solution might be enough ;)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27887
