### PR TITLE
Fix and unify parent business right labels

### DIFF
--- a/src/RuleAsset.php
+++ b/src/RuleAsset.php
@@ -208,7 +208,6 @@ class RuleAsset extends Rule
     {
 
         $values = parent::getRights();
-       //TRANS: short for : Business rules for ticket (entity parent)
         $values[self::PARENT] = ['short' => __('Parent business'),
             'long'  => __('Business rules (entity parent)')
         ];

--- a/src/RuleAsset.php
+++ b/src/RuleAsset.php
@@ -210,7 +210,7 @@ class RuleAsset extends Rule
         $values = parent::getRights();
        //TRANS: short for : Business rules for ticket (entity parent)
         $values[self::PARENT] = ['short' => __('Parent business'),
-            'long'  => __('Business rules for ticket (entity parent)')
+            'long'  => __('Business rules (entity parent)')
         ];
 
         return $values;

--- a/src/RuleTicket.php
+++ b/src/RuleTicket.php
@@ -1044,7 +1044,6 @@ class RuleTicket extends Rule
     {
 
         $values = parent::getRights();
-       //TRANS: short for : Business rules for ticket (entity parent)
         $values[self::PARENT] = ['short' => __('Parent business'),
             'long'  => __('Business rules (entity parent)')
         ];

--- a/src/RuleTicket.php
+++ b/src/RuleTicket.php
@@ -1046,7 +1046,7 @@ class RuleTicket extends Rule
         $values = parent::getRights();
        //TRANS: short for : Business rules for ticket (entity parent)
         $values[self::PARENT] = ['short' => __('Parent business'),
-            'long'  => __('Business rules for ticket (entity parent)')
+            'long'  => __('Business rules (entity parent)')
         ];
 
         return $values;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fix bad label for asset rules and make the long label the same to keep them in the same column.