### PR TITLE
Debug bar formating + Use datagrid instead of html tables

### DIFF
--- a/css/includes/components/_debug-toolbar.scss
+++ b/css/includes/components/_debug-toolbar.scss
@@ -36,10 +36,12 @@
 .datagrid {
     --tblr-datagrid-padding   : 1.5rem;
     --tblr-datagrid-item-width: 15rem;
+
     display                   : grid;
     grid-gap                  : var(--tblr-datagrid-padding);
     grid-template-columns     : repeat(auto-fit, minmax(var(--tblr-datagrid-item-width), 1fr));
 }
+
 .datagrid-title {
     font-size     : .625rem;
     font-weight   : 600;

--- a/css/includes/components/_debug-toolbar.scss
+++ b/css/includes/components/_debug-toolbar.scss
@@ -31,6 +31,25 @@
  * ---------------------------------------------------------------------
  */
 
+// Our tabler version does not support datagrid
+// TODO: remove after updating tabler
+.datagrid {
+    --tblr-datagrid-padding   : 1.5rem;
+    --tblr-datagrid-item-width: 15rem;
+    display                   : grid;
+    grid-gap                  : var(--tblr-datagrid-padding);
+    grid-template-columns     : repeat(auto-fit, minmax(var(--tblr-datagrid-item-width), 1fr));
+}
+.datagrid-title {
+    font-size     : .625rem;
+    font-weight   : 600;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+    line-height   : 1rem;
+    color         : var(--tblr-muted);
+    margin-bottom : .25rem;
+}
+
 #debug-toolbar {
     z-index: 9999;
     outline: none;

--- a/js/modules/Debug/Debug.js
+++ b/js/modules/Debug/Debug.js
@@ -729,15 +729,22 @@ window.GLPI.Debug = new class Debug {
             const total_heap = perf.memory.totalJSHeapSize / 1024 / 1024;
 
             // Non-standard feature supported by Chrome
-            content_area.find('tbody').append(`
-                <tr><th colspan="4">Memory</th></tr>
-                <tr>
-                    <th>Used JS Heap</th><td>${used_heap.toFixed(2)}mio</td>
-                    <th>Total JS Heap</th><td>${total_heap.toFixed(2)}mio</td>
-                </tr>
-                <tr>
-                    <th>JS Heap Limit</th><td>${heap_limit.toFixed(2)}mio</td>
-                </tr>
+            content_area.find('.datagrid:last').append(`
+                <<h3 class="mt-3 mb-2">Memory</h3>
+                <div class="datagrid">
+                    <div class="datagrid-item">
+                        <div class="datagrid-title">Used JS Heap</div>
+                        <div class="datagrid-content">${+used_heap.toFixed(2)}</div>
+                    </div>
+                    <div class="datagrid-item">
+                        <div class="datagrid-title">Total JS Heap</div>
+                        <div class="datagrid-content">${+total_heap.toFixed(2)} MiB</div>
+                    </div>
+                    <div class="datagrid-item">
+                        <div class="datagrid-title">JS Heap Limit</div>
+                        <div class="datagrid-content">${+heap_limit.toFixed(2)} MiB</div>
+                    </div>
+                </div>
             `);
         }
     }

--- a/js/modules/Debug/Debug.js
+++ b/js/modules/Debug/Debug.js
@@ -386,8 +386,8 @@ window.GLPI.Debug = new class Debug {
     refreshWidgetButtons() {
         // Server performance
         const server_perf = this.initial_request.server_performance;
-        const memory_usage_mb = +(server_perf.memory_usage / 1000 / 1000).toFixed(2);
-        const server_performance_button_label = `${server_perf.execution_time} <span class="text-muted"> ms using </span> ${memory_usage_mio} <span class="text-muted"> MB </span>`;
+        const memory_usage = +(server_perf.memory_usage / 1024 / 1024).toFixed(2);
+        const server_performance_button_label = `${server_perf.execution_time} <span class="text-muted"> ms using </span> ${memory_usage} <span class="text-muted"> MiB </span>`;
         this.getWidgetButton('server_performance').find('.debug-text').html(server_performance_button_label);
 
         // Database performance
@@ -461,9 +461,9 @@ window.GLPI.Debug = new class Debug {
         }
 
         const server_perf = this.initial_request.server_performance;
-        const memory_usage_mio = (server_perf.memory_usage / 1024 / 1024).toFixed(2);
-        const memory_peak_mio = (server_perf.memory_peak / 1024 / 1024).toFixed(2);
-        const memory_limit_mio = (server_perf.memory_limit / 1024 / 1024).toFixed(2);
+        const memory_usage = (server_perf.memory_usage / 1024 / 1024).toFixed(2);
+        const memory_peak = (server_perf.memory_peak / 1024 / 1024).toFixed(2);
+        const memory_limit = (server_perf.memory_limit / 1024 / 1024).toFixed(2);
         let total_execution_time = this.initial_request.server_performance.execution_time;
         this.ajax_requests.forEach((request) => {
             if (request.profile) {
@@ -483,11 +483,11 @@ window.GLPI.Debug = new class Debug {
             </div>
             <div class="datagrid-item">
                 <div class="datagrid-title">Memory Usage</div>
-                <div class="datagrid-content h-100 col-8">${+memory_usage_mio} MB / ${+memory_limit_mio} MB</div>
+                <div class="datagrid-content h-100 col-8">${+memory_usage} MiB / ${+memory_limit} MiB</div>
             </div>
             <div class="datagrid-item">
                 <div class="datagrid-title">Memory Peak</div>
-                <div class="datagrid-content">${+memory_peak_mio} MB / ${+memory_limit_mio} MB</div>
+                <div class="datagrid-content">${+memory_peak} MiB / ${+memory_limit} MiB</div>
             </div>
         `);
     }
@@ -541,7 +541,7 @@ window.GLPI.Debug = new class Debug {
                         ${filtered_request_id === undefined ? `<td><button class="btn btn-link request-link">${request_id}</button></td>` : ''}
                         <td>${query['num']}</td>
                         <td style="max-width: 50vw; white-space: break-spaces;"><code class="d-block cm-s-default border-0">${query['query']}</code></td>
-                        <td data-value-unit="ms">${query['time']}ms</td>
+                        <td data-value-unit="ms">${query['time']} ms</td>
                         <td>${query['rows']}</td>
                         <td>${escapeMarkupText(query['warnings'])}</td>
                         <td>${escapeMarkupText(query['errors'])}</td>
@@ -715,7 +715,7 @@ window.GLPI.Debug = new class Debug {
                     </div>
                     <div class="datagrid-item">
                         <div class="datagrid-title">Total resources size</div>
-                        <div class="datagrid-content">${+total_resources_size.toFixed(2)} MB</div>
+                        <div class="datagrid-content">${+total_resources_size.toFixed(2)} MiB</div>
                     </div>
                     <!-- Keep empty item at the end to align with previous grid -->
                     <div class="datagrid-item"></div>
@@ -814,7 +814,7 @@ window.GLPI.Debug = new class Debug {
                         </span>
                     </td>
                     <td>${escapeMarkupText(section.name)}</td><td>${section.start}</td><td>${section.end}</td>
-                    <td data-column="duration" data-duration-raw="${duration}">${duration.toFixed(0)}ms</td>
+                    <td data-column="duration" data-duration-raw="${duration}">${duration.toFixed(0)} ms</td>
                     <td>${percent_of_parent}%</td>
                 </tr>
             `;
@@ -838,7 +838,7 @@ window.GLPI.Debug = new class Debug {
         content_area.append(`
             <div>
                <label>
-                 Hide near-instant sections (&lt;=1ms):
+                 Hide near-instant sections (&lt;= 1 ms):
                  <input type="checkbox" name="hide_instant_sections">
                </label>
             </div>
@@ -860,7 +860,7 @@ window.GLPI.Debug = new class Debug {
             table_rows.removeClass('d-none');
 
             if (hide) {
-                // hide all rows in the table that have the duration column set less than 1ms
+                // hide all rows in the table that have the duration column set less than 1 ms
                 table_rows.each((index, row) => {
                     const duration_cell = $(row).find('> td[data-column="duration"]');
                     if (duration_cell.length > 0) {
@@ -965,7 +965,7 @@ window.GLPI.Debug = new class Debug {
                     <td style="max-width: 200px; white-space: pre-wrap;" title="${window.location.pathname}" data-truncated="${is_truncated ? 'true' : 'false'}">${truncated_pathname}</td>
                     <td>-</td>
                     <td>${this.initial_request.globals.server['REQUEST_METHOD'] || '-'}</td>
-                    <td>${this.initial_request.server_performance.execution_time}ms</td>
+                    <td>${this.initial_request.server_performance.execution_time} ms</td>
                 </tr>
             `);
             if (is_truncated) {
@@ -1038,7 +1038,7 @@ window.GLPI.Debug = new class Debug {
                         <td style="max-width: 200px; white-space: pre-wrap;" title="${request.url}" data-truncated="${is_truncated ? 'true' : 'false'}">${truncated_url}</td>
                         <td>${request.status}</td>
                         <td>${request.type}</td>
-                        <td data-value-unit="ms">${request.time}ms</td>
+                        <td data-value-unit="ms">${request.time} ms</td>
                     </tr>
                 `);
                 if (is_truncated) {
@@ -1066,7 +1066,7 @@ window.GLPI.Debug = new class Debug {
                 }
             } else {
                 row.find('> td:nth-child(3)').text(request.status);
-                row.find('> td:nth-child(5)').text(`${request.time}ms`);
+                row.find('> td:nth-child(5)').text(`${request.time} ms`);
             }
         });
     }
@@ -1095,9 +1095,9 @@ window.GLPI.Debug = new class Debug {
             return;
         }
         const server_perf = profile.server_performance;
-        const memory_usage_mio = (server_perf.memory_usage / 1024 / 1024).toFixed(2);
-        const memory_peak_mio = (server_perf.memory_peak / 1024 / 1024).toFixed(2);
-        const memory_limit_mio = (server_perf.memory_limit / 1024 / 1024).toFixed(2);
+        const memory_usage = (server_perf.memory_usage / 1024 / 1024).toFixed(2);
+        const memory_peak = (server_perf.memory_peak / 1024 / 1024).toFixed(2);
+        const memory_limit = (server_perf.memory_limit / 1024 / 1024).toFixed(2);
         let total_execution_time = profile.server_performance.execution_time;
 
         let total_sql_duration = 0;
@@ -1112,19 +1112,19 @@ window.GLPI.Debug = new class Debug {
                 <tbody>
                     <tr>
                         <td>
-                            Initial Execution Time: ${total_execution_time}ms
+                            Initial Execution Time: ${total_execution_time} ms
                         </td>
                         <td>
-                            Memory Usage: ${memory_usage_mio}mio / ${memory_limit_mio}mio
+                            Memory Usage: ${memory_usage} MiB / ${memory_limit} MiB
                             <br>
-                            Memory Peak: ${memory_peak_mio}mio / ${memory_limit_mio}mio
+                            Memory Peak: ${memory_peak} MiB / ${memory_limit} MiB
                         </td>
                     </tr>
                     <tr>
                         <td>
                             SQL Requests: ${total_sql_queries}
                             <br>
-                            SQL Duration: ${total_sql_duration}ms
+                            SQL Duration: ${total_sql_duration} ms
                         </td>
                     </tr>
                 </tbody>
@@ -1317,7 +1317,7 @@ window.GLPI.Debug = new class Debug {
             const canvas_width = canvas_el.width();
             const canvas_height = canvas_el.height();
 
-            // round end_ts to nearest 100ms
+            // round end_ts to nearest 100 ms
             const end_ts_rounded = Math.ceil(end_ts / 100) * 100;
             const division_count = Math.min(Math.ceil(canvas_width / DIVIDER_WIDTH), Math.ceil(end_ts_rounded / division_length));
             const dividers = [];
@@ -1339,7 +1339,7 @@ window.GLPI.Debug = new class Debug {
                 ctx.moveTo(divider.canvas_x, 0);
                 ctx.lineTo(divider.canvas_x, canvas_height);
                 ctx.stroke();
-                ctx.fillText(`${divider.time}ms`, divider.canvas_x + 2, 10);
+                ctx.fillText(`${divider.time} ms`, divider.canvas_x + 2, 10);
             });
 
             // draw sections
@@ -1384,7 +1384,7 @@ window.GLPI.Debug = new class Debug {
                 if (section_name.length > 100) {
                     section_name = section_name.slice(0, 100) + '...';
                 }
-                const text = `${section_name} ${hover_data.target.timing} (${duration.toFixed(0)}ms)`;
+                const text = `${section_name} ${hover_data.target.timing} (${duration.toFixed(0)} ms)`;
                 ctx.font = ctx.font.replace(/\d+px/, '14px');
                 const text_width = ctx.measureText(text).width;
 

--- a/js/modules/Debug/Debug.js
+++ b/js/modules/Debug/Debug.js
@@ -563,10 +563,10 @@ window.GLPI.Debug = new class Debug {
                 }
             });
             content_area.find('h2').first()
-                .text(`${total_requests} Queries took ${total_duration}`);
+                .text(`${total_requests} Queries took ${total_duration} ms`);
         } else {
             content_area.find('h2').first()
-                .text(`${sql_data.total_requests} Queries took ${sql_data.total_duration}`);
+                .text(`${sql_data.total_requests} Queries took ${sql_data.total_duration} ms`);
         }
 
         if (sql_table.data('sort')) {

--- a/js/modules/Debug/Debug.js
+++ b/js/modules/Debug/Debug.js
@@ -730,7 +730,7 @@ window.GLPI.Debug = new class Debug {
 
             // Non-standard feature supported by Chrome
             content_area.find('.datagrid:last').append(`
-                <<h3 class="mt-3 mb-2">Memory</h3>
+                <h3 class="mt-3 mb-2">Memory</h3>
                 <div class="datagrid">
                     <div class="datagrid-item">
                         <div class="datagrid-title">Used JS Heap</div>

--- a/js/modules/Debug/Debug.js
+++ b/js/modules/Debug/Debug.js
@@ -386,7 +386,7 @@ window.GLPI.Debug = new class Debug {
     refreshWidgetButtons() {
         // Server performance
         const server_perf = this.initial_request.server_performance;
-        const memory_usage_mio = (server_perf.memory_usage / 1024 / 1024).toFixed(2);
+        const memory_usage_mio = +(server_perf.memory_usage / 1024 / 1024).toFixed(2);
         const server_performance_button_label = `${server_perf.execution_time} <span class="text-muted"> ms using </span> ${memory_usage_mio} <span class="text-muted"> MB </span>`;
         this.getWidgetButton('server_performance').find('.debug-text').html(server_performance_button_label);
 
@@ -399,7 +399,7 @@ window.GLPI.Debug = new class Debug {
         this.getWidgetButton('requests').find('.debug-text').html(`${this.ajax_requests.length} <span class="text-muted"> requests </span>`);
 
         // Client performances
-        const dom_timing = window.performance.getEntriesByType('navigation')[0].domComplete;
+        const dom_timing = +window.performance.getEntriesByType('navigation')[0].domComplete.toFixed(2);
         const client_performance_button_label = `${dom_timing} <span class="text-muted"> ms </span>`;
         this.getWidgetButton('client_performance').find('.debug-text').html(client_performance_button_label);
     }
@@ -453,10 +453,10 @@ window.GLPI.Debug = new class Debug {
             content_area.empty();
 
             content_area.append(`
-                <h1>Server performance</h1>
-                <table class="table">
-                    <tbody></tbody>
-                </table>
+                <div class="py-2 px-3 col-xxl-7 col-xl-9 col-12">
+                    <h2 class="mb-3">Server performance</h2>
+                    <div class="datagrid"></div>
+                </div>
             `);
         }
 
@@ -472,19 +472,23 @@ window.GLPI.Debug = new class Debug {
         });
         total_execution_time = total_execution_time.toFixed(2);
 
-        content_area.find('table tbody').empty().append(`
-            <tr>
-                <td>
-                    Initial Execution Time: ${this.initial_request.server_performance.execution_time}ms
-                    <br>
-                    Total Execution Time: ${total_execution_time}ms
-                </td>
-                <td>
-                    Memory Usage: ${memory_usage_mio}mio / ${memory_limit_mio}mio
-                    <br>
-                    Memory Peak: ${memory_peak_mio}mio / ${memory_limit_mio}mio
-                </td>
-            </tr>
+        content_area.find('.datagrid').empty().append(`
+            <div class="datagrid-item">
+                <div class="datagrid-title">Initial Execution Time</div>
+                <div class="datagrid-content">${+this.initial_request.server_performance.execution_time} ms</div>
+            </div>
+            <div class="datagrid-item">
+                <div class="datagrid-title">Total Execution Time</div>
+                <div class="datagrid-content">${+total_execution_time} ms</div>
+            </div>
+            <div class="datagrid-item">
+                <div class="datagrid-title">Memory Usage</div>
+                <div class="datagrid-content h-100 col-8">${+memory_usage_mio} MB / ${+memory_limit_mio} MB</div>
+            </div>
+            <div class="datagrid-item">
+                <div class="datagrid-title">Memory Peak</div>
+                <div class="datagrid-content">${+memory_peak_mio} MB / ${+memory_limit_mio} MB</div>
+            </div>
         `);
     }
 
@@ -497,8 +501,8 @@ window.GLPI.Debug = new class Debug {
         if (!refresh) {
             content_area.empty();
             content_area.append(`
-                <div class="overflow-auto">
-                   <h1></h1>
+                <div class="overflow-auto py-2 px-3">
+                   <h2 class="mb-3"></h2>
                    <table id="debug-sql-request-table" class="table card-table">
                       <thead>
                       <tr>
@@ -558,10 +562,10 @@ window.GLPI.Debug = new class Debug {
                     });
                 }
             });
-            content_area.find('h1').first()
+            content_area.find('h2').first()
                 .text(`${total_requests} Queries took ${total_duration}`);
         } else {
-            content_area.find('h1').first()
+            content_area.find('h2').first()
                 .text(`${sql_data.total_requests} Queries took ${sql_data.total_duration}`);
         }
 
@@ -686,23 +690,37 @@ window.GLPI.Debug = new class Debug {
         total_resources_size = total_resources_size / 1024 / 1024;
 
         content_area.append(`
-            <table class="table">
-                <tbody>
-                    <tr><th colspan="4">Timings</th></tr>
-                    <tr>
-                        <th>${paint_timing_label}</th><td>${time_to_first_paint.toFixed(2)}ms</td>
-                        <th>Time to DOM interactive</th><td>${time_to_dom_interactive.toFixed(2)}ms</td>
-                    </tr>
-                    <tr>
-                        <th>Time to DOM complete</th><td>${time_to_dom_complete.toFixed(2)}ms</td>
-                    </tr>
-                    <tr><th colspan="4">Resource Loading</th></tr>
-                    <tr>
-                        <th>Total resources</th><td>${total_resources}</td>
-                        <th>Total resources size</th><td>${total_resources_size.toFixed(2)}mio</td>
-                    </tr>
-                </tbody>
-            </table>
+            <div class="py-2 px-3 col-xxl-7 col-xl-9 col-12">
+                <h2 class="mb-3">Client performance</h2>
+                <h3 class="mb-2">Timings</h3>
+                <div class="datagrid">
+                    <div class="datagrid-item">
+                        <div class="datagrid-title">${paint_timing_label}</div>
+                        <div class="datagrid-content">${+time_to_first_paint.toFixed(2)} ms</div>
+                    </div>
+                    <div class="datagrid-item">
+                        <div class="datagrid-title">Time to DOM interactive</div>
+                        <div class="datagrid-content">${+time_to_dom_interactive.toFixed(2)} ms</div>
+                    </div>
+                    <div class="datagrid-item">
+                        <div class="datagrid-title">Time to DOM complete</div>
+                        <div class="datagrid-content">${+time_to_dom_complete.toFixed(2)} ms</div>
+                    </div>
+                </div>
+                <h3 class="mt-3 mb-2">Resource Loading</h3>
+                <div class="datagrid">
+                    <div class="datagrid-item">
+                        <div class="datagrid-title">Total resources</div>
+                        <div class="datagrid-content">${total_resources}</div>
+                    </div>
+                    <div class="datagrid-item">
+                        <div class="datagrid-title">Total resources size</div>
+                        <div class="datagrid-content">${+total_resources_size.toFixed(2)} MB</div>
+                    </div>
+                    <!-- Keep empty item at the end to align with previous grid -->
+                    <div class="datagrid-item"></div>
+                </div>
+            </div>
         `);
 
         if (perf.memory != undefined) {

--- a/js/modules/Debug/Debug.js
+++ b/js/modules/Debug/Debug.js
@@ -386,7 +386,7 @@ window.GLPI.Debug = new class Debug {
     refreshWidgetButtons() {
         // Server performance
         const server_perf = this.initial_request.server_performance;
-        const memory_usage_mio = +(server_perf.memory_usage / 1024 / 1024).toFixed(2);
+        const memory_usage_mb = +(server_perf.memory_usage / 1000 / 1000).toFixed(2);
         const server_performance_button_label = `${server_perf.execution_time} <span class="text-muted"> ms using </span> ${memory_usage_mio} <span class="text-muted"> MB </span>`;
         this.getWidgetButton('server_performance').find('.debug-text').html(server_performance_button_label);
 


### PR DESCRIPTION
Somes changes suggested by @cedric-anne regarding formatting :
* Round X.00 values
* Always use spaces before units
* mio -> MB

I've also replaced the HTML tables by [tabler's datagrids](https://tabler.io/docs/components/datagrid) + added some margins/padding + reduced titles to h2.

Server perf before:

![image](https://github.com/glpi-project/glpi/assets/42734840/57edb824-c17d-415f-9bc4-8199e11912e8)

Server perf after:

![image](https://github.com/glpi-project/glpi/assets/42734840/3a9a5aa8-a56a-4d68-99a1-ddc235b1ce8c)

Client perf before:

![image](https://github.com/glpi-project/glpi/assets/42734840/8473aebe-531e-4c82-a45a-f99b1e341d1c)

Client perf after:

![image](https://github.com/glpi-project/glpi/assets/42734840/054cf966-a741-4f0e-9c1c-125a4d2de811)


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
