### PR TITLE
fix(Receveir): handle folder with emphasised character

### DIFF
--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -1393,7 +1393,7 @@ class MailCollector extends CommonDBTM
         }
 
         if (!empty($config['mailbox'])) {
-            $params['folder'] = $config['mailbox'];
+            $params['folder'] = imap_utf8_to_mutf7($config['mailbox']);
         }
 
         if ($config['validate-cert'] === false) {

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -1393,7 +1393,7 @@ class MailCollector extends CommonDBTM
         }
 
         if (!empty($config['mailbox'])) {
-            $params['folder'] = imap_utf8_to_mutf7($config['mailbox']);
+            $params['folder'] = mb_convert_encoding($config['mailbox'], 'UTF7-IMAP', 'UTF-8');
         }
 
         if ($config['validate-cert'] === false) {


### PR DESCRIPTION
Mailbox ```folder``` with  emphasised character (like ```collège_saint_vincent```) are thrown an error (from ```Gmail``` , at least that's the only case reported so far)

```
[2023-06-05 08:34:34] glpiphplog.CRITICAL:   *** Uncaught Exception Laminas\Mail\Storage\Exception\RuntimeException: cannot change folder, maybe it does not exist in /home/stanislas/TECLIB/DEV/GLPI/10.0-bugfixes/vendor/laminas/laminas-mail/src/Storage/Imap.php at line 387
  Backtrace :
  ...r/laminas/laminas-mail/src/Storage/Imap.php:228 Laminas\Mail\Storage\Imap->selectFolder()
  src/Toolbox.php:2193                               Laminas\Mail\Storage\Imap->__construct()
  src/MailCollector.php:1405                         Toolbox::getMailServerStorageInstance()
  src/MailCollector.php:698                          MailCollector->connect()
  front/mailcollector.form.php:103                   MailCollector->collect()
  
``` 

IMAP by default does not send 8-bit characters, and the original protocol defines mailboxes with non-English ASCII characters to be UTF-7 encoded (with some modifications). 

see : https://stackoverflow.com/questions/52506476/bad-could-not-parse-command-is-returned-if-mailbox-name-contains-non-english-s


NB : 
This problem does not exist with the AJAX search for a folder.

![image](https://github.com/glpi-project/glpi/assets/7335054/7be76c54-8f66-4101-9ef0-4c59e0443a03)

```{smtp.gmail.com:993/imap/ssl}collège_saint_vincent```

Who doesn't use the ```laminas-mail``` search (```examineOrSelect```) but simply browses the folder tree.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28194
