### PR TITLE
feat(inventory): handle several IPV4 or IPV6

### DIFF
--- a/src/Inventory/Asset/NetworkCard.php
+++ b/src/Inventory/Asset/NetworkCard.php
@@ -197,27 +197,45 @@ class NetworkCard extends Device
                 }
 
                 if (isset($this->ports[$portkey])) {
-                    if (property_exists($val_port, 'ip') && $val_port->ip != '') {
-                        if (!in_array($val_port->ip, $this->ports[$portkey]->ipaddress)) {
-                             $this->ports[$portkey]->ipaddress[] = $val_port->ip;
+                    if (!property_exists($this->ports[$portkey], "ipaddress") || !is_array($this->ports[$portkey]->ipaddress)) {
+                        $this->ports[$portkey]->ipaddress = [];
+                    }
+                    if (property_exists($val_port, "ip")) {
+                        if (is_array($val_port->ip)) {
+                            $this->ports[$portkey]->ipaddress = array_merge($this->ports[$portkey]->ipaddress, $val_port->ip);
+                        } else {
+                            array_push($this->ports[$portkey]->ipaddress, $val_port->ip);
                         }
                     }
-                    if (property_exists($val_port, 'ipaddress6') && $val_port->ipaddress6 != '') {
-                        if (!in_array($val_port->ipaddress6, $this->ports[$portkey]->ipaddress)) {
-                            $this->ports[$portkey]->ipaddress[] = $val_port->ipaddress6;
+                    if (property_exists($val_port, 'ipaddress6')) {
+                        if (is_array($val_port->ipaddress6)) {
+                            $this->ports[$portkey]->ipaddress = array_merge($this->ports[$portkey]->ipaddress, $val_port->ipaddress6);
+                        } else {
+                            array_push($this->ports[$portkey]->ipaddress, $val_port->ipaddress6);
                         }
                     }
+                    $this->ports[$portkey]->ipaddress = array_merge(array_filter($this->ports[$portkey]->ipaddress), []);
                 } else {
-                    if (property_exists($val_port, 'ip')) {
-                        if ($val_port->ip != '') {
-                             $val_port->ipaddress = [$val_port->ip];
-                        }
-                        unset($val_port->ip);
-                    } else if (property_exists($val_port, 'ipaddress6') && $val_port->ipaddress6 != '') {
-                        $val_port->ipaddress = [$val_port->ipaddress6];
-                    } else {
+                    if (!property_exists($val_port, "ipaddress") || !is_array($val_port->ipaddress)) {
                         $val_port->ipaddress = [];
                     }
+                    if (property_exists($val_port, "ip")) {
+                        if (is_array($val_port->ip)) {
+                            $val_port->ipaddress = array_merge($val_port->ipaddress, $val_port->ip);
+                        } else {
+                            array_push($val_port->ipaddress, $val_port->ip);
+                        }
+                    }
+
+                    if (property_exists($val_port, 'ipaddress6')) {
+                        if (is_array($val_port->ipaddress6)) {
+                            $val_port->ipaddress = array_merge($val_port->ipaddress, $val_port->ipaddress6);
+                        } else {
+                            array_push($val_port->ipaddress, $val_port->ipaddress6);
+                        }
+                    }
+
+                    $val_port->ipaddress = array_merge(array_filter($val_port->ipaddress), []);
 
                     if (property_exists($val_port, 'instantiation_type')) {
                         switch ($val_port->instantiation_type) {

--- a/tests/functional/Glpi/Inventory/Assets/Computer.php
+++ b/tests/functional/Glpi/Inventory/Assets/Computer.php
@@ -1403,4 +1403,66 @@ class Computer extends AbstractInventoryAsset
         $this->boolean($domain_item->getFromDBByCrit(['domains_id' => $domain->fields['id']]))->isTrue();
         $this->boolean($domain_item->getFromDBByCrit(['domains_id' => $ndyn_domain->fields['id']]))->isTrue();
     }
+
+    public function testSeveralIPV4()
+    {
+        global $DB;
+        $json_str = file_get_contents(self::INV_FIXTURES . 'computer_with_several_ipv4.json');
+        $json = json_decode($json_str);
+
+        $this->doInventory($json);
+
+        //check created agent
+        $agents = $DB->request(['FROM' => \Agent::getTable()]);
+        $this->integer(count($agents))->isIdenticalTo(1);
+        $agent = $agents->current();
+        $this->array($agent)
+            ->string['deviceid']->isIdenticalTo('16823975')
+            ->string['itemtype']->isIdenticalTo('Computer');
+
+        //check created computer
+        $computers_id = $agent['items_id'];
+
+        $this->integer($computers_id)->isGreaterThan(0);
+        $computer = new \Computer();
+        $this->boolean($computer->getFromDB($computers_id))->isTrue();
+
+        $ipaddress = new \IPAddress();
+        $ips = $ipaddress->find(["mainitems_id" => $computers_id, "mainitemtype" => "Computer", "version" => '4']);
+        $this->integer(count($ips))->isIdenticalTo(6);
+
+        $ips = $ipaddress->find(["mainitems_id" => $computers_id, "mainitemtype" => "Computer" , "version" => '6']);
+        $this->integer(count($ips))->isIdenticalTo(1);
+    }
+
+    public function testSeveralIPV6()
+    {
+        global $DB;
+        $json_str = file_get_contents(self::INV_FIXTURES . 'computer_with_several_ipv6.json');
+        $json = json_decode($json_str);
+
+        $this->doInventory($json);
+
+        //check created agent
+        $agents = $DB->request(['FROM' => \Agent::getTable()]);
+        $this->integer(count($agents))->isIdenticalTo(1);
+        $agent = $agents->current();
+        $this->array($agent)
+            ->string['deviceid']->isIdenticalTo('16811420')
+            ->string['itemtype']->isIdenticalTo('Computer');
+
+        //check created computer
+        $computers_id = $agent['items_id'];
+
+        $this->integer($computers_id)->isGreaterThan(0);
+        $computer = new \Computer();
+        $this->boolean($computer->getFromDB($computers_id))->isTrue();
+
+        $ipaddress = new \IPAddress();
+        $ips = $ipaddress->find(["mainitems_id" => $computers_id, "mainitemtype" => "Computer", "version" => '4']);
+        $this->integer(count($ips))->isIdenticalTo(2);
+
+        $ips = $ipaddress->find(["mainitems_id" => $computers_id, "mainitemtype" => "Computer" , "version" => '6']);
+        $this->integer(count($ips))->isIdenticalTo(5);
+    }
 }

--- a/tests/functional/Glpi/Inventory/Inventory.php
+++ b/tests/functional/Glpi/Inventory/Inventory.php
@@ -5084,6 +5084,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         $ips = [
             'No description found'  => [
                 'v4'   => '172.28.214.132',
+                'v6'   => 'fe80::8077:63ff:fe5b:2a71',
             ]
         ];
 


### PR DESCRIPTION
Add capability to manage several IPV4 and IPV6 from one ```NetworkPort```

This particularity has been seen from ```SCCM``` plugin 

see this thread -> https://github.com/pluginsGLPI/sccm/pull/98#issuecomment-1548021772

![image](https://github.com/glpi-project/inventory_format/assets/7335054/78f4eaff-1869-40ce-a19b-2bda902abc63)

which generates the following XML:

```xml
<NETWORKS>
    <IPADDRESS>169.254.41.148</IPADDRESS>
    <IPADDRESS>192.168.0.225</IPADDRESS>
    <IPADDRESS>10.50.78.89</IPADDRESS>
    <IPADDRESS6>fe80::c0b2:cf62:cba8:8d8</IPADDRESS6>
    <DESCRIPTION>Intel(R) Ethernet Connection (7) I219-V</DESCRIPTION>
    <IPMASK>255.255.255.0, 255.255.255.0, 255.255.255.128, 64</IPMASK>
    <IPDHCP/>
    <IPGATEWAY>10.50.78.19</IPGATEWAY>
    <MACADDR>04:92:26:D7:AC:51</MACADDR>
</NETWORKS>

<NETWORKS>
    <IPADDRESS>192.168.1.133</IPADDRESS>
    <IPADDRESS6>fe80::9bbb:c6ae:3cd5:d9fb</IPADDRESS6>
    <IPADDRESS6>2a0c:5a80:140d:4400:c480:da92:e839:ec9d</IPADDRESS6>
    <IPADDRESS6>2a0c:5a80:140d:4400:70f7:45d7:71fd:4d85</IPADDRESS6>
    <IPADDRESS6>2a0c:5a80:140d:4400:c3a:ccfe:ecdc:42b4</IPADDRESS6>
    <IPADDRESS6>2a0c:5a80:140d:4400:89d2:18f3:d43:2dfb</IPADDRESS6>
    <DESCRIPTION>Intel(R) Ethernet Connection (7) I219-LM</DESCRIPTION>
    <IPMASK>255.255.255.0, 64, 128, 128, 128, 64</IPMASK>
    <IPDHCP>192.168.1.1</IPDHCP>
    <IPGATEWAY>192.168.1.1, fe80::1</IPGATEWAY>
    <MACADDR>9C:7B:EF:B3:50:96</MACADDR>
</NETWORKS>
```

Code developed with great care by @tolemac 

I just added the unit tests

Need : https://github.com/glpi-project/inventory_format/pull/111

Best regards



| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
