### PR TITLE
Add redirection if user lacks rights to view the page upon profile change

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -626,6 +626,7 @@ class Html
      **/
     public static function displayRightError(string $additional_info = '')
     {
+        Toolbox::handleProfileChangeRedirect();
         $requested_url = (isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : 'Unknown');
         $user_id = Session::getLoginUserID() ?? 'Anonymous';
         if (empty($additional_info)) {

--- a/src/Session.php
+++ b/src/Session.php
@@ -1078,6 +1078,7 @@ class Session
            // Gestion timeout session
             self::redirectIfNotLoggedIn();
             $right_name = self::getRightNameForError($right);
+            Toolbox::handleProfileChangeRedirect();
             Html::displayRightError("User is missing the $right ($right_name) right for $module");
         }
     }

--- a/src/Session.php
+++ b/src/Session.php
@@ -1078,7 +1078,6 @@ class Session
            // Gestion timeout session
             self::redirectIfNotLoggedIn();
             $right_name = self::getRightNameForError($right);
-            Toolbox::handleProfileChangeRedirect();
             Html::displayRightError("User is missing the $right ($right_name) right for $module");
         }
     }


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When a user changes their profile in GLPI, the current page is reloaded. However, the new active profile does not guarantee that the user has the necessary rights to view the page, which can result in a permissions error. This pull request aims to address this issue by redirecting the user to the homepage if they lack the required rights. If the user has the necessary rights, no changes are made.