### PR TITLE
Prevent deleted actors to receive new actors notifications

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8107,6 +8107,22 @@ abstract class CommonITILObject extends CommonDBTM
             'observer',
         ];
 
+        // Process deleted actors
+        foreach ($actor_types as $actor_type) {
+            foreach ($actor_itemtypes as $actor_itemtype) {
+                $actor_fkey = getForeignKeyFieldForItemType($actor_itemtype);
+                $actors_deleted_input_key = sprintf('_%s_%s_deleted', $actor_fkey, $actor_type);
+
+                $deleted = array_key_exists($actors_deleted_input_key, $this->input)
+                    ? $this->input[$actors_deleted_input_key]
+                    : [];
+                foreach ($deleted as $actor) {
+                    $actor_obj = $this->getActorObjectForItem($actor['itemtype']);
+                    $actor_obj->delete(['id' => $actor['id']]);
+                }
+            }
+        }
+
         foreach ($actor_types as $actor_type) {
             $actor_type_value = constant(CommonITILActor::class . '::' . strtoupper($actor_type));
 
@@ -8368,22 +8384,6 @@ abstract class CommonITILObject extends CommonDBTM
             foreach ($updated as $actor) {
                 $actor_obj = $this->getActorObjectForItem($actor['itemtype']);
                 $actor_obj->update($common_actor_input + $actor);
-            }
-        }
-
-        // Process deleted actors
-        foreach ($actor_types as $actor_type) {
-            foreach ($actor_itemtypes as $actor_itemtype) {
-                $actor_fkey = getForeignKeyFieldForItemType($actor_itemtype);
-                $actors_deleted_input_key = sprintf('_%s_%s_deleted', $actor_fkey, $actor_type);
-
-                $deleted = array_key_exists($actors_deleted_input_key, $this->input)
-                    ? $this->input[$actors_deleted_input_key]
-                    : [];
-                foreach ($deleted as $actor) {
-                    $actor_obj = $this->getActorObjectForItem($actor['itemtype']);
-                    $actor_obj->delete(['id' => $actor['id']]);
-                }
             }
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | see #14704

When some actors are deleted and some actors are added at the same time, deleted actor will receive notifications for new added actors. Problem is that the notification will contains deleted actors in `assigntousers`, `assigntogroups`, ... tags.

For instance, default template would contains `Assigned to technicians: {$old_user}, {$new_user}`.

In GLPI 9.5, there was no issue on this, beacause people were forced to add/remove actors in separate operations.