### PR TITLE
Fix RAM field migration

### DIFF
--- a/install/migrations/update_10.0.7_to_10.0.8/ram_field.php
+++ b/install/migrations/update_10.0.7_to_10.0.8/ram_field.php
@@ -49,6 +49,13 @@ $migration->changeField(
     "int unsigned DEFAULT NULL",
 );
 
+$migration->changeField(
+    ComputerVirtualMachine::getTable(),
+    'ram',
+    'ram',
+    'varchar(255) DEFAULT NULL',
+);
+$migration->migrationOneTable(ComputerVirtualMachine::getTable());
 $DB->update(
     ComputerVirtualMachine::getTable(),
     ['ram' => null],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Until #14965, `glpi_computervirtualmachines.ram` was not nullable. To be able to update `''` values to `null`, field must first be made nullable.

```
SQL Error "1048": Column 'ram' cannot be null in query "UPDATE `glpi_computervirtualmachines` SET `ram` = NULL WHERE `ram` = ''"
SQL Error "1366": Incorrect integer value: '' for column 'ram' at row 4 in query "ALTER TABLE `glpi_computervirtualmachines` CHANGE `ram` `ram` int unsigned DEFAULT NULL   "
```