### PR TITLE
Notifications: avoid divide by zero exception

### DIFF
--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -275,6 +275,12 @@ class NotificationEventMailing extends NotificationEventAbstract
                                     }
 
                                     $img_infos = getimagesize(GLPI_DOC_DIR . "/" . $doc->fields['filepath']);
+
+                                    if (!$img_infos) {
+                                        // Failure to read image size, skip to avoid a divide by zero exception
+                                        continue;
+                                    }
+
                                     $initial_width = $img_infos[0];
                                     $initial_height = $img_infos[1];
 


### PR DESCRIPTION
The mail queue cron will fail if there is a broken image in a ticket.

![image](https://github.com/glpi-project/glpi/assets/42734840/4644b6c6-b5c5-4dc5-ac0b-ff113bcd8577)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
