### PR TITLE
Fix double form submission protection

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -1431,14 +1431,16 @@ function blockFormSubmit(form, e) {
     form.attr('data-submitted', 'true');
 }
 
-$(document.body).on('submit', 'form[data-submit-once]', (e) => {
-    const form = $(e.target).closest('form');
-    if (form.attr('data-submitted') === 'true') {
-        e.preventDefault();
-        return false;
-    } else {
-        blockFormSubmit(form, e);
-    }
+$(() => {
+    $(document.body).on('submit', 'form[data-submit-once]', (e) => {
+        const form = $(e.target).closest('form');
+        if (form.attr('data-submitted') === 'true') {
+            e.preventDefault();
+            return false;
+        } else {
+            blockFormSubmit(form, e);
+        }
+    });
 });
 
 /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

At some point, the submit once feature for forms broke. It seems the common.js script is loaded before the body element ready so the event listener is not properly added. This issue was noticed by @kabassanov during the login process when a mobile browser was automatically filling the login details and submitting the form (unknown at the time) and he was also manually pressing the Sign In button. The automatic action was consuming the CSRF token, while the later manual action was cancelling the first and trying to re-submit with an then-invalid token.

This PR delays the event listener binding until after the DOM is ready and resolved the issue both with the login form, and other forms that have the "data-submit-once" attribute.