### PR TITLE
fix(dictionnaryOS): fix repaly rule on existing data

### DIFF
--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -1037,7 +1037,7 @@ $RELATION = [
     ],
 
     'glpi_operatingsystems' => [
-        '_glpi_items_operatingsystems' => 'operatingsystems_id',
+        'glpi_items_operatingsystems' => 'operatingsystems_id',
         'glpi_softwareversions'        => 'operatingsystems_id',
     ],
 

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -925,12 +925,18 @@ class CommonDBTM extends CommonGLPI
                     );
                     foreach ($result as $data) {
                         $item = new $itemtype();
-                        $item->update(
-                            [
-                                $id_field       => $data[$id_field],
-                                '_disablenotif' => true,
-                            ] + $update
-                        );
+                        $input =  [
+                            $id_field       => $data[$id_field],
+                            '_disablenotif' => true,
+                        ] + $update;
+
+                        //prevent lock if item is dynamic
+                        //as the dictionary rules are played out during the inventory anyway
+                        if (isset($data['is_dynamic'])) {
+                            $input['is_dynamic'] = $data['is_dynamic'];
+                        }
+
+                        $item->update($input);
                     }
                 }
             }

--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -43,6 +43,8 @@ class Item_OperatingSystem extends CommonDBRelation
     public static $items_id_2 = 'items_id';
     public static $checkItem_1_Rights = self::DONT_CHECK_ITEM_RIGHTS;
 
+    public static $mustBeAttached_1 = false;
+
 
     public static function getTypeName($nb = 0)
     {

--- a/src/OperatingSystem.php
+++ b/src/OperatingSystem.php
@@ -43,5 +43,4 @@ class OperatingSystem extends CommonDropdown
     {
         return _n('Operating system', 'Operating systems', $nb);
     }
-
 }

--- a/src/OperatingSystem.php
+++ b/src/OperatingSystem.php
@@ -44,12 +44,4 @@ class OperatingSystem extends CommonDropdown
         return _n('Operating system', 'Operating systems', $nb);
     }
 
-    public function cleanDBonPurge()
-    {
-        $this->deleteChildrenAndRelationsFromDb(
-            [
-                Item_OperatingSystem::class
-            ]
-        );
-    }
 }

--- a/src/RuleDictionnaryDropdownCollection.php
+++ b/src/RuleDictionnaryDropdownCollection.php
@@ -56,7 +56,7 @@ class RuleDictionnaryDropdownCollection extends RuleCollection
             return $this->replayRulesOnExistingDBForModel($offset, $maxtime);
         }
 
-        if (isCommandLine() && !defined('TU_USER')) {
+        if (isCommandLine()) {
             printf(__('Replay rules on existing database started on %s') . "\n", date("r"));
         }
 
@@ -79,9 +79,7 @@ class RuleDictionnaryDropdownCollection extends RuleCollection
                 if (!($i % $step)) {
                     if (isCommandLine()) {
                         //TRANS: %1$s is a row, %2$s is total rows
-                        if (!defined('TU_USER')) {
-                            printf(__('Replay rules on existing database: %1$s/%2$s') . "\r", $i, $nb);
-                        }
+                        printf(__('Replay rules on existing database: %1$s/%2$s') . "\r", $i, $nb);
                     } else {
                         Html::changeProgressBarPosition($i, $nb, "$i / $nb");
                     }
@@ -117,9 +115,7 @@ class RuleDictionnaryDropdownCollection extends RuleCollection
         }
 
         if (isCommandLine()) {
-            if (!defined('TU_USER')) {
-                printf(__('Replay rules on existing database started on %s') . "\n", date("r"));
-            }
+            printf(__('Replay rules on existing database started on %s') . "\n", date("r"));
         } else {
             Html::changeProgressBarPosition($i, $nb, "$i / $nb");
         }

--- a/src/RuleDictionnaryDropdownCollection.php
+++ b/src/RuleDictionnaryDropdownCollection.php
@@ -56,7 +56,7 @@ class RuleDictionnaryDropdownCollection extends RuleCollection
             return $this->replayRulesOnExistingDBForModel($offset, $maxtime);
         }
 
-        if (isCommandLine()) {
+        if (isCommandLine() && !defined('TU_USER')) {
             printf(__('Replay rules on existing database started on %s') . "\n", date("r"));
         }
 
@@ -78,8 +78,10 @@ class RuleDictionnaryDropdownCollection extends RuleCollection
             foreach ($iterator as $data) {
                 if (!($i % $step)) {
                     if (isCommandLine()) {
-                      //TRANS: %1$s is a row, %2$s is total rows
-                        printf(__('Replay rules on existing database: %1$s/%2$s') . "\r", $i, $nb);
+                        //TRANS: %1$s is a row, %2$s is total rows
+                        if (!defined('TU_USER')) {
+                            printf(__('Replay rules on existing database: %1$s/%2$s') . "\r", $i, $nb);
+                        }
                     } else {
                         Html::changeProgressBarPosition($i, $nb, "$i / $nb");
                     }
@@ -115,7 +117,9 @@ class RuleDictionnaryDropdownCollection extends RuleCollection
         }
 
         if (isCommandLine()) {
-            printf(__('Replay rules on existing database started on %s') . "\n", date("r"));
+            if (!defined('TU_USER')) {
+                printf(__('Replay rules on existing database started on %s') . "\n", date("r"));
+            }
         } else {
             Html::changeProgressBarPosition($i, $nb, "$i / $nb");
         }

--- a/tests/functional/Glpi/Inventory/Assets/OperatingSystem.php
+++ b/tests/functional/Glpi/Inventory/Assets/OperatingSystem.php
@@ -1263,18 +1263,20 @@ class OperatingSystem extends AbstractInventoryAsset
         $this->string($theos1['install_date'])->isIdenticalTo("2022-01-01");
 
         //enable rule to clean OS
-        $DB->update(
-            Rule::getTable(),
-            [
-                'is_active' => 1,
-            ],
-            [
-                "sub_type" =>
+        $this->boolean(
+            $DB->update(
+                Rule::getTable(),
                 [
-                    RuleDictionnaryOperatingSystem::class,
+                    'is_active' => 1,
+                ],
+                [
+                    "sub_type" =>
+                    [
+                        RuleDictionnaryOperatingSystem::class,
+                    ]
                 ]
-            ]
-        );
+            )
+        )->isTrue();
 
         //replay rule
         $this->login('glpi', 'glpi');

--- a/tests/functional/Glpi/Inventory/Assets/OperatingSystem.php
+++ b/tests/functional/Glpi/Inventory/Assets/OperatingSystem.php
@@ -1192,7 +1192,7 @@ class OperatingSystem extends AbstractInventoryAsset
         $this->string($theos['install_date'])->isIdenticalTo("2022-10-14");
     }
 
-    public function testReplayruleOnOS()
+    public function testReplayRuleOnOS()
     {
         $os = new \OperatingSystem();
         $cos = new \Item_OperatingSystem();

--- a/tests/functional/Glpi/Inventory/Assets/OperatingSystem.php
+++ b/tests/functional/Glpi/Inventory/Assets/OperatingSystem.php
@@ -1183,6 +1183,7 @@ class OperatingSystem extends AbstractInventoryAsset
         $list = $os->find();
         $this->integer(count($list))->isIdenticalTo(2);
 
+        //but still only one linked to computer
         $list = $cos->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
         $this->integer(count($list))->isIdenticalTo(1);
         $theos = current($list);

--- a/tests/functional/Glpi/Inventory/Assets/OperatingSystem.php
+++ b/tests/functional/Glpi/Inventory/Assets/OperatingSystem.php
@@ -1183,12 +1183,128 @@ class OperatingSystem extends AbstractInventoryAsset
         $list = $os->find();
         $this->integer(count($list))->isIdenticalTo(2);
 
-       //but still only one linked to computer
         $list = $cos->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
         $this->integer(count($list))->isIdenticalTo(1);
         $theos = current($list);
         $this->integer($theos['operatingsystems_id'])->isNotIdenticalTo($os_id, 'Operating system link has not been updated');
         $this->integer($theos['is_dynamic'])->isIdenticalTo(1);
         $this->string($theos['install_date'])->isIdenticalTo("2022-10-14");
+    }
+
+    public function testReplayruleOnOS()
+    {
+        $os = new \OperatingSystem();
+        $cos = new \Item_OperatingSystem();
+        global $DB;
+
+        $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<REQUEST>
+  <CONTENT>
+    <OPERATINGSYSTEM>
+      <ARCH>x86_64</ARCH>
+      <BOOT_TIME>2018-10-02 08:56:09</BOOT_TIME>
+      <FQDN>test-pc002</FQDN>
+      <FULL_NAME>Fedora 28 (Workstation Edition)</FULL_NAME>
+      <HOSTID>a8c07701</HOSTID>
+      <INSTALL_DATE>2022-01-01 10:35:07</INSTALL_DATE>
+      <KERNEL_NAME>linux</KERNEL_NAME>
+      <KERNEL_VERSION>4.18.9-200.fc28.x86_64</KERNEL_VERSION>
+      <NAME>Fedora</NAME>
+      <TIMEZONE>
+        <NAME>CEST</NAME>
+        <OFFSET>+0200</OFFSET>
+      </TIMEZONE>
+      <VERSION>28 (Workstation Edition)</VERSION>
+    </OPERATINGSYSTEM>
+    <HARDWARE>
+      <NAME>pc002</NAME>
+    </HARDWARE>
+    <BIOS>
+      <SSN>ggheb7ne7</SSN>
+    </BIOS>
+    <VERSIONCLIENT>FusionInventory-Agent_v2.3.19</VERSIONCLIENT>
+  </CONTENT>
+  <DEVICEID>test-pc002</DEVICEID>
+  <QUERY>INVENTORY</QUERY>
+</REQUEST>";
+
+        $this->doInventory($xml_source, true);
+
+        //check created agent
+        $agents = $DB->request(['FROM' => \Agent::getTable()]);
+        $this->integer(count($agents))->isIdenticalTo(1);
+        $agent = $agents->current();
+        $this->array($agent)
+            ->string['deviceid']->isIdenticalTo('test-pc002')
+            ->string['itemtype']->isIdenticalTo('Computer');
+
+
+        //check created computer
+        $computers_id = $agent['items_id'];
+        $this->integer($computers_id)->isGreaterThan(0);
+        $computer = new \Computer();
+        $this->boolean($computer->getFromDB($computers_id))->isTrue();
+
+        //check found OS
+        $list = $os->find();
+        $this->integer(count($list))->isIdenticalTo(1);
+
+        //check found item_OS
+        $list = $cos->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
+        $this->integer(count($list))->isIdenticalTo(1);
+        $theos1 = current($list);
+
+        $os->getFromDBByCrit([ 'name' => 'Fedora 28 (Workstation Edition)']);
+        $this->integer($os->fields['id'])->isGreaterThan(0);
+
+        //check item_OS data
+        $this->integer($theos1['operatingsystems_id'])->isIdenticalTo($os->fields['id']);
+        $this->integer($theos1['is_dynamic'])->isIdenticalTo(1);
+        $this->string($theos1['install_date'])->isIdenticalTo("2022-01-01");
+
+        //enable rule to clean OS
+        $DB->update(
+            Rule::getTable(),
+            [
+                'is_active' => 1,
+            ],
+            [
+                "sub_type" =>
+                [
+                    RuleDictionnaryOperatingSystem::class,
+                ]
+            ]
+        );
+
+        //replay rule
+        $this->login('glpi', 'glpi');
+        $start = explode(" ", microtime());
+        $start = $start[0] + $start[1];
+
+        $max = get_cfg_var("max_execution_time");
+        $max = $start + ($max > 0 ? $max / 2.0 : 30.0);
+
+        $os_dictionnary = new \RuleDictionnaryOperatingSystemCollection();
+        $os_dictionnary->replayRulesOnExistingDB(0, $max, [], []);
+
+        $list = $cos->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
+        $this->integer(count($list))->isIdenticalTo(1);
+        $theos2 = current($list);
+        //same Item_OperatingSystem before and after
+        $this->integer($theos2['id'])->isIdenticalTo($theos1['id']);
+
+        //load new OS name cleaned by dictionnary
+        $os->getFromDBByCrit([ 'name' => 'Fedora']);
+        $this->integer($os->fields['id'])->isGreaterThan(0);
+
+        //check item_OS data
+        $this->integer($theos2['operatingsystems_id'])->isIdenticalTo($os->fields['id']);
+        $this->integer($theos2['is_dynamic'])->isIdenticalTo(1);
+        $this->string($theos2['install_date'])->isIdenticalTo("2022-01-01");
+
+        //no lock
+        $lockedfield = new \Lockedfield();
+        $this->boolean($lockedfield->isHandled($computer))->isTrue();
+        $this->array($lockedfield->getLockedValues($computer->getType(), $computers_id))->isEmpty();
     }
 }

--- a/tests/functional/Glpi/Inventory/Assets/OperatingSystem.php
+++ b/tests/functional/Glpi/Inventory/Assets/OperatingSystem.php
@@ -1288,7 +1288,13 @@ class OperatingSystem extends AbstractInventoryAsset
         $max = $start + ($max > 0 ? $max / 2.0 : 30.0);
 
         $os_dictionnary = new \RuleDictionnaryOperatingSystemCollection();
-        $os_dictionnary->replayRulesOnExistingDB(0, $max, [], []);
+
+        $this->output(
+            function () use ($os_dictionnary, $max) {
+                $os_dictionnary->replayRulesOnExistingDB(0, $max, [], []);
+            }
+        )->contains("Replay rules on existing database started on");
+
 
         $list = $cos->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
         $this->integer(count($list))->isIdenticalTo(1);

--- a/tests/functional/Glpi/Inventory/Assets/OperatingSystem.php
+++ b/tests/functional/Glpi/Inventory/Assets/OperatingSystem.php
@@ -1281,17 +1281,11 @@ class OperatingSystem extends AbstractInventoryAsset
 
         //replay rule
         $this->login('glpi', 'glpi');
-        $start = explode(" ", microtime());
-        $start = $start[0] + $start[1];
-
-        $max = get_cfg_var("max_execution_time");
-        $max = $start + ($max > 0 ? $max / 2.0 : 30.0);
 
         $os_dictionnary = new \RuleDictionnaryOperatingSystemCollection();
-
         $this->output(
-            function () use ($os_dictionnary, $max) {
-                $os_dictionnary->replayRulesOnExistingDB(0, $max, [], []);
+            function () use ($os_dictionnary) {
+                $os_dictionnary->replayRulesOnExistingDB(0, 0, [], []);
             }
         )->contains("Replay rules on existing database started on");
 


### PR DESCRIPTION
Bug found after https://github.com/glpi-project/glpi/pull/14897

bad relation declared from ```relation.constant.php```

```_glpi_items_operatingsystems``` instead of ```glpi_items_operatingsystems```

See other relation like 

```php
 'glpi_operatingsystemservicepacks' => [
        'glpi_items_operatingsystems' => 'operatingsystemservicepacks_id',
    ],

    'glpi_operatingsystemversions' => [
        'glpi_items_operatingsystems' => 'operatingsystemversions_id',
    ],

    'glpi_operatingsystemkernels' => [
        'glpi_operatingsystemkernelversions' => 'operatingsystemkernels_id',
    ],

    'glpi_operatingsystemkernelversions' => [
        'glpi_items_operatingsystems' => 'operatingsystemkernelversions_id',
    ],
```

and when an ```OperatingSystem``` is purged GLPI purged ```Item_OperatingSystem``` too.

Behavior not equal to  ```OperatingSystemVersion```,  ```OperatingSystemEdition```,  ```OperatingSystemArchitecture``` etc ...   

(who do nothing)

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
