### PR TITLE
Fix cleaning of debug profiles stored in session

### DIFF
--- a/ajax/debug.php
+++ b/ajax/debug.php
@@ -43,14 +43,18 @@ if ($_SESSION['glpi_use_mode'] !== Session::DEBUG_MODE) {
     die();
 }
 
-// No need to save session data. Cannot use Session::writeClose because it doesn't do anything in debug mode
-session_write_close();
 \Glpi\Debug\Profiler::getInstance()->disable();
 
 if (isset($_GET['ajax_id'])) {
     // Get debug data for a specific ajax call
     $ajax_id = $_GET['ajax_id'];
-    $profile = \Glpi\Debug\Profile::load($ajax_id);
+    $profile = \Glpi\Debug\Profile::pull($ajax_id);
+
+    // Close session ASAP to not block other requests.
+    // DO NOT do it before call to `\Glpi\Debug\Profile::pull()`,
+    // as we have to delete profile from `$_SESSION` during the pull operation.
+    session_write_close();
+
     if ($profile) {
         $data = $profile->getDebugInfo();
         if ($data) {

--- a/src/Debug/Profile.php
+++ b/src/Debug/Profile.php
@@ -78,7 +78,7 @@ final class Profile
         return self::$current;
     }
 
-    public static function load(string $id, bool $delete = true): ?self
+    public static function pull(string $id): ?self
     {
         if (!isset($_SESSION['debug_profiles'][$id])) {
             return null;
@@ -90,9 +90,8 @@ final class Profile
             $profile->is_readonly = true;
             $profile->debug_info = $profile_data;
 
-            if ($delete) {
-                unset($_SESSION['debug_profiles'][$id]);
-            }
+            unset($_SESSION['debug_profiles'][$id]);
+
             return $profile;
         } catch (\Throwable $e) {
             return null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Debug profiles were not cleaned up from the session because `session_write_close()` was call too early. The result was that the session data size was growing disproportionately.

I fixed it and renamed `\Glpi\Debug\Profile::load()` to `\Glpi\Debug\Profile::pull()` in order to have a name that clearly indicates that the data is removed from the session when recovered.