### PR TITLE
Fix priority JS error when using hidden impact/urgency

### DIFF
--- a/ajax/priority.php
+++ b/ajax/priority.php
@@ -44,8 +44,7 @@ if (
     && isset($_REQUEST["impact"])
 ) {
     // Read predefined templates fields
-    $predefined_fields  = $_REQUEST["_predefined_fields"] ?? [];
-    $predefined_fields  = Toolbox::decodeArrayFromInput($predefined_fields);
+    $predefined_fields  = array_key_exists('_predefined_fields', $_REQUEST) ? Toolbox::decodeArrayFromInput($_REQUEST["_predefined_fields"]) : [];
 
     // Fallback to Form value -> Template values -> Medium
     $priority = Ticket::computePriority(

--- a/ajax/priority.php
+++ b/ajax/priority.php
@@ -43,13 +43,21 @@ if (
     isset($_REQUEST["urgency"])
     && isset($_REQUEST["impact"])
 ) {
-    $priority = Ticket::computePriority($_REQUEST["urgency"], $_REQUEST["impact"]);
+    // Read predefined templates fields
+    $predefined_fields  = $_REQUEST["_predefined_fields"] ?? [];
+    $predefined_fields  = Toolbox::decodeArrayFromInput($predefined_fields);
+
+    // Fallback to Form value -> Template values -> Medium
+    $priority = Ticket::computePriority(
+        $_REQUEST["urgency"] ?: $predefined_fields['urgency'] ?? 3 /* Medium */,
+        $_REQUEST["impact"]  ?: $predefined_fields['impact']  ?? 3 /* Medium */
+    );
 
     if (isset($_REQUEST['getJson'])) {
         header("Content-Type: application/json; charset=UTF-8");
         echo json_encode(['priority' => $priority]);
-    } else if ($_REQUEST["priority"]) {
-       // Send UTF8 Headers
+    } elseif ($_REQUEST["priority"]) {
+        // Send UTF8 Headers
         header("Content-Type: text/html; charset=UTF-8");
         echo "<script type='text/javascript' >\n";
         echo Html::jsSetDropdownValue($_REQUEST["priority"], $priority);

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -610,6 +610,20 @@ abstract class CommonITILObject extends CommonDBTM
             }
         }
 
+        // Recompute priority if not predefined and impact/urgency was changed
+        if (
+            !isset($predefined_fields['priority'])
+            && (
+                isset($predefined_fields['urgency'])
+                || isset($predefined_fields['impact'])
+            )
+        ) {
+            $this->fields['priority'] = self::computePriority(
+                $this->fields['urgency'] ?? 3,
+                $this->fields['impact'] ?? 3
+            );
+        }
+
         return $predefined_fields;
     }
 

--- a/templates/components/itilobject/fields/priority_matrix.html.twig
+++ b/templates/components/itilobject/fields/priority_matrix.html.twig
@@ -103,8 +103,8 @@ $(function() {
          url: "{{ path('/ajax/priority.php') }}",
          datatype: 'json',
          data: {
-            'urgency': $('#dropdown_urgency{{ rand }}').select2('data')[0].id ?? 0,
-            'impact':  $('#dropdown_impact{{ rand }}').select2('data')[0].id ?? 0,
+            'urgency': $('#dropdown_urgency{{ rand }}').select2('data') ? $('#dropdown_urgency{{ rand }}').select2('data')[0].id : 0,
+            'impact':  $('#dropdown_impact{{ rand }}').select2('data') ? $('#dropdown_impact{{ rand }}').select2('data')[0].id : 0,
             'getJson': true,
          }
       }).done(function(data) {

--- a/templates/components/itilobject/fields/priority_matrix.html.twig
+++ b/templates/components/itilobject/fields/priority_matrix.html.twig
@@ -103,8 +103,8 @@ $(function() {
          url: "{{ path('/ajax/priority.php') }}",
          datatype: 'json',
          data: {
-            'urgency': $('#dropdown_urgency{{ rand }}').select2('data') ? $('#dropdown_urgency{{ rand }}').select2('data')[0].id : 0,
-            'impact':  $('#dropdown_impact{{ rand }}').select2('data') ? $('#dropdown_impact{{ rand }}').select2('data')[0].id : 0,
+            'urgency': $('#dropdown_urgency{{ rand }}').select2('data')?.[0]?.id ?? 0,
+            'impact':  $('#dropdown_impact{{ rand }}').select2('data')?.[0]?.id ?? 0,
             'getJson': true,
          }
       }).done(function(data) {

--- a/templates/components/itilobject/fields/priority_matrix.html.twig
+++ b/templates/components/itilobject/fields/priority_matrix.html.twig
@@ -103,8 +103,8 @@ $(function() {
          url: "{{ path('/ajax/priority.php') }}",
          datatype: 'json',
          data: {
-            'urgency': $('#dropdown_urgency{{ rand }}').select2('data')?.[0]?.id ?? 0,
-            'impact':  $('#dropdown_impact{{ rand }}').select2('data')?.[0]?.id ?? 0,
+            'urgency': $('#dropdown_urgency{{ rand }}').select2('data') ? $('#dropdown_urgency{{ rand }}').select2('data')[0].id : 0,
+            'impact':  $('#dropdown_impact{{ rand }}').select2('data') ? $('#dropdown_impact{{ rand }}').select2('data')[0].id : 0,
             'getJson': true,
          }
       }).done(function(data) {

--- a/templates/components/itilobject/fields/priority_matrix.html.twig
+++ b/templates/components/itilobject/fields/priority_matrix.html.twig
@@ -105,6 +105,7 @@ $(function() {
          data: {
             'urgency': $('#dropdown_urgency{{ rand }}').select2('data') ? $('#dropdown_urgency{{ rand }}').select2('data')[0].id : 0,
             'impact':  $('#dropdown_impact{{ rand }}').select2('data') ? $('#dropdown_impact{{ rand }}').select2('data')[0].id : 0,
+            '_predefined_fields':  $('input[name="_predefined_fields"]').val(),
             'getJson': true,
          }
       }).done(function(data) {


### PR DESCRIPTION
Javascript error that trigger when you set impact as hidden in your ticket template and try to edit the urgency dropdown (or the opposite).

![image](https://github.com/glpi-project/glpi/assets/42734840/7a7791ab-f1d2-445e-80ea-b88356074d6d)

![image](https://github.com/glpi-project/glpi/assets/42734840/29fc910d-4826-40c4-8675-fbbdc0eddc43)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
