### PR TITLE
TicketRule: fix category code change detection

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1127,6 +1127,12 @@ class Ticket extends CommonITILObject
             $input['itilcategories_id_code'] = ITILCategory::getById($cat_id)->fields['code'];
         }
 
+        // Set previous category code, this is needed to let the rule engine
+        // decide if the code was changed
+        if ($category = ITILCategory::getById($this->fields['itilcategories_id'] ?? 0)) {
+            $this->fields['itilcategories_id_code'] = $category->fields['code'];
+        }
+
        // Set _contract_type for rules
         $input['_contract_types'] = [];
         $contracts_link = Ticket_Contract::getListForItem($this);

--- a/tests/functional/RuleTicket.php
+++ b/tests/functional/RuleTicket.php
@@ -1721,7 +1721,7 @@ class RuleTicket extends DbTestCase
             'match'        => 'AND',
             'is_active'    => 1,
             'sub_type'     => 'RuleTicket',
-            'condition'    => \RuleTicket::ONADD,
+            'condition'    => \RuleTicket::ONADD | \RuleTicket::ONUPDATE,
             'is_recursive' => 1,
         ]);
         $this->checkInput($ruleticket, $ruletid, $ruletinput);
@@ -1776,6 +1776,25 @@ class RuleTicket extends DbTestCase
        // Check that the rule was NOT executed
         $this->boolean($ticket->getFromDB($tickets_id))->isTrue();
         $this->integer($ticket->fields['impact'])->isNotEqualTo(1);
+
+        // Update ticket to match the rule
+        $this->updateItem('Ticket', $ticket->getID(), [
+            'itilcategories_id' => $category_id,
+        ]);
+
+        // Check that the rule was executed
+        $this->boolean($ticket->getFromDB($tickets_id))->isTrue();
+        $this->integer($ticket->fields['impact'])->isEqualTo(1);
+
+        // Change impact, the rule must not be executed again as the category didn't change
+        $this->updateItem('Ticket', $ticket->getID(), [
+            'itilcategories_id' => $category_id, // Simulate same category being sent from the user form
+            'impact' => 2,
+        ]);
+
+         // Check that the rule was not executed
+         $this->boolean($ticket->getFromDB($tickets_id))->isTrue();
+         $this->integer($ticket->fields['impact'])->isNotEqualTo(1);
     }
 
     /**

--- a/tests/functional/RuleTicket.php
+++ b/tests/functional/RuleTicket.php
@@ -1711,12 +1711,12 @@ class RuleTicket extends DbTestCase
     {
         $this->login();
 
-       // Create rule
-        $ruleticket = new \RuleTicket();
-        $rulecrit   = new \RuleCriteria();
-        $ruleaction = new \RuleAction();
+        // Common variables that will be reused
+        $rule_criteria_category_code = "R";
+        $rule_action_impact_value = 1; // very low
 
-        $ruletid = $ruleticket->add($ruletinput = [
+        // Create rule, rule criteria and rule action
+        $rule = $this->createItem('RuleTicket', [
             'name'         => 'test category code',
             'match'        => 'AND',
             'is_active'    => 1,
@@ -1724,77 +1724,67 @@ class RuleTicket extends DbTestCase
             'condition'    => \RuleTicket::ONADD | \RuleTicket::ONUPDATE,
             'is_recursive' => 1,
         ]);
-        $this->checkInput($ruleticket, $ruletid, $ruletinput);
-
-       // Create criteria to check if category code is R
-        $crit_id = $rulecrit->add($crit_input = [
-            'rules_id'  => $ruletid,
+        $this->createItem('RuleCriteria', [
+            'rules_id'  => $rule->getID(),
             'criteria'  => 'itilcategories_id_code',
             'condition' => \Rule::PATTERN_IS,
-            'pattern'   => 'R',
+            'pattern'   => $rule_criteria_category_code,
         ]);
-        $this->checkInput($rulecrit, $crit_id, $crit_input);
-
-       // Create action to put impact to very low
-        $action_id = $ruleaction->add($action_input = [
-            'rules_id'    => $ruletid,
+        $this->createItem('RuleAction', [
+            'rules_id'    => $rule->getID(),
             'action_type' => 'assign',
             'field'       => 'impact',
-            'value'       => 1,
+            'value'       => $rule_action_impact_value,
         ]);
-        $this->checkInput($ruleaction, $action_id, $action_input);
 
-       // Create new group
-        $category = new \ITILCategory();
-        $category_id = $category->add($category_input = [
-            "name" => "group1",
-            "code" => "R"
+        // Create new category
+        $category = $this->createItem('ITILCategory', [
+            "name" => "category_test",
+            "code" => $rule_criteria_category_code,
         ]);
-        $this->checkInput($category, $category_id, $category_input);
 
-       // Check ticket that trigger rule on creation
-        $ticket = new \Ticket();
-        $tickets_id = $ticket->add($ticket_input = [
+        // Check ticket that trigger rule on creation
+        $ticket = $this->createItem('Ticket', [
             'name'              => 'test category code',
             'content'           => 'test category code',
-            'itilcategories_id' => $category_id
+            'itilcategories_id' => $category->getID(),
         ]);
-        $this->checkInput($ticket, $tickets_id, $ticket_input);
+        $tickets_id = $ticket->getID();
 
-       // Check that the rule was executed
+        // Check that the rule was executed
         $this->boolean($ticket->getFromDB($tickets_id))->isTrue();
-        $this->integer($ticket->fields['impact'])->isEqualTo(1);
+        $this->integer($ticket->fields['impact'])->isEqualTo($rule_action_impact_value);
 
-       // Create another ticket that doesn't match the rule
-        $tickets_id = $ticket->add($ticket_input = [
+        // Create another ticket that doesn't match the rule
+        $ticket = $this->createItem('Ticket', [
             'name'              => 'test category code',
             'content'           => 'test category code',
             'itilcategories_id' => 0
         ]);
-        $this->checkInput($ticket, $tickets_id, $ticket_input);
+        $tickets_id = $ticket->getID();
 
-       // Check that the rule was NOT executed
+        // Check that the rule was NOT executed
         $this->boolean($ticket->getFromDB($tickets_id))->isTrue();
-        $this->integer($ticket->fields['impact'])->isNotEqualTo(1);
+        $this->integer($ticket->fields['impact'])->isNotEqualTo($rule_action_impact_value);
 
         // Update ticket to match the rule
         $this->updateItem('Ticket', $ticket->getID(), [
-            'itilcategories_id' => $category_id,
+            'itilcategories_id' => $category->getID(),
         ]);
 
         // Check that the rule was executed
         $this->boolean($ticket->getFromDB($tickets_id))->isTrue();
-        $this->integer($ticket->fields['impact'])->isEqualTo(1);
+        $this->integer($ticket->fields['impact'])->isEqualTo($rule_action_impact_value);
 
         // Change impact, the rule must not be executed again as the category didn't change
         $this->updateItem('Ticket', $ticket->getID(), [
-            'itilcategories_id' => $category_id, // Simulate same category being sent from the user form
+            'itilcategories_id' => $category->getID(), // Simulate same category being sent from the user form
             'impact' => 2,
         ]);
 
-         // Check that the rule was not executed
-         $this->boolean($ticket->getFromDB($tickets_id))->isTrue();
-         $this->integer($ticket->fields['impact'])->isNotEqualTo(1);
+        // Check that the rule was not executed
+        $this->boolean($ticket->getFromDB($tickets_id))->isTrue();
+        $this->integer($ticket->fields['impact'])->isNotEqualTo($rule_action_impact_value);
     }
 
     /**


### PR DESCRIPTION
`$input['itilcategories_id_code']` is set before updating a ticket:

![image](https://github.com/glpi-project/glpi/assets/42734840/b956cf13-95e8-4f25-9c2f-04ad487e4229)

Since this not a real field, `$this->fields['itilcategories_id_code']` will always be empty so the rule engine will always think that the category code was modified even if the category didn't change.
This is problematic as it will trigger rules based on this criteria on any ticket update.

Fixed by also adding the category code into `$this>-fields` to allow the rule engine to compare the values properly and thus correctly understand if the category was changed or not.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27995
