### PR TITLE
Document::canViewItem(): validate itemtype

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -708,7 +708,7 @@ class Document extends CommonDBTM
         $items_id = $options['items_id'] ?? null;
 
         // Validate itemtype, as it might come directly from $_GET
-        if (!Toolbox::isCommonDBTM($itemtype)) {
+        if ($itemtype !== null && !Toolbox::isCommonDBTM($itemtype)) {
             return false;
         }
 

--- a/src/Document.php
+++ b/src/Document.php
@@ -707,11 +707,6 @@ class Document extends CommonDBTM
         $itemtype = $options['itemtype'] ?? null;
         $items_id = $options['items_id'] ?? null;
 
-        // Validate itemtype, as it might come directly from $_GET
-        if ($itemtype !== null && !Toolbox::isCommonDBTM($itemtype)) {
-            return false;
-        }
-
         // legacy options
         $changes_id  = $itemtype === null ? ($options['changes_id'] ?? null) : ($itemtype === 'Change' ? $items_id : null);
         $problems_id = $itemtype === null ? ($options['problems_id'] ?? null) : ($itemtype === 'Problem' ? $items_id : null);
@@ -727,6 +722,7 @@ class Document extends CommonDBTM
 
         if (
             $itemtype !== null
+            && is_a($itemtype, CommonDBTM::class, true)
             && $items_id !== null
             && $this->canViewFileFromItem($itemtype, $items_id)
         ) {

--- a/src/Document.php
+++ b/src/Document.php
@@ -707,6 +707,11 @@ class Document extends CommonDBTM
         $itemtype = $options['itemtype'] ?? null;
         $items_id = $options['items_id'] ?? null;
 
+        // Validate itemtype, as it might come directly from $_GET
+        if (!Toolbox::isCommonDBTM($itemtype)) {
+            return false;
+        }
+
         // legacy options
         $changes_id  = $itemtype === null ? ($options['changes_id'] ?? null) : ($itemtype === 'Change' ? $items_id : null);
         $problems_id = $itemtype === null ? ($options['problems_id'] ?? null) : ($itemtype === 'Problem' ? $items_id : null);

--- a/tests/functional/Document.php
+++ b/tests/functional/Document.php
@@ -283,7 +283,6 @@ class Document extends DbTestCase
             'itemtype' => 'not_a_class',
             'items_id' => 'not an id',
         ]))->isFalse();
-
         $this->boolean(
             $document->update(
                 [
@@ -293,7 +292,6 @@ class Document extends DbTestCase
             )
         )->isTrue();
         $this->boolean($document->canViewFile())->isTrue();
-
     }
 
     /**

--- a/tests/functional/Document.php
+++ b/tests/functional/Document.php
@@ -279,6 +279,11 @@ class Document extends DbTestCase
 
        // post-only can see its own documents
         $this->login('post-only', 'postonly');
+        $this->boolean($document->canViewFile([
+            'itemtype' => 'not_a_class',
+            'items_id' => 'not an id',
+        ]))->isFalse();
+
         $this->boolean(
             $document->update(
                 [
@@ -288,6 +293,7 @@ class Document extends DbTestCase
             )
         )->isTrue();
         $this->boolean($document->canViewFile())->isTrue();
+
     }
 
     /**


### PR DESCRIPTION
Requests on `document.send.php` with invalid  `$_GET['itemtype']` will trigger an error:

```
[2023-05-23 13:13:53] glpiphplog.CRITICAL:   *** Uncaught Exception Error: Class "this_class_does_not_exist" not found in /var/www/glpi/src/Document.php at line 919
  Backtrace :
  src/Document.php:726                               Document->canViewFileFromItem()
  front/document.send.php:55                         Document->canViewFile()
  public/index.php:73                                require()
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
