### PR TITLE
Fix `glpi_queuednotifications`.`event` column creation

### DIFF
--- a/install/migrations/update_10.0.7_to_10.0.8/queuednotification.php
+++ b/install/migrations/update_10.0.7_to_10.0.8/queuednotification.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+/* Add `event` to some glpi_queuednotifications */
+if (!$DB->fieldExists('glpi_queuednotifications', 'event')) {
+    $migration->addField('glpi_queuednotifications', 'event', 'varchar(255) DEFAULT NULL', ['value' => null]);
+}

--- a/install/migrations/update_10.0.8_to_10.0.9.php
+++ b/install/migrations/update_10.0.8_to_10.0.9.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * Update from 10.0.8 to 10.0.9
+ *
+ * @return bool for success (will die for most error)
+ **/
+function update1008to1009()
+{
+    global $DB, $migration;
+
+    $updateresult       = true;
+    $ADDTODISPLAYPREF   = [];
+    $DELFROMDISPLAYPREF = [];
+    $update_dir = __DIR__ . '/update_10.0.8_to_10.0.9/';
+
+    //TRANS: %s is the number of new version
+    $migration->displayTitle(sprintf(__('Update to %s'), '10.0.9'));
+    $migration->setVersion('10.0.9');
+
+    $update_scripts = scandir($update_dir);
+    foreach ($update_scripts as $update_script) {
+        if (preg_match('/\.php$/', $update_script) !== 1) {
+            continue;
+        }
+        require $update_dir . $update_script;
+    }
+
+    // ************ Keep it at the end **************
+    $migration->updateDisplayPrefs($ADDTODISPLAYPREF, $DELFROMDISPLAYPREF);
+
+    $migration->executeMigration();
+
+    return $updateresult;
+}

--- a/install/migrations/update_10.0.8_to_10.0.9/queuednotification.php
+++ b/install/migrations/update_10.0.8_to_10.0.9/queuednotification.php
@@ -38,9 +38,8 @@
  * @var Migration $migration
  */
 
-$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
-
- /* Add `event` to some glpi_queuednotifications */
+/* Add `event` to some glpi_queuednotifications */
+/* This migration was not executed during from 10.0.7 to 10.0.8 (see #15133) */
 if (!$DB->fieldExists('glpi_queuednotifications', 'event')) {
     $migration->addField('glpi_queuednotifications', 'event', 'varchar(255) DEFAULT NULL', ['value' => null]);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15133

Migration was not located in the correct directory (`10.0.6_to_10.0.7` -> `10.0.7_to_10.0.8`). People migrating from GLPI 10.0.7 will not have this field created. People migrating from a previous version will not have this issue.
