### PR TITLE
Make CI test fails on migration errors

### DIFF
--- a/.github/actions/test_update-from-9.5.sh
+++ b/.github/actions/test_update-from-9.5.sh
@@ -10,9 +10,9 @@ bin/console database:configure \
   --strict-configuration
 
 # Execute update
-## First run should do the migration (with no warnings).
+## First run should do the migration (with no warnings/errors).
 bin/console database:update --config-dir=./tests/config --ansi --no-interaction --allow-unstable | tee $LOG_FILE
-if [[ -n $(grep "Warning\|No migration needed." $LOG_FILE) ]];
+if [[ -n $(grep "Error\|Warning\|No migration needed." $LOG_FILE) ]];
   then echo "bin/console database:update command FAILED" && exit 1;
 fi
 ## Second run should do nothing.

--- a/.github/actions/test_update-from-older-version.sh
+++ b/.github/actions/test_update-from-older-version.sh
@@ -10,9 +10,9 @@ bin/console database:configure \
   --reconfigure --db-name=glpitest080 --db-host=db --db-user=root
 
 # Execute update
-## First run should do the migration (with no warnings).
+## First run should do the migration (with no warnings/errors).
 bin/console database:update --config-dir=./tests/config --ansi --no-interaction --allow-unstable | tee $LOG_FILE
-if [[ -n $(grep "Warning\|No migration needed." $LOG_FILE) ]];
+if [[ -n $(grep "Error\|Warning\|No migration needed." $LOG_FILE) ]];
   then echo "bin/console database:update command FAILED" && exit 1;
 fi
 ## Second run should do nothing.

--- a/install/migrations/update_0.90.1_to_0.90.5.php
+++ b/install/migrations/update_0.90.1_to_0.90.5.php
@@ -71,7 +71,7 @@ function update0901to0905()
 
    // fix https://github.com/glpi-project/glpi/issues/820
    // remove empty suppliers in tickets
-    $DB->delete("glpi_suppliers_tickets", [
+    $DB->deleteOrDie("glpi_suppliers_tickets", [
         'suppliers_id'       => 0,
         'alternative_email'  => ""
     ]);

--- a/install/migrations/update_0.90.x_to_9.1.0.php
+++ b/install/migrations/update_0.90.x_to_9.1.0.php
@@ -802,7 +802,7 @@ function update090xto910()
                           ],
                       ]);
                     if (count($iterator) == 0) {
-                         $DB->insert("glpi_displaypreferences", [
+                         $DB->insertOrDie("glpi_displaypreferences", [
                              'itemtype'  => $type,
                              'num'       => $newval,
                              'rank'      => $rank++,
@@ -814,7 +814,7 @@ function update090xto910()
         } else { // Add for default user
             $rank = 1;
             foreach ($tab as $newval) {
-                $DB->insert("glpi_displaypreferences", [
+                $DB->insertOrDie("glpi_displaypreferences", [
                     'itemtype'  => $type,
                     'num'       => $newval,
                     'rank'      => $rank++,

--- a/install/migrations/update_10.0.0_to_10.0.1.php
+++ b/install/migrations/update_10.0.0_to_10.0.1.php
@@ -79,7 +79,7 @@ function update1000to1001()
         }
     }
     foreach ($DELFROMDISPLAYPREF as $type => $tab) {
-        $DB->delete(
+        $DB->deleteOrDie(
             'glpi_displaypreferences',
             Toolbox::addslashes_deep(
                 [

--- a/install/migrations/update_10.0.1_to_10.0.2.php
+++ b/install/migrations/update_10.0.1_to_10.0.2.php
@@ -79,7 +79,7 @@ function update1001to1002()
         }
     }
     foreach ($DELFROMDISPLAYPREF as $type => $tab) {
-        $DB->delete(
+        $DB->deleteOrDie(
             'glpi_displaypreferences',
             Toolbox::addslashes_deep(
                 [

--- a/install/migrations/update_10.0.2_to_10.0.3.php
+++ b/install/migrations/update_10.0.2_to_10.0.3.php
@@ -79,7 +79,7 @@ function update1002to1003()
         }
     }
     foreach ($DELFROMDISPLAYPREF as $type => $tab) {
-        $DB->delete(
+        $DB->deleteOrDie(
             'glpi_displaypreferences',
             Toolbox::addslashes_deep(
                 [

--- a/install/migrations/update_10.0.3_to_10.0.4.php
+++ b/install/migrations/update_10.0.3_to_10.0.4.php
@@ -79,7 +79,7 @@ function update1003to1004()
         }
     }
     foreach ($DELFROMDISPLAYPREF as $type => $tab) {
-        $DB->delete(
+        $DB->deleteOrDie(
             'glpi_displaypreferences',
             Toolbox::addslashes_deep(
                 [

--- a/install/migrations/update_10.0.4_to_10.0.5.php
+++ b/install/migrations/update_10.0.4_to_10.0.5.php
@@ -79,7 +79,7 @@ function update1004to1005()
         }
     }
     foreach ($DELFROMDISPLAYPREF as $type => $tab) {
-        $DB->delete(
+        $DB->deleteOrDie(
             'glpi_displaypreferences',
             Toolbox::addslashes_deep(
                 [

--- a/install/migrations/update_10.0.5_to_10.0.6/inventory.php
+++ b/install/migrations/update_10.0.5_to_10.0.6/inventory.php
@@ -42,7 +42,7 @@ $migration->addConfig(["entities_id_default" => 0], 'inventory');
 $config = \Config::getConfigurationValues('inventory');
 if (isset($config['stale_agents_action']) && is_numeric($config['stale_agents_action'])) {
     //convert stale_agents_action to an array
-    $DB->update(
+    $DB->updateOrDie(
         'glpi_configs',
         [
             'value' => exportArrayToDB([$config['stale_agents_action']])

--- a/install/migrations/update_10.0.6_to_10.0.7/unmanageds.php
+++ b/install/migrations/update_10.0.6_to_10.0.7/unmanageds.php
@@ -48,7 +48,7 @@ if ($DB->fieldExists(\Unmanaged::getTable(), 'domains_id')) {
     ]);
     if (count($iterator)) {
         foreach ($iterator as $row) {
-            $DB->insert("glpi_domains_items", [
+            $DB->insertOrDie("glpi_domains_items", [
                 'domains_id'   => $row['domains_id'],
                 'itemtype'     => 'Unmanaged',
                 'items_id'     => $row['id']

--- a/install/migrations/update_9.2.x_to_9.3.0.php
+++ b/install/migrations/update_9.2.x_to_9.3.0.php
@@ -860,7 +860,7 @@ function update92xto930()
             'WHERE'  => ['id' => $row['items_id']]
         ]);
         if (!count($exists)) {
-            $DB->delete(
+            $DB->deleteOrDie(
                 Item_Rack::getTable(),
                 [
                     'id' => $row['id']

--- a/install/migrations/update_9.3.1_to_9.3.2.php
+++ b/install/migrations/update_9.3.1_to_9.3.2.php
@@ -61,8 +61,8 @@ function update931to932()
             'items_id' => 0,
         ],
     ];
-    $DB->delete(Item_Rack::getTable(), $corrupted_criteria);
-    $DB->delete(Item_Enclosure::getTable(), $corrupted_criteria);
+    $DB->deleteOrDie(Item_Rack::getTable(), $corrupted_criteria);
+    $DB->deleteOrDie(Item_Enclosure::getTable(), $corrupted_criteria);
     /** /Clean rack/enclosure items corrupted relations */
 
    // limit state visibility for enclosures and pdus

--- a/install/migrations/update_9.3.x_to_9.4.0.php
+++ b/install/migrations/update_9.3.x_to_9.4.0.php
@@ -126,7 +126,7 @@ function update93xto940()
     $migration->createRule($rule, $criteria, $action);
 
     if (!countElementsInTable('glpi_profilerights', ['profiles_id' => 4, 'name' => 'rule_asset'])) {
-        $DB->insert("glpi_profilerights", [
+        $DB->insertOrDie("glpi_profilerights", [
             'id'           => null,
             'profiles_id'  => "4",
             'name'         => "rule_asset",

--- a/install/migrations/update_9.4.0_to_9.4.1.php
+++ b/install/migrations/update_9.4.0_to_9.4.1.php
@@ -147,7 +147,7 @@ function update940to941()
             );
             foreach ($elements_to_fix as $data) {
                  $data['content'] = $DB->escape($fix_content_fct($data['content'], $data['items_id'], $itil_fkey));
-                 $DB->update($itil_element_table, $data, ['id' => $data['id']]);
+                 $DB->updateOrDie($itil_element_table, $data, ['id' => $data['id']]);
             }
         }
 
@@ -163,7 +163,7 @@ function update940to941()
         );
         foreach ($tasks_to_fix as $data) {
             $data['content'] = $DB->escape($fix_content_fct($data['content'], $data[$itil_fkey], $itil_fkey));
-            $DB->update($task_table, $data, ['id' => $data['id']]);
+            $DB->updateOrDie($task_table, $data, ['id' => $data['id']]);
         }
     }
     /** /Fix URL of images inside ITIL objects contents */

--- a/install/migrations/update_9.4.1_to_9.4.2.php
+++ b/install/migrations/update_9.4.1_to_9.4.2.php
@@ -124,7 +124,7 @@ function update941to942()
             );
             foreach ($elements_to_fix as $data) {
                  $data['content'] = $DB->escape($fix_content_fct($data['content'], $data['items_id'], $itil_fkey));
-                 $DB->update($itil_element_table, $data, ['id' => $data['id']]);
+                 $DB->updateOrDie($itil_element_table, $data, ['id' => $data['id']]);
             }
         }
 
@@ -140,7 +140,7 @@ function update941to942()
         );
         foreach ($tasks_to_fix as $data) {
             $data['content'] = $DB->escape($fix_content_fct($data['content'], $data[$itil_fkey], $itil_fkey));
-            $DB->update($task_table, $data, ['id' => $data['id']]);
+            $DB->updateOrDie($task_table, $data, ['id' => $data['id']]);
         }
     }
     /** /Fix URL of images inside ITIL objects contents */

--- a/install/migrations/update_9.4.2_to_9.4.3.php
+++ b/install/migrations/update_9.4.2_to_9.4.3.php
@@ -107,7 +107,7 @@ function update942to943()
             );
             foreach ($elements_to_fix as $data) {
                  $data['content'] = $DB->escape($fix_content_fct($data['content'], $data['items_id'], $itil_fkey));
-                 $DB->update($itil_element_table, $data, ['id' => $data['id']]);
+                 $DB->updateOrDie($itil_element_table, $data, ['id' => $data['id']]);
             }
         }
 
@@ -123,7 +123,7 @@ function update942to943()
         );
         foreach ($tasks_to_fix as $data) {
             $data['content'] = $DB->escape($fix_content_fct($data['content'], $data[$itil_fkey], $itil_fkey));
-            $DB->update($task_table, $data, ['id' => $data['id']]);
+            $DB->updateOrDie($task_table, $data, ['id' => $data['id']]);
         }
     }
     /** /Fix URL of images inside ITIL objects contents */

--- a/install/migrations/update_9.4.x_to_9.5.0.php
+++ b/install/migrations/update_9.4.x_to_9.5.0.php
@@ -417,7 +417,7 @@ function update94xto950()
         foreach ($elements_to_fix as $data) {
             $data['picture_front'] = $DB->escape($fix_picture_fct($data['picture_front']));
             $data['picture_rear']  = $DB->escape($fix_picture_fct($data['picture_rear']));
-            $DB->update($table, $data, ['id' => $data['id']]);
+            $DB->updateOrDie($table, $data, ['id' => $data['id']]);
         }
     }
 
@@ -432,7 +432,7 @@ function update94xto950()
     );
     foreach ($elements_to_fix as $data) {
         $data['blueprint'] = $DB->escape($fix_picture_fct($data['blueprint']));
-        $DB->update('glpi_dcrooms', $data, ['id' => $data['id']]);
+        $DB->updateOrDie('glpi_dcrooms', $data, ['id' => $data['id']]);
     }
     /** /Make datacenter pictures path relative */
 
@@ -1137,7 +1137,7 @@ function update94xto950()
                  //migrate existing data
                  $migration->migrationOneTable('glpi_domains_items');
                 foreach ($iterator as $row) {
-                    $DB->insert("glpi_domains_items", [
+                    $DB->insertOrDie("glpi_domains_items", [
                         'domains_id'   => $row['domains_id'],
                         'itemtype'     => $itemtype,
                         'items_id'     => $row['id']

--- a/install/migrations/update_9.5.3_to_9.5.4.php
+++ b/install/migrations/update_9.5.3_to_9.5.4.php
@@ -49,7 +49,7 @@ function update953to954()
     $migration->setVersion('9.5.4');
 
    /* Remove invalid Profile SO */
-    $DB->delete('glpi_displaypreferences', ['itemtype' => 'Profile', 'num' => 62]);
+    $DB->deleteOrDie('glpi_displaypreferences', ['itemtype' => 'Profile', 'num' => 62]);
    /* /Remove invalid Profile SO */
 
    /* Add is_default_profile */

--- a/install/migrations/update_9.5.x_to_10.0.0.php
+++ b/install/migrations/update_9.5.x_to_10.0.0.php
@@ -79,7 +79,7 @@ function update95xto1000()
         }
     }
     foreach ($DELFROMDISPLAYPREF as $type => $tab) {
-        $DB->delete(
+        $DB->deleteOrDie(
             'glpi_displaypreferences',
             Toolbox::addslashes_deep(
                 [

--- a/install/migrations/update_9.5.x_to_10.0.0/cache.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/cache.php
@@ -40,11 +40,11 @@
 
 $had_custom_config = false;
 if (countElementsInTable('glpi_configs', ['name' => 'cache_db', 'context' => 'core'])) {
-    $DB->delete('glpi_configs', ['name' => 'cache_db', 'context' => 'core']);
+    $DB->deleteOrDie('glpi_configs', ['name' => 'cache_db', 'context' => 'core']);
     $had_custom_config = true;
 }
 if (countElementsInTable('glpi_configs', ['name' => 'cache_trans', 'context' => 'core'])) {
-    $DB->delete('glpi_configs', ['name' => 'cache_trans', 'context' => 'core']);
+    $DB->deleteOrDie('glpi_configs', ['name' => 'cache_trans', 'context' => 'core']);
     $had_custom_config = true;
 }
 

--- a/install/migrations/update_9.5.x_to_10.0.0/knowbaseitem_knowbaseitemcategory.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/knowbaseitem_knowbaseitemcategory.php
@@ -64,7 +64,7 @@ if ($DB->fieldExists('glpi_knowbaseitems', 'knowbaseitemcategories_id')) {
     if (count($iterator)) {
        //migrate existing data
         foreach ($iterator as $row) {
-            $DB->insert("glpi_knowbaseitems_knowbaseitemcategories", [
+            $DB->insertOrDie("glpi_knowbaseitems_knowbaseitemcategories", [
                 'knowbaseitemcategories_id'   => $row['knowbaseitemcategories_id'],
                 'knowbaseitems_id'            => $row['id']
             ]);

--- a/install/migrations/update_9.5.x_to_10.0.0/native_inventory.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/native_inventory.php
@@ -531,7 +531,7 @@ if (!$DB->tableExists('glpi_printerlogs')) {
         );
         $to_preserve_result = $DB->query($to_preserve_sql->getValue())->fetch_all(MYSQLI_ASSOC);
         if (!empty($to_preserve_result)) { // If there is no entries to preserve, it means that table is empty, and nothing has to be deleted
-            $DB->delete(
+            $DB->deleteOrDie(
                 'glpi_printerlogs',
                 [
                     'NOT' => ['id' => array_column($to_preserve_result, 'id')]
@@ -611,7 +611,7 @@ if (!$DB->tableExists('glpi_networkportmetrics')) {
         );
         $to_preserve_result = $DB->query($to_preserve_sql->getValue())->fetch_all(MYSQLI_ASSOC);
         if (!empty($to_preserve_result)) { // If there is no entries to preserve, it means that table is empty, and nothing has to be deleted
-            $DB->delete(
+            $DB->deleteOrDie(
                 'glpi_networkportmetrics',
                 [
                     'NOT' => ['id' => array_column($to_preserve_result, 'id')]

--- a/install/migrations/update_9.5.x_to_10.0.0/pendingreason.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/pendingreason.php
@@ -103,9 +103,7 @@ if (empty($config['system_user'])) {
         'password'      => '',
         'authtype'      => 1,
     ];
-    if (!$DB->insert('glpi_users', $system_user_params)) {
-        die("Can't add 'glpi-system' user");
-    }
+    $DB->insertOrDie('glpi_users', $system_user_params, "Can't add 'glpi-system' user");
 
     Config::setConfigurationValues('core', ['system_user' => $DB->insertId()]);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Make CI test fails on migration errors
See https://github.com/cedric-anne/glpi/actions/runs/5486306414/jobs/9996236529 for a failure example (I forced execution of a broken query).

2. In migrations, replace `DBmysql::insert()`, `DBmysql::update()` and `DBmysql::delete()` usages by `DBmysql::insertOrDie()`, `DBmysql::updateOrDie()` and `DBmysql::deleteOrDie()`. Most of other DB operations are using a `XXXorDie()` method.