### PR TITLE
Prevent dashboard cache collisions

### DIFF
--- a/src/Dashboard/Dashboard.php
+++ b/src/Dashboard/Dashboard.php
@@ -215,10 +215,6 @@ class Dashboard extends \CommonDBTM
         if (!$skip_child && count($this->rights) > 0) {
             $this->saveRights($this->rights);
         }
-
-       // invalidate dashboard cache
-        $cache_key = "dashboard_card_" . $this->key;
-        $GLPI_CACHE->delete($cache_key);
     }
 
 

--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -150,14 +150,6 @@ class Grid
                <i class="fas fa-spinner fa-spin fa-3x"></i>
             </div>
 HTML;
-           // manage cache
-            $dashboard_key = $this->current;
-            $footprint = sha1(serialize($card_options) .
-            ($_SESSION['glpiactiveentities_string'] ?? "") .
-            ($_SESSION['glpilanguage']));
-            $cache_key    = "dashboard_card_{$dashboard_key}_{$footprint}";
-            $card_options['cache_key'] = $cache_key;
-
             $this->addGridItem(
                 $card_html,
                 $gridstack_id,
@@ -916,23 +908,9 @@ HTML;
             }
             $card = $cards[$card_id];
 
-            // allows plugins to control uniqueness of its cards in cache system
-            if (isset($card['custom_hash'])) {
-                $card_options['custom_hash'] = $card['custom_hash'];
-            }
-
-            // manage cache
-            $options_footprint = sha1(
-                serialize($card_options) .
-                ($_SESSION['glpiactiveentities_string'] ?? "") .
-                $_SESSION['glpilanguage'] .
-                $_SESSION['glpiactiveprofile']['id'] ?? ""
-            );
-
             $use_cache = !$force
                 && $_SESSION['glpi_use_mode'] != Session::DEBUG_MODE
                 && (!isset($card['cache']) || $card['cache'] == true);
-            $cache_key = "dashboard_card_{$dashboard}_{$options_footprint}";
             $cache_age = 40;
 
             if ($use_cache) {
@@ -941,12 +919,6 @@ HTML;
                 header('Cache-Control: public');
                 header('Cache-Control: max-age=' . $cache_age);
                 header('Expires: ' . gmdate('D, d M Y H:i:s \G\M\T', time() + $cache_age));
-
-                // server cache
-                $dashboard_cards = $GLPI_CACHE->get($cache_key, []);
-                if (isset($dashboard_cards[$gridstack_id])) {
-                    return (string)$dashboard_cards[$gridstack_id];
-                }
             }
 
             $html = "";
@@ -1001,13 +973,6 @@ HTML;
             }
 
             $execution_time = round(microtime(true) - $start, 3);
-
-            // store server cache
-            if (strlen($dashboard)) {
-                $dashboard_cards = $GLPI_CACHE->get($cache_key, []);
-                $dashboard_cards[$gridstack_id] = $html;
-                $GLPI_CACHE->set($cache_key, $dashboard_cards, new \DateInterval("PT" . $cache_age . "S"));
-            }
         } catch (\Throwable $e) {
             $html = $render_error_html;
             $execution_time = round(microtime(true) - $start, 3);

--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -922,9 +922,12 @@ HTML;
             }
 
             // manage cache
-            $options_footprint = sha1(serialize($card_options) .
+            $options_footprint = sha1(
+                serialize($card_options) .
                 ($_SESSION['glpiactiveentities_string'] ?? "") .
-                ($_SESSION['glpilanguage']));
+                $_SESSION['glpilanguage'] .
+                $_SESSION['glpiactiveprofile']['id'] ?? ""
+            );
 
             $use_cache = !$force
                 && $_SESSION['glpi_use_mode'] != Session::DEBUG_MODE


### PR DESCRIPTION
Dashboard cards are cached depending on the card's options and the current entity.

The cache key should also take into account the current profile as different rights will lead to different results that should thus use an unique cache key.

Exemple using one super admin account + a technician account on the same entity.
The super admin can see all tickets (~1000) while the technician can only see 28.

If the super admin load the dashboard first, it will display 1k tickets for both users:

![image](https://github.com/glpi-project/glpi/assets/42734840/72e97e06-7b04-47a7-b14a-5f1a36a326c0)

On the other hand, if the technician load the dashboard first, it will display 28 tickets for both users:

![image](https://github.com/glpi-project/glpi/assets/42734840/a4064761-9653-4d18-9a94-36a64b1a1307)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28420
