### PR TITLE
Remove some cleaning operations from build script

### DIFF
--- a/tools/build_glpi.sh
+++ b/tools/build_glpi.sh
@@ -69,54 +69,23 @@ composer update nothing --ansi --no-interaction --ignore-platform-reqs --no-dev 
 # Remove user generated files (i.e. cache and log from CLI commands ran during release)
 find $WORKING_DIR/files -depth -mindepth 2 -exec rm -rf {} \;
 
-# Remove hidden files and directory, except .htaccess files
-find $WORKING_DIR -depth \( -iname ".*" ! -iname ".htaccess" \) -exec rm -rf {} \;
+# Remove hidden files and directories
+find $WORKING_DIR -depth -iname ".*" -exec rm -rf {} \;
 
 # Remove useless dev files and directories
 dev_nodes=(
     "composer.json"
     "composer.lock"
-    "ISSUE_TEMPLATE.md"
     "locales/glpi.pot"
     "node_modules"
     "package.json"
     "package-lock.json"
     "phpstan.neon"
-    "PULL_REQUEST_TEMPLATE.md"
     "stubs"
     "tests"
     "tools"
-    "vendor/bin"
-    "vendor/blueimp/jquery-file-upload/cors"
-    "vendor/blueimp/jquery-file-upload/test"
-    "vendor/blueimp/jquery-file-upload/wdio"
-    "vendor/blueimp/jquery-file-upload/index.html"
-    "vendor/donatj/phpuseragentparser/.helpers"
-    "vendor/donatj/phpuseragentparser/bin"
-    "vendor/donatj/phpuseragentparser/tests"
     "vendor/glpi-project/inventory_format/examples"
     "vendor/glpi-project/inventory_format/source_files"
-    "vendor/html2text/html2text/test"
-    "vendor/league/oauth2-google/examples"
-    "vendor/mexitek/phpcolors/demo"
-    "vendor/mexitek/phpcolors/tests"
-    "vendor/michelf/php-markdown/test"
-    "vendor/phplang/scope-exit/tests"
-    "vendor/rlanvin/php-rrule/bin"
-    "vendor/rlanvin/php-rrule/tests"
-    "vendor/sabre/dav/bin"
-    "vendor/sabre/event/bin"
-    "vendor/sabre/http/bin"
-    "vendor/sabre/http/examples"
-    "vendor/sabre/http/tests"
-    "vendor/sabre/vobject/bin"
-    "vendor/sabre/xml/bin"
-    "vendor/scssphp/scssphp/bin"
-    "vendor/seld/jsonlint/bin"
-    "vendor/tecnickcom/tcpdf/examples"
-    "vendor/tecnickcom/tcpdf/tools"
-    "vendor/wapmorgan/unified-archive/bin"
-    "vendor/wapmorgan/unified-archive/tests"
 )
 for node in "${dev_nodes[@]}"
 do


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. There is no more `.htaccess` files, so we can simplify the hidden files cleaning.

2. Some files are not existing anymore, they can be removed from cleaning list.

3. As vendor directory is not in public scope anymore, cleaning it for security reasons is not required anymore (people may accidentally expose the whole GLPI sources files, but IMHO, we could not handle such case as it has too many implications), but maintaining the cleaning list is a pain (I used to check vendor packages regularly, but it takes too many time).
I keep cleaning of `glpi-project/inventory_format` as we need some files only for dev purpose, and their compressed size is 2.5MB.
For other vendors that were cleaned, I made some PRs to do the clean on their side (see https://github.com/thephpleague/oauth2-google/pull/120, https://github.com/wapmorgan/UnifiedArchive/pull/36, https://github.com/rlanvin/php-rrule/pull/110, https://github.com/mexitek/phpColors/pull/61, ...)

With vendors cleaning, archive weights 61.2MB, without it, it weights 62.8MB.