### PR TITLE
fix(RichText): Correct handling of DOM ol li

### DIFF
--- a/src/RichText/RichText.php
+++ b/src/RichText/RichText.php
@@ -197,6 +197,7 @@ final class RichText
             'pre',
             'table',
             'ul',
+            'ol',
         ];
         return preg_match('/<(' . implode('|', $html_tags) . ')(\s+[^>]*)?>/i', $content) === 1;
     }


### PR DESCRIPTION
Fix bad handling for ```ol``` DOM 

![image](https://github.com/glpi-project/glpi/assets/7335054/0bb12a12-722e-43cc-9f40-45e15eff6bb6)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28000
