### PR TITLE
Fix missing names on Kanban for users with only usernames

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8646,6 +8646,7 @@ abstract class CommonITILObject extends CommonDBTM
                     $user_link_class::getTableField('users_id'),
                     User::getTableField('firstname'),
                     User::getTableField('realname'),
+                    User::getTableField('name'),
                 ],
                 'FROM'   => $user_link_table,
                 'LEFT JOIN' => [
@@ -8677,7 +8678,7 @@ abstract class CommonITILObject extends CommonDBTM
                     'realname'  => $linked_user_row['realname'],
                     'name'      => formatUserName(
                         $linked_user_row['users_id'],
-                        '',
+                        $linked_user_row['name'],
                         $linked_user_row['realname'],
                         $linked_user_row['firstname']
                     ),

--- a/src/Project.php
+++ b/src/Project.php
@@ -2045,7 +2045,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
 
        // Build team member data
         $supported_teamtypes = [
-            'User' => ['id', 'firstname', 'realname'],
+            'User' => ['id', 'name', 'firstname', 'realname'],
             'Group' => ['id', 'name'],
             'Supplier' => ['id', 'name'],
             'Contact' => ['id', 'name', 'firstname']
@@ -2114,8 +2114,9 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
                         if (count($contact_matches)) {
                               $match = reset($contact_matches);
                               // contact -> name, user -> realname
-                              $realname = $match['name'] ?? $match['realname'] ?? "";
-                              $match['name'] = formatUserName($match['id'], '', $realname, $match['firstname']);
+                              $realname = $teammember['itemtype'] === 'User' ? $match['realname'] : $match['name'];
+                              $name = $teammember['itemtype'] === 'User' ? $match['name'] : '';
+                              $match['name'] = formatUserName($match['id'], $name, $realname, $match['firstname']);
                               $item['_team'][] = array_merge($teammember, $match);
                         }
                         break;
@@ -2162,7 +2163,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
                         if (count($contact_matches)) {
                               $match = reset($contact_matches);
                             if ($teammember['itemtype'] === 'User') {
-                                $match['name'] = formatUserName($match['id'], '', $match['realname'], $match['firstname']);
+                                $match['name'] = formatUserName($match['id'], $match['name'], $match['realname'], $match['firstname']);
                             } else {
                                 $match['name'] = formatUserName($match['id'], '', $match['name'], $match['firstname']);
                             }


### PR DESCRIPTION
 Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The name field wasn't being retrieved/used to calculate the display name for users so if they had no first name or real name, an empty string or just the ID was shown depending on the user preference for showing IDs. This PR fixes that an allows the username to show in this case, as was originally intended.