### PR TITLE
Kanban: add missing join

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8613,17 +8613,28 @@ abstract class CommonITILObject extends CommonDBTM
             $WHERE[] = new QueryExpression(Search::addDefaultWhere(static::class));
         }
         $base_common_itil_query = [
-            'SELECT' => ['id'],
+            'SELECT' => [static::getTableField('id')],
             'FROM'   => static::getTable(),
             'WHERE'  => $WHERE
         ];
 
+        // Add JOIN
+        $linked_tables = [];
+        $default_joint = Search::addDefaultJoin(
+            $itemtype,
+            getTableForItemType($itemtype),
+            $linked_tables, // Passed by reference, must be a defined variable even if empty
+        );
+        if (!empty($default_joint)) {
+            $base_common_itil_query['LEFT JOIN'] = [new QueryExpression($default_joint)];
+        }
+
         // Load common_itil
         $common_itil_query = $base_common_itil_query;
-        $common_itil_query['SELECT'][] = 'name';
-        $common_itil_query['SELECT'][] = 'status';
-        $common_itil_query['SELECT'][] = 'itilcategories_id';
-        $common_itil_query['SELECT'][] = 'content';
+        $common_itil_query['SELECT'][] = static::getTableField('name');
+        $common_itil_query['SELECT'][] = static::getTableField('status');
+        $common_itil_query['SELECT'][] = static::getTableField('itilcategories_id');
+        $common_itil_query['SELECT'][] = static::getTableField('content');
         $common_itil_iterator = $DB->request($common_itil_query);
 
         // Load actors (users)
@@ -8868,12 +8879,12 @@ abstract class CommonITILObject extends CommonDBTM
         });
         if (count($statuses_from_db)) {
             $criteria = [
-                'status' => $statuses_from_db
+                static::getTableField('status') => $statuses_from_db
             ];
         }
 
         // Avoid fetching everything when nothing is needed
-        if (isset($criteria['status'])) {
+        if (isset($criteria[static::getTableField('status')])) {
             $items = self::getDataToDisplayOnKanban($ID, $criteria);
         } else {
             $items = [];

--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -669,6 +669,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
             }
 
             foreach ($jointables as $jointablekey => $jointablecrit) {
+                // QueryExpression support, can be removed once Search::getDefaultJoin no longer returns raw SQL
                 if ($jointablecrit instanceof QueryExpression) {
                     $query .= $jointablecrit->getValue();
                     continue;

--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -669,6 +669,11 @@ class DBmysqlIterator implements SeekableIterator, Countable
             }
 
             foreach ($jointables as $jointablekey => $jointablecrit) {
+                if ($jointablecrit instanceof QueryExpression) {
+                    $query .= $jointablecrit->getValue();
+                    continue;
+                }
+
                 if (isset($jointablecrit['TABLE'])) {
                    //not a "simple" FKEY
                     $jointablekey = $jointablecrit['TABLE'];

--- a/tests/units/DBmysqlIterator.php
+++ b/tests/units/DBmysqlIterator.php
@@ -37,6 +37,7 @@ namespace tests\units;
 
 use DbTestCase;
 use Psr\Log\LogLevel;
+use QueryExpression;
 
 // Generic test classe, to be extended for CommonDBTM Object
 
@@ -492,6 +493,11 @@ class DBmysqlIterator extends DbTestCase
         )
          ->isInstanceOf('RuntimeException')
          ->hasMessage('BAD JOIN');
+
+        // QueryExpression
+        $expression = "LEFT JOIN xxxx";
+        $join = $this->it->analyseJoins(['LEFT JOIN' => [new QueryExpression($expression)]]);
+        $this->string($join)->isIdenticalTo($expression);
     }
 
     public function testHaving()


### PR DESCRIPTION
Issue introduced in #14333: `Search::addDefaultWhere()`  is used without the needed `JOIN` clause, which lead to invalid SQL requests.

This affect any user who can't see all the tickets and thus will have some conditions on external tables (linked user, groups, validation, ...) returned by `Search::addDefaultWhere()`.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27631
