### PR TITLE
fix(knowbase): save tree browser

### DIFF
--- a/ajax/knowbase.php
+++ b/ajax/knowbase.php
@@ -45,6 +45,8 @@ if (
     exit;
 }
 
+$_SESSION['kb_cat_id'] = $_REQUEST['cat_id'] ?? 0;
+
 switch ($_REQUEST['action']) {
     case "getItemslist":
         header("Content-Type: application/json; charset=UTF-8");

--- a/src/Knowbase.php
+++ b/src/Knowbase.php
@@ -152,6 +152,7 @@ class Knowbase extends CommonGLPI
         $ajax_url    = $CFG_GLPI["root_doc"] . "/ajax/knowbase.php";
         $loading_txt = __s('Loading...');
         $start       = (int)($_REQUEST['start'] ?? 0);
+        $cat_id      = (int)($_SESSION['kb_cat_id'] ?? 0);
 
         $category_list = json_encode(self::getTreeCategoryList());
         $no_cat_found  = __s("No category found");
@@ -201,7 +202,8 @@ class Knowbase extends CommonGLPI
                   'start': $start
                });
             };
-            loadNode(0);
+            loadNode($cat_id);
+            $.ui.fancytree.getTree("#tree_category$rand").activateKey($cat_id);
 
             $(document).on('keyup', '#browser_tree_search$rand', function() {
                var search_text = $(this).val();


### PR DESCRIPTION
The tree state was not saved and was reset each time the page was reloaded. So it always came back to the root category.

_Does not concern `main` branch_

![image](https://github.com/glpi-project/glpi/assets/8530352/a142f1e2-1e37-4f3d-9b7f-db386a88a084)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28580
