### PR TITLE
fix(CommonITILObject): display requester instead of users id recipient

### DIFF
--- a/templates/components/itilobject/timeline/main_description.html.twig
+++ b/templates/components/itilobject/timeline/main_description.html.twig
@@ -31,7 +31,23 @@
  # ---------------------------------------------------------------------
  #}
 
-{% set users_id = (item.fields['users_id_recipient'] > 0 ? item.fields['users_id_recipient'] : 0) %}
+{# Compute users_id (requester) to display identity / thumbnail if #}
+{# - there is only one requester #}
+{# - it is not an anonymous user #}
+{# else diaply a blank thumbnail without identity #}
+
+{% set array_user = item.getUsers(constant('CommonITILActor::REQUESTER')) %}
+{% if array_user|length == 1 and array_user[0].users_id > 0 %}
+   {% set display_requester = get_item('User', array_user[0].users_id) is not null ? 1 : 0 %}
+   {% if display_requester %}
+      {% set users_id = array_user[0].users_id %}
+   {% else %}
+      {% set users_id = 0 %}
+   {% endif %}
+{% else %}
+   {% set users_id = 0 %}
+{% endif %}
+
 {% set entry_rand = random() %}
 
 <div class="timeline-item mb-3 ITILContent"


### PR DESCRIPTION
Actually, when a user create a ticket for another (see example "glpi" create a ticket for "tech") 

![image](https://github.com/glpi-project/glpi/assets/7335054/f43d2e55-31d1-4771-be55-56f356adfe5b)

Display author attached to main description is related to ```users_id_recipient```

some users are confused about this display (one to be honest)

In GLPI version 9.5 we have a dedicated method to display ```requester``` if

- there is only one requester
- it is not an anonymous user

```php

      $user = new User();
      $display_requester = false;
      $requesters = $this->getUsers(CommonITILActor::REQUESTER);
      if (count($requesters) === 1) {
         $requester = reset($requesters);
         if ($requester['users_id'] > 0) {
            // Display requester identity only if there is only one requester
            // and only if it is not an anonymous user
            $display_requester = $user->getFromDB($requester['users_id']);
         }
      }
```

This PR try to resettle this behavior from twig template


I just noticed something on 9.5

If there are several requesters the identity becomes "Requesters" and the image is the default one

![image](https://github.com/glpi-project/glpi/assets/7335054/bcd466ed-cf66-4d05-9e90-61e7a4f26483)


should I reproduce the same behaviour on this part? it seems to me heavy to carry on in ```picture.html.twig```


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27988
