### PR TITLE
Try fixing battery wear level display from device model form

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -922,7 +922,7 @@ class Html
             $out = <<<HTML
             <div class="progress" style="height: 16px" id="{$id}">
                <div class="progress-bar progress-bar-striped bg-info" role="progressbar"
-                     style="width: 0%;"
+                     style="width: 0%; overflow: visible"
                      aria-valuenow="0"
                      aria-valuemin="0" aria-valuemax="100"
                      id="{$id}_text">

--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -965,6 +965,7 @@ class Item_Devices extends CommonDBRelation
             $peer = null;
         }
 
+        $iterator = $DB->request($criteria);
         // Will be loaded only if/when data is needed from the device model
         $device_type = static::getDeviceType();
         /** @var CommonDevice $device */

--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -966,9 +966,9 @@ class Item_Devices extends CommonDBRelation
         }
 
         // Will be loaded only if/when data is needed from the device model
+        $device_type = static::getDeviceType();
         /** @var CommonDevice $device */
-        $device = new (static::getDeviceType());
-        $iterator = $DB->request($criteria);
+        $device = new $device_type();
         foreach ($iterator as $link) {
             Session::addToNavigateListItems(static::getType(), $link["id"]);
             $this->getFromDB($link['id']);

--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -1042,7 +1042,6 @@ class Item_Devices extends CommonDBRelation
                                     $device->getFromDB($link[$device::getForeignKeyField()]);
                                 }
 
-                                // Let percent be 100 by default so the label is visible when there is missing data
                                 $percent = 100;
                                 $message = sprintf(__('%1$s (%2$s%%) '), Html::formatNumber($this->fields[$field], false, 0), __('Unknown'));
                                 if ($device->fields[$attributs['max']] > 0) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15099

When looking at batteries from the DeviceBattery form on the Items tab, it was trying to get the capacity from the asset rather than the device so nothing was showing and a warning was thrown. From the asset form, it was displaying correctly.

This PR fixes it by always using the device rather than the peer (the opposite of whichever type you are looking at). It also makes the available information visible when the individual battery has a capacity set but the battery model does not. Finally, it improves the display of progress bars in general by allowing the text to overflow since it is set on the inner part of the progress bar. This resulted in text being cut off or invisible when the percent is too low.