### PR TITLE
fix(display): fix html entities from actor field

### DIFF
--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -63,8 +63,8 @@
             {% if (actor['itemtype'] == 'User' and itiltemplate.isHiddenField('_users_id_' ~ actortype)) or (actor['itemtype'] == 'Group' and itiltemplate.isHiddenField('_groups_id_' ~ actortype)) %}
                disabled="disabled" style="display: none;"
             {% endif %}
-            data-text="{{ actor['text']|verbatim_value }}" data-title="{{ actor['title']|verbatim_value }}" data-glpi-popover-source="content{{ unique_id }}">
-         {{ actor['title']|verbatim_value }}
+            data-text="{{ actor['text']|raw }}" data-title="{{ actor['title']|raw }}" data-glpi-popover-source="content{{ unique_id }}">
+         {{ actor['title']|raw }}
       </option>
    {% endfor %}
    </select>


### PR DESCRIPTION
If group name contain ```&``` (like "R&D") , the actor form does not display it correctly 

![image](https://github.com/glpi-project/glpi/assets/7335054/cdf351a1-a0be-49cf-9447-0a41013686d4)

database value : 

```sql
+----+--------------------+------------------------------+
| id | name               | completename                 |
+----+--------------------+------------------------------+
|  5 | IT R&#38;D Support | Group 1 > IT R&#38;D Support |
+----+--------------------+------------------------------+
```


With this PR

![image](https://github.com/glpi-project/glpi/assets/7335054/1e3fcd05-dc7e-4497-8e87-ea5335af0cb1)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27844
