### PR TITLE
Fix ticket counter in simplified interface

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -5125,7 +5125,7 @@ JAVASCRIPT;
      *
      * @param boolean $foruser Only for current login user as requester or observer (false by default)
      */
-    public static function showCentralCountCriteria(bool $foruser = false)
+    private static function showCentralCountCriteria(bool $foruser): array
     {
         $table = self::getTable();
         $criteria = [

--- a/tests/functional/Ticket.php
+++ b/tests/functional/Ticket.php
@@ -5562,13 +5562,23 @@ HTML
 
         $this->login();
 
+        // Create entities
+        $entity = new Entity();
+        $entity_id = $entity->add([
+            'name' => 'testShowCentralCountCriteria',
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+        ]);
+        $this->integer($entity_id)->isGreaterThan(0);
+
         // Create a new user
         $user = new User();
         $user_id = $user->add([
             'name' => 'testShowCentralCountCriteria',
             'password' => 'testShowCentralCountCriteria',
             'password2' => 'testShowCentralCountCriteria',
-            '_profiles_id' => getItemByTypeName('Profile', 'Self-Service', true)
+            '_profiles_id' => getItemByTypeName('Profile', 'Self-Service', true),
+            '_entities_id' => $entity_id,
+            'entities_id' => $entity_id,
         ]);
         $this->integer($user_id)->isGreaterThan(0);
 
@@ -5577,6 +5587,7 @@ HTML
         $ticket_id_requester = $ticket_requester->add([
             'name' => 'testShowCentralCountCriteria',
             'content' => 'testShowCentralCountCriteria',
+            'entities_id' => $entity_id,
         ]);
         $this->integer($ticket_id_requester)->isGreaterThan(0);
 
@@ -5594,6 +5605,7 @@ HTML
         $ticket_id_observer = $ticket_observer->add([
             'name' => 'testShowCentralCountCriteria',
             'content' => 'testShowCentralCountCriteria',
+            'entities_id' => $entity_id,
         ]);
         $this->integer($ticket_id_observer)->isGreaterThan(0);
 
@@ -5611,6 +5623,7 @@ HTML
         $ticket_id = $ticket->add([
             'name' => 'testShowCentralCountCriteria',
             'content' => 'testShowCentralCountCriteria',
+            'entities_id' => $entity_id,
         ]);
         $this->integer($ticket_id)->isGreaterThan(0);
 

--- a/tests/functional/Ticket.php
+++ b/tests/functional/Ticket.php
@@ -5555,4 +5555,58 @@ HTML
         $entities = $ticket->getEntitiesForRequesters(["_users_id_requester" => $user_id]);
         $this->array($entities)->isIdenticalTo([$entity2_id, $entity1_id]);
     }
+
+    public function testShowCentralCountCriteria()
+    {
+        global $DB;
+
+        $user = new User();
+        $user_id = $user->add([
+            'name' => 'testShowCentralCountCriteria',
+            'password' => 'testShowCentralCountCriteria',
+            'password2' => 'testShowCentralCountCriteria',
+            '_profiles_id' => getItemByTypeName('Profile', 'Self-Service', true)
+        ]);
+        $this->integer($user_id)->isGreaterThan(0);
+
+        $ticket_requester = new \Ticket();
+        $ticket_id_requester = $ticket_requester->add([
+            'name' => 'testShowCentralCountCriteria',
+            'content' => 'testShowCentralCountCriteria',
+        ]);
+        $this->integer($ticket_id_requester)->isGreaterThan(0);
+
+        $ticket_user_requester = new \Ticket_User();
+        $ticket_user_id_requester = $ticket_user_requester->add([
+            'tickets_id' => $ticket_id_requester,
+            'users_id' => $user_id,
+            'type' => CommonITILActor::REQUESTER,
+        ]);
+        $this->integer($ticket_user_id_requester)->isGreaterThan(0);
+
+        $ticket_observer = new \Ticket();
+        $ticket_id_observer = $ticket_observer->add([
+            'name' => 'testShowCentralCountCriteria',
+            'content' => 'testShowCentralCountCriteria',
+        ]);
+        $this->integer($ticket_id_observer)->isGreaterThan(0);
+
+        $ticket_user_observer = new \Ticket_User();
+        $ticket_user_observer_id = $ticket_user_observer->add([
+            'tickets_id' => $ticket_id_observer,
+            'users_id' => $user_id,
+            'type' => CommonITILActor::OBSERVER,
+        ]);
+        $this->integer($ticket_user_observer_id)->isGreaterThan(0);
+
+        $criteria = \Ticket::showCentralCountCriteria(true);
+        $iterator = $DB->request($criteria);
+        foreach ($iterator as $data) {
+            $this->array($data)
+                ->hasKey('status')
+                ->hasKey('COUNT')
+                ->integer['status']->isEqualTo(1)
+                ->integer['COUNT']->isEqualTo(2);
+        }
+    }
 }

--- a/tests/functional/Ticket.php
+++ b/tests/functional/Ticket.php
@@ -5560,6 +5560,9 @@ HTML
     {
         global $DB;
 
+        $this->login();
+
+        // Create a new user
         $user = new User();
         $user_id = $user->add([
             'name' => 'testShowCentralCountCriteria',
@@ -5569,6 +5572,7 @@ HTML
         ]);
         $this->integer($user_id)->isGreaterThan(0);
 
+        // Create a new ticket with the user as requester
         $ticket_requester = new \Ticket();
         $ticket_id_requester = $ticket_requester->add([
             'name' => 'testShowCentralCountCriteria',
@@ -5576,6 +5580,7 @@ HTML
         ]);
         $this->integer($ticket_id_requester)->isGreaterThan(0);
 
+        // Add the user as requester for the ticket
         $ticket_user_requester = new \Ticket_User();
         $ticket_user_id_requester = $ticket_user_requester->add([
             'tickets_id' => $ticket_id_requester,
@@ -5584,6 +5589,7 @@ HTML
         ]);
         $this->integer($ticket_user_id_requester)->isGreaterThan(0);
 
+        // Create a new ticket with the user as observer
         $ticket_observer = new \Ticket();
         $ticket_id_observer = $ticket_observer->add([
             'name' => 'testShowCentralCountCriteria',
@@ -5591,6 +5597,7 @@ HTML
         ]);
         $this->integer($ticket_id_observer)->isGreaterThan(0);
 
+        // Add the user as observer for the ticket
         $ticket_user_observer = new \Ticket_User();
         $ticket_user_observer_id = $ticket_user_observer->add([
             'tickets_id' => $ticket_id_observer,
@@ -5599,6 +5606,18 @@ HTML
         ]);
         $this->integer($ticket_user_observer_id)->isGreaterThan(0);
 
+        // Create a new ticket
+        $ticket = new \Ticket();
+        $ticket_id = $ticket->add([
+            'name' => 'testShowCentralCountCriteria',
+            'content' => 'testShowCentralCountCriteria',
+        ]);
+        $this->integer($ticket_id)->isGreaterThan(0);
+
+        // Login with the new user
+        $this->login('testShowCentralCountCriteria', 'testShowCentralCountCriteria');
+
+        // Check if the user can see 2 tickets
         $criteria = $this->callPrivateMethod($this->newTestedInstance(), 'showCentralCountCriteria', true);
         $iterator = $DB->request($criteria);
         foreach ($iterator as $data) {
@@ -5607,6 +5626,17 @@ HTML
                 ->hasKey('COUNT')
                 ->integer['status']->isEqualTo(1)
                 ->integer['COUNT']->isEqualTo(2);
+        }
+
+        // Check if the global view return 3 tickets
+        $criteria = $this->callPrivateMethod($this->newTestedInstance(), 'showCentralCountCriteria', false);
+        $iterator = $DB->request($criteria);
+        foreach ($iterator as $data) {
+            $this->array($data)
+                ->hasKey('status')
+                ->hasKey('COUNT')
+                ->integer['status']->isEqualTo(1)
+                ->integer['COUNT']->isEqualTo(3);
         }
     }
 }

--- a/tests/functional/Ticket.php
+++ b/tests/functional/Ticket.php
@@ -5599,7 +5599,7 @@ HTML
         ]);
         $this->integer($ticket_user_observer_id)->isGreaterThan(0);
 
-        $criteria = \Ticket::showCentralCountCriteria(true);
+        $criteria = $this->callPrivateMethod($this->newTestedInstance(), 'showCentralCountCriteria', true);
         $iterator = $DB->request($criteria);
         foreach ($iterator as $data) {
             $this->array($data)


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->
In the simplified interface, the summary showing the number of tickets for each status is incorrect.
The counters do not take into account tickets where the user is an observer, even though they appear in the list.

Summary with the number of tickets for each status. "Processing" is set to 0.
![image](https://github.com/glpi-project/glpi/assets/42278610/d0af19af-7523-4e17-9aba-084f0bd1a31b)
But if you click on "Processing", the list includes a ticket where the user is an observer.
![image](https://github.com/glpi-project/glpi/assets/42278610/5e0f2236-84c0-4fe5-a12f-6f4089f26233)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28453
