### PR TITLE
fix(core): use non sensitive case to find user

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -565,7 +565,7 @@ class User extends CommonDBTM
             'WHERE' =>
                 [
                     'RAW' => [
-                        'LOWER(' . UserEmail::getTable() . '.email' . ')'  => strtolower($email)
+                        'LOWER(' . UserEmail::getTable() . '.email' . ')'  => Toolbox::strtolower($email)
                     ]
                 ]
              + $condition

--- a/src/User.php
+++ b/src/User.php
@@ -562,7 +562,13 @@ class User extends CommonDBTM
                     ]
                 ]
             ],
-            'WHERE' => [UserEmail::getTable() . '.email' => $email] + $condition
+            'WHERE' =>
+                [
+                    'RAW' => [
+                        'LOWER(' . UserEmail::getTable() . '.email' . ')'  => strtolower($email)
+                    ]
+                ]
+             + $condition
         ];
 
         $data = iterator_to_array($DB->request($query));


### PR DESCRIPTION
To avoid misunderstandings and data entry errors,
 I suggest modifying the function to find users by their email address by performing a search using lower case letters.


From RFC 5321, section 2.3.11:

    The standard mailbox naming convention is defined to be "local-part@domain"; contemporary usage permits a much broader set of applications than simple "user names". Consequently, and due to a long history of problems when intermediate hosts have attempted to optimize transport by modifying them, the local-part MUST be interpreted and assigned semantics only by the host specified in the domain part of the address.

So yes, the part before the "@" could be case-sensitive, since it is entirely under the control of the host system. In practice though, no widely used mail systems distinguish different addresses based on case.

see : https://stackoverflow.com/questions/9807909/are-email-addresses-case-sensitive


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28716
