### PR TITLE
fix(export): preserve line breaks and > from completename

### DIFF
--- a/src/RichText/RichText.php
+++ b/src/RichText/RichText.php
@@ -96,6 +96,7 @@ final class RichText
      * @param boolean $keep_presentation      Indicates whether the presentation elements have to be replaced by plaintext equivalents
      * @param boolean $compact                Indicates whether the output should be compact (limited line length, no links URL, ...)
      * @param boolean $encode_output_entities Indicates whether the output should be encoded (encoding of HTML special chars)
+     * @param boolean $preserve_line_breaks    Indicates whether the line breaks elements have to be replaced by space
      *
      * @return string
      */
@@ -104,7 +105,8 @@ final class RichText
         bool $keep_presentation = true,
         bool $compact = false,
         bool $encode_output_entities = false,
-        bool $preserve_case = false
+        bool $preserve_case = false,
+        bool $preserve_line_breaks = false
     ): string {
         global $CFG_GLPI;
 
@@ -144,10 +146,11 @@ final class RichText
             $config['keep_bad'] = 6; // remove invalid/disallowed tag but keep content intact
             $content = htmLawed($content, $config);
 
-           // Remove supernumeraries whitespaces chars
-            $content = preg_replace('/\s+/', ' ', trim($content));
-
-           // Content is no more considered as HTML, decode its entities
+            if (!$preserve_line_breaks) {
+                // Remove supernumeraries whitespaces chars
+                $content = preg_replace('/\s+/', ' ', trim($content));
+            }
+            // Content is no more considered as HTML, decode its entities
             $content = Html::entity_decode_deep($content);
         }
 

--- a/src/RichText/RichText.php
+++ b/src/RichText/RichText.php
@@ -96,7 +96,7 @@ final class RichText
      * @param boolean $keep_presentation      Indicates whether the presentation elements have to be replaced by plaintext equivalents
      * @param boolean $compact                Indicates whether the output should be compact (limited line length, no links URL, ...)
      * @param boolean $encode_output_entities Indicates whether the output should be encoded (encoding of HTML special chars)
-     * @param boolean $preserve_line_breaks    Indicates whether the line breaks elements have to be replaced by space
+     * @param boolean $preserve_whitespaces   Indicates whether the whitespaces (line breaks, multiple spaces, ...) should be preserved
      *
      * @return string
      */
@@ -106,7 +106,7 @@ final class RichText
         bool $compact = false,
         bool $encode_output_entities = false,
         bool $preserve_case = false,
-        bool $preserve_line_breaks = false
+        bool $preserve_whitespaces = false
     ): string {
         global $CFG_GLPI;
 
@@ -146,10 +146,11 @@ final class RichText
             $config['keep_bad'] = 6; // remove invalid/disallowed tag but keep content intact
             $content = htmLawed($content, $config);
 
-            if (!$preserve_line_breaks) {
+            if (!$preserve_whitespaces) {
                 // Remove supernumeraries whitespaces chars
                 $content = preg_replace('/\s+/', ' ', trim($content));
             }
+
             // Content is no more considered as HTML, decode its entities
             $content = Html::entity_decode_deep($content);
         }

--- a/src/RichText/RichText.php
+++ b/src/RichText/RichText.php
@@ -96,7 +96,7 @@ final class RichText
      * @param boolean $keep_presentation      Indicates whether the presentation elements have to be replaced by plaintext equivalents
      * @param boolean $compact                Indicates whether the output should be compact (limited line length, no links URL, ...)
      * @param boolean $encode_output_entities Indicates whether the output should be encoded (encoding of HTML special chars)
-     * @param boolean $preserve_whitespaces   Indicates whether the whitespaces (line breaks, multiple spaces, ...) should be preserved
+     * @param boolean $preserve_line_breaks   Indicates whether the line breaks should be preserved
      *
      * @return string
      */
@@ -106,7 +106,7 @@ final class RichText
         bool $compact = false,
         bool $encode_output_entities = false,
         bool $preserve_case = false,
-        bool $preserve_whitespaces = false
+        bool $preserve_line_breaks = false
     ): string {
         global $CFG_GLPI;
 
@@ -146,9 +146,17 @@ final class RichText
             $config['keep_bad'] = 6; // remove invalid/disallowed tag but keep content intact
             $content = htmLawed($content, $config);
 
-            if (!$preserve_whitespaces) {
-                // Remove supernumeraries whitespaces chars
+            if (!$preserve_line_breaks) {
+                // Remove multiple whitespace sequences
                 $content = preg_replace('/\s+/', ' ', trim($content));
+            } else {
+                // Remove supernumeraries whitespaces chars but preserve line breaks
+                $content = trim($content);
+                $content = preg_replace('/[ \t]+/', ' ', $content); // compact horizontal spaces
+                $content = preg_replace('/[\r\v\f]/', "\n", $content); // normalize vertical spaces
+                $content = preg_replace('/\n +/', "\n", $content); // remove spaces at start of each line
+
+                $content = preg_replace('/\n{3,}/', "\n\n", $content); // compact line breaks to keep only relevant ones
             }
 
             // Content is no more considered as HTML, decode its entities

--- a/src/Search.php
+++ b/src/Search.php
@@ -6793,14 +6793,24 @@ JAVASCRIPT;
                             }
                         }
                         return $out;
-                    } else if (($so["datatype"] ?? "") != "itemlink" && !empty($data[$ID][0]['name'])) {
+                    } elseif (($so["datatype"] ?? "") != "itemlink" && !empty($data[$ID][0]['name'])) {
                         $completename = $data[$ID][0]['name'];
-                        if (!$_SESSION['glpiuse_flat_dropdowntree_on_search_result']) {
-                            $split_name = explode(">", $completename);
-                            $entity_name = trim(end($split_name));
-                            return Entity::badgeCompletename($entity_name, CommonTreeDropdown::sanitizeSeparatorInCompletename($completename));
+                        if ($html_output) {
+                            if (!$_SESSION['glpiuse_flat_dropdowntree_on_search_result']) {
+                                $split_name = explode(">", $completename);
+                                $entity_name = trim(end($split_name));
+                                return Entity::badgeCompletename($entity_name, CommonTreeDropdown::sanitizeSeparatorInCompletename($completename));
+                            }
+                            return Entity::badgeCompletename($completename);
+                        } else { //export
+                            if (!$_SESSION['glpiuse_flat_dropdowntree_on_search_result']) {
+                                $split_name = explode(">", $completename);
+                                $entity_name = trim(end($split_name));
+                                return $entity_name;
+                            }
+                            return Entity::sanitizeSeparatorInCompletename($completename);
                         }
-                        return Entity::badgeCompletename($completename);
+
                     }
                     break;
                 case $table . ".completename":
@@ -7471,7 +7481,7 @@ JAVASCRIPT;
 
                             $plaintext = '';
                             if (isset($so['htmltext']) && $so['htmltext']) {
-                                $plaintext = RichText::getTextFromHtml($data[$ID][$k]['name'], false, true, $html_output);
+                                $plaintext = RichText::getTextFromHtml($data[$ID][$k]['name'], false, true, $html_output, false, true);
                             } else {
                                 $plaintext = nl2br($data[$ID][$k]['name']);
                             }

--- a/src/Search.php
+++ b/src/Search.php
@@ -6810,7 +6810,6 @@ JAVASCRIPT;
                             }
                             return Entity::sanitizeSeparatorInCompletename($completename);
                         }
-
                     }
                     break;
                 case $table . ".completename":

--- a/tests/units/Glpi/RichText/RichText.php
+++ b/tests/units/Glpi/RichText/RichText.php
@@ -364,7 +364,7 @@ HTML,
             'compact'                => false,
             'encode_output_entities' => false,
             'preserve_case'          => false,
-            'preserve_whitespaces'   => false,
+            'preserve_line_breaks'   => false,
             'expected_result'        => 'Some HTML text',
         ];
 
@@ -375,7 +375,7 @@ HTML,
             'compact'                => false,
             'encode_output_entities' => true,
             'preserve_case'          => false,
-            'preserve_whitespaces'   => false,
+            'preserve_line_breaks'   => false,
             'expected_result'        => 'Some HTML content with special chars like &gt; &amp; &lt;.',
         ];
 
@@ -397,7 +397,7 @@ PLAINTEXT;
             'compact'                => false,
             'encode_output_entities' => false,
             'preserve_case'          => false,
-            'preserve_whitespaces'   => false,
+            'preserve_line_breaks'   => false,
             'expected_result'        => $result,
         ];
         yield [
@@ -406,7 +406,7 @@ PLAINTEXT;
             'compact'                => false,
             'encode_output_entities' => false,
             'preserve_case'          => false,
-            'preserve_whitespaces'   => false,
+            'preserve_line_breaks'   => false,
             'expected_result'        => $result,
         ];
 
@@ -429,7 +429,7 @@ HTML;
             'compact'                => false,
             'encode_output_entities' => false,
             'preserve_case'          => false,
-            'preserve_whitespaces'   => false,
+            'preserve_line_breaks'   => false,
             'expected_result'        => 'A title Text in a paragraph el 1 el 2 Should I yell for the important words?',
         ];
         yield [
@@ -438,17 +438,15 @@ HTML;
             'compact'                => false,
             'encode_output_entities' => false,
             'preserve_case'          => false,
-            'preserve_whitespaces'   => true,
+            'preserve_line_breaks'   => true,
             'expected_result'        => <<<PLAINTEXT
 A title
 Text in a paragraph
 
-  el 1
-  el 2
+el 1
+el 2
 
-
-  
-  Should I yell for the important words?
+Should I yell for the important words?
 PLAINTEXT,
         ];
 
@@ -460,7 +458,7 @@ PLAINTEXT,
             'compact'                => false,
             'encode_output_entities' => false,
             'preserve_case'          => false,
-            'preserve_whitespaces'   => false,
+            'preserve_line_breaks'   => false,
             'expected_result'        => <<<PLAINTEXT
 A TITLE
 
@@ -481,7 +479,7 @@ PLAINTEXT,
             'compact'                => true,
             'encode_output_entities' => false,
             'preserve_case'          => false,
-            'preserve_whitespaces'   => false,
+            'preserve_line_breaks'   => false,
             'expected_result'        => <<<PLAINTEXT
 A TITLE
 
@@ -502,7 +500,7 @@ PLAINTEXT,
             'compact'                => true,
             'encode_output_entities' => false,
             'preserve_case'          => true,
-            'preserve_whitespaces'   => false,
+            'preserve_line_breaks'   => false,
             'expected_result'        => <<<PLAINTEXT
 A title
 
@@ -525,12 +523,12 @@ PLAINTEXT,
         bool $compact,
         bool $encode_output_entities,
         bool $preserve_case,
-        bool $preserve_whitespaces,
+        bool $preserve_line_breaks,
         string $expected_result
     ) {
         $richtext = $this->newTestedInstance();
 
-        $this->string($richtext->getTextFromHtml($content, $keep_presentation, $compact, $encode_output_entities, $preserve_case, $preserve_whitespaces))
+        $this->string($richtext->getTextFromHtml($content, $keep_presentation, $compact, $encode_output_entities, $preserve_case, $preserve_line_breaks))
             ->isEqualTo($expected_result);
     }
 

--- a/tests/units/Glpi/RichText/RichText.php
+++ b/tests/units/Glpi/RichText/RichText.php
@@ -364,6 +364,7 @@ HTML,
             'compact'                => false,
             'encode_output_entities' => false,
             'preserve_case'          => false,
+            'preserve_whitespaces'   => false,
             'expected_result'        => 'Some HTML text',
         ];
 
@@ -374,6 +375,7 @@ HTML,
             'compact'                => false,
             'encode_output_entities' => true,
             'preserve_case'          => false,
+            'preserve_whitespaces'   => false,
             'expected_result'        => 'Some HTML content with special chars like &gt; &amp; &lt;.',
         ];
 
@@ -395,6 +397,7 @@ PLAINTEXT;
             'compact'                => false,
             'encode_output_entities' => false,
             'preserve_case'          => false,
+            'preserve_whitespaces'   => false,
             'expected_result'        => $result,
         ];
         yield [
@@ -403,6 +406,7 @@ PLAINTEXT;
             'compact'                => false,
             'encode_output_entities' => false,
             'preserve_case'          => false,
+            'preserve_whitespaces'   => false,
             'expected_result'        => $result,
         ];
 
@@ -425,7 +429,27 @@ HTML;
             'compact'                => false,
             'encode_output_entities' => false,
             'preserve_case'          => false,
+            'preserve_whitespaces'   => false,
             'expected_result'        => 'A title Text in a paragraph el 1 el 2 Should I yell for the important words?',
+        ];
+        yield [
+            'content'                => $content,
+            'keep_presentation'      => false,
+            'compact'                => false,
+            'encode_output_entities' => false,
+            'preserve_case'          => false,
+            'preserve_whitespaces'   => true,
+            'expected_result'        => <<<PLAINTEXT
+A title
+Text in a paragraph
+
+  el 1
+  el 2
+
+
+  
+  Should I yell for the important words?
+PLAINTEXT,
         ];
 
         // Text with presentation from complex HTML
@@ -436,6 +460,7 @@ HTML;
             'compact'                => false,
             'encode_output_entities' => false,
             'preserve_case'          => false,
+            'preserve_whitespaces'   => false,
             'expected_result'        => <<<PLAINTEXT
 A TITLE
 
@@ -456,6 +481,7 @@ PLAINTEXT,
             'compact'                => true,
             'encode_output_entities' => false,
             'preserve_case'          => false,
+            'preserve_whitespaces'   => false,
             'expected_result'        => <<<PLAINTEXT
 A TITLE
 
@@ -476,6 +502,7 @@ PLAINTEXT,
             'compact'                => true,
             'encode_output_entities' => false,
             'preserve_case'          => true,
+            'preserve_whitespaces'   => false,
             'expected_result'        => <<<PLAINTEXT
 A title
 
@@ -498,11 +525,12 @@ PLAINTEXT,
         bool $compact,
         bool $encode_output_entities,
         bool $preserve_case,
+        bool $preserve_whitespaces,
         string $expected_result
     ) {
         $richtext = $this->newTestedInstance();
 
-        $this->string($richtext->getTextFromHtml($content, $keep_presentation, $compact, $encode_output_entities, $preserve_case))
+        $this->string($richtext->getTextFromHtml($content, $keep_presentation, $compact, $encode_output_entities, $preserve_case, $preserve_whitespaces))
             ->isEqualTo($expected_result);
     }
 


### PR DESCRIPTION
preserve  ```>```  (only needed for Entity ```completename``` (becasue of HTML use) other ```dropdown``` are not affected)

![image](https://github.com/glpi-project/glpi/assets/7335054/d87675c1-e18f-49d5-8273-58aabbdf9d68)

preserve line breaks (like GLPI 9.5 export)

![image](https://github.com/glpi-project/glpi/assets/7335054/eead2466-fa32-470e-b437-a8e8ef51d85e)

See result : 

![image](https://github.com/glpi-project/glpi/assets/7335054/04a04255-0272-4bc1-909c-0e372ffdad2d)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28620
