### PR TITLE
fix(Computer): fix is_dynamic source

### DIFF
--- a/src/Computer.php
+++ b/src/Computer.php
@@ -217,8 +217,8 @@ class Computer extends CommonDBTM
                      $tID = $data['items_id'];
                      $item->getFromDB($tID);
                     if (!$item->getField('is_global')) {
-                        $changes['id'] = $item->getField('id');
                         $item_input = $changes;
+                        $item_input['id'] = $item->getID();
                         //propage is_dynamic value if needed to prevent locked fields
                         if ((bool) ($item->fields['is_dynamic'] ?? false) && $is_input_dynamic) {
                             $item_input['is_dynamic'] = 1;
@@ -254,8 +254,8 @@ class Computer extends CommonDBTM
                     foreach ($devices_result as $data) {
                         $tID = $data['id'];
                         $item->getFromDB($tID);
-                        $changes['id'] = $item->getField('id');
                         $item_input = $changes;
+                        $item_input['id'] = $item->getID();
                         //propage is_dynamic value if needed to prevent locked fields
                         if ((bool) ($item->fields['is_dynamic'] ?? false) && $is_input_dynamic) {
                             $item_input['is_dynamic'] = 1;

--- a/src/Computer.php
+++ b/src/Computer.php
@@ -197,6 +197,7 @@ class Computer extends CommonDBTM
 
         if (count($changes)) {
             $update_done = false;
+            $is_input_dynamic = (bool) ($this->input['is_dynamic'] ?? false);
 
             // Propagates the changes to linked items
             foreach ($CFG_GLPI['directconnect_types'] as $type) {
@@ -217,11 +218,12 @@ class Computer extends CommonDBTM
                      $item->getFromDB($tID);
                     if (!$item->getField('is_global')) {
                         $changes['id'] = $item->getField('id');
+                        $item_input = $changes;
                         //propage is_dynamic value if needed to prevent locked fields
-                        if (isset($item->fields['is_dynamic'])) {
-                            $changes['is_dynamic'] = $item->fields['is_dynamic'];
+                        if ((bool) ($item->fields['is_dynamic'] ?? false) && $is_input_dynamic) {
+                            $item_input['is_dynamic'] = 1;
                         }
-                        if ($item->update($changes)) {
+                        if ($item->update($item_input)) {
                             $update_done = true;
                         }
                     }
@@ -253,11 +255,12 @@ class Computer extends CommonDBTM
                         $tID = $data['id'];
                         $item->getFromDB($tID);
                         $changes['id'] = $item->getField('id');
+                        $item_input = $changes;
                         //propage is_dynamic value if needed to prevent locked fields
-                        if (isset($item->fields['is_dynamic'])) {
-                            $changes['is_dynamic'] = $item->fields['is_dynamic'];
+                        if ((bool) ($item->fields['is_dynamic'] ?? false) && $is_input_dynamic) {
+                            $item_input['is_dynamic'] = 1;
                         }
-                        if ($item->update($changes)) {
+                        if ($item->update($item_input)) {
                             $update_done = true;
                         }
                     }

--- a/src/Computer.php
+++ b/src/Computer.php
@@ -196,11 +196,6 @@ class Computer extends CommonDBTM
         }
 
         if (count($changes)) {
-            //propage is_dynamic value if needed to prevent locked fields
-            if (isset($this->input['is_dynamic'])) {
-                $changes['is_dynamic'] = $this->input['is_dynamic'];
-            }
-
             $update_done = false;
 
             // Propagates the changes to linked items
@@ -222,6 +217,10 @@ class Computer extends CommonDBTM
                      $item->getFromDB($tID);
                     if (!$item->getField('is_global')) {
                         $changes['id'] = $item->getField('id');
+                        //propage is_dynamic value if needed to prevent locked fields
+                        if (isset($item->fields['is_dynamic'])) {
+                            $changes['is_dynamic'] = $item->fields['is_dynamic'];
+                        }
                         if ($item->update($changes)) {
                             $update_done = true;
                         }
@@ -251,9 +250,13 @@ class Computer extends CommonDBTM
                         ]
                     );
                     foreach ($devices_result as $data) {
-                           $tID = $data['id'];
-                           $item->getFromDB($tID);
-                           $changes['id'] = $item->getField('id');
+                        $tID = $data['id'];
+                        $item->getFromDB($tID);
+                        $changes['id'] = $item->getField('id');
+                        //propage is_dynamic value if needed to prevent locked fields
+                        if (isset($item->fields['is_dynamic'])) {
+                            $changes['is_dynamic'] = $item->fields['is_dynamic'];
+                        }
                         if ($item->update($changes)) {
                             $update_done = true;
                         }


### PR DESCRIPTION
To avoid updating a manual element into a dynamic one

```is_dynamic``` propagation need to be done switch related item (cf : ```Monitor```) and not from mainasset (cf : ```Computer```)


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !27194
