### PR TITLE
fix(purge): better check

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -887,7 +887,7 @@ class CommonDBTM extends CommonGLPI
                 foreach ($fields as $field) {
                     if (is_array($field)) {
                         // Relation based on 'itemtype'/'items_id' (polymorphic relationship)
-                        if ($itemtype instanceof IPAddress && in_array('mainitemtype', $field) && in_array('mainitems_id', $field)) {
+                        if (is_a($itemtype, IPAddress::class, true) && in_array('mainitemtype', $field) && in_array('mainitems_id', $field)) {
                             // glpi_ipaddresses relationship that does not respect naming conventions
                             $itemtype_field = 'mainitemtype';
                             $items_id_field = 'mainitems_id';


### PR DESCRIPTION
despite of
https://github.com/glpi-project/glpi/pull/15032

another problem (the same as before) appeared  with

https://github.com/glpi-project/glpi/pull/15032/commits/80eb0cad7faf97a64119427aa5760310c2f0255d

```$itemtype``` is just a 'string' here, and check with ```ìnstanceof``` return ```false```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
