### PR TITLE
Fix handling of notifications queued before upgrade to GLPI 10.0.8

### DIFF
--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -143,6 +143,7 @@ class NotificationEventMailing extends NotificationEventAbstract
                             ],
                             [
                                 Config::getUuid('notification'),
+                                $current->fields['itemtype'],
                                 $current->fields['items_id']
                             ],
                             "In-Reply-To: <GLPI-%uuid-%itemtype-%items_id>"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fix #14804 was incorrect. Indeed, the `itemtype` value was missing in replacement logic.