### PR TITLE
fix(Dropdown): retrieve item recursivly

### DIFF
--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -508,7 +508,7 @@ class ReservationItem extends CommonDBChild
             'FROM'            => 'glpi_reservationitems',
             'WHERE'           => [
                 'is_active' => 1
-            ] + getEntitiesRestrictCriteria('glpi_reservationitems', 'entities_id', $_SESSION['glpiactiveentities'])
+            ] + getEntitiesRestrictCriteria('glpi_reservationitems', 'entities_id', $_SESSION['glpiactiveentities'], true)
         ]);
 
         foreach ($iterator as $data) {
@@ -541,7 +541,7 @@ class ReservationItem extends CommonDBChild
                 'itemtype'           => 'Peripheral',
                 'is_active'          => 1,
                 'peripheraltypes_id' => ['>', 0]
-            ] + getEntitiesRestrictCriteria('glpi_reservationitems', 'entities_id', $_SESSION['glpiactiveentities']),
+            ] + getEntitiesRestrictCriteria('glpi_reservationitems', 'entities_id', $_SESSION['glpiactiveentities'], true),
             'ORDERBY'   => 'glpi_peripheraltypes.name'
         ]);
 


### PR DESCRIPTION
When the user wants to filter the list of reservable items,

```Dropdown``` returns the list of ```itemtype``` for the current entity, without taking into account the notion of recursion.

Consequently, from a sub-entity, the itemtypes are no longer displayed.

The list below takes this recursion into account

from ```root``` entity

![image](https://github.com/glpi-project/glpi/assets/7335054/edc40f62-b398-4db3-bf8b-10ebc0280f0b)


from ```sub``` entity

![image](https://github.com/glpi-project/glpi/assets/7335054/3fc5db06-e98b-4bf6-b047-b6d3d077da4f)




| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28076
