### PR TITLE
Fix IDOR token performances

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -1683,6 +1683,10 @@ class Session
             foreach ($_SESSION['glpiidortokens'] as $footprint => $token) {
                 if ($token['expires'] < $now) {
                     unset($_SESSION['glpiidortokens'][$footprint]);
+                } else {
+                    // Token are stored from oldest to youngest
+                    // If this token is still valid, all the remaining token are valid too
+                    break;
                 }
             }
         }


### PR DESCRIPTION
I've noticed that sometimes my local GLPI get very slow until I log out to reset my session.

Thanks to the new debug bar, I've also noticed that my allocated memory keep growing until I relog, reaching about 300MiB (up from only 10MiB after a fresh login).

I suspect that the IDOR tokens stored in `$_SESSION` fill up the memory and degrade performances as the `cleanIDORTokens` function will iterate on every exiting token multiple times per GLPI pages.

These changes should fix the performances issue by cutting drastically the number of iterations.

Memory size still needs to be fixed but I'm unsure how.
300MiB just from the session after a few hours of using GLPI is way too much.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
