### PR TITLE
completly hide headings field in self-service interface when adding a doc to an existing ticket

### DIFF
--- a/templates/components/itilobject/timeline/form_document_item.html.twig
+++ b/templates/components/itilobject/timeline/form_document_item.html.twig
@@ -102,18 +102,20 @@
                 <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
                 {{ call_plugin_hook('pre_item_form', {"item": subitem, 'options': params}) }}
 
-                {{ fields.dropdownField(
-                    'DocumentCategory',
-                    'documentcategories_id',
-                    null,
-                    __("Heading"),
-                    {
-                        'label_class': 'col-xxl-3',
-                        'field_class': 'col-xxl-11',
-                        'full_width': true,
-                        'is_horizontal': false
-                    }
-                ) }}
+                {% if get_current_interface() == 'central' %}
+                    {{ fields.dropdownField(
+                        'DocumentCategory',
+                        'documentcategories_id',
+                        null,
+                        __("Heading"),
+                        {
+                            'label_class': 'col-xxl-3',
+                            'field_class': 'col-xxl-11',
+                            'full_width': true,
+                            'is_horizontal': false
+                        }
+                    ) }}
+                {% endif %}
 
                 {% set max_size %}
                     <div class="alert alert-info">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11849

As most of instance uses formcreator for self-service ticketing and I'm in favor of simplification for ui, I though hiding completly the field should be ok.

Ping @tsmr 
