### PR TITLE
Fix non-unique cookie name for the same domain

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -225,16 +225,50 @@ class Session
      **/
     public static function start()
     {
-
         if (session_status() === PHP_SESSION_NONE) {
             ini_set('session.use_only_cookies', '1'); // Force session to use cookies
-
-            session_name("glpi_" . md5(realpath(GLPI_ROOT)));
+            session_name(self::buildSessionName());
 
             @session_start();
         }
        // Define current time for sync of action timing
         $_SESSION["glpi_currenttime"] = date("Y-m-d H:i:s");
+    }
+
+    /**
+     * Build the session name based on GLPI's folder path + full domain + port
+     *
+     * Adding the full domain name prevent two GLPI instances on the same
+     * domain (e.g. test.domain and prod.domain) with identical folder's
+     * path (e.g. /var/www/glpi) to compete for the same cookie name
+     *
+     * Adding the port prevent some conflicts when using docker
+     *
+     * @param string|null $path Default to GLPI_ROOT
+     * @param string|null $host Default to $_SERVER['HTTP_HOST']
+     * @param string|null $port Default to $_SERVER['HTTP_PORT']
+     *
+     * @return string An unique session name
+     */
+    public static function buildSessionName(
+        ?string $path = null,
+        ?string $host = null,
+        ?string $port = null
+    ): string
+    {
+        if (is_null($path)) {
+            $path = realpath(GLPI_ROOT);
+        }
+
+        if (is_null($host)) {
+            $host = $_SERVER['HTTP_HOST'] ?? '';
+        }
+
+        if (is_null($port)) {
+            $port = $_SERVER['HTTP_PORT'] ?? '';
+        }
+
+        return "glpi_" . md5($path . $host . $port);
     }
 
 

--- a/src/Session.php
+++ b/src/Session.php
@@ -246,7 +246,7 @@ class Session
      *
      * @param string|null $path Default to GLPI_ROOT
      * @param string|null $host Default to $_SERVER['HTTP_HOST']
-     * @param string|null $port Default to $_SERVER['HTTP_PORT']
+     * @param string|null $port Default to $_SERVER['SERVER_PORT']
      *
      * @return string An unique session name
      */

--- a/src/Session.php
+++ b/src/Session.php
@@ -264,7 +264,7 @@ class Session
         }
 
         if (is_null($port)) {
-            $port = $_SERVER['HTTP_PORT'] ?? '';
+            $port = $_SERVER['SERVER_PORT'] ?? '';
         }
 
         return "glpi_" . md5($path . $host . $port);

--- a/src/Session.php
+++ b/src/Session.php
@@ -254,8 +254,7 @@ class Session
         ?string $path = null,
         ?string $host = null,
         ?string $port = null
-    ): string
-    {
+    ): string {
         if (is_null($path)) {
             $path = realpath(GLPI_ROOT);
         }

--- a/tests/units/Session.php
+++ b/tests/units/Session.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use DbTestCase;
+
+class Session extends DbTestCase
+{
+    protected function testUniqueSessionNameProvider(): iterable
+    {
+        // Same host, different path
+        yield [
+            \Session::buildSessionName("/var/www/localhost/glpi1", 'localhost', '80'),
+            \Session::buildSessionName("/var/www/localhost/glpi2", 'localhost', '80'),
+            \Session::buildSessionName("/var/www/localhost/glpi3", 'localhost', '80'),
+            \Session::buildSessionName("/var/www/localhost/glpi4", 'localhost', '80'),
+        ];
+
+        // Same path, different full domains
+        yield [
+            \Session::buildSessionName("/var/www/glpi", 'test.localhost', '80'),
+            \Session::buildSessionName("/var/www/glpi", 'preprod.localhost', '80'),
+            \Session::buildSessionName("/var/www/glpi", 'prod.localhost', '80'),
+            \Session::buildSessionName("/var/www/glpi", 'localhost', '80'),
+        ];
+
+        // Same host and path but different ports
+        yield [
+            \Session::buildSessionName("/var/www/glpi", 'localhost', '80'),
+            \Session::buildSessionName("/var/www/glpi", 'localhost', '8000'),
+            \Session::buildSessionName("/var/www/glpi", 'localhost', '8008'),
+        ];
+    }
+
+    /**
+     * @dataProvider testUniqueSessionNameProvider
+     */
+    public function testUniqueSessionName(
+        ...$cookie_names
+    ): void {
+        // Each cookie name must be unique
+        $this->array($cookie_names)->isEqualTo(array_unique($cookie_names));
+    }
+}


### PR DESCRIPTION
GLPI base its cookie name on the `glpi` folder path.

This mean two GLPI with identical server path will have the same cookie name, which is an issue if they are on the same domain as cookies must be unique per top level domain name (so `test.domain` and `prod.domain` can't use the same cookie names).

Fixed by using additional data from `$_SERVER['HTTP_HOST']` and `$_SERVER['HTTP_PORT']` to get unique cookies name depending on the full domain name and port.

The port part was requested by @cedric-anne as he told me it would solve some issues when using multiple docker instances.

Note : the `instance_uuid` field from GLPI's config would be even better but we can't access it from this function as `$DB` is not yet initialized.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28360
