### PR TITLE
Fix LDAP `use_bind` option label

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -487,7 +487,7 @@ class AuthLDAP extends CommonDBTM
             echo "</td></tr>";
 
             echo "<tr class='tab_bg_1'><td><label for='use_bind'>";
-            echo __('Use simple bind') . "</label>&nbsp;";
+            echo __('Use bind') . "</label>&nbsp;";
             Html::showToolTip(__("Indicates whether a simple bind operation should be used during connection to LDAP server. Disabling this behaviour can be required when LDAPS bind is used."));
             echo "</td>";
             echo "<td colspan='3'>";

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -487,8 +487,8 @@ class AuthLDAP extends CommonDBTM
             echo "</td></tr>";
 
             echo "<tr class='tab_bg_1'><td><label for='use_bind'>";
-            echo __('Use Bind (for non-anonymous binds)') . "</label>&nbsp;";
-            Html::showToolTip(__("Allow to use RootDN and Password for non-anonymous binds."));
+            echo __('Use simple bind') . "</label>&nbsp;";
+            Html::showToolTip(__("Indicates whether a simple bind operation should be used during connection to LDAP server. Disabling this behaviour can be required when LDAPS bind is used."));
             echo "</td>";
             echo "<td colspan='3'>";
             $rand_use_bind = mt_rand();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

As far as I understand, the `ldap_bind()` operation is mandatory unless the `LDAPS bind` method is used (using a `tls_certfile`/`tls_keyfile`). Since #10186, the label/helper of the `use_bind` option indicates that it could be used `for non-anonymous binds`, but in fact, this option must also be active when anonymous bind has to be done.

See https://github.com/glpi-project/glpi/blob/b5c8cc574e6094643c4cd8c543e24d3fd36b3283/src/AuthLDAP.php#L3134-L3140