### PR TITLE
fix(Notification): prevent private item exposure from notification

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -6750,7 +6750,7 @@ abstract class CommonITILObject extends CommonDBTM
 
        //checks rights
         $restrict_fup = $restrict_task = [];
-        if (!$params['expose_private'] && !Session::haveRight("followup", ITILFollowup::SEEPRIVATE)) {
+        if (!$params['expose_private'] || (!Session::haveRight("followup", ITILFollowup::SEEPRIVATE) && !$params['bypass_rights'])) {
             $restrict_fup = [
                 'OR' => [
                     'is_private' => 0,
@@ -6770,7 +6770,10 @@ abstract class CommonITILObject extends CommonDBTM
 
         $taskClass = $objType . "Task";
         $task_obj  = new $taskClass();
-        if (!$params['expose_private'] && $task_obj->maybePrivate() && !Session::haveRight("task", CommonITILTask::SEEPRIVATE)) {
+        if (
+            $task_obj->maybePrivate()
+            && (!$params['expose_private'] || (!Session::haveRight("followup", CommonITILTask::SEEPRIVATE) && !$params['bypass_rights']))
+        ) {
             $restrict_task = [
                 'OR' => [
                     'is_private'   => 0,

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -6770,7 +6770,10 @@ abstract class CommonITILObject extends CommonDBTM
 
         $taskClass = $objType . "Task";
         $task_obj  = new $taskClass();
-        if (!$params['expose_private'] || ($task_obj->maybePrivate() && !Session::haveRight("followup", CommonITILTask::SEEPRIVATE) && !$params['bypass_rights'])) {
+        if (
+            $task_obj->maybePrivate()
+            && (!$params['expose_private'] || (!Session::haveRight("followup", CommonITILTask::SEEPRIVATE) && !$params['bypass_rights']))
+        ) {
             $restrict_task = [
                 'OR' => [
                     'is_private'   => 0,

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -6759,7 +6759,7 @@ abstract class CommonITILObject extends CommonDBTM
             ];
         }
 
-        if ($params['is_self_service']) {
+        if ($params['is_self_service'] || (!$params['expose_private'] &&  $params['bypass_rights'])) {
             $restrict_fup = [
                 'is_private'   => 0
             ];
@@ -6781,7 +6781,7 @@ abstract class CommonITILObject extends CommonDBTM
             ];
         }
 
-        if ($params['is_self_service']) {
+        if ($params['is_self_service'] || (!$params['expose_private'] &&  $params['bypass_rights'])) {
             $restrict_task = [
                 'is_private'   => 0
             ];

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -6750,7 +6750,7 @@ abstract class CommonITILObject extends CommonDBTM
 
        //checks rights
         $restrict_fup = $restrict_task = [];
-        if (!$params['expose_private'] || (!Session::haveRight("followup", ITILFollowup::SEEPRIVATE) && !$params['bypass_rights'])) {
+        if (!$params['expose_private'] && !Session::haveRight("followup", ITILFollowup::SEEPRIVATE)) {
             $restrict_fup = [
                 'OR' => [
                     'is_private' => 0,
@@ -6759,7 +6759,7 @@ abstract class CommonITILObject extends CommonDBTM
             ];
         }
 
-        if ($params['is_self_service']) {
+        if ($params['is_self_service'] || !$params['expose_private']) {
             $restrict_fup = [
                 'is_private'   => 0
             ];
@@ -6770,10 +6770,7 @@ abstract class CommonITILObject extends CommonDBTM
 
         $taskClass = $objType . "Task";
         $task_obj  = new $taskClass();
-        if (
-            $task_obj->maybePrivate()
-            && (!$params['expose_private'] || (!Session::haveRight("followup", CommonITILTask::SEEPRIVATE) && !$params['bypass_rights']))
-        ) {
+        if (!$params['expose_private'] && $task_obj->maybePrivate() && !Session::haveRight("task", CommonITILTask::SEEPRIVATE)) {
             $restrict_task = [
                 'OR' => [
                     'is_private'   => 0,
@@ -6784,7 +6781,7 @@ abstract class CommonITILObject extends CommonDBTM
             ];
         }
 
-        if ($params['is_self_service']) {
+        if ($params['is_self_service'] || !$params['expose_private']) {
             $restrict_task = [
                 'is_private'   => 0
             ];

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -6750,7 +6750,7 @@ abstract class CommonITILObject extends CommonDBTM
 
        //checks rights
         $restrict_fup = $restrict_task = [];
-        if (!$params['expose_private'] && !Session::haveRight("followup", ITILFollowup::SEEPRIVATE)) {
+        if (!$params['expose_private'] || (!Session::haveRight("followup", ITILFollowup::SEEPRIVATE) && !$params['bypass_rights'])) {
             $restrict_fup = [
                 'OR' => [
                     'is_private' => 0,
@@ -6759,7 +6759,7 @@ abstract class CommonITILObject extends CommonDBTM
             ];
         }
 
-        if ($params['is_self_service'] || (!$params['expose_private'] &&  $params['bypass_rights'])) {
+        if ($params['is_self_service']) {
             $restrict_fup = [
                 'is_private'   => 0
             ];
@@ -6770,7 +6770,7 @@ abstract class CommonITILObject extends CommonDBTM
 
         $taskClass = $objType . "Task";
         $task_obj  = new $taskClass();
-        if (!$params['expose_private'] && $task_obj->maybePrivate() && !Session::haveRight("task", CommonITILTask::SEEPRIVATE)) {
+        if (!$params['expose_private'] || ($task_obj->maybePrivate() && !Session::haveRight("followup", CommonITILTask::SEEPRIVATE) && !$params['bypass_rights'])) {
             $restrict_task = [
                 'OR' => [
                     'is_private'   => 0,
@@ -6781,7 +6781,7 @@ abstract class CommonITILObject extends CommonDBTM
             ];
         }
 
-        if ($params['is_self_service'] || (!$params['expose_private'] &&  $params['bypass_rights'])) {
+        if ($params['is_self_service']) {
             $restrict_task = [
                 'is_private'   => 0
             ];

--- a/src/NotificationTargetCommonITILObject.php
+++ b/src/NotificationTargetCommonITILObject.php
@@ -1591,8 +1591,6 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                 'is_self_service'   => $is_self_service,
             ];
 
-            //Toolbox::logDebug($show_private, $is_self_service);
-
             $timeline = $item->getTimelineItems($options);
 
             foreach ($timeline as $timeline_data) {

--- a/src/NotificationTargetCommonITILObject.php
+++ b/src/NotificationTargetCommonITILObject.php
@@ -1591,6 +1591,8 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                 'is_self_service'   => $is_self_service,
             ];
 
+            //Toolbox::logDebug($show_private, $is_self_service);
+
             $timeline = $item->getTimelineItems($options);
 
             foreach ($timeline as $timeline_data) {

--- a/tests/functional/NotificationTargetTicket.php
+++ b/tests/functional/NotificationTargetTicket.php
@@ -361,12 +361,12 @@ class NotificationTargetTicket extends DbTestCase
         ];
 
         //add second test for post-only
-        //simulate that is a self-service (because of one profil with interface = helpdesk)
+        //simulate that is a not self-service (because of one profil with interface = central)
         //he can't see private because of self-service who has no right TILFollowup::SEEPRIVATE
         $basic_options = [
             'additionnaloption' => [
                 'usertype' => NotificationTarget::GLPI_USER,
-                'is_self_service' => true,
+                'is_self_service' => false,
                 'show_private'    => false,
             ]
         ];

--- a/tests/functional/NotificationTargetTicket.php
+++ b/tests/functional/NotificationTargetTicket.php
@@ -363,6 +363,8 @@ class NotificationTargetTicket extends DbTestCase
         //add second test for post-only
         //simulate that is a not self-service (because of one profil with interface = central)
         //he can't see private because of self-service who has no right TILFollowup::SEEPRIVATE
+        //log as tech to trigger Session check (As if tech was at the origin of noticication )
+        $this->login("tech", "tech");
         $basic_options = [
             'additionnaloption' => [
                 'usertype' => NotificationTarget::GLPI_USER,

--- a/tests/functional/NotificationTargetTicket.php
+++ b/tests/functional/NotificationTargetTicket.php
@@ -360,6 +360,52 @@ class NotificationTargetTicket extends DbTestCase
             ]
         ];
 
+        //add second test for post-only
+        //simulate that is not a self-service (because of second profil tech)
+        //he can't see private because of self-service who has no right TILFollowup::SEEPRIVATE
+        $basic_options = [
+            'additionnaloption' => [
+                'usertype' => NotificationTarget::GLPI_USER,
+                'is_self_service' => false,
+                'show_private'    => false,
+            ]
+        ];
+
+        $ret = $notiftargetticket->getDataForObject($ticket, $basic_options);
+
+        //get only public task / followup / Solution (because is post_only)
+        $expected = [
+            [
+                "##timelineitems.type##"        => "ITILSolution",
+                "##timelineitems.typename##"    => "Solutions",
+                "##timelineitems.date##"        =>  \Html::convDateTime($solution->fields['date_creation']),
+                "##timelineitems.description##" => $solution->fields['content'],
+                "##timelineitems.position##"    => "right",
+                "##timelineitems.author##"      => "tech", //empty
+            ],[
+                "##timelineitems.type##"        => "TicketTask",
+                "##timelineitems.typename##"    => "Ticket tasks",
+                "##timelineitems.date##"        =>  \Html::convDateTime($task_tech->fields['date']),
+                "##timelineitems.description##" => $task_tech->fields['content'],
+                "##timelineitems.position##"    => "right",
+                "##timelineitems.author##"      => "tech",
+            ],[
+                "##timelineitems.type##"        => "ITILFollowup",
+                "##timelineitems.typename##"    => "Followups",
+                "##timelineitems.date##"        =>  \Html::convDateTime($fup_post_only->fields['date']),
+                "##timelineitems.description##" => $fup_post_only->fields['content'],
+                "##timelineitems.position##"    => "left",
+                "##timelineitems.author##"      => "post-only",
+            ],[
+                "##timelineitems.type##" => "ITILFollowup",
+                "##timelineitems.typename##" => "Followups",
+                "##timelineitems.date##"        =>  \Html::convDateTime($fup_tech->fields['date']),
+                "##timelineitems.description##" => $fup_tech->fields['content'],
+                "##timelineitems.position##" => "right",
+                "##timelineitems.author##" => "tech",
+            ]
+        ];
+
         $this->array($ret['timelineitems'])->isIdenticalTo($expected);
     }
 }

--- a/tests/functional/NotificationTargetTicket.php
+++ b/tests/functional/NotificationTargetTicket.php
@@ -361,12 +361,12 @@ class NotificationTargetTicket extends DbTestCase
         ];
 
         //add second test for post-only
-        //simulate that is not a self-service (because of second profil tech)
+        //simulate that is a self-service (because of one profil with interface = helpdesk)
         //he can't see private because of self-service who has no right TILFollowup::SEEPRIVATE
         $basic_options = [
             'additionnaloption' => [
                 'usertype' => NotificationTarget::GLPI_USER,
-                'is_self_service' => false,
+                'is_self_service' => true,
                 'show_private'    => false,
             ]
         ];

--- a/tests/functional/NotificationTargetTicket.php
+++ b/tests/functional/NotificationTargetTicket.php
@@ -360,10 +360,8 @@ class NotificationTargetTicket extends DbTestCase
             ]
         ];
 
-        //add second test for post-only
-        //simulate that is a not self-service (because of one profil with interface = central)
-        //he can't see private because of self-service who has no right TILFollowup::SEEPRIVATE
-        //log as tech to trigger Session check (As if tech was at the origin of noticication )
+        //add a test for tech, but force the `show_private` option to false to ensure that presence of this option will
+        //hide private items
         $this->login("tech", "tech");
         $basic_options = [
             'additionnaloption' => [


### PR DESCRIPTION
When a ```requester``` have 2 profiles
 - ```self-service```
 - ```tech``` (without see private followup)

Notification contain private followup

why ?

When ```NotificationTargetCommonITILObject``` call ``` $item->getTimelineItems($options);```

With this options
```
            $options = [
                'with_documents'    => false,
                'with_logs'         => false,
                'with_validations'  => false,
                'expose_private'    => $show_private,
                'bypass_rights'     => true,
                'sort_by_date_desc' => true,
                'is_self_service'   => $is_self_service,
            ];
```

```$show_private``` is ```false``` because it's computed according to the profiles that have the right to ``ITILFollowup::SEEPRIVATE``.

```$is_self_service``` is ```false```, because ```requester``` have one profile with ```interface``` = ```central``` (tech)

First option ```$show_private``` is used with current session 

```php
 $restrict_fup = $restrict_task = [];
        if (!$params['expose_private'] && !Session::haveRight("followup", ITILFollowup::SEEPRIVATE)) {
            $restrict_fup = [
                'OR' => [
                    'is_private' => 0,
                    'users_id'   => Session::getLoginUserID()
                ]
            ];
        }
```

while the second option is always used ( ```helpdesk``` interface, notification etc ...)

```php
        if ($params['is_self_service'] ) {
            $restrict_fup = [
                'is_private'   => 0
            ];
        }
```

In my case all private followup are send.

this PR prevent this


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27671
