### PR TITLE
Fix duplicated header in notifications

### DIFF
--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -144,9 +144,9 @@ class NotificationEventMailing extends NotificationEventAbstract
                             $current->fields['items_id'],
                             $reference_event
                         );
-                        $mmail->AddCustomHeader('In-Reply-To', "<{$email_ref}>");
                         $mmail->AddCustomHeader("<{$email_ref}>");
-                        $mmail->AddCustomHeader("References: <{$email_ref}>");
+                        $mail->getHeaders()->addTextHeader('In-Reply-To', "<{$email_ref}>");
+                        $mail->getHeaders()->addTextHeader("References", "<{$email_ref}>");
                     }
                 }
 

--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -144,8 +144,7 @@ class NotificationEventMailing extends NotificationEventAbstract
                             $current->fields['items_id'],
                             $reference_event
                         );
-                        $mail->getHeaders()->addTextHeader('In-Reply-To', "<{$email_ref}>");
-                        $mail->getHeaders()->addTextHeader('References', "<{$email_ref}>");
+                        $mmail->AddCustomHeader('In-Reply-To', "<{$email_ref}>");
                         $mmail->AddCustomHeader("<{$email_ref}>");
                         $mmail->AddCustomHeader("References: <{$email_ref}>");
                     }

--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -144,7 +144,6 @@ class NotificationEventMailing extends NotificationEventAbstract
                             $current->fields['items_id'],
                             $reference_event
                         );
-                        $mmail->AddCustomHeader("<{$email_ref}>");
                         $mail->getHeaders()->addTextHeader('In-Reply-To', "<{$email_ref}>");
                         $mail->getHeaders()->addTextHeader("References", "<{$email_ref}>");
                     }


### PR DESCRIPTION
Notifications are broken on `main`: 

![image](https://github.com/glpi-project/glpi/assets/42734840/78543789-5b43-4506-917f-011816bbc617)

There is a duplicated "References" header added twice, I've removed one occurrence.
Also we add the headers with two different methods :
* `$mmail->AddCustomHeader`
* `$mail->getHeaders()->addTextHeader()`

Not sure which one is correct, I've kept `AddCustomHeader` to keep things identical.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
