### PR TITLE
GraphQL wrapper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,8 @@
         "twig/markdown-extra": "^3.7",
         "twig/string-extra": "^3.7",
         "twig/twig": "^3.7",
-        "wapmorgan/unified-archive": "^1.2"
+        "wapmorgan/unified-archive": "^1.2",
+        "webonyx/graphql-php": "^15.5"
     },
     "require-dev": {
         "ext-xml": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fbcc1c2ce637ad7371316a17a2854e46",
+    "content-hash": "8eed5bf22715616da1009259f556ff64",
     "packages": [
         {
             "name": "apereo/phpcas",
@@ -6843,6 +6843,79 @@
                 "source": "https://github.com/webmozarts/assert/tree/1.11.0"
             },
             "time": "2022-06-03T18:03:27+00:00"
+        },
+        {
+            "name": "webonyx/graphql-php",
+            "version": "v15.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webonyx/graphql-php.git",
+                "reference": "b305633164a48947e22d53b6b15fcb98613c6592"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/b305633164a48947e22d53b6b15fcb98613c6592",
+                "reference": "b305633164a48947e22d53b6b15fcb98613c6592",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": "^7.4 || ^8"
+            },
+            "require-dev": {
+                "amphp/amp": "^2.6",
+                "amphp/http-server": "^2.1",
+                "dms/phpunit-arraysubset-asserts": "dev-master",
+                "ergebnis/composer-normalize": "^2.28",
+                "mll-lab/php-cs-fixer-config": "^5",
+                "nyholm/psr7": "^1.5",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "1.10.19",
+                "phpstan/phpstan-phpunit": "1.3.13",
+                "phpstan/phpstan-strict-rules": "1.5.1",
+                "phpunit/phpunit": "^9.5 || ^10",
+                "psr/http-message": "^1 || ^2",
+                "react/http": "^1.6",
+                "react/promise": "^2.9",
+                "rector/rector": "^0.17.0",
+                "symfony/polyfill-php81": "^1.23",
+                "symfony/var-exporter": "^5 || ^6",
+                "thecodingmachine/safe": "^1.3 || ^2"
+            },
+            "suggest": {
+                "amphp/http-server": "To leverage async resolving with webserver on AMPHP platform",
+                "psr/http-message": "To use standard GraphQL server",
+                "react/promise": "To leverage async resolving on React PHP platform"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GraphQL\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A PHP port of GraphQL reference implementation",
+            "homepage": "https://github.com/webonyx/graphql-php",
+            "keywords": [
+                "api",
+                "graphql"
+            ],
+            "support": {
+                "issues": "https://github.com/webonyx/graphql-php/issues",
+                "source": "https://github.com/webonyx/graphql-php/tree/v15.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/webonyx-graphql-php",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-06-16T12:19:23+00:00"
         }
     ],
     "packages-dev": [
@@ -7940,5 +8013,5 @@
     "platform-overrides": {
         "php": "8.1.99"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/resources/api_doc.MD
+++ b/resources/api_doc.MD
@@ -103,3 +103,54 @@ For example, if an endpoint returns a collection of items and each item has an `
 
 For specific documentation on each endpoint, see the Swagger documentation at `/api.php/doc`.
 You may also make a request to `/api.php/doc` to get the raw Swagger JSON document if you set the `Content-Type` header to `application/json` or add `.json` to the end of the URL.
+
+## GraphQL
+
+The GLPI API is also available via a GraphQL wrapper at `/api.php/graphql`. Like all compliant GraphQL implementations, it is self documenting and accepts only POST requests.
+Since it is a wrapper around the REST API, that means that any object schema defined and available through the REST API is also available via GraphQL.
+It also means that authentication is the exact same as the rest of the API.
+The only difference is that you can access more properties in some cases via the GraphQL API.
+For example, when you request a list of cartridge models (`CartridgeItem`) via the REST API it returns the `id`, `name`, and `comment` properties for the associated printer models.
+When you request the data for cartridge models via GraphQL, it unlocks access to all the properties of the `PrinterModal` schema.
+This can reduce the number of requests that need to be made to the API in some cases.
+
+The implementation of the GraphQL does not include any mutators. It is read-only.
+
+The GraphQL API supports the same parameters as the REST API for filtering, sorting, and pagination.
+
+Example:
+```graphql
+query {
+    Ticket(limit: 1, filter: "name=ilike=test") {
+        id
+        name
+        status {
+            id
+            name
+        }
+    }
+}
+```
+
+You can explore the schemas using standard GraphQL requests like:
+```graphql
+query {
+    __schema {
+        types {
+            name
+            description
+            fields {
+                description
+                type {
+                    name
+                    description
+                }
+            }
+        }
+    }
+}
+```
+
+As is standard with GraphQL, you MUST specify each property that you want to be returned.
+
+For more information about GraphQL, see the [GraphQL documentation](https://graphql.org/learn/).

--- a/resources/api_doc.MD
+++ b/resources/api_doc.MD
@@ -106,7 +106,7 @@ You may also make a request to `/api.php/doc` to get the raw Swagger JSON docume
 
 ## GraphQL
 
-The GLPI API is also available via a GraphQL wrapper at `/api.php/graphql`. Like all compliant GraphQL implementations, it is self documenting and accepts only POST requests.
+The GLPI API is also available via a GraphQL wrapper at `/api.php/GraphQL`. Like all compliant GraphQL implementations, it is self documenting and accepts only POST requests.
 Since it is a wrapper around the REST API, that means that any object schema defined and available through the REST API is also available via GraphQL.
 It also means that authentication is the exact same as the rest of the API.
 The only difference is that you can access more properties in some cases via the GraphQL API.
@@ -150,6 +150,8 @@ query {
     }
 }
 ```
+
+Alternatively, a REST API interface is available for the raw GraphQL type declarations at `/api.php/GraphQL/Schema` using a GET request.
 
 As is standard with GraphQL, you MUST specify each property that you want to be returned.
 

--- a/src/Api/HL/Controller/AssetController.php
+++ b/src/Api/HL/Controller/AssetController.php
@@ -951,8 +951,8 @@ final class AssetController extends AbstractController
                 'schema_name' => $schema_name,
                 'itemtype' => $itemtype,
             ];
-            if ($shared_properties === []) {
-                $shared_properties = Doc\Schema::flattenProperties($schema['properties']);
+            if (empty($shared_properties)) {
+                $shared_properties = $schema['properties'];
                 // Remove array properties (complex handling may be required. No support added for now)
                 $shared_properties = array_filter($shared_properties, static function ($property) {
                     return !isset($property['type']) || $property['type'] !== Doc\Schema::TYPE_ARRAY;

--- a/src/Api/HL/Controller/GraphQLController.php
+++ b/src/Api/HL/Controller/GraphQLController.php
@@ -48,7 +48,7 @@ use Glpi\Http\Response;
 #[Route(path: '/GraphQL', priority: 1, tags: ['GraphQL'])]
 final class GraphQLController extends AbstractController
 {
-    #[Route(path: '/', methods: ['GET'], security_level: Route::SECURITY_AUTHENTICATED)]
+    #[Route(path: '/', methods: ['POST'], security_level: Route::SECURITY_AUTHENTICATED)]
     #[Doc\Route(
         description: 'GraphQL API',
     )]

--- a/src/Api/HL/Controller/GraphQLController.php
+++ b/src/Api/HL/Controller/GraphQLController.php
@@ -63,6 +63,7 @@ final class GraphQLController extends AbstractController
     )]
     public function getSchema(Request $request): Response
     {
-        return new Response(200, [], GraphQLGenerator::getSchema());
+        $graphql_generator = new GraphQLGenerator();
+        return new Response(200, [], $graphql_generator->getSchema());
     }
 }

--- a/src/Api/HL/Controller/GraphQLController.php
+++ b/src/Api/HL/Controller/GraphQLController.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Api\HL\Controller;
+
+use Glpi\Api\HL\Doc as Doc;
+use Glpi\Api\HL\GraphQL;
+use Glpi\Api\HL\GraphQLGenerator;
+use Glpi\Api\HL\Middleware\CookieAuthMiddleware;
+use Glpi\Api\HL\Route;
+use Glpi\Api\HL\Router;
+use Glpi\Http\JSONResponse;
+use Glpi\Http\Request;
+use Glpi\Http\Response;
+
+#[Route(path: '/GraphQL', priority: 1, tags: ['GraphQL'])]
+final class GraphQLController extends AbstractController
+{
+    #[Route(path: '/', methods: ['GET'], security_level: Route::SECURITY_AUTHENTICATED)]
+    #[Doc\Route(
+        description: 'GraphQL API',
+    )]
+    public function index(Request $request): Response
+    {
+        return new JSONResponse(GraphQL::processRequest($request));
+    }
+
+    #[Route(path: '/Schema', methods: ['GET'], security_level: Route::SECURITY_AUTHENTICATED)]
+    #[Doc\Route(
+        description: 'GraphQL API Schema',
+    )]
+    public function getSchema(Request $request): Response
+    {
+        return new Response(200, [], GraphQLGenerator::getSchema());
+    }
+}

--- a/src/Api/HL/GraphQL.php
+++ b/src/Api/HL/GraphQL.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Api\HL;
+
+use Glpi\Http\Request;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Utils\BuildSchema;
+
+/**
+ * GraphQL processor
+ */
+final class GraphQL
+{
+    /**
+     * Maximum depth of fields in the query that will be recognized.
+     */
+    public const MAX_QUERY_FIELD_DEPTH = 25;
+
+    public static function processRequest(Request $request): array
+    {
+        $query = (string) $request->getBody();
+        $generator = new GraphQLGenerator();
+        $schema_str = $generator->getSchema();
+        try {
+            $result = \GraphQL\GraphQL::executeQuery(
+                schema: BuildSchema::build($schema_str),
+                source: $query,
+                fieldResolver: function ($source, $args, $context, ResolveInfo $info) {
+                    $resolve_obj = true;
+                    if ($source !== null) {
+                        $resolve_obj = false;
+                    }
+                    if ($resolve_obj) {
+                        $field_selection = $info->getFieldSelection(self::MAX_QUERY_FIELD_DEPTH);
+                        $fields_requested = array_keys($info->getFieldSelection());
+                        // Get the raw Schema for the type
+                        $requested_type = $info->fieldName;
+                        $schema = OpenAPIGenerator::getComponentSchemas()[$requested_type] ?? null;
+                        if ($schema === null) {
+                            return null;
+                        }
+                        $completed_schema = self::expandSchemaFromRequestedFields($schema, $field_selection);
+
+                        foreach ($completed_schema['properties'] as $schema_field => $schema_field_data) {
+                            if (!in_array($schema_field, $fields_requested)) {
+                                unset($completed_schema['properties'][$schema_field]);
+                            }
+                        }
+
+                        if (isset($args['id'])) {
+                            $result = json_decode(Search::getOneBySchema($completed_schema, ['id' => $args['id']], [])->getBody(), true);
+                            return [$result];
+                        }
+                        return json_decode(Search::searchBySchema($completed_schema, $args)->getBody(), true);
+                    }
+
+                    return $source[$info->fieldName] ?? null;
+                }
+            );
+        } catch (\Throwable $e) {
+            return [];
+        }
+        return $result->toArray();
+    }
+
+    private static function expandSchemaFromRequestedFields(array $schema, array $fields_requested): array
+    {
+        $is_schema_array = array_key_exists('items', $schema) && !array_key_exists('properties', $schema);
+        if ($is_schema_array) {
+            $properties = $schema['items']['properties'];
+        } else {
+            $properties = $schema['properties'];
+        }
+        $field_names = array_keys($fields_requested);
+        foreach ($field_names as $field_name) {
+            // Check if any requested field is missing and then try to replace it with the full schema
+            if (!isset($properties[$field_name])) {
+                $properties = self::replacePartialObjectType($schema);
+                if ($is_schema_array) {
+                    $properties = $properties['items']['properties'];
+                } else {
+                    $properties = $properties['properties'];
+                }
+                break;
+            }
+        }
+        foreach ($properties as $schema_field => $schema_field_data) {
+            if (!in_array($schema_field, $field_names, true)) {
+                unset($properties[$schema_field]);
+            } else if (isset($fields_requested[$schema_field]) && is_array($fields_requested[$schema_field])) {
+                $properties[$schema_field] = self::expandSchemaFromRequestedFields($schema_field_data, $fields_requested[$schema_field]);
+            }
+        }
+        if ($is_schema_array) {
+            $schema['items']['properties'] = $properties;
+        } else {
+            $schema['properties'] = $properties;
+        }
+        return $schema;
+    }
+
+    private static function replacePartialObjectType(array $schema): array
+    {
+        $is_schema_array = array_key_exists('items', $schema) && !array_key_exists('properties', $schema);
+        $full_schema_name = ($is_schema_array ? $schema['items']['x-full-schema'] : $schema['x-full-schema']) ?? null;
+        if ($full_schema_name === null) {
+            return $schema;
+        }
+        $full_schema = OpenAPIGenerator::getComponentSchemas()[$full_schema_name] ?? null;
+        if ($full_schema === null) {
+            return $schema;
+        }
+
+        if ($is_schema_array) {
+            $schema['items']['properties'] = $full_schema['properties'];
+        } else {
+            $schema['properties'] = $full_schema['properties'];
+        }
+        return $schema;
+    }
+}

--- a/src/Api/HL/GraphQLGenerator.php
+++ b/src/Api/HL/GraphQLGenerator.php
@@ -78,9 +78,6 @@ final class GraphQLGenerator
         if (is_callable($type)) {
             $type = $type();
         }
-        if ($type_name === 'PrinterModel') {
-            $t = '';
-        }
         foreach ($type->getFields() as $field_name => $field) {
             $type_str .= "  $field_name: {$field->getType()}\n";
         }

--- a/src/Api/HL/GraphQLGenerator.php
+++ b/src/Api/HL/GraphQLGenerator.php
@@ -1,0 +1,191 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Api\HL;
+
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+
+final class GraphQLGenerator
+{
+    private array $types = [];
+
+    private function normalizeTypeName(string $type_name): string
+    {
+        return str_replace(array(' ', '-'), array('', '_'), $type_name);
+    }
+
+    public function getSchema()
+    {
+        $this->loadTypes();
+        $schema_str = '';
+        foreach ($this->types as $type_name => $type) {
+            $schema_str .= $this->writeType($type_name, $type);
+        }
+
+        // Write Query
+        $schema_str .= "type Query {\n";
+        foreach ($this->types as $type_name => $type) {
+            if (str_starts_with($type_name, '_')) {
+                continue;
+            }
+            $type_name = $this->normalizeTypeName($type_name);
+            $args_str = '(id: Int, filter: String, start: Int, limit: Int, sort: String, order: String)';
+
+            $schema_str .= "  {$type_name}{$args_str}: [$type_name]\n";
+        }
+        $schema_str .= "}\n";
+
+        return $schema_str;
+    }
+
+    private function writeType($type_name, ObjectType|callable $type): string
+    {
+        $type_name = $this->normalizeTypeName($type_name);
+        $type_str = "type $type_name {\n";
+        if (is_callable($type)) {
+            $type = $type();
+        }
+        if ($type_name === 'PrinterModel') {
+            $t = '';
+        }
+        foreach ($type->getFields() as $field_name => $field) {
+            $type_str .= "  $field_name: {$field->getType()}\n";
+        }
+        $type_str .= "}\n";
+        return $type_str;
+    }
+
+    private function loadTypes()
+    {
+        $component_schemas = OpenAPIGenerator::getComponentSchemas();
+        foreach ($component_schemas as $schema_name => $schema) {
+            $new_types = $this->getTypesForSchema($schema_name, $schema);
+            foreach ($new_types as $type_name => $type) {
+                $this->types[$type_name] = $type;
+            }
+        }
+    }
+
+    private function getTypesForSchema(string $schema_name, array $schema): array
+    {
+        $types = [];
+        if (in_array($schema_name, ['EntityTransferRecord'])) {
+            return [];
+        }
+        //Names cannot have spaces or dashes
+        $schema_name = self::normalizeTypeName($schema_name);
+        $types[$schema_name] = self::convertRESTSchemaToGraphQLSchema($schema_name, $schema);
+
+        // Handle "internal" types that are used for object properties
+        foreach ($schema['properties'] as $prop_name => $prop) {
+            if (isset($prop['x-full-schema'])) {
+                continue;
+            }
+            if ($prop['type'] === Doc\Schema::TYPE_OBJECT) {
+                $namespaced_type = "{$schema_name}_{$prop_name}";
+                $types['_' . $namespaced_type] = $this->convertRESTPropertyToGraphQLType($prop, $namespaced_type);
+            } else if ($prop['type'] === Doc\Schema::TYPE_ARRAY) {
+                $items = $prop['items'];
+                if ($items['type'] === Doc\Schema::TYPE_OBJECT) {
+                    $namespaced_type = "{$schema_name}_{$prop_name}";
+                    $types['_' . $namespaced_type] = $this->convertRESTPropertyToGraphQLType($items, $namespaced_type);
+                }
+            }
+        }
+        return $types;
+    }
+
+    private function convertRESTSchemaToGraphQLSchema(string $schema_name, array $schema): ObjectType
+    {
+        $fields = [];
+        foreach ($schema['properties'] as $name => $property) {
+            $fields[$name] = [
+                'type' => $this->convertRESTPropertyToGraphQLType($property, $name, $schema_name),
+                'resolve' => function () {
+                    return '';
+                }
+            ];
+        }
+        return new ObjectType([
+            'name' => $schema_name,
+            'fields' => $fields,
+        ]);
+    }
+
+    private function convertRESTPropertyToGraphQLType(array $property, ?string $name = null, string $prefix = '')
+    {
+        $type = $property['type'] ?? 'string';
+        $graphql_type = match ($type) {
+            Doc\Schema::TYPE_STRING => Type::string(),
+            Doc\Schema::TYPE_INTEGER => Type::int(),
+            Doc\Schema::TYPE_NUMBER => Type::float(),
+            Doc\Schema::TYPE_BOOLEAN => Type::boolean(),
+            default => null,
+        };
+        if ($graphql_type !== null) {
+            return $graphql_type;
+        }
+
+        // Handle array and object types
+        if ($type === Doc\Schema::TYPE_ARRAY) {
+            $items = $property['items'];
+            $graphql_type = $this->convertRESTPropertyToGraphQLType($items, $name, $prefix);
+            return Type::listOf($graphql_type);
+        }
+
+        if ($type === Doc\Schema::TYPE_OBJECT) {
+            $properties = $property['properties'];
+            $fields = [];
+            foreach ($properties as $prop_name => $prop_value) {
+                $fields[$prop_name] = [
+                    'type' => $this->convertRESTPropertyToGraphQLType($prop_value, $prop_name, $prefix),
+                    'resolve' => function () {
+                        return '';
+                    }
+                ];
+            }
+            if (isset($property['x-full-schema'])) {
+                return function () use ($property) {
+                    return $this->types[$property['x-full-schema']];
+                };
+            }
+            return new ObjectType([
+                'name' => "_{$prefix}_{$name}",
+                'fields' => $fields,
+            ]);
+        }
+    }
+}

--- a/src/Api/HL/Router.php
+++ b/src/Api/HL/Router.php
@@ -43,6 +43,7 @@ use Glpi\Api\HL\Controller\ComponentController;
 use Glpi\Api\HL\Controller\CoreController;
 use Glpi\Api\HL\Controller\CRUDControllerTrait;
 use Glpi\Api\HL\Controller\DropdownController;
+use Glpi\Api\HL\Controller\GraphQLController;
 use Glpi\Api\HL\Controller\ITILController;
 use Glpi\Api\HL\Controller\ManagementController;
 use Glpi\Api\HL\Controller\ProjectController;
@@ -165,6 +166,7 @@ EOT;
             $instance->registerController(new ManagementController());
             $instance->registerController(new ProjectController());
             $instance->registerController(new DropdownController());
+            $instance->registerController(new GraphQLController());
 
             // Register controllers from plugins
             if (isset($PLUGIN_HOOKS[Hooks::API_CONTROLLERS])) {

--- a/src/Api/HL/Search.php
+++ b/src/Api/HL/Search.php
@@ -194,7 +194,8 @@ final class Search
                 $query = $criteria;
                 // Remove join props from the select for now (complex to handle)
                 $query['SELECT'] = array_filter($query['SELECT'], static function ($select) use ($DB) {
-                    return str_contains($select, $DB::quoteName('_') . '.');
+                    $select_str = (string) $select;
+                    return str_starts_with($select_str, $DB::quoteName('_.id'));
                 });
                 //Inject a field for the schema name as the first select
                 $schema_name = $this->table_schemas[$table];

--- a/src/Api/HL/Search.php
+++ b/src/Api/HL/Search.php
@@ -83,7 +83,7 @@ final class Search
     private function getSQLFieldForProperty(string $prop_name): string
     {
         $prop = $this->flattened_properties[$prop_name];
-        $is_join = str_contains($prop_name, '.');
+        $is_join = str_contains($prop_name, '.') && array_key_exists(explode('.', $prop_name)[0], $this->joins);
         $sql_field = $prop['x-field'] ?? $prop_name;
         if (!$is_join) {
             // Only add the _. prefix if it isn't a join
@@ -530,11 +530,12 @@ final class Search
                     $join_name = '_';
 
                     if ($fkey === 'id') {
-                        $props_to_use = array_filter($this->flattened_properties, static function ($prop_params, $prop_name) {
+                        $props_to_use = array_filter($this->flattened_properties, function ($prop_params, $prop_name) {
                             $prop_field = $prop_params['x-field'] ?? $prop_name;
                             $mapped_from_other = isset($prop_params['x-mapped-from']) && $prop_params['x-mapped-from'] !== $prop_field;
                             // We aren't handling joins or mapped fields here
-                            return !str_contains($prop_name, '.') && !$mapped_from_other;
+                            $is_join = str_contains($prop_name, '.') && array_key_exists(explode('.', $prop_name)[0], $this->joins);
+                            return !$is_join && !$mapped_from_other;
                         }, ARRAY_FILTER_USE_BOTH);
                         $criteria['FROM'] = "$table AS " . $DB::quoteName('_');
                         if ($this->union_search_mode) {
@@ -592,8 +593,14 @@ final class Search
                     foreach ($it as $data) {
                         $cleaned_data = [];
                         foreach ($data as $k => $v) {
-                            if (!str_contains($k, chr(0x1F))) {
-                                $cleaned_data[$k] = $v;
+                            $is_join = str_contains($k, chr(0x1F)) && array_key_exists(explode(chr(0x1F), $k)[0], $this->joins);
+                            if (!$is_join) {
+                                if (str_contains($k, chr(0x1F))) {
+                                    $kp = explode(chr(0x1F), $k);
+                                    $cleaned_data[$kp[0]][$kp[1]] = $v;
+                                } else {
+                                    $cleaned_data[$k] = $v;
+                                }
                                 continue;
                             }
                             $cleaned_data[explode(chr(0x1F), $k)[1]] = $v;

--- a/src/Config.php
+++ b/src/Config.php
@@ -1266,6 +1266,10 @@ HTML;
             [
                 'name' => 'twig/markdown-extra',
                 'check' => 'Twig\\Extra\\Markdown\\LeagueMarkdown'
+            ],
+            [
+                'name' => 'webonyx/graphql-php',
+                'check' => 'GraphQL\\GraphQL'
             ]
         ];
         return $deps;

--- a/tests/functional/Glpi/Api/HL/Controller/GraphQLController.php
+++ b/tests/functional/Glpi/Api/HL/Controller/GraphQLController.php
@@ -1,0 +1,198 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Api\HL\Controller;
+
+use Glpi\Http\Request;
+use Glpi\OAuth\Server;
+
+class GraphQLController extends \HLAPITestCase
+{
+    public function testGraphQLListSchemas()
+    {
+        $this->login();
+
+        $request = new Request('POST', '/GraphQL', [], 'query { __schema { types { name } } }');
+        $this->api->call($request, function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->status(fn ($status) => $this->integer($status)->isEqualTo(200))
+                ->jsonContent(function ($content) {
+                    $this->array($content)->hasKey('data');
+                    $this->array($content['data'])->hasKey('__schema');
+                    $this->array($content['data']['__schema'])->hasKey('types');
+                    $this->array($content['data']['__schema']['types'])->size->isGreaterThan(150);
+                    $types = $content['data']['__schema']['types'];
+                    $some_expected = ['Computer', 'Ticket', 'User', 'PrinterModel', 'FirmwareType'];
+                    $found = [];
+                    foreach ($types as $type) {
+                        $this->array($type)->hasKey('name');
+                        $this->array($type)->notHasKey('description');
+                        $this->array($type)->notHasKey('fields');
+                        $this->string($type['name'])->isNotEmpty();
+                        if (in_array($type['name'], $some_expected, true)) {
+                            $found[] = $type['name'];
+                        }
+                    }
+                    $this->array($found)->size->isEqualTo(count($some_expected));
+                });
+        });
+
+        $request = new Request('POST', '/GraphQL', [], 'query { __schema { types { name description } } }');
+        $this->api->call($request, function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->status(fn ($status) => $this->integer($status)->isEqualTo(200))
+                ->jsonContent(function ($content) {
+                    $types = $content['data']['__schema']['types'];
+                    foreach ($types as $type) {
+                        $this->array($type)->hasKey('name');
+                        $this->array($type)->hasKey('description');
+                        $this->array($type)->notHasKey('fields');
+                    }
+                });
+        });
+
+        $request = new Request('POST', '/GraphQL', [], 'query { __schema { types { name fields { type { name } } } } }');
+        $this->api->call($request, function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->status(fn ($status) => $this->integer($status)->isEqualTo(200))
+                ->jsonContent(function ($content) {
+                    $types = $content['data']['__schema']['types'];
+                    foreach ($types as $type) {
+                        $this->array($type)->hasKey('name');
+                        $this->array($type)->notHasKey('description');
+                        $this->array($type)->hasKey('fields');
+                    }
+                });
+        });
+    }
+
+    public function testGetComputer()
+    {
+        $this->login();
+
+        $request = new Request('POST', '/GraphQL', [], 'query { Computer(id: 1) { id name } }');
+        $this->api->call($request, function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->status(fn ($status) => $this->integer($status)->isEqualTo(200))
+                ->jsonContent(function ($content) {
+                    $this->array($content)->hasKey('data');
+                    $this->array($content['data'])->hasSize(1);
+                    $this->array($content['data']['Computer'])->hasSize(1);
+                    $this->array($content['data']['Computer'][0])->hasKey('id');
+                    $this->array($content['data']['Computer'][0])->hasKey('name');
+                    $this->integer($content['data']['Computer'][0]['id'])->isEqualTo(1);
+                    $this->string($content['data']['Computer'][0]['name'])->isEqualTo('_test_pc01');
+                });
+        });
+    }
+
+    public function testGetComputers()
+    {
+        $this->login();
+
+        $request = new Request('POST', '/GraphQL', [], 'query { Computer { id name } }');
+        $this->api->call($request, function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->status(fn ($status) => $this->integer($status)->isEqualTo(200))
+                ->jsonContent(function ($content) {
+                    $this->array($content)->hasKey('data');
+                    $this->array($content['data'])->hasSize(1);
+                    $this->array($content['data']['Computer'])->size->isGreaterThan(2);
+                });
+        });
+    }
+
+    public function testGetComputersWithFilter()
+    {
+        $this->login();
+
+        $request = new Request('POST', '/GraphQL', [], 'query { Computer(filter: "name=like=\'*_test_pc*\'") { id name } }');
+        $this->api->call($request, function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->status(fn ($status) => $this->integer($status)->isEqualTo(200))
+                ->jsonContent(function ($content) {
+                    $this->array($content)->hasKey('data');
+                    $this->array($content['data'])->hasSize(1);
+                    $this->array($content['data']['Computer'])->size->isEqualTo(9);
+                });
+        });
+    }
+
+    public function testFullSchemaReplacement()
+    {
+        $this->login();
+        $this->loginWeb();
+
+        // Create some data just to ensure there is something to return
+        $printer_model = new \PrinterModel();
+        $this->integer($printer_model->add([
+            'name' => '_test_printer_model',
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true)
+        ]))->isGreaterThan(0);
+        $cartridge_item = new \CartridgeItem();
+        $this->integer($cartridge_item->add([
+            'name' => '_test_cartridge_item',
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true)
+        ]))->isGreaterThan(0);
+        $this->integer((new \CartridgeItem_PrinterModel())->add([
+            'cartridgeitems_id' => $cartridge_item->getID(),
+            'printermodels_id'  => $printer_model->getID()
+        ]))->isGreaterThan(0);
+
+        // product_number is not available this way via the REST API, but should be available here as the partial schema gets replaced by the full schema
+        $request = new Request('POST', '/GraphQL', [], 'query { CartridgeItem { id name printer_models { name product_number } } }');
+        $this->api->call($request, function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->status(fn ($status) => $this->integer($status)->isEqualTo(200))
+                ->jsonContent(function ($content) {
+                    $this->array($content)->hasKey('data');
+                    $this->array($content['data'])->hasSize(1);
+                    $this->array($content['data']['CartridgeItem'][0])->hasKey('id');
+                    $this->array($content['data']['CartridgeItem'][0])->hasKey('name');
+                    $this->array($content['data']['CartridgeItem'][0])->hasKey('printer_models');
+                    $this->array($content['data']['CartridgeItem'][0]['printer_models'])->size->isGreaterThan(0);
+                    $this->array($content['data']['CartridgeItem'][0]['printer_models'][0])->hasKey('name');
+                    $this->array($content['data']['CartridgeItem'][0]['printer_models'][0])->hasKey('product_number');
+                });
+        });
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Generic wrapper for the new API allowing access with GraphQL queries.
For when the REST API doesn't return what you want in a single response, you want less information in the response, or you just want to torture your database server.

Supports RSQL filters just like the base API.

```graphql
query {
    Ticket(limit: 1, filter: "name=ilike=test") {
        id
        name
        status {
            id
            name
        }
    }
}
```

Normally, the `product_number` property for the printer models array in the CartridgeItem type is not accessible in the REST API, only the `id` and `name`, and `comment`. However, there was a recent schema flag `x-full-schema` added which adds a pointer for the `product_models` array schema to the full type of `PrinterModel`. The GraphQL API can now recognize that the requested `product_number` property is missing, and replace the partial schema with the full one.

It also handles cases where a property is required (primary key or referenced by a mapped property) and ensures it is still fetched from the DB. The GraphQL client then removes it from the final response.

``` graphql
query {
    CartridgeItem {
        id
        name
         printer_models {
            name
            product_number
        }
    }
}
```