### PR TITLE
fix(reservation): class not found

### DIFF
--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -512,7 +512,7 @@ class ReservationItem extends CommonDBChild
         ]);
 
         foreach ($iterator as $data) {
-            if (class_exists($data['itemtype']) && $data['itemtype']::canView()) {
+            if (is_a($data['itemtype'], CommonDBTM::class, true) && $data['itemtype']::canView()) {
                 $values[$data['itemtype']] = $data['itemtype']::getTypeName();
             }
         }

--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -512,7 +512,9 @@ class ReservationItem extends CommonDBChild
         ]);
 
         foreach ($iterator as $data) {
-            $values[$data['itemtype']] = $data['itemtype']::getTypeName();
+            if (class_exists($data['itemtype']) && $data['itemtype']::canView()) {
+                $values[$data['itemtype']] = $data['itemtype']::getTypeName();
+            }
         }
 
         $iterator = $DB->request([


### PR DESCRIPTION
Prevent dirty case with GenericObject: the plugin code has been deleted directly, so the data is still in the database.

![image](https://github.com/glpi-project/glpi/assets/8530352/5e09cbce-938a-4d5e-aee0-bb7b7599c606)

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
