### PR TITLE
Fixed an error when sending a reservation form empty.

### DIFF
--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -117,6 +117,7 @@ if (isset($_POST["update"])) {
     ksort($dates_to_add);
     if (
         count($dates_to_add)
+        && isset($_POST['items'])
         && count($_POST['items'])
         && isset($_POST['users_id'])
     ) {


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When a reservation form is sent without a defined item, an error occurs.

Form :
![image](https://github.com/glpi-project/glpi/assets/42278610/b8f2e651-29db-4bba-bd1e-61f871932aeb)
or
![image](https://github.com/glpi-project/glpi/assets/42278610/cef44061-3957-4526-b284-763af3417b47)


Error
![image](https://github.com/glpi-project/glpi/assets/42278610/ea67efec-d3d1-4e24-9a16-ac0ce4cb1bca)

