### PR TITLE
Fix plugin search options display

### DIFF
--- a/src/DisplayPreference.php
+++ b/src/DisplayPreference.php
@@ -491,7 +491,7 @@ class DisplayPreference extends CommonDBTM
 
         for ($key = array_search($search_option_key, $search_options_keys) - 1; $key > 0; $key--) {
             if (is_string($search_options_keys[$key])) {
-                return $search_options[$search_options_keys[$key]]['name'] . " - ";
+                return ($search_options[$search_options_keys[$key]]['name'] ?? $key) . " - ";
             }
         }
 

--- a/src/Search.php
+++ b/src/Search.php
@@ -8257,7 +8257,9 @@ HTML;
                 $plugsearch = Plugin::getAddSearchOptions($itemtype);
                 $plugsearch = $plugsearch + Plugin::getAddSearchOptionsNew($itemtype);
                 if (count($plugsearch)) {
-                    self::$search[$itemtype] += ['plugins' => _n('Plugin', 'Plugins', Session::getPluralNumber())];
+                    self::$search[$itemtype]['plugins'] = [
+                        'name' => _n('Plugin', 'Plugins', Session::getPluralNumber())
+                    ];
                     self::$search[$itemtype] += $plugsearch;
                 }
             }

--- a/src/Search.php
+++ b/src/Search.php
@@ -8257,9 +8257,7 @@ HTML;
                 $plugsearch = Plugin::getAddSearchOptions($itemtype);
                 $plugsearch = $plugsearch + Plugin::getAddSearchOptionsNew($itemtype);
                 if (count($plugsearch)) {
-                    self::$search[$itemtype]['plugins'] = [
-                        'name' => _n('Plugin', 'Plugins', Session::getPluralNumber())
-                    ];
+                    self::$search[$itemtype] += ['plugins' => ['name' => _n('Plugin', 'Plugins', Session::getPluralNumber())]];
                     self::$search[$itemtype] += $plugsearch;
                 }
             }


### PR DESCRIPTION
Fix a small regression introduced in #14947 which trigger an exception for search options added by plugins.

As seen with @cedric-anne, the format used in `Search::&getOptions()` to store theses plugin search options was incorrect.
We've also added a safety check in the `nameOfGroupForItemInSearchopt` method to avoid failure even if the data's format is incorrect.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
