### PR TITLE
Prevent invalid rules to be executed

### DIFF
--- a/src/Rule.php
+++ b/src/Rule.php
@@ -53,9 +53,6 @@ class Rule extends CommonDBTM
     public $actions               = [];
    ///Criterias affected to this rule
 
-    // Keep track of rule type (ONADD, ONUPDATE or both)
-    public int $rule_type;
-
     public $criterias             = [];
    /// Rules can be sorted ?
     public $can_sort              = false;
@@ -1057,9 +1054,6 @@ class Rule extends CommonDBTM
             ) {
                 $this->criterias = $RuleCriterias->getRuleCriterias($ID);
             }
-
-            // Keep track of rule type so we can verify later that the cached rules match the correct condition
-            $this->rule_type = $this->fields['condition'] ?? 0;
 
             return true;
         }

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -52,7 +52,6 @@ class Rule extends CommonDBTM
    ///Actions affected to this rule
     public $actions               = [];
    ///Criterias affected to this rule
-
     public $criterias             = [];
    /// Rules can be sorted ?
     public $can_sort              = false;

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -52,6 +52,10 @@ class Rule extends CommonDBTM
    ///Actions affected to this rule
     public $actions               = [];
    ///Criterias affected to this rule
+
+    // Keep track of rule type (ONADD, ONUPDATE or both)
+    public int $rule_type;
+
     public $criterias             = [];
    /// Rules can be sorted ?
     public $can_sort              = false;
@@ -1039,7 +1043,7 @@ class Rule extends CommonDBTM
         if ($ID == "") {
             return $this->getEmpty();
         }
-        if ($ret = $this->getFromDB($ID)) {
+        if ($this->getFromDB($ID)) {
             if (
                 $withactions
                 && ($RuleAction = getItemForItemtype($this->ruleactionclass))
@@ -1053,6 +1057,9 @@ class Rule extends CommonDBTM
             ) {
                 $this->criterias = $RuleCriterias->getRuleCriterias($ID);
             }
+
+            // Keep track of rule type so we can verify later that the cached rules match the correct condition
+            $this->rule_type = $this->fields['condition'];
 
             return true;
         }

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -1059,7 +1059,7 @@ class Rule extends CommonDBTM
             }
 
             // Keep track of rule type so we can verify later that the cached rules match the correct condition
-            $this->rule_type = $this->fields['condition'];
+            $this->rule_type = $this->fields['condition'] ?? 0;
 
             return true;
         }

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -1628,7 +1628,7 @@ JAVASCRIPT;
         if (count($this->RuleList->list)) {
             /** @var Rule $rule */
             foreach ($this->RuleList->list as $rule) {
-                if ($p['condition'] && !($rule->rule_type & $p['condition'])) {
+                if ($p['condition'] && !($rule->fields['condition'] & $p['condition'])) {
                     // Rule is loaded in the cache but is not relevant for the current condition
                     continue;
                 }

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -1628,7 +1628,7 @@ JAVASCRIPT;
         if (count($this->RuleList->list)) {
             /** @var Rule $rule */
             foreach ($this->RuleList->list as $rule) {
-                if (!($rule->rule_type & $p['condition'])) {
+                if ($p['condition'] && !($rule->rule_type & $p['condition'])) {
                     // Rule is loaded in the cache but is not relevant for the current condition
                     continue;
                 }

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -1596,14 +1596,14 @@ JAVASCRIPT;
     /**
      * Process all the rules collection
      *
-     * @param input            array the input data used to check criterias (need to be clean slashes)
-     * @param output           array the initial ouput array used to be manipulate by actions (need to be clean slashes)
-     * @param params           array parameters for all internal functions (need to be clean slashes)
-     * @param options          array options :
-     *                            - condition : specific condition to limit rule list
-     *                            - only_criteria : only react on specific criteria
+     * @param array $input    Input data used to check criterias (need to be clean slashes)
+     * @param array $output   Initial ouput array used to be manipulate by actions (need to be clean slashes)
+     * @param array $params   Parameters for all internal functions (need to be clean slashes)
+     * @param array $options  Options :
+     *                         - condition : specific condition to limit rule list
+     *                         - only_criteria : only react on specific criteria
      *
-     * @return the output array updated by actions (addslashes datas)
+     * @return array the output array updated by actions (addslashes datas)
      **/
     public function processAllRules($input = [], $output = [], $params = [], $options = [])
     {
@@ -1617,23 +1617,32 @@ JAVASCRIPT;
             }
         }
 
-       // Get Collection datas
+        // Get Collection datas
         $this->getCollectionDatas(1, 1, $p['condition']);
         $input                      = $this->prepareInputDataForProcessWithPlugins($input, $params);
         $output["_no_rule_matches"] = true;
-       //Store rule type being processed (for plugins)
+
+        //Store rule type being processed (for plugins)
         $params['rule_itemtype']    = $this->getRuleClassName();
 
         if (count($this->RuleList->list)) {
             /** @var Rule $rule */
             foreach ($this->RuleList->list as $rule) {
+                if (!($rule->rule_type & $p['condition'])) {
+                    // Rule is loaded in the cache but is not relevant for the current condition
+                    continue;
+                }
+
                //If the rule is active, process it
 
                 if ($rule->fields["is_active"]) {
                     $output["_rule_process"] = false;
                     $rule->process($input, $output, $params, $p);
 
-                    if ((isset($output['_stop_rules_processing']) && (int) $output['_stop_rules_processing'] === 1) || ($output["_rule_process"] && $this->stop_on_first_match)) {
+                    if (
+                        (isset($output['_stop_rules_processing']) && (int) $output['_stop_rules_processing'] === 1)
+                        || ($output["_rule_process"] && $this->stop_on_first_match)
+                    ) {
                         unset($output["_stop_rules_processing"], $output["_rule_process"]);
                         $output["_ruleid"] = $rule->fields["id"];
                         return Toolbox::addslashes_deep($output);


### PR DESCRIPTION
The rule engine may be executed multiple times for one action due to some post_addItem code.

For example, consider this backtrace:

![image](https://github.com/glpi-project/glpi/assets/42734840/4bc23fc6-2ec5-463b-ab85-1c5781696693)

One user action (ticket creation) resulted in 3 database operation (one add and two update) for the ticket object.

The issue is that the rule engine use some kind of cache so the first operation (add) load the rules defined for "on add", which are then reused for the 2nd and 3rd operation despite being updates.

The test case show a concrete example that can be easily reproduced (the test will fail if you remove the changes).

Also fixed some lint warnings.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28287
