### PR TITLE
Do not login to STMP for each mail

### DIFF
--- a/src/GLPIMailer.php
+++ b/src/GLPIMailer.php
@@ -73,11 +73,11 @@ class GLPIMailer
      */
     private ?string $debug_header_line;
 
-    public function __construct()
+    public function __construct(?TransportInterface $transport = null)
     {
         global $CFG_GLPI;
 
-        $this->transport = Transport::fromDsn($this->buildDsn(true));
+        $this->transport = $transport ?? Transport::fromDsn(self::buildDsn(true));
 
         if (method_exists($this->transport, 'getStream')) {
             $stream = $this->transport->getStream();
@@ -97,7 +97,7 @@ class GLPIMailer
      *
      * @return string
      */
-    final public function buildDsn(bool $with_clear_password): string
+    final public static function buildDsn(bool $with_clear_password): string
     {
         global $CFG_GLPI;
 

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -2007,7 +2007,7 @@ class MailCollector extends CommonDBTM
         }
         if ($CFG_GLPI['smtp_mode'] != MAIL_MAIL) {
             $mailer = new GLPIMailer();
-            $msg .= sprintf('(%s)', $mailer->buildDsn(false));
+            $msg .= sprintf('(%s)', $mailer::buildDsn(false));
         }
         echo wordwrap($msg . "\n", $width, "\n\t\t");
         echo "\n</pre></td></tr>";

--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -33,6 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Symfony\Component\Mailer\Transport;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 
@@ -117,9 +118,12 @@ class NotificationEventMailing extends NotificationEventAbstract
 
         $processed = [];
 
+        // Init transport once to avoid login in to the smtp server for every mail
+        $transport = Transport::fromDsn(GLPIMailer::buildDsn(true));
+
         foreach ($data as $row) {
             //make sure mailer is reset on each mail
-            $mmail = new GLPIMailer();
+            $mmail = new GLPIMailer($transport);
             $mail = $mmail->getEmail();
             $current = new QueuedNotification();
             $current->getFromResultSet($row);

--- a/tests/units/GLPIMailer.php
+++ b/tests/units/GLPIMailer.php
@@ -93,16 +93,16 @@ class GLPIMailer extends DbTestCase
         $bkp_check_certif = $CFG_GLPI['smtp_check_certificate'];
 
         $mailer = new \GLPIMailer();
-        $this->string($mailer->buildDsn(true))->isIdenticalTo('native://default');
-        $this->string($mailer->buildDsn(false))->isIdenticalTo('native://default');
+        $this->string($mailer::buildDsn(true))->isIdenticalTo('native://default');
+        $this->string($mailer::buildDsn(false))->isIdenticalTo('native://default');
 
         $CFG_GLPI['smtp_mode'] = MAIL_SMTP;
         $CFG_GLPI['smtp_port'] = 123;
         $CFG_GLPI['smtp_host'] = 'myhost.com';
         $CFG_GLPI['smtp_username'] = 'myuser';
         $CFG_GLPI['smtp_passwd'] = (new \GLPIKey())->encrypt('mypass');
-        $this->string($mailer->buildDsn(true))->isIdenticalTo('smtp://myuser:mypass@myhost.com:123');
-        $this->string($mailer->buildDsn(false))->isIdenticalTo('smtp://myuser:********@myhost.com:123');
+        $this->string($mailer::buildDsn(true))->isIdenticalTo('smtp://myuser:mypass@myhost.com:123');
+        $this->string($mailer::buildDsn(false))->isIdenticalTo('smtp://myuser:********@myhost.com:123');
 
         //reset values
         $CFG_GLPI['smtp_mode'] = $bkp_mode;


### PR DESCRIPTION
When trying to send a lot of emails on our support, we often get the following email message:

```
Error: SMTP connect() failed. https://github.com/PHPMailer/PHPMailer/wiki/TroubleshootingSMTP
server error: QUIT command failed Detail: Too many login attempts, please try again later
```

At first I thought that we were sending too many mails at once (thus hitting the rate limit of our provider) but the error message actually mention too much "login attempts", not too much mails.

After checking the code we are indeed login in to the STMP server once for each mail to send, which seems unnecessary.
I think we should be able to login once and then send all our mails.  

The solution seem simple for this branch as the component we use cleanly separate the transport layer.

It it however not the case in the `10.0/bugfixes` branch (PHPMailer), I will try to look into it (open to suggestions).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 