### PR TITLE
Deprecate `DBmysql::truncate()` and `DBmysql::truncateOrDie()` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,8 @@ The present file will list all changes made to the project; according to the
 - `CommonITILValidation::alreadyExists()`
 - `CommonITILValidation::getTicketStatusNumber()`
 - `Config::validatePassword()`
+- `DBmysql::truncate()`
+- `DBmysql::truncateOrDie()`
 - `Glpi\Application\View\Extension::getVerbatimValue()`
 - `Glpi\Event::showList()`
 - `Glpi\Features\DCBreadcrumb::getDcBreadcrumb()`

--- a/src/Console/Migration/AppliancesPluginToCoreCommand.php
+++ b/src/Console/Migration/AppliancesPluginToCoreCommand.php
@@ -229,7 +229,7 @@ class AppliancesPluginToCoreCommand extends AbstractCommand
         ];
 
         foreach ($core_tables as $table) {
-            $result = $this->db->doQuery('TRUNCATE ' . $this->db->quoteName($table));
+            $result = $this->db->delete($table, [1]);
 
             if (!$result) {
                 throw new \Symfony\Component\Console\Exception\RuntimeException(

--- a/src/Console/Migration/RacksPluginToCoreCommand.php
+++ b/src/Console/Migration/RacksPluginToCoreCommand.php
@@ -404,7 +404,7 @@ class RacksPluginToCoreCommand extends AbstractCommand
         ];
 
         foreach ($core_tables as $table) {
-            $result = $this->db->doQuery('TRUNCATE ' . $this->db->quoteName($table));
+            $result = $this->db->delete($table, [1]);
 
             if (!$result) {
                 throw new \Symfony\Component\Console\Exception\RuntimeException(

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -1664,12 +1664,15 @@ class DBmysql
      *
      * @since 10.0.0
      *
-     * @param string $table  Table name
+     * @param string $table Table name
      *
      * @return mysqli_result|boolean Query result handler
+     *
+     * @deprecated 10.1.0
      */
     public function truncate($table)
     {
+        Toolbox::deprecated();
         // Use delete to prevent table corruption on some MySQL operations
         // (i.e. when using mysqldump without `--single-transaction` option)
         return $this->delete($table, [1]);
@@ -1685,26 +1688,13 @@ class DBmysql
      * @param string $message Explanation of query (default '')
      *
      * @return mysqli_result|boolean Query result handler
+     *
+     * @deprecated 10.1.0
      */
     public function truncateOrDie($table, $message = '')
     {
-        $table_name = $this::quoteName($table);
-        $res = $this->doQuery("TRUNCATE $table_name");
-        if (!$res) {
-           //TRANS: %1$s is the description, %2$s is the query, %3$s is the error message
-            $message = sprintf(
-                __('%1$s - Error during the database query: %2$s - Error is %3$s'),
-                $message,
-                "TRUNCATE $table",
-                $this->error()
-            );
-            if (isCommandLine()) {
-                 throw new \RuntimeException($message);
-            }
-            echo $message . "\n";
-            die(1);
-        }
-        return $res;
+        Toolbox::deprecated();
+        return $this->deleteOrDie($table, [1], $message);
     }
 
     /**

--- a/src/NotImportedEmail.php
+++ b/src/NotImportedEmail.php
@@ -218,7 +218,7 @@ class NotImportedEmail extends CommonDBTM
     {
         global $DB;
 
-        $DB->truncate('glpi_notimportedemails');
+        $DB->delete('glpi_notimportedemails', [1]);
     }
 
 

--- a/tests/functional/Profile_User.php
+++ b/tests/functional/Profile_User.php
@@ -88,7 +88,7 @@ class Profile_User extends DbTestCase
         $entity2  = getItemByTypeName(\Entity::class, '_test_child_1');
 
         // Create items
-        $DB->truncate(\Log::getTable());
+        $DB->delete(\Log::getTable(), [1]);
 
         $input1 = [
             'users_id'     => $user->getId(),
@@ -253,7 +253,7 @@ class Profile_User extends DbTestCase
         }
 
         // Delete items
-        $DB->truncate(\Log::getTable());
+        $DB->delete(\Log::getTable(), [1]);
 
         $profile_user = new \Profile_User();
         $this->boolean($profile_user->deleteByCriteria($input1))->isTrue();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes

`truncate()` and `truncateOrDie()` are inconsistent, the first rely on a `delete()` the second performs a real SQL `TRUNCATE`. 
Behaviour is not the same (truncate resets autoincrement while delete does not).

This has been changed in #10853; but I cannot find the main reason, expect a bug from a plugin.

In any case, if a delete is needed, we should not call a method named truncate. Maybe the `truncateOrDie()` method should be removed aswell. 
This way, we do not allow any `TRUNCATE` SQL in GLPI nor its plugins. SQL `TRUNCATE` are issued in plugins migration commands and tests only in GLPI core (so this does not seems a problem to use `delete()` instead).