### PR TITLE
Fix SLA waiting time duration

### DIFF
--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -261,13 +261,15 @@ class Calendar extends CommonDropdown
     /**
      * Get active time between to date time for the active calendar
      *
-     * @param $start           datetime begin
-     * @param $end             datetime end
-     * @param $work_in_days    boolean  force working in days (false by default)
+     * @param string $start                 begin datetime
+     * @param string $end                   end datetime
+     * @param bool   $include_inactive_time true to just get the time passed between start time and end time
      *
-     * @return integer timestamp of delay
+     * @return int timestamp of delay
+     *
+     * @FIXME Remove `$include_inactive_time` parameter in GLPI 10.1. It does not seems to be used and makes no sense.
      */
-    public function getActiveTimeBetween($start, $end, $work_in_days = false)
+    public function getActiveTimeBetween($start, $end, $include_inactive_time = false)
     {
 
         if (!isset($this->fields['id'])) {
@@ -287,7 +289,7 @@ class Calendar extends CommonDropdown
 
         $activetime = 0;
 
-        if ($work_in_days) {
+        if ($include_inactive_time) {
             $activetime = $timeend - $timestart;
         } else {
             $cache_duration = $this->getDurationsCache();
@@ -415,29 +417,28 @@ class Calendar extends CommonDropdown
            // Invalid calendar (no working day = unable to find any date inside calendar hours)
             return false;
         }
+        $cache_duration = $this->getDurationsCache();
 
         $actualtime = strtotime($start);
         $timestart  = strtotime($start);
         $datestart  = date('Y-m-d', $timestart);
 
-       // manage dates in past
+        // manage dates in past
         $negative_delay = false;
         if ($delay < 0) {
             $delay = -$delay;
             $negative_delay = true;
         }
 
-       // End of working day
+        // Compute initial target date
         if ($end_of_working_day) {
-            $numberofdays = $delay / DAY_TIMESTAMP;
-           // Add $additional_delay to start time.
-           // If start + delay is next day : +1 day
-            $actualtime += $additional_delay;
-            $cache_duration = $this->getDurationsCache();
-            $dayofweek      = self::getDayNumberInWeek($actualtime);
-            $actualdate     = date('Y-m-d', $actualtime);
+            // Computation that will result in a target date that corresponds to the end of a working day.
 
-           // Begin next day working
+            $numberofdays = $delay / DAY_TIMESTAMP;
+            $dayofweek  = self::getDayNumberInWeek($actualtime);
+            $actualdate = date('Y-m-d', $actualtime);
+
+            // Begin next day working
             if (
                 $this->isHoliday($actualdate)
                 || ($cache_duration[$dayofweek] == 0)
@@ -464,7 +465,7 @@ class Calendar extends CommonDropdown
                 $dayofweek   = self::getDayNumberInWeek($actualtime);
             }
 
-           // Get next working day
+            // Get next working day
             if (
                 $this->isHoliday($actualdate)
                 || ($cache_duration[$dayofweek] == 0)
@@ -481,17 +482,11 @@ class Calendar extends CommonDropdown
 
             $lastworkinghour = CalendarSegment::getLastWorkingHour($this->fields['id'], $dayofweek);
             $actualtime      = strtotime(date('Y-m-d', $actualtime) . ' ' . $lastworkinghour);
-            return date('Y-m-d H:i:s', $actualtime);
-        }
+        } else if ($work_in_days) {
+            // Computation that is based on a delay expressed in full days.
 
-       // Add additional delay to initial delay
-        $delay += $additional_delay;
-
-        if ($work_in_days) { // only based on days
-            $cache_duration = $this->getDurationsCache();
-
-           // Compute Real starting time
-           // If day is an holiday must start on the begin of next working day
+            // Compute Real starting time
+            // If day is an holiday must start on the begin of next working day
             $actualdate = date('Y-m-d', $actualtime);
             $dayofweek  = self::getDayNumberInWeek($actualtime);
             if (
@@ -514,7 +509,7 @@ class Calendar extends CommonDropdown
             }
 
             while ($delay > 0) {
-               // Begin next day : do not take into account first day : must finish to a working day
+                // Begin next day : do not take into account first day : must finish to a working day
                 $actualtime = self::getActualTime($actualtime, DAY_TIMESTAMP, $negative_delay);
                 $actualdate = date('Y-m-d', $actualtime);
                 $dayofweek  = self::getDayNumberInWeek($actualtime);
@@ -530,26 +525,15 @@ class Calendar extends CommonDropdown
                 }
             }
 
-           // If > last working hour set last working hour
+            // If > last working hour set last working hour
             $dayofweek       = self::getDayNumberInWeek($actualtime);
             $lastworkinghour = CalendarSegment::getLastWorkingHour($this->fields['id'], $dayofweek);
             if ($lastworkinghour < date('H:i:s', $actualtime)) {
                 $actualtime   = strtotime(date('Y-m-d', $actualtime) . ' ' . $lastworkinghour);
             }
+        } else {
+            // Computation based on a delay expressed in working hours.
 
-            return date('Y-m-d H:i:s', $actualtime);
-        }
-
-       // else  // based on working hours
-        $cache_duration = $this->getDurationsCache();
-
-       // Only if segments exists
-        if (
-            countElementsInTable(
-                'glpi_calendarsegments',
-                ['calendars_id' => $this->fields['id']]
-            )
-        ) {
             while ($delay >= 0) {
                 $actualdate = date('Y-m-d', $actualtime);
                 if (!$this->isHoliday($actualdate)) {
@@ -577,21 +561,36 @@ class Calendar extends CommonDropdown
                          $actualtime = self::getActualTime($actualtime, DAY_TIMESTAMP, $negative_delay);
                          $delay      -= $timeoftheday;
                     } else {
-                    // End of the delay in the day : get hours with this delay
+                        // End of the delay in the day : get hours with this delay
                         $endhour = CalendarSegment::addDelayInDay(
                             $this->fields['id'],
                             $dayofweek,
                             $beginhour,
                             $delay
                         );
-                        return $actualdate . ' ' . $endhour;
+                        $actualtime = strtotime($actualdate . ' ' . $endhour);
+                        break;
                     }
-                } else { // Holiday : pass to next day
+                } else {
+                    // Holiday : pass to next day
                     $actualtime = self::getActualTime($actualtime, DAY_TIMESTAMP, $negative_delay);
                 }
             }
         }
-        return false;
+
+        $actualdate = date('Y-m-d H:i:s', $actualtime);
+
+        if ($additional_delay) {
+            // Add additional delay in `$work_in_days = false` mode.
+            // For OLA/SLA, additional delay only include "waiting times" inside calendar working hours
+            // and should therefore be added inside working hours only, in addition to the initial target date.
+            $actualdate = $this->computeEndDate(
+                $actualdate,
+                $additional_delay
+            );
+        }
+
+        return $actualdate;
     }
 
     public static function getActualTime($current_time, $number = 0, $negative = false)

--- a/src/LevelAgreement.php
+++ b/src/LevelAgreement.php
@@ -96,6 +96,11 @@ abstract class LevelAgreement extends CommonDBChild
         return [$dateField, $laField];
     }
 
+    public static function getWaitingFieldName(): string
+    {
+        return static::$prefix . '_waiting_duration';
+    }
+
     public function defineTabs($options = [])
     {
 
@@ -795,12 +800,11 @@ abstract class LevelAgreement extends CommonDBChild
 
         if (isset($this->fields['id'])) {
             $cal          = new Calendar();
-            $work_in_days = ($this->fields['definition_time'] == 'day');
 
            // Based on a calendar
             if ($this->fields['calendars_id'] > 0) {
                 if ($cal->getFromDB($this->fields['calendars_id'])) {
-                    return $cal->getActiveTimeBetween($start, $end, $work_in_days);
+                    return $cal->getActiveTimeBetween($start, $end);
                 }
             } else { // No calendar
                 $timestart = strtotime($start);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28382

When SLA/OLA had a definition time in days (e.g. must be resolved within 5 business days), the wait time calculation was not excluding closing hours and holidays during its computation and its restitution.

The behaviour of `Calendar::getActiveTimeBetween()` when using `$work_in_days=true` parameter does not make really sense as it returns both active (business hours/days) and inactive (closing hours/days and holidays) time. I renamed it to make things clear, and I guess we could remove it in GLPI 10.1 as it is not used anymore (plugins are not using this param).