### PR TITLE
Fix select2 placeholder escaping

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -4886,7 +4886,7 @@ JAVASCRIPT
          const select2_el = $('#$field_id').select2({
             width: '$width',
             multiple: '$multiple',
-            placeholder: '$placeholder',
+            placeholder: " . json_encode($placeholder) . ",
             allowClear: $allowclear,
             minimumInputLength: 0,
             quietMillis: 100,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

If placeholder contains a simple quote, javascript is broken.
![image](https://github.com/glpi-project/glpi/assets/33253653/7c909ecb-57cf-4f2e-845d-a062f64312ab)
