### PR TITLE
Clarify cache manager warnings

### DIFF
--- a/src/Cache/CacheManager.php
+++ b/src/Cache/CacheManager.php
@@ -430,6 +430,11 @@ class CacheManager
             $config  = include($config_file);
             $contexts = $config['contexts'] ?? [];
             foreach ($contexts as $context => $context_config) {
+                if (!$this->isContextValid($context, true)) {
+                    trigger_error(sprintf('Invalid or non configurable context: "%s".', $context), E_USER_NOTICE);
+                    unset($config['contexts'][$context]);
+                    continue;
+                }
                 if (
                     !$this->isContextValid($context, true)
                     || !is_array($context_config)
@@ -484,8 +489,8 @@ PHP;
 
         if (!$only_configurable) {
            // 'installer' and 'translations' cache storages cannot not be configured (they always use the filesystem storage)
-            $core_contexts[] = 'installer';
-            $core_contexts[] = 'translations';
+            $core_contexts[] = self::CONTEXT_INSTALLER;
+            $core_contexts[] = self::CONTEXT_TRANSLATIONS;
         }
 
         return in_array($context, $core_contexts, true) || preg_match('/^plugin:\w+$/', $context) === 1;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

See https://forum.glpi-project.org/viewtopic.php?pid=501487

Not sur how it could happen except when cache configuration is manually changed, but when a `translations` entry is present in cache config, it triggers errors on every GLPI script execution, and this error is not really clear (it does not says that this cache context is not supposed to be configured).

Adding a dedicated message could help to understand the issue. Also, I put this message to `NOTICE` level, so, by default, it would not be added in logs except on debug mode.