### PR TITLE
move html inputs macros to a dedicated file

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -212,6 +212,18 @@ body.in_modal {
     }
 }
 
+.btn-group {
+    .btn.btn-outline-secondary {
+        border: $input-border-width solid $input-border-color;
+
+        @include dark-mode {
+            & {
+                border-color: $input-border;
+            }
+        }
+    }
+}
+
 .toast-container {
     z-index: 999999;
     position: fixed;

--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -1,0 +1,401 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2023 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% macro input(name, value, options = {}) %}
+    {% set options = {
+        'id': '%id%',
+        'type': 'text',
+        'input_addclass': '',
+        'more_atributes': '',
+        'readonly': false,
+        'disabled': false,
+        'multiple': false,
+        'required': false,
+        'is_disclosable': false,
+        'is_copyable': false,
+        'clearable': false,
+    }|merge(options) %}
+
+    {% if options.fields_template.isMandatoryField(name) %}
+        {% set options = options|merge({'required': true}) %}
+    {% endif %}
+
+    {% if options.fields_template.isReadonlyField(name) %}
+        {% set options = options|merge({'readonly': true}) %}
+    {% endif %}
+
+    {% set input %}
+        <input type="{{ options.type }}" id="{{ options.id }}"
+               class="form-control {{ options.input_addclass }}"
+               name="{{ name }}" value="{{ value }}"
+               {{ options.more_atributes }}
+               {{ options.maxlength ? 'maxlength=' ~ options.maxlength : '' }}
+               {{ options.readonly ? 'readonly' : '' }}
+               {{ options.disabled ? 'disabled' : '' }}
+               {{ options.multiple ? 'multiple' : '' }} {# Only for emailField #}
+               {{ options.required ? 'required' : '' }}
+               {% if options.min is defined %}min="{{ options.min }}"{% endif %}
+               {% if options.max is defined %}max="{{ options.max }}"{% endif %}
+               {% if options.step is defined %}step="{{ options.step }}"{% endif %} />
+    {% endset %}
+
+    {% set more_html %}
+        {% if options.is_disclosable %}
+            <div class="btn btn-outline-secondary">
+                <i class="ti ti-eye disclose" onmousedown="showDisclosablePasswordField('{{ options.id }}')"
+                onmouseup="hideDisclosablePasswordField('{{ options.id }}')"
+                onmouseout="hideDisclosablePasswordField('{{ options.id }}')"></i>
+            </div>
+        {% endif %}
+
+        {% if options.is_copyable %}
+            <div class="btn btn-outline-secondary">
+                <i class="ti ti-clipboard-copy disclose" onclick="copyDisclosablePasswordFieldToClipboard('{{ options.id }}')"></i>
+            </div>
+        {% endif %}
+    {% endset %}
+
+    {% if more_html|trim|length > 0 %}
+        {% set input %}
+            <div class="btn-group btn-group-sm d-flex">
+                {{ input }}
+                {{ more_html }}
+            </div>
+        {% endset %}
+    {% endif %}
+
+    {% if options.clearable %}
+        <span class="d-inline-flex">
+            <input type="checkbox" name="_blank_{{ name }}" id="_blank_{{ name }}" class="ms-1">
+            <label for="_blank_{{ name }}" class="ms-1">
+                {{ __('Clear') }}
+            </label>
+        <span>
+    {% endif %}
+
+    {{ input }}
+{% endmacro %}
+
+
+{% macro text(name, value, options = {}) %}
+    {{ _self.input(name, value, options|merge({'type': 'text'})) }}
+{% endmacro %}
+
+
+{% macro number(name, value, options = {}) %}
+    {% set options = {
+        'step': 1,
+    }|merge(options) %}
+
+    {% if value == "" %}
+        {% set value = (options.min is defined ? options.min : 0) %}
+    {% endif %}
+
+    {% if options.step != 'any' and options.step|round(0, 'floor') != options.step %}
+        {# Only format number if not a whole number #}
+        {% set value = call('Html::formatNumber', [value, true]) %}
+    {% endif %}
+
+    {{ _self.input(name, value, options|merge({'type': 'number'})) }}
+{% endmacro %}
+
+
+{% macro color(name, value, options = {}) %}
+    {{ _self.input(name, value, options|merge({'type': 'text'})) }}
+    <script>
+        $(function () {
+            $("#%id%").spectrum({
+                showInput: true,
+                preferredFormat: "hex",
+                type: "text",
+                change: function (color) {
+                    if (color !== null && color.getAlpha() !== 1) {
+                        let hex = color.toHexString();
+                        hex += ("0" + Math.round(parseFloat(color.getAlpha()) * 255).toString(16)).slice(-2);
+                        this.value = hex;
+                    }
+                }
+            });
+        });
+    </script>
+{% endmacro %}
+
+
+{% macro password(name, value, options = {}) %}
+    {{ _self.input(name, value, options|merge({'type': 'password'})) }}
+{% endmacro %}
+
+
+{% macro email(name, value, options = {}) %}
+    {{ _self.input(name, value, options|merge({'type': 'email'})) }}
+{% endmacro %}
+
+
+{% macro file(name, value, options = {}) %}
+    {% set options = {
+        'simple': false,
+    }|merge(options) %}
+
+    {% if options.simple %}
+        {{ _self.input(name, value, options|merge({'type': 'file'})) }}
+    {% else %}
+        {% do call('Html::file', [
+            options|merge({
+                'name': name,
+            })
+        ]) %}
+    {% endif %}
+{% endmacro %}
+
+
+{% macro hidden(name, value, options = {}) %}
+    {{ _self.input(name, value, options|merge({'type': 'hidden'})) }}
+{% endmacro %}
+
+
+{% macro date(name, value, options = {}) %}
+    {% set options = {
+        'rand': random(),
+        'enableTime': false,
+        'checkIsExpired ': false,
+    }|merge(options) %}
+    {% set options = {'id': name|slug ~ '_' ~ options.rand}|merge(options) %}
+
+    {% if value == 'NULL' %}
+      {% set value = null %}
+   {% endif %}
+
+    {% set final_expiration_class = '' %}
+    {% if options.checkIsExpired %}
+        {% if value|date('Y-m-d H:i:s') < "now"|date('Y-m-d H:i:s') %}
+            {% set final_expiration_class = ' warn' %}
+        {% endif %}
+    {% else %}
+        {% if options.expiration_class is defined %}
+            {% set final_expiration_class = ' ' ~ options.expiration_class %}
+        {% else %}
+            {% set final_expiration_class = '' %}
+        {% endif %}
+    {% endif %}
+
+    <div class="input-group flex-grow-1 flatpickr" id="{{ options.id }}">
+        {{ _self.input(name, value, options|merge({
+            'type': 'text',
+            'id': options.id ~ '_input',
+            'more_atributes': 'data-input',
+            'input_addclass': options.input_addclass ~ final_expiration_class
+        })) }}
+
+        {% if not options.readonly %}
+            {% set calendar_icon = options.enableTime ? 'ti ti-calendar-time' : 'ti ti-calendar' %}
+            <i class="input-group-text {{ calendar_icon }}" data-toggle role="button"></i>
+        {% endif %}
+    </div>
+
+    {% set locale = get_current_locale() %}
+    {% set date_format = options.enableTime ? 'Y-m-d H:i:S' : 'Y-m-d' %}
+    {% set alt_format = call('Toolbox::getDateFormat', ['js']) ~ (options.enableTime ? ' H:i:S' : '') %}
+    <script>
+        $(function() {
+            $("#{{ options.id }}").flatpickr({
+                wrap: true,
+                altInput: true,
+                dateFormat: '{{ date_format }}',
+                altFormat: '{{ alt_format }}',
+                enableTime: {{ options.enableTime ? "true" : "false" }},
+                enableSeconds: {{ options.enableTime ? "true" : "false" }},
+                weekNumbers: true,
+                time_24hr: true,
+                allowInput: {{ options.readonly ? 'false' : 'true' }},
+                clickOpens: {{ options.readonly ? 'false' : 'true' }},
+                locale: getFlatPickerLocale("{{ locale['language'] }}", "{{ locale['region'] }}"),
+                onClose(dates, currentdatestring, picker) {
+                    picker.setDate(picker.altInput.value, true, picker.config.altFormat)
+                },
+                plugins: [
+                    CustomFlatpickrButtons()
+                ]
+            });
+        });
+    </script>
+{% endmacro %}
+
+
+{% macro datetime(name, value, options = {}) %}
+    {{ _self.date(name, value, options|merge({
+        'enableTime': true
+    })) }}
+{% endmacro %}
+
+
+{% macro textarea(name, value, options = {}) %}
+    {% set options = {
+        'rand': random(),
+        'rows': 3,
+        'enable_richtext': false,
+        'enable_images': true,
+        'enable_mentions': false,
+        'entities_id': session('glpiactive_entity'),
+        'readonly': false,
+        'disabled': false,
+        'required': false,
+    }|merge(options) %}
+
+    {% if options.fields_template.isMandatoryField(name) %}
+        {% set options = {'required': true}|merge(options) %}
+    {% endif %}
+    {% set options = options|merge({
+        'id': options.id|length > 0 ? options.id : (name ~ '_' ~ options.rand)
+    }) %}
+
+    {# 100% width is here to prevent width issues with tinymce #}
+    <textarea class="form-control {{ options.input_addclass }}"
+            id="{{ options.id }}" name="{{ name }}" rows="{{ options.rows }}"
+            style="width: 100%;"
+            {{ options.disabled ? 'disabled' : '' }}
+            {{ options.readonly ? 'readonly' : '' }}
+            {{ options.required ? 'required' : '' }}>{{ options.enable_richtext ? value|safe_html|escape : value }}</textarea>
+
+    {% if options.enable_richtext %}
+        {% do call('Html::initEditorSystem', [
+            options.id,
+            options.rand,
+            true,
+            options.disabled|default(false),
+            options.enable_images,
+            options.editor_height|default(150),
+        ]) %}
+   {% endif %}
+
+    {% if options.enable_mentions and config('use_notifications') %}
+        <script>
+            $(function() {
+                const user_mention = new GLPI.RichText.UserMention(
+                    tinymce.get('{{ options.id }}'),
+                    {{ options.entities_id }},
+                    '{{ idor_token('User', {'right': 'all', 'entity_restrict': options.entities_id}) }}'
+                );
+                user_mention.register();
+            });
+        </script>
+    {% endif %}
+{% endmacro %}
+
+
+{% macro checkbox(name, value, options = {}) %}
+    {% set options = {
+        'id': '%id%',
+        'input_addclass': '',
+        'readonly': false,
+        'disabled': false,
+        'required': false,
+    }|merge(options) %}
+
+    <input type="hidden"   name="{{ name }}" value="0" />
+    <input type="checkbox" name="{{ name }}" value="1"
+           class="form-check-input {{ options.input_addclass }}"
+           id="{{ options.id }}"
+           {{ value == 1 ? 'checked' : '' }}
+           {{ options.readonly ? 'readonly' : '' }}
+           {{ options.required ? 'required' : '' }}
+           {{ options.disabled ? 'disabled' : '' }} />
+{% endmacro %}
+
+
+{% macro button(name, label = '', type = 'button', value = '', options = {}) %}
+    {% set options = {
+        'type': 'submit',
+        'class': 'btn btn-primary',
+        'icon': '',
+        'icon_title': '',
+    }|merge(options) %}
+
+    <button class="{{ options.class }}" type="{{ type }}" name="{{ name }}" value="{{ value }}">
+        {% if options.icon is not empty %}
+            <i class="{{ options.icon }}" title="{{ options.icon_title }}"></i>
+        {% endif %}
+        {% if label is not empty %}
+            <span>{{ label }}</span>
+        {% endif %}
+    </button>
+{% endmacro %}
+
+
+{% macro submit(name, label = '', value = '', options = {}) %}
+    {{ _self.button(name, value, 'submit', label, options) }}
+{% endmacro %}
+
+{% macro label(label, id, options = {}, class = 'form-label') %}
+    {% set options = {
+        locked: false,
+        locked_value: null
+    }|merge(options) %}
+
+    {% set required_mark = '' %}
+    {% if options.fields_template.isMandatoryField(options.name) or options.required %}
+        {% set required_mark = '<span class="required">*</span>' %}
+    {% endif %}
+
+    {% set helper = '' %}
+    {% if options.helper %}
+        {% set helper %}
+        <span class="form-help"
+              data-bs-toggle="popover"
+              data-bs-placement="top"
+              data-bs-html="true"
+              data-bs-content="{{ options.helper }}">
+            ?
+        </span>
+        {% endset %}
+    {% endif %}
+
+    {% set locked_mark = '' %}
+    {% if options.locked %}
+        {% set locked_mark %}
+        {% set locked_title %}{{ __('Field will not be updated from inventory') }}{% endset %}
+        {% if options.locked_value is not empty %}
+            {% set locked_title %}{{ locked_title }}
+            -
+            {{ __('Last inventory value was:') ~ ' ' ~ options.locked_value }}{% endset %}
+        {% endif %}
+        <i class="ti ti-lock" title="{{ locked_title }}" data-bs-toggle="tooltip"></i>
+        {% endset %}
+    {% endif %}
+
+    <label class="{{ class }}" for="{{ id }}">
+        {{ label|raw }}
+        {{ locked_mark|raw }}
+        {{ required_mark|raw }}
+        {{ helper|raw }}
+    </label>
+{% endmacro %}

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -86,23 +86,9 @@
 
 
 {% macro textField(name, value, label = '', options = {}) %}
-   {% set options = {'type': 'text'}|merge(options) %}
-   {% if options.fields_template.isMandatoryField(name) %}
-      {% set options = {'required': true}|merge(options) %}
-   {% endif %}
-   {% if options.fields_template.isReadonlyField(name) %}
-      {% set options = options|merge({'readonly': true}) %}
-   {% endif %}
-
    {% set field %}
-      <input type="{{ options.type }}" id="%id%"
-             class="form-control {{ options.input_addclass }}"
-             name="{{ name }}" value="{{ value }}"
-             {{ options.maxlength ? 'maxlength=' ~ options.maxlength : '' }}
-             {{ options.readonly ? 'readonly' : '' }}
-             {{ options.disabled ? 'disabled' : '' }}
-             {{ options.multiple ? 'multiple' : '' }} {# Only for emailField #}
-             {{ options.required ? 'required' : '' }} />
+        {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
+        {{ _inputs.text(name, value, options) }}
    {% endset %}
 
    {{ _self.field(name, field, label, options) }}
@@ -110,27 +96,16 @@
 
 
 {% macro checkboxField(name, value, label = '', options = {}) %}
-   {% if options.fields_template.isMandatoryField(name) %}
-      {% set options = {'required': true}|merge(options) %}
-   {% endif %}
-   {% if options.fields_template.isReadonlyField(name) %}
-      {% set options = options|merge({'readonly': true}) %}
-   {% endif %}
-
    {% set options = {
       'center': true,
    }|merge(options) %}
 
-   {% set field %}
-      <input type="hidden"   name="{{ name }}" value="0" />
-      <input type="checkbox" name="{{ name }}" value="1" class="form-check-input" id="%id%"
-             {{ value == 1 ? 'checked' : '' }}
-             {{ options.readonly ? 'readonly' : '' }}
-             {{ options.required ? 'required' : '' }}
-             {{ options.disabled ? 'disabled' : '' }} />
-   {% endset %}
+    {% set field %}
+        {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
+        {{ _inputs.checkbox(name, value, options) }}
+    {% endset %}
 
-   {{ _self.field(name, field, label, options) }}
+    {{ _self.field(name, field, label, options) }}
 {% endmacro %}
 
 
@@ -167,31 +142,12 @@
 
 
 {% macro numberField(name, value, label = '', options = {}) %}
-   {% if options.step != 'any' and options.step|round(0, 'floor') != options.step %}
-      {# Only format number if not a whole number #}
-      {% set value = call('Html::formatNumber', [value, true]) %}
-   {% endif %}
+    {% set field %}
+        {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
+        {{ _inputs.number(name, value, options) }}
+    {% endset %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
-      {% set options = options|merge({'readonly': true}) %}
-   {% endif %}
-
-   {% if value == "" %}
-      {% set value = (options.min is defined ? options.min : 0) %}
-   {% endif %}
-
-   {% set field %}
-      <input type="number" id="%id%"
-             class="form-control {{ options.input_addclass }}"
-             name="{{ name }}" value="{{ value }}"
-         {{ options.readonly ? 'readonly' : '' }}
-         {{ options.disabled ? 'disabled' : '' }}
-         {{ options.required ? 'required' : '' }}
-         {% if options.min is defined %}min="{{ options.min }}"{% endif %}
-         {% if options.max is defined %}max="{{ options.max }}"{% endif %}
-         {% if options.step is defined %}step="{{ options.step }}"{% endif %} />
-   {% endset %}
-   {{ _self.field(name, field, label, options) }}
+    {{ _self.field(name, field, label, options) }}
 {% endmacro %}
 
 
@@ -221,39 +177,16 @@
       'uploads': []
    }|merge(options) %}
 
-   {% if options.fields_template.isMandatoryField(name) %}
-      {% set options = {'required': true}|merge(options) %}
-   {% endif %}
-   {% if options.fields_template.isReadonlyField(name) %}
-      {% set options = options|merge({'readonly': true}) %}
-   {% endif %}
-   {% set id = options.id|length > 0 ? options.id : (name ~ '_' ~ options.rand) %}
-
    {% set field %}
-      {# 100% width is here to prevent width issues with tinymce #}
-      <textarea class="form-control {{ options.input_addclass }}" id="{{ id }}" name="{{ name }}" rows="3"
-                style="width: 100%;"
-                {{ options.disabled ? 'disabled' : '' }}
-                {{ options.readonly ? 'readonly' : '' }}
-                {{ options.required ? 'required' : '' }}>{{ options.enable_richtext ? value|safe_html|escape : value }}</textarea>
+        {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
+        {{ _inputs.textarea(name, value, options) }}
    {% endset %}
-
-   {% if options.enable_richtext %}
-      {% do call('Html::initEditorSystem', [
-         id,
-         options.rand,
-         true,
-         options.disabled|default(false),
-         options.enable_images,
-         options.editor_height|default(150),
-      ]) %}
-   {% endif %}
 
    {% set add_html = '' %}
    {% if not options.readonly and options.enable_fileupload %}
       {% set add_html %}
          {% do call('Html::file', [{
-             'editor_id': id,
+             'editor_id': options.id,
              'multiple': true,
              'uploads': options.uploads,
              'required': options.fields_template.isMandatoryField('_documents_id')
@@ -262,7 +195,7 @@
    {% elseif not options.readonly and not options.enable_fileupload and options.enable_richtext and options.enable_images %}
       {% set add_html %}
          {% do call('Html::file', [{
-             'editor_id': id,
+             'editor_id': options.id,
              'name': name,
              'only_uploaded_files': true,
              'uploads': options.uploads,
@@ -279,239 +212,72 @@
    {% endif %}
 
    {{ _self.field(name, field, label, options) }}
-   {% if options.enable_mentions and config('use_notifications') %}
-      <script>
-         $(
-            function() {
-               const user_mention = new GLPI.RichText.UserMention(
-                  tinymce.get('{{ id }}'),
-                  {{ options.entities_id }},
-                  '{{ idor_token('User', {'right': 'all', 'entity_restrict': options.entities_id}) }}'
-               );
-               user_mention.register();
-            }
-         )
-      </script>
-   {% endif %}
 {% endmacro %}
 
-{% macro flatpickrHtmlInput(name, value, label = '', options = {}) %}
-   {% if options.fields_template.isMandatoryField(name) %}
-      {% set options = {'required': true}|merge(options) %}
-   {% endif %}
-   {% if options.fields_template.isReadonlyField(name) %}
-      {% set options = options|merge({'readonly': true}) %}
-   {% endif %}
-
-   {% if value == 'NULL' %}
-      {% set value = null %}
-   {% endif %}
-   {% if options.checkIsExpired %}
-      {% if value|date('Y-m-d H:i:s') < "now"|date('Y-m-d H:i:s') %}
-         {% set class = 'warn' %}
-      {% endif %}
-   {% else %}
-      {% if options.expiration_class is defined %}
-         {% set class = options.expiration_class %}
-      {% else %}
-         {% set class = '' %}
-      {% endif %}
-   {% endif %}
-
-   <div class="input-group flex-grow-1 flatpickr" id="{{ options.id }}">
-      {# .rounded-start added to prevent issue with bootstrap .input-group #}
-      {# the first element is an input[type=hidden] added by flatpickr and so we don't have border-radius on the start #}
-      <input type="text" class="form-control rounded-start ps-2 {{ options.input_addclass }} {{ class }}" data-input
-             name="{{ name }}" value="{{ value }}"
-             {{ options.required ? 'required' : '' }}
-             {{ options.readonly ? 'readonly' : '' }}
-             {{ options.disabled ? 'disabled' : '' }} />
-      {% if not options.readonly %}
-         <i class="input-group-text far fa-calendar-alt" data-toggle role="button"></i>
-      {% endif %}
-   </div>
-{% endmacro %}
 
 {% macro dateField(name, value, label = '', options = {}) %}
-   {% set options = {'rand': random()}|merge(options) %}
-   {% set options = {'id': name|slug ~ '_' ~ options.rand}|merge(options) %}
-   {% set locale = get_current_locale() %}
-
-   {% if options.fields_template.isReadonlyField(name) %}
-      {% set options = options|merge({'readonly': true}) %}
-   {% endif %}
-
    {% set field %}
-      {{ _self.flatpickrHtmlInput(name, value, label, options) }}
-      <script>
-      $(function() {
-         $("#{{ options.id }}").flatpickr({
-            wrap: true,
-            altInput: true,
-            altFormat: '{{ call('Toolbox::getDateFormat', ['js']) }}',
-            dateFormat: 'Y-m-d',
-            enableTime: false,
-            weekNumbers: true,
-            time_24hr: true,
-            allowInput: {{ options.readonly ? 'false' : 'true' }},
-            clickOpens: {{ options.readonly ? 'false' : 'true' }},
-            locale: getFlatPickerLocale("{{ locale['language'] }}", "{{ locale['region'] }}"),
-            onClose(dates, currentdatestring, picker) {
-               picker.setDate(picker.altInput.value, true, picker.config.altFormat)
-            },
-            plugins: [
-               CustomFlatpickrButtons()
-            ]
-         });
-      });
-      </script>
+        {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
+        {{ _inputs.date(name, value, options) }}
    {% endset %}
 
    {{ _self.field(name, field, label, options) }}
 {% endmacro %}
+
 
 {% macro datetimeField(name, value, label = '', options = {}) %}
-   {% set options = {'rand': random()}|merge(options) %}
-   {% set options = {'id': name|slug ~ '_' ~ options.rand}|merge(options) %}
-   {% set locale = get_current_locale() %}
-
-   {% if options.fields_template.isReadonlyField(name) %}
-      {% set options = options|merge({'readonly': true}) %}
-   {% endif %}
-
    {% set field %}
-      {{ _self.flatpickrHtmlInput(name, value, label, options) }}
-      <script>
-      $(function() {
-         $('#{{ options.id }}').flatpickr({
-            altInput: true,
-            dateFormat: 'Y-m-d H:i:S',
-            altFormat: '{{ call('Toolbox::getDateFormat', ['js']) }} H:i:S',
-            enableTime: true,
-            wrap: true,
-            enableSeconds: true,
-            weekNumbers: true,
-            time_24hr: true,
-            allowInput: {{ options.readonly ? 'false' : 'true' }},
-            clickOpens: {{ options.readonly ? 'false' : 'true' }},
-            locale: getFlatPickerLocale('{{ locale['language'] }}', '{{ locale['region'] }}'),
-            onClose(dates, currentdatestring, picker) {
-               picker.setDate(picker.altInput.value, true, picker.config.altFormat)
-            },
-            plugins: [
-               CustomFlatpickrButtons()
-            ]
-         });
-      });
-      </script>
+        {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
+        {{ _inputs.datetime(name, value, options) }}
    {% endset %}
 
    {{ _self.field(name, field, label, options) }}
 {% endmacro %}
+
 
 {% macro colorField(name, value, label = '', options = {}) %}
-   {% if options.fields_template.isReadonlyField(name) %}
-      {% set options = options|merge({'readonly': true}) %}
-   {% endif %}
-   {% set field %}
-      <input id="%id%"
-             class="form-control {{ options.input_addclass }}"
-             name="{{ name }}" value="{{ value }}"
-         {{ options.readonly ? 'readonly' : '' }}
-         {{ options.disabled ? 'disabled' : '' }}
-         {{ options.required ? 'required' : '' }} />
-      <script>
-      $(function() {
-        $("#%id%").spectrum({
-            showInput: true,
-            preferredFormat: "hex",
-            type: "text",
-            change: function(color) {
-                if (color !== null && color.getAlpha() !== 1) {
-                    let hex = color.toHexString();
-                    hex += ("0" + Math.round(parseFloat(color.getAlpha()) * 255).toString(16)).slice(-2);
-                    this.value = hex;
-                }
-            }
-        });
-      });
-      </script>
-   {% endset %}
-   {{ _self.field(name, field, label, options) }}
+    {% set field %}
+        {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
+        {{ _inputs.color(name, value, options) }}
+    {% endset %}
+
+    {{ _self.field(name, field, label, options) }}
 {% endmacro %}
+
 
 {% macro passwordField(name, value, label = '', options = {}) %}
    {% set options = {
-      'autocomplete': 'new-password',
-      'is_disclosable': false,
-      'rand': options.rand ?? random()
-   }|merge(options) %}
-   {% set options = {
       'id': options.id is defined ? options.id : name ~ random(),
       'clearable': options.clearable is defined ? options.clearable : not options.is_disclosable,
+      'is_copyable': options.is_disclosable ?? false
    }|merge(options) %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
-      {% set options = options|merge({'readonly': true}) %}
-   {% endif %}
-
-   {% set field %}
-      <input type="password" id="{{ options.id }}"
-             class="form-control {{ options.input_addclass }}"
-             name="{{ name }}"
-             value="{{ options.is_disclosable ? value : '' }}"
-         {{ options.readonly ? 'readonly' : '' }}
-         {{ options.disabled ? 'disabled' : '' }}
-         {{ options.required ? 'required' : '' }} />
-   {% endset %}
-   {% set btn_group %}
-      &nbsp;<i class="far fa-eye pointer disclose" onmousedown="showDisclosablePasswordField('{{ options.id }}')"
-               onmouseup="hideDisclosablePasswordField('{{ options.id }}')"
-               onmouseout="hideDisclosablePasswordField('{{ options.id }}')"></i>
-      &nbsp;<i class="fa fa-paste pointer disclose" onclick="copyDisclosablePasswordFieldToClipboard('{{ options.id }}')"></i>
-   {% endset %}
-   {% if options.is_disclosable %}
-      {% set label = label ~ btn_group %}
-   {% endif %}
-   {% if options.clearable %}
-      {% set clear_chk %}
-         <input type="checkbox" name="_blank_{{ name }}" id="_blank_{{ name }}">&nbsp;<label for="_blank_{{ name }}">{{ __('Clear') }}</label>
-      {% endset %}
-      {% set field = field ~ clear_chk %}
-   {% endif %}
+    {% set field %}
+        {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
+        {{ _inputs.password(name, value, options) }}
+    {% endset %}
 
    {{ _self.field(name, field, label, options) }}
 {% endmacro %}
 
+
 {% macro emailField(name, value, label = '', options = {}) %}
-   {% set options = {'type': 'email'}|merge(options) %}
-   {% if options.fields_template.isReadonlyField(name) %}
-      {% set options = options|merge({'readonly': true}) %}
-   {% endif %}
-   {{ _self.textField(name, value, label, options) }}
+    {% set field %}
+        {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
+        {{ _inputs.email(name, value, options) }}
+    {% endset %}
+
+   {{ _self.field(name, field, label, options) }}
 {% endmacro %}
 
 {% macro fileField(name, value, label = '', options = {}) %}
    {% set options = {
       'rand': random(),
-      'name': name,
       'simple': false,
    }|merge(options) %}
-   {% if options.fields_template.isReadonlyField(name) %}
-      {% set options = options|merge({'readonly': true}) %}
-   {% endif %}
    {% set field %}
-      {% if options.simple %}
-        <input type="file" id="%id%"
-               class="form-control {{ options.input_addclass }}"
-               name="{{ name }}"
-               {{ options.multiple ? 'multiple' : '' }}
-               {{ options.readonly ? 'readonly' : '' }}
-               {{ options.disabled ? 'disabled' : '' }}
-               {{ options.required ? 'required' : '' }} />
-      {% else %}
-        {% do call('Html::file', [options]) %}
-      {% endif %}
+        {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
+        {{ _inputs.file(name, value, options) }}
    {% endset %}
    {{ _self.field(name, field, label, options) }}
 {% endmacro %}
@@ -569,7 +335,8 @@
    {% endif %}
 
    {% set id = options.id|length > 0 ? options.id : (name ~ '_' ~ options.rand) %}
-   {{ _self.label(label, id, options) }}
+   {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
+   {{ _inputs.label(label, id, options) }}
    {{ _self.field(name, field, label, options|merge({
       'full_width': true,
       'no_label': true
@@ -583,12 +350,8 @@
       }|merge(options) %}
    {% endif %}
    {% set field %}
-      <input type="hidden" id="%id%"
-             class="form-control {{ options.input_addclass }}"
-             name="{{ name }}" value="{{ value }}"
-         {{ options.readonly ? 'readonly' : '' }}
-         {{ options.disabled ? 'disabled' : '' }}
-         {{ options.required ? 'required' : '' }} />
+        {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
+        {{ _inputs.hidden(name, value, options) }}
    {% endset %}
    {{ _self.field(name, field, label, options) }}
 {% endmacro %}
@@ -1002,7 +765,8 @@
    {% endif %}
 
    <div class="form-field row align-items-center {{ options.field_class }} {{ options.add_field_class }} {{ options.mb }}" {{ extra_attribs|raw }}>
-      {{ _self.label(label, id, options, 'col-form-label ' ~ options.label_class) }}
+      {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
+      {{ _inputs.label(label, id, options, 'col-form-label ' ~ options.label_class) }}
       {% if options.center %}
          {% set flex_class = "d-flex align-items-center" %}
       {% endif %}
@@ -1036,7 +800,8 @@
    {% endif %}
 
    <div class="form-field {{ options.field_class }} {{ options.add_field_class }} {{ options.mb }}" {{ extra_attribs|raw }}>
-      {{ _self.label(label, id, options, 'col-form-label ' ~ options.label_class) }}
+      {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
+      {{ _inputs.label(label, id, options, 'col-form-label ' ~ options.label_class) }}
       <div class="{{ options.input_class }} field-container">
          {{ field|raw }}
       </div>
@@ -1046,43 +811,6 @@
 
 
 {% macro label(label, id, options = {}, class = 'form-label') %}
-    {% set options = {
-        locked: false,
-        locked_value: null
-    }|merge(options) %}
-
-   {% set required_mark = '' %}
-   {% if options.fields_template.isMandatoryField(options.name) or options.required %}
-      {% set required_mark = '<span class="required">*</span>' %}
-   {% endif %}
-
-   {% set helper = '' %}
-   {% if options.helper %}
-      {% set helper %}
-         <span class="form-help" data-bs-toggle="popover" data-bs-placement="top" data-bs-html="true"
-               data-bs-content="{{ options.helper }}">
-            ?
-         </span>
-      {% endset %}
-   {% endif %}
-
-   {% set locked_mark = '' %}
-   {% if options.locked %}
-      {% set locked_mark %}
-        {% set locked_title %}{{ __('Field will not be updated from inventory') }}{% endset %}
-        {% if options.locked_value is not empty %}
-            {% set locked_title %}{{ locked_title }} - {{ __('Last inventory value was:') ~ ' ' ~ options.locked_value }}{% endset %}
-        {% endif %}
-        <i class="ti ti-lock"
-           title="{{ locked_title }}"
-           data-bs-toggle="tooltip"></i>
-      {% endset %}
-   {% endif %}
-
-   <label class="{{ class }}" for="{{ id }}">
-      {{ label|raw }}
-      {{ locked_mark|raw }}
-      {{ required_mark|raw }}
-      {{ helper|raw }}
-   </label>
+    {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
+    {{ _inputs.label(label, id, options, class) }}
 {% endmacro %}


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | [#14852](https://github.com/glpi-project/glpi/pull/14852)

Add a new twig macro to create a button.
To use it, simply enter its label, name and type. You can also add the button class and an icon.
![image](https://github.com/glpi-project/glpi/assets/107540223/4afc9b0f-b716-4721-8937-099a2c36461d)
![image](https://github.com/glpi-project/glpi/assets/107540223/00fb8ed3-2b71-4b4c-bcc0-f040e8e87bea)
