### PR TITLE
Fix iCal/WebCal export

### DIFF
--- a/front/planning.php
+++ b/front/planning.php
@@ -33,6 +33,13 @@
  * ---------------------------------------------------------------------
  */
 
+if (isset($_GET['genical'])) {
+    // A new sssion is generated and destroyed during the ical/webcal export.
+    // Prevent sending cookies to browser to ensure that user will not be disconnected when using the export feature.
+    // It will also prevent to send a session cookie related to another user in case an error made the script exit before session destroying.
+    ini_set('session.use_cookies', 0);
+}
+
 include('../inc/includes.php');
 
 if (!isset($_GET['genical'])) {

--- a/front/planning.php
+++ b/front/planning.php
@@ -85,15 +85,6 @@ if (isset($_GET['checkavailability'])) {
                     Session::changeProfile(key($_SESSION['glpiprofiles']));
                 }
             }
-
-            // reset rights as we only need planning view (avoid giving access to other modules)
-            $_SESSION['glpiactiveprofile'] = [
-                'id'        => $_SESSION['glpiactiveprofile']['id'],
-                'name'      => $_SESSION['glpiactiveprofile']['name'],
-                'interface' => $_SESSION['glpiactiveprofile']['interface'],
-                'planning'  => $_SESSION['glpiactiveprofile']['planning'],
-            ];
-
             //// check if the request is valid: rights on uID / gID
             // First check mine : user then groups
             $ismine = false;

--- a/front/planning.php
+++ b/front/planning.php
@@ -86,29 +86,13 @@ if (isset($_GET['checkavailability'])) {
                 }
             }
 
-            // Clean rights to keep only `READ` rights on planning itemtypes and their parent.
-            // This should permit to avoid leak of unexpected data.
-            $planning_types_rights = [];
-            foreach ($CFG_GLPI['planning_types'] as $planning_itemtype) {
-                if (!is_a($planning_itemtype, CommonGLPI::class, true)) {
-                    continue;
-                }
-                $planning_types_rights[] = $planning_itemtype::$rightname;
-
-                if (is_a($planning_itemtype, CommonITILTask::class, true)) {
-                    $planning_types_rights[] = (new $planning_itemtype())->getItilObjectItemType()::$rightname;
-                } elseif (is_a($planning_itemtype, CommonDBChild::class, true)) {
-                    $planning_types_rights[] = $planning_itemtype::$itemtype::$rightname;
-                }
-            }
-            $all_possible_rights = array_keys(ProfileRight::getAllPossibleRights());
-            foreach ($_SESSION['glpiactiveprofile'] as $key => $value) {
-                if (in_array($key, $all_possible_rights) && !in_array($key, $planning_types_rights)) {
-                    $_SESSION['glpiactiveprofile'][$key] = 0;
-                } elseif (is_int($_SESSION['glpiactiveprofile'][$key])) {
-                    $_SESSION['glpiactiveprofile'][$key] = $_SESSION['glpiactiveprofile'][$key] & READ;
-                }
-            }
+            // reset rights as we only need planning view (avoid giving access to other modules)
+            $_SESSION['glpiactiveprofile'] = [
+                'id'        => $_SESSION['glpiactiveprofile']['id'],
+                'name'      => $_SESSION['glpiactiveprofile']['name'],
+                'interface' => $_SESSION['glpiactiveprofile']['interface'],
+                'planning'  => $_SESSION['glpiactiveprofile']['planning'],
+            ];
 
             //// check if the request is valid: rights on uID / gID
             // First check mine : user then groups


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14711 and !28706

c4075349e3eb0b98733fb5cc1c65460c5d83da4d and 422f73ea2e272260e68afd236f8ca09e8e17b5bf were made to prevent giving too many rights to the session generated during the iCal/WebCal export. Problem is that some items are requiring much more rights than the basic `READ` to be readable, see https://github.com/glpi-project/glpi/blob/6e3e752988792990f08be1a50670332250ea8f2b/src/Ticket.php#L250-L312

A simplier solution is to NOT send the session cookie to the browser. With this solution, it is not possible to steal the generated session.

Also, it fixes a small bug. Indeed, due to session creation/destruction, the current session of the user was killed because he was receiving a session cookie with a new session ID. Now, he will not receive any cookie, so its current session will not be altered.

