### PR TITLE
fix(inventory): prevent 'Missing Entity ID' warning

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1746,6 +1746,11 @@ class CommonDBTM extends CommonGLPI
                 if ($lock == 'states_id' && $config['states_id_default']) {
                     continue;
                 }
+                //bypass for entities_id // default inventory conf is 0 'root entity')
+                if ($lock == 'entities_id') {
+                    continue;
+                }
+
                 if (array_key_exists($lock, $this->input)) {
                     $lockedfield->setLastValue($this->getType(), 0, $lock, $this->input[$lock]);
                     unset($this->input[$lock]);

--- a/tests/functional/Glpi/Inventory/Assets/Computer.php
+++ b/tests/functional/Glpi/Inventory/Assets/Computer.php
@@ -1581,7 +1581,6 @@ class Computer extends AbstractInventoryAsset
 
     public function testEntityGlobalLockedField()
     {
-      $this->login();
         $computer = new \Computer();
         $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
         <REQUEST>

--- a/tests/functional/Glpi/Inventory/Assets/Computer.php
+++ b/tests/functional/Glpi/Inventory/Assets/Computer.php
@@ -1578,4 +1578,40 @@ class Computer extends AbstractInventoryAsset
         $this->boolean($domain_item->getFromDBByCrit(['domains_id' => $domain->fields['id']]))->isTrue();
         $this->boolean($domain_item->getFromDBByCrit(['domains_id' => $ndyn_domain->fields['id']]))->isTrue();
     }
+
+    public function testEntityGlobalLockedField()
+    {
+      $this->login();
+        $computer = new \Computer();
+        $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+        <REQUEST>
+        <CONTENT>
+          <HARDWARE>
+            <NAME>glpixps</NAME>
+            <UUID>5BCB-25C1BB60B18F-5404A6A534C4</UUID>
+          </HARDWARE>
+          <BIOS>
+            <MSN>640HP72</MSN>
+          </BIOS>
+          <VERSIONCLIENT>FusionInventory-Inventory_v2.4.1-2.fc28</VERSIONCLIENT>
+        </CONTENT>
+        <DEVICEID>glpixps.teclib.infra-2018-10-03-08-42-36</DEVICEID>
+        <QUERY>INVENTORY</QUERY>
+        </REQUEST>";
+
+        $lockedfield = new \Lockedfield();
+        $this->integer($lockedfield->add(['itemtype' => 'Computer', 'items_id' => 0, 'field' => 'entities_id', 'is_global' => 1 ]))->isGreaterThan(0);
+
+        $inventory = $this->doInventory($xml_source, true);
+        $computers_id = $inventory->getItem()->fields['id'];
+        $this->integer($computers_id)->isGreaterThan(0);
+        //load computer
+        $this->boolean($computer->getFromDB($computers_id))->isTrue();
+        //test entities_id
+        $this->integer($computer->fields['entities_id'])->isEqualTo(0);
+
+        $lockedfield = new \Lockedfield();
+        $locks = $lockedfield->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
+        $this->integer(count($locks))->isIdenticalTo(0);
+    }
 }


### PR DESCRIPTION
When inventory handle an asset for the first time (creation)

when GLPI ```cleanLockedsOnAdd```

if a global lock on ```entities_id``` exist for this ```itemtype```, this ```key``` ```entities_id``` is unset from ```$this->input``` 



and trigger a PHP warning during unicity check

```shell
[2023-07-03 11:46:15] glpiphplog.WARNING:   *** PHP User Warning (512): Missing entity ID! in /home/DEV/GLPI/10.0-bugfixes/src/CommonDBTM.php at line 4485
  Backtrace :
  src/CommonDBTM.php:4485                            trigger_error()
  src/CommonDBTM.php:1322                            CommonDBTM->checkUnicity()
  src/Inventory/Asset/MainAsset.php:697              CommonDBTM->add()
  src/RuleImportAsset.php:988                        Glpi\Inventory\Asset\MainAsset->rulepassed()
  src/Rule.php:1525                                  RuleImportAsset->executeActions()
  src/RuleCollection.php:1640                        Rule->process()
  src/Inventory/Asset/MainAsset.php:573              RuleCollection->processAllRules()
  src/Inventory/Inventory.php:709                    Glpi\Inventory\Asset\MainAsset->handle()
  src/Inventory/Inventory.php:340                    Glpi\Inventory\Inventory->handleItem()
  src/Inventory/Request.php:360                      Glpi\Inventory\Inventory->doInventory()
  src/Inventory/Request.php:90                       Glpi\Inventory\Request->inventory()
  src/Agent/Communication/AbstractRequest.php:332    Glpi\Inventory\Request->handleAction()
  src/Agent/Communication/AbstractRequest.php:269    Glpi\Agent\Communication\AbstractRequest->handleXMLRequest()
  src/Inventory/Conf.php:242                         Glpi\Agent\Communication\AbstractRequest->handleRequest()
  src/Inventory/Conf.php:187                         Glpi\Inventory\Conf->importContentFile()
  src/Inventory/Conf.php:287                         Glpi\Inventory\Conf->importFiles()
  front/inventory.conf.php:47                        Glpi\Inventory\Conf->displayImportFiles()

```

This PR fix this.

Add bypass like ```states_id```  (no need to check default conf for ```entities_id``` default value is root entity ```0```)

```php
    protected function cleanLockedsOnAdd()
    {
        if (isset($this->input['is_dynamic']) && $this->input['is_dynamic'] == true) {
            $lockedfield = new Lockedfield();
            $config = Config::getConfigurationValues('inventory');
            $locks = $lockedfield->getLockedNames($this->getType(), 0);
            foreach ($locks as $lock) {
                //bypass for states_id if default value is define from inventory conf
                if ($lock == 'states_id' && $config['states_id_default']) {
                    continue;
                }
                //bypass for entities_id // default inventory conf is 0 'root entity')
                if ($lock == 'entities_id') {
                    continue;
                }

                if (array_key_exists($lock, $this->input)) {
                    $lockedfield->setLastValue($this->getType(), 0, $lock, $this->input[$lock]);
                    unset($this->input[$lock]);
                }
            }
        }
    }
```

Unit test added, just comment lines about ```entities_id``` bypass to see php warning

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28606
