### PR TITLE
fix(CommonITILObject): clone actors

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -2728,7 +2728,7 @@ abstract class CommonITILObject extends CommonDBTM
 
     public function getCloneRelations(): array
     {
-        return [$this->userlinkclass, $this->grouplinkclass];
+        return [$this->userlinkclass, $this->grouplinkclass, $this->supplierlinkclass];
     }
 
 

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -2728,7 +2728,7 @@ abstract class CommonITILObject extends CommonDBTM
 
     public function getCloneRelations(): array
     {
-        return [];
+        return [$this->userlinkclass, $this->grouplinkclass];
     }
 
 

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -2729,7 +2729,7 @@ abstract class CommonITILObject extends CommonDBTM
     public function getCloneRelations(): array
     {
         $relations = [];
-        
+
         if (is_a($this->userlinkclass, CommonITILActor::class, true)) {
             $relations[] = $this->userlinkclass;
         }
@@ -2739,7 +2739,7 @@ abstract class CommonITILObject extends CommonDBTM
         if (is_a($this->supplierlinkclass, CommonITILActor::class, true)) {
             $relations[] = $this->supplierlinkclass;
         }
-        
+
         return $relations;
     }
 

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -2728,7 +2728,19 @@ abstract class CommonITILObject extends CommonDBTM
 
     public function getCloneRelations(): array
     {
-        return [$this->userlinkclass, $this->grouplinkclass, $this->supplierlinkclass];
+        $relations = [];
+        
+        if (is_a($this->userlinkclass, CommonITILActor::class, true)) {
+            $relations[] = $this->userlinkclass;
+        }
+        if (is_a($this->grouplinkclass, CommonITILActor::class, true)) {
+            $relations[] = $this->grouplinkclass;
+        }
+        if (is_a($this->supplierlinkclass, CommonITILActor::class, true)) {
+            $relations[] = $this->supplierlinkclass;
+        }
+        
+        return $relations;
     }
 
 

--- a/tests/functional/Ticket.php
+++ b/tests/functional/Ticket.php
@@ -1856,6 +1856,19 @@ class Ticket extends DbTestCase
             'type' => 2
         ]))->isGreaterThan(0);
 
+        $ticket_Supplier = new Supplier_Ticket();
+        $this->integer((int)$ticket_Supplier->add([
+            'tickets_id' => $ticket->getID(),
+            'suppliers_id' => (int)getItemByTypeName('Supplier', '_suplier01_name', true), //observer
+            'type' => 3
+        ]))->isGreaterThan(0);
+
+        $this->integer((int)$ticket_Supplier->add([
+            'tickets_id' => $ticket->getID(),
+            'suppliers_id' => (int)getItemByTypeName('Supplier', '_suplier02_name', true), //requester
+            'type' => 1
+        ]))->isGreaterThan(0);
+
         $this->integer($ticket_user->add([
             'tickets_id' => $ticket->getID(),
             'users_id' => (int)getItemByTypeName('User', 'normal', true), //observer
@@ -1894,8 +1907,8 @@ class Ticket extends DbTestCase
 
         $this->integer(count($clonedTicket->getTimelineItems([
             'with_logs'         => true,
-        ])))->isEqualTo(6);
-        //User: Add a link with an item: 3 times
+        ])))->isEqualTo(8);
+        //User: Add a link with an item: 5 times
         //Group: Add a link with an item: 2 times
         //Status: Change New to Processing (assigned): once
 
@@ -1910,25 +1923,37 @@ class Ticket extends DbTestCase
             'tickets_id' => $clonedTicket->getID(),
             'users_id' => (int)getItemByTypeName('User', 'tech', true), //assign
             'type' => 2
-        ]))->isTrue(0);
+        ]))->isTrue();
 
         $this->boolean($ticket_user->getFromDBByCrit([
             'tickets_id' => $clonedTicket->getID(),
             'users_id' => (int)getItemByTypeName('User', 'normal', true), //observer
             'type' => 3
-        ]))->isTrue(0);
+        ]))->isTrue();
+
+        $this->boolean($ticket_Supplier->getFromDBByCrit([
+            'tickets_id' => $ticket->getID(),
+            'suppliers_id' => (int)getItemByTypeName('Supplier', '_suplier01_name', true), //observer
+            'type' => 3
+        ]))->isTrue();
+
+        $this->boolean($ticket_Supplier->getFromDBByCrit([
+            'tickets_id' => $ticket->getID(),
+            'suppliers_id' => (int)getItemByTypeName('Supplier', '_suplier02_name', true), //requester
+            'type' => 1
+        ]))->isTrue();
 
         $this->boolean($group_ticket->getFromDBByCrit([
             'tickets_id' => $clonedTicket->getID(),
             'groups_id' => (int)getItemByTypeName('Group', '_test_group_1', true), //observer
             'type' => 3
-        ]))->isTrue(0);
+        ]))->isTrue();
 
         $this->boolean($group_ticket->getFromDBByCrit([
             'tickets_id' => $clonedTicket->getID(),
             'groups_id' => (int)getItemByTypeName('Group', '_test_group_2', true), //assign
             'type' => 3
-        ]))->isTrue(0);
+        ]))->isTrue();
 
 
 

--- a/tests/functional/Ticket.php
+++ b/tests/functional/Ticket.php
@@ -1981,8 +1981,6 @@ class Ticket extends DbTestCase
                     )->variable($clonedTicket->getField($k))->isEqualTo($ticket->getField($k));
             }
         }
-
-
     }
 
     protected function testGetTimelinePosition2($tlp, $tickets_id)


### PR DESCRIPTION
Actors of a ```CommonITILObject``` object are not cloned

This PR fix this


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
