### PR TITLE
Fix API search join character

### DIFF
--- a/src/Api/HL/Search.php
+++ b/src/Api/HL/Search.php
@@ -111,9 +111,9 @@ final class Search
                     if (array_key_exists($join_name, $this->joins) && $this->joins[$join_name]['parent_type'] === 'array') {
                         $expression = QueryFunction::ifnull($sql_field, new QueryExpression('0x0'));
                         if ($distinct_groups) {
-                            $expression = QueryFunction::groupConcat($expression, new QueryExpression('0x1D'), true);
+                            $expression = QueryFunction::groupConcat($expression, new QueryExpression(chr(0x1D)), true);
                         } else {
-                            $expression = QueryFunction::groupConcat($expression, new QueryExpression('0x1D'), false);
+                            $expression = QueryFunction::groupConcat($expression, new QueryExpression(chr(0x1D)), false);
                         }
                     }
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

For joined data returned from the API, we need the unicode character `0x1D` to be used as the separator, not "0x1D" string.