### PR TITLE
fix(IPNetwork): fix WHERE clause from ITERATOR query

### DIFF
--- a/src/IPNetwork.php
+++ b/src/IPNetwork.php
@@ -678,7 +678,7 @@ class IPNetwork extends CommonImplicitTreeDropdown
 
             if ($relation == "equals") {
                 for ($i = $startIndex; $i < 4; ++$i) {
-                    $WHERE = [
+                    $WHERE[] = [
                         new \QueryExpression("(" . $DB->quoteName($addressDB[$i]) . " & " . $DB->quoteValue($netmaskPa[$i]) . ") = (" . $DB->quoteValue($addressPa[$i]) . " & " . $DB->quoteValue($netmaskPa[$i]) . ")"),
                         $netmaskDB[$i]  => $netmaskPa[$i]
                     ];
@@ -691,7 +691,7 @@ class IPNetwork extends CommonImplicitTreeDropdown
                         $globalNetmask = $DB->quoteName($netmaskDB[$i]);
                     }
 
-                    $WHERE = [
+                    $WHERE[] = [
                         new \QueryExpression("(" . $DB->quoteName($addressDB[$i]) . " & $globalNetmask) = (" . $DB->quoteValue($addressPa[$i]) . " & $globalNetmask)"),
                         new \QueryExpression("(" . $DB->quoteValue($netmaskPa[$i]) . " & " . $DB->quoteName($netmaskDB[$i]) . ")=$globalNetmask")
                     ];


### PR DESCRIPTION
```$WHERE``` are computed with ```for``` statement

but actually ```$WHERE``` overwrites the previous value

This Pr fix this


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
