### PR TITLE
Fix "read" right for reservations

### DIFF
--- a/ajax/reservations.php
+++ b/ajax/reservations.php
@@ -35,7 +35,7 @@
 
 include('../inc/includes.php');
 
-Session::checkRight('reservation', ReservationItem::RESERVEANITEM);
+Session::checkRightsOr('reservation', [READ, ReservationItem::RESERVEANITEM]);
 
 if (!isset($_REQUEST["action"])) {
     exit;
@@ -46,6 +46,8 @@ if ($_REQUEST["action"] == "get_events") {
     echo json_encode(Reservation::getEvents($_REQUEST));
     exit;
 }
+
+Session::checkRight('reservation', ReservationItem::RESERVEANITEM);
 
 if ($_REQUEST["action"] == "get_resources") {
     header("Content-Type: application/json; charset=UTF-8");

--- a/front/helpdesk.public.php
+++ b/front/helpdesk.public.php
@@ -83,7 +83,7 @@ if (
         ])
     ) {
         Html::redirect($CFG_GLPI['root_doc'] . "/front/ticket.php");
-    } else if (Session::haveRight('reservation', ReservationItem::RESERVEANITEM)) {
+    } else if (Session::haveRightsOr('reservation', [READ, ReservationItem::RESERVEANITEM])) {
         Html::redirect($CFG_GLPI['root_doc'] . "/front/reservationitem.php");
     } else if (Session::haveRight('knowbase', KnowbaseItem::READFAQ)) {
         Html::redirect($CFG_GLPI['root_doc'] . "/front/helpdesk.faq.php");

--- a/js/reservations.js
+++ b/js/reservations.js
@@ -43,6 +43,7 @@ var Reservations = function() {
     this.license_key = null;
     this.currentv    = null;
     this.defaultDate = null;
+    this.can_reserve = true;
 
     var my = this;
 
@@ -56,6 +57,9 @@ var Reservations = function() {
         my.currentv     = config.currentv || 'dayGridMonth';
         my.defaultDate  = config.defaultDate || new Date();
         my.defaultPDate = new Date(my.defaultDate);
+        if (config.can_reserve != undefined) {
+            my.can_reserve = config.can_reserve;
+        }
     };
 
     my.displayPlanning = function() {
@@ -227,17 +231,19 @@ var Reservations = function() {
             // ADD EVENTS
             selectable: true,
             select: function(info) {
-                glpi_ajax_dialog({
-                    title: __("Add reservation"),
-                    url: CFG_GLPI.root_doc+"/ajax/reservations.php",
-                    params: {
-                        action: 'add_reservation_fromselect',
-                        id:     my.id,
-                        start:  info.start.toISOString(),
-                        end:    info.end.toISOString(),
-                    },
-                    dialogclass: 'modal-lg',
-                });
+                if (my.can_reserve) {
+                    glpi_ajax_dialog({
+                        title: __("Add reservation"),
+                        url: CFG_GLPI.root_doc+"/ajax/reservations.php",
+                        params: {
+                            action: 'add_reservation_fromselect',
+                            id:     my.id,
+                            start:  info.start.toISOString(),
+                            end:    info.end.toISOString(),
+                        },
+                        dialogclass: 'modal-lg',
+                    });
+                }
 
                 my.calendar.unselect();
             },

--- a/js/reservations.js
+++ b/js/reservations.js
@@ -229,7 +229,7 @@ var Reservations = function() {
             },
 
             // ADD EVENTS
-            selectable: true,
+            selectable: my.can_reserve,
             select: function(info) {
                 if (my.can_reserve) {
                     glpi_ajax_dialog({

--- a/src/Html.php
+++ b/src/Html.php
@@ -1560,7 +1560,7 @@ HTML;
             }
         }
 
-        if (Session::haveRight("reservation", ReservationItem::RESERVEANITEM)) {
+        if (Session::haveRightsOr("reservation", [READ, ReservationItem::RESERVEANITEM])) {
             $menu['reservation'] = [
                 'default' => '/front/reservationitem.php',
                 'title'   => _n('Reservation', 'Reservations', Session::getPluralNumber()),

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -416,7 +416,7 @@ class Reservation extends CommonDBChild
     {
         global $CFG_GLPI;
 
-        if (!Session::haveRight("reservation", ReservationItem::RESERVEANITEM)) {
+        if (!Session::haveRightsOr("reservation", [READ, ReservationItem::RESERVEANITEM])) {
             return false;
         }
 
@@ -469,6 +469,7 @@ class Reservation extends CommonDBChild
         echo "<div id='reservations_planning_$rand' class='card-body reservations-planning'></div>";
         echo "</div>"; // .reservation_panel
 
+        $can_reserve = Session::haveRight("reservation", ReservationItem::RESERVEANITEM) ? "true" : "false";
         $js = <<<JAVASCRIPT
       $(function() {
          var reservation = new Reservations();
@@ -477,6 +478,7 @@ class Reservation extends CommonDBChild
             is_all: $is_all,
             rand: $rand,
             license_key: '$scheduler_key',
+            can_reserve: $can_reserve,
          });
          reservation.displayPlanning();
       });

--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -428,7 +428,7 @@ class ReservationItem extends CommonDBChild
     {
         global $DB, $CFG_GLPI;
 
-        if (!Session::haveRight(self::$rightname, self::RESERVEANITEM)) {
+        if (!Session::haveRightsOr(self::$rightname, [READ, self::RESERVEANITEM])) {
             return false;
         }
 
@@ -723,7 +723,7 @@ class ReservationItem extends CommonDBChild
                 $ok = true;
             }
         }
-        if ($ok) {
+        if ($ok && Session::haveRight("reservation", self::RESERVEANITEM)) {
             echo "<tr class='tab_bg_1'>";
             echo "<th><i class='fas fa-level-up-alt fa-flip-horizontal fa-lg mx-2'></i></th>";
             echo "<th colspan='" . ($showentity ? "5" : "4") . "'>";
@@ -948,7 +948,7 @@ class ReservationItem extends CommonDBChild
 
         if ($item->getType() == __CLASS__) {
             $tabs = [];
-            if (Session::haveRight("reservation", ReservationItem::RESERVEANITEM)) {
+            if (Session::haveRightsOr("reservation", [READ, ReservationItem::RESERVEANITEM])) {
                 $tabs[1] = Reservation::getTypeName(1);
             }
             if (


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28443

Added the ability to view reservations with the `READ` right.
Until now, the `ReservationItem::RESERVEANITEM` right was required to display reservations.
The `READ` right was already present but had no effect.
