### PR TITLE
Fix table used for Domain entity ID search option

### DIFF
--- a/src/Domain.php
+++ b/src/Domain.php
@@ -226,7 +226,7 @@ class Domain extends CommonDBTM
 
         $tab[] = [
             'id'                 => '81',
-            'table'              => 'glpi_entities',
+            'table'              => self::getTable(),
             'field'              => 'entities_id',
             'name'               => __('Entity-ID')
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14938

The Domain table should be used instead of the entities table. Using the entity table results in it returning that entity's parent ID instead.