### PR TITLE
Display actor default email as input placeholder

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -4064,7 +4064,8 @@ JAVASCRIPT;
                     'itemtype'          => "User",
                     'items_id'          => $ID,
                     'use_notification'  => strlen($user['default_email'] ?? "") > 0 ? 1 : 0,
-                    'alternative_email' => $user['default_email'],
+                    'default_email'     => $user['default_email'],
+                    'alternative_email' => '',
                 ];
             }
         }
@@ -4128,7 +4129,8 @@ JAVASCRIPT;
                         $children['id']                = "Supplier_" . $children['id'];
                         $children['itemtype']          = "Supplier";
                         $children['use_notification']  = strlen($supplier_obj->fields['email']) > 0 ? 1 : 0;
-                        $children['alternative_email'] = $supplier_obj->fields['email'];
+                        $children['default_email']     = $supplier_obj->fields['email'];
+                        $children['alternative_email'] = '';
                     }
                 }
 

--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -58,7 +58,8 @@
       <option selected="true" value="{{ actor['itemtype'] ~ '_' ~ actor['items_id'] }}"
             data-itemtype="{{ actor['itemtype'] }}" data-items-id="{{ actor['items_id'] }}"
             data-use-notification="{{ actor['use_notification'] }}"
-            data-alternative-email="{{ actor['alternative_email'] }}"
+            data-default-email="{{ actor['default_email'] ?? '' }}"
+            data-alternative-email="{{ actor['alternative_email'] ?? '' }}"
             {% if (actor['itemtype'] == 'User' and itiltemplate.isHiddenField('_users_id_' ~ actortype)) or (actor['itemtype'] == 'Group' and itiltemplate.isHiddenField('_groups_id_' ~ actortype)) %}
                disabled="disabled" style="display: none;"
             {% endif %}
@@ -305,6 +306,7 @@
             var itemtype  = selection.itemtype ?? element.data('itemtype');
             var items_id  = selection.items_id ?? element.data('items-id');
             var use_notif = selection.use_notification  ?? element.data('use-notification')  ?? false;
+            var def_email = selection.default_email ?? element.data('default-email') ?? '';
             var alt_email = selection.alternative_email ?? element.data('alternative-email') ?? '';
 
             if (itemtype == "Email") {
@@ -317,6 +319,7 @@
                itemtype: itemtype,
                items_id: items_id,
                use_notification: use_notif,
+               default_email: def_email,
                alternative_email: alt_email,
             });
          });

--- a/templates/components/itilobject/actors/main.html.twig
+++ b/templates/components/itilobject/actors/main.html.twig
@@ -202,9 +202,8 @@
                itemtype: "{{ actor['itemtype'] }}",
                items_id: "{{ actor['items_id'] }}",
                use_notification: {{ actor['use_notification'] ? "1" : "0" }},
-               {% if actor['alternative_email'] is defined %}
-                  alternative_email: "{{ actor['alternative_email'] }}",
-               {% endif %}
+               alternative_email: "{{ actor['alternative_email'] ?? '' }}",
+               default_email: "{{ actor['default_email'] ?? '' }}",
             },
             {% endfor %}
          ],
@@ -229,6 +228,7 @@
       modal.find("input[name=_notifications_actorindex]").val(actorIndex);
       modal.find("input[name=_notifications_actorname]").removeAttr('readonly').val(text).attr('readonly', 'true');
       modal.find("input[name=_notifications_use_notification]").prop('checked', parseInt(actor.use_notification));
+      modal.find("input[name=_notifications_alternative_email]").attr('placeholder', actor.default_email);
       modal.find("input[name=_notifications_alternative_email]").val(actor.alternative_email);
 
       editActorNotifySettings_modal.show();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When a person does not receive a notification for a ticket, people usually check if the email address is set correctly in the corresponding actor's notification settings. In GLPI 10.0, the value of the `alternative_email` field of an actor is no longer forced with the default email of this actor. In this case, when the modal notification setting is opened, the field is empty (see screenshots below) and users think that is why their user did not receive notifications. This is not a correct statement, as their user will receive a notification on their default email.

To clarify this behaviour, I added a placeholder that contains the default email of the actor. People will now be able to see what email used in notification system, even when there is no `alternative_email` defined.

Before:
![image](https://github.com/glpi-project/glpi/assets/33253653/da3f68cc-8c01-43c6-93d7-1bfee3ce332f)

After:
![image](https://github.com/glpi-project/glpi/assets/33253653/7048456d-5788-4a50-b0e4-47dc92064ae8)
