### PR TITLE
Fix error during update from GLPI < 0.85

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -2457,7 +2457,14 @@ HTML;
 
             $url_base = $CFG_GLPI['url_base'] ?? null;
             // $CFG_GLPI may have not been loaded yet, load value form DB if `$CFG_GLPI['url_base']` is not set.
-            if ($url_base === null && $DB instanceof DBmysql && $DB->connected) {
+            if (
+                $url_base === null
+                && $DB instanceof DBmysql
+                && $DB->connected
+                // table/field may not exists in edge case (e.g. update from GLPI < 0.85)
+                && $DB->tableExists('glpi_configs')
+                && $DB->fieldExists('glpi_configs', 'context')
+            ) {
                 $url_base = Config::getConfigurationValue('core', 'url_base');
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | see !28461

Fix a non blocking SQL error, introduced in GLPI 10.0.0 by #11085, that appears in CLI update from GLPI < 0.85.

Visible in our test suite:
![image](https://github.com/glpi-project/glpi/assets/33253653/1ea3c006-7766-4415-9b9a-69d7609029dc)
