### PR TITLE
missing translation for kanban filters

### DIFF
--- a/js/modules/SearchTokenizer/SearchInput.js
+++ b/js/modules/SearchTokenizer/SearchInput.js
@@ -641,7 +641,7 @@ export default class SearchInput {
                 return; // continue
             }
             const description = info.description || '';
-            const label = info.label
+            const label = info.label || name;
             let prefix_content = '';
             const prefix_count = Object.keys(info.supported_prefixes || {}).length;
 

--- a/js/modules/SearchTokenizer/SearchInput.js
+++ b/js/modules/SearchTokenizer/SearchInput.js
@@ -641,6 +641,7 @@ export default class SearchInput {
                 return; // continue
             }
             const description = info.description || '';
+            const label = info.label
             let prefix_content = '';
             const prefix_count = Object.keys(info.supported_prefixes || {}).length;
 
@@ -655,7 +656,7 @@ export default class SearchInput {
             helper += `
             <li class="list-group-item list-group-item-action" style="cursor: pointer" data-tag="${name}">
                 <div class="d-flex flex-grow-1 justify-content-between">
-                   <b>${name}</b>
+                   <b>${label}</b>
                    <span>${prefix_content}</span>
                 </div>
                 <div class="text-muted fst-italic">${description}</div>

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8992,34 +8992,42 @@ abstract class CommonITILObject extends CommonDBTM
             ],
             'supported_filters'           => [
                 'title' => [
+                    'label' => __('title'),
                     'description' => _x('filters', 'The title of the item'),
                     'supported_prefixes' => ['!', '#'] // Support exclusions and regex
                 ],
                 'type' => [
+                    'label' => __('type'),
                     'description' => _x('filters', 'The type of the item'),
                     'supported_prefixes' => ['!']
                 ],
                 'category' => [
+                    'label' => __('category'),
                     'description' => _x('filters', 'The category of the item'),
                     'supported_prefixes' => ['!', '#']
                 ],
                 'content' => [
+                    'label' => __('content'),
                     'description' => _x('filters', 'The content of the item'),
                     'supported_prefixes' => ['!', '#'] // Support exclusions and regex
                 ],
                 'team' => [
+                    'label' => __('team'),
                     'description' => _x('filters', 'A team member for the item'),
                     'supported_prefixes' => ['!']
                 ],
                 'user' => [
+                    'label' => __('description'),
                     'description' => _x('filters', 'A user in the team of the item'),
                     'supported_prefixes' => ['!']
                 ],
                 'group' => [
+                    'label' => __('group'),
                     'description' => _x('filters', 'A group in the team of the item'),
                     'supported_prefixes' => ['!']
                 ],
                 'supplier' => [
+                    'label' => __('supplier'),
                     'description' => _x('filters', 'A supplier in the team of the item'),
                     'supported_prefixes' => ['!']
                 ],

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8992,42 +8992,42 @@ abstract class CommonITILObject extends CommonDBTM
             ],
             'supported_filters'           => [
                 'title' => [
-                    'label' => __('title'),
+                    'label' => _x('filters', 'title'),
                     'description' => _x('filters', 'The title of the item'),
                     'supported_prefixes' => ['!', '#'] // Support exclusions and regex
                 ],
                 'type' => [
-                    'label' => __('type'),
+                    'label' => _x('filters', 'type'),
                     'description' => _x('filters', 'The type of the item'),
                     'supported_prefixes' => ['!']
                 ],
                 'category' => [
-                    'label' => __('category'),
+                    'label' => _x('filters', 'category'),
                     'description' => _x('filters', 'The category of the item'),
                     'supported_prefixes' => ['!', '#']
                 ],
                 'content' => [
-                    'label' => __('content'),
+                    'label' => _x('filters', 'content'),
                     'description' => _x('filters', 'The content of the item'),
                     'supported_prefixes' => ['!', '#'] // Support exclusions and regex
                 ],
                 'team' => [
-                    'label' => __('team'),
+                    'label' => _x('filters', 'team'),
                     'description' => _x('filters', 'A team member for the item'),
                     'supported_prefixes' => ['!']
                 ],
                 'user' => [
-                    'label' => __('description'),
+                    'label' => _x('filters', 'description'),
                     'description' => _x('filters', 'A user in the team of the item'),
                     'supported_prefixes' => ['!']
                 ],
                 'group' => [
-                    'label' => __('group'),
+                    'label' => _x('filters', 'group'),
                     'description' => _x('filters', 'A group in the team of the item'),
                     'supported_prefixes' => ['!']
                 ],
                 'supplier' => [
-                    'label' => __('supplier'),
+                    'label' => _x('filters', 'supplier'),
                     'description' => _x('filters', 'A supplier in the team of the item'),
                     'supported_prefixes' => ['!']
                 ],

--- a/src/Project.php
+++ b/src/Project.php
@@ -2462,42 +2462,52 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
             ],
             'supported_filters'           => [
                 'title' => [
+                    'label' => __('title'),
                     'description' => _x('filters', 'The title of the item'),
                     'supported_prefixes' => ['!', '#'] // Support exclusions and regex
                 ],
                 'type' => [
+                    'label' => __('type'),
                     'description' => _x('filters', 'The type of the item'),
                     'supported_prefixes' => ['!'] // Support exclusions only
                 ],
                 'milestone' => [
+                    'label' => __('milestone'),
                     'description' => _x('filters', 'If the item represents a milestone or not'),
                     'supported_prefixes' => ['!']
                 ],
                 'content' => [
+                    'label' => __('content'),
                     'description' => _x('filters', 'The content of the item'),
                     'supported_prefixes' => ['!', '#']
                 ],
                 'deleted' => [
+                    'label' => __('deleted'),
                     'description' => _x('filters', 'If the item is deleted or not'),
                     'supported_prefixes' => ['!']
                 ],
                 'team' => [
+                    'label' => __('team'),
                     'description' => _x('filters', 'A team member for the item'),
                     'supported_prefixes' => ['!']
                 ],
                 'user' => [
+                    'label' => __('user'),
                     'description' => _x('filters', 'A user in the team of the item'),
                     'supported_prefixes' => ['!']
                 ],
                 'group' => [
+                    'label' => __('group'),
                     'description' => _x('filters', 'A group in the team of the item'),
                     'supported_prefixes' => ['!']
                 ],
                 'supplier' => [
+                    'label' => __('supplier'),
                     'description' => _x('filters', 'A supplier in the team of the item'),
                     'supported_prefixes' => ['!']
                 ],
                 'contact' => [
+                    'label' => __('contact'),
                     'description' => _x('filters', 'A contact in the team of the item'),
                     'supported_prefixes' => ['!']
                 ],

--- a/src/Project.php
+++ b/src/Project.php
@@ -2462,52 +2462,52 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
             ],
             'supported_filters'           => [
                 'title' => [
-                    'label' => __('title'),
+                    'label' => _x('filters', 'title'),
                     'description' => _x('filters', 'The title of the item'),
                     'supported_prefixes' => ['!', '#'] // Support exclusions and regex
                 ],
                 'type' => [
-                    'label' => __('type'),
+                    'label' => _x('filters', 'type'),
                     'description' => _x('filters', 'The type of the item'),
                     'supported_prefixes' => ['!'] // Support exclusions only
                 ],
                 'milestone' => [
-                    'label' => __('milestone'),
+                    'label' => _x('filters', 'milestone'),
                     'description' => _x('filters', 'If the item represents a milestone or not'),
                     'supported_prefixes' => ['!']
                 ],
                 'content' => [
-                    'label' => __('content'),
+                    'label' => _x('filters', 'content'),
                     'description' => _x('filters', 'The content of the item'),
                     'supported_prefixes' => ['!', '#']
                 ],
                 'deleted' => [
-                    'label' => __('deleted'),
+                    'label' => _x('filters', 'deleted'),
                     'description' => _x('filters', 'If the item is deleted or not'),
                     'supported_prefixes' => ['!']
                 ],
                 'team' => [
-                    'label' => __('team'),
+                    'label' => _x('filters', 'team'),
                     'description' => _x('filters', 'A team member for the item'),
                     'supported_prefixes' => ['!']
                 ],
                 'user' => [
-                    'label' => __('user'),
+                    'label' => _x('filters', 'user'),
                     'description' => _x('filters', 'A user in the team of the item'),
                     'supported_prefixes' => ['!']
                 ],
                 'group' => [
-                    'label' => __('group'),
+                    'label' => _x('filters', 'group'),
                     'description' => _x('filters', 'A group in the team of the item'),
                     'supported_prefixes' => ['!']
                 ],
                 'supplier' => [
-                    'label' => __('supplier'),
+                    'label' => _x('filters', 'supplier'),
                     'description' => _x('filters', 'A supplier in the team of the item'),
                     'supported_prefixes' => ['!']
                 ],
                 'contact' => [
-                    'label' => __('contact'),
+                    'label' => _x('filters', 'contact'),
                     'description' => _x('filters', 'A contact in the team of the item'),
                     'supported_prefixes' => ['!']
                 ],


### PR DESCRIPTION
Kanban filters are not translated. No matter the current language, the filter names are in english.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 28006


