### PR TITLE
Replace CURRENT_TIMESTAMP

### DIFF
--- a/src/CartridgeItem.php
+++ b/src/CartridgeItem.php
@@ -35,6 +35,7 @@
 
 use Glpi\DBAL\QueryExpression;
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\DBAL\QueryFunction;
 use Glpi\Features\AssetImage;
 
 /**
@@ -422,7 +423,11 @@ class CartridgeItem extends CommonDBTM
                             'glpi_cartridgeitems.entities_id'     => $entity,
                             'OR'                                  => [
                                 ['glpi_alerts.date' => null],
-                                ['glpi_alerts.date' => ['<', new QueryExpression('CURRENT_TIMESTAMP() - INTERVAL ' . $repeat . ' second')]],
+                                ['glpi_alerts.date' => ['<', QueryFunction::dateSub(
+                                    date: QueryFunction::now(),
+                                    interval: $repeat,
+                                    interval_unit: 'SECOND'
+                                )]],
                             ],
                         ],
                     ]

--- a/src/CartridgeItem.php
+++ b/src/CartridgeItem.php
@@ -423,11 +423,15 @@ class CartridgeItem extends CommonDBTM
                             'glpi_cartridgeitems.entities_id'     => $entity,
                             'OR'                                  => [
                                 ['glpi_alerts.date' => null],
-                                ['glpi_alerts.date' => ['<', QueryFunction::dateSub(
-                                    date: QueryFunction::now(),
-                                    interval: $repeat,
-                                    interval_unit: 'SECOND'
-                                )]],
+                                [
+                                    'glpi_alerts.date' => ['<',
+                                        QueryFunction::dateSub(
+                                            date: QueryFunction::now(),
+                                            interval: $repeat,
+                                            interval_unit: 'SECOND'
+                                        )
+                                    ]
+                                ],
                             ],
                         ],
                     ]

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -720,11 +720,15 @@ class Certificate extends CommonDBTM
                 $where_date = [
                     'OR' => [
                         ['glpi_alerts.date' => null],
-                        ['glpi_alerts.date' => ['<', QueryFunction::dateSub(
-                            date: QueryFunction::now(),
-                            interval: $repeat,
-                            interval_unit: 'SECOND'
-                        )]],
+                        [
+                            'glpi_alerts.date' => ['<',
+                                QueryFunction::dateSub(
+                                    date: QueryFunction::now(),
+                                    interval: $repeat,
+                                    interval_unit: 'SECOND'
+                                )
+                            ]
+                        ],
                     ]
                 ];
             } else {

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -35,6 +35,7 @@
 
 use Glpi\DBAL\QueryExpression;
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\DBAL\QueryFunction;
 
 /**
  * @since 9.2
@@ -719,7 +720,11 @@ class Certificate extends CommonDBTM
                 $where_date = [
                     'OR' => [
                         ['glpi_alerts.date' => null],
-                        ['glpi_alerts.date' => ['<', new QueryExpression('CURRENT_TIMESTAMP() - INTERVAL ' . $repeat . ' second')]],
+                        ['glpi_alerts.date' => ['<', QueryFunction::dateSub(
+                            date: QueryFunction::now(),
+                            interval: $repeat,
+                            interval_unit: 'SECOND'
+                        )]],
                     ]
                 ];
             } else {

--- a/src/CommonITILValidationCron.php
+++ b/src/CommonITILValidationCron.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\DBAL\QueryExpression;
+use Glpi\DBAL\QueryFunction;
 
 /**
  * Cron task for approval reminder
@@ -82,10 +83,18 @@ class CommonITILValidationCron extends CommonDBTM
                         'WHERE'  => [
                             'status'          => CommonITILValidation::WAITING,
                             'entities_id'     => $entity,
-                            'submission_date' => ['<', new QueryExpression('CURRENT_TIMESTAMP() - INTERVAL ' . $repeat . ' second')],
+                            'submission_date' => ['<', QueryFunction::dateSub(
+                                date: QueryFunction::now(),
+                                interval: $repeat,
+                                interval_unit: 'SECOND'
+                            )],
                             'OR'              => [
                                 ['last_reminder_date' => null],
-                                ['last_reminder_date' => ['<', new QueryExpression('CURRENT_TIMESTAMP() - INTERVAL ' . $repeat . ' second')]],
+                                ['last_reminder_date' => ['<', QueryFunction::dateSub(
+                                    date: QueryFunction::now(),
+                                    interval: $repeat,
+                                    interval_unit: 'SECOND'
+                                )]],
                             ],
                         ]
                     ]);

--- a/src/CommonITILValidationCron.php
+++ b/src/CommonITILValidationCron.php
@@ -83,18 +83,24 @@ class CommonITILValidationCron extends CommonDBTM
                         'WHERE'  => [
                             'status'          => CommonITILValidation::WAITING,
                             'entities_id'     => $entity,
-                            'submission_date' => ['<', QueryFunction::dateSub(
-                                date: QueryFunction::now(),
-                                interval: $repeat,
-                                interval_unit: 'SECOND'
-                            )],
-                            'OR'              => [
-                                ['last_reminder_date' => null],
-                                ['last_reminder_date' => ['<', QueryFunction::dateSub(
+                            'submission_date' => ['<',
+                                QueryFunction::dateSub(
                                     date: QueryFunction::now(),
                                     interval: $repeat,
                                     interval_unit: 'SECOND'
-                                )]],
+                                )
+                            ],
+                            'OR'              => [
+                                ['last_reminder_date' => null],
+                                [
+                                    'last_reminder_date' => ['<',
+                                        QueryFunction::dateSub(
+                                            date: QueryFunction::now(),
+                                            interval: $repeat,
+                                            interval_unit: 'SECOND'
+                                        )
+                                    ]
+                                ],
                             ],
                         ]
                     ]);

--- a/src/ConsumableItem.php
+++ b/src/ConsumableItem.php
@@ -342,11 +342,15 @@ class ConsumableItem extends CommonDBTM
                             'glpi_consumableitems.entities_id'     => $entity,
                             'OR'                                  => [
                                 ['glpi_alerts.date' => null],
-                                ['glpi_alerts.date' => ['<', QueryFunction::dateSub(
-                                    date: QueryFunction::now(),
-                                    interval: $repeat,
-                                    interval_unit: 'SECOND'
-                                )]],
+                                [
+                                    'glpi_alerts.date' => ['<',
+                                        QueryFunction::dateSub(
+                                            date: QueryFunction::now(),
+                                            interval: $repeat,
+                                            interval_unit: 'SECOND'
+                                        )
+                                    ]
+                                ],
                             ],
                         ],
                     ]

--- a/src/ConsumableItem.php
+++ b/src/ConsumableItem.php
@@ -35,6 +35,7 @@
 
 use Glpi\DBAL\QueryExpression;
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\DBAL\QueryFunction;
 use Glpi\Features\AssetImage;
 
 //!  ConsumableItem Class
@@ -341,7 +342,11 @@ class ConsumableItem extends CommonDBTM
                             'glpi_consumableitems.entities_id'     => $entity,
                             'OR'                                  => [
                                 ['glpi_alerts.date' => null],
-                                ['glpi_alerts.date' => ['<', new QueryExpression('CURRENT_TIMESTAMP() - INTERVAL ' . $repeat . ' second')]],
+                                ['glpi_alerts.date' => ['<', QueryFunction::dateSub(
+                                    date: QueryFunction::now(),
+                                    interval: $repeat,
+                                    interval_unit: 'SECOND'
+                                )]],
                             ],
                         ],
                     ]

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -38,6 +38,7 @@ declare(ticks=1);
 
 use Glpi\DBAL\QueryExpression;
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\DBAL\QueryFunction;
 use Glpi\Event;
 
 /**
@@ -504,7 +505,11 @@ class CronTask extends CommonDBTM
                 'WHERE'     => [
                     'items_id' => $this->fields['id'],
                     'itemtype' => 'CronTask',
-                    'date'     => ['>', new QueryExpression('CURRENT_TIMESTAMP() - INTERVAL 1 day')],
+                    'date'     => ['>', QueryFunction::dateSub(
+                        date: QueryFunction::now(),
+                        interval: 1,
+                        interval_unit: 'DAY'
+                    )],
                 ],
             ]
         );

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -505,11 +505,13 @@ class CronTask extends CommonDBTM
                 'WHERE'     => [
                     'items_id' => $this->fields['id'],
                     'itemtype' => 'CronTask',
-                    'date'     => ['>', QueryFunction::dateSub(
-                        date: QueryFunction::now(),
-                        interval: 1,
-                        interval_unit: 'DAY'
-                    )],
+                    'date'     => ['>',
+                        QueryFunction::dateSub(
+                            date: QueryFunction::now(),
+                            interval: 1,
+                            interval_unit: 'DAY'
+                        )
+                    ],
                 ],
             ]
         );

--- a/src/DBAL/QueryFunction.php
+++ b/src/DBAL/QueryFunction.php
@@ -114,6 +114,23 @@ class QueryFunction
     }
 
     /**
+     * Build an DATE_SUB SQL function call
+     * @param string|QueryExpression $date Date to add interval to
+     * @param int|string|QueryExpression $interval Interval to add
+     * @param string $interval_unit Interval unit
+     * @param string|null $alias Function result alias (will be automatically quoted)
+     * @return QueryExpression
+     */
+    public static function dateSub(string|QueryExpression $date, int|string|QueryExpression $interval, string $interval_unit, ?string $alias = null): QueryExpression
+    {
+        global $DB;
+        $date = $date instanceof QueryExpression ? $date : $DB::quoteName($date);
+        $interval = is_string($interval) ? $DB::quoteValue($interval) : $interval;
+        $exp = sprintf('DATE_SUB(%s, INTERVAL %s %s)', $date, $interval, strtoupper($interval_unit));
+        return new QueryExpression($exp, $alias);
+    }
+
+    /**
      * Build an IF SQL function call
      * @param string|QueryExpression|array $condition Condition to test
      * @param string|QueryExpression $true_expression Expression to return if condition is true

--- a/src/SavedSearch_Alert.php
+++ b/src/SavedSearch_Alert.php
@@ -35,6 +35,7 @@
 
 use Glpi\DBAL\QueryExpression;
 use Glpi\Application\ErrorHandler;
+use Glpi\DBAL\QueryFunction;
 use Glpi\Plugin\Hooks;
 
 /**
@@ -399,12 +400,11 @@ class SavedSearch_Alert extends CommonDBChild
                 'glpi_savedsearches_alerts.is_active' => true,
                 'OR' => [
                     ['glpi_alerts.date' => null],
-                    ['glpi_alerts.date' => ['<', new QueryExpression(sprintf(
-                        'CURRENT_TIMESTAMP() - INTERVAL %s second',
-                        $DB->quoteName('glpi_savedsearches_alerts.frequency')
-                    ))
-                    ]
-                    ],
+                    ['glpi_alerts.date' => ['<', QueryFunction::dateSub(
+                        date: QueryFunction::now(),
+                        interval: 'glpi_savedsearches_alerts.frequency',
+                        interval_unit: 'SECOND'
+                    )]]
                 ]
             ]
         ]);

--- a/src/SavedSearch_Alert.php
+++ b/src/SavedSearch_Alert.php
@@ -404,7 +404,7 @@ class SavedSearch_Alert extends CommonDBChild
                         'glpi_alerts.date' => ['<',
                             QueryFunction::dateSub(
                                 date: QueryFunction::now(),
-                                interval: 'glpi_savedsearches_alerts.frequency',
+                                interval: new QueryExpression($DB::quoteName('glpi_savedsearches_alerts.frequency')),
                                 interval_unit: 'SECOND'
                             )
                         ]

--- a/src/SavedSearch_Alert.php
+++ b/src/SavedSearch_Alert.php
@@ -400,11 +400,15 @@ class SavedSearch_Alert extends CommonDBChild
                 'glpi_savedsearches_alerts.is_active' => true,
                 'OR' => [
                     ['glpi_alerts.date' => null],
-                    ['glpi_alerts.date' => ['<', QueryFunction::dateSub(
-                        date: QueryFunction::now(),
-                        interval: 'glpi_savedsearches_alerts.frequency',
-                        interval_unit: 'SECOND'
-                    )]]
+                    [
+                        'glpi_alerts.date' => ['<',
+                            QueryFunction::dateSub(
+                                date: QueryFunction::now(),
+                                interval: 'glpi_savedsearches_alerts.frequency',
+                                interval_unit: 'SECOND'
+                            )
+                        ]
+                    ]
                 ]
             ]
         ]);

--- a/src/User.php
+++ b/src/User.php
@@ -6219,7 +6219,11 @@ JAVASCRIPT;
                // Get only users that has not yet been notified within last day
                     'OR'                              => [
                         [Alert::getTableField('date') => null],
-                        [Alert::getTableField('date') => ['<', new QueryExpression('CURRENT_TIMESTAMP() - INTERVAL 1 day')]],
+                        [Alert::getTableField('date') => ['<', QueryFunction::dateSub(
+                            date: QueryFunction::now(),
+                            interval: 1,
+                            interval_unit: 'DAY'
+                        )]],
                     ],
                 ],
             ];

--- a/src/User.php
+++ b/src/User.php
@@ -6219,11 +6219,15 @@ JAVASCRIPT;
                // Get only users that has not yet been notified within last day
                     'OR'                              => [
                         [Alert::getTableField('date') => null],
-                        [Alert::getTableField('date') => ['<', QueryFunction::dateSub(
-                            date: QueryFunction::now(),
-                            interval: 1,
-                            interval_unit: 'DAY'
-                        )]],
+                        [
+                            Alert::getTableField('date') => ['<',
+                                QueryFunction::dateSub(
+                                    date: QueryFunction::now(),
+                                    interval: 1,
+                                    interval_unit: 'DAY'
+                                )
+                            ]
+                        ],
                     ],
                 ],
             ];


### PR DESCRIPTION
 Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

According to MySQL docs, `CURRENT_TIMESTAMP()` is an alias of `NOW()`. All current uses of it can be replaced by a `DATE_SUB` function using `NOW()`.