### PR TITLE
Fix LDAP authentication when `use_bind` is false

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -3128,7 +3128,7 @@ class AuthLDAP extends CommonDBTM
         }
 
         if (!$use_bind) {
-            return true;
+            return $ds;
         }
 
         if ($login != '') {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Regression introduced in GLPI 10.0.8 by https://github.com/glpi-project/glpi/pull/14561/files#diff-a2b8bab26c2a6fc2656bb8a9a4a03e5e9690fe475a326288d952bc4bd17c1547R3126-R3128