### PR TITLE
Add simple API response formatter middleware

### DIFF
--- a/src/Api/HL/Controller/AdministrationController.php
+++ b/src/Api/HL/Controller/AdministrationController.php
@@ -37,6 +37,7 @@ namespace Glpi\Api\HL\Controller;
 
 use Entity;
 use Glpi\Api\HL\Doc as Doc;
+use Glpi\Api\HL\Middleware\ResultFormatterMiddleware;
 use Glpi\Api\HL\Route;
 use Glpi\Api\HL\Search;
 use Glpi\Http\JSONResponse;
@@ -291,7 +292,7 @@ final class AdministrationController extends AbstractController
         ];
     }
 
-    #[Route(path: '/User', methods: ['GET'])]
+    #[Route(path: '/User', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search users',
         responses: [
@@ -303,7 +304,7 @@ final class AdministrationController extends AbstractController
         return Search::searchBySchema($this->getKnownSchema('User'), $request->getParameters());
     }
 
-    #[Route(path: '/Group', methods: ['GET'])]
+    #[Route(path: '/Group', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search groups',
         responses: [
@@ -315,7 +316,7 @@ final class AdministrationController extends AbstractController
         return Search::searchBySchema($this->getKnownSchema('Group'), $request->getParameters());
     }
 
-    #[Route(path: '/Entity', methods: ['GET'])]
+    #[Route(path: '/Entity', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search entities',
         responses: [
@@ -327,7 +328,7 @@ final class AdministrationController extends AbstractController
         return Search::searchBySchema($this->getKnownSchema('Entity'), $request->getParameters());
     }
 
-    #[Route(path: '/Profile', methods: ['GET'])]
+    #[Route(path: '/Profile', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search profiles',
         responses: [
@@ -369,7 +370,7 @@ final class AdministrationController extends AbstractController
         return $emails;
     }
 
-    #[Route(path: '/User/me', methods: ['GET'])]
+    #[Route(path: '/User/me', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get the current user',
         responses: [
@@ -382,7 +383,7 @@ final class AdministrationController extends AbstractController
         return Search::getOneBySchema($this->getKnownSchema('User'), ['id' => $my_user_id], $request->getParameters());
     }
 
-    #[Route(path: '/User/me/emails', methods: ['GET'])]
+    #[Route(path: '/User/me/emails', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get the current user\'s email addresses',
         responses: [
@@ -453,7 +454,7 @@ final class AdministrationController extends AbstractController
         return self::getCRUDCreateResponse($emails_id, self::getAPIPathForRouteFunction(self::class, 'getMyEmail', ['id' => $emails_id]));
     }
 
-    #[Route(path: '/User/me/emails/{id}', methods: ['GET'], requirements: ['id' => '\d+'])]
+    #[Route(path: '/User/me/emails/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a specific email address for the current user',
         responses: [
@@ -485,7 +486,7 @@ final class AdministrationController extends AbstractController
         return Search::createBySchema($this->getKnownSchema('User'), $request->getParameters(), [self::class, 'getUserByID']);
     }
 
-    #[Route(path: '/User/{id}', methods: ['GET'], requirements: ['id' => '\d+'])]
+    #[Route(path: '/User/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a user by ID',
         responses: [
@@ -497,7 +498,7 @@ final class AdministrationController extends AbstractController
         return Search::getOneBySchema($this->getKnownSchema('User'), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/User/username/{username}', methods: ['GET'], requirements: ['username' => '[a-zA-Z0-9_]+'])]
+    #[Route(path: '/User/username/{username}', methods: ['GET'], requirements: ['username' => '[a-zA-Z0-9_]+'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a user by username',
         responses: [
@@ -581,7 +582,7 @@ final class AdministrationController extends AbstractController
         return Search::createBySchema($this->getKnownSchema('Group'), $request->getParameters(), [self::class, 'getGroupByID']);
     }
 
-    #[Route(path: '/Group/{id}', methods: ['GET'], requirements: ['id' => '\d+'])]
+    #[Route(path: '/Group/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a group by ID',
         responses: [
@@ -634,7 +635,7 @@ final class AdministrationController extends AbstractController
         return Search::createBySchema($this->getKnownSchema('Entity'), $request->getParameters(), [self::class, 'getEntityByID']);
     }
 
-    #[Route(path: '/Entity/{id}', methods: ['GET'], requirements: ['id' => '\d+'])]
+    #[Route(path: '/Entity/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get an entity by ID',
         responses: [
@@ -687,7 +688,7 @@ final class AdministrationController extends AbstractController
         return Search::createBySchema($this->getKnownSchema('Profile'), $request->getParameters(), [self::class, 'getProfileByID']);
     }
 
-    #[Route(path: '/Profile/{id}', methods: ['GET'], requirements: ['id' => '\d+'])]
+    #[Route(path: '/Profile/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a profile by ID',
         responses: [

--- a/src/Api/HL/Controller/AssetController.php
+++ b/src/Api/HL/Controller/AssetController.php
@@ -701,11 +701,9 @@ final class AssetController extends AbstractController
         return Search::searchBySchema($this->getGlobalAssetSchema(), $request->getParameters());
     }
 
-    #[Route(
-        path: '/{itemtype}', methods: ['GET'], requirements: [
-            'itemtype' => [self::class, 'getAssetTypes']
-        ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class]
-    )]
+    #[Route(path: '/{itemtype}', methods: ['GET'], requirements: [
+        'itemtype' => [self::class, 'getAssetTypes']
+    ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search assets of a specific type'
     )]

--- a/src/Api/HL/Controller/AssetController.php
+++ b/src/Api/HL/Controller/AssetController.php
@@ -39,6 +39,7 @@ use AutoUpdateSystem;
 use CommonDBTM;
 use Entity;
 use Glpi\Api\HL\Doc as Doc;
+use Glpi\Api\HL\Middleware\ResultFormatterMiddleware;
 use Glpi\Api\HL\Route;
 use Glpi\Api\HL\Search;
 use Glpi\Http\JSONResponse;
@@ -616,7 +617,7 @@ final class AssetController extends AbstractController
         return $classes_only ? array_keys($assets) : $assets;
     }
 
-    #[Route(path: '/', methods: ['GET'], tags: ['Assets'])]
+    #[Route(path: '/', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get all available asset types',
         methods: ['GET'],
@@ -694,13 +695,16 @@ final class AssetController extends AbstractController
         ];
     }
 
-    #[Route(path: '/Global', methods: ['GET'], tags: ['Assets'])]
+    #[Route(path: '/Global', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     public function searchAll(Request $request): Response
     {
         return Search::searchBySchema($this->getGlobalAssetSchema(), $request->getParameters());
     }
 
-    #[Route(path: '/{itemtype}', methods: ['GET'], requirements: ['itemtype' => [self::class, 'getAssetTypes']], tags: ['Assets'])]
+    #[Route(
+        path: '/{itemtype}', methods: ['GET'], requirements: ['itemtype' => [self::class, 'getAssetTypes']],
+        tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class]
+    )]
     #[Doc\Route(
         description: 'List or search assets of a specific type'
     )]
@@ -713,7 +717,7 @@ final class AssetController extends AbstractController
     #[Route(path: '/{itemtype}/{id}', methods: ['GET'], requirements: [
         'itemtype' => [self::class, 'getAssetTypes'],
         'id' => '\d+'
-    ], tags: ['Assets'])]
+    ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get an asset of a specific type by ID',
     )]
@@ -761,7 +765,7 @@ final class AssetController extends AbstractController
         return Search::deleteBySchema($this->getKnownSchema($itemtype), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/Cartridge', methods: ['GET'], tags: ['Assets'])]
+    #[Route(path: '/Cartridge', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search cartridges models'
     )]
@@ -772,7 +776,7 @@ final class AssetController extends AbstractController
 
     #[Route(path: '/Cartridge/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
-    ], tags: ['Assets'])]
+    ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a cartridge model by ID',
     )]
@@ -814,7 +818,7 @@ final class AssetController extends AbstractController
 
     #[Route(path: '/Cartridge/{cartridgeitems_id}/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
-    ], tags: ['Assets'])]
+    ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a cartridge by ID',
     )]
@@ -854,7 +858,7 @@ final class AssetController extends AbstractController
         return Search::deleteBySchema($this->getKnownSchema('Cartridge'), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/Consumable', methods: ['GET'], tags: ['Assets'])]
+    #[Route(path: '/Consumable', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search consumables models'
     )]
@@ -865,7 +869,7 @@ final class AssetController extends AbstractController
 
     #[Route(path: '/Consumable/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
-    ], tags: ['Assets'])]
+    ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a consumable model by ID',
     )]
@@ -907,7 +911,7 @@ final class AssetController extends AbstractController
 
     #[Route(path: '/Consumable/{consumableitems_id}/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
-    ], tags: ['Assets'])]
+    ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a consumable by ID',
     )]
@@ -947,7 +951,7 @@ final class AssetController extends AbstractController
         return Search::deleteBySchema($this->getKnownSchema('Consumable'), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/Software', methods: ['GET'], tags: ['Assets'])]
+    #[Route(path: '/Software', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search software'
     )]
@@ -958,7 +962,7 @@ final class AssetController extends AbstractController
 
     #[Route(path: '/Software/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
-    ], tags: ['Assets'])]
+    ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a software by ID',
     )]
@@ -998,7 +1002,7 @@ final class AssetController extends AbstractController
         return Search::deleteBySchema($this->getKnownSchema('Software'), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/Rack', methods: ['GET'], tags: ['Assets'])]
+    #[Route(path: '/Rack', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search racks'
     )]
@@ -1009,7 +1013,7 @@ final class AssetController extends AbstractController
 
     #[Route(path: '/Rack/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
-    ], tags: ['Assets'])]
+    ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a rack by ID',
     )]
@@ -1049,7 +1053,7 @@ final class AssetController extends AbstractController
         return Search::deleteBySchema($this->getKnownSchema('Rack'), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/Enclosure', methods: ['GET'], tags: ['Assets'])]
+    #[Route(path: '/Enclosure', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search enclosure'
     )]
@@ -1060,7 +1064,7 @@ final class AssetController extends AbstractController
 
     #[Route(path: '/Enclosure/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
-    ], tags: ['Assets'])]
+    ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a enclosure by ID',
     )]
@@ -1100,7 +1104,7 @@ final class AssetController extends AbstractController
         return Search::deleteBySchema($this->getKnownSchema('Enclosure'), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/PDU', methods: ['GET'], tags: ['Assets'])]
+    #[Route(path: '/PDU', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search PDUs'
     )]
@@ -1111,7 +1115,7 @@ final class AssetController extends AbstractController
 
     #[Route(path: '/PDU/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
-    ], tags: ['Assets'])]
+    ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a PDU by ID',
     )]
@@ -1151,7 +1155,7 @@ final class AssetController extends AbstractController
         return Search::deleteBySchema($this->getKnownSchema('PDU'), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/PassiveDCEquipment', methods: ['GET'], tags: ['Assets'])]
+    #[Route(path: '/PassiveDCEquipment', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search passive DC equipment'
     )]
@@ -1162,7 +1166,7 @@ final class AssetController extends AbstractController
 
     #[Route(path: '/PassiveDCEquipment/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
-    ], tags: ['Assets'])]
+    ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a passive DC equipment by ID',
     )]
@@ -1202,7 +1206,7 @@ final class AssetController extends AbstractController
         return Search::deleteBySchema($this->getKnownSchema('PassiveDCEquipment'), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/Cable', methods: ['GET'], tags: ['Assets'])]
+    #[Route(path: '/Cable', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search cables'
     )]
@@ -1213,7 +1217,7 @@ final class AssetController extends AbstractController
 
     #[Route(path: '/Cable/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
-    ], tags: ['Assets'])]
+    ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a cable by ID',
     )]
@@ -1253,7 +1257,7 @@ final class AssetController extends AbstractController
         return Search::deleteBySchema($this->getKnownSchema('Cable'), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/Socket', methods: ['GET'], tags: ['Assets'])]
+    #[Route(path: '/Socket', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search sockets'
     )]
@@ -1264,7 +1268,7 @@ final class AssetController extends AbstractController
 
     #[Route(path: '/Socket/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
-    ], tags: ['Assets'])]
+    ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a socket by ID',
     )]
@@ -1306,7 +1310,7 @@ final class AssetController extends AbstractController
 
     #[Route(path: '/Software/{software_id}/Version', methods: ['GET'], requirements: [
         'software_id' => '\d+',
-    ], tags: ['Assets'])]
+    ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search software versions'
     )]
@@ -1317,7 +1321,7 @@ final class AssetController extends AbstractController
 
     #[Route(path: '/SoftwareVersion/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
-    ], tags: ['Assets'])]
+    ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a software version by ID',
     )]

--- a/src/Api/HL/Controller/AssetController.php
+++ b/src/Api/HL/Controller/AssetController.php
@@ -702,8 +702,9 @@ final class AssetController extends AbstractController
     }
 
     #[Route(
-        path: '/{itemtype}', methods: ['GET'], requirements: ['itemtype' => [self::class, 'getAssetTypes']],
-        tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class]
+        path: '/{itemtype}', methods: ['GET'], requirements: [
+            'itemtype' => [self::class, 'getAssetTypes']
+        ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class]
     )]
     #[Doc\Route(
         description: 'List or search assets of a specific type'

--- a/src/Api/HL/Controller/ComponentController.php
+++ b/src/Api/HL/Controller/ComponentController.php
@@ -36,6 +36,7 @@
 namespace Glpi\Api\HL\Controller;
 
 use Glpi\Api\HL\Doc as Doc;
+use Glpi\Api\HL\Middleware\ResultFormatterMiddleware;
 use Glpi\Api\HL\Route;
 use Glpi\Api\HL\Search;
 use Glpi\Http\JSONResponse;
@@ -426,7 +427,7 @@ class ComponentController extends AbstractController
         ];
     }
 
-    #[Route(path: '/Components', methods: ['GET'], tags: ['Components'])]
+    #[Route(path: '/Components', methods: ['GET'], tags: ['Components'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get all available component types',
         methods: ['GET'],
@@ -472,7 +473,7 @@ class ComponentController extends AbstractController
 
     #[Route(path: '/Components/{component_type}', methods: ['GET'], requirements: [
         'component_type' => '\w*'
-    ], tags: ['Components'])]
+    ], tags: ['Components'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get the component definitions of the specified type',
     )]
@@ -485,7 +486,7 @@ class ComponentController extends AbstractController
     #[Route(path: '/Components/{component_type}/{id}', methods: ['GET'], requirements: [
         'component_type' => '\w*',
         'id' => '\d+'
-    ], tags: ['Components'])]
+    ], tags: ['Components'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a specific component definition',
     )]
@@ -512,7 +513,7 @@ class ComponentController extends AbstractController
     #[Route(path: '/Components/{component_type}/{id}/Items', methods: ['GET'], requirements: [
         'component_type' => '\w*',
         'id' => '\d+'
-    ], tags: ['Components'])]
+    ], tags: ['Components'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get the components of a specific component definition',
     )]
@@ -569,7 +570,7 @@ class ComponentController extends AbstractController
     #[Route(path: '/Components/{component_type}/Items/{id}', methods: ['GET'], requirements: [
         'component_type' => '\w*',
         'id' => '\d+'
-    ], tags: ['Components'])]
+    ], tags: ['Components'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a specific component',
     )]
@@ -585,7 +586,7 @@ class ComponentController extends AbstractController
         'itemtype' => '\w*',
         'component_type' => '\w*',
         'id' => '\d+'
-    ], tags: ['Assets', 'Components'])]
+    ], tags: ['Assets', 'Components'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get all components for an asset',
     )]

--- a/src/Api/HL/Controller/ITILController.php
+++ b/src/Api/HL/Controller/ITILController.php
@@ -42,6 +42,7 @@ use CommonDBTM;
 use CommonITILObject;
 use Entity;
 use Glpi\Api\HL\Doc as Doc;
+use Glpi\Api\HL\Middleware\ResultFormatterMiddleware;
 use Glpi\Api\HL\Route;
 use Glpi\Api\HL\Search;
 use Glpi\Http\JSONResponse;
@@ -316,7 +317,7 @@ final class ITILController extends AbstractController
         return $subitem_schema;
     }
 
-    #[Route(path: '/{itemtype}/', methods: ['GET'])]
+    #[Route(path: '/{itemtype}/', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search Tickets, Changes or Problems'
     )]
@@ -326,7 +327,7 @@ final class ITILController extends AbstractController
         return Search::searchBySchema($this->getKnownSchema($itemtype), $request->getParameters());
     }
 
-    #[Route(path: '/{itemtype}/{id}', methods: ['GET'])]
+    #[Route(path: '/{itemtype}/{id}', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a Ticket, Change or Problem by ID',
         parameters: [
@@ -423,7 +424,7 @@ final class ITILController extends AbstractController
         return $items;
     }
 
-    #[Route(path: '/{itemtype}/{id}/Timeline', methods: ['GET'])]
+    #[Route(path: '/{itemtype}/{id}/Timeline', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get all timeline items for a Ticket, Change or Problem by ID',
         parameters: [
@@ -445,7 +446,7 @@ final class ITILController extends AbstractController
 
     #[Route(path: '/{itemtype}/{id}/Timeline/{subitem_type}', methods: ['GET'], requirements: [
         'subitem_type' => 'Followup|Task|Document|Solution|Validation|Log'
-    ])]
+    ], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get all timeline items of a specific type for a Ticket, Change or Problem by ID',
         parameters: [
@@ -518,7 +519,7 @@ final class ITILController extends AbstractController
     #[Route(path: '/{itemtype}/{id}/Timeline/{subitem_type}/{subitem_id}', methods: ['GET'], requirements: [
         'subitem_type' => 'Followup|Task|Document|Solution|Validation|Log',
         'subitem_id' => '\d+'
-    ])]
+    ], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a specific timeline item by type and ID for a Ticket, Change or Problem by ID',
         parameters: [
@@ -720,7 +721,7 @@ final class ITILController extends AbstractController
         };
     }
 
-    #[Route(path: '/{itemtype}/{id}/TeamMember', methods: ['GET'])]
+    #[Route(path: '/{itemtype}/{id}/TeamMember', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get the team members for a specific Ticket, Change or Problem by ID'
     )]
@@ -733,7 +734,7 @@ final class ITILController extends AbstractController
         return new JSONResponse($team);
     }
 
-    #[Route(path: '/{itemtype}/{id}/TeamMember/{role}', methods: ['GET'])]
+    #[Route(path: '/{itemtype}/{id}/TeamMember/{role}', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get the team members by role for specific Ticket, Change, Problem by ID',
         parameters: [
@@ -849,7 +850,7 @@ final class ITILController extends AbstractController
         return self::getInvalidParametersErrorResponse();
     }
 
-    #[Route(path: '/RecurringTicket', methods: ['GET'])]
+    #[Route(path: '/RecurringTicket', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search recurring tickets'
     )]
@@ -860,7 +861,7 @@ final class ITILController extends AbstractController
 
     #[Route(path: '/RecurringTicket/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
-    ])]
+    ], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a recurring ticket by ID',
     )]
@@ -900,7 +901,7 @@ final class ITILController extends AbstractController
         return Search::deleteBySchema($this->getKnownSchema('RecurringTicket'), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/RecurringChange', methods: ['GET'])]
+    #[Route(path: '/RecurringChange', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search recurring changes'
     )]
@@ -911,7 +912,7 @@ final class ITILController extends AbstractController
 
     #[Route(path: '/RecurringChange/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
-    ])]
+    ], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a recurring change by ID',
     )]
@@ -951,7 +952,7 @@ final class ITILController extends AbstractController
         return Search::deleteBySchema($this->getKnownSchema('RecurringChange'), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/ExternalEvent', methods: ['GET'])]
+    #[Route(path: '/ExternalEvent', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search external evenst'
     )]
@@ -962,7 +963,7 @@ final class ITILController extends AbstractController
 
     #[Route(path: '/ExternalEvent/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
-    ])]
+    ], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a recurring change by ID',
     )]

--- a/src/Api/HL/Controller/ManagementController.php
+++ b/src/Api/HL/Controller/ManagementController.php
@@ -52,6 +52,7 @@ use Document;
 use Domain;
 use Entity;
 use Glpi\Api\HL\Doc as Doc;
+use Glpi\Api\HL\Middleware\ResultFormatterMiddleware;
 use Glpi\Api\HL\Route;
 use Glpi\Api\HL\Search;
 use Glpi\Http\Request;
@@ -204,7 +205,7 @@ final class ManagementController extends AbstractController
         return $schemas;
     }
 
-    #[Route(path: '/Budget', methods: ['GET'])]
+    #[Route(path: '/Budget', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search budgets',
         responses: [
@@ -216,7 +217,7 @@ final class ManagementController extends AbstractController
         return Search::searchBySchema($this->getKnownSchema('Budget'), $request->getParameters());
     }
 
-    #[Route(path: '/Budget/{id}', methods: ['GET'], requirements: ['id' => '\d+'])]
+    #[Route(path: '/Budget/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a budget by ID',
         responses: [
@@ -261,7 +262,7 @@ final class ManagementController extends AbstractController
         return Search::deleteBySchema($this->getKnownSchema('Budget'), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/License', methods: ['GET'])]
+    #[Route(path: '/License', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search licenses',
         responses: [
@@ -273,7 +274,7 @@ final class ManagementController extends AbstractController
         return Search::searchBySchema($this->getKnownSchema('License'), $request->getParameters());
     }
 
-    #[Route(path: '/License/{id}', methods: ['GET'], requirements: ['id' => '\d+'])]
+    #[Route(path: '/License/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a license by ID',
         responses: [
@@ -318,7 +319,7 @@ final class ManagementController extends AbstractController
         return Search::deleteBySchema($this->getKnownSchema('License'), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/Supplier', methods: ['GET'])]
+    #[Route(path: '/Supplier', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search suppliers',
         responses: [
@@ -330,7 +331,7 @@ final class ManagementController extends AbstractController
         return Search::searchBySchema($this->getKnownSchema('Supplier'), $request->getParameters());
     }
 
-    #[Route(path: '/Supplier/{id}', methods: ['GET'], requirements: ['id' => '\d+'])]
+    #[Route(path: '/Supplier/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a supplier by ID',
         responses: [
@@ -383,7 +384,7 @@ final class ManagementController extends AbstractController
         return Search::deleteBySchema($this->getKnownSchema('Supplier'), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/Contact', methods: ['GET'])]
+    #[Route(path: '/Contact', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search contacts',
         responses: [
@@ -395,7 +396,7 @@ final class ManagementController extends AbstractController
         return Search::searchBySchema($this->getKnownSchema('Contact'), $request->getParameters());
     }
 
-    #[Route(path: '/Contact/{id}', methods: ['GET'], requirements: ['id' => '\d+'])]
+    #[Route(path: '/Contact/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a contact by ID',
         responses: [
@@ -440,7 +441,7 @@ final class ManagementController extends AbstractController
         return Search::deleteBySchema($this->getKnownSchema('Contact'), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/Contract', methods: ['GET'])]
+    #[Route(path: '/Contract', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search contracts',
         responses: [
@@ -452,7 +453,7 @@ final class ManagementController extends AbstractController
         return Search::searchBySchema($this->getKnownSchema('Contract'), $request->getParameters());
     }
 
-    #[Route(path: '/Contract/{id}', methods: ['GET'], requirements: ['id' => '\d+'])]
+    #[Route(path: '/Contract/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a contract by ID',
         responses: [
@@ -497,7 +498,7 @@ final class ManagementController extends AbstractController
         return Search::deleteBySchema($this->getKnownSchema('Contract'), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/Document', methods: ['GET'])]
+    #[Route(path: '/Document', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search documents',
         responses: [
@@ -509,7 +510,7 @@ final class ManagementController extends AbstractController
         return Search::searchBySchema($this->getKnownSchema('Document'), $request->getParameters());
     }
 
-    #[Route(path: '/Document/{id}', methods: ['GET'], requirements: ['id' => '\d+'])]
+    #[Route(path: '/Document/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a document by ID',
         responses: [
@@ -554,7 +555,7 @@ final class ManagementController extends AbstractController
         return Search::deleteBySchema($this->getKnownSchema('Document'), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/Line', methods: ['GET'])]
+    #[Route(path: '/Line', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search lines',
         responses: [
@@ -566,7 +567,7 @@ final class ManagementController extends AbstractController
         return Search::searchBySchema($this->getKnownSchema('Line'), $request->getParameters());
     }
 
-    #[Route(path: '/Line/{id}', methods: ['GET'], requirements: ['id' => '\d+'])]
+    #[Route(path: '/Line/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a line by ID',
         responses: [
@@ -611,7 +612,7 @@ final class ManagementController extends AbstractController
         return Search::deleteBySchema($this->getKnownSchema('Line'), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/Certificate', methods: ['GET'])]
+    #[Route(path: '/Certificate', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search certificates',
         responses: [
@@ -623,7 +624,7 @@ final class ManagementController extends AbstractController
         return Search::searchBySchema($this->getKnownSchema('Certificate'), $request->getParameters());
     }
 
-    #[Route(path: '/Certificate/{id}', methods: ['GET'], requirements: ['id' => '\d+'])]
+    #[Route(path: '/Certificate/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a certificate by ID',
         responses: [
@@ -668,7 +669,7 @@ final class ManagementController extends AbstractController
         return Search::deleteBySchema($this->getKnownSchema('Certificate'), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/DataCenter', methods: ['GET'])]
+    #[Route(path: '/DataCenter', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search data centers',
         responses: [
@@ -680,7 +681,7 @@ final class ManagementController extends AbstractController
         return Search::searchBySchema($this->getKnownSchema('DataCenter'), $request->getParameters());
     }
 
-    #[Route(path: '/DataCenter/{id}', methods: ['GET'], requirements: ['id' => '\d+'])]
+    #[Route(path: '/DataCenter/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a data center by ID',
         responses: [
@@ -725,7 +726,7 @@ final class ManagementController extends AbstractController
         return Search::deleteBySchema($this->getKnownSchema('DataCenter'), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/Cluster', methods: ['GET'])]
+    #[Route(path: '/Cluster', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search clusters',
         responses: [
@@ -737,7 +738,7 @@ final class ManagementController extends AbstractController
         return Search::searchBySchema($this->getKnownSchema('Cluster'), $request->getParameters());
     }
 
-    #[Route(path: '/Cluster/{id}', methods: ['GET'], requirements: ['id' => '\d+'])]
+    #[Route(path: '/Cluster/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a cluster by ID',
         responses: [
@@ -782,7 +783,7 @@ final class ManagementController extends AbstractController
         return Search::deleteBySchema($this->getKnownSchema('Cluster'), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/Domain', methods: ['GET'])]
+    #[Route(path: '/Domain', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search domains',
         responses: [
@@ -794,7 +795,7 @@ final class ManagementController extends AbstractController
         return Search::searchBySchema($this->getKnownSchema('Domain'), $request->getParameters());
     }
 
-    #[Route(path: '/Domain/{id}', methods: ['GET'], requirements: ['id' => '\d+'])]
+    #[Route(path: '/Domain/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a domain by ID',
         responses: [
@@ -839,7 +840,7 @@ final class ManagementController extends AbstractController
         return Search::deleteBySchema($this->getKnownSchema('Domain'), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/Appliance', methods: ['GET'])]
+    #[Route(path: '/Appliance', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search appliances',
         responses: [
@@ -851,7 +852,7 @@ final class ManagementController extends AbstractController
         return Search::searchBySchema($this->getKnownSchema('Appliance'), $request->getParameters());
     }
 
-    #[Route(path: '/Appliance/{id}', methods: ['GET'], requirements: ['id' => '\d+'])]
+    #[Route(path: '/Appliance/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a appliance by ID',
         responses: [
@@ -896,7 +897,7 @@ final class ManagementController extends AbstractController
         return Search::deleteBySchema($this->getKnownSchema('Appliance'), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/Database', methods: ['GET'])]
+    #[Route(path: '/Database', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search databases',
         responses: [
@@ -908,7 +909,7 @@ final class ManagementController extends AbstractController
         return Search::searchBySchema($this->getKnownSchema('Database'), $request->getParameters());
     }
 
-    #[Route(path: '/Database/{id}', methods: ['GET'], requirements: ['id' => '\d+'])]
+    #[Route(path: '/Database/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a database by ID',
         responses: [

--- a/src/Api/HL/Controller/ProjectController.php
+++ b/src/Api/HL/Controller/ProjectController.php
@@ -35,6 +35,7 @@
 
 namespace Glpi\Api\HL\Controller;
 
+use Glpi\Api\HL\Middleware\ResultFormatterMiddleware;
 use Glpi\Api\HL\Route;
 use Glpi\Api\HL\Search;
 use Glpi\Http\Request;
@@ -109,7 +110,7 @@ final class ProjectController extends AbstractController
         ];
     }
 
-    #[Route(path: '/', methods: ['GET'])]
+    #[Route(path: '/', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search projects',
         responses: [
@@ -121,7 +122,7 @@ final class ProjectController extends AbstractController
         return Search::searchBySchema($this->getKnownSchema('Project'), $request->getParameters());
     }
 
-    #[Route(path: '/{id}', methods: ['GET'], requirements: ['id' => '\d+'])]
+    #[Route(path: '/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a project by ID',
         responses: [
@@ -166,7 +167,7 @@ final class ProjectController extends AbstractController
         return Search::deleteBySchema($this->getKnownSchema('Project'), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/Task', methods: ['GET'])]
+    #[Route(path: '/Task', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search project tasks',
         responses: [
@@ -178,7 +179,7 @@ final class ProjectController extends AbstractController
         return Search::searchBySchema($this->getKnownSchema('Task'), $request->getParameters());
     }
 
-    #[Route(path: '/Task/{id}', methods: ['GET'], requirements: ['id' => '\d+'])]
+    #[Route(path: '/Task/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a task by ID',
         responses: [
@@ -223,7 +224,7 @@ final class ProjectController extends AbstractController
         return Search::deleteBySchema($this->getKnownSchema('Task'), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/{project_id}/Task', methods: ['GET'])]
+    #[Route(path: '/{project_id}/Task', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search project tasks',
         responses: [

--- a/src/Api/HL/Middleware/ResultFormatterMiddleware.php
+++ b/src/Api/HL/Middleware/ResultFormatterMiddleware.php
@@ -101,13 +101,14 @@ class ResultFormatterMiddleware extends AbstractMiddleware implements ResponseMi
     private function formatXML(array $data): string
     {
         $xml = new \SimpleXMLElement('<root/>');
-        $fn_get_data = static function ($data, $prefix, $xml) use (&$fn_get_data) {
-            foreach ($data as $key => $value) {
-                $full_key = $prefix !== '' ? "{$prefix}.{$key}" : $key;
-                if (is_array($value)) {
-                    $xml = $fn_get_data($value, $full_key, $xml);
-                } else {
-                    $xml->addChild($full_key, $value);
+        $fn_get_data = static function ($data, $xml) use (&$fn_get_data) {
+            if (is_array($data)) {
+                foreach ($data as $key => $value) {
+                    if (is_array($value)) {
+                        $fn_get_data($value, $xml->addChild($key));
+                    } else {
+                        $xml->addChild($key, $value);
+                    }
                 }
             }
             return $xml;
@@ -116,7 +117,7 @@ class ResultFormatterMiddleware extends AbstractMiddleware implements ResponseMi
             $data = [$data];
         }
         foreach ($data as $result_row) {
-            $fn_get_data($result_row, '', $xml->addChild('row'));
+            $fn_get_data($result_row, $xml->addChild('row'));
         }
         return $xml->asXML();
     }

--- a/src/Api/HL/Middleware/ResultFormatterMiddleware.php
+++ b/src/Api/HL/Middleware/ResultFormatterMiddleware.php
@@ -88,12 +88,12 @@ class ResultFormatterMiddleware extends AbstractMiddleware implements ResponseMi
             $rows[] = $fn_get_data($result_row, '');
         }
         $csv = implode(',', array_map(static function ($value) {
-                return '"' . str_replace('"', '""', $value) . '"';
-            }, $columns)) . "\n";
+            return '"' . str_replace('"', '""', $value) . '"';
+        }, $columns)) . "\n";
         foreach ($rows as $row) {
             $csv .= implode(',', array_map(static function ($value) {
-                    return '"' . str_replace('"', '""', $value) . '"';
-                }, $row)) . "\n";
+                return '"' . str_replace('"', '""', $value) . '"';
+            }, $row)) . "\n";
         }
         return $csv;
     }

--- a/src/Api/HL/Middleware/ResultFormatterMiddleware.php
+++ b/src/Api/HL/Middleware/ResultFormatterMiddleware.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Api\HL\Middleware;
+
+use Glpi\Http\JSONResponse;
+use Glpi\Http\Response;
+
+class ResultFormatterMiddleware extends AbstractMiddleware implements ResponseMiddlewareInterface
+{
+    public function process(MiddlewareInput $input, callable $next): void
+    {
+        if (!$input->response instanceof JSONResponse) {
+            $next($input);
+            return;
+        }
+        try {
+            $data = json_decode($input->response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            $next($input);
+            return;
+        }
+        if (strtolower($input->request->getHeaderLine('Accept')) === 'text/csv') {
+            $input->response = new Response(200, [
+                'Content-Type' => 'text/csv',
+            ], $this->formatCSV($data));
+        } else if (strtolower($input->request->getHeaderLine('Accept')) === 'application/xml') {
+            $input->response = new Response(200, [
+                'Content-Type' => 'application/xml',
+            ], $this->formatXML($data));
+        }
+        $next($input);
+    }
+
+    private function formatCSV(array $data): string
+    {
+        $columns = [];
+        $rows = [];
+        $fn_get_data = static function ($data, $prefix, $row = []) use (&$columns, &$fn_get_data) {
+            foreach ($data as $key => $value) {
+                $full_key = $prefix !== '' ? "{$prefix}.{$key}" : $key;
+                if (is_array($value)) {
+                    $row = $fn_get_data($value, $full_key, $row);
+                } else {
+                    $columns[$full_key] = $full_key;
+                    $row[$full_key] = $value;
+                }
+            }
+            return $row;
+        };
+
+        if (!array_is_list($data)) {
+            $data = [$data];
+        }
+        foreach ($data as $result_row) {
+            $rows[] = $fn_get_data($result_row, '');
+        }
+        $csv = implode(',', array_map(static function ($value) {
+                return '"' . str_replace('"', '""', $value) . '"';
+            }, $columns)) . "\n";
+        foreach ($rows as $row) {
+            $csv .= implode(',', array_map(static function ($value) {
+                    return '"' . str_replace('"', '""', $value) . '"';
+                }, $row)) . "\n";
+        }
+        return $csv;
+    }
+
+    private function formatXML(array $data): string
+    {
+        $xml = new \SimpleXMLElement('<root/>');
+        $fn_get_data = static function ($data, $prefix, $xml) use (&$fn_get_data) {
+            foreach ($data as $key => $value) {
+                $full_key = $prefix !== '' ? "{$prefix}.{$key}" : $key;
+                if (is_array($value)) {
+                    $xml = $fn_get_data($value, $full_key, $xml);
+                } else {
+                    $xml->addChild($full_key, $value);
+                }
+            }
+            return $xml;
+        };
+        if (!array_is_list($data)) {
+            $data = [$data];
+        }
+        foreach ($data as $result_row) {
+            $fn_get_data($result_row, '', $xml->addChild('row'));
+        }
+        return $xml->asXML();
+    }
+}

--- a/src/Api/HL/Router.php
+++ b/src/Api/HL/Router.php
@@ -189,7 +189,7 @@ EOT;
             // Always run the security middleware (no condition set)
             $instance->registerResponseMiddleware(new SecurityResponseMiddleware());
             $instance->registerResponseMiddleware(new DebugResponseMiddleware(), PHP_INT_MAX);
-            $instance->registerResponseMiddleware(new ResultFormatterMiddleware());
+            $instance->registerResponseMiddleware(new ResultFormatterMiddleware(), 0, static fn(RoutePath $route_path) => false);
 
             // Register middleware from plugins
             if (isset($PLUGIN_HOOKS[Hooks::API_MIDDLEWARE])) {

--- a/src/Api/HL/Router.php
+++ b/src/Api/HL/Router.php
@@ -53,6 +53,7 @@ use Glpi\Api\HL\Middleware\DebugResponseMiddleware;
 use Glpi\Api\HL\Middleware\MiddlewareInput;
 use Glpi\Api\HL\Middleware\RequestMiddlewareInterface;
 use Glpi\Api\HL\Middleware\ResponseMiddlewareInterface;
+use Glpi\Api\HL\Middleware\ResultFormatterMiddleware;
 use Glpi\Api\HL\Middleware\RSQLRequestMiddleware;
 use Glpi\Api\HL\Middleware\SecurityResponseMiddleware;
 use Glpi\Http\JSONResponse;
@@ -188,6 +189,7 @@ EOT;
             // Always run the security middleware (no condition set)
             $instance->registerResponseMiddleware(new SecurityResponseMiddleware());
             $instance->registerResponseMiddleware(new DebugResponseMiddleware(), PHP_INT_MAX);
+            $instance->registerResponseMiddleware(new ResultFormatterMiddleware());
 
             // Register middleware from plugins
             if (isset($PLUGIN_HOOKS[Hooks::API_MIDDLEWARE])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Add simple response middleware for new API to optionally transform the JSON output into CSV or XML format to ease the integration of external systems.