### PR TITLE
fix php warning (undefined session var)

### DIFF
--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -352,7 +352,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
         $this->fields["users_id"]     = Session::getLoginUserID();
         $this->fields["is_private"]   = 1;
         $this->fields["is_recursive"] = 1;
-        $this->fields["entities_id"]  = $_SESSION["glpiactive_entity"];
+        $this->fields["entities_id"]  = Session::getActiveEntity();
     }
 
 


### PR DESCRIPTION
occurs when checking html encoding via CLI.

```
$ ./bin/console diagnostic:check_html_encoding
Command execution may take a long time and should not be interrupted.
PHP Warning (2): Undefined array key "glpiactive_entity" in /home/bugier/public_html/glpi-100a/src/SavedSearch.php at line 355
PHP Warning:  Undefined array key "glpiactive_entity" in /home/bugier/public_html/glpi-100a/src/SavedSearch.php on line 355
Scanning database for items to fix...
No item to fix.
```

```
  Backtrace :
  src/CommonDBTM.php:628                             SavedSearch->post_getEmpty()
  src/CommonDBTM.php:3429                            CommonDBTM->getEmpty()
  src/CommonDBTM.php:3845                            CommonDBTM->isField()
  src/SavedSearch.php:194                            CommonDBTM->rawSearchOptions()
  src/CommonDBTM.php:3782                            SavedSearch->rawSearchOptions()
  src/Search.php:8117                                CommonDBTM->searchOptions()
  ...ole/Diagnostic/CheckHtmlEncodingCommand.php:384 Search::getOptions()
  ...ole/Diagnostic/CheckHtmlEncodingCommand.php:123 Glpi\Console\Diagnostic\CheckHtmlEncodingCommand->findTextFields()
  vendor/symfony/console/Command/Command.php:298     Glpi\Console\Diagnostic\CheckHtmlEncodingCommand->execute()
  vendor/symfony/console/Application.php:1040        Symfony\Component\Console\Command\Command->run()
  src/Console/Application.php:272                    Symfony\Component\Console\Application->doRunCommand()
  vendor/symfony/console/Application.php:301         Glpi\Console\Application->doRunCommand()
  vendor/symfony/console/Application.php:171         Symfony\Component\Console\Application->doRun()
  bin/console:122                                    Symfony\Component\Console\Application->run()
```



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
