### PR TITLE
Bad url to pic

### DIFF
--- a/src/RichText/RichText.php
+++ b/src/RichText/RichText.php
@@ -479,6 +479,8 @@ HTML;
 
         // Unsanitize images urls
         $imgs = array_map(function ($img) {
+            // URL may contain &amp; which is not handled by Sanitizer::decodeHtmlSpecialChars(); htmlawed problem, see RichText::getSafeHtml().
+            $img['src'] = str_replace('&amp;', '&#38;', $img['src']);
             $img['src'] = Sanitizer::decodeHtmlSpecialChars($img['src']);
             return $img;
         }, $imgs);


### PR DESCRIPTION
When one clicks on a picture in a followup, a HTTP request is sent to document.send.php. The HTTP request is buggy.

 
![image](https://github.com/glpi-project/glpi/assets/14139801/73670f7b-9728-4056-8d42-c7f350ae21a2)

![image](https://github.com/glpi-project/glpi/assets/14139801/b0ce3532-3225-4081-81e6-bd0995fe885a)

![image](https://github.com/glpi-project/glpi/assets/14139801/bd26d38b-e0a0-41d7-8957-6d31a03be514)


The source of the issue is in the generation of the URL server side (in RichText/RichText.php . Sanitizer::decodeHtmlSpecialChars()  does not detects any clue of HTML encoding because it does not scans encoded ampersand (```&amp;```). Therefore, decoding does not happens.


![image](https://github.com/glpi-project/glpi/assets/14139801/e9a8035d-7279-4150-8228-7cd8897bd269)

In the follolowup un DB there is no `&amp;` . The content is altered here, we enter in RichText::getSafeHtml().
```
$content = htmLawed($content, $config);
```
 does bad job here (https://github.com/glpi-project/glpi/blob/10.0/bugfixes/src/RichText/RichText.php#L68)


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal ref 28020
