### PR TITLE
Filter reservable itemtype dropdowns

### DIFF
--- a/tests/functional/Reservation.php
+++ b/tests/functional/Reservation.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use DbTestCase;
+
+class Reservation extends DbTestCase
+{
+    public function testGetReservableItemtypes(): void
+    {
+        // No reservable items
+        $this->array(\Reservation::getReservableItemtypes())->isEqualTo([]);
+
+        $root = getItemByTypeName("Entity", "_test_root_entity", true);
+
+        // Enable reservation on a computer
+        $computer = $this->createItem("Computer", [
+            "name"        => "test",
+            "entities_id" => $root,
+        ]);
+        $this->createItem("ReservationItem", [
+            "itemtype"    => "Computer",
+            "items_id"    => $computer->getID(),
+            "is_active"   => true,
+            "entities_id" => $root,
+        ]);
+        $this->array(\Reservation::getReservableItemtypes())->isEqualTo(["Computer"]);
+    }
+}


### PR DESCRIPTION
Small improvement to reservations; do not show itemtypes that have no valid reservable items.

![image](https://github.com/glpi-project/glpi/assets/42734840/acb9c9d9-b55e-4c52-a3d5-93144118b122)

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28083
