### PR TITLE
Drop unused AuthLDAP entity code (and misc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,7 @@ The present file will list all changes made to the project; according to the
 - `XML` class.
 - Usage of `Search::addOrderBy` signature with ($itemtype, $ID, $order) parameters
 - Javascript file upload functions `dataURItoBlob`, `extractSrcFromImgTag`, `insertImgFromFile()`, `insertImageInTinyMCE`, `isImageBlobFromPaste`, `isImageFromPaste`.
+- `CommonDBTM::$fkfield` property.
 
 ## [10.0.8] unreleased
 

--- a/install/migrations/update_10.0.x_to_10.1.0/authldap.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/authldap.php
@@ -41,3 +41,6 @@
 $table = "glpi_authldaps";
 $migration->addField($table, "begin_date_field", "string");
 $migration->addField($table, "end_date_field", "string");
+
+$migration->dropField($table, 'entity_field');
+$migration->dropField($table, 'entity_condition');

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -96,8 +96,6 @@ CREATE TABLE `glpi_authldaps` (
   `title_field` varchar(255) DEFAULT NULL,
   `category_field` varchar(255) DEFAULT NULL,
   `language_field` varchar(255) DEFAULT NULL,
-  `entity_field` varchar(255) DEFAULT NULL,
-  `entity_condition` text,
   `date_mod` timestamp NULL DEFAULT NULL,
   `comment` text,
   `is_default` tinyint NOT NULL DEFAULT '0',

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -251,8 +251,6 @@ class AuthLDAP extends CommonDBTM
                 $this->fields['registration_number_field'] = 'employeenumber';
                 $this->fields['comment_field']             = 'info';
                 $this->fields['title_field']               = 'title';
-                $this->fields['entity_field']              = 'ou';
-                $this->fields['entity_condition']          = '(objectclass=organizationalUnit)';
                 $this->fields['use_dn']                    = 1;
                 $this->fields['can_support_pagesize']      = 1;
                 $this->fields['pagesize']                  = '1000';
@@ -283,8 +281,6 @@ class AuthLDAP extends CommonDBTM
                 $this->fields['registration_number_field'] = 'employeenumber';
                 $this->fields['comment_field']             = 'description';
                 $this->fields['title_field']               = 'title';
-                $this->fields['entity_field']              = 'ou';
-                $this->fields['entity_condition']          = '(objectClass=organizationalUnit)';
                 $this->fields['use_dn']                    = 1;
                 $this->fields['can_support_pagesize']      = 1;
                 $this->fields['pagesize']                  = '1000';
@@ -586,8 +582,8 @@ class AuthLDAP extends CommonDBTM
            //Fill fields when using preconfiguration models
             if (!$ID) {
                 $hidden_fields = ['comment_field', 'email1_field', 'email2_field',
-                    'email3_field', 'email4_field', 'entity_condition',
-                    'entity_field', 'firstname_field', 'group_condition',
+                    'email3_field', 'email4_field',
+                    'firstname_field', 'group_condition',
                     'group_field', 'group_member_field', 'group_search_type',
                     'mobile_field', 'phone_field', 'phone2_field',
                     'realname_field', 'registration_number_field', 'title_field',
@@ -985,42 +981,6 @@ class AuthLDAP extends CommonDBTM
                 'responsible_field'         => __('Supervisor'),
             ]
         ]);
-    }
-
-    /**
-     * Show entity config form
-     *
-     * @return void
-     */
-    public function showFormEntityConfig()
-    {
-
-        $ID = $this->getField('id');
-
-        echo "<div class='center'>";
-        echo "<form method='post' action='" . Toolbox::getItemTypeFormURL(__CLASS__) . "'>";
-        echo "<input type='hidden' name='id' value='$ID'>";
-        echo "<table class='tab_cadre_fixe'>";
-
-        echo "<tr><th class='center' colspan='4'>" . __('Import entities from LDAP directory') .
-           "</th></tr>";
-
-        echo "<tr class='tab_bg_1'><td>" . __('Attribute representing entity') . "</td>";
-        echo "<td colspan='3'>";
-        echo "<input type='text' name='entity_field' value='" . $this->fields["entity_field"] . "'>";
-        echo "</td></tr>";
-
-        echo "<tr class='tab_bg_1'><td>" . __('Search filter for entities') . "</td>";
-        echo "<td colspan='3'>";
-        echo "<input type='text' name='entity_condition' value='" . $this->fields["entity_condition"] . "'
-             size='100'></td></tr>";
-
-        echo "<tr class='tab_bg_2'><td class='center' colspan='4'>";
-        echo "<input type='submit' name='update' class='btn btn-primary' value=\"" . __s('Save') . "\">";
-        echo "</td></tr>";
-        echo "</table>";
-        Html::closeForm();
-        echo "</div>";
     }
 
     public function defineTabs($options = [])
@@ -4288,8 +4248,6 @@ class AuthLDAP extends CommonDBTM
             $ong[1]  = self::createTabEntry(_sx('button', 'Test'));                     // test connexion
             $ong[2]  = self::createTabEntry(User::getTypeName(Session::getPluralNumber()), 0, $item::getType(), User::getIcon());
             $ong[3]  = self::createTabEntry(Group::getTypeName(Session::getPluralNumber()), 0, $item::getType(), User::getIcon());
-           // TODO clean fields entity_XXX if not used
-           // $ong[4]  = Entity::getTypeName(1);                  // params for entity config
             $ong[5]  = self::createTabEntry(__('Advanced information'));   // params for entity advanced config
             $ong[6]  = self::createTabEntry(_n('Replicate', 'Replicates', Session::getPluralNumber()));
 
@@ -4321,10 +4279,6 @@ class AuthLDAP extends CommonDBTM
 
             case 3:
                 $item->showFormGroupsConfig();
-                break;
-
-            case 4:
-                $item->showFormEntityConfig();
                 break;
 
             case 5:

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -132,13 +132,6 @@ class CommonDBTM extends CommonGLPI
     protected static $forward_entity_to = [];
 
     /**
-     * Foreign key field cache : set dynamically calling getForeignKeyField
-     *
-     * @TODO Remove this variable as it is not used ?
-     */
-    protected $fkfield = "";
-
-    /**
      * Search option of item. Initialized on first call to self::getOptions() and used as cache.
      *
      * @var array

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -206,33 +206,6 @@ class Document_Item extends CommonDBRelation
         return true;
     }
 
-
-    /**
-     * @TODO Remove `_do_update_ticket` handling in GLPI 10.1, it is not used anymore.
-     */
-    public function post_addItem()
-    {
-
-        if ($this->fields['itemtype'] == 'Ticket' && ($this->input['_do_update_ticket'] ?? true)) {
-            $ticket = new Ticket();
-            $input  = [
-                'id'              => $this->fields['items_id'],
-                'date_mod'        => $_SESSION["glpi_currenttime"],
-            ];
-
-            if (!isset($this->input['_do_notif']) || $this->input['_do_notif']) {
-                $input['_forcenotif'] = true;
-            }
-            if (isset($this->input['_disablenotif']) && $this->input['_disablenotif']) {
-                $input['_disablenotif'] = true;
-            }
-
-            $ticket->update($input);
-        }
-        parent::post_addItem();
-    }
-
-
     /**
      * @since 0.83
      *

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -206,6 +206,28 @@ class Document_Item extends CommonDBRelation
         return true;
     }
 
+    public function post_addItem()
+    {
+
+        if ($this->fields['itemtype'] == 'Ticket') {
+            $ticket = new Ticket();
+            $input  = [
+                'id'              => $this->fields['items_id'],
+                'date_mod'        => $_SESSION["glpi_currenttime"],
+            ];
+
+            if (!isset($this->input['_do_notif']) || $this->input['_do_notif']) {
+                $input['_forcenotif'] = true;
+            }
+            if (isset($this->input['_disablenotif']) && $this->input['_disablenotif']) {
+                $input['_disablenotif'] = true;
+            }
+
+            $ticket->update($input);
+        }
+        parent::post_addItem();
+    }
+
     /**
      * @since 0.83
      *

--- a/src/NotificationEventAbstract.php
+++ b/src/NotificationEventAbstract.php
@@ -66,8 +66,6 @@ abstract class NotificationEventAbstract implements NotificationEventInterface
             if (isset($options['processed'])) {
                 $processed = &$options['processed'];
                 unset($options['processed']);
-            } else { // Compat with GLPI < 9.4.2 TODO: remove in 9.5
-                $processed = [];
             }
 
             $targets = getAllDataFromTable(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

There used to be an Entity tab for the AuthLDAP form, but it has been commented out since 2014 (859058b22de6c356c891fb0f2d19ede63bd1493d). There are `entity_field` and `entity_condition` fields that are only used in the display of this "hidden" tab. They should be safe to finally remove completely now.

Two other very minor removals:
1. The unused $fkfield CommonDBTM property
2. Special handling in NotificationEventAbstract that was marked for removal in 9.5