### PR TITLE
Confirmation before uninstalling a plugin

### DIFF
--- a/src/Marketplace/View.php
+++ b/src/Marketplace/View.php
@@ -816,16 +816,17 @@ HTML;
 
             $buttons .= TemplateRenderer::getInstance()->render('components/plugin_uninstall_modal.html.twig', [
                 'plugin_name' => $plugin_inst->getField('name'),
-                'open_btn' => "<button data-bs-toggle='modal'
-                                       data-bs-target='#uninstallModal'
-                                       title='" . __s("Uninstall") . "'>
-                                   <i class='ti ti-folder-x'></i>
-                               </button>",
-                'uninstall_btn' => "<a href='#' class='btn btn-danger w-100 modify_plugin'
-                                       data-action='uninstall_plugin'
-                                       data-bs-dismiss='modal'>
-                                       " . _x('button', 'Uninstall') . "
-                                   </a>",
+                'modal_id' => 'uninstallModal' . $plugin_inst->getField('directory'),
+                'open_btn' => '<button data-bs-toggle="modal"
+                                       data-bs-target="#uninstallModal' . $plugin_inst->getField('directory') . '"
+                                       title="' . __s('Uninstall') . '">
+                                   <i class="ti ti-folder-x"></i>
+                               </button>',
+                'uninstall_btn' => '<a href="#" class="btn btn-danger w-100 modify_plugin"
+                                       data-action="uninstall_plugin"
+                                       data-bs-dismiss="modal">
+                                       ' . _x("button", "Uninstall") . '
+                                   </a>',
             ]);
 
             if (!strlen($error) && $is_actived && $config_page) {

--- a/src/Marketplace/View.php
+++ b/src/Marketplace/View.php
@@ -37,6 +37,7 @@ namespace Glpi\Marketplace;
 
 use CommonGLPI;
 use Config;
+use Glpi\Application\View\TemplateRenderer;
 use Glpi\Marketplace\Api\Plugins as PluginsApi;
 use GLPINetwork;
 use Html;
@@ -813,11 +814,18 @@ HTML;
                 }
             }
 
-            $buttons .= "<button class='modify_plugin'
-                                 data-action='uninstall_plugin'
-                                 title='" . __s("Uninstall") . "'>
-                    <i class='ti ti-folder-x'></i>
-                </button>";
+            $buttons .= TemplateRenderer::getInstance()->render('components/plugin_uninstall_modal.html.twig', [
+                'open_btn' => "<button data-bs-toggle='modal'
+                                       data-bs-target='#uninstallModal'
+                                       title='" . __s("Uninstall") . "'>
+                                   <i class='ti ti-folder-x'></i>
+                               </button>",
+                'uninstall_btn' => "<a href='#' class='btn btn-danger w-100 modify_plugin'
+                                       data-action='uninstall_plugin'
+                                       data-bs-dismiss='modal'>
+                                       " . _x('button', 'Uninstall') . "
+                                   </a>",
+            ]);
 
             if (!strlen($error) && $is_actived && $config_page) {
                 $plugin_dir = Plugin::getWebDir($plugin_key, true);

--- a/src/Marketplace/View.php
+++ b/src/Marketplace/View.php
@@ -815,6 +815,7 @@ HTML;
             }
 
             $buttons .= TemplateRenderer::getInstance()->render('components/plugin_uninstall_modal.html.twig', [
+                'plugin_name' => $plugin_inst->getField('name'),
                 'open_btn' => "<button data-bs-toggle='modal'
                                        data-bs-target='#uninstallModal'
                                        title='" . __s("Uninstall") . "'>

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -37,6 +37,7 @@
  * Based on cacti plugin system
  */
 
+use Glpi\Application\View\TemplateRenderer;
 use Glpi\Cache\CacheManager;
 use Glpi\Marketplace\Controller as MarketplaceController;
 use Glpi\Marketplace\View as MarketplaceView;
@@ -2670,13 +2671,22 @@ class Plugin extends CommonDBTM
                 if (in_array($state, [self::ACTIVATED, self::NOTUPDATED, self::TOBECONFIGURED, self::NOTACTIVATED], true)) {
                    // Uninstall button for installed plugins
                     if (function_exists("plugin_" . $directory . "_uninstall")) {
-                        $output .= Html::getSimpleForm(
-                            static::getFormURL(),
-                            ['action' => 'uninstall'],
-                            _x('button', 'Uninstall'),
-                            ['id' => $ID],
-                            'fa-fw fa-folder-minus fa-2x'
-                        ) . '&nbsp;';
+                        $output .= TemplateRenderer::getInstance()->render('components/plugin_uninstall_modal.html.twig', [
+                            'open_btn' => '<span class="fas fa-fw fa-folder-minus fa-2x pointer"
+                                                 data-bs-toggle="modal"
+                                                 data-bs-target="#uninstallModal"
+                                                 title="' . __s("Uninstall") . '">
+                                               <span class="sr-only">' . __s("Uninstall") . '</span>
+                                           </span>',
+                            'uninstall_btn' => Html::getSimpleForm(
+                                static::getFormURL(),
+                                ['action' => 'uninstall'],
+                                _x('button', 'Uninstall'),
+                                ['id' => $ID],
+                                '',
+                                'class="btn btn-danger w-100"'
+                            ),
+                        ]);
                     } else {
                        //TRANS: %s is the list of missing functions
                         $output .= sprintf(

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2672,6 +2672,7 @@ class Plugin extends CommonDBTM
                    // Uninstall button for installed plugins
                     if (function_exists("plugin_" . $directory . "_uninstall")) {
                         $output .= TemplateRenderer::getInstance()->render('components/plugin_uninstall_modal.html.twig', [
+                            'plugin_name' => $plugin->getField('name'),
                             'open_btn' => '<span class="fas fa-fw fa-folder-minus fa-2x pointer"
                                                  data-bs-toggle="modal"
                                                  data-bs-target="#uninstallModal"

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2673,9 +2673,10 @@ class Plugin extends CommonDBTM
                     if (function_exists("plugin_" . $directory . "_uninstall")) {
                         $output .= TemplateRenderer::getInstance()->render('components/plugin_uninstall_modal.html.twig', [
                             'plugin_name' => $plugin->getField('name'),
+                            'modal_id' => 'uninstallModal' . $plugin->getField('directory'),
                             'open_btn' => '<span class="fas fa-fw fa-folder-minus fa-2x pointer"
                                                  data-bs-toggle="modal"
-                                                 data-bs-target="#uninstallModal"
+                                                 data-bs-target="#uninstallModal' . $plugin->getField('directory') . '"
                                                  title="' . __s("Uninstall") . '">
                                                <span class="sr-only">' . __s("Uninstall") . '</span>
                                            </span>',

--- a/templates/components/plugin_uninstall_modal.html.twig
+++ b/templates/components/plugin_uninstall_modal.html.twig
@@ -43,8 +43,8 @@
             <div
                 class="modal-body text-center py-4">
                 <i class="fa-2x ti ti-alert-triangle mb-2 text-danger"></i>
-                <h3>{{ __('Are you sure?') }}</h3>
-                <div class="text-muted">{{ __('By uninstalling the plugin you will lose all the data of the plugin.') }}</div>
+                <h3>{{ _x('uninstall_plugin', 'Are you sure?') }}</h3>
+                <div class="text-muted">{{ _x('uninstall_plugin', 'By uninstalling the "%plugin_name%" plugin you will lose all the data of the plugin.')|replace({'%plugin_name%': plugin_name}) }}</div>
             </div>
             <div class="modal-footer">
                 <div class="w-100">

--- a/templates/components/plugin_uninstall_modal.html.twig
+++ b/templates/components/plugin_uninstall_modal.html.twig
@@ -43,8 +43,8 @@
             <div
                 class="modal-body text-center py-4">
                 <i class="fa-2x ti ti-alert-triangle mb-2 text-danger"></i>
-                <h3>{{ _x('uninstall_plugin', 'Are you sure?') }}</h3>
-                <div class="text-muted">{{ _x('uninstall_plugin', 'By uninstalling the plugin you will lose all the data of the plugin.') }}</div>
+                <h3>{{ __('Are you sure?') }}</h3>
+                <div class="text-muted">{{ __('By uninstalling the plugin you will lose all the data of the plugin.') }}</div>
             </div>
             <div class="modal-footer">
                 <div class="w-100">

--- a/templates/components/plugin_uninstall_modal.html.twig
+++ b/templates/components/plugin_uninstall_modal.html.twig
@@ -1,0 +1,65 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2023 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+<!-- Button trigger modal -->
+{{ open_btn|raw }}
+
+<!-- Modal -->
+<div class="modal fade" id="uninstallModal" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <a type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></a>
+            <div class="modal-status bg-danger"></div>
+            <div
+                class="modal-body text-center py-4">
+                <i class="fa-2x ti ti-alert-triangle mb-2 text-danger"></i>
+                <h3>{{ _x('uninstall_plugin', 'Are you sure?') }}</h3>
+                <div class="text-muted">{{ _x('uninstall_plugin', 'By uninstalling the plugin you will lose all the data of the plugin.') }}</div>
+            </div>
+            <div class="modal-footer">
+                <div class="w-100">
+                    <div class="row">
+                        <div class="col">
+                            <a class="btn w-100" data-bs-dismiss="modal">
+                                {{ __('Cancel') }}
+                            </a>
+                        </div>
+                        <div class="col">
+                            {{ uninstall_btn|raw }}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/components/plugin_uninstall_modal.html.twig
+++ b/templates/components/plugin_uninstall_modal.html.twig
@@ -35,7 +35,7 @@
 {{ open_btn|raw }}
 
 <!-- Modal -->
-<div class="modal fade" id="uninstallModal" tabindex="-1" role="dialog" aria-hidden="true">
+<div class="modal fade" id="{{ modal_id }}" tabindex="-1" role="dialog" aria-hidden="true">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <a type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></a>


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Added a confirmation modal before uninstalling the plugin.
Both "plugins" and "marketplace" views have been taken into account.

![image](https://github.com/glpi-project/glpi/assets/42278610/93c16e50-e6ca-4935-8546-8d837acca286)