### PR TITLE
Drop non-OAuth authentication for new API

### DIFF
--- a/src/Api/HL/OpenAPIGenerator.php
+++ b/src/Api/HL/OpenAPIGenerator.php
@@ -300,20 +300,6 @@ EOT;
                     ]
                 ]
             ],
-            'basicAuth' => [
-                'type' => 'http',
-                'scheme' => 'basic',
-            ],
-            'userTokenAuth' => [
-                'type' => 'apiKey',
-                'in' => 'header',
-                'name' => 'Glpi-User-Token',
-            ],
-            'sessionTokenAuth' => [
-                'type' => 'apiKey',
-                'in' => 'header',
-                'name' => 'Glpi-Session-Token',
-            ],
         ];
     }
 
@@ -417,16 +403,7 @@ EOT;
             ]
         ];
         // Handle special Session case
-        if ($route_method === 'POST' && $route_path->getRoutePath() === '/Session') {
-            $schemas = array_merge($schemas, [
-                [
-                    'basicAuth' => []
-                ],
-                [
-                    'userTokenAuth' => []
-                ]
-            ]);
-        } else if ($route_path->getRouteSecurityLevel() !== Route::SECURITY_NONE) {
+        if ($route_path->getRouteSecurityLevel() !== Route::SECURITY_NONE) {
             $schemas = array_merge($schemas, [
                 [
                     'sessionTokenAuth' => []

--- a/src/Api/HL/RoutePath.php
+++ b/src/Api/HL/RoutePath.php
@@ -98,6 +98,11 @@ final class RoutePath
     private int $security;
 
     /**
+     * @var AbstractController|null The controller instance
+     */
+    private $controller_instance;
+
+    /**
      * @param class-string<AbstractController> $class
      * @param string $method
      */
@@ -249,12 +254,11 @@ final class RoutePath
     public function getControllerInstance(): AbstractController
     {
         /** @var ?AbstractController $instance */
-        static $instance = null;
-        if ($instance === null) {
+        if ($this->controller_instance === null) {
             $this->hydrate();
-            $instance = $this->controller->newInstance();
+            $this->controller_instance = $this->controller->newInstance();
         }
-        return $instance;
+        return $this->controller_instance;
     }
 
     /**

--- a/src/Api/HL/Router.php
+++ b/src/Api/HL/Router.php
@@ -574,7 +574,7 @@ EOT;
             $requires_auth = $matched_route->getRouteSecurityLevel() !== Route::SECURITY_NONE;
             $unauthenticated_response = new JSONResponse([
                 'title' => _x('api', 'You are not authenticated'),
-                'detail' => _x('api', 'The Glpi-Session-Token header is missing or invalid'),
+                'detail' => _x('api', 'The Authorization header is missing or invalid'),
                 'status' => 'ERROR_UNAUTHENTICATED',
             ], 401);
             $middleware_input = new MiddlewareInput($request, $matched_route, $unauthenticated_response);
@@ -583,16 +583,8 @@ EOT;
             $auth_from_middleware = $middleware_input->response === null;
 
             if ($requires_auth && !$auth_from_middleware) {
-                if (!$request->hasHeader('Glpi-Session-Token')) {
-                    if (!($request->hasHeader('Authorization') && Session::getLoginUserID() !== false)) {
-                        $response = $unauthenticated_response;
-                    }
-                } else {
-                    $current_session_id = session_id();
-                    $session_token = $request->getHeaderLine('Glpi-Session-Token');
-                    if (($current_session_id !== $session_token && !empty($current_session_id)) || !isset($_SESSION['glpiID'])) {
-                        $response = $unauthenticated_response;
-                    }
+                if (!($request->hasHeader('Authorization') && Session::getLoginUserID() !== false)) {
+                    $response = $unauthenticated_response;
                 }
             }
 
@@ -628,7 +620,7 @@ EOT;
     }
 
     /**
-     * Try resuming the session from the Glpi-Session-Token header or start a temporary session if an OAuth token is provided.
+     * Try to start a temporary session if an OAuth token is provided and handle the profile and entity headers.
      * @param Request $request
      * @return void
      * @throws OAuthServerException
@@ -636,39 +628,21 @@ EOT;
     private function handleAuth(Request $request): void
     {
         if ($request->hasHeader('Authorization')) {
-            $auth_header = $request->getHeaderLine('Authorization');
-            // if basic auth
-            if (preg_match('/^Basic\s+(.*)$/i', $auth_header, $matches)) {
-                $this->resumeSession('');
-            } else {
-                $this->startTemporarySession($request);
-                if ($request->hasHeader('GLPI-Profile')) {
-                    $requested_profile = $request->getHeaderLine('GLPI-Profile');
-                    if (is_numeric($requested_profile)) {
-                        Session::changeProfile((int)$requested_profile);
-                    }
-                }
-                if ($request->hasHeader('GLPI-Entity')) {
-                    $requested_entity = $request->getHeaderLine('GLPI-Entity');
-                    if (is_numeric($requested_entity)) {
-                        $is_recursive = $request->hasHeader('GLPI-Entity-Recursive') && strtolower($request->getHeaderLine('GLPI-Entity-Recursive')) === 'true';
-                        Session::changeActiveEntities((int)$requested_entity, $is_recursive);
-                    }
+            $this->startTemporarySession($request);
+            if ($request->hasHeader('GLPI-Profile')) {
+                $requested_profile = $request->getHeaderLine('GLPI-Profile');
+                if (is_numeric($requested_profile)) {
+                    Session::changeProfile((int)$requested_profile);
                 }
             }
-            return;
+            if ($request->hasHeader('GLPI-Entity')) {
+                $requested_entity = $request->getHeaderLine('GLPI-Entity');
+                if (is_numeric($requested_entity)) {
+                    $is_recursive = $request->hasHeader('GLPI-Entity-Recursive') && strtolower($request->getHeaderLine('GLPI-Entity-Recursive')) === 'true';
+                    Session::changeActiveEntities((int)$requested_entity, $is_recursive);
+                }
+            }
         }
-        if (
-            $request->hasHeader('Glpi-Session-Token')
-            && !empty($request->getHeaderLine('Glpi-Session-Token'))
-        ) {
-            $this->resumeSession($request->getHeaderLine('Glpi-Session-Token'));
-        }
-        Session::setPath();
-        Session::start();
-
-        // Clear all messages in the session to avoid unhandled messages being displayed in the errors of unrelated API requests
-        $_SESSION['MESSAGE_AFTER_REDIRECT'] = [];
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -36,6 +36,7 @@
 use Glpi\Application\ErrorHandler;
 use Glpi\Cache\CacheManager;
 use Glpi\Cache\SimpleCache;
+use Glpi\OAuth\Server;
 use Glpi\Socket;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
@@ -110,7 +111,7 @@ function loadDataset()
    // Unit test data definition
     $data = [
       // bump this version to force reload of the full dataset, when content change
-        '_version' => '4.10',
+        '_version' => '4.11',
 
       // Type => array of entries
         'Entity' => [
@@ -723,6 +724,16 @@ function loadDataset()
                 'users_id_recipient' => TU_USER,
                 'entities_id'    => '_test_root_entity'
             ],
+        ],
+        'OAuthClient' => [
+            [
+                'redirect_uri' => '/api.php/oauth2/redirection',
+                'grants' => ['password', 'client_credentials', 'authorization_code'],
+                'scopes' => [],
+                'is_active' => 1,
+                'is_confidential' => 1,
+                'name' => 'Test OAuth Client',
+            ]
         ]
     ];
 
@@ -830,3 +841,7 @@ function getItemByTypeName($type, $name, $onlyid = false)
 }
 
 loadDataset();
+
+$tu_oauth_client = getItemByTypeName('OAuthClient', 'Test OAuth Client');
+define('TU_OAUTH_CLIENT_ID', $tu_oauth_client->fields['identifier']);
+define('TU_OAUTH_CLIENT_SECRET', $tu_oauth_client->fields['secret']);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -842,6 +842,7 @@ function getItemByTypeName($type, $name, $onlyid = false)
 
 loadDataset();
 
-$tu_oauth_client = getItemByTypeName('OAuthClient', 'Test OAuth Client');
+$tu_oauth_client = new OAuthClient();
+$tu_oauth_client->getFromDBByCrit(['name' => 'Test OAuth Client']);
 define('TU_OAUTH_CLIENT_ID', $tu_oauth_client->fields['identifier']);
 define('TU_OAUTH_CLIENT_SECRET', $tu_oauth_client->fields['secret']);

--- a/tests/functional/Glpi/Api/HL/Controller/AdministrationController.php
+++ b/tests/functional/Glpi/Api/HL/Controller/AdministrationController.php
@@ -416,7 +416,9 @@ class AdministrationController extends \HLAPITestCase
     public function testGetUserPictureByID()
     {
         $this->login();
-        $this->api->call(new Request('GET', '/Administration/User/' . $_SESSION['glpiID'] . '/Picture'), function ($call) {
+
+        $tu_id = getItemByTypeName('User', TU_USER, true);
+        $this->api->call(new Request('GET', '/Administration/User/' . $tu_id . '/Picture'), function ($call) {
             /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
@@ -426,7 +428,7 @@ class AdministrationController extends \HLAPITestCase
         });
         $this->addCustomUserPicture($_SESSION['glpiID'], GLPI_ROOT . '/tests/fixtures/uploads/foo.png');
 
-        $this->api->call(new Request('GET', '/Administration/User/' . $_SESSION['glpiID'] . '/Picture'), function ($call) {
+        $this->api->call(new Request('GET', '/Administration/User/' . $tu_id . '/Picture'), function ($call) {
             /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
@@ -439,7 +441,8 @@ class AdministrationController extends \HLAPITestCase
     public function testGetUserPictureByUsername()
     {
         $this->login();
-        $this->api->call(new Request('GET', '/Administration/User/username/' . $_SESSION['glpiname'] . '/Picture'), function ($call) {
+
+        $this->api->call(new Request('GET', '/Administration/User/username/' . TU_USER . '/Picture'), function ($call) {
             /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
@@ -449,7 +452,7 @@ class AdministrationController extends \HLAPITestCase
         });
         $this->addCustomUserPicture($_SESSION['glpiID'], GLPI_ROOT . '/tests/fixtures/uploads/foo.png');
 
-        $this->api->call(new Request('GET', '/Administration/User/username/' . $_SESSION['glpiname'] . '/Picture'), function ($call) {
+        $this->api->call(new Request('GET', '/Administration/User/username/' . TU_USER . '/Picture'), function ($call) {
             /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

With the inclusion of the OAuth server component in GLPI now, we no longer need to support the less safe HTTP Basic authentication option. The `user_token` authentication also seems redundant now. Additionally, we can drop support for the `Session-Token` header. All of the OAuth authentication methods were stateless anyways and that is how it is usually expected to work with REST. A session would still be initialized, but it would only last for that single request.

The `GLPI-Profile`, `GLPI-Entity` and `GLPI-Entity-Recursive` headers were added along with the OAuth server feature and can be used to specify profile/entity ID and if you want to use "tree" mode to see sub-entities. By default, the user's default entity and profile would be used.
A `GLPI-Debug-Mode` header also already exists to control debug mode.