### PR TITLE
prevent sub documents to break timeline layout

### DIFF
--- a/css/includes/components/itilobject/_timeline.scss
+++ b/css/includes/components/itilobject/_timeline.scss
@@ -530,7 +530,9 @@
                 }
 
                 .sub-documents {
-                    width: 100%;
+                    flex-wrap: wrap;
+                    max-width: 820px;
+                    min-width: 100%;
 
                     .list-group-item {
                         width: max-content;

--- a/css/includes/components/itilobject/_timeline.scss
+++ b/css/includes/components/itilobject/_timeline.scss
@@ -336,6 +336,15 @@
             display: inline-block;
         }
     }
+
+    .sub-documents {
+        max-width: 820px;
+        min-width: 100%;
+
+        .pswp-horizontal-gallery {
+            flex-wrap: wrap;
+        }
+    }
 }
 
 #new-itilobject-form {
@@ -530,9 +539,7 @@
                 }
 
                 .sub-documents {
-                    flex-wrap: wrap;
-                    max-width: 820px;
-                    min-width: 100%;
+                    width: 100%;
 
                     .list-group-item {
                         width: max-content;

--- a/templates/components/itilobject/timeline/sub_documents.html.twig
+++ b/templates/components/itilobject/timeline/sub_documents.html.twig
@@ -32,7 +32,7 @@
  #}
 
 {% set documents = entry['documents'] ?? [] %}
-<ul class="list-group list-group-hoverable sub-documents">
+<div class="list-group list-group-hoverable sub-documents">
    {% set media_docs = documents|filter(d => d['_is_image'] or d['item']['mime'] starts with 'video') %}
    {% set other_docs = documents|filter(d => not (d['_is_image'] or d['item']['mime'] starts with 'video')) %}
 
@@ -107,11 +107,11 @@
    {% endif %}
 
    {% for document in other_docs %}
-      <li class="list-group-item border-0">
+      <div class="list-group-item border-0">
          {{ include('components/itilobject/timeline/form_document_item.html.twig', {
             'form_mode': 'view',
             'entry_i': document['item'],
          }) }}
-      </li>
+      </div>
    {% endfor %}
-</ul>
+</div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Issue visible in !26398#ITILFollowup_123123, when a lot of screenshots are attached to a followup in the timeline, no wrap is present and so width continues to grow. It increase also the length of parent followup and text may start to be unreadable (very long lines)
