### PR TITLE
fix(inventory): remove duplicate TAG searchOption on computer

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -327,13 +327,6 @@ class Agent extends CommonDBTM
             'datatype'   => 'text',
         ] + $baseopts;
 
-        $tab[] = [
-            'id'         => 907,
-            'field'      => 'tag',
-            'name'       => __('TAG'),
-            'datatype'   => 'text',
-        ] + $baseopts;
-
         return $tab;
     }
 


### PR DESCRIPTION
Revert https://github.com/glpi-project/glpi/pull/15090

```TAG``` search already exists

```php
        $tab[] = [
            'id'         => 901,
            'field'      => 'tag',
            'name'       => __('Tag'),
            'datatype'   => 'text',
        ] + $baseopts;
```


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
