### PR TITLE
Fix network port wiring uniqueness check

### DIFF
--- a/src/NetworkPort_NetworkPort.php
+++ b/src/NetworkPort_NetworkPort.php
@@ -263,11 +263,16 @@ class NetworkPort_NetworkPort extends CommonDBRelation
 
     public function prepareInputForAdd($input)
     {
+        $crit = [
+            'OR'  => [
+                ['networkports_id_1'  => $input['networkports_id_1']],
+                ['networkports_id_1'  => $input['networkports_id_2']],
+                ['networkports_id_2'  => $input['networkports_id_1']],
+                ['networkports_id_2'  => $input['networkports_id_2']],
+            ]
+        ];
 
-        if (
-            $this->getFromDBForNetworkPort($input['networkports_id_1'])
-            || $this->getFromDBForNetworkPort($input['networkports_id_2'])
-        ) {
+        if (countElementsInTable($this->getTable(), $crit)) {
             trigger_error('Wired non unique!', E_USER_WARNING);
             return false;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | see #14853

The check that should prevent a same network port to be wired multiple times is not working when there is already a lack of uniqueness in wiring. Indeed, if there is already multiple entries for the network port, `getFromDBByCrit()/getFromDBForNetworkPort()` will return false, and existing check will pass.