### PR TITLE
Fix dashboard when "Items seen" search is not the default criteria

### DIFF
--- a/src/Dashboard/Provider.php
+++ b/src/Dashboard/Provider.php
@@ -1671,8 +1671,9 @@ class Provider
             array_push($s_criteria, ...$filter_criteria);
         }
 
-        if ($default_criteria_on_empty === true && count($s_criteria) === 0) {
-            $s_criteria = Search::getDefaultCriteria();
+        $itemtype = getItemTypeForTable($table);
+        if (is_a($itemtype, CommonDBTM::class, true) && $default_criteria_on_empty === true && count($s_criteria) === 0) {
+            $s_criteria = Search::getDefaultCriteria($itemtype);
         }
 
         return ['criteria' => $s_criteria];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15131

Despite its default empty value, `$itemtype` param of `Search::getDefaultCriteria()` method is not optional. When `Items seen` configuration is not `Yes (default criterion)`, calling `Search::getDefaultCriteria()` without a valid itemtype triggers an error.