### PR TITLE
Handled missing document entries in notifications

### DIFF
--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -223,9 +223,12 @@ class NotificationEventMailing extends NotificationEventAbstract
                 } else {
                     $mmail->Body = '';
                     $inline_docs = [];
-                    $doc = new Document();
                     foreach ($documents_ids as $document_id) {
-                        $doc->getFromDB($document_id);
+                        $doc = new Document();
+                        if ($doc->getFromDB($document_id) === false) {
+                            trigger_error(sprintf('Unable to load document %d.', $document_id), E_USER_WARNING);
+                            continue;
+                        }
                         // Add embeded image if tag present in ticket content
                         if (
                             preg_match_all(
@@ -272,64 +275,72 @@ class NotificationEventMailing extends NotificationEventAbstract
                     ) {
                         if (isset($matches[2])) {
                             foreach ($matches[2] as $pos => $docID) {
-                                if (!in_array($docID, $inline_docs)) {
-                                    $doc->getFromDB($docID);
+                                if (in_array($docID, $inline_docs)) {
+                                    // Already in mapping
+                                    continue;
+                                }
 
-                                    //find width
-                                    $custom_width = null;
-                                    if (preg_match("/width=[\"|'](\d+)(\.\d+)?[\"|']/", $matches[0][$pos], $wmatches)) {
-                                        $custom_width = intval($wmatches[1]);
-                                    }
-                                    $custom_height = null;
-                                    if (preg_match("/height=[\"|'](\d+)(\.\d+)?[\"|']/", $matches[0][$pos], $hmatches)) {
-                                        $custom_height = intval($hmatches[1]);
-                                    }
+                                $doc = new Document();
+                                if ($doc->getFromDB($docID) === false) {
+                                    $inline_docs[$docID] = 'notfound'; // Add mapping entry to ensure that src is converted to an absolute URL
+                                    trigger_error(sprintf('Unable to load document %d.', $docID), E_USER_WARNING);
+                                    continue;
+                                }
 
-                                    // Make sure file still exists
-                                    if (!file_exists(GLPI_DOC_DIR . "/" . $doc->fields['filepath'])) {
-                                        trigger_error('Failed to add document ' . $doc->fields['filepath'] . ' to mail: file not found', E_USER_WARNING);
-                                        continue;
-                                    }
+                                //find width
+                                $custom_width = null;
+                                if (preg_match("/width=[\"|'](\d+)(\.\d+)?[\"|']/", $matches[0][$pos], $wmatches)) {
+                                    $custom_width = intval($wmatches[1]);
+                                }
+                                $custom_height = null;
+                                if (preg_match("/height=[\"|'](\d+)(\.\d+)?[\"|']/", $matches[0][$pos], $hmatches)) {
+                                    $custom_height = intval($hmatches[1]);
+                                }
 
-                                    $img_infos = getimagesize(GLPI_DOC_DIR . "/" . $doc->fields['filepath']);
+                                // Make sure file still exists
+                                if (!file_exists(GLPI_DOC_DIR . "/" . $doc->fields['filepath'])) {
+                                    trigger_error('Failed to add document ' . $doc->fields['filepath'] . ' to mail: file not found', E_USER_WARNING);
+                                    continue;
+                                }
 
-                                    if (!$img_infos) {
-                                        // Failure to read image size, skip to avoid a divide by zero exception
-                                        continue;
-                                    }
+                                $img_infos = getimagesize(GLPI_DOC_DIR . "/" . $doc->fields['filepath']);
 
-                                    $initial_width = $img_infos[0];
-                                    $initial_height = $img_infos[1];
+                                if (!$img_infos) {
+                                    // Failure to read image size, skip to avoid a divide by zero exception
+                                    continue;
+                                }
 
-                                    if ($custom_width !== null && $custom_height === null) {
-                                        //compute height if needed
-                                        $custom_height = $initial_height * $custom_width / $initial_width;
-                                    } elseif ($custom_height !== null && $custom_width === null) {
-                                        //compute width if needed
-                                        $custom_width = $initial_width * $custom_height / $initial_height;
-                                    } elseif ($custom_height === null && $custom_width === null) {
-                                        //if both are null keep initial size
-                                        $custom_width = $initial_width;
-                                        $custom_height = $initial_height;
-                                    }
+                                $initial_width = $img_infos[0];
+                                $initial_height = $img_infos[1];
 
-                                    $image_path = Document::getImage(
-                                        GLPI_DOC_DIR . "/" . $doc->fields['filepath'],
-                                        'mail',
-                                        $custom_width,
-                                        $custom_height
-                                    );
-                                    if (
-                                        $mmail->AddEmbeddedImage(
-                                            $image_path,
-                                            $doc->fields['tag'],
-                                            $doc->fields['filename'],
-                                            'base64',
-                                            $doc->fields['mime']
-                                        )
-                                    ) {
-                                        $inline_docs[$docID] = $doc->fields['tag'];
-                                    }
+                                if ($custom_width !== null && $custom_height === null) {
+                                    //compute height if needed
+                                    $custom_height = $initial_height * $custom_width / $initial_width;
+                                } elseif ($custom_height !== null && $custom_width === null) {
+                                    //compute width if needed
+                                    $custom_width = $initial_width * $custom_height / $initial_height;
+                                } elseif ($custom_height === null && $custom_width === null) {
+                                    //if both are null keep initial size
+                                    $custom_width = $initial_width;
+                                    $custom_height = $initial_height;
+                                }
+
+                                $image_path = Document::getImage(
+                                    GLPI_DOC_DIR . "/" . $doc->fields['filepath'],
+                                    'mail',
+                                    $custom_width,
+                                    $custom_height
+                                );
+                                if (
+                                    $mmail->AddEmbeddedImage(
+                                        $image_path,
+                                        $doc->fields['tag'],
+                                        $doc->fields['filename'],
+                                        'base64',
+                                        $doc->fields['mime']
+                                    )
+                                ) {
+                                    $inline_docs[$docID] = $doc->fields['tag'];
                                 }
                             }
                         }
@@ -476,7 +487,10 @@ class NotificationEventMailing extends NotificationEventAbstract
 
         $document = new Document();
         foreach ($documents_ids as $document_id) {
-            $document->getFromDB($document_id);
+            if ($document->getFromDB($document_id) === false) {
+                trigger_error(sprintf('Unable to load document %d.', $document_id), E_USER_WARNING);
+                continue;
+            }
             $path = GLPI_DOC_DIR . "/" . $document->fields['filepath'];
             if (Document::isImage($path)) {
                 $path = Document::getImage(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | see #14901

It is probably an edge case, but documents handling in notifications does not correctly handle missing documents in DB.

Whitespace changes should be ignored to make review easier.