### PR TITLE
Fix SMTP OAuth callback on PHP 7.4

### DIFF
--- a/front/smtp_oauth2_callback.php
+++ b/front/smtp_oauth2_callback.php
@@ -41,7 +41,7 @@ if (!array_key_exists('cookie_refresh', $_GET)) {
     // Redirecting on self using `http-equiv="refresh"` will get around this limitation.
     $url = htmlspecialchars(
         $_SERVER['REQUEST_URI']
-        . (str_contains($_SERVER['REQUEST_URI'], '?') ? '&' : '?')
+        . (strpos($_SERVER['REQUEST_URI'], '?') !== false ? '&' : '?')
         . 'cookie_refresh'
     );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

At this point of code, polyfills are not yet loaded, so `str_contains()` function is not available.