### PR TITLE
Catch `\Throwable` instead of `\Exception`

### DIFF
--- a/ajax/massiveaction.php
+++ b/ajax/massiveaction.php
@@ -50,7 +50,7 @@ Session::checkLoginUser();
 
 try {
     $ma = new MassiveAction($_POST, $_GET, 'initial');
-} catch (\Exception $e) {
+} catch (\Throwable $e) {
     echo "<div class='center'><img src='" . $CFG_GLPI["root_doc"] . "/pics/warning.png' alt='" .
                               __s('Warning') . "'><br><br>";
     echo "<span class='b'>" . $e->getMessage() . "</span><br>";

--- a/front/inventory.php
+++ b/front/inventory.php
@@ -90,7 +90,7 @@ if (isset($_GET['refused'])) {
 if ($handle === true) {
     try {
         $inventory_request->handleRequest($contents);
-    } catch (\Exception $e) {
+    } catch (\Throwable $e) {
         $inventory_request->addError($e->getMessage());
     }
 }

--- a/front/massiveaction.php
+++ b/front/massiveaction.php
@@ -42,7 +42,7 @@ Html::header_nocache();
 
 try {
     $ma = new MassiveAction($_POST, $_GET, 'process');
-} catch (\Exception $e) {
+} catch (\Throwable $e) {
     Html::popHeader(__('Bulk modification error'), $_SERVER['PHP_SELF']);
 
     echo "<div class='center'><img src='" . $CFG_GLPI["root_doc"] . "/pics/warning.png' alt='" .

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -709,7 +709,7 @@ class Agent extends CommonDBTM
             } catch (\GuzzleHttp\Exception\RequestException $e) {
                 // got an error response, we don't need to try other addresses
                 break;
-            } catch (Exception $e) {
+            } catch (\Throwable $e) {
                 // many addresses will be incorrect
             }
         }
@@ -737,7 +737,7 @@ class Agent extends CommonDBTM
             ErrorHandler::getInstance()->handleException($e);
             // not authorized
             return ['answer' => __('Not allowed')];
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             // no response
             return ['answer' => __('Unknown')];
         }
@@ -758,7 +758,7 @@ class Agent extends CommonDBTM
             ErrorHandler::getInstance()->handleException($e);
             // not authorized
             return ['answer' => __('Not allowed')];
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             // no response
             return ['answer' => __('Unknown')];
         }

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -216,7 +216,7 @@ class Auth extends CommonGLPI
             );
 
             return $protocol->login($login, $pass);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->addToError($e->getMessage());
             return false;
         } finally {

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -4405,7 +4405,7 @@ class AuthLDAP extends CommonDBTM
                     throw new \RuntimeException('Not an objectguid!');
                 }
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
            //well... this is not an objectguid apparently
             $value = $infos[$field];
         }

--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -1005,7 +1005,7 @@ HTML;
                 $dashboard_cards[$gridstack_id] = $html;
                 $GLPI_CACHE->set($cache_key, $dashboard_cards, new \DateInterval("PT" . $cache_age . "S"));
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $html = $render_error_html;
             $execution_time = round(microtime(true) - $start, 3);
             // Log the error message without exiting

--- a/src/Html.php
+++ b/src/Html.php
@@ -194,7 +194,7 @@ class Html
 
         try {
             $date = new \DateTime($time);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             ErrorHandler::getInstance()->handleException($e);
             Session::addMessageAfterRedirect(
                 sprintf(

--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -824,7 +824,7 @@ class Infocom extends CommonDBChild
                 throw new \RuntimeException('Empty date');
             }
             $fiscaldate = new \DateTime($fiscaldate, new DateTimeZone($TZ));
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Session::addMessageAfterRedirect(
                 __('Please fill you fiscal year date in preferences.'),
                 false,
@@ -843,7 +843,7 @@ class Infocom extends CommonDBChild
             } else {
                 $usedate = new \DateTime($buydate, new DateTimeZone($TZ));
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Session::addMessageAfterRedirect(
                 __('Please fill either buy or use date in preferences.'),
                 false,

--- a/src/Inventory/Asset/Software.php
+++ b/src/Inventory/Asset/Software.php
@@ -448,7 +448,7 @@ class Software extends InventoryAsset
             $this->populateVersions();
             $this->storeVersions();
             $this->storeAssetLink();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             throw $e;
         }
     }

--- a/src/Inventory/Conf.php
+++ b/src/Inventory/Conf.php
@@ -258,7 +258,7 @@ class Conf extends CommonGLPI
                     'items'   => $inventory_request->getInventory()->getItems(),
                 ];
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             throw $e;
         }
 

--- a/src/Inventory/Inventory.php
+++ b/src/Inventory/Inventory.php
@@ -350,7 +350,7 @@ class Inventory
                     $DB->commit();
                 }
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $DB->rollback();
             throw $e;
         } finally {

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -764,7 +764,7 @@ class MailCollector extends CommonDBTM
                         }
 
                         $messages[$message_id] = $message;
-                    } catch (\Exception $e) {
+                    } catch (\Throwable $e) {
                         $GLPI->getErrorHandler()->handleException($e);
                         Toolbox::logInFile(
                             'mailgate',
@@ -1412,7 +1412,7 @@ class MailCollector extends CommonDBTM
                     'errors' => 0
                 ]);
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->update([
                 'id'     => $this->getID(),
                 'errors' => ($this->fields['errors'] + 1)
@@ -1848,7 +1848,7 @@ class MailCollector extends CommonDBTM
             try {
                 $this->storage->moveMessage($this->storage->getNumberByUniqueId($uid), $name);
                 return true;
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                // raise an error and fallback to delete
                 trigger_error(
                     sprintf(

--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -355,7 +355,7 @@ class NotificationEventMailing extends NotificationEventAbstract
                 if (!empty($current->fields['messageid'])) {
                     $mmail->MessageID = "<" . $current->fields['messageid'] . ">";
                 }
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 self::handleFailedSend($current, $e->getMessage());
             }
 

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -1240,7 +1240,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
                               $stmt->bind_param('sss', $execution_time, $now, $row['id']);
                               $DB->executeStatement($stmt);
                         }
-                    } catch (\Exception $e) {
+                    } catch (\Throwable $e) {
                         ErrorHandler::getInstance()->handleException($e);
                     }
                 }

--- a/src/SavedSearch_Alert.php
+++ b/src/SavedSearch_Alert.php
@@ -504,7 +504,7 @@ class SavedSearch_Alert extends CommonDBChild
                               'items_id' => $row['id'],
                           ]);
                     }
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     self::restoreContext($context);
                     ErrorHandler::getInstance()->handleException($e);
                 }

--- a/src/System/Status/StatusChecker.php
+++ b/src/System/Status/StatusChecker.php
@@ -445,7 +445,7 @@ final class StatusChecker
                                 $status['servers'][$mc['name']] = [
                                     'status' => self::STATUS_OK
                                 ];
-                            } catch (\Exception $e) {
+                            } catch (\Throwable $e) {
                                 $status['servers'][$mc['name']] = [
                                     'status'       => self::STATUS_PROBLEM,
                                     'error_code'   => $e->getCode(),

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -413,7 +413,7 @@ class Toolbox
 
         try {
             $logger->addRecord($level, $msg, $extra);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
            //something went wrong, make sure logging does not cause fatal
             error_log($e);
         }

--- a/src/Transfer.php
+++ b/src/Transfer.php
@@ -287,7 +287,7 @@ class Transfer extends CommonDBTM
                 if (!$intransaction && $DB->inTransaction()) {
                     $DB->commit();
                 }
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 if (!$intransaction && $DB->inTransaction()) {
                     $DB->rollBack();
                 }

--- a/tests/web/APIRest.php
+++ b/tests/web/APIRest.php
@@ -112,7 +112,7 @@ class APIRest extends APIBaseClass
                     $this->base_uri . $relative_uri,
                     $params
                 );
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 throw $e;
             }
         }

--- a/tests/web/APIXmlrpc.php
+++ b/tests/web/APIXmlrpc.php
@@ -85,7 +85,7 @@ class APIXmlrpc extends APIBaseClass
        // launch query
         try {
             $res = $this->doHttpRequest($resource, $flat_params);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $response = $e->getResponse();
             $this->variable($response->getStatusCode())->isEqualTo($expected_codes);
             $body = xmlrpc_decode($response->getBody());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

See #14756.

PHP internal errors are not extending `\Exception`, but `\Error`. Both of them are implementing the `\Throwable` interface. When code is made to cache any error, it should then catch  `\Throwable`.

Tree of classes that are extending `\Error` and will not be catched by `catch(\Exception $e)`:
```
Error
   ArithmeticError
      DivisionByZeroError
   AssertionError
   CompileError
      ParseError
   FiberError
   TypeError
      ArgumentCountError
   UnhandledMatchError
   ValueError
```