### PR TITLE
fix(knowbase): search article with multi categories

### DIFF
--- a/src/Features/TreeBrowse.php
+++ b/src/Features/TreeBrowse.php
@@ -193,26 +193,24 @@ JAVASCRIPT;
         // We can remove all the SELECT fields and replace it with just the ID field
         $raw_select = $data['sql']['raw']['SELECT'];
         $replacement_select = 'SELECT DISTINCT ' . $itemtype::getTableField('id');
-        $sql = preg_replace('/^' . preg_quote($raw_select, '/') . '/', $replacement_select, $sql, 1);
+        $sql_id = preg_replace('/^' . preg_quote($raw_select, '/') . '/', $replacement_select, $sql, 1);
         // Remove GROUP BY and ORDER BY clauses
-        $sql = str_replace([$data['sql']['raw']['GROUPBY'], $data['sql']['raw']['ORDER']], '', $sql);
+        $sql_id = str_replace([$data['sql']['raw']['GROUPBY'], $data['sql']['raw']['ORDER']], '', $sql_id);
 
-        $id_criteria = new QueryExpression($itemtype::getTableField('id') . ' IN ( SELECT * FROM (' . $sql . ') AS id_criteria )');
+        $id_criteria = new QueryExpression($itemtype::getTableField('id') . ' IN ( SELECT * FROM (' . $sql_id . ') AS id_criteria )');
 
         $cat_table = $cat_itemtype::getTable();
         $cat_fk    = $cat_itemtype::getForeignKeyField();
         $cat_join = $itemtype . '_' . $cat_itemtype;
 
         // This query is used to get the IDs of all results matching the search criteria
-        $sql = $data['sql']['search'];
         // We can remove all the SELECT fields and replace it with just the ID field
-        $raw_select = $data['sql']['raw']['SELECT'];
         $replacement_select = "SELECT DISTINCT " . $cat_join::getTableField($cat_fk);
-        $sql = preg_replace('/^' . preg_quote($raw_select, '/') . '/', $replacement_select, $sql, 1);
+        $sql_cat = preg_replace('/^' . preg_quote($raw_select, '/') . '/', $replacement_select, $sql, 1);
         // Remove GROUP BY and ORDER BY clauses
-        $sql = str_replace([$data['sql']['raw']['GROUPBY'], $data['sql']['raw']['ORDER']], '', $sql);
+        $sql_cat = str_replace([$data['sql']['raw']['GROUPBY'], $data['sql']['raw']['ORDER']], '', $sql_cat);
 
-        $cat_criteria = new QueryExpression($cat_join::getTableField($cat_fk) . ' IN ( SELECT * FROM (' . $sql . ') AS cat_criteria )');
+        $cat_criteria = new QueryExpression($cat_join::getTableField($cat_fk) . ' IN ( SELECT * FROM (' . $sql_cat . ') AS cat_criteria )');
 
         if (class_exists($cat_join)) {
             $join = [

--- a/src/Features/TreeBrowse.php
+++ b/src/Features/TreeBrowse.php
@@ -268,6 +268,7 @@ JAVASCRIPT;
 
         $inst = new $cat_itemtype();
         $categories = [];
+        $parents = [];
         foreach ($cat_iterator as $category) {
             if (DropdownTranslation::canBeTranslated($inst)) {
                 $tname = DropdownTranslation::getTranslatedValue(
@@ -278,7 +279,10 @@ JAVASCRIPT;
                     $category['name'] = $tname;
                 }
             }
-            $categories[] = $category;
+            if (($category['items_count'] > 0) || (in_array($category['id'], $parents))) {
+                $parents[] = $category[$cat_fk];
+                $categories[] = $category;
+            }
         }
 
         // Without category

--- a/src/Features/TreeBrowse.php
+++ b/src/Features/TreeBrowse.php
@@ -203,20 +203,20 @@ JAVASCRIPT;
         $cat_fk    = $cat_itemtype::getForeignKeyField();
         $cat_join = $itemtype . '_' . $cat_itemtype;
 
-        $cat_criteria = [1];
-        // If there is a category filter, apply this filter to the tree too
-        if (preg_match("/$cat_table/", $data['sql']['raw']['WHERE'])) {
-            // This query is used to get the IDs of all results matching the search criteria
-            // We can remove all the SELECT fields and replace it with just the ID field
-            $replacement_select = "SELECT DISTINCT " . $cat_join::getTableField($cat_fk);
-            $sql_cat = preg_replace('/^' . preg_quote($raw_select, '/') . '/', $replacement_select, $sql, 1);
-            // Remove GROUP BY and ORDER BY clauses
-            $sql_cat = str_replace([$data['sql']['raw']['GROUPBY'], $data['sql']['raw']['ORDER']], '', $sql_cat);
-
-            $cat_criteria = new QueryExpression($cat_join::getTableField($cat_fk) . ' IN ( SELECT * FROM (' . $sql_cat . ') AS cat_criteria )');
-        }
-
         if (class_exists($cat_join)) {
+            $cat_criteria = [1];
+            // If there is a category filter, apply this filter to the tree too
+            if (preg_match("/$cat_table/", $data['sql']['raw']['WHERE'])) {
+                // This query is used to get the IDs of all results matching the search criteria
+                // We can remove all the SELECT fields and replace it with just the ID field
+                $replacement_select = "SELECT DISTINCT " . $cat_join::getTableField($cat_fk);
+                $sql_cat = preg_replace('/^' . preg_quote($raw_select, '/') . '/', $replacement_select, $sql, 1);
+                // Remove GROUP BY and ORDER BY clauses
+                $sql_cat = str_replace([$data['sql']['raw']['GROUPBY'], $data['sql']['raw']['ORDER']], '', $sql_cat);
+
+                $cat_criteria = new QueryExpression($cat_join::getTableField($cat_fk) . ' IN ( SELECT * FROM (' . $sql_cat . ') AS cat_criteria )');
+            }
+
             $join = [
                 $cat_join::getTable() => [
                     'ON'  => [

--- a/src/Features/TreeBrowse.php
+++ b/src/Features/TreeBrowse.php
@@ -203,14 +203,18 @@ JAVASCRIPT;
         $cat_fk    = $cat_itemtype::getForeignKeyField();
         $cat_join = $itemtype . '_' . $cat_itemtype;
 
-        // This query is used to get the IDs of all results matching the search criteria
-        // We can remove all the SELECT fields and replace it with just the ID field
-        $replacement_select = "SELECT DISTINCT " . $cat_join::getTableField($cat_fk);
-        $sql_cat = preg_replace('/^' . preg_quote($raw_select, '/') . '/', $replacement_select, $sql, 1);
-        // Remove GROUP BY and ORDER BY clauses
-        $sql_cat = str_replace([$data['sql']['raw']['GROUPBY'], $data['sql']['raw']['ORDER']], '', $sql_cat);
+        $cat_criteria = [1];
+        // If there is a category filter, apply this filter to the tree too
+        if (preg_match("/$cat_table/", $data['sql']['raw']['WHERE'])) {
+            // This query is used to get the IDs of all results matching the search criteria
+            // We can remove all the SELECT fields and replace it with just the ID field
+            $replacement_select = "SELECT DISTINCT " . $cat_join::getTableField($cat_fk);
+            $sql_cat = preg_replace('/^' . preg_quote($raw_select, '/') . '/', $replacement_select, $sql, 1);
+            // Remove GROUP BY and ORDER BY clauses
+            $sql_cat = str_replace([$data['sql']['raw']['GROUPBY'], $data['sql']['raw']['ORDER']], '', $sql_cat);
 
-        $cat_criteria = new QueryExpression($cat_join::getTableField($cat_fk) . ' IN ( SELECT * FROM (' . $sql_cat . ') AS cat_criteria )');
+            $cat_criteria = new QueryExpression($cat_join::getTableField($cat_fk) . ' IN ( SELECT * FROM (' . $sql_cat . ') AS cat_criteria )');
+        }
 
         if (class_exists($cat_join)) {
             $join = [

--- a/tests/functional/TreeBrowse.php
+++ b/tests/functional/TreeBrowse.php
@@ -107,54 +107,6 @@ class Knowbase extends DbTestCase
         // Expected for normal user
         $expected = [
             [
-                'key' => 1,
-                'title' => 'cat 1',
-                'parent' => 0,
-                'a_attr' => ['data-id' => 1],
-                'children' => [
-                    [
-                        'key' => 2,
-                        'title' => 'cat 1.1',
-                        'parent' => 1,
-                        'a_attr' => ['data-id' => 2],
-                        'children' => [
-                            [
-                                'key' => 3,
-                                'title' => 'cat 1.1.1',
-                                'parent' => 2,
-                                'a_attr' => ['data-id' => 3],
-                            ],
-                            [
-                                'key' => 4,
-                                'title' => 'cat 1.1.2',
-                                'parent' => 2,
-                                'a_attr' => ['data-id' => 4],
-                            ]
-                        ]
-                    ],
-                    [
-                        'key' => 5,
-                        'title' => 'cat 1.2',
-                        'parent' => 1,
-                        'a_attr' => ['data-id' => 5],
-                        'children' => [
-                            [
-                                'key' => 6,
-                                'title' => 'cat 1.2.1',
-                                'parent' => 5,
-                                'a_attr' => ['data-id' => 6],
-                            ]
-                        ]
-                    ],
-                    [
-                        'key' => 7,
-                        'title' => 'cat 1.3',
-                        'parent' => 1,
-                        'a_attr' => ['data-id' => 7],
-                    ]
-                ]
-            ],
-            [
                 'key' => -1,
                 'title' => 'Without Category <span class="badge bg-azure-lt" title="This category contains Knowledge base">2</span>',
                 'parent' => 0,
@@ -194,7 +146,36 @@ class Knowbase extends DbTestCase
         $this->integer($kbitem_target_id)->isGreaterThan(0);
 
         $tree = $itemtype::getTreeCategoryList($itemtype, []);
-        $expected[0]['children'][0]['children'][1]['title'] = 'cat 1.1.2 <span class="badge bg-azure-lt" title="This category contains Knowledge base">1</span>';
+        $expected = [
+            [
+                'key' => 1,
+                'title' => 'cat 1',
+                'parent' => 0,
+                'a_attr' => ['data-id' => 1],
+                'children' => [
+                    [
+                        'key' => 2,
+                        'title' => 'cat 1.1',
+                        'parent' => 1,
+                        'a_attr' => ['data-id' => 2],
+                        'children' => [
+                            [
+                                'key' => 4,
+                                'title' => 'cat 1.1.2 <span class="badge bg-azure-lt" title="This category contains Knowledge base">1</span>',
+                                'parent' => 2,
+                                'a_attr' => ['data-id' => 4],
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            [
+                'key' => -1,
+                'title' => 'Without Category <span class="badge bg-azure-lt" title="This category contains Knowledge base">2</span>',
+                'parent' => 0,
+                'a_attr' => ['data-id' => -1],
+            ]
+        ];
         $this->array($tree)->isEqualTo($expected);
 
         // Add 2nd category
@@ -217,7 +198,42 @@ class Knowbase extends DbTestCase
         $this->integer($kbitem_target_id)->isGreaterThan(0);
 
         $tree = $itemtype::getTreeCategoryList($itemtype, []);
-        $expected[0]['children'][2]['title'] = 'cat 1.3 <span class="badge bg-azure-lt" title="This category contains Knowledge base">1</span>';
+        $expected = [
+            [
+                'key' => 1,
+                'title' => 'cat 1',
+                'parent' => 0,
+                'a_attr' => ['data-id' => 1],
+                'children' => [
+                    [
+                        'key' => 2,
+                        'title' => 'cat 1.1',
+                        'parent' => 1,
+                        'a_attr' => ['data-id' => 2],
+                        'children' => [
+                            [
+                                'key' => 4,
+                                'title' => 'cat 1.1.2 <span class="badge bg-azure-lt" title="This category contains Knowledge base">1</span>',
+                                'parent' => 2,
+                                'a_attr' => ['data-id' => 4],
+                            ]
+                        ]
+                    ],
+                    [
+                        'key' => 7,
+                        'title' => 'cat 1.3 <span class="badge bg-azure-lt" title="This category contains Knowledge base">1</span>',
+                        'parent' => 1,
+                        'a_attr' => ['data-id' => 7],
+                    ]
+                ]
+            ],
+            [
+                'key' => -1,
+                'title' => 'Without Category <span class="badge bg-azure-lt" title="This category contains Knowledge base">2</span>',
+                'parent' => 0,
+                'a_attr' => ['data-id' => -1],
+            ]
+        ];
         $this->array($tree)->isEqualTo($expected);
 
         // Add a FAQ item
@@ -264,12 +280,46 @@ class Knowbase extends DbTestCase
         $_SESSION = $session_bck;
         $CFG_GLPI['use_public_faq'] = $use_public_faq_bck;
 
-        $expected[0]['children'][0]['children'][1]['title'] = 'cat 1.1.2';
-        $expected[0]['children'][2]['title'] = 'cat 1.3';
-        $expected[1]['title'] = 'Without Category';
+        $expected = [
+            [
+                'key' => -1,
+                'title' => 'Without Category',
+                'parent' => 0,
+                'a_attr' => ['data-id' => -1],
+            ]
+        ];
         $this->array($tree_with_no_public_faq)->isEqualTo($expected);
 
-        $expected[0]['children'][1]['children'][0]['title'] = 'cat 1.2.1 <span class="badge bg-azure-lt" title="This category contains Knowledge base">1</span>';
+        $expected = [
+            [
+                'key' => 1,
+                'title' => 'cat 1',
+                'parent' => 0,
+                'a_attr' => ['data-id' => 1],
+                'children' => [
+                    [
+                        'key' => 5,
+                        'title' => 'cat 1.2',
+                        'parent' => 1,
+                        'a_attr' => ['data-id' => 5],
+                        'children' => [
+                            [
+                                'key' => 6,
+                                'title' => 'cat 1.2.1 <span class="badge bg-azure-lt" title="This category contains Knowledge base">1</span>',
+                                'parent' => 5,
+                                'a_attr' => ['data-id' => 6],
+                            ]
+                        ]
+                    ],
+                ]
+            ],
+            [
+                'key' => -1,
+                'title' => 'Without Category',
+                'parent' => 0,
+                'a_attr' => ['data-id' => -1],
+            ]
+        ];
         $this->array($tree_with_public_faq)->isEqualTo($expected);
     }
 }


### PR DESCRIPTION
When an article belongs to several categories and you filter on the category in the search, in the tree you have the counter on the categories excluded by the filter, but no result when you open the category.

Before:
![image](https://github.com/glpi-project/glpi/assets/8530352/6c44b364-b6bd-471d-bd8e-6364c460f76c)

After:
![image](https://github.com/glpi-project/glpi/assets/8530352/3dcab5f9-b053-4b8b-b0b1-939e192d8310)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
