### PR TITLE
fix(html): use sprintf instead of concat space

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -3260,7 +3260,7 @@ JAVASCRIPT;
             'id'                 => '32',
             'table'              => 'glpi_slalevels',
             'field'              => 'name',
-            'name'               => __('SLA') . ' ' . _n('Escalation level', 'Escalation levels', 1),
+            'name'               => sprintf('%s %s', __('SLA'), _n('Escalation level', 'Escalation levels', 1)),
             'massiveaction'      => false,
             'datatype'           => 'dropdown',
             'joinparams'         => [
@@ -3311,7 +3311,7 @@ JAVASCRIPT;
             'id'                 => '192',
             'table'              => 'glpi_olalevels',
             'field'              => 'name',
-            'name'               => __('OLA') . ' ' . _n('Escalation level', 'Escalation levels', 1),
+            'name'               => sprintf('%s %s', __('OLA'), _n('Escalation level', 'Escalation levels', 1)),
             'massiveaction'      => false,
             'datatype'           => 'dropdown',
             'joinparams'         => [


### PR DESCRIPTION

Prevent ```&nbsp;```

![image](https://github.com/glpi-project/glpi/assets/7335054/9a365a51-ac53-4765-b099-880845610110)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28636
