### PR TITLE
Handle failure during error log operation

### DIFF
--- a/src/Application/ErrorHandler.php
+++ b/src/Application/ErrorHandler.php
@@ -473,10 +473,19 @@ class ErrorHandler
             return;
         }
 
-        $this->logger->log(
-            $log_level,
-            '  *** ' . $type . ': ' . $description . (!empty($trace) ? "\n" . $trace : '')
-        );
+        try {
+            $this->logger->log(
+                $log_level,
+                '  *** ' . $type . ': ' . $description . (!empty($trace) ? "\n" . $trace : '')
+            );
+        } catch (\Throwable $e) {
+            $this->outputDebugMessage(
+                'Error',
+                'An error has occurred, but the trace of this error could not recorded because of a problem accessing the log file.',
+                LogLevel::CRITICAL,
+                true
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When error handler tries to record an error trace, if the log file is not writable, it throw an exception that is not catched. Result is often the display of an empty 500 error page, without anything that could indicate that there is problem with log files permissions.

Also, depending on the `error_reporting` level, even a simple deprecation "error", that should not be blocking, could result in such a 500 error.

I propose to catch log operations error and, in such case, display an error message in the interface.

Here is an example of what would be shown by an error generated by the following patch:
```diff
diff --git a/front/central.php b/front/central.php
index 04ca4e4536..4b8fe6447d 100644
--- a/front/central.php
+++ b/front/central.php
@@ -81,6 +81,8 @@ Session::checkCentralAccess();
 
 Html::header(Central::getTypeName(1), $_SERVER['PHP_SELF'], 'central', 'central');
 
+trigger_error('...', E_USER_WARNING);
+
 // Redirect management
 if (isset($_GET["redirect"])) {
     Toolbox::manageRedirect($_GET["redirect"]);
```
![image](https://github.com/glpi-project/glpi/assets/33253653/f8f2ed03-71ac-4d5c-b8ff-945072d0d246)
