### PR TITLE
fix(License Form): Display link on update instaed of dropdown

### DIFF
--- a/templates/pages/management/softwarelicense.html.twig
+++ b/templates/pages/management/softwarelicense.html.twig
@@ -36,20 +36,39 @@
 {% set params  = params ?? [] %}
 
 {% block form_fields %}
-   {{ fields.dropdownField(
-      'Software',
-      'softwares_id',
-      item.fields['softwares_id'],
-      "Software"|itemtype_name,
-      {
-         'entity': item.fields['entities_id'],
-         'condition': {
-            'is_template': 0,
-            'is_deleted': 0,
-         },
-         'on_change': 'this.form.submit()'
-      }
-   ) }}
+
+
+   {% if item.fields['id'] > 0 %}
+
+      <input type="hidden" name="softwares_id" value="{{ item.fields['softwares_id'] }}" />
+
+      {% set software_link %}
+         <a href="{{ call('Software::getFormURLWithID', [item.fields['softwares_id']]) }}">
+         {{ call('Dropdown::getDropdownName', ["glpi_softwares", item.fields['softwares_id']]) }} </a>
+      {% endset %}
+
+      {{ fields.field('software', software_link, __('Software')) }}
+
+   {% else %}
+
+      {{ fields.dropdownField(
+         'Software',
+         'softwares_id',
+         item.fields['softwares_id'],
+         "Software"|itemtype_name,
+         {
+            'entity': item.fields['entities_id'],
+            'condition': {
+               'is_template': 0,
+               'is_deleted': 0,
+            },
+            'on_change': 'this.form.submit()'
+         }
+      ) }}
+
+   {% endif %}
+
+
 
    {{ fields.nullField() }}
 

--- a/templates/pages/management/softwarelicense.html.twig
+++ b/templates/pages/management/softwarelicense.html.twig
@@ -47,7 +47,7 @@
          {{ call('Dropdown::getDropdownName', ["glpi_softwares", item.fields['softwares_id']]) }} </a>
       {% endset %}
 
-      {{ fields.field('software', software_link, __('Software')) }}
+      {{ fields.field('software', software_link,  _n('Software', 'Softwares', get_plural_number())) }}
 
    {% else %}
 

--- a/templates/pages/management/softwarelicense.html.twig
+++ b/templates/pages/management/softwarelicense.html.twig
@@ -47,7 +47,16 @@
          {{ call('Dropdown::getDropdownName', ["glpi_softwares", item.fields['softwares_id']]) }} </a>
       {% endset %}
 
-      {{ fields.field('software', software_link,  _n('Software', 'Softwares', get_plural_number())) }}
+      {{ fields.field(
+         'software',
+         software_link,
+         _n('Software', 'Softwares', get_plural_number()),
+         {
+            'width': '100%',
+            'height': '100%',
+            'input_class' : 'd-flex col-xxl-7 field-container align-items-center'
+         }
+      ) }}
 
    {% else %}
 


### PR DESCRIPTION
From GLPI 9.5

License form on update display software link instead of ```dropdown```

![image](https://github.com/glpi-project/glpi/assets/7335054/18fbe116-c59c-4f6a-a63e-cee41e6160c3)

this PR implement same behavior on GLPI 10

![image](https://github.com/glpi-project/glpi/assets/7335054/94ff65e9-bb7f-444a-947e-88cfeca7da08)

this avoids the refresh problem when changing the selected dropdown item (works correctly on add)
 


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
