### PR TITLE
Support insert into select queries

### DIFF
--- a/tests/units/DB.php
+++ b/tests/units/DB.php
@@ -144,6 +144,13 @@ class DB extends \GLPITestCase
                     'other'  => new \QueryParam()
                 ],
                 'INSERT INTO `table` (`field`, `other`) VALUES (?, ?)'
+            ], [
+                'table', new \QuerySubQuery([
+                    'SELECT' => ['id', 'name'],
+                    'FROM' => 'other',
+                    'WHERE' => ['NOT' => ['name' => null]]
+                ]),
+                'INSERT INTO `table` (SELECT `id`, `name` FROM `other` WHERE NOT (`name` IS NULL))'
             ]/*, [
                 'table', [
                     'field'  => new \QueryParam('field'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Add support for `INSERT INTO ... SELECT` type of query.
Given the following query from the escalade plugin:
```php
$query_users = "INSERT INTO glpi_tickets_users
      SELECT '' AS id, $newID as tickets_id, users_id, type, use_notification, alternative_email
      FROM glpi_tickets_users
      WHERE tickets_id = $tickets_id AND type != 2";
```
The current solution to replace this raw query would be to first make the `SELECT` query and then iterate the results and make individual `INSERT` queries for each result. Depending on the amount of data, this could be a performance issue.

This PR allows you to specify a `QuerySubQuery` in place of the usual parameter array for `DBmysql::insert` to make it an INSERT INTO ... SELECT.