### PR TITLE
Prevent orphan documents to break ITIL timeline

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -6902,7 +6902,10 @@ abstract class CommonITILObject extends CommonDBTM
                 'timeline_position'  => ['>', self::NO_TIMELINE]
             ]);
             foreach ($document_items as $document_item) {
-                $document_obj->getFromDB($document_item['documents_id']);
+                if (!$document_obj->getFromDB($document_item['documents_id'])) {
+                    // Orphan `Document_Item`
+                    continue;
+                }
 
                 $date = $document_item['date'] ?? $document_item['date_creation'];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | see #14585

See #14585. For some unknown reason, a `Document_Item` entry may be linked to an unexisting document. I do not know if it is caused by a plugin, a bug in mail collector, or something else, but this case should be handled to prevent timeline to be broken.