### PR TITLE
Fix error when rule pattern is null

### DIFF
--- a/src/Rule.php
+++ b/src/Rule.php
@@ -2332,7 +2332,7 @@ class Rule extends CommonDBTM
         return [
             'criterion' => Sanitizer::encodeHtmlSpecialChars(Sanitizer::getVerbatimValue($criterion)),
             'condition' => Sanitizer::encodeHtmlSpecialChars(Sanitizer::getVerbatimValue($condition)),
-            'pattern'   => Sanitizer::encodeHtmlSpecialChars(Sanitizer::getVerbatimValue($pattern)),
+            'pattern'   => Sanitizer::encodeHtmlSpecialChars(Sanitizer::getVerbatimValue($pattern ?? '')),
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

It is probably not a valid rule, but if pattern is null, then an error is triggered.
```
*** Uncaught Exception TypeError: Argument 1 passed to Glpi\Toolbox\Sanitizer::getVerbatimValue() must be of the type string, null given, called in /srv/glpi/src/Rule.php on line 2335
```