### PR TITLE
Fix issue with phpCAS 1.3.6-1 debian package

### DIFF
--- a/front/logout.php
+++ b/front/logout.php
@@ -54,8 +54,14 @@ if (
     && $_SESSION["glpiauthtype"] == Auth::CAS
     && Toolbox::canUseCAS()
 ) {
-    if (version_compare(phpCAS::getVersion(), '1.6.0', '<')) {
-        // Prior to version 1.6.0, 5th argument was `$changeSessionID`.
+    // Adapt phpCAS::client() signature.
+    // A new signature has been introduced in 1.6.0 version of the official package.
+    // This new signature has been backported in the `1.3.6-1` version of the debian package,
+    // so we have to check for method argument counts too.
+    $has_service_base_url_arg = version_compare(phpCAS::getVersion(), '1.6.0', '>=')
+        || count((new ReflectionMethod(phpCAS::class, 'client'))->getParameters()) > 6;
+    if (!$has_service_base_url_arg) {
+        // Prior to version 1.6.0, `$service_base_url` argument was not present, and 5th argument was `$changeSessionID`.
         phpCAS::client(
             constant($CFG_GLPI["cas_version"]),
             $CFG_GLPI["cas_host"],
@@ -64,7 +70,8 @@ if (
             false
         );
     } else {
-        // Starting from version 1.6.0, 5th argument is `$service_base_url`.
+        // Starting from version 1.6.0, `$service_base_url` argument was added at 5th position, and `$changeSessionID`
+        // was moved at 6th position.
         phpCAS::client(
             constant($CFG_GLPI["cas_version"]),
             $CFG_GLPI["cas_host"],

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,6 +13,7 @@ parameters:
     ignoreErrors:
         - '/Call to static method \w+\(\) on an unknown class phpCAS/'
         - '/Class Ldap\\Connection not found/'
+        - '/Class phpCAS not found/'
         - '/Instantiated class (DB|DBSlave) not found/'
         - '/Instantiated class XHProfRuns_Default not found/'
         - '/\w+ has been replaced by \w+/'

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -520,8 +520,14 @@ class Auth extends CommonGLPI
                     return false;
                 }
 
-                if (version_compare(phpCAS::getVersion(), '1.6.0', '<')) {
-                    // Prior to version 1.6.0, 5th argument was `$changeSessionID`.
+                // Adapt phpCAS::client() signature.
+                // A new signature has been introduced in 1.6.0 version of the official package.
+                // This new signature has been backported in the `1.3.6-1` version of the debian package,
+                // so we have to check for method argument counts too.
+                $has_service_base_url_arg = version_compare(phpCAS::getVersion(), '1.6.0', '>=')
+                    || count((new ReflectionMethod(phpCAS::class, 'client'))->getParameters()) > 6;
+                if (!$has_service_base_url_arg) {
+                    // Prior to version 1.6.0, `$service_base_url` argument was not present, and 5th argument was `$changeSessionID`.
                     phpCAS::client(
                         constant($CFG_GLPI["cas_version"]),
                         $CFG_GLPI["cas_host"],
@@ -530,7 +536,8 @@ class Auth extends CommonGLPI
                         false
                     );
                 } else {
-                    // Starting from version 1.6.0, 5th argument is `$service_base_url`.
+                    // Starting from version 1.6.0, `$service_base_url` argument was added at 5th position, and `$changeSessionID`
+                    // was moved at 6th position.
                     phpCAS::client(
                         constant($CFG_GLPI["cas_version"]),
                         $CFG_GLPI["cas_host"],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28776

`phpCAS::client()` signature changed in 1.6.0 version of `phpCAS`, in order to fix a security issue. Unfortunatelly, this signature change has been backported in the `1.3.6-1` version of the debian package, and checking only the version `phpCAS` to adpat the code is not anymore sufficient.

With proposed change, we will use the new signature if `phpCAS` version is >= 1.6.0 or if the `phpCAS::client()` method has more than 6 arguments.

Counting arguments will make this code work for all existing versions. On first version (0.7.0), there was only 5 arguments, then  starting on 1.3.0 version, there was 6 arguments. I guess that future versions will not drop existing arguments.

Anyway, this problem will be solved in GLPI 10.1 as the library has been embed in GLPI and only one signature has to be used.