### PR TITLE
Fix dropdown results when searching for `>`, `<` or `&` chars

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -2714,13 +2714,16 @@ JAVASCRIPT;
                 $where["$table.id"] = $one_item;
             } else {
                 if (!empty($post['searchText'])) {
-                    $search = Search::makeTextSearchValue($post['searchText']);
+                    $raw_search     = Search::makeTextSearchValue($post['searchText']);
+                    $encoded_search = Sanitizer::encodeHtmlSpecialChars($raw_search);
 
                     $swhere = [
-                        "$table.completename" => ['LIKE', $search],
+                        ["$table.completename" => ['LIKE', $raw_search]],
+                        ["$table.completename" => ['LIKE', $encoded_search]],
                     ];
                     if (Session::haveTranslations($post['itemtype'], 'completename')) {
-                        $swhere["namet.value"] = ['LIKE', $search];
+                        $swhere[] = ["namet.value" => ['LIKE', $raw_search]];
+                        $swhere[] = ["namet.value" => ['LIKE', $encoded_search]];
                     }
 
                     if (
@@ -2733,7 +2736,8 @@ JAVASCRIPT;
                    // search also in displaywith columns
                     if ($displaywith && count($post['displaywith'])) {
                         foreach ($post['displaywith'] as $with) {
-                            $swhere["$table.$with"] = ['LIKE', $search];
+                            $swhere[] = ["$table.$with" => ['LIKE', $raw_search]];
+                            $swhere[] = ["$table.$with" => ['LIKE', $encoded_search]];
                         }
                     }
 
@@ -3105,8 +3109,13 @@ JAVASCRIPT;
             }
 
             if (!empty($post['searchText'])) {
-                $search = Search::makeTextSearchValue($post['searchText']);
-                $orwhere = ["$table.$field" => ['LIKE', $search]];
+                $raw_search     = Search::makeTextSearchValue($post['searchText']);
+                $encoded_search = Sanitizer::encodeHtmlSpecialChars($raw_search);
+
+                $orwhere = [
+                    ["$table.$field" => ['LIKE', $raw_search]],
+                    ["$table.$field" => ['LIKE', $encoded_search]],
+                ];
 
                 if (
                     $_SESSION['glpiis_ids_visible']
@@ -3116,20 +3125,24 @@ JAVASCRIPT;
                 }
 
                 if ($item instanceof CommonDCModelDropdown) {
-                    $orwhere[$table . '.product_number'] = ['LIKE', $search];
+                    $orwhere[] = [$table . '.product_number' => ['LIKE', $raw_search]];
+                    $orwhere[] = [$table . '.product_number' => ['LIKE', $encoded_search]];
                 }
 
                 if (Session::haveTranslations($post['itemtype'], $field)) {
-                    $orwhere['namet.value'] = ['LIKE', $search];
+                    $orwhere[] = ['namet.value' => ['LIKE', $raw_search]];
+                    $orwhere[] = ['namet.value' => ['LIKE', $encoded_search]];
                 }
                 if ($post['itemtype'] == "SoftwareLicense") {
-                    $orwhere['glpi_softwares.name'] = ['LIKE', $search];
+                    $orwhere[] = ['glpi_softwares.name' => ['LIKE', $raw_search]];
+                    $orwhere[] = ['glpi_softwares.name' => ['LIKE', $encoded_search]];
                 }
 
                // search also in displaywith columns
                 if ($displaywith && count($post['displaywith'])) {
                     foreach ($post['displaywith'] as $with) {
-                        $orwhere["$table.$with"] = ['LIKE', $search];
+                        $orwhere[] = ["$table.$with" => ['LIKE', $raw_search]];
+                        $orwhere[] = ["$table.$with" => ['LIKE', $encoded_search]];
                     }
                 }
 
@@ -3455,11 +3468,15 @@ JAVASCRIPT;
         }
 
         if (isset($post['searchText']) && (strlen($post['searchText']) > 0)) {
-            $search = Search::makeTextSearchValue($post['searchText']);
+            $raw_search     = Search::makeTextSearchValue($post['searchText']);
+            $encoded_search = Sanitizer::encodeHtmlSpecialChars($raw_search);
             $where['OR'] = [
-                "$table.name"        => ['LIKE', $search],
-                "$table.otherserial" => ['LIKE', $search],
-                "$table.serial"      => ['LIKE', $search]
+                ["$table.name"        => ['LIKE', $raw_search]],
+                ["$table.name"        => ['LIKE', $encoded_search]],
+                ["$table.otherserial" => ['LIKE', $raw_search]],
+                ["$table.otherserial" => ['LIKE', $encoded_search]],
+                ["$table.serial"      => ['LIKE', $raw_search]],
+                ["$table.serial"      => ['LIKE', $encoded_search]],
             ];
         }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -110,7 +110,7 @@ function loadDataset()
    // Unit test data definition
     $data = [
       // bump this version to force reload of the full dataset, when content change
-        '_version' => '4.10',
+        '_version' => '4.11',
 
       // Type => array of entries
         'Entity' => [
@@ -303,7 +303,15 @@ function loadDataset()
                 'completename' => '_cat_1 > _subcat_1',
                 'comment'      => 'Comment for sub-category _subcat_1',
                 'level'        => 2,
-            ]
+            ],
+            [
+                'is_recursive' => 1,
+                'taskcategories_id' => '_cat_1',
+                'name'         => 'R&#38;D', // sanitized value for "R&D"
+                'completename' => '_cat_1 > R&#38;D',
+                'comment'      => 'Comment for sub-category _subcat_2',
+                'level'        => 2,
+            ],
         ], 'DropdownTranslation' => [
             [
                 'items_id'   => '_cat_1',

--- a/tests/functional/Dropdown.php
+++ b/tests/functional/Dropdown.php
@@ -333,12 +333,19 @@ class Dropdown extends DbTestCase
                                     'level'          => 2,
                                     'title'          => '_cat_1 > _subcat_1 - Comment for sub-category _subcat_1',
                                     'selection_text' => '_cat_1 > _subcat_1',
-                                ]
+                                ],
+                                2 => [
+                                    'id'             => getItemByTypeName('TaskCategory', 'R&#38;D', true),
+                                    'text'           => 'R&D',
+                                    'level'          => 2,
+                                    'title'          => '_cat_1 > R&D - Comment for sub-category _subcat_2',
+                                    'selection_text' => '_cat_1 > R&D',
+                                ],
                             ],
                             'itemtype' => 'Entity'
                         ]
                     ],
-                    'count' => 2
+                    'count' => 3
                 ]
             ], [
                 'params' => [
@@ -364,6 +371,96 @@ class Dropdown extends DbTestCase
                                     'title'          => '_cat_1 > _subcat_1 - Comment for sub-category _subcat_1',
                                     'selection_text' => '_cat_1 > _subcat_1',
                                 ]
+                            ],
+                            'itemtype' => 'Entity'
+                        ]
+                    ],
+                    'count' => 1
+                ]
+            ], [
+                'params' => [
+                    'display_emptychoice'   => 0,
+                    'itemtype'              => 'TaskCategory',
+                    'searchText'            => '_cat_1 > _subcat'
+                ],
+                'expected'  => [
+                    'results' => [
+                        0 => [
+                            'text'      => 'Root entity',
+                            'children'  => [
+                                0 => [
+                                    'id'     => getItemByTypeName('TaskCategory', '_cat_1', true),
+                                    'text'   => '_cat_1',
+                                    'level'  => 1,
+                                    'disabled' => true
+                                ],
+                                1 => [
+                                    'id'             => getItemByTypeName('TaskCategory', '_subcat_1', true),
+                                    'text'           => '_subcat_1',
+                                    'level'          => 2,
+                                    'title'          => '_cat_1 > _subcat_1 - Comment for sub-category _subcat_1',
+                                    'selection_text' => '_cat_1 > _subcat_1',
+                                ]
+                            ],
+                            'itemtype' => 'Entity'
+                        ]
+                    ],
+                    'count' => 1
+                ]
+            ], [
+                'params' => [
+                    'display_emptychoice'   => 0,
+                    'itemtype'              => 'TaskCategory',
+                    'searchText'            => 'R&D' // raw value
+                ],
+                'expected'  => [
+                    'results' => [
+                        0 => [
+                            'text'      => 'Root entity',
+                            'children'  => [
+                                0 => [
+                                    'id'     => getItemByTypeName('TaskCategory', '_cat_1', true),
+                                    'text'   => '_cat_1',
+                                    'level'  => 1,
+                                    'disabled' => true
+                                ],
+                                1 => [
+                                    'id'             => getItemByTypeName('TaskCategory', 'R&#38;D', true),
+                                    'text'           => 'R&D',
+                                    'level'          => 2,
+                                    'title'          => '_cat_1 > R&D - Comment for sub-category _subcat_2',
+                                    'selection_text' => '_cat_1 > R&D',
+                                ],
+                            ],
+                            'itemtype' => 'Entity'
+                        ]
+                    ],
+                    'count' => 1
+                ]
+            ], [
+                'params' => [
+                    'display_emptychoice'   => 0,
+                    'itemtype'              => 'TaskCategory',
+                    'searchText'            => 'R&#38;D' // sanitized value from front file
+                ],
+                'expected'  => [
+                    'results' => [
+                        0 => [
+                            'text'      => 'Root entity',
+                            'children'  => [
+                                0 => [
+                                    'id'     => getItemByTypeName('TaskCategory', '_cat_1', true),
+                                    'text'   => '_cat_1',
+                                    'level'  => 1,
+                                    'disabled' => true
+                                ],
+                                1 => [
+                                    'id'             => getItemByTypeName('TaskCategory', 'R&#38;D', true),
+                                    'text'           => 'R&D',
+                                    'level'          => 2,
+                                    'title'          => '_cat_1 > R&D - Comment for sub-category _subcat_2',
+                                    'selection_text' => '_cat_1 > R&D',
+                                ],
                             ],
                             'itemtype' => 'Entity'
                         ]
@@ -398,12 +495,19 @@ class Dropdown extends DbTestCase
                                     'level'          => 2,
                                     'title'          => '_cat_1 > _subcat_1 - Comment for sub-category _subcat_1',
                                     'selection_text' => '_cat_1 > _subcat_1',
-                                ]
+                                ],
+                                2 => [
+                                    'id'             => getItemByTypeName('TaskCategory', 'R&#38;D', true),
+                                    'text'           => 'R&D',
+                                    'level'          => 2,
+                                    'title'          => '_cat_1 > R&D - Comment for sub-category _subcat_2',
+                                    'selection_text' => '_cat_1 > R&D',
+                                ],
                             ],
                             'itemtype' => 'Entity'
                         ]
                     ],
-                    'count' => 2
+                    'count' => 3
                 ]
             ], [
                 'params' => [
@@ -428,12 +532,19 @@ class Dropdown extends DbTestCase
                                     'level'          => 2,
                                     'title'          => '_cat_1 > _subcat_1 - Comment for sub-category _subcat_1',
                                     'selection_text' => '_cat_1 > _subcat_1',
-                                ]
+                                ],
+                                2 => [
+                                    'id'             => getItemByTypeName('TaskCategory', 'R&#38;D', true),
+                                    'text'           => 'R&D',
+                                    'level'          => 2,
+                                    'title'          => '_cat_1 > R&D - Comment for sub-category _subcat_2',
+                                    'selection_text' => '_cat_1 > R&D',
+                                ],
                             ],
                             'itemtype' => 'Entity'
                         ]
                     ],
-                    'count' => 1
+                    'count' => 2
                 ]
             ], [
                 'params' => [
@@ -597,12 +708,19 @@ class Dropdown extends DbTestCase
                                     'level'          => 0,
                                     'title'          => '_cat_1 > _subcat_1 - Comment for sub-category _subcat_1',
                                     'selection_text' => '_cat_1 > _subcat_1',
-                                ]
+                                ],
+                                2 => [
+                                    'id'             => getItemByTypeName('TaskCategory', 'R&#38;D', true),
+                                    'text'           => '_cat_1 > R&D',
+                                    'level'          => 0,
+                                    'title'          => '_cat_1 > R&D - Comment for sub-category _subcat_2',
+                                    'selection_text' => '_cat_1 > R&D',
+                                ],
                             ],
                             'itemtype' => 'Entity'
                         ]
                     ],
-                    'count' => 2
+                    'count' => 3
                 ],
                 'session_params' => [
                     'glpiuse_flat_dropdowntree' => true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | part of !27844

`Search::makeTextSearchValue()` unsanitizes input, and changint it may have unexpected side effects. The problem with this is that a users that is searching for `>`, `<` or `&` values in dropdowns will not find matches, as these chars are, most of the time, encoded in DB.
To be sure to find all expected results, we have to search for both raw and encoded values.