### PR TITLE
Add `GLPI_ENVIRONMENT_TYPE` constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ The present file will list all changes made to the project; according to the
 - Usage of `DBmysql::query()` method is prohibited to ensure that legacy unsafe DB are no more executed. To execute DB queries,
   either `DBmysql::request()` can be used to craft query using the GLPI query builder,
   either `DBmysql::doQuery()` can be used for safe queries to execute DB query using a self-crafted a SQL string.
+- `Html::generateMenuSession()` `$force` argument has been removed.
 - `QueryExpression` class moved to `Glpi\DBAL` namespace.
 - `QueryParam` class moved to `Glpi\DBAL` namespace.
 - `QuerySubQuery` class moved to `Glpi\DBAL` namespace.

--- a/front/css.php
+++ b/front/css.php
@@ -61,7 +61,9 @@ $css = Html::compileScss($_GET);
 
 header('Content-Type: text/css');
 
-$is_cacheable = !isset($_GET['debug']) && !isset($_GET['nocache']);
+$is_cacheable = !isset($_GET['nocache'])
+    && GLPI_ENVIRONMENT_TYPE !== GLPI::ENV_DEVELOPMENT // do not use browser cache on development env
+;
 if ($is_cacheable) {
    // Makes CSS cacheable by browsers and proxies
     $max_age = WEEK_TIMESTAMP;

--- a/front/locale.php
+++ b/front/locale.php
@@ -44,13 +44,14 @@ session_write_close(); // Unlocks session to permit concurrent calls
 
 header("Content-Type: application/json; charset=UTF-8");
 
-$is_cacheable = !isset($_GET['debug']);
+$is_cacheable = GLPI_ENVIRONMENT_TYPE !== GLPI::ENV_DEVELOPMENT; // do not use browser cache on development env
 if (!Update::isDbUpToDate()) {
    // Make sure to not cache if in the middle of a GLPI update
     $is_cacheable = false;
 }
 if ($is_cacheable) {
-   // Makes CSS cacheable by browsers and proxies
+    // Makes CSS cacheable by browsers and proxies,
+    // unless when we are in the middle of a GLPI update.
     $max_age = WEEK_TIMESTAMP;
     header_remove('Pragma');
     header('Cache-Control: public');

--- a/inc/based_config.php
+++ b/inc/based_config.php
@@ -173,6 +173,20 @@ if (!isCommandLine()) {
         }
     }
 
+    // GLPI environment, possible values are: `production`, `staging`, `testing`, `development`.
+    $allowed_envs = ['production', 'staging', 'testing', 'development'];
+    if (!defined('GLPI_ENVIRONMENT_TYPE')) {
+        define('GLPI_ENVIRONMENT_TYPE', 'production');
+    } elseif (!in_array(GLPI_ENVIRONMENT_TYPE, $allowed_envs)) {
+        throw new \UnexpectedValueException(
+            sprintf(
+                'Invalid GLPI_ENVIRONMENT_TYPE constant value `%s`. Allowed values are: `%s`',
+                GLPI_ENVIRONMENT_TYPE,
+                implode('`, `', $allowed_envs)
+            )
+        );
+    }
+
    // Where to load plugins.
    // Order in this array is important (priority to first found).
     if (!defined('PLUGINS_DIRECTORIES')) {

--- a/src/Application/View/Extension/FrontEndAssetsExtension.php
+++ b/src/Application/View/Extension/FrontEndAssetsExtension.php
@@ -200,7 +200,6 @@ JAVASCRIPT;
                 '/front/locale.php'
                 . '?domain=' . $locale_domain
                 . '&v=' . FrontEnd::getVersionCacheKey($locale_version)
-                . ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE ? '&debug' : '')
             );
             $script .= <<<JAVASCRIPT
             $(function() {

--- a/src/Application/View/TemplateRenderer.php
+++ b/src/Application/View/TemplateRenderer.php
@@ -35,6 +35,7 @@
 
 namespace Glpi\Application\View;
 
+use GLPI;
 use Glpi\Application\ErrorHandler;
 use Glpi\Application\View\Extension\ConfigExtension;
 use Glpi\Application\View\Extension\DataHelpersExtension;
@@ -81,7 +82,7 @@ class TemplateRenderer
 
         $env_params = [
             'debug'       => $_SESSION['glpi_use_mode'] ?? null === Session::DEBUG_MODE,
-            'auto_reload' => true, // Force refresh
+            'auto_reload' => GLPI_ENVIRONMENT_TYPE === GLPI::ENV_DEVELOPMENT,
         ];
 
         $tpl_cachedir = $cachedir . '/templates';

--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -37,6 +37,7 @@ namespace Glpi\Dashboard;
 
 use DateInterval;
 use Dropdown;
+use GLPI;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Plugin\Hooks;
 use Html;
@@ -266,11 +267,6 @@ HTML;
             for ($x = 0; $x < $this->grid_cols; $x++) {
                 $add_controls .= "<div class='cell-add' data-x='$x' data-y='$y'>&nbsp;</div>";
             }
-        }
-
-        // Force clear the cards cache in debug mode
-        if ($_SESSION['glpi_use_mode'] === Session::DEBUG_MODE) {
-            $GLPI_CACHE->delete(self::getAllDashboardCardsCacheKey());
         }
 
         // prepare all available cards
@@ -911,7 +907,7 @@ HTML;
             $card = $cards[$card_id];
 
             $use_cache = !$force
-                && $_SESSION['glpi_use_mode'] != Session::DEBUG_MODE
+                && GLPI_ENVIRONMENT_TYPE !== GLPI::ENV_DEVELOPMENT
                 && (!isset($card['cache']) || $card['cache'] == true);
             $cache_age = 40;
 
@@ -1360,7 +1356,11 @@ HTML;
                     'content' => __("Toggle edit mode to edit content"),
                 ]
             ];
-            $GLPI_CACHE->set(self::getAllDashboardCardsCacheKey(), $cards);
+
+            if (GLPI_ENVIRONMENT_TYPE !== GLPI::ENV_DEVELOPMENT) {
+                // Do not cache dashboard cards on `development` envs
+                $GLPI_CACHE->set(self::getAllDashboardCardsCacheKey(), $cards);
+            }
         }
 
         $more_cards = Plugin::doHookFunction(Hooks::DASHBOARD_CARDS);

--- a/src/GLPI.php
+++ b/src/GLPI.php
@@ -44,6 +44,11 @@ use Psr\Log\LogLevel;
  **/
 class GLPI
 {
+    public const ENV_PRODUCTION  = 'production';
+    public const ENV_STAGING     = 'staging';
+    public const ENV_TESTING     = 'testing';
+    public const ENV_DEVELOPMENT = 'development';
+
     private $error_handler;
     private $log_level;
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -1370,16 +1370,15 @@ HTML;
      *
      * @since  9.2
      *
-     * @param  boolean $force do we need to force regeneration of $_SESSION['glpimenu']
-     * @return array          the menu array
+     * @return array the menu array
      */
-    public static function generateMenuSession($force = false)
+    public static function generateMenuSession()
     {
         global $PLUGIN_HOOKS;
         $menu = [];
 
         if (
-            $force
+            GLPI_ENVIRONMENT_TYPE === GLPI::ENV_DEVELOPMENT
             || !isset($_SESSION['glpimenu'])
             || !is_array($_SESSION['glpimenu'])
             || (count($_SESSION['glpimenu']) == 0)
@@ -1645,7 +1644,7 @@ HTML;
 
         $tmp_active_item = explode("/", $item);
         $active_item     = array_pop($tmp_active_item);
-        $menu            = self::generateMenuSession($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE);
+        $menu            = self::generateMenuSession();
         $menu_active     = $menu[$sector]['content'][$active_item]['title'] ?? "";
 
         $menu = Plugin::doHookFunction("redefine_menus", $menu);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -39,6 +39,8 @@ use Glpi\Cache\SimpleCache;
 use Glpi\Socket;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
+define('GLPI_ENVIRONMENT_TYPE', 'development');
+
 ini_set('display_errors', 'On');
 error_reporting(E_ALL);
 

--- a/tests/router.php
+++ b/tests/router.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+define('GLPI_ENVIRONMENT_TYPE', 'development');
+
 define('GLPI_CONFIG_DIR', __DIR__ . '/config');
 define('GLPI_VAR_DIR', __DIR__ . '/files');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15109 

Purpose of this new `GLPI_ENVIRONMENT_TYPE` constant is to be able to adapt some code behaviours.

To enhance performances, following operations will be done only on `development` envs:
 - auto reload of twig templates on each rendering (implies an additional file access to detect whether the template changed);
 - menu regeneration on each request.

To improve responsiveness to changes during development, following behaviours will be disabled specifically on `development` envs (it was previously done on `debug` mode):
 - `front/css.php` response cache headers will not be sent to browser;
 - `front/locales.php` response cache headers will not be sent to browser;
 - dashboard cards will not be cached on server side.

Each commit can be reviewed independently.

More changes will probably done in a near future.