### PR TITLE
Adapt error output to environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,8 @@ The present file will list all changes made to the project; according to the
 - Usage of `CommonITILValidation::dropdownValidator()` with the `name` and `users_id_validate` options are no longer supported. Use `prefix` and `itemtype_target`/`items_id_target` respectively instead.
 - Namespaced plugins files must be placed in a subdirectory of the plugin `src` directory that corresponds to the second part of the plugin namespace (e.g. `src/Myplugin/` for a plugin called `myplugin`).
 - The `helper` property of form fields will not support anymore the presence of HTML code.
+- `Glpi\Application\ErrorHandler` constructor visibility has been changed to private.
+- `GLPI::initErrorHandler()` does not return any value anymore.
 
 #### Deprecated
 - Usage of `MAIL_SMTPSSL` and `MAIL_SMTPTLS` constants.
@@ -262,6 +264,7 @@ The present file will list all changes made to the project; according to the
 - `DropdownTranslation::canBeTranslated()`. Translations are now always active.
 - `DropdownTranslation::isDropdownTranslationActive()`. Translations are now always active.
 - `Entity::getDefaultContractValues()`
+- `GLPI::getErrorHandler()`
 - `GLPI::getLogLevel()`
 - `Glpi\Api\API::returnSanitizedContent()`
 - `Glpi\Dashboard\Filter::dates()`

--- a/ajax/dashboard.php
+++ b/ajax/dashboard.php
@@ -33,6 +33,9 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\ErrorHandler;
+use Glpi\Dashboard\Grid;
+
 /**
  * @var string|null $SECURITY_STRATEGY
  */
@@ -41,8 +44,6 @@ global $SECURITY_STRATEGY;
 $SECURITY_STRATEGY = 'no_check'; // specific checks done later to allow anonymous access to embed dashboards
 
 include('../inc/includes.php');
-
-use Glpi\Dashboard\Grid;
 
 if (!isset($_REQUEST["action"])) {
     exit;
@@ -229,9 +230,7 @@ switch ($_REQUEST['action']) {
             } catch (\Throwable $e) {
                 // Send exception to logger without actually exiting.
                 // Use quiet mode to not break JSON result.
-                /** @var \GLPI $GLPI */
-                global $GLPI;
-                $GLPI->getErrorHandler()->handleException($e, true);
+                ErrorHandler::getInstance()->handleException($e, true);
             }
         }
         \Glpi\Debug\Profiler::getInstance()->stop('Get cards HTML');

--- a/api.php
+++ b/api.php
@@ -62,6 +62,9 @@ $GLPI = new GLPI();
 $GLPI->initLogger();
 $GLPI->initErrorHandler();
 
+// Ensure errors will not break API output.
+ErrorHandler::getInstance()->disableOutput();
+
 //init cache
 $cache_manager = new CacheManager();
 $GLPI_CACHE = $cache_manager->getCoreCacheInstance();

--- a/apirest.php
+++ b/apirest.php
@@ -38,6 +38,7 @@
  */
 
 use Glpi\Cache\CacheManager;
+use Glpi\Application\ErrorHandler;
 
 /**
  * @var GLPI $GLPI
@@ -54,6 +55,9 @@ include_once(GLPI_ROOT . "/inc/based_config.php");
 $GLPI = new GLPI();
 $GLPI->initLogger();
 $GLPI->initErrorHandler();
+
+// Ensure errors will not break API output.
+ErrorHandler::getInstance()->disableOutput();
 
 //init cache
 $cache_manager = new CacheManager();

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -36,8 +36,9 @@
 // Needed for signal handler to handle SIGTERM in CLI mode
 declare(ticks=1);
 
-use Glpi\DBAL\QueryExpression;
+use Glpi\Application\ErrorHandler;
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
 use Glpi\Event;
 
@@ -872,9 +873,7 @@ class CronTask extends CommonDBTM
                             try {
                                   $retcode = $function($crontask);
                             } catch (\Throwable $e) {
-                                /** @var \GLPI $GLPI */
-                                global $GLPI;
-                                $GLPI->getErrorHandler()->handleException($e);
+                                ErrorHandler::getInstance()->handleException($e);
                                 Toolbox::logInFile(
                                     'cron',
                                     sprintf(

--- a/src/GLPI.php
+++ b/src/GLPI.php
@@ -57,13 +57,13 @@ class GLPI
 
     /**
      * Testing environment.
-     * Suitable for quality control and internal acceptance tests.
+     * Suitable for CI runners, quality control and internal acceptance tests.
      */
     public const ENV_TESTING     = 'testing';
 
     /**
      * Development environment.
-     * Suitable for developer machines and servers and CI tests runners.
+     * Suitable for developer machines and development servers.
      */
     public const ENV_DEVELOPMENT = 'development';
 
@@ -127,23 +127,10 @@ class GLPI
     /**
      * Init and register error handler.
      *
-     * @return ErrorHandler
+     * @return void
      */
-    public function initErrorHandler()
+    public function initErrorHandler(): void
     {
-        $this->error_handler = ErrorHandler::getInstance();
-        $this->error_handler->register();
-
-        return $this->error_handler;
-    }
-
-    /**
-     * Get registered error handler.
-     *
-     * @return null|ErrorHandler
-     */
-    public function getErrorHandler()
-    {
-        return $this->error_handler;
+        ErrorHandler::getInstance()->register();
     }
 }

--- a/src/Glpi/Console/Application.php
+++ b/src/Glpi/Console/Application.php
@@ -214,7 +214,7 @@ class Application extends BaseApplication
         global $CFG_GLPI;
 
         $this->output = $output;
-        $this->error_handler->setOutputHandler($output);
+        ErrorHandler::getInstance()->setOutputHandler($output);
 
         parent::configureIO($input, $output);
 
@@ -320,7 +320,7 @@ class Application extends BaseApplication
         global $GLPI;
         $GLPI = new GLPI();
         $GLPI->initLogger();
-        $this->error_handler = $GLPI->initErrorHandler();
+        $GLPI->initErrorHandler();
     }
 
     /**

--- a/src/Glpi/ContentTemplates/TemplateManager.php
+++ b/src/Glpi/ContentTemplates/TemplateManager.php
@@ -36,6 +36,7 @@
 namespace Glpi\ContentTemplates;
 
 use CommonITILObject;
+use Glpi\Application\ErrorHandler;
 use Glpi\RichText\RichText;
 use Twig\Environment;
 use Twig\Extension\SandboxExtension;
@@ -115,9 +116,7 @@ class TemplateManager
                 ]
             );
         } catch (\Twig\Error\Error $e) {
-            /** @var \GLPI $GLPI */
-            global $GLPI;
-            $GLPI->getErrorHandler()->handleException($e);
+            ErrorHandler::getInstance()->handleException($e);
             return null;
         }
         return $html;

--- a/src/Glpi/Dashboard/Grid.php
+++ b/src/Glpi/Dashboard/Grid.php
@@ -39,6 +39,7 @@ use Config;
 use DateInterval;
 use Dropdown;
 use GLPI;
+use Glpi\Application\ErrorHandler;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Debug\Profiler;
 use Glpi\Plugin\Hooks;
@@ -1029,9 +1030,7 @@ HTML;
         } catch (\Throwable $e) {
             $html = $render_error_html;
             // Log the error message without exiting
-            /** @var \GLPI $GLPI */
-            global $GLPI;
-            $GLPI->getErrorHandler()->handleException($e, true);
+            ErrorHandler::getInstance()->handleException($e, true);
         }
         Profiler::getInstance()->stop(__METHOD__ . ' get card data');
 

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -490,9 +490,8 @@ class MailCollector extends CommonDBTM
     {
         /**
          * @var array $CFG_GLPI
-         * @var \GLPI $GLPI
          */
-        global $CFG_GLPI, $GLPI;
+        global $CFG_GLPI;
 
         if ($this->getFromDB($mailgateID)) {
             $this->uid          = -1;
@@ -578,7 +577,7 @@ class MailCollector extends CommonDBTM
 
                         $messages[$message_id] = $message;
                     } catch (\Throwable $e) {
-                        $GLPI->getErrorHandler()->handleException($e);
+                        ErrorHandler::getInstance()->handleException($e);
                         Toolbox::logInFile(
                             'mailgate',
                             sprintf(
@@ -626,7 +625,7 @@ class MailCollector extends CommonDBTM
                         }
                     } catch (\Throwable $e) {
                         $error++;
-                        $GLPI->getErrorHandler()->handleException($e);
+                        ErrorHandler::getInstance()->handleException($e);
                         Toolbox::logInFile(
                             'mailgate',
                             sprintf(

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -522,14 +522,6 @@ class Toolbox
         if (isset($log_in_files)) {
             $CFG_GLPI['use_log_in_files'] = $log_in_files;
         }
-
-       // If debug mode activated : display some information
-        if ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE) {
-           // Force reporting of all errors
-            error_reporting(E_ALL);
-           // Disable native error displaying as it will be done by custom handler
-            ini_set('display_errors', 'Off');
-        }
     }
 
 

--- a/tests/GLPITestCase.php
+++ b/tests/GLPITestCase.php
@@ -158,6 +158,26 @@ class GLPITestCase extends atoum
         return $method->invoke($instance, ...$args);
     }
 
+    /**
+     * Call a private constructor, and get the created instance.
+     *
+     * @param string    $classname  Class to instanciate
+     * @param mixed     $arg        Constructor arguments
+     *
+     * @return mixed
+     */
+    protected function callPrivateConstructor($classname, $args)
+    {
+        $class = new ReflectionClass($classname);
+        $instance = $class->newInstanceWithoutConstructor();
+
+        $constructor = $class->getConstructor();
+        $constructor->setAccessible(true);
+        $constructor->invokeArgs($instance, $args);
+
+        return $instance;
+    }
+
     protected function resetSession()
     {
         Session::destroy();

--- a/tests/units/Glpi/Application/ErrorHandler.php
+++ b/tests/units/Glpi/Application/ErrorHandler.php
@@ -35,71 +35,85 @@
 
 namespace tests\units\Glpi\Application;
 
+use GLPI;
 use Monolog\Handler\TestHandler;
 use Monolog\Level;
+use Session;
 
 class ErrorHandler extends \GLPITestCase
 {
     /**
      * @return array
      */
-    protected function errorProvider(): array
+    protected function errorProvider(): iterable
     {
-
         $log_prefix = '/';
         $log_suffix = '.*' . preg_quote(' in ' . __FILE__ . ' at line ', '/') . '\d+' . '/i';
 
-        $data = [
-            [
-                'error_call'           => function () {
-                    file_get_contents('this-file-does-not-exists');
-                },
-                'expected_log_level'   => Level::Warning,
-                'expected_msg_pattern' => $log_prefix
-               . preg_quote('PHP Warning (' . E_WARNING . '): file_get_contents(this-file-does-not-exists): failed to open stream: No such file or directory', '/')
-               . $log_suffix,
-            ],
-            [
-                'error_call'           => function () {
-                    trigger_error('this is a warning', E_USER_WARNING);
-                },
-                'expected_log_level'   => Level::Warning,
-                'expected_msg_pattern' => $log_prefix
-               . preg_quote('PHP User Warning (' . E_USER_WARNING . '): this is a warning', '/')
-               . $log_suffix,
-            ],
-            [
-                'error_call'           => function () {
-                    trigger_error('some notice', E_USER_NOTICE);
-                },
-                'expected_log_level'   => Level::Notice,
-                'expected_msg_pattern' => $log_prefix
-               . preg_quote('PHP User Notice (' . E_USER_NOTICE . '): some notice', '/')
-               . $log_suffix,
-            ],
-            [
-                'error_call'           => function () {
-                    trigger_error('this method is deprecated', E_USER_DEPRECATED);
-                },
-                'expected_log_level'   => Level::Notice,
-                'expected_msg_pattern' => $log_prefix
-               . preg_quote('PHP User deprecated function (' . E_USER_DEPRECATED . '): this method is deprecated', '/')
-               . $log_suffix,
-            ],
-        ];
+        foreach ([Session::NORMAL_MODE, Session::DEBUG_MODE] as $session_mode) {
+            foreach ([GLPI::ENV_DEVELOPMENT, GLPI::ENV_TESTING, GLPI::ENV_STAGING, GLPI::ENV_PRODUCTION] as $env) {
+                yield [
+                    'session_mode'         => $session_mode,
+                    'env'                  => $env,
+                    'error_call'           => function () {
+                        file_get_contents('this-file-does-not-exists');
+                    },
+                    'expected_log_level'   => Level::Warning,
+                    'expected_msg_pattern' => $log_prefix
+                        . preg_quote('PHP Warning (' . E_WARNING . '): file_get_contents(this-file-does-not-exists): failed to open stream: No such file or directory', '/')
+                        . $log_suffix,
+                ];
 
-        $data[] = [
-            'error_call'           => function () {
-                $param = new \ReflectionParameter([\Config::class, 'getTypeName'], 0);
-                $param->isCallable();
-            },
-            'expected_log_level'   => Level::Notice,
-            'expected_msg_pattern' => $log_prefix
-           . preg_quote('PHP Deprecated function (' . E_DEPRECATED . '): Method ReflectionParameter::isCallable() is deprecated', '/')
-           . $log_suffix,
-        ];
+                yield [
+                    'session_mode'         => $session_mode,
+                    'env'                  => $env,
+                    'error_call'           => function () {
+                        trigger_error('this is a warning', E_USER_WARNING);
+                    },
+                    'expected_log_level'   => Level::Warning,
+                    'expected_msg_pattern' => $log_prefix
+                        . preg_quote('PHP User Warning (' . E_USER_WARNING . '): this is a warning', '/')
+                        . $log_suffix,
+                ];
 
-        return $data;
+                yield [
+                    'session_mode'         => $session_mode,
+                    'env'                  => $env,
+                    'error_call'           => function () {
+                        trigger_error('some notice', E_USER_NOTICE);
+                    },
+                    'expected_log_level'   => Level::Notice,
+                    'expected_msg_pattern' => $log_prefix
+                        . preg_quote('PHP User Notice (' . E_USER_NOTICE . '): some notice', '/')
+                        . $log_suffix,
+                ];
+
+                yield [
+                    'session_mode'         => $session_mode,
+                    'env'                  => $env,
+                    'error_call'           => function () {
+                        trigger_error('this method is deprecated', E_USER_DEPRECATED);
+                    },
+                    'expected_log_level'   => Level::Info,
+                    'expected_msg_pattern' => $log_prefix
+                        . preg_quote('PHP User deprecated function (' . E_USER_DEPRECATED . '): this method is deprecated', '/')
+                        . $log_suffix,
+                ];
+
+                yield [
+                    'session_mode'         => $session_mode,
+                    'env'                  => $env,
+                    'error_call'           => function () {
+                        $param = new \ReflectionParameter([\Config::class, 'getTypeName'], 0);
+                        $param->isCallable();
+                    },
+                    'expected_log_level'   => Level::Info,
+                    'expected_msg_pattern' => $log_prefix
+                        . preg_quote('PHP Deprecated function (' . E_DEPRECATED . '): Method ReflectionParameter::isCallable() is deprecated', '/')
+                        . $log_suffix,
+                ];
+            }
+        }
     }
 
     /**
@@ -111,6 +125,8 @@ class ErrorHandler extends \GLPITestCase
      * @dataProvider errorProvider
      */
     public function testRegisteredErrorHandler(
+        int $session_mode,
+        string $env,
         callable $error_call,
         Level $expected_log_level,
         string $expected_msg_pattern
@@ -118,119 +134,176 @@ class ErrorHandler extends \GLPITestCase
         $handler = new TestHandler();
         $logger = $this->newMockInstance('Monolog\\Logger', null, null, ['test-logger', [$handler]]);
 
-       // Force session in debug mode (to get debug output)
         $previous_use_mode         = $_SESSION['glpi_use_mode'];
-        $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
 
-        $this->newTestedInstance($logger);
-        $this->testedInstance->setForwardToInternalHandler(false);
-        $this->testedInstance->register();
+        $error_handler = $this->callPrivateConstructor(
+            \Glpi\Application\ErrorHandler::class,
+            [$logger, $env]
+        );
+        $error_handler->setForwardToInternalHandler(false);
+        $error_handler->register();
 
-       // Assert that nothing is logged when using '@' operator
-        $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
+        // Assert that nothing is logged when using '@' operator
+        $_SESSION['glpi_use_mode'] = $session_mode;
         @$error_call();
         $_SESSION['glpi_use_mode'] = $previous_use_mode;
         $this->integer(count($handler->getRecords()))->isEqualTo(0);
         $this->output->isEmpty();
 
-       // Assert that error handler acts as expected when not using '@' operator
-        $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
+        // Assert that error handler acts as expected when not using '@' operator
+        $_SESSION['glpi_use_mode'] = $session_mode;
         $error_call();
         $_SESSION['glpi_use_mode'] = $previous_use_mode;
-
         $this->integer(count($handler->getRecords()))->isEqualTo(1);
         $this->boolean($handler->hasRecordThatMatches($expected_msg_pattern, $expected_log_level));
-
-        $this->output->matches($expected_msg_pattern);
+        if (
+            $env === GLPI::ENV_DEVELOPMENT
+            || (
+                $session_mode === Session::DEBUG_MODE
+                && ($expected_log_level->isHigherThan(Level::Info)  || !in_array($env, [GLPI::ENV_STAGING, GLPI::ENV_PRODUCTION]))
+            )
+        ) {
+            $this->output->matches($expected_msg_pattern);
+        } else {
+            $this->output->isEmpty();
+        }
     }
 
-    /**
-     * @return array
-     */
-    protected function handleErrorProvider(): array
+    protected function handleErrorProvider(): iterable
     {
 
         $log_prefix = '/';
         $log_suffix = ' \(\d+\): .*' . preg_quote(' in ' . __FILE__ . ' at line ', '/') . '\d+' . '/';
 
-        return [
-            [
-                'error_code'           => E_ERROR,
-                'expected_log_level'   => Level::Critical,
-                'expected_msg_pattern' => $log_prefix . 'PHP Error' . $log_suffix,
-                'is_fatal_error'       => true,
-            ],
-            [
-                'error_code'           => E_WARNING,
-                'expected_log_level'   => Level::Warning,
-                'expected_msg_pattern' => $log_prefix . 'PHP Warning' . $log_suffix,
-            ],
-            [
-                'error_code'           => E_PARSE,
-                'expected_log_level'   => Level::Alert,
-                'expected_msg_pattern' => $log_prefix . 'PHP Parsing Error' . $log_suffix,
-                'is_fatal_error'       => true,
-            ],
-            [
-                'error_code'           => E_NOTICE,
-                'expected_log_level'   => Level::Notice,
-                'expected_msg_pattern' => $log_prefix . 'PHP Notice' . $log_suffix,
-            ],
-            [
-                'error_code'           => E_CORE_ERROR,
-                'expected_log_level'   => Level::Critical,
-                'expected_msg_pattern' => $log_prefix . 'PHP Core Error' . $log_suffix,
-                'is_fatal_error'       => true,
-            ],
-            [
-                'error_code'           => E_CORE_WARNING,
-                'expected_log_level'   => Level::Warning,
-                'expected_msg_pattern' => $log_prefix . 'PHP Core Warning' . $log_suffix,
-            ],
-            [
-                'error_code'           => E_COMPILE_ERROR,
-                'expected_log_level'   => Level::Alert,
-                'expected_msg_pattern' => $log_prefix . 'PHP Compile Error' . $log_suffix,
-                'is_fatal_error'       => true,
-            ],
-            [
-                'error_code'           => E_COMPILE_WARNING,
-                'expected_log_level'   => Level::Warning,
-                'expected_msg_pattern' => $log_prefix . 'PHP Compile Warning' . $log_suffix,
-            ],
-            [
-                'error_code'           => E_USER_ERROR,
-                'expected_log_level'   => Level::Error,
-                'expected_msg_pattern' => $log_prefix . 'PHP User Error' . $log_suffix,
-                'is_fatal_error'       => true,
-            ],
-            [
-                'error_code'           => E_USER_WARNING,
-                'expected_log_level'   => Level::Warning,
-                'expected_msg_pattern' => $log_prefix . 'PHP User Warning' . $log_suffix,
-            ],
-            [
-                'error_code'           => E_USER_NOTICE,
-                'expected_log_level'   => Level::Notice,
-                'expected_msg_pattern' => $log_prefix . 'PHP User Notice' . $log_suffix,
-            ],
-            [
-                'error_code'           => E_RECOVERABLE_ERROR,
-                'expected_log_level'   => Level::Error,
-                'expected_msg_pattern' => $log_prefix . 'PHP Catchable Fatal Error' . $log_suffix,
-                'is_fatal_error'       => true,
-            ],
-            [
-                'error_code'           => E_DEPRECATED,
-                'expected_log_level'   => Level::Notice,
-                'expected_msg_pattern' => $log_prefix . 'PHP Deprecated function' . $log_suffix,
-            ],
-            [
-                'error_code'           => E_USER_DEPRECATED,
-                'expected_log_level'   => Level::Notice,
-                'expected_msg_pattern' => $log_prefix . 'PHP User deprecated function' . $log_suffix,
-            ],
-        ];
+        foreach ([Session::NORMAL_MODE, Session::DEBUG_MODE] as $session_mode) {
+            foreach ([GLPI::ENV_DEVELOPMENT, GLPI::ENV_TESTING, GLPI::ENV_STAGING, GLPI::ENV_PRODUCTION] as $env) {
+                yield [
+                    'session_mode'         => $session_mode,
+                    'env'                  => $env,
+                    'error_code'           => E_ERROR,
+                    'expected_log_level'   => Level::Critical,
+                    'expected_msg_pattern' => $log_prefix . 'PHP Error' . $log_suffix,
+                    'is_fatal_error'       => true,
+                ];
+
+                yield [
+                    'session_mode'         => $session_mode,
+                    'env'                  => $env,
+                    'error_code'           => E_WARNING,
+                    'expected_log_level'   => Level::Warning,
+                    'expected_msg_pattern' => $log_prefix . 'PHP Warning' . $log_suffix,
+                    'is_fatal_error'       => false,
+                ];
+
+                yield [
+                    'session_mode'         => $session_mode,
+                    'env'                  => $env,
+                    'error_code'           => E_PARSE,
+                    'expected_log_level'   => Level::Alert,
+                    'expected_msg_pattern' => $log_prefix . 'PHP Parsing Error' . $log_suffix,
+                    'is_fatal_error'       => true,
+                ];
+
+                yield [
+                    'session_mode'         => $session_mode,
+                    'env'                  => $env,
+                    'error_code'           => E_NOTICE,
+                    'expected_log_level'   => Level::Notice,
+                    'expected_msg_pattern' => $log_prefix . 'PHP Notice' . $log_suffix,
+                    'is_fatal_error'       => false,
+                ];
+
+                yield [
+                    'session_mode'         => $session_mode,
+                    'env'                  => $env,
+                    'error_code'           => E_CORE_ERROR,
+                    'expected_log_level'   => Level::Critical,
+                    'expected_msg_pattern' => $log_prefix . 'PHP Core Error' . $log_suffix,
+                    'is_fatal_error'       => true,
+                ];
+
+                yield [
+                    'session_mode'         => $session_mode,
+                    'env'                  => $env,
+                    'error_code'           => E_CORE_WARNING,
+                    'expected_log_level'   => Level::Warning,
+                    'expected_msg_pattern' => $log_prefix . 'PHP Core Warning' . $log_suffix,
+                    'is_fatal_error'       => false,
+                ];
+
+                yield [
+                    'session_mode'         => $session_mode,
+                    'env'                  => $env,
+                    'error_code'           => E_COMPILE_ERROR,
+                    'expected_log_level'   => Level::Alert,
+                    'expected_msg_pattern' => $log_prefix . 'PHP Compile Error' . $log_suffix,
+                    'is_fatal_error'       => true,
+                ];
+
+                yield [
+                    'session_mode'         => $session_mode,
+                    'env'                  => $env,
+                    'error_code'           => E_COMPILE_WARNING,
+                    'expected_log_level'   => Level::Warning,
+                    'expected_msg_pattern' => $log_prefix . 'PHP Compile Warning' . $log_suffix,
+                    'is_fatal_error'       => false,
+                ];
+
+                yield [
+                    'session_mode'         => $session_mode,
+                    'env'                  => $env,
+                    'error_code'           => E_USER_ERROR,
+                    'expected_log_level'   => Level::Error,
+                    'expected_msg_pattern' => $log_prefix . 'PHP User Error' . $log_suffix,
+                    'is_fatal_error'       => true,
+                ];
+
+                yield [
+                    'session_mode'         => $session_mode,
+                    'env'                  => $env,
+                    'error_code'           => E_USER_WARNING,
+                    'expected_log_level'   => Level::Warning,
+                    'expected_msg_pattern' => $log_prefix . 'PHP User Warning' . $log_suffix,
+                    'is_fatal_error'       => false,
+                ];
+
+                yield [
+                    'session_mode'         => $session_mode,
+                    'env'                  => $env,
+                    'error_code'           => E_USER_NOTICE,
+                    'expected_log_level'   => Level::Notice,
+                    'expected_msg_pattern' => $log_prefix . 'PHP User Notice' . $log_suffix,
+                    'is_fatal_error'       => false,
+                ];
+
+                yield [
+                    'session_mode'         => $session_mode,
+                    'env'                  => $env,
+                    'error_code'           => E_RECOVERABLE_ERROR,
+                    'expected_log_level'   => Level::Error,
+                    'expected_msg_pattern' => $log_prefix . 'PHP Catchable Fatal Error' . $log_suffix,
+                    'is_fatal_error'       => true,
+                ];
+
+                yield [
+                    'session_mode'         => $session_mode,
+                    'env'                  => $env,
+                    'error_code'           => E_DEPRECATED,
+                    'expected_log_level'   => Level::Info,
+                    'expected_msg_pattern' => $log_prefix . 'PHP Deprecated function' . $log_suffix,
+                    'is_fatal_error'       => false,
+                ];
+
+                yield [
+                    'session_mode'         => $session_mode,
+                    'env'                  => $env,
+                    'error_code'           => E_USER_DEPRECATED,
+                    'expected_log_level'   => Level::Info,
+                    'expected_msg_pattern' => $log_prefix . 'PHP User deprecated function' . $log_suffix,
+                    'is_fatal_error'       => false,
+                ];
+            }
+        }
     }
 
     /**
@@ -239,37 +312,40 @@ class ErrorHandler extends \GLPITestCase
      * @dataProvider handleErrorProvider
      */
     public function testHandleErrorAndHandleFatalError(
+        int $session_mode,
+        string $env,
         int $error_code,
         Level $expected_log_level,
         string $expected_msg_pattern,
-        bool $is_fatal_error = false
+        bool $is_fatal_error
     ) {
         $handler = new TestHandler();
         $logger = $this->newMockInstance('Monolog\\Logger', null, null, ['test-logger', [$handler]]);
 
-       // Force session in debug mode (to get debug output)
         $previous_use_mode         = $_SESSION['glpi_use_mode'];
-        $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
 
-        $this->newTestedInstance($logger);
-        $this->testedInstance->setForwardToInternalHandler(false);
+        $error_handler = $this->callPrivateConstructor(
+            \Glpi\Application\ErrorHandler::class,
+            [$logger, $env]
+        );
+        $error_handler->setForwardToInternalHandler(false);
 
-       // Assert that nothing is logged when using '@' operator
-        $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
-        @$this->testedInstance->handleError($error_code, 'err_msg', __FILE__, __LINE__);
+        // Assert that nothing is logged when using '@' operator
+        $_SESSION['glpi_use_mode'] = $session_mode;
+        @$error_handler->handleError($error_code, 'err_msg', __FILE__, __LINE__);
         $_SESSION['glpi_use_mode'] = $previous_use_mode;
         $this->integer(count($handler->getRecords()))->isEqualTo(0);
         $this->output->isEmpty();
 
-       // Assert that error handler acts as expected when not using '@' operator
-       // Fatal error are not logged by function, but other errors should be
-        $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
-        $this->testedInstance->handleError($error_code, 'err_msg', __FILE__, __LINE__);
+        // Assert that error handler acts as expected when not using '@' operator
+        // Fatal error are not logged by function, but other errors should be
+        $_SESSION['glpi_use_mode'] = $session_mode;
+        $error_handler->handleError($error_code, 'err_msg', __FILE__, __LINE__);
         $_SESSION['glpi_use_mode'] = $previous_use_mode;
 
         if ($is_fatal_error) {
-           // If error is a Fatal error, message logging should be delegated to
-           // the 'handleFatalError' method which will be used as shutdown function.
+            // If error is a Fatal error, message logging should be delegated to
+            // the 'handleFatalError' method which will be used as shutdown function.
             $this->integer(count($handler->getRecords()))->isEqualTo(0);
 
             $this->function->error_get_last = [
@@ -278,15 +354,25 @@ class ErrorHandler extends \GLPITestCase
                 'file'    => __FILE__,
                 'line'    => __LINE__,
             ];
-            $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
-            $this->testedInstance->handleFatalError();
+            $_SESSION['glpi_use_mode'] = $session_mode;
+            $error_handler->handleFatalError();
             $_SESSION['glpi_use_mode'] = $previous_use_mode;
         }
 
         $this->integer(count($handler->getRecords()))->isEqualTo(1);
         $this->boolean($handler->hasRecordThatMatches($expected_msg_pattern, $expected_log_level));
 
-        $this->output->matches($expected_msg_pattern);
+        if (
+            $env === GLPI::ENV_DEVELOPMENT
+            || (
+                $session_mode === Session::DEBUG_MODE
+                && ($expected_log_level->isHigherThan(Level::Info)  || !in_array($env, [GLPI::ENV_STAGING, GLPI::ENV_PRODUCTION]))
+            )
+        ) {
+            $this->output->matches($expected_msg_pattern);
+        } else {
+            $this->output->isEmpty();
+        }
     }
 
     /**
@@ -294,47 +380,61 @@ class ErrorHandler extends \GLPITestCase
      */
     public function testHandleException()
     {
-        $handler = new TestHandler();
-        $logger = $this->newMockInstance('Monolog\\Logger', null, null, ['test-logger', [$handler]]);
-
         $exception = new \RuntimeException('Something went wrong');
         $expected_msg_pattern = '/'
          . preg_quote('Uncaught Exception RuntimeException: Something went wrong in ' . __FILE__ . ' at line ', '/')
          . '\d+'
          . '/';
 
-       // Force session in debug mode (to get debug output)
         $previous_use_mode         = $_SESSION['glpi_use_mode'];
-        $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
-        $this->newTestedInstance($logger);
 
-       // Assert that exception handler logs exception and output error when quiet parameter is not set
-        $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
-        $this->testedInstance->handleException($exception);
-        $_SESSION['glpi_use_mode'] = $previous_use_mode;
+        foreach ([Session::NORMAL_MODE, Session::DEBUG_MODE] as $session_mode) {
+            foreach ([GLPI::ENV_DEVELOPMENT, GLPI::ENV_TESTING, GLPI::ENV_STAGING, GLPI::ENV_PRODUCTION] as $env) {
+                $handler = new TestHandler();
+                $logger = $this->newMockInstance('Monolog\\Logger', null, null, ['test-logger', [$handler]]);
 
-        $this->integer(count($handler->getRecords()))->isEqualTo(1);
-        $this->boolean($handler->hasRecordThatMatches($expected_msg_pattern, Level::Critical));
-        $this->output->matches($expected_msg_pattern);
-        $handler->reset(); // Remove records
+                $error_handler = $this->callPrivateConstructor(
+                    \Glpi\Application\ErrorHandler::class,
+                    [$logger, $env]
+                );
 
-       // Assert that exception handler logs exception and DO NOT output error when parameter mode is set to true
-        $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
-        $this->testedInstance->handleException($exception, true);
-        $_SESSION['glpi_use_mode'] = $previous_use_mode;
+                // Assert that exception handler logs exception and output error when quiet parameter is not set
+                $_SESSION['glpi_use_mode'] = $session_mode;
+                $error_handler->handleException($exception);
+                $_SESSION['glpi_use_mode'] = $previous_use_mode;
 
-        $this->integer(count($handler->getRecords()))->isEqualTo(1);
-        $this->boolean($handler->hasRecordThatMatches($expected_msg_pattern, Level::Critical));
-        $this->output->isEmpty();
-        $handler->reset(); // Remove records
+                $this->integer(count($handler->getRecords()))->isEqualTo(1);
+                $this->boolean($handler->hasRecordThatMatches($expected_msg_pattern, Level::Critical));
+                if ($env === GLPI::ENV_DEVELOPMENT || $session_mode === Session::DEBUG_MODE) {
+                    $this->output->matches($expected_msg_pattern);
+                } else {
+                    $this->output->isEmpty();
+                }
+                $handler->reset(); // Remove records
 
-       // Assert that exception handler logs exception and output error when parameter mode is set to false
-        $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
-        $this->testedInstance->handleException($exception, false);
-        $_SESSION['glpi_use_mode'] = $previous_use_mode;
+                // Assert that exception handler logs exception and DO NOT output error when parameter mode is set to true
+                $_SESSION['glpi_use_mode'] = $session_mode;
+                $error_handler->handleException($exception, true);
+                $_SESSION['glpi_use_mode'] = $previous_use_mode;
 
-        $this->integer(count($handler->getRecords()))->isEqualTo(1);
-        $this->boolean($handler->hasRecordThatMatches($expected_msg_pattern, Level::Critical));
-        $this->output->matches($expected_msg_pattern);
+                $this->integer(count($handler->getRecords()))->isEqualTo(1);
+                $this->boolean($handler->hasRecordThatMatches($expected_msg_pattern, Level::Critical));
+                $this->output->isEmpty();
+                $handler->reset(); // Remove records
+
+                // Assert that exception handler logs exception and output error when parameter mode is set to false
+                $_SESSION['glpi_use_mode'] = $session_mode;
+                $error_handler->handleException($exception, false);
+                $_SESSION['glpi_use_mode'] = $previous_use_mode;
+
+                $this->integer(count($handler->getRecords()))->isEqualTo(1);
+                $this->boolean($handler->hasRecordThatMatches($expected_msg_pattern, Level::Critical));
+                if ($env === GLPI::ENV_DEVELOPMENT || $session_mode === Session::DEBUG_MODE) {
+                    $this->output->matches($expected_msg_pattern);
+                } else {
+                    $this->output->isEmpty();
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | see #15109 

1) On `development` environment, error messages will now be output even when debug mode is not active. Purpose of this change is to ensure that developer see these errors, even when he has not the debug mode active (when using CLI, API, simplified interface, ...).

2) On `production` environment, debug and info messages will no longer be output in debug mode. These messages are not meant to be used by end users. For instance, it will prevent end users to consider usage of deprecated function/methods as bugs.