### PR TITLE
fix: set default rack color if unset and fix bad addition if rack pos…

### DIFF
--- a/src/Rack.php
+++ b/src/Rack.php
@@ -711,7 +711,7 @@ JAVASCRIPT;
 
     public function prepareInputForUpdate($input)
     {
-        if (!isset($input['bgcolor']) || empty($input['bgcolor'])) {
+        if (array_key_exists('bgcolor', $input) && empty($input['bgcolor'])) {
             $input['bgcolor'] = '#FEC95C';
         }
         return $this->prepareInput($input);

--- a/src/Rack.php
+++ b/src/Rack.php
@@ -700,6 +700,9 @@ JAVASCRIPT;
             }
             unset($input['id']);
             unset($input['withtemplate']);
+            if (!isset($input['bgcolor']) || empty($input['bgcolor'])) {
+                $input['bgcolor'] = '#FEC95C';
+            }
 
             return $input;
         }
@@ -708,6 +711,9 @@ JAVASCRIPT;
 
     public function prepareInputForUpdate($input)
     {
+        if (!isset($input['bgcolor']) || empty($input['bgcolor'])) {
+            $input['bgcolor'] = '#FEC95C';
+        }
         return $this->prepareInput($input);
     }
 
@@ -732,7 +738,6 @@ JAVASCRIPT;
         }
 
         if ($input['position'] == 0) {
-            return $input;
             Session::addMessageAfterRedirect(
                 __('Position must be set'),
                 true,


### PR DESCRIPTION
…ition = 0
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

Fix the possibility to set rack background at null, because if it's null, it's impossible to see this rack in a dcroom.
![image](https://github.com/glpi-project/glpi/assets/107540223/ae570f5f-fd8f-4c40-a899-98057621a0a3)
The default color is defined if bgcolor is null or empty.

Also corrected addition with wrong position if this rack is in dcroom.
