### PR TITLE
fix agent form save

### DIFF
--- a/templates/pages/admin/inventory/agent.html.twig
+++ b/templates/pages/admin/inventory/agent.html.twig
@@ -81,7 +81,7 @@
             __('Item link'),
             field_options
         ) }}
-        <input type="hidden" name="items_id" value="{{ items.fields['items_id'] }}">
+        <input type="hidden" name="items_id" value="{{ item.fields['items_id'] }}">
 
         {% set versions %}
             {% set versions_array = call("importArrayFromDB", [versions_field]) %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15036

items_id wasn't being added to the form because of a typo and a blank string was present instead, so updates were failing as it tried to replace the items_id with a string in an int column.