### PR TITLE
Prevent empty IN error during rule import

### DIFF
--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -1224,6 +1224,11 @@ JAVASCRIPT;
                 }
 
                 foreach ($rule['rulecriteria'] as $k_crit => $criteria) {
+                    // Fix patterns decoded as empty arrays to prevent empty IN clauses in SQL generation.
+                    if (is_array($criteria['pattern']) && empty($criteria['pattern'])) {
+                        $criteria['pattern'] = '';
+                    }
+
                     $available_criteria = $tmprule->getCriterias();
                     $crit               = $criteria['criteria'];
                    //check FK (just in case of "is", "is_not" and "under" criteria)
@@ -1261,6 +1266,10 @@ JAVASCRIPT;
                 }
 
                 foreach ($rule['ruleaction'] as $k_action => $action) {
+                    // Fix values decoded as empty arrays to prevent empty IN clauses in SQL generation.
+                    if (is_array($action['value']) && empty($action['value'])) {
+                        $action['value'] = '';
+                    }
                     $available_actions = $tmprule->getActions();
                     $act               = $action['field'];
 
@@ -1271,9 +1280,9 @@ JAVASCRIPT;
                     ) {
                        //pass root entity and empty array (N/A value)
                         if (
-                            ($action['field'] == "entities_id")
+                            (in_array($action['value'], ['entities_id', 'new_entities_id'], true))
                             && (($action['value'] == 0)
-                            || ($action['value'] == []))
+                            || ($action['value'] == ''))
                         ) {
                             continue;
                         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In some cases, criteria patterns and action values can be blank in the exported XML. When it get decoded during import, it is treated as an empty array so a runtime error is thrown as it would have been an empty IN clause when creating the SQL.

Related forum post:
https://forum.glpi-project.org/viewtopic.php?id=287315

Sample dictionary rule with issue:
```xml
<rule>
        <entities_id>Root Entity</entities_id>
        <sub_type>RuleDictionnarySoftware</sub_type>
        <ranking>1</ranking>
        <name>Freeplane</name>
        <description></description>
        <match>AND</match>
        <is_active>0</is_active>
        <comment></comment>
        <is_recursive>0</is_recursive>
        <uuid>69852acb-a15eaa47-61ec978ba72991.96225898</uuid>
        <condition>0</condition>
        <date_creation>2022-01-22 18:47:23</date_creation>
        <rulecriteria>
                <criteria>name</criteria>
                <condition>0</condition>
                <pattern>Freeplane</pattern>
        </rulecriteria>
        <ruleaction>
                <action_type>assign</action_type>
                <field>new_entities_id</field>
                <value></value>
        </ruleaction>
        <ruleaction>
                <action_type>assign</action_type>
                <field>name</field>
                <value>Freeplane</value>
        </ruleaction>
</rule>
```
How it shows in the UI:
Criteria: Software is Freeplane
Actions:
1. Entity Assign Root Entity
2. Software Assign Freeplane