### PR TITLE
fix handling search data from plugin hooks

### DIFF
--- a/src/Search/Provider/SQLProvider.php
+++ b/src/Search/Provider/SQLProvider.php
@@ -114,7 +114,7 @@ final class SQLProvider implements SearchProviderInterface
                 // Plugin can override core definition for its type
                 if ($plug = isPluginItemType($itemtype)) {
                     $default_select = \Plugin::doOneHook($plug['plugin'], 'addDefaultSelect', $itemtype);
-                    if ($default_select !== "") {
+                    if (!empty($default_select)) {
                         $ret[] = new QueryExpression(rtrim($default_select, ' ,'));
                     }
                 }
@@ -979,7 +979,7 @@ final class SQLProvider implements SearchProviderInterface
                 // Plugin can override core definition for its type
                 if ($plug = isPluginItemType($itemtype)) {
                     $default_where = \Plugin::doOneHook($plug['plugin'], 'addDefaultWhere', $itemtype);
-                    if ($default_where !== '') {
+                    if (!empty($default_where)) {
                         $criteria = [new QueryExpression($default_where)];
                     }
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

For some search plugin hooks, only an empty string would prevent adding an empty QueryExpression to the criteria, but null needs to be handled too.