### PR TITLE
Fix SCSS compilation failure on PHP 7.4

### DIFF
--- a/front/css.php
+++ b/front/css.php
@@ -47,10 +47,11 @@ $skip_db_check               = true;
 include_once GLPI_ROOT . "/inc/db.function.php";
 include_once GLPI_ROOT . '/inc/config.php';
 
-if (Toolbox::getMemoryLimit() < (128 * 1024 * 1024)) {
-    // Main CSS compilation requires about 90MB of memory.
-    // Increase it a bit to ensure it will not reach memory limit.
-    ini_set('memory_limit', '128M');
+// Main CSS compilation requires about 140MB of memory on PHP 7.4 (110MB on PHP 8.2).
+// Ensure to have enough memory to not reach memory limit.
+$max_memory = 192;
+if (Toolbox::getMemoryLimit() < ($max_memory * 1024 * 1024)) {
+    ini_set('memory_limit', sprintf('%dM', $max_memory));
 }
 
 // Ensure warnings will not break CSS output.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

On PHP 7.4, SCSS compilation was failing when no cache was present due to lack of memory.
It seems that memory required to compile SCSS file increased since we added this workaround in #10487.