### PR TITLE
fix log entries icon

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7241,6 +7241,7 @@ abstract class CommonITILObject extends CommonDBTM
                     'item'     => [
                         'id'                 => $log_item['id'],
                         'content'            => $content,
+                        'is_content_safe'    => true,
                         'date'               => $log_item['date_mod'],
                         'users_id'           => 0,
                         'can_edit'           => false,

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -159,7 +159,11 @@
                         {% endif %}
                      {% else %}
                         <div class="read-only-content">
-                           {{ entry_i['content']|safe_html }}
+                            {% if entry_i['is_content_safe'] %}
+                                {{ entry_i['content']|raw }}
+                            {% else %}
+                                {{ entry_i['content']|safe_html }}
+                            {% endif %}
                         </div>
                      {% endif %}
                      <div class="edit-content collapse">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Icon prefixing log entries was missing since merge of #14592 

bug:
![image](https://github.com/glpi-project/glpi/assets/418844/4333df2f-7a2f-46ae-a1f7-c1d8837bfc83)

fixed:
![image](https://github.com/glpi-project/glpi/assets/418844/39e665c6-1204-47f1-b122-c10fe343dcb5)


ping @FragDev, for your #14698 pr you need to declare `is_content_safe` also for your new timeline entry
