### PR TITLE
Fix `ram` field migration when value is >= 2^32

### DIFF
--- a/install/migrations/update_10.0.7_to_10.0.8/ram_field.php
+++ b/install/migrations/update_10.0.7_to_10.0.8/ram_field.php
@@ -48,11 +48,6 @@ foreach (['glpi_computervirtualmachines', 'glpi_networkequipments'] as $table) {
     );
     $migration->migrationOneTable($table);
 
-    $DB->updateOrDie(
-        $table,
-        ['ram' => null],
-        ['ram' => '']
-    );
     $iterator = $DB->request([
         'FROM'  => $table,
         'WHERE' => [
@@ -66,6 +61,19 @@ foreach (['glpi_computervirtualmachines', 'glpi_networkequipments'] as $table) {
             ['id'  => $row['id']]
         );
     }
+    $DB->updateOrDie(
+        $table,
+        ['ram' => null],
+        [
+            'OR' => [
+                'ram' => '',
+                // We expect the `ram` value to be expressed in MiB, so if the value exceeds the maximum value of the field,
+                // it is probably invalid, since it corresponds to more than 4096 TiB of RAM.
+                // Setting value to null will prevent a `Out of range value for column 'ram'` SQL error.
+                new QueryExpression(sprintf('CAST(%s AS UNSIGNED) >= POW(2, 32)', 'ram')),
+            ],
+        ]
+    );
     $migration->changeField(
         $table,
         'ram',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | see #15202 
