### PR TITLE
glpi_networkequipments.ram is a string, not an integer

### DIFF
--- a/src/NetworkEquipment.php
+++ b/src/NetworkEquipment.php
@@ -421,7 +421,7 @@ class NetworkEquipment extends CommonDBTM
             'table'              => $this->getTable(),
             'field'              => 'ram',
             'name'               => sprintf(__('%1$s (%2$s)'), _n('Memory', 'Memories', 1), __('Mio')),
-            'datatype'           => 'number',
+            'datatype'           => 'string',
         ];
 
         $tab[] = [


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
