### PR TITLE
Ensure upload failure messages are always displayed

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -5547,21 +5547,18 @@ HTML;
                       . ($p['multiple'] ? " multiple='multiple'" : "")
                       . ($p['onlyimages'] ? " accept='.gif,.png,.jpg,.jpeg'" : "") . ">";
 
-        $progressall_js = '';
-        if (!$p['only_uploaded_files']) {
-            $display .= "<div id='progress{$p['rand']}' style='display:none'>" .
-                 "<div class='uploadbar' style='width: 0%;'></div></div>";
-            $progressall_js = "
-            progressall: function(event, data) {
-               var progress = parseInt(data.loaded / data.total * 100, 10);
-               $('#progress{$p['rand']}').show();
-               $('#progress{$p['rand']} .uploadbar')
-                  .text(progress + '%')
-                  .css('width', progress + '%')
-                  .show();
-            },
-         ";
-        }
+        $display .= "<div id='progress{$p['rand']}' style='display:none'>" .
+                "<div class='uploadbar' style='width: 0%;'></div></div>";
+        $progressall_js = "
+        progressall: function(event, data) {
+            var progress = parseInt(data.loaded / data.total * 100, 10);
+            $('#progress{$p['rand']}').show();
+            $('#progress{$p['rand']} .uploadbar')
+                .text(progress + '%')
+                .css('width', progress + '%')
+                .show();
+        },
+        ";
 
         $display .= Html::scriptBlock("
       $(function() {
@@ -5612,7 +5609,8 @@ HTML;
                         $('#progress{$p['rand']}').show();
                         $('#progress{$p['rand']} .uploadbar')
                            .text(file.error)
-                           .css('width', '100%');
+                           .css('width', '100%')
+                           .show();
                         return;
                      }
                   }


### PR DESCRIPTION
In Formcreator, we may have textarea fields with uploads enabled **and** without showing an area to drop files. 

With this context, if someone uploads a too big image (usually 2MB), the upload is rejected, but no feedback is provided to the user. The file seems uploaded successfully because it appears in the text area, and its name shows below it.

![image](https://github.com/glpi-project/glpi/assets/14139801/d6dedf0c-7737-4a7d-98cf-750f9afba7c4)

(test picture credit: a wallpaper picked [here](https://www.pexels.com/photo/reflection-of-mountain-on-lake-braies-1525041/) by Fancesco Ungaro) size : 5 MB.

With the patch, the upload failure becomes visible

![image](https://github.com/glpi-project/glpi/assets/14139801/41e87f2f-589b-4a07-a918-86da3677b2a3)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal ref 28203
