### PR TITLE
Fix printer log tests

### DIFF
--- a/src/PrinterLog.php
+++ b/src/PrinterLog.php
@@ -138,7 +138,8 @@ class PrinterLog extends CommonDBChild
             'FROM'   => $this->getTable(),
             'WHERE'  => [
                 'printers_id'  => $printer->fields['id']
-            ] + $filters
+            ] + $filters,
+            'ORDER'  => 'date ASC',
         ]);
 
         $series = iterator_to_array($iterator, false);

--- a/tests/functional/PrinterLog.php
+++ b/tests/functional/PrinterLog.php
@@ -54,8 +54,7 @@ class PrinterLog extends DbTestCase
 
         $log = new \PrinterLog();
 
-        $cdate1 = clone $now;
-        $cdate1->sub(new \DateInterval('P14M'));
+        $cdate1 = new \DateTime('-14 months');
         $input = [
             'printers_id' => $printers_id,
             'total_pages' => 5132,
@@ -67,8 +66,7 @@ class PrinterLog extends DbTestCase
         ];
         $this->integer($log->add($input))->isGreaterThan(0);
 
-        $cdate2 = clone $now;
-        $cdate2->sub(new \DateInterval('P6M'));
+        $cdate2 = new \DateTime('-6 months');
         $input = [
             'printers_id' => $printers_id,
             'total_pages' => 6521,
@@ -77,6 +75,18 @@ class PrinterLog extends DbTestCase
             'rv_pages' => 5987,
             'scanned' => 15542,
             'date' => $cdate2->format('Y-m-d')
+        ];
+        $this->integer($log->add($input))->isGreaterThan(0);
+
+        $cdate3 = new \DateTime('first day of previous month');
+        $input = [
+            'printers_id' => $printers_id,
+            'total_pages' => 3464,
+            'bw_pages' => 2154,
+            'color_pages' => 1310,
+            'rv_pages' => 548,
+            'scanned' => 4657,
+            'date' => $cdate3->format('Y-m-d')
         ];
         $this->integer($log->add($input))->isGreaterThan(0);
 
@@ -91,19 +101,20 @@ class PrinterLog extends DbTestCase
         ];
         $this->integer($log->add($input))->isGreaterThan(0);
 
-       //per default, get 1Y old, first not included
-        $this->array($log->getMetrics($printer))->hasSize(2);
+        //per default, get 1Y old, first not included
+        $this->array($log->getMetrics($printer))->hasSize(3);
 
-       //same with start_date parameter
-        $this->array($log->getMetrics($printer, start_date: $cdate1))->hasSize(3);
-       //same with interval parameter
-        $this->array($log->getMetrics($printer, interval: 'P14M'))->hasSize(3);
+        //same with start_date parameter
+        $this->array($log->getMetrics($printer, start_date: $cdate1))->hasSize(4);
+        //same with interval parameter
+        $this->array($log->getMetrics($printer, interval: 'P14M'))->hasSize(4);
 
-       //use end_date parameter to exclude last report
-        $this->array($log->getMetrics($printer, start_date: $cdate1, end_date: $now->sub(new \DateInterval('P1D'))))->hasSize(2);
+        //use end_date parameter to exclude last report
+        $this->array($log->getMetrics($printer, start_date: $cdate1, end_date: $now->sub(new \DateInterval('P1D'))))->hasSize(3);
 
-        for ($i = 0; $i < 20; $i++) {
-            $now->sub(new \DateInterval('P1D'));
+        $datex = new \DateTime();
+        for ($i = 0; $i < 21; $i++) {
+            $datex->sub(new \DateInterval('P1D'));
             $input = [
                 'printers_id' => $printers_id,
                 'total_pages' => 9299,
@@ -111,21 +122,21 @@ class PrinterLog extends DbTestCase
                 'color_pages' => 3041,
                 'rv_pages' => 7654,
                 'scanned' => 28177,
-                'date' => $now->format('Y-m-d')
+                'date' => $datex->format('Y-m-d')
             ];
             $this->integer($log->add($input))->isGreaterThan(0);
         }
 
-       // check working of daily format
-        $this->array($log->getMetrics($printer, interval: 'P2M', format: 'daily'))->hasSize(21);
+        // check working of daily format
+        $this->array($log->getMetrics($printer, interval: 'P2M', format: 'daily'))->hasSize(23);
 
-       // check working of weekly format
-        $this->array($log->getMetrics($printer, interval: 'P1M', format: 'weekly'))->hasSize(4);
+        // check working of weekly format
+        $this->array($log->getMetrics($printer, interval: 'P28D', format: 'weekly'))->hasSize(4);
 
-       // check working of monthly format
-        $this->array($log->getMetrics($printer, format: 'monthly', interval: 'P2Y'))->hasSize(3);
+        // check working of monthly format
+        $this->array($log->getMetrics($printer, format: 'monthly', interval: 'P2Y'))->hasSize(4);
 
-       // check working of yearly format
+        // check working of yearly format
         $this->array($log->getMetrics($printer, format: 'yearly', interval: 'P2Y'))->hasSize(2);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Filtering logic expect logs to be ordered by date, but default order in database is based on `id` and it can lead to unexpected results whn logs are not created in the expected order (this is the case in the test suite). I added the `ORDER => date ASC` to fix this.

2. The loop that adds logs in the past 21 days can create logs on 1 or 2 months, depending on the current date. This affects the "logs by month" results. To prevent issues with that, I added a log entry for the previous month to ensuire we always have the same count of months in log entries.
