### PR TITLE
fix loading of light theme of tinymce

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -3843,7 +3843,7 @@ JS;
         $js = <<<JS
          $(function() {
             const html_el = $('html');
-            var is_dark = html_el.attr('data-glpi-theme-dark') || html_el.css('--is-dark').trim() === 'true';
+            var is_dark = html_el.attr('data-glpi-theme-dark') === "1" || html_el.css('--is-dark').trim() === 'true';
             var richtext_layout = "{$_SESSION['glpirichtext_layout']}";
 
             // init editor


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Since a bunch of month, tinymce editors in light palette load oxyde-dark theme.
Due to:
`Boolean("0") === true`
