### PR TITLE
fix(upload): prevent form submit during file upload

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -5609,7 +5609,7 @@ HTML;
             },
             processfail: function (e, data) {
                 // enable submit button after upload
-                $(this).closest('form').find('button:submit').prop('disabled', '');
+                $(this).closest('form').find(':submit').prop('disabled', false);
                $.each(
                   data.files,
                   function(index, file) {

--- a/src/Html.php
+++ b/src/Html.php
@@ -5595,7 +5595,7 @@ HTML;
                   '{$p['editor_id']}'
                );
                // enable submit button after upload
-               $(this).closest('form').find('button:submit').prop('disabled', '');
+               $(this).closest('form').find(':submit').prop('disabled', false);
                // remove required
                 $('#fileupload{$p['rand']}').removeAttr('required');
             },

--- a/src/Html.php
+++ b/src/Html.php
@@ -5601,7 +5601,7 @@ HTML;
             },
             fail: function (e, data) {
                 // enable submit button after upload
-                $(this).closest('form').find('button:submit').prop('disabled', '');
+                $(this).closest('form').find(':submit').prop('disabled', false);
                const err = 'responseText' in data.jqXHR && data.jqXHR.responseText.length > 0
                   ? data.jqXHR.responseText
                   : data.jqXHR.statusText;

--- a/src/Html.php
+++ b/src/Html.php
@@ -5577,6 +5577,8 @@ HTML;
             maxFileSize: {$max_file_size},
             maxChunkSize: {$max_chunk_size},
             add: function (e, data) {
+               // disable submit button during upload
+               $(this).closest('form').find('button:submit').prop('disabled', 'disabled');
                // randomize filename
                for (var i = 0; i < data.files.length; i++) {
                   data.files[i].uploadName = uniqid('', true) + data.files[i].name;
@@ -5592,16 +5594,22 @@ HTML;
                   $('#{$p['filecontainer']}'),
                   '{$p['editor_id']}'
                );
+               // enable submit button after upload
+               $(this).closest('form').find('button:submit').prop('disabled', '');
                // remove required
                 $('#fileupload{$p['rand']}').removeAttr('required');
             },
             fail: function (e, data) {
+                // enable submit button after upload
+                $(this).closest('form').find('button:submit').prop('disabled', '');
                const err = 'responseText' in data.jqXHR && data.jqXHR.responseText.length > 0
                   ? data.jqXHR.responseText
                   : data.jqXHR.statusText;
                alert(err);
             },
             processfail: function (e, data) {
+                // enable submit button after upload
+                $(this).closest('form').find('button:submit').prop('disabled', '');
                $.each(
                   data.files,
                   function(index, file) {

--- a/src/Html.php
+++ b/src/Html.php
@@ -5578,7 +5578,7 @@ HTML;
             maxChunkSize: {$max_chunk_size},
             add: function (e, data) {
                // disable submit button during upload
-               $(this).closest('form').find('button:submit').prop('disabled', 'disabled');
+               $(this).closest('form').find(':submit').prop('disabled', true);
                // randomize filename
                for (var i = 0; i < data.files.length; i++) {
                   data.files[i].uploadName = uniqid('', true) + data.files[i].name;


### PR DESCRIPTION
If the user sends a file to GLPI and then tries to submit the form, 

The added element may be truncated (especially images) 

Nothing prevents the user from adding the element, even if the file has not been fully uploaded.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28447
