### PR TITLE
HL API Allow document download

### DIFF
--- a/src/Api/HL/Controller/ManagementController.php
+++ b/src/Api/HL/Controller/ManagementController.php
@@ -518,6 +518,14 @@ final class ManagementController extends AbstractController
     )]
     public function getDocument(Request $request): Response
     {
+        if ($request->hasHeader('Accept') && $request->getHeaderLine('Accept') === 'application/octet-stream') {
+            // User is requesting the actual file
+            $document = new Document();
+            if ($document->getFromDB($request->getAttribute('id'))) {
+                return $document->send(null, true);
+            }
+            return self::getNotFoundErrorResponse();
+        }
         return Search::getOneBySchema($this->getKnownSchema('Document'), $request->getAttributes(), $request->getParameters());
     }
 

--- a/src/Api/HL/Controller/ManagementController.php
+++ b/src/Api/HL/Controller/ManagementController.php
@@ -201,6 +201,17 @@ final class ManagementController extends AbstractController
             }
         }
 
+        $schemas['Document']['properties']['filename'] = ['type' => Doc\Schema::TYPE_STRING];
+        $schemas['Document']['properties']['filepath'] = [
+            'type' => Doc\Schema::TYPE_STRING,
+            'x-mapped-from' => 'id',
+            'x-mapper' => static function ($v) use ($CFG_GLPI) {
+                return $CFG_GLPI["root_doc"] . "/front/document.send.php?docid=" . $v;
+            }
+        ];
+        $schemas['Document']['properties']['mime'] = ['type' => Doc\Schema::TYPE_STRING];
+        $schemas['Document']['properties']['sha1sum'] = ['type' => Doc\Schema::TYPE_STRING];
+
         return $schemas;
     }
 
@@ -511,7 +522,7 @@ final class ManagementController extends AbstractController
 
     #[Route(path: '/Document/{id}', methods: ['GET'], requirements: ['id' => '\d+'])]
     #[Doc\Route(
-        description: 'Get a document by ID',
+        description: 'Get a document by ID. If the Accept header is set to application/octet-stream, the file will be returned. Otherwise, the document metadata will be returned.',
         responses: [
             ['schema' => 'Document']
         ]

--- a/src/Api/HL/Controller/ManagementController.php
+++ b/src/Api/HL/Controller/ManagementController.php
@@ -522,7 +522,10 @@ final class ManagementController extends AbstractController
             // User is requesting the actual file
             $document = new Document();
             if ($document->getFromDB($request->getAttribute('id'))) {
-                return $document->send(null, true);
+                if ($document->canViewFile()) {
+                    return $document->send(null, true);
+                }
+                return self::getAccessDeniedErrorResponse();
             }
             return self::getNotFoundErrorResponse();
         }

--- a/src/Document.php
+++ b/src/Document.php
@@ -35,6 +35,7 @@
 
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\Event;
+use Glpi\Http\Response;
 
 /**
  * Document class
@@ -520,14 +521,20 @@ class Document extends CommonDBTM
      * Send a document to navigator
      *
      * @param string $context Context to resize image, if any
+     * @param bool   $return_response
+     * @return Response|void
+     * @phpstan-return $return_response ? Response : void
      **/
-    public function send($context = null)
+    public function send($context = null, bool $return_response = false)
     {
         $file = GLPI_DOC_DIR . "/" . $this->fields['filepath'];
         if ($context !== null) {
             $file = self::getImage($file, $context);
         }
-        Toolbox::sendFile($file, $this->fields['filename'], $this->fields['mime']);
+        $response = Toolbox::sendFile($file, $this->fields['filename'], $this->fields['mime'], false, $return_response);
+        if ($response !== null) {
+            return $response;
+        }
     }
 
 

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -612,13 +612,13 @@ class Toolbox
 
        // HTTP_IF_NONE_MATCH takes precedence over HTTP_IF_MODIFIED_SINCE
        // http://tools.ietf.org/html/rfc7232#section-3.3
-        $matches_cache = true;
+        $matches_cache = false;
         if (isset($_SERVER['HTTP_IF_NONE_MATCH']) && trim($_SERVER['HTTP_IF_NONE_MATCH']) === $etag) {
-            $matches_cache = false;
+            $matches_cache = true;
         } else if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) && @strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']) >= $lastModified) {
-            $matches_cache = false;
+            $matches_cache = true;
         }
-        if (!$matches_cache) {
+        if ($matches_cache) {
             $response = new Response(304, $headers);
             if ($return_response) {
                 return $response;

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -612,14 +612,13 @@ class Toolbox
 
        // HTTP_IF_NONE_MATCH takes precedence over HTTP_IF_MODIFIED_SINCE
        // http://tools.ietf.org/html/rfc7232#section-3.3
-        $condition_met = true;
+        $matches_cache = true;
         if (isset($_SERVER['HTTP_IF_NONE_MATCH']) && trim($_SERVER['HTTP_IF_NONE_MATCH']) === $etag) {
-            $condition_met = false;
+            $matches_cache = false;
+        } else if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) && @strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']) >= $lastModified) {
+            $matches_cache = false;
         }
-        if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) && @strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']) >= $lastModified) {
-            $condition_met = false;
-        }
-        if (!$condition_met) {
+        if (!$matches_cache) {
             $response = new Response(304, $headers);
             if ($return_response) {
                 return $response;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Similar to the legacy API, sending a request to the `/Management/Document/{id}` endpoint with an `Accept` header of `application/octet-stream` will tell the server to respond with the file contents instead of the metadata.
Sending a HEAD request with the `Accept` header for downloading a document will respond with the correct headers but without the content.

`Toolbox::sendFile` was modified to accept a new parameter to allow the returning of a Response object rather than having the headers and content sent directly.