### PR TITLE
Fix handling of null values in additional fields

### DIFF
--- a/src/ManualLink.php
+++ b/src/ManualLink.php
@@ -358,6 +358,10 @@ JAVASCRIPT
     private static function getLinkHtml(array $fields): string
     {
 
+        if (empty($fields['url'])) {
+            return '';
+        }
+
         $html = '';
 
         // decode `&` to prevent doube encoding when value will be printed using `htmlspecialchars()`

--- a/src/Search.php
+++ b/src/Search.php
@@ -3968,7 +3968,7 @@ JAVASCRIPT;
                 ) {
                     $ADDITONALFIELDS .= " IFNULL(GROUP_CONCAT(DISTINCT CONCAT(IFNULL(`$table$addtable`.`$key`,
                                                                          '" . self::NULLVALUE . "'),
-                                                   '" . self::SHORTSEP . "', $tocomputeid)ORDER BY $tocomputeid SEPARATOR '" . self::LONGSEP . "'), '" . self::NULLVALUE . self::SHORTSEP . "')
+                                                   '" . self::SHORTSEP . "', $tocomputeid)ORDER BY $tocomputeid SEPARATOR '" . self::LONGSEP . "'), '" . self::NULLVALUE . "')
                                     AS `" . $NAME . "_$key`, ";
                 } else {
                     $ADDITONALFIELDS .= "`$table$addtable`.`$key` AS `" . $NAME . "_$key`, ";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15145

On `additionalfields`, when value was `NULL`, fallback value was containing an unexpected `Search::SHORTSEP`.

```diff
- "IFNULL(GROUP_CONTACT(...), '" . self::NULLVALUE . self::SHORTSEP . '")"
+ "IFNULL(GROUP_CONTACT(...), '" . self::NULLVALUE . '")"
```