### PR TITLE
Add type for generic devices in components tab

### DIFF
--- a/src/DeviceGeneric.php
+++ b/src/DeviceGeneric.php
@@ -91,6 +91,7 @@ class DeviceGeneric extends CommonDevice
         switch ($itemtype) {
             case 'Computer':
                 Manufacturer::getHTMLTableHeader(__CLASS__, $base, $super, $father, $options);
+                $base->addHeader('devicegenerictypes_id', _n('Type', 'Types', 1), $super, $father);
                 break;
         }
     }
@@ -112,6 +113,13 @@ class DeviceGeneric extends CommonDevice
         switch ($item->getType()) {
             case 'Computer':
                 Manufacturer::getHTMLTableCellsForItem($row, $this, null, $options);
+                if ($this->fields["devicegenerictypes_id"]) {
+                    $type_name = Dropdown::getDropdownName(
+                        "glpi_devicegenerictypes",
+                        $this->fields["devicegenerictypes_id"]
+                    );
+                    $row->addCell($row->getHeaderByName('devicegenerictypes_id'), $type_name);
+                }
                 break;
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

https://forum.glpi-project.org/viewtopic.php?id=287073

Given the nature of generic devices, the type could contain valuable information and it should be shown in the components tab for a computer.