### PR TITLE
fix(css): fix logo with dark mode

### DIFF
--- a/templates/layout/parts/page_header.html.twig
+++ b/templates/layout/parts/page_header.html.twig
@@ -54,7 +54,7 @@
             </button>
 
             <a href="{{ index_path() }}" accesskey="1" title="{{ __('Home') }}"
-               class="navbar-brand navbar-brand-autodark">
+               class="navbar-brand">
                <span class="glpi-logo"></span>
             </a>
 
@@ -107,7 +107,7 @@
                </button>
 
                <a href="{{ index_path() }}" accesskey="1" title="{{ __('Home') }}"
-                  class="navbar-brand navbar-brand-autodark">
+                  class="navbar-brand">
                   <span class="glpi-logo"></span>
                </a>
 


### PR DESCRIPTION
```navbar-brand-autodark``` use when dark mode is enabled (with ```auror dark```, ```darker```, ```midnight``` css) alters the rendering of the logo added from the ```branding``` plugin.

because of ```autodark-image``` mixin call by ```navbar-brand-autodark```

```css
@mixin autodark-image {
  filter: brightness(0) invert(1);
}
```

Before : 
![image](https://github.com/glpi-project/glpi/assets/7335054/063b31b8-1459-40a9-b1e8-b580b5a09411)

After : 
![image](https://github.com/glpi-project/glpi/assets/7335054/57eb206e-c2df-40de-b65a-03a596751a8c)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28491
