### PR TITLE
fix(purge): prevent SQL query with 'true' on WHERE clause

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -887,7 +887,7 @@ class CommonDBTM extends CommonGLPI
                 foreach ($fields as $field) {
                     if (is_array($field)) {
                         // Relation based on 'itemtype'/'items_id' (polymorphic relationship)
-                        if (($this instanceof IPAddress || $tablename == IPAddress::getTable()) && in_array('mainitemtype', $field) && in_array('mainitems_id', $field)) {
+                        if ($itemtype instanceof IPAddress && in_array('mainitemtype', $field) && in_array('mainitems_id', $field)) {
                             // glpi_ipaddresses relationship that does not respect naming conventions
                             $itemtype_field = 'mainitemtype';
                             $items_id_field = 'mainitems_id';

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -887,7 +887,7 @@ class CommonDBTM extends CommonGLPI
                 foreach ($fields as $field) {
                     if (is_array($field)) {
                         // Relation based on 'itemtype'/'items_id' (polymorphic relationship)
-                        if ($this instanceof IPAddress && in_array('mainitemtype', $field) && in_array('mainitems_id', $field)) {
+                        if (($this instanceof IPAddress || $tablename == IPAddress::getTable()) && in_array('mainitemtype', $field) && in_array('mainitems_id', $field)) {
                             // glpi_ipaddresses relationship that does not respect naming conventions
                             $itemtype_field = 'mainitemtype';
                             $items_id_field = 'mainitems_id';


### PR DESCRIPTION
When we try to purged a ```Computer```

GLPI try to clean all relation data ```CommonDBTM->cleanRelationData()```

When handle ```IPAddress``` this method redefine key because ```IPAddress``` relationship that does not respect naming conventions

```mainitemtype``` and ```mainitems_id``` are used instead of ```itemtype``` and ```items_id``` 

It's down when current purged object is ```IPAddress``` but not when the table concerned by purged is ```glpi_ipaddresses```

GLPI therefore generates this request

```sql
SELECT * FROM `glpi_ipaddresses` WHERE (COMPUTER_ID)
```

because of bad criteria

```php
Array
  (
      [FROM] => glpi_ipaddresses
      [WHERE] => Array
          (
              [0] => COMPUTER_ID
          )
  
  )
```

which returns all IPs

in the rest of the purge process, GLPI loops over all the IPs

This PR fix this 
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28576 and !28441
