### PR TITLE
fix(notification): force `quoted-printable` encoding

### DIFF
--- a/src/GLPIMailer.php
+++ b/src/GLPIMailer.php
@@ -56,6 +56,8 @@ class GLPIMailer extends PHPMailer
 
         $this->CharSet            = "utf-8";
 
+        $this->Encoding           = "base64";
+
        // Comes from config
         $this->SetLanguage("en", Config::getLibraryDir("PHPMailer") . "/language/");
 

--- a/src/GLPIMailer.php
+++ b/src/GLPIMailer.php
@@ -56,7 +56,7 @@ class GLPIMailer extends PHPMailer
 
         $this->CharSet            = "utf-8";
 
-        $this->Encoding           = "base64";
+        $this->Encoding           = self::ENCODING_QUOTED_PRINTABLE;
 
        // Comes from config
         $this->SetLanguage("en", Config::getLibraryDir("PHPMailer") . "/language/");


### PR DESCRIPTION
I've been trying for a while to understand why some notifications have a poor HTML rendering in Outlook.

- GLPI Notification template translation

![image](https://github.com/glpi-project/glpi/assets/7335054/6618f283-0d25-447b-8f6a-de38d77da86f)

```sql
+----+--------------------------+----------+---------+--------------+--------------------------+
| id | notificationtemplates_id | language | subject | content_text | content_html             |
+----+--------------------------+----------+---------+--------------+--------------------------+
| 35 |                       36 | fr_FR    | toto    | a            | &#60;p&#62;a&#60;/p&#62; |
+----+--------------------------+----------+---------+--------------+--------------------------+
```

- Generated notification

![image](https://github.com/glpi-project/glpi/assets/7335054/1cb360ab-84be-4c4c-a238-9b31e8e62107)


```sql
MariaDB [preprod]> select * from glpi_queuednotifications where id = 44659 \G
*************************** 1. row ***************************
                      id: 44659
                itemtype: Ticket
                items_id: 362876
notificationtemplates_id: 36
             entities_id: 0
              is_deleted: 1
                sent_try: 0
             create_time: 2023-06-20 09:38:30
               send_time: 2023-06-20 09:38:30
               sent_time: 2023-06-20 09:38:37
                    name: [***** Ticketing System #0362876] test
                  sender: *******@*****.com
              sendername: 
               recipient: teclib@****.com
           recipientname: teclib
                 replyto: NULL
             replytoname: NULL
                 headers: {"Auto-Submitted":"auto-generated","X-Auto-Response-Suppress":"OOF, DR, NDR, RN, NRN"}
               body_html: &#60;!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
                        'http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd'&#62;&#60;html&#62;
                        &#60;head&#62;
                         &#60;META http-equiv='Content-Type' content='text/html; charset=utf-8'&#62;
                         &#60;title&#62;[***** Ticketing System #0362876] teest&#60;/title&#62;
                         &#60;style type='text/css'&#62;
                           
                         &#60;/style&#62;
                        &#60;/head&#62;
                        &#60;body&#62;
&#60;p&#62;a&#60;/p&#62;&#60;br&#62;&#60;br&#62;-- 
&#60;br&#62;&#60;br&#62;Généré automatiquement par GLPI&#60;br&#62;&#60;br&#62;

&#60;/body&#62;&#60;/html&#62;
               body_text: a

-- 

Généré automatiquement par GLPI


               messageid: GLPI_fjdKeHbgf6PeW4iOhjztWKNiRBIfPDgYcKZsxWKN-Ticket-362876.1687246710.2147018271@5326-glpi
               documents: 
                    mode: mailing
```

- Decoded raw

```html
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
                        'http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd'><html>
                        <head>
                         <META http-equiv='Content-Type' content='text/html; charset=utf-8'>
                         <title>[**** Ticketing System #0362876] toto</title>
                         <style type='text/css'>

                         </style>
                        </head>
                        <body>
<p>a</p><br><br>-- 
<br><br>Généré automatiquement par GLPI<br><br>

</body></html>
```

- Outlook rendering

![image](https://github.com/glpi-project/glpi/assets/7335054/1a35867d-ec6c-4d22-ad80-09b10d8c8e92)


Switching to the 'base64' encoding seems to fix the problem.

I therefore think that the problem lies with PHPMailer





| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27844
