### PR TITLE
feat(search): check field pattern

### DIFF
--- a/css/includes/components/_search_input.scss
+++ b/css/includes/components/_search_input.scss
@@ -97,3 +97,17 @@ div.search-input {
         }
     }
 }
+
+input:invalid {
+    background-color: $warning !important;
+}
+
+input + span.info {
+    display: none;
+}
+
+input:invalid + span.info {
+    display: inline;
+    color: $warning;
+    font-size: 0.8rem;
+}

--- a/src/Search/Provider/SQLProvider.php
+++ b/src/Search/Provider/SQLProvider.php
@@ -42,6 +42,7 @@ use DBmysqlIterator;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Debug\Profiler;
 use Glpi\RichText\RichText;
+use Glpi\Search\Input\QueryBuilder;
 use Glpi\Search\SearchEngine;
 use Glpi\Search\SearchOption;
 use Group;
@@ -1006,6 +1007,15 @@ final class SQLProvider implements SearchProviderInterface
         $table     = $opt["table"];
         $field     = $opt["field"];
 
+        if (
+            $searchtype == 'contains'
+            && !preg_match(QueryBuilder::getInputValidationPattern($opt['datatype'] ?? '')['pattern'], $val)
+        ) {
+            return [ // Invalid search
+                '1=0'
+            ];
+        }
+
         $inittable = $table;
         $addtable  = '';
         $is_fkey_composite_on_self = getTableNameForForeignKeyField($opt["linkfield"]) === $table
@@ -1107,7 +1117,7 @@ final class SQLProvider implements SearchProviderInterface
                 break;
 
             case "equals":
-                $SEARCH = [$nott ? "<>>" : "=", $val];
+                $SEARCH = [$nott ? "<>" : "=", $val];
                 break;
 
             case "notequals":

--- a/tests/functional/Search.php
+++ b/tests/functional/Search.php
@@ -364,12 +364,12 @@ class Search extends DbTestCase
                     'criteria'   => [
                         [
                             'link'       => 'AND',
-                            'field'      => 2,
+                            'field'      => 5, //serial
                             'searchtype' => 'contains',
                             'value'      => 'test',
                         ], [
                             'link'       => 'OR',
-                            'field'      => 2,
+                            'field'      => 5, //serial
                             'searchtype' => 'contains',
                             'value'      => 'test2',
                         ], [
@@ -430,7 +430,7 @@ class Search extends DbTestCase
                     " AND `glpi_computers`.`entities_id` IN (0))")
          ->contains("`glpi_computers`.`name` LIKE '%test%'")
          ->contains("AND `glpi_softwares`.`id` = '10784'")
-         ->contains("OR (`glpi_computers`.`id` LIKE '%test2%'")
+         ->contains("OR (`glpi_computers`.`serial` LIKE '%test2%'")
          ->contains("AND (`glpi_locations`.`id` = '11')")
          ->contains("(`glpi_users`.`id` = '2')")
          ->contains("OR (`glpi_users`.`id` = '3')")
@@ -471,7 +471,7 @@ class Search extends DbTestCase
          ->matches("/OR\s*\(`glpi_computertypes`\.`name`\s*LIKE '%test%'\s*\)/")
          ->matches("/OR\s*\(`glpi_computermodels`\.`name`\s*LIKE '%test%'\s*\)/")
          ->matches("/OR\s*\(`glpi_locations`\.`completename`\s*LIKE '%test%'\s*\)/")
-         ->matches("/OR\s*\(CONVERT\(`glpi_computers`\.`date_mod` USING {$default_charset}\)\s*LIKE '%test%'\s*\)\)/");
+         ->matches("/OR\s*\(1=0\s*\)/")->notmatches("/OR\s*\(CONVERT\(`glpi_computers`\.`date_mod` USING {$default_charset}\)\s*LIKE '%test%'\s*\)\)/");
     }
 
     public function testSearchOnRelationTable()
@@ -1902,16 +1902,6 @@ class Search extends DbTestCase
             [
                 'link' => ' AND ',
                 'nott' => 0,
-                'itemtype' => \Monitor::class,
-                'ID' => 11, // Search ID 11 (size field)
-                'searchtype' => 'contains',
-                'val' => '70.5%',
-                'meta' => false,
-                'expected' => "AND (`glpi_monitors`.`size` LIKE '%70.5%')",
-            ],
-            [
-                'link' => ' AND ',
-                'nott' => 0,
                 'itemtype' => \Computer::class,
                 'ID' => 121, // Search ID 121 (date_creation field)
                 'searchtype' => 'contains',
@@ -2522,8 +2512,8 @@ class Search extends DbTestCase
             'itemtype'          => \AuthLDAP::class,
             'search_option'     => 4, // port
             'value'             => 'test',
-            'expected_and'      => "(`glpi_authldaps`.`port` LIKE '%test%')",
-            'expected_and_not'  => "(`glpi_authldaps`.`port` NOT LIKE '%test%' OR `glpi_authldaps`.`port` IS NULL)",
+            'expected_and'      => "(1=0)",
+            'expected_and_not'  => "(1=0)",
         ];
         yield [
             'itemtype'          => \AuthLDAP::class,
@@ -2538,8 +2528,8 @@ class Search extends DbTestCase
             'itemtype'          => \AuthLDAP::class,
             'search_option'     => 32, // timeout
             'value'             => 'test',
-            'expected_and'      => "(`glpi_authldaps`.`timeout` LIKE '%test%')",
-            'expected_and_not'  => "(`glpi_authldaps`.`timeout` NOT LIKE '%test%' OR `glpi_authldaps`.`timeout` IS NULL)",
+            'expected_and'      => "(1=0)",
+            'expected_and_not'  => "(1=0)",
         ];
         yield [
             'itemtype'          => \AuthLDAP::class,
@@ -2570,8 +2560,8 @@ class Search extends DbTestCase
             'itemtype'          => \Budget::class,
             'search_option'     => 7, // value
             'value'             => 'test',
-            'expected_and'      => "(`glpi_budgets`.`value` LIKE '%test%')",
-            'expected_and_not'  => "(`glpi_budgets`.`value` NOT LIKE '%test%' OR `glpi_budgets`.`value` IS NULL)",
+            'expected_and'      => "(1=0)",
+            'expected_and_not'  => "(1=0)",
         ];
         yield [
             'itemtype'          => \Budget::class,
@@ -2657,8 +2647,8 @@ class Search extends DbTestCase
             'itemtype'          => \CronTask::class,
             'search_option'     => 6, // frequency
             'value'             => 'test',
-            'expected_and'      => "(`glpi_crontasks`.`frequency` LIKE '%test%')",
-            'expected_and_not'  => "(`glpi_crontasks`.`frequency` NOT LIKE '%test%' OR `glpi_crontasks`.`frequency` IS NULL)",
+            'expected_and'      => "(1=0)",
+            'expected_and_not'  => "(1=0)",
         ];
         yield [
             'itemtype'          => \CronTask::class,
@@ -2689,8 +2679,8 @@ class Search extends DbTestCase
             'itemtype'          => \Computer::class,
             'search_option'     => 9, // last_inventory_update
             'value'             => 'test',
-            'expected_and'      => "(CONVERT(`glpi_computers`.`last_inventory_update` USING utf8mb4) LIKE '%test%')",
-            'expected_and_not'  => "(CONVERT(`glpi_computers`.`last_inventory_update` USING utf8mb4) NOT LIKE '%test%' OR CONVERT(`glpi_computers`.`last_inventory_update` USING utf8mb4) IS NULL)",
+            'expected_and'      => "(1=0)",
+            'expected_and_not'  => "(1=0)",
         ];
         yield [
             'itemtype'          => \Computer::class,
@@ -2721,8 +2711,8 @@ class Search extends DbTestCase
             'itemtype'          => \Budget::class,
             'search_option'     => 5, // begin_date
             'value'             => 'test',
-            'expected_and'      => "(CONVERT(`glpi_budgets`.`begin_date` USING utf8mb4) LIKE '%test%')",
-            'expected_and_not'  => "(CONVERT(`glpi_budgets`.`begin_date` USING utf8mb4) NOT LIKE '%test%' OR CONVERT(`glpi_budgets`.`begin_date` USING utf8mb4) IS NULL)",
+            'expected_and'      => "(1=0)",
+            'expected_and_not'  => "(1=0)",
         ];
         yield [
             'itemtype'          => \Budget::class,
@@ -2737,8 +2727,8 @@ class Search extends DbTestCase
             'itemtype'          => \Contract::class,
             'search_option'     => 20, // end_date
             'value'             => 'test',
-            'expected_and'      => "(DATE_ADD(`glpi_contracts`.`begin_date`, INTERVAL `glpi_contracts`.`duration` MONTH) LIKE '%test%')",
-            'expected_and_not'  => "(DATE_ADD(`glpi_contracts`.`begin_date`, INTERVAL `glpi_contracts`.`duration` MONTH) NOT LIKE '%test%' OR DATE_ADD(`glpi_contracts`.`begin_date`, INTERVAL `glpi_contracts`.`duration` MONTH) IS NULL)",
+            'expected_and'      => "(1=0)",
+            'expected_and_not'  => "(1=0)",
         ];
         if ($is_mysql_5_7) {
             // log for both AND and AND NOT cases
@@ -2797,8 +2787,8 @@ class Search extends DbTestCase
             'itemtype'          => \Cable::class,
             'search_option'     => 15, // color
             'value'             => 'test',
-            'expected_and'      => "(`glpi_cables`.`color` LIKE '%test%')",
-            'expected_and_not'  => "(`glpi_cables`.`color` NOT LIKE '%test%' OR `glpi_cables`.`color` IS NULL)",
+            'expected_and'      => "(1=0)",
+            'expected_and_not'  => "(1=0)",
         ];
         yield [
             'itemtype'          => \Cable::class,
@@ -3438,8 +3428,8 @@ class Search extends DbTestCase
                     'itemtype'          => \Cable::class,
                     'search_option'     => 15, // color
                     'value'             => $searched_value,
-                    'expected_and'      => "(`glpi_cables`.`color` LIKE '%{$searched_value}%')",
-                    'expected_and_not'  => "(`glpi_cables`.`color` NOT LIKE '%{$searched_value}%' OR `glpi_cables`.`color` IS NULL)",
+                    'expected_and'      => "(1=0)", // invalid pattern
+                    'expected_and_not'  => "(1=0)", // invalid pattern
                 ];
 
                 // datatype=language

--- a/tests/units/Glpi/Search/Input/QueryBuilder.php
+++ b/tests/units/Glpi/Search/Input/QueryBuilder.php
@@ -1,0 +1,371 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Search\Input;
+
+class QueryBuilder extends \GLPITestCase
+{
+    protected function inputValidationPatternProvider(): iterable
+    {
+        // string
+        foreach (['dropdown', 'itemlink', 'itemtypename', 'specific', 'string', 'text', 'email'] as $datatype) {
+            yield [
+                'datatype' => $datatype,
+                'valid_values' => [
+                    // null values
+                    'NULL',
+                    'null',
+
+                    // any text
+                    'test',
+                    '10',
+                    '‣unicode',
+
+                    // ^ and $ operators
+                    '^test',
+                    'test$',
+                    '^test$',
+                ],
+                'invalid_values' => [
+                    // pattern allows everything, nothing should be invalid
+                ],
+            ];
+        }
+
+        // number
+        foreach (['count', 'integer', 'number', 'actiontime', 'decimal', 'timestamp'] as $datatype) {
+            yield [
+                'datatype' => $datatype,
+                'valid_values' => [
+                    // null values
+                    'NULL',
+                    'null',
+
+                    // zero
+                    '0',
+
+                    // positive integer values, absolute and relative
+                    '1',
+                    '128',
+                    '>128',
+                    '> 128',
+                    '>=128',
+                    '>= 128',
+                    '<512',
+                    '< 512',
+                    '<=512',
+                    '<= 512',
+
+                    // negative integer values, absolute and relative
+                    '-1',
+                    '>-128',
+                    '> -128',
+                    '>=-128',
+                    '>= -128',
+                    '<-256',
+                    '< -256',
+                    '<=-256',
+                    '<= -256',
+
+                    // decimal values, absolute and relative, with one or more numbers after decimal separator
+                    '0.156',
+                    '10.5',
+                    '<0.156',
+                    '< 10.5',
+                    '<=0.156',
+                    '<= 10.5',
+                    '>0.156',
+                    '> 10.5',
+                    '>=0.156',
+                    '>= 10.5',
+                ],
+                'invalid_values' => [
+                    // wrong relative operators place
+                    '=> 1',
+                    '15 >',
+                    '3<=',
+
+                    // wrong minus char place
+                    '- > 5',
+                    '12 -',
+
+                    // invalid decimal
+                    '15.3.25',
+
+                    // text value
+                    'a',
+
+                    // ^ and $ special operators are not allowed
+                    '^1',
+                    '1$',
+                    '^1$',
+                ],
+            ];
+        }
+
+        // date
+        foreach (['date', 'date_delay'] as $datatype) {
+            yield [
+                'datatype' => $datatype,
+                'valid_values' => [
+                    // null values
+                    'NULL',
+                    'null',
+
+                    // date values
+                    '2023-01',
+                    '2023',
+                    '-12-', // all dates in december
+                    '04-01',
+
+                    // now + X month
+                    '<0.5',
+                    '< 6',
+                    '<=0.5',
+                    '<= 6',
+                    '>6',
+                    '> 0.5',
+                    '>=0.5',
+                    '>= 6',
+
+                    // now - X month
+                    '<-0.5',
+                    '< -12',
+                    '<=-12',
+                    '<= -0.25',
+                    '>-12',
+                    '> -12',
+                    '>=-0.5',
+                    '>= -12',
+                ],
+                'invalid_values' => [
+                    // wrong relative operators place
+                    '=> 5',
+                    '3 >',
+                    '0.5<=',
+
+                    // wrong minus char place
+                    '- > 5',
+                    '12 -',
+
+                    // invalid date separator
+                    '2023/06',
+
+                    // invalid decimal
+                    '15.3.25',
+
+                    // time value
+                    '23:00:00',
+
+                    // text value
+                    'a',
+
+                    // ^ and $ special operators are not allowed
+                    '^2023',
+                    '06-15$',
+                    '^2023-06-15$',
+                ],
+            ];
+        }
+
+        // timestamp
+        foreach (['datetime'] as $datatype) {
+            yield [
+                'datatype' => $datatype,
+                'valid_values' => [
+                    // null values
+                    'NULL',
+                    'null',
+
+                    // date values
+                    '2023-01',
+                    '2023',
+                    '-12-', // all dates in december
+                    '04-01',
+
+                    // time value
+                    '23:00:00',
+
+                    // now + X month
+                    '<0.5',
+                    '< 6',
+                    '<=0.5',
+                    '<= 6',
+                    '>6',
+                    '> 0.5',
+                    '>=0.5',
+                    '>= 6',
+
+                    // now - X month
+                    '<-0.5',
+                    '< -12',
+                    '<=-12',
+                    '<= -0.25',
+                    '>-12',
+                    '> -12',
+                    '>=-0.5',
+                    '>= -12',
+                ],
+                'invalid_values' => [
+                    // wrong relative operators place
+                    '=> 5',
+                    '3 >',
+                    '0.5<=',
+
+                    // wrong minus char place
+                    '- > 5',
+
+                    // invalid date separator
+                    '2023/06',
+
+                    // invalid decimal
+                    '15.3.25',
+
+                    // text value
+                    'a',
+
+                    // ^ and $ special operators are not allowed
+                    '^2023',
+                    '06-15$',
+                    '^2023-06-15$',
+                ],
+            ];
+        }
+
+        // boolean
+        yield [
+            'datatype' => 'bool',
+            'valid_values' => [
+                // null values
+                'NULL',
+                'null',
+
+                // boolean values
+                '0',
+                '1',
+            ],
+            'invalid_values' => [
+                // negative value
+                '-1',
+
+                // any other integer
+                '2',
+
+                // relative operators
+                '<0',
+                '< 1',
+                '<=1',
+                '<= 0',
+                '>1',
+                '> 0',
+                '>=0',
+                '>= 1',
+
+                // text value
+                'a',
+
+                // ^ and $ special operators are not allowed
+                '^0',
+                '1$',
+                '^1$',
+            ],
+        ];
+
+        // color
+        yield [
+            'datatype' => 'color',
+            'valid_values' => [
+                // null values
+                'NULL',
+                'null',
+
+                // color values
+                '#000000',
+                '000000',
+                '#ffffff',
+                'ffffff',
+                '#0d0d0d',
+                '0d0d0d',
+
+                // ^ and $ operators
+                '^#00',
+                'ef$',
+                '^#0d0d0d$',
+            ],
+            'invalid_values' => [
+                // non hexa decimal char
+                'g',
+                'y',
+                '@',
+                '-',
+
+                // relative operators
+                '<00',
+                '< 0ef',
+                '<=a5',
+                '<= 32',
+                '>ae',
+                '> 0a',
+                '>=4f',
+                '>= 8c',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider inputValidationPatternProvider
+     */
+    public function testGetInputValidationPattern(
+        string $datatype,
+        array $valid_values,
+        array $invalid_values
+    ) {
+        $this->newTestedInstance();
+
+        $result = \Glpi\Search\Input\QueryBuilder::getInputValidationPattern($datatype);
+
+        $this->array($result)->hasKeys(['pattern', 'validation_message']);
+
+        foreach ($valid_values as $value) {
+            $this->integer(preg_match($result['pattern'], $value))
+                ->isEqualTo(1, sprintf('Invalid result for field `%s` with value `%s`.', $datatype, $value));
+        }
+
+        foreach ($invalid_values as $value) {
+            $this->integer(preg_match($result['pattern'], $value))
+                ->isEqualTo(0, sprintf('Invalid result for field `%s` with value `%s`.', $datatype, $value));
+        }
+    }
+}


### PR DESCRIPTION
Checks the format entered with the "contains" search entry.

This informs the user that their input is incorrect while they are typing and does not execute the search query (which can be a significant resource saving in some cases).

Suggested warning, probably to be improved:

![image](https://github.com/glpi-project/glpi/assets/8530352/69e3a22d-7479-43df-8ff1-6f27e2277cdd)


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26543
