### PR TITLE
Drop glpi_auth_tables references

### DIFF
--- a/src/Log.php
+++ b/src/Log.php
@@ -173,26 +173,24 @@ class Log extends CommonDBTM
                         $changes = [$id_search_option, $oldval ?? '', $values[$key]];
                     } else {
                        // other cases; link field -> get data from dropdown
-                        if ($val2["table"] != 'glpi_auth_tables') {
-                            $changes = [$id_search_option,
-                                sprintf(
-                                    __('%1$s (%2$s)'),
-                                    Dropdown::getDropdownName(
-                                        $val2["table"],
-                                        $oldval
-                                    ),
+                        $changes = [$id_search_option,
+                            sprintf(
+                                __('%1$s (%2$s)'),
+                                Dropdown::getDropdownName(
+                                    $val2["table"],
                                     $oldval
                                 ),
-                                sprintf(
-                                    __('%1$s (%2$s)'),
-                                    Dropdown::getDropdownName(
-                                        $val2["table"],
-                                        $values[$key]
-                                    ),
+                                $oldval
+                            ),
+                            sprintf(
+                                __('%1$s (%2$s)'),
+                                Dropdown::getDropdownName(
+                                    $val2["table"],
                                     $values[$key]
-                                )
-                            ];
-                        }
+                                ),
+                                $values[$key]
+                            )
+                        ];
                     }
                     break;
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

After some research, it looks like the references to `glpi_auth_tables` have been dead since 2012 (45a340e63847cbda93e1f3cdfd5d8591a977e137) and they used to be for a non-existent "virtual" table.

There is no search option in the core that uses this non-existent table. The only references in plugins that I have found exist in `printercounters` and that is only because it looks like their `inc/search.class.php` is a copy of the Search engine in the core with some modifications added on top.