### PR TITLE
Fix api app_token regeneration

### DIFF
--- a/src/APIClient.php
+++ b/src/APIClient.php
@@ -238,7 +238,7 @@ class APIClient extends CommonDBTM
             $input['ipv6'] = "NULL";
         }
 
-        if (isset($input['_reset_app_token'])) {
+        if (isset($input['_reset_app_token']) && $input['_reset_app_token']) {
             $input['app_token']      = self::getUniqueAppToken();
             $input['app_token_date'] = $_SESSION['glpi_currenttime'];
         }

--- a/templates/pages/setup/apiclient.html.twig
+++ b/templates/pages/setup/apiclient.html.twig
@@ -71,7 +71,7 @@
     {% set reset_btn %}
         {{ fields.checkboxField(
             '_reset_app_token',
-            '',
+            item.isNewItem() ? 1 : 0,
             __('Regenerate'),
             {
                 'full_width': true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fixes issue where the App Token would always be regenerated after saving an API Client regardless of the state of the checkbox.
Bug seemed to be introduced when the form was moved to Twig.