### PR TITLE
fix missing inter-all fonts

### DIFF
--- a/.webpack.config.js
+++ b/.webpack.config.js
@@ -185,6 +185,11 @@ var filesToCopy = [
         to: scssOutputPath,
     },
     {
+        package: '@fontsource/inter',
+        from: '{scss/mixins.scss,files/*all-[0-9]00*.woff}',
+        to: scssOutputPath,
+    },
+    {
         package: '@tabler/core',
         from: 'src/scss/**/*.scss',
         to: scssOutputPath,

--- a/.webpack.config.js
+++ b/.webpack.config.js
@@ -181,12 +181,7 @@ var filesToCopy = [
     // SCSS files
     {
         package: '@fontsource/inter',
-        from: '{scss/mixins.scss,files/*[0-9]00*.woff2}',
-        to: scssOutputPath,
-    },
-    {
-        package: '@fontsource/inter',
-        from: '{scss/mixins.scss,files/*all-[0-9]00*.woff}',
+        from: '{scss/mixins.scss,files/*all-[0-9]00*.woff,files/*[0-9]00*.woff2}',
         to: scssOutputPath,
     },
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When using compiled CSS files, there are requests being made to for `/css/lib/fontsource/inter/files/inter-all-*-normal.woff` files which are not present. The webpack config only copies the `woff2` font files and the "all" fonts are not available as woff2. These missing fonts are referenced in `/css/lib/fontsource/inter/scss/mixins.scss`.