### PR TITLE
Get user pictures from API

### DIFF
--- a/src/Api/HL/Controller/AdministrationController.php
+++ b/src/Api/HL/Controller/AdministrationController.php
@@ -556,7 +556,7 @@ final class AdministrationController extends AbstractController
         return Search::getOneBySchema($this->getKnownSchema('User'), $request->getAttributes(), $request->getParameters(), 'username');
     }
 
-    #[Route(path: '/User/{id}/Picture', methods: ['GET'])]
+    #[Route(path: '/User/{id}/Picture', methods: ['GET'], requirements: ['id' => '\d+'])]
     #[Doc\Route(
         description: 'Get the picture for the current user'
     )]
@@ -574,7 +574,7 @@ final class AdministrationController extends AbstractController
         return $this->getUserPictureResponse($data['name'], $data['picture']);
     }
 
-    #[Route(path: '/User/username/{username}/Picture', methods: ['GET'])]
+    #[Route(path: '/User/username/{username}/Picture', methods: ['GET'], requirements: ['username' => '[a-zA-Z0-9_]+'])]
     #[Doc\Route(
         description: 'Get the picture for the current user'
     )]

--- a/src/Api/HL/Controller/AdministrationController.php
+++ b/src/Api/HL/Controller/AdministrationController.php
@@ -148,6 +148,18 @@ final class AdministrationController extends AbstractController
                         'description' => 'Password confirmation',
                         'x-writeonly' => true,
                     ],
+                    'picture' => [
+                        'type' => Doc\Schema::TYPE_STRING,
+                        'x-mapped-from' => 'picture',
+                        'x-mapper' => static function ($v) {
+                            global $CFG_GLPI;
+                            $path = \Toolbox::getPictureUrl($v, false);
+                            if (!empty($path)) {
+                                return $path;
+                            }
+                            return $CFG_GLPI["root_doc"] . '/pics/picture.png';
+                        }
+                    ]
                 ]
             ],
             'Group' => [
@@ -472,6 +484,40 @@ final class AdministrationController extends AbstractController
         return self::getNotFoundErrorResponse();
     }
 
+    /**
+     * Get the specified user picture as a Response
+     * @param string $username The username of the user. Used in Content-Disposition header.
+     * @param string|null $picture_path The path to the picture from the user's "picture" field.
+     * @return Response A response with the picture as binary content (or the placeholder user picture if the user has no picture).
+     */
+    private function getUserPictureResponse(string $username, ?string $picture_path): Response
+    {
+        if ($picture_path !== null) {
+            $picture_path = GLPI_PICTURE_DIR . '/' . $picture_path;
+        } else {
+            $picture_path = 'pics/picture.png';
+        }
+        return \Toolbox::sendFile($picture_path, $username, null, false, true);
+    }
+
+    #[Route(path: '/User/me/Picture', methods: ['GET'])]
+    #[Doc\Route(
+        description: 'Get the picture for the current user'
+    )]
+    public function getMyPicture(Request $request): Response
+    {
+        global $DB;
+        $it = $DB->request([
+            'SELECT' => ['name', 'picture'],
+            'FROM' => User::getTable(),
+            'WHERE' => [
+                'id' => $this->getMyUserID(),
+            ],
+        ]);
+        $data = $it->current();
+        return $this->getUserPictureResponse($data['name'], $data['picture']);
+    }
+
     #[Route(path: '/User', methods: ['POST'])]
     #[Doc\Route(description: 'Create a new user', parameters: [
         [
@@ -508,6 +554,42 @@ final class AdministrationController extends AbstractController
     public function getUserByUsername(Request $request): Response
     {
         return Search::getOneBySchema($this->getKnownSchema('User'), $request->getAttributes(), $request->getParameters(), 'username');
+    }
+
+    #[Route(path: '/User/{id}/Picture', methods: ['GET'])]
+    #[Doc\Route(
+        description: 'Get the picture for the current user'
+    )]
+    public function getUserPictureByID(Request $request): Response
+    {
+        global $DB;
+        $it = $DB->request([
+            'SELECT' => ['name', 'picture'],
+            'FROM' => User::getTable(),
+            'WHERE' => [
+                'id' => $request->getAttribute('id'),
+            ],
+        ]);
+        $data = $it->current();
+        return $this->getUserPictureResponse($data['name'], $data['picture']);
+    }
+
+    #[Route(path: '/User/username/{username}/Picture', methods: ['GET'])]
+    #[Doc\Route(
+        description: 'Get the picture for the current user'
+    )]
+    public function getUserPictureByUsername(Request $request): Response
+    {
+        global $DB;
+        $it = $DB->request([
+            'SELECT' => ['name', 'picture'],
+            'FROM' => User::getTable(),
+            'WHERE' => [
+                'name' => $request->getAttribute('username'),
+            ],
+        ]);
+        $data = $it->current();
+        return $this->getUserPictureResponse($data['name'], $data['picture']);
     }
 
     #[Route(path: '/User/{id}', methods: ['PATCH'], requirements: ['id' => '\d+'])]

--- a/src/Api/HL/Search.php
+++ b/src/Api/HL/Search.php
@@ -437,7 +437,8 @@ final class Search
 
                     if ($fkey === 'id') {
                         $props_to_use = array_filter($this->flattened_properties, static function ($prop_params, $prop_name) {
-                            $mapped_from_other = isset($prop_params['x-mapped-from']) && $prop_params['x-mapped-from'] !== $prop_name;
+                            $prop_field = $prop_params['x-field'] ?? $prop_name;
+                            $mapped_from_other = isset($prop_params['x-mapped-from']) && $prop_params['x-mapped-from'] !== $prop_field;
                             // We aren't handling joins or mapped fields here
                             return !str_contains($prop_name, '.') && !$mapped_from_other;
                         }, ARRAY_FILTER_USE_BOTH);

--- a/src/Api/HL/Search.php
+++ b/src/Api/HL/Search.php
@@ -437,8 +437,9 @@ final class Search
 
                     if ($fkey === 'id') {
                         $props_to_use = array_filter($this->flattened_properties, static function ($prop_params, $prop_name) {
+                            $mapped_from_other = isset($prop_params['x-mapped-from']) && $prop_params['x-mapped-from'] !== $prop_name;
                             // We aren't handling joins or mapped fields here
-                            return !str_contains($prop_name, '.') && !isset($prop_params['x-mapped-from']);
+                            return !str_contains($prop_name, '.') && !$mapped_from_other;
                         }, ARRAY_FILTER_USE_BOTH);
                         $criteria['FROM'] = "$table AS " . $DB::quoteName('_');
                         if ($this->union_search_mode) {

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2859,7 +2859,7 @@ class Toolbox
      *
      * @since 9.5.0
      */
-    public static function savePicture($src, $uniq_prefix = '')
+    public static function savePicture($src, $uniq_prefix = '', $keep_src = false)
     {
 
         if (!Document::isImage($src)) {
@@ -2884,7 +2884,11 @@ class Toolbox
             return false;
         }
 
-        if (!rename($src, $dest)) {
+        if (!$keep_src) {
+            if (!rename($src, $dest)) {
+                return false;
+            }
+        } else if (!copy($src, $dest)) {
             return false;
         }
 

--- a/tests/GLPITestCase.php
+++ b/tests/GLPITestCase.php
@@ -61,6 +61,9 @@ class GLPITestCase extends atoum
        // By default, no session, not connected
         $this->resetSession();
 
+        // By default, there shouldn't be any pictures in the test files
+        $this->resetPictures();
+
        // Ensure cache is clear
         global $GLPI_CACHE;
         $GLPI_CACHE->clear();
@@ -100,6 +103,32 @@ class GLPITestCase extends atoum
                     )
                 );
             }
+        }
+    }
+
+    protected function resetPictures()
+    {
+        // Delete contents of test files/_pictures
+        $dir = GLPI_PICTURE_DIR;
+        if (!str_contains($dir, '/tests/files/_pictures')) {
+            throw new \RuntimeException('Invalid picture dir: ' . $dir);
+        }
+        // Delete nested folders and files in dir
+        $fn_delete = function ($dir, $parent) use (&$fn_delete) {
+            $files = glob($dir . '/*') ?? [];
+            foreach ($files as $file) {
+                if (is_dir($file)) {
+                    $fn_delete($file, $parent);
+                } else {
+                    unlink($file);
+                }
+            }
+            if ($dir !== $parent) {
+                rmdir($dir);
+            }
+        };
+        if (file_exists($dir) && is_dir($dir)) {
+            $fn_delete($dir, $dir);
         }
     }
 

--- a/tests/functional/Glpi/Api/HL/Controller/AdministrationController.php
+++ b/tests/functional/Glpi/Api/HL/Controller/AdministrationController.php
@@ -394,6 +394,15 @@ class AdministrationController extends \HLAPITestCase
         });
         $this->addCustomUserPicture($_SESSION['glpiID'], GLPI_ROOT . '/tests/fixtures/uploads/foo.png');
 
+        $this->api->call(new Request('GET', '/Administration/User/me'), function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->isOK()
+                ->jsonContent(function ($content) {
+                    $this->string($content['picture'])->contains('/front/document.send.php');
+                });
+        });
+
         $this->api->call(new Request('GET', '/Administration/User/me/picture'), function ($call) {
             /** @var \HLAPICallAsserter $call */
             $call->response

--- a/tests/functional/Glpi/Api/HL/Controller/AdministrationController.php
+++ b/tests/functional/Glpi/Api/HL/Controller/AdministrationController.php
@@ -368,6 +368,88 @@ class AdministrationController extends \HLAPITestCase
         });
     }
 
+    private function addCustomUserPicture(int $user_id, string $picture_path)
+    {
+        global $DB;
+        $picture_path = \Toolbox::savePicture($picture_path, '', true);
+        $this->variable($picture_path)->isNotFalse();
+        $DB->update('glpi_users', [
+            'id' => $user_id,
+            'picture' => $picture_path
+        ], [
+            'id' => $user_id
+        ]);
+    }
+
+    public function testGetMyPicture()
+    {
+        $this->login();
+        $this->api->call(new Request('GET', '/Administration/User/me/picture'), function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->isOK()
+                ->content(function ($content) {
+                    $this->string($content)->isIdenticalTo(file_get_contents(GLPI_ROOT . '/pics/picture.png'));
+                });
+        });
+        $this->addCustomUserPicture($_SESSION['glpiID'], GLPI_ROOT . '/tests/fixtures/uploads/foo.png');
+
+        $this->api->call(new Request('GET', '/Administration/User/me/picture'), function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->isOK()
+                ->content(function ($content) {
+                    $this->string($content)->isIdenticalTo(file_get_contents(GLPI_ROOT . '/tests/fixtures/uploads/foo.png'));
+                });
+        });
+    }
+
+    public function testGetUserPictureByID()
+    {
+        $this->login();
+        $this->api->call(new Request('GET', '/Administration/User/' . $_SESSION['glpiID'] . '/Picture'), function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->isOK()
+                ->content(function ($content) {
+                    $this->string($content)->isIdenticalTo(file_get_contents(GLPI_ROOT . '/pics/picture.png'));
+                });
+        });
+        $this->addCustomUserPicture($_SESSION['glpiID'], GLPI_ROOT . '/tests/fixtures/uploads/foo.png');
+
+        $this->api->call(new Request('GET', '/Administration/User/' . $_SESSION['glpiID'] . '/Picture'), function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->isOK()
+                ->content(function ($content) {
+                    $this->string($content)->isIdenticalTo(file_get_contents(GLPI_ROOT . '/tests/fixtures/uploads/foo.png'));
+                });
+        });
+    }
+
+    public function testGetUserPictureByUsername()
+    {
+        $this->login();
+        $this->api->call(new Request('GET', '/Administration/User/username/' . $_SESSION['glpiname'] . '/Picture'), function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->isOK()
+                ->content(function ($content) {
+                    $this->string($content)->isIdenticalTo(file_get_contents(GLPI_ROOT . '/pics/picture.png'));
+                });
+        });
+        $this->addCustomUserPicture($_SESSION['glpiID'], GLPI_ROOT . '/tests/fixtures/uploads/foo.png');
+
+        $this->api->call(new Request('GET', '/Administration/User/username/' . $_SESSION['glpiname'] . '/Picture'), function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->isOK()
+                ->content(function ($content) {
+                    $this->string($content)->isIdenticalTo(file_get_contents(GLPI_ROOT . '/tests/fixtures/uploads/foo.png'));
+                });
+        });
+    }
+
     public function testCreateUpdateDeleteUser()
     {
         $this->login();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Add `picture` download URL to User schema.
Add endpoints to get a user's picture as a binary response:
1. /User/me/Picture
2. /User/{id}/Picture
3. /User/username/{username}/Picture

Fixed:
- Retrieving a field that is mapped from itself (like transforming the internal picture path to the download URL)