### PR TITLE
fix(RuleDictionnary): keep main key 'name'

### DIFF
--- a/install/migrations/update_10.0.7_to_10.0.8/rule.php
+++ b/install/migrations/update_10.0.7_to_10.0.8/rule.php
@@ -7,7 +7,7 @@
  *
  * http://glpi-project.org
  *
- * @copyright 2015-2022 Teclib' and contributors.
+ * @copyright 2015-2023 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
@@ -32,7 +32,6 @@
  *
  * ---------------------------------------------------------------------
  */
-
 global $DB;
 
 //move criteria 'os_name' to 'name' for 'RuleDictionnaryOperatingSystem'

--- a/install/migrations/update_10.0.7_to_10.0.8/rule.php
+++ b/install/migrations/update_10.0.7_to_10.0.8/rule.php
@@ -63,7 +63,7 @@ foreach ($sub_types as $criteria => $sub_type) {
                             'glpi_rulecriterias' => 'rules_id',
                             'glpi_rules' => 'id',
                             [
-                                'AND' => ['glpi_rules.sub_type' => array_values($sub_type)],
+                                'AND' => ['glpi_rules.sub_type' => $sub_type],
                             ]
                         ],
                     ],

--- a/install/migrations/update_10.0.7_to_10.0.8/rule.php
+++ b/install/migrations/update_10.0.7_to_10.0.8/rule.php
@@ -1,4 +1,3 @@
-
 <?php
 
 /**
@@ -33,6 +32,7 @@
  *
  * ---------------------------------------------------------------------
  */
+
 global $DB;
 
 //move criteria 'os_name' to 'name' for 'RuleDictionnaryOperatingSystem'
@@ -40,8 +40,6 @@ global $DB;
 //move criteria 'os_edition' to 'name' for 'RuleDictionnaryOperatingSystemEdition'
 //move criteria 'arch_name' to 'name' for 'RuleDictionnaryOperatingSystemArchitecture'
 //move criteria 'servicepack_name' to 'name' for 'RuleDictionnaryOperatingSystemServicePack'
-
-
 
 $subType = [
     'servicepack_name' => 'RuleDictionnaryOperatingSystemServicePack',
@@ -84,4 +82,3 @@ foreach ($result as $data) {
                WHERE `id` = " . $data['criteria_id'];
     $DB->queryOrDie($query, "10.0.6 change crtieria name");
 }
-

--- a/install/migrations/update_10.0.7_to_10.0.8/rule.php
+++ b/install/migrations/update_10.0.7_to_10.0.8/rule.php
@@ -32,6 +32,7 @@
  *
  * ---------------------------------------------------------------------
  */
+
 global $DB;
 
 //move criteria 'os_name' to 'name' for 'RuleDictionnaryOperatingSystem'

--- a/install/migrations/update_10.0.7_to_10.0.8/rule.php
+++ b/install/migrations/update_10.0.7_to_10.0.8/rule.php
@@ -80,5 +80,5 @@ foreach ($result as $data) {
     $query = "UPDATE `glpi_rulecriterias`
                SET `criteria` = 'name'
                WHERE `id` = " . $data['criteria_id'];
-    $DB->queryOrDie($query, "10.0.6 change crtieria name");
+    $DB->queryOrDie($query, "10.0.8 change crtieria name");
 }

--- a/install/migrations/update_10.0.7_to_10.0.8/rule.php
+++ b/install/migrations/update_10.0.7_to_10.0.8/rule.php
@@ -1,0 +1,87 @@
+
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2022 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+global $DB;
+
+//move criteria 'os_name' to 'name' for 'RuleDictionnaryOperatingSystem'
+//move criteria 'os_version' to 'name' for 'RuleDictionnaryOperatingSystemVersion'
+//move criteria 'os_edition' to 'name' for 'RuleDictionnaryOperatingSystemEdition'
+//move criteria 'arch_name' to 'name' for 'RuleDictionnaryOperatingSystemArchitecture'
+//move criteria 'servicepack_name' to 'name' for 'RuleDictionnaryOperatingSystemServicePack'
+
+
+
+$subType = [
+    'servicepack_name' => 'RuleDictionnaryOperatingSystemServicePack',
+    'os_edition' => 'RuleDictionnaryOperatingSystemEdition',
+    'arch_name' => 'RuleDictionnaryOperatingSystemArchitecture',
+    'os_version' => 'RuleDictionnaryOperatingSystemVersion',
+    'os_name' => 'RuleDictionnaryOperatingSystem',
+];
+
+//Get all glpi_rulecrtiteria with 'name' criteria for OS Dictionnary
+$result = $DB->request(
+    [
+        'SELECT'    => [
+            'glpi_rulecriterias.id AS criteria_id' ,
+            'glpi_rulecriterias.criteria' ,
+            'glpi_rules.sub_type' ,
+        ],
+        'FROM'      => 'glpi_rulecriterias',
+        'LEFT JOIN' => [
+            'glpi_rules' => [
+                'FKEY' => [
+                    'glpi_rulecriterias'   => 'rules_id',
+                    'glpi_rules'            => 'id',
+                    [
+                        'AND' => ['glpi_rules.sub_type' => array_values($subType)],
+                    ],
+                ]
+            ]
+        ],
+        'WHERE'     => [
+            'glpi_rulecriterias.criteria'      => array_keys($subType)
+        ],
+    ]
+);
+
+//foreach crierias, change 'name' key to desired
+foreach ($result as $data) {
+    $query = "UPDATE `glpi_rulecriterias`
+               SET `criteria` = 'name'
+               WHERE `id` = " . $data['criteria_id'];
+    $DB->queryOrDie($query, "10.0.6 change crtieria name");
+}
+

--- a/src/Inventory/Asset/OperatingSystem.php
+++ b/src/Inventory/Asset/OperatingSystem.php
@@ -58,7 +58,7 @@ class OperatingSystem extends InventoryAsset
             'service_pack'   => 'operatingsystemservicepacks_id',
             'arch'           => 'operatingsystemarchitectures_id',
             'kernel_name'    => 'operatingsystemkernels_id',
-            'kernel_version' => 'operatingsystemkernelversions_id'
+            'kernel_version' => 'operatingsystemkernelversions_id',
         ];
 
         $val = (object)$this->data;
@@ -87,11 +87,26 @@ class OperatingSystem extends InventoryAsset
         }
 
         $mapping = [
-            'operatingsystems_id'               => RuleDictionnaryOperatingSystemCollection::class,
-            'operatingsystemversions_id'        => RuleDictionnaryOperatingSystemVersionCollection::class,
-            'operatingsystemservicepacks_id'    => RuleDictionnaryOperatingSystemServicePackCollection::class,
-            'operatingsystemarchitectures_id'   => RuleDictionnaryOperatingSystemArchitectureCollection::class,
-            'operatingsystemeditions_id'        => RuleDictionnaryOperatingSystemEditionCollection::class
+            'operatingsystems_id'               => [
+                "collection_class" => RuleDictionnaryOperatingSystemCollection::class,
+                "main_value" => $val->operatingsystems_id ?? ''
+            ],
+            'operatingsystemversions_id'        => [
+                "collection_class" => RuleDictionnaryOperatingSystemVersionCollection::class,
+                "main_value" => $val->operatingsystemversions_id ?? ''
+            ],
+            'operatingsystemservicepacks_id'    => [
+                "collection_class" => RuleDictionnaryOperatingSystemServicePackCollection::class,
+                "main_value" => $val->operatingsystemservicepacks_id ?? ''
+            ],
+            'operatingsystemarchitectures_id'   => [
+                "collection_class" => RuleDictionnaryOperatingSystemArchitectureCollection::class ,
+                "main_value" => $val->operatingsystemarchitectures_id ?? ''
+            ],
+            'operatingsystemeditions_id'        => [
+                "collection_class" => RuleDictionnaryOperatingSystemEditionCollection::class,
+                "main_value" => $val->operatingsystemeditions_id ?? ''
+            ],
         ];
 
         $rule_input = [
@@ -102,8 +117,9 @@ class OperatingSystem extends InventoryAsset
             'os_edition'        => $val->operatingsystemeditions_id ?? '',
         ];
 
-        foreach ($mapping as $key => $rule_class) {
-            $rulecollection = new $rule_class();
+        foreach ($mapping as $key => $value) {
+            $rulecollection = new $value['collection_class']();
+            $rule_input['name'] = $value['main_value'];
             $res_rule = $rulecollection->processAllRules($rule_input);
             if (isset($res_rule['name'])) {
                 $val->{$key} = $res_rule['name'];

--- a/src/RuleDictionnaryOperatingSystem.php
+++ b/src/RuleDictionnaryOperatingSystem.php
@@ -46,9 +46,9 @@ class RuleDictionnaryOperatingSystem extends RuleDictionnaryDropdown
             return $criterias;
         }
 
-        $criterias['os_name']['field'] = 'name';
-        $criterias['os_name']['name']  = OperatingSystem::getTypeName(1);
-        $criterias['os_name']['table'] = 'glpi_operatingsystems';
+        $criterias['name']['field'] = 'name';
+        $criterias['name']['name']  = OperatingSystem::getTypeName(1);
+        $criterias['name']['table'] = 'glpi_operatingsystems';
 
         $criterias['os_version_name']['field'] = 'name';
         $criterias['os_version_name']['name']  = OperatingSystemVersion::getTypeName(1);

--- a/src/RuleDictionnaryOperatingSystemArchitecture.php
+++ b/src/RuleDictionnaryOperatingSystemArchitecture.php
@@ -47,9 +47,9 @@ class RuleDictionnaryOperatingSystemArchitecture extends RuleDictionnaryDropdown
             return $criterias;
         }
 
-        $criterias['arch_name']['field'] = 'name';
-        $criterias['arch_name']['name']  = OperatingSystemArchitecture::getTypeName(1);
-        $criterias['arch_name']['table'] = 'glpi_operatingsystemarchitectures';
+        $criterias['name']['field'] = 'name';
+        $criterias['name']['name']  = OperatingSystemArchitecture::getTypeName(1);
+        $criterias['name']['table'] = 'glpi_operatingsystemarchitectures';
 
         $criterias['os_name']['field'] = 'name';
         $criterias['os_name']['name']  = OperatingSystem::getTypeName(1);

--- a/src/RuleDictionnaryOperatingSystemEdition.php
+++ b/src/RuleDictionnaryOperatingSystemEdition.php
@@ -49,9 +49,9 @@ class RuleDictionnaryOperatingSystemEdition extends RuleDictionnaryDropdown
             return $criterias;
         }
 
-        $criterias['os_edition']['field'] = 'name';
-        $criterias['os_edition']['name']  = _n('Edition', 'Editions', 1);
-        $criterias['os_edition']['table'] = 'glpi_operatingsystemeditions';
+        $criterias['name']['field'] = 'name';
+        $criterias['name']['name']  = _n('Edition', 'Editions', 1);
+        $criterias['name']['table'] = 'glpi_operatingsystemeditions';
 
         $criterias['os_name']['field'] = 'name';
         $criterias['os_name']['name']  = OperatingSystem::getTypeName(1);

--- a/src/RuleDictionnaryOperatingSystemServicePack.php
+++ b/src/RuleDictionnaryOperatingSystemServicePack.php
@@ -47,9 +47,9 @@ class RuleDictionnaryOperatingSystemServicePack extends RuleDictionnaryDropdown
             return $criterias;
         }
 
-        $criterias['servicepack_name']['field'] = 'name';
-        $criterias['servicepack_name']['name']  = OperatingSystemServicePack::getTypeName(1);
-        $criterias['servicepack_name']['table'] = 'glpi_operatingsystemservicepacks';
+        $criterias['name']['field'] = 'name';
+        $criterias['name']['name']  = OperatingSystemServicePack::getTypeName(1);
+        $criterias['name']['table'] = 'glpi_operatingsystemservicepacks';
 
         $criterias['os_name']['field'] = 'name';
         $criterias['os_name']['name']  = OperatingSystem::getTypeName(1);

--- a/src/RuleDictionnaryOperatingSystemVersion.php
+++ b/src/RuleDictionnaryOperatingSystemVersion.php
@@ -49,9 +49,9 @@ class RuleDictionnaryOperatingSystemVersion extends RuleDictionnaryDropdown
             return $criterias;
         }
 
-        $criterias['os_version']['field'] = 'name';
-        $criterias['os_version']['name']  = _n('Version', 'Versions', 1);
-        $criterias['os_version']['table'] = 'glpi_operatingsystemversions';
+        $criterias['name']['field'] = 'name';
+        $criterias['name']['name']  = _n('Version', 'Versions', 1);
+        $criterias['name']['table'] = 'glpi_operatingsystemversions';
 
         $criterias['os_name']['field'] = 'name';
         $criterias['os_name']['name']  = OperatingSystem::getTypeName(1);


### PR DESCRIPTION
"Replay the dictionary rules" 

![image](https://github.com/glpi-project/glpi/assets/7335054/64683d93-7377-4815-bc92-320e2523a94e)

no longer works since https://github.com/glpi-project/glpi/commit/3c8c655d207d893dae07e3e854492580a27c9cd2

Because the feature use "generic" field name ```['name']```.

But 

- ```RuleDictionnaryOperatingSystemCollection```
- ```RuleDictionnaryOperatingSystemVersionCollection```
- ```RuleDictionnaryOperatingSystemServicePackCollection```
- ```RuleDictionnaryOperatingSystemEditionCollection```

have been updated so that the ```name``` key is no longer used, but instead ```os_name```, ```os_version_name``` etc ....

This PR revert this change to keep generic behavior


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28216
