### PR TITLE
fix(export): preserve line breaks for 'old' HTML format

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -7480,7 +7480,11 @@ JAVASCRIPT;
 
                             $plaintext = '';
                             if (isset($so['htmltext']) && $so['htmltext']) {
-                                $plaintext = RichText::getTextFromHtml($data[$ID][$k]['name'], false, true, $html_output, false, true);
+                                if ($html_output) {
+                                    $plaintext = RichText::getTextFromHtml($data[$ID][$k]['name'], false, true, $html_output);
+                                } else {
+                                    $plaintext = RichText::getTextFromHtml($data[$ID][$k]['name'], true, true, $html_output);
+                                }
                             } else {
                                 $plaintext = nl2br($data[$ID][$k]['name']);
                             }


### PR DESCRIPTION
in addition to
https://github.com/glpi-project/glpi/pull/15054

old HTML format 

```
&lt;p&gt;Bonjour&lt;/p&gt;&lt;p&gt;Suite aux tests Firefox 90 esr 32 bits, j'ai mis à jour mon poste avec Firefox 64 bits&lt;/p&gt;&lt;p&gt;Cordialement&lt;/p&gt;
```

is not handle correctly when performing a CSV export (also on a line)

This PR fix this.

Previous PR that adds ```preserve_line_breaks``` option can be kept


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
