### PR TITLE
Reduced execution time for showCentralCount requests

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -5143,12 +5143,7 @@ JAVASCRIPT;
                 'glpi_tickets_users' => [
                     'ON' => [
                         'glpi_tickets_users' => 'tickets_id',
-                        $table               => 'id', [
-                            'OR' => [
-                                ['glpi_tickets_users.type' => CommonITILActor::REQUESTER],
-                                ['glpi_tickets_users.type' => CommonITILActor::OBSERVER]
-                            ]
-                        ]
+                        $table               => 'id'
                     ]
                 ],
                 'glpi_ticketvalidations' => [
@@ -5174,9 +5169,15 @@ JAVASCRIPT;
                 ];
             }
 
-            $ORWHERE = [
+            $WHERE = [
                 'OR' => [
-                    'glpi_tickets_users.users_id'                => Session::getLoginUserID(),
+                    'AND' => [
+                        'glpi_tickets_users.users_id' => Session::getLoginUserID(),
+                        'OR' => [
+                            ['glpi_tickets_users.type' => CommonITILActor::REQUESTER],
+                            ['glpi_tickets_users.type' => CommonITILActor::OBSERVER]
+                        ],
+                    ],
                     'glpi_tickets.users_id_recipient'            => Session::getLoginUserID(),
                     'glpi_ticketvalidations.users_id_validate'   => Session::getLoginUserID()
                 ]
@@ -5187,9 +5188,9 @@ JAVASCRIPT;
                 && isset($_SESSION["glpigroups"])
                 && count($_SESSION["glpigroups"])
             ) {
-                $ORWHERE['OR']['glpi_groups_tickets.groups_id'] = $_SESSION['glpigroups'];
+                $WHERE['OR']['glpi_groups_tickets.groups_id'] = $_SESSION['glpigroups'];
             }
-            $criteria['WHERE'][] = $ORWHERE;
+            $criteria['WHERE'][] = $WHERE;
         }
 
         return $criteria;


### PR DESCRIPTION
<!-- 

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28453

Optimization of query execution time (`showCentralCount` and `showCentralCountCriteria` methods) which displays the ticket counter by status.
Performance loss after merge of PR #14972.

### Execution time (same conditions)
**Before - 124ms :**
![Screenshot](https://github.com/glpi-project/glpi/assets/42278610/dcc84cf9-0be5-4c38-9dd5-094ebe646c5b)

**After - 17ms :**
![Screenshot](https://github.com/glpi-project/glpi/assets/42278610/13e5dd7c-dfc7-4dbe-9c2c-5c3934b66db6)
