### PR TITLE
fix(user): prevent error message

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -6686,7 +6686,8 @@ JAVASCRIPT;
                         $added         = [];
                         for ($k = 0; $k < $data[$ID]['count']; $k++) {
                             if (
-                                strlen(trim($data[$ID][$k]['name'])) > 0
+                                isset($data[$ID][$k]['name'])
+                                && strlen(trim($data[$ID][$k]['name'])) > 0
                                 && !in_array(
                                     $data[$ID][$k]['name'] . "-" . $data[$ID][$k]['entities_id'],
                                     $added


### PR DESCRIPTION
```
PHP Deprecated function (8192): trim(): Passing null to parameter #1 ($string) of type string is deprecated in lhome/ubuntu/Dev/GLPl/10.O-bugfixes/src/Search.php at line 6689
```

![image](https://github.com/glpi-project/glpi/assets/8530352/5d474546-f545-4fd5-9562-e17c7528e656)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28185
