### PR TITLE
fix(inventory): fix ID keep in memory (and use from SoftwareVersion)

### DIFF
--- a/src/Inventory/Asset/OperatingSystem.php
+++ b/src/Inventory/Asset/OperatingSystem.php
@@ -172,7 +172,7 @@ class OperatingSystem extends InventoryAsset
 
         $ioskey = 'operatingsystems_id' . $val->operatingsystems_id;
         $this->known_links[$ioskey] = $ios->fields['id'];
-        $this->operatingsystems_id = $ios->fields['id'];
+        $this->operatingsystems_id =  $input_os['operatingsystems_id'];
 
         //cleanup
         if (!$this->main_asset || !$this->main_asset->isPartial()) {

--- a/tests/functional/Glpi/Inventory/Assets/Software.php
+++ b/tests/functional/Glpi/Inventory/Assets/Software.php
@@ -159,7 +159,7 @@ class Software extends AbstractInventoryAsset
 
         $version = new \SoftwareVersion();
         $this->boolean($version->getFromDB($sov->fields['softwareversions_id']))->isTrue();
-        $this->integer($version->fields['operatingsystems_id'])->isIdenticalTo(0);
+        $this->integer($version->fields['operatingsystems_id'])->isIdenticalTo(0); // no OS from $this->assetProvider()[0];
 
         //convert data
         $expected = $this->assetProvider()[1];
@@ -192,9 +192,15 @@ class Software extends AbstractInventoryAsset
 
         $this->integer($sov->fields['softwareversions_id'])->isNotEqualTo($version->fields['id']);
 
+        $ios = new \Item_OperatingSystem();
+        $this->boolean($ios->getFromDBByCrit([
+          "itemtype" => 'Computer',
+          "items_id" => $computer->fields['id']
+        ]))->isTrue();
+
         $version = new \SoftwareVersion();
         $this->boolean($version->getFromDB($sov->fields['softwareversions_id']))->isTrue();
-        $this->integer($version->fields['operatingsystems_id'])->isGreaterThan(0);
+        $this->integer($version->fields['operatingsystems_id'])->isEqualTo($ios->fields['operatingsystems_id']); //check linked OS from SoftwareVersion
 
         //new computer with same software
         global $DB;

--- a/tests/functional/Glpi/Inventory/Assets/Software.php
+++ b/tests/functional/Glpi/Inventory/Assets/Software.php
@@ -194,8 +194,8 @@ class Software extends AbstractInventoryAsset
 
         $ios = new \Item_OperatingSystem();
         $this->boolean($ios->getFromDBByCrit([
-          "itemtype" => 'Computer',
-          "items_id" => $computer->fields['id']
+            "itemtype" => 'Computer',
+            "items_id" => $computer->fields['id']
         ]))->isTrue();
 
         $version = new \SoftwareVersion();


### PR DESCRIPTION
```operatingystems_id``` used by ```SoftwareVersion``` comes from ```\Glpi\Inventory\Asset\OperatingSystem->getId()```

But from ```OperatingSystem``` when an ```OS``` is handled, ```getId()```  return ID of link between ```Computer``` and ```OS```

```php
$this->operatingsystems_id =  $ios->fields['id'];
``` 

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28498
