### PR TITLE
Use user-friendly permission labels in access-errors log

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -3000,8 +3000,9 @@ class CommonDBTM extends CommonGLPI
             if (!$this->can($ID, $right, $input)) {
                // Gestion timeout session
                 Session::redirectIfNotLoggedIn();
-                $right_name = Session::getRightNameForError($right);
+                /** @var class-string<CommonDBTM> $itemtype */
                 $itemtype = static::getType();
+                $right_name = Session::getRightNameForError($itemtype::$rightname, $right);
                 $info = "User failed a can* method check for right $right ($right_name) on item Type: $itemtype ID: $ID";
                 Html::displayRightError($info);
             }
@@ -3048,7 +3049,9 @@ class CommonDBTM extends CommonGLPI
         if (!$this->canGlobal($right)) {
            // Gestion timeout session
             Session::redirectIfNotLoggedIn();
-            $right_name = Session::getRightNameForError($right);
+            /** @var class-string<CommonDBTM> $itemtype */
+            $itemtype = static::getType();
+            $right_name = Session::getRightNameForError($itemtype::$rightname, $right);
             $itemtype = static::getType();
             $info = "User failed a global can* method check for right $right ($right_name) on item Type: $itemtype";
             Html::displayRightError($info);

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -788,9 +788,8 @@ class Profile extends CommonDBTM
      * @param string $interface The interface name
      * @phpstan-param 'central'|'helpdesk' $interface
      * @return array
-     * @phpstan-return array<string, array{
-     *     rights?: array{}, itemtype?: class-string<CommonDBTM>, label: string, field: string, group: string, scope: string
-     * }>
+     * @phpstan-type RightDefinition = array{rights: array{}, label: string, field: string, scope: string}
+     * @phpstan-return $interface == 'all' ? array<string, array<string, array<string, RightDefinition[]>>> : ($form == 'all' ? array<string, array<string, RightDefinition[]>> : ($group == 'all' ? array<string, RightDefinition[]> : RightDefinition[]))
      * @internal BC not guaranteed. Only public so it can be used in tests to ensure search options are made for all rights.
      */
     public static function getRightsForForm(string $interface = 'all', string $form = 'all', string $group = 'all'): array

--- a/src/Session.php
+++ b/src/Session.php
@@ -1004,13 +1004,15 @@ class Session
 
     /**
      * Get the name of the right.
+     * This should only be used when it is expected that the request going to be terminated.
+     * The session will be closed by this method.
      *
-     * This only works for well-known rights.
+     * @param string $module The module
      * @param int $right The right
      * @return string The right name
      * @internal No backwards compatibility promise. Use in core only.
      */
-    public static function getRightNameForError(int $right): string
+    public static function getRightNameForError(string $module, int $right): string
     {
         // Well known rights
         $rights = [
@@ -1024,10 +1026,32 @@ class Session
             UPDATENOTE => 'UPDATENOTE',
             UNLOCK => 'UNLOCK',
         ];
-        if (array_key_exists($right, $rights)) {
-            return $rights[$right];
+        // Close session and force the default language so the logged right name is standardized
+        session_write_close();
+        $_SESSION['glpilanguage'] = 'en_GB';
+
+        $all_specific_rights = Profile::getRightsForForm(self::getCurrentInterface());
+        $specific_rights = [];
+        foreach ($all_specific_rights as $forms) {
+            foreach ($forms as $group_rights) {
+                foreach ($group_rights as $right_definition) {
+                    if ($right_definition['field'] === $module) {
+                        $rights_arr = $right_definition['rights'];
+                        foreach ($rights_arr as $right_val => $right_label) {
+                            $label = $right_label;
+                            if (is_array($label) && isset($label['short'])) {
+                                $label = $label['short'];
+                            }
+                            if (!is_array($label)) {
+                                $specific_rights[$right_val] = $label;
+                            }
+                        }
+                    }
+                }
+            }
         }
-        return "unknown right name";
+
+        return $specific_rights[$right] ?? $rights[$right] ?? 'unknown right name';
     }
 
     /**
@@ -1044,7 +1068,7 @@ class Session
         if (!self::haveRight($module, $right)) {
            // Gestion timeout session
             self::redirectIfNotLoggedIn();
-            $right_name = self::getRightNameForError($right);
+            $right_name = self::getRightNameForError($module, $right);
             Html::displayRightError("User is missing the $right ($right_name) right for $module");
         }
     }
@@ -1064,7 +1088,7 @@ class Session
             self::redirectIfNotLoggedIn();
             $info = "User is missing all of the following rights: ";
             foreach ($rights as $right) {
-                $right_name = self::getRightNameForError($right);
+                $right_name = self::getRightNameForError($module, $right);
                 $info .= $right . "($right_name), ";
             }
             $info = substr($info, 0, -2);
@@ -1108,7 +1132,7 @@ class Session
             self::redirectIfNotLoggedIn();
             $info = "User is missing all of the following rights: ";
             foreach ($modules as $mod => $right) {
-                $right_name = self::getRightNameForError($right);
+                $right_name = self::getRightNameForError($mod, $right);
                 $info .= $right . "($right_name) for module $mod, ";
             }
             $info = substr($info, 0, -2);

--- a/src/Session.php
+++ b/src/Session.php
@@ -1029,7 +1029,7 @@ class Session
         // Close session and force the default language so the logged right name is standardized
         session_write_close();
         $current_lang = $_SESSION['glpilanguage'];
-        $_SESSION['glpilanguage'] = 'en_GB';
+        self::loadLanguage('en_GB');
 
         $all_specific_rights = Profile::getRightsForForm(self::getCurrentInterface());
         $specific_rights = [];
@@ -1053,7 +1053,7 @@ class Session
         }
 
         // Restore language so the error displayed is in the user language
-        $_SESSION['glpilanguage'] = $current_lang;
+        self::loadLanguage($current_lang);
 
         return $specific_rights[$right] ?? $rights[$right] ?? 'unknown right name';
     }

--- a/src/Session.php
+++ b/src/Session.php
@@ -1028,6 +1028,7 @@ class Session
         ];
         // Close session and force the default language so the logged right name is standardized
         session_write_close();
+        $current_lang = $_SESSION['glpilanguage'];
         $_SESSION['glpilanguage'] = 'en_GB';
 
         $all_specific_rights = Profile::getRightsForForm(self::getCurrentInterface());
@@ -1050,6 +1051,9 @@ class Session
                 }
             }
         }
+
+        // Restore language so the error displayed is in the user language
+        $_SESSION['glpilanguage'] = $current_lang;
 
         return $specific_rights[$right] ?? $rights[$right] ?? 'unknown right name';
     }

--- a/tests/functional/Session.php
+++ b/tests/functional/Session.php
@@ -450,4 +450,28 @@ class Session extends \DbTestCase
         ]);
         $this->boolean($result)->isTrue();
     }
+
+    protected function getRightNameForErrorProvider()
+    {
+        return [
+            ['_nonexistant', READ, 'READ'],
+            ['_nonexistant', ALLSTANDARDRIGHT, 'ALLSTANDARDRIGHT'],
+            ['_nonexistant', UPDATENOTE, 'UPDATENOTE'],
+            ['_nonexistant', UNLOCK, 'UNLOCK'],
+            ['ticket', READ, 'See my ticket'],
+            ['ticket', \Ticket::READALL, 'See all tickets'],
+            ['user', \User::IMPORTEXTAUTHUSERS, 'Add external']
+        ];
+    }
+
+    /**
+     * @dataProvider getRightNameForErrorProvider
+     */
+    public function testGetRightNameForError($module, $right, $expected)
+    {
+        $this->login();
+        // Set language to French to ensure we always get names back as en_GB regardless of the user's language
+        \Session::loadLanguage('fr_FR');
+        $this->string(\Session::getRightNameForError($module, $right))->isEqualTo($expected);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Now that rights are more organized in the Profile class, it is relatively easy to resolve a label from a module and right value.
Allows showing a right name for non-standard rights like "Add external" for Users.
Allows showing overridden rights like "See my ticket" instead of READ (same value).
Session is closed and the language is forced to "en_GB" to standardize new names in the log. This shouldn't be an issue though as the access errors are logged when a `check*` call fails which stops the request anyways. Before the method ends, the user's language is restored just to ensure the error displayed in the web UI is in the right language.