### PR TITLE
only reload create ticket form for requester actors (not observer/tech)

### DIFF
--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -46,7 +46,7 @@
 {% endif %}
 
 {% set onchange = '' %}
-{% if item.isNewItem() %}
+{% if item.isNewItem() and actortype == "requester" %}
    {% set onchange = 'this.form.submit();' %}
 {% endif %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14881

According to https://github.com/glpi-project/glpi/blob/10.0.7/src/Ticket.php#L4337, entities are only imported from requesters, not others actors.
So we should only reload form for ticket creator for requester (and avoid in some case long waiting page load)
