### PR TITLE
Fix timeline items order

### DIFF
--- a/tests/functional/NotificationTargetTicket.php
+++ b/tests/functional/NotificationTargetTicket.php
@@ -183,7 +183,7 @@ class NotificationTargetTicket extends DbTestCase
             'itemtype' => 'Ticket',
             'is_private' => 0,
             'items_id' => $tickets_id,
-            'date' => date('Y-m-d H:i:s', strtotime($_SESSION['glpi_currenttime']) + 1),
+            'date_creation' => date('Y-m-d H:i:s', strtotime($_SESSION['glpi_currenttime']) + 1),
         ]);
         $this->integer($fup1_id)->isGreaterThan(0);
 
@@ -196,7 +196,7 @@ class NotificationTargetTicket extends DbTestCase
             'itemtype' => 'Ticket',
             'is_private' => 0,
             'items_id' => $tickets_id,
-            'date' => date('Y-m-d H:i:s', strtotime($_SESSION['glpi_currenttime']) + 2),
+            'date_creation' => date('Y-m-d H:i:s', strtotime($_SESSION['glpi_currenttime']) + 2),
         ]);
         $this->integer($fup2_id)->isGreaterThan(0);
 
@@ -209,7 +209,7 @@ class NotificationTargetTicket extends DbTestCase
             'itemtype' => 'Ticket',
             'is_private' => 1,
             'items_id' => $tickets_id,
-            'date' => date('Y-m-d H:i:s', strtotime($_SESSION['glpi_currenttime']) + 3),
+            'date_creation' => date('Y-m-d H:i:s', strtotime($_SESSION['glpi_currenttime']) + 3),
         ]);
         $this->integer($fup3_id)->isGreaterThan(0);
 
@@ -224,7 +224,7 @@ class NotificationTargetTicket extends DbTestCase
             'actiontime'        => "172800",                                  //1hours
             'content'           => "Private Task",
             'users_id_tech'     => getItemByTypeName('User', 'tech', true),
-            'date'     => date('Y-m-d H:i:s', strtotime($_SESSION['glpi_currenttime']) + 4),
+            'date_creation'     => date('Y-m-d H:i:s', strtotime($_SESSION['glpi_currenttime']) + 4),
         ]);
         $this->integer($task1_id)->isGreaterThan(0);
 
@@ -239,7 +239,7 @@ class NotificationTargetTicket extends DbTestCase
             'actiontime'        => "172800",                                  //1hours
             'content'           => "Task",
             'users_id_tech'     => getItemByTypeName('User', 'tech', true),
-            'date'     => date('Y-m-d H:i:s', strtotime($_SESSION['glpi_currenttime']) + 5),
+            'date_creation'     => date('Y-m-d H:i:s', strtotime($_SESSION['glpi_currenttime']) + 5),
         ]);
         $this->integer($task2_id)->isGreaterThan(0);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14102

The timeline items are ordered using their `date` field value. This field is editable for tasks, and it may result in unexpected order in timeline.
For instance, if user put a date in the future, here is the result:
![image](https://github.com/glpi-project/glpi/assets/33253653/13fa5b97-0061-4cc2-9ac4-18fb6b035220)

Ordering items by `creation_date`, when this field exist, solves the issue.