### PR TITLE
Clarify LDAP sync "only update" mode

### DIFF
--- a/src/Console/Ldap/SynchronizeUsersCommand.php
+++ b/src/Console/Ldap/SynchronizeUsersCommand.php
@@ -84,7 +84,7 @@ class SynchronizeUsersCommand extends AbstractCommand
             'only-update-existing',
             'u',
             InputOption::VALUE_NONE,
-            __('Only update existing users')
+            __('Only update existing users (will not handle deleted users)')
         );
 
         $this->addOption(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14677

As stated in the code, this mode does not handle deleted users:
https://github.com/glpi-project/glpi/blob/aa15da313a064a7d9a92e182f4119aeebf80d473/src/Console/Ldap/SynchronizeUsersCommand.php#L192-L195