### PR TITLE
fix(inventory): set date creation when needed

### DIFF
--- a/src/Inventory/Asset/Software.php
+++ b/src/Inventory/Asset/Software.php
@@ -719,6 +719,8 @@ class Software extends InventoryAsset
                 $stmt_columns = $this->cleanInputToPrepare((array)$val, $soft_fields);
 
                 $software->handleCategoryRules($stmt_columns);
+                //set create date
+                $stmt_columns['date_creation'] = $_SESSION["glpi_currenttime"];
 
                 if ($stmt === null) {
                     $stmt_types = str_repeat('s', count($stmt_columns));
@@ -785,6 +787,8 @@ class Software extends InventoryAsset
                  $stmt_columns = $this->cleanInputToPrepare((array)$val, $version_fields);
                  $stmt_columns['name'] = $version_name;
                  $stmt_columns['softwares_id'] = $softwares_id;
+                 //set create date
+                 $stmt_columns['date_creation'] = $_SESSION["glpi_currenttime"];
                 if ($stmt === null) {
                     $stmt_types = str_repeat('s', count($stmt_columns));
                     $reference = array_fill_keys(


### PR DESCRIPTION
```date_creation``` is not filled (for ```Software``` and ```SoftwareVersion```) during inventory step.

This Pr fix this.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28498
