### PR TITLE
Fix creating schema with pattern from array

### DIFF
--- a/src/Api/HL/Doc/Schema.php
+++ b/src/Api/HL/Doc/Schema.php
@@ -181,7 +181,7 @@ class Schema implements \ArrayAccess
         if (isset($schema['enum'])) {
             $enum = $schema['enum'];
         }
-        return new Schema(type: $type, format: $format, properties: $properties, items: $items, enum: $enum);
+        return new Schema(type: $type, format: $format, properties: $properties, items: $items, enum: $enum, pattern: $pattern);
     }
 
     public function offsetExists(mixed $offset): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Calling `fromArray` to create an API schema from an array of properties was not passing the `pattern` property to the constructed Schema object.