### PR TITLE
CriteriaFilter - Handle non-standard ID option number

### DIFF
--- a/src/Search/FilterableTrait.php
+++ b/src/Search/FilterableTrait.php
@@ -51,6 +51,22 @@ trait FilterableTrait
             return true;
         }
 
+        // The ID is not always search option 2
+        $opts = SearchOption::getOptionsForItemtype($item::getType());
+        $item_table = $item::getTable();
+        $id_opt_num = null;
+        foreach ($opts as $opt_num => $opt) {
+            if (isset($opt['field']) && $opt['field'] === 'id' && $opt['table'] === $item_table) {
+                $id_opt_num = $opt_num;
+                break;
+            }
+        }
+
+        if ($id_opt_num === null) {
+            trigger_error("Could not find ID option for itemtype {$item::getType()}. Cannot use FilterableTrait on this itemtype.", E_USER_WARNING);
+            return false;
+        }
+
         // Intersect current item's id with the filter
         $criteria = [
             [
@@ -60,7 +76,7 @@ trait FilterableTrait
             [
                 'link' => 'AND',
                 // Id field
-                'field' => 2,
+                'field' => $id_opt_num,
                 // Search engine seems to expect "contains" here, even if the
                 // real search will be done with "equals
                 'searchtype' => "contains",

--- a/src/Search/FilterableTrait.php
+++ b/src/Search/FilterableTrait.php
@@ -54,16 +54,17 @@ trait FilterableTrait
         // The ID is not always search option 2
         $opts = SearchOption::getOptionsForItemtype($item::getType());
         $item_table = $item::getTable();
+        $id_field = $item::getIndexName();
         $id_opt_num = null;
         foreach ($opts as $opt_num => $opt) {
-            if (isset($opt['field']) && $opt['field'] === 'id' && $opt['table'] === $item_table) {
+            if (isset($opt['field']) && $opt['field'] === $id_field && $opt['table'] === $item_table) {
                 $id_opt_num = $opt_num;
                 break;
             }
         }
 
         if ($id_opt_num === null) {
-            trigger_error("Could not find ID option for itemtype {$item::getType()}. Cannot use FilterableTrait on this itemtype.", E_USER_WARNING);
+            trigger_error("Could not find {$id_field} option for itemtype {$item::getType()}. Cannot use FilterableTrait on this itemtype.", E_USER_WARNING);
             return false;
         }
 

--- a/src/Search/FilterableTrait.php
+++ b/src/Search/FilterableTrait.php
@@ -81,7 +81,7 @@ trait FilterableTrait
                 // Search engine seems to expect "contains" here, even if the
                 // real search will be done with "equals
                 'searchtype' => "contains",
-                'value' => $item->fields['id'],
+                'value' => $item->fields[$id_field],
             ],
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This may not affect any filterable types currently in the main branch, but globally the ID search option for an itemtype may not even exist yet and if it does, it may not be option number 2. Followups for example have no ID search option yet as they were not meant to be searched as the primary itemtype. In the webhooks feature this option will need added, but ID 2 is already being used.

The criteria injection will need to manually search for the option number for the ID field. If it is missing, it will throw a warning to make debugging this kind of issue easier in the future.