### PR TITLE
Fix column remap for joined properties

### DIFF
--- a/src/Api/HL/Search.php
+++ b/src/Api/HL/Search.php
@@ -76,9 +76,16 @@ final class Search
     private function getSQLFieldForProperty(string $prop_name): string
     {
         $prop = $this->flattened_properties[$prop_name];
+        $is_join = str_contains($prop_name, '.');
         $sql_field = $prop['x-field'] ?? $prop_name;
-        if (!str_contains($sql_field, '.')) {
+        if (!$is_join) {
+            // Only add the _. prefix if it isn't a join
             $sql_field = "_.$sql_field";
+        } else if ($prop_name !== $sql_field) {
+            // If the property name is different from the SQL field name, we will need to add/change the table alias
+            // $prop_name is a join where the part before the dot is the join alias (also the property on the main item), and the part after the dot is the property on the joined item
+            $join_alias = explode('.', $prop_name)[0];
+            $sql_field = "{$join_alias}.{$sql_field}";
         }
         return $sql_field;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In the new API, when a property added within a join uses a property name different than the column name, the SQL column was not being properly calculated from the `x-field` property.
Not currently used by the core, but was used with the API integration of the VIP plugin:
https://github.com/pluginsGLPI/vip/pull/5