### PR TITLE
fix: checkbox with high contrast

### DIFF
--- a/css/includes/_highcontrast.scss
+++ b/css/includes/_highcontrast.scss
@@ -194,10 +194,19 @@
         margin-right: 2px;
     }
 
-    .form-check {
+    .form-switch {
         input {
             border: 2px solid;
             background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%23777777'/%3e%3c/svg%3e");
+        }
+    }
+
+    .form-check:not(.form-switch) {
+        input {
+            border: 2px solid $hc-border-color-contrast;
+        }
+        input:checked {
+            background-color: $hc-border-color-contrast;
         }
     }
 

--- a/css/includes/_highcontrast.scss
+++ b/css/includes/_highcontrast.scss
@@ -205,6 +205,7 @@
         input {
             border: 2px solid $hc-border-color-contrast;
         }
+
         input:checked {
             background-color: $hc-border-color-contrast;
         }


### PR DESCRIPTION
When high contrast is enabled, there is almost no difference between a checked or unchecked box

Before:
![image](https://github.com/glpi-project/glpi/assets/8530352/bd6f659c-0f32-4b5d-90f1-8766974660b3) unchecked

![image](https://github.com/glpi-project/glpi/assets/8530352/1f903ca7-36f0-4079-b7af-5a974d33b618) checked

After:
![image](https://github.com/glpi-project/glpi/assets/8530352/3a25db36-5288-45b9-9304-366dcd4531b3)

![image](https://github.com/glpi-project/glpi/assets/8530352/4a7c8d12-7de6-4d12-b117-c9d5cc93d545)


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
