### PR TITLE
Fix export link

### DIFF
--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -106,7 +106,7 @@
         'sort': sort,
         'order': order,
         'start': start,
-      }|url_encode ~ posthref %}
+      }|url_encode ~ '&' ~ posthref %}
       <ul class="dropdown-menu" aria-labelledby="dropdown-export">
          <li><a class="dropdown-item" href="{{ exporthref ~ '&display_type=' ~ constant('Search::PDF_OUTPUT_LANDSCAPE') }}">
             <i class="far fa-lg fa-file-pdf"></i>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

There was a missing `&`:
![image](https://github.com/glpi-project/glpi/assets/33253653/4db1746f-c8cf-45cb-97f0-928a7e33270a)
