### PR TITLE
Fix computation of joins inside nested objects

### DIFF
--- a/src/Api/HL/Doc/Schema.php
+++ b/src/Api/HL/Doc/Schema.php
@@ -213,9 +213,9 @@ class Schema implements \ArrayAccess
         $joins = [];
         foreach ($props as $name => $prop) {
             if ($prop['type'] === self::TYPE_OBJECT && isset($prop['x-join'])) {
-                $joins[$name] = $prop['x-join'] + ['parent_type' => self::TYPE_OBJECT];
+                $joins[$prefix . $name] = $prop['x-join'] + ['parent_type' => self::TYPE_OBJECT];
             } else if ($prop['type'] === self::TYPE_ARRAY && isset($prop['items']['x-join'])) {
-                $joins[$name] = $prop['items']['x-join'] + ['parent_type' => self::TYPE_ARRAY];
+                $joins[$prefix . $name] = $prop['items']['x-join'] + ['parent_type' => self::TYPE_ARRAY];
             } else if ($prop['type'] === self::TYPE_OBJECT && isset($prop['properties'])) {
                 $joins += self::getJoins($prop['properties'], $prefix . $name . '.');
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

While working on https://github.com/pluginsGLPI/fields/pull/670 I found that joins were not working for the custom fields.
Until now, joins where only needed for top-level properties like the `location` property. The nested properties like `location.id` were always scalar properties.
For the fields plugin, the complex nature of the DB schema where each field is in its own table, the joins were nested. There is a `custom_fields` object property and then for each field, there is a child object which has the join info.

This is still a draft until I fix remaining issues with the fields plugin integration.