### PR TITLE
Fix access check to caldav debug UI

### DIFF
--- a/src/CalDAV/Plugin/Browser.php
+++ b/src/CalDAV/Plugin/Browser.php
@@ -35,6 +35,7 @@
 
 namespace Glpi\CalDAV\Plugin;
 
+use Config;
 use Glpi\CalDAV\Traits\CalDAVUriUtilTrait;
 use Sabre\DAV\Browser\Plugin;
 use Sabre\HTTP\RequestInterface;
@@ -71,8 +72,6 @@ class Browser extends Plugin
             return false;
         }
 
-        $user = $this->getPrincipalItemFromUri($authPlugin->getCurrentPrincipal());
-
-        return $user instanceof \User && \Session::DEBUG_MODE == $user->fields['use_mode'];
+        return Config::canUpdate();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Access to caldav debug UI was checking the `use_mode` of the connected user (connected using basic auth). It mean that this debug UI was accessible only if user had the debug mode active on its latest GLPI session, and this condition was not explained anywhere.

As user is connected, instead of checking his `use_mode` in database, we can directly check that he is able to access the debug mode (possible when he has the `config::UPDATE` right.