### PR TITLE
fix(DebugBar): reverse arrows

### DIFF
--- a/js/modules/Debug/Debug.js
+++ b/js/modules/Debug/Debug.js
@@ -363,10 +363,10 @@ window.GLPI.Debug = new class Debug {
         const toggle_icon = $('#debug-toolbar .debug-toolbar-controls button[name="toggle_content_area"] i');
         if (content_area.hasClass('d-none') || force_show) {
             content_area.removeClass('d-none');
-            toggle_icon.removeClass('ti-square-arrow-down').addClass('ti-square-arrow-up');
+            toggle_icon.removeClass('ti-square-arrow-up').addClass('ti-square-arrow-down');
         } else {
             content_area.addClass('d-none');
-            toggle_icon.removeClass('ti-square-arrow-up').addClass('ti-square-arrow-down');
+            toggle_icon.removeClass('ti-square-arrow-down').addClass('ti-square-arrow-up');
         }
     }
 

--- a/templates/components/debug/debug_toolbar.html.twig
+++ b/templates/components/debug/debug_toolbar.html.twig
@@ -62,7 +62,7 @@
          <div class="debug-toolbar-controls pt-2">
             <div class="debug-toolbar-control">
                <button type="button" class="btn btn-icon border-0 p-1" name="toggle_content_area" onclick="GLPI.Debug.toggleExtraContentArea();">
-                  <i class="ti ti-square-arrow-down"></i>
+                  <i class="ti ti-square-arrow-up"></i>
                </button>
                <button type="button" class="btn btn-icon border-0 p-1" title="{{ __('Close') }}" onclick="GLPI.Debug.hideDebugToolbar();">
                   <i class="ti ti-square-x"></i>


### PR DESCRIPTION
The arrows are reversed to open or close the debug bar.

Before (when debug bar is collapsed) : 

![image](https://github.com/glpi-project/glpi/assets/7335054/07663d8c-b66d-46ba-afb2-dfad58c05292)


After  (when debug bar is collapsed)  : 

![image](https://github.com/glpi-project/glpi/assets/7335054/0a84888d-f988-47af-971b-4620d06b4b10)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
