### PR TITLE
Remove unused networkequipments.ip reference

### DIFF
--- a/src/Search/Provider/SQLProvider.php
+++ b/src/Search/Provider/SQLProvider.php
@@ -3434,8 +3434,6 @@ final class SQLProvider implements SearchProviderInterface
                             $criterion = "`" . $table . $addtable . "`.`name` $order";
                         }
                         break;
-                    //FIXME glpi_networkequipments.ip seems like a dead case
-                    case "glpi_networkequipments.ip":
                     case "glpi_ipaddresses.name":
                         $criterion = "INET6_ATON(`$table$addtable`.`$field`) $order";
                         break;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This field hasn't existed since 2012 (7fe68ae80afaf067f2748e5070d40639da7e916f).