### PR TITLE
[HLAPI] Object type partials

### DIFF
--- a/src/Api/HL/Controller/AbstractController.php
+++ b/src/Api/HL/Controller/AbstractController.php
@@ -106,12 +106,12 @@ abstract class AbstractController
      * @param string|null $field
      * @return array
      */
-    protected static function getDropdownTypeSchema(string $class, ?string $field = null, string $name_field = 'name'): array
+    protected static function getDropdownTypeSchema(string $class, ?string $field = null, string $name_field = 'name', ?string $full_schema = null): array
     {
         if ($field === null) {
             $field = $class::getForeignKeyField();
         }
-        return [
+        $schema = [
             'type' => Doc\Schema::TYPE_OBJECT,
             'x-field' => $field,
             'x-join' => [
@@ -128,6 +128,10 @@ abstract class AbstractController
                 $name_field => ['type' => Doc\Schema::TYPE_STRING],
             ]
         ];
+        if ($full_schema !== null) {
+            $schema['x-full-schema'] = $full_schema;
+        }
+        return $schema;
     }
 
     /**

--- a/src/Api/HL/Controller/AbstractController.php
+++ b/src/Api/HL/Controller/AbstractController.php
@@ -102,9 +102,11 @@ abstract class AbstractController
     }
 
     /**
-     * @param class-string<CommonDBTM> $class
-     * @param string|null $field
-     * @return array
+     * @param class-string<CommonDBTM> $class The class this schema represents. Used in the SQL join.
+     * @param string|null $field The SQL field to use as a reference in the SQL join.
+     * @param string $name_field The field that contains the name
+     * @param string|null $full_schema The name of the schema that represents the full object
+     * @return array The schema
      */
     protected static function getDropdownTypeSchema(string $class, ?string $field = null, string $name_field = 'name', ?string $full_schema = null): array
     {

--- a/src/Api/HL/Controller/AdministrationController.php
+++ b/src/Api/HL/Controller/AdministrationController.php
@@ -98,6 +98,7 @@ final class AdministrationController extends AbstractController
                         'description' => 'Email addresses',
                         'items' => [
                             'type' => Doc\Schema::TYPE_OBJECT,
+                            'x-full-schema' => 'EmailAddress',
                             'x-join' => [
                                 'table' => 'glpi_useremails',
                                 'fkey' => 'id',
@@ -187,6 +188,7 @@ final class AdministrationController extends AbstractController
                     'parent' => [
                         'type' => Doc\Schema::TYPE_OBJECT,
                         'x-itemtype' => Group::class,
+                        'x-full-schema' => 'Group',
                         'x-join' => [
                             'table' => 'glpi_groups',
                             'fkey' => 'groups_id',
@@ -235,6 +237,7 @@ final class AdministrationController extends AbstractController
                     'parent' => [
                         'type' => Doc\Schema::TYPE_OBJECT,
                         'x-itemtype' => Entity::class,
+                        'x-full-schema' => 'Entity',
                         'x-join' => [
                             'table' => 'glpi_entities',
                             'fkey' => 'entities_id',

--- a/src/Api/HL/Controller/AssetController.php
+++ b/src/Api/HL/Controller/AssetController.php
@@ -45,6 +45,8 @@ use Glpi\Api\HL\Search;
 use Glpi\Http\JSONResponse;
 use Glpi\Http\Request;
 use Glpi\Http\Response;
+use Glpi\Socket;
+use Glpi\SocketModel;
 use Group;
 use Location;
 use Manufacturer;
@@ -93,6 +95,247 @@ final class AssetController extends AbstractController
             ]
         ];
 
+        $schemas['PrinterModel'] = [
+            'x-itemtype' => \PrinterModel::class,
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'x-readonly' => true,
+                ],
+                'name' => ['type' => Doc\Schema::TYPE_STRING],
+                'comment' => ['type' => Doc\Schema::TYPE_STRING],
+                'product_number' => ['type' => Doc\Schema::TYPE_STRING],
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ]
+        ];
+
+        $schemas['SoftwareCategory'] = [
+            'x-itemtype' => \SoftwareCategory::class,
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'x-readonly' => true,
+                ],
+                'name' => ['type' => Doc\Schema::TYPE_STRING],
+                'completename' => ['type' => Doc\Schema::TYPE_STRING],
+                'comment' => ['type' => Doc\Schema::TYPE_STRING],
+                'parent' => self::getDropdownTypeSchema(class: \SoftwareCategory::class, full_schema: 'SoftwareCategory'),
+                'level' => ['type' => Doc\Schema::TYPE_INTEGER],
+            ]
+        ];
+
+        $schemas['OperatingSystem'] = [
+            'x-itemtype' => \OperatingSystem::class,
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'x-readonly' => true,
+                ],
+                'name' => ['type' => Doc\Schema::TYPE_STRING],
+                'comment' => ['type' => Doc\Schema::TYPE_STRING],
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ]
+        ];
+
+        $schemas['RackModel'] = [
+            'x-itemtype' => \RackModel::class,
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'x-readonly' => true,
+                ],
+                'name' => ['type' => Doc\Schema::TYPE_STRING],
+                'comment' => ['type' => Doc\Schema::TYPE_STRING],
+                'product_number' => ['type' => Doc\Schema::TYPE_STRING],
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ]
+        ];
+
+        $schemas['RackType'] = [
+            'x-itemtype' => \RackType::class,
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'x-readonly' => true,
+                ],
+                'name' => ['type' => Doc\Schema::TYPE_STRING],
+                'comment' => ['type' => Doc\Schema::TYPE_STRING],
+                'entity' => self::getDropdownTypeSchema(class: \Entity::class, full_schema: 'Entity'),
+                'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ]
+        ];
+
+        $schemas['PDUModel'] = [
+            'x-itemtype' => \PDUModel::class,
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'x-readonly' => true,
+                ],
+                'name' => ['type' => Doc\Schema::TYPE_STRING],
+                'comment' => ['type' => Doc\Schema::TYPE_STRING],
+                'product_number' => ['type' => Doc\Schema::TYPE_STRING],
+                'weight' => ['type' => Doc\Schema::TYPE_INTEGER],
+                'rack_units' => ['x-field' => 'required_units', 'type' => Doc\Schema::TYPE_INTEGER],
+                'depth' => ['type' => Doc\Schema::TYPE_NUMBER, 'format' => Doc\Schema::FORMAT_NUMBER_FLOAT],
+                'power_connections' => ['type' => Doc\Schema::TYPE_INTEGER],
+                'max_power' => ['type' => Doc\Schema::TYPE_INTEGER],
+                'is_half_rack' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'is_rackable' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ]
+        ];
+
+        $schemas['PDUType'] = [
+            'x-itemtype' => \PDUType::class,
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'x-readonly' => true,
+                ],
+                'name' => ['type' => Doc\Schema::TYPE_STRING],
+                'comment' => ['type' => Doc\Schema::TYPE_STRING],
+                'entity' => self::getDropdownTypeSchema(class: \Entity::class, full_schema: 'Entity'),
+                'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ]
+        ];
+
+        $schemas['PassiveDCEquipmentModel'] = [
+            'x-itemtype' => \PassiveDCEquipmentModel::class,
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'x-readonly' => true,
+                ],
+                'name' => ['type' => Doc\Schema::TYPE_STRING],
+                'comment' => ['type' => Doc\Schema::TYPE_STRING],
+                'product_number' => ['type' => Doc\Schema::TYPE_STRING],
+                'weight' => ['type' => Doc\Schema::TYPE_INTEGER],
+                'rack_units' => ['x-field' => 'required_units', 'type' => Doc\Schema::TYPE_INTEGER],
+                'depth' => ['type' => Doc\Schema::TYPE_NUMBER, 'format' => Doc\Schema::FORMAT_NUMBER_FLOAT],
+                'power_connections' => ['type' => Doc\Schema::TYPE_INTEGER],
+                'power_consumption' => ['type' => Doc\Schema::TYPE_INTEGER],
+                'max_power' => ['type' => Doc\Schema::TYPE_INTEGER],
+                'is_half_rack' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ]
+        ];
+
+        $schemas['PassiveDCEquipmentType'] = [
+            'x-itemtype' => \PassiveDCEquipmentType::class,
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'x-readonly' => true,
+                ],
+                'name' => ['type' => Doc\Schema::TYPE_STRING],
+                'comment' => ['type' => Doc\Schema::TYPE_STRING],
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ]
+        ];
+
+        $schemas['SocketModel'] = [
+            'x-itemtype' => SocketModel::class,
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'x-readonly' => true,
+                ],
+                'name' => ['type' => Doc\Schema::TYPE_STRING],
+                'comment' => ['type' => Doc\Schema::TYPE_STRING],
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ]
+        ];
+
+        $schemas['NetworkPort'] = [
+            'x-itemtype' => \NetworkPort::class,
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'x-readonly' => true,
+                ],
+                'name' => ['type' => Doc\Schema::TYPE_STRING],
+                'comment' => ['type' => Doc\Schema::TYPE_STRING],
+                'entity' => self::getDropdownTypeSchema(class: \Entity::class, full_schema: 'Entity'),
+                'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'logical_number' => ['type' => Doc\Schema::TYPE_INTEGER],
+                'mac' => ['type' => Doc\Schema::TYPE_STRING],
+                'is_deleted' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'is_dynamic' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'if_mtu' => ['x-field' => 'ifmtu', 'type' => Doc\Schema::TYPE_INTEGER],
+                'if_speed' => ['x-field' => 'ifspeed', 'type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64],
+                'if_internal_status' => ['x-field' => 'ifinternalstatus', 'type' => Doc\Schema::TYPE_STRING],
+                'if_connection_status' => ['x-field' => 'ifconnectionstatus', 'type' => Doc\Schema::TYPE_INTEGER],
+                'if_last_change' => ['x-field' => 'iflastchange', 'type' => Doc\Schema::TYPE_STRING],
+                'if_in_bytes' => ['x-field' => 'ifinbytes', 'type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64],
+                'if_out_bytes' => ['x-field' => 'ifoutbytes', 'type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64],
+                'if_in_errors' => ['x-field' => 'ifinerrors', 'type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64],
+                'if_out_errors' => ['x-field' => 'ifouterrors', 'type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64],
+                'if_status' => ['x-field' => 'ifstatus', 'type' => Doc\Schema::TYPE_STRING],
+                'if_description' => ['x-field' => 'ifdescr', 'type' => Doc\Schema::TYPE_STRING],
+                'if_alias' => ['x-field' => 'ifalias', 'type' => Doc\Schema::TYPE_STRING],
+                'port_duplex' => ['x-field' => 'portduplex', 'type' => Doc\Schema::TYPE_STRING],
+                'trunk' => ['type' => Doc\Schema::TYPE_INTEGER],
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ]
+        ];
+
+        $schemas['DCRoom'] = [
+            'x-itemtype' => \DCRoom::class,
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'x-readonly' => true,
+                ],
+                'name' => ['type' => Doc\Schema::TYPE_STRING],
+                'entity' => self::getDropdownTypeSchema(class: \Entity::class, full_schema: 'Entity'),
+                'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'is_deleted' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'location' => self::getDropdownTypeSchema(class: \Location::class, full_schema: 'Location'),
+                'datacenter' => self::getDropdownTypeSchema(class: \Datacenter::class, full_schema: 'DataCenter'),
+                'rows' => ['x-field' => 'vis_rows', 'type' => Doc\Schema::TYPE_INTEGER],
+                'cols' => ['x-field' => 'vis_cols', 'type' => Doc\Schema::TYPE_INTEGER],
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ]
+        ];
+
         $asset_types = self::getAssetTypes();
 
         foreach ($asset_types as $asset_type) {
@@ -108,11 +351,11 @@ final class AssetController extends AbstractController
             $asset = new $asset_type();
 
             if (in_array($asset_type, $CFG_GLPI['state_types'], true)) {
-                $schemas[$schema_name]['properties']['status'] = self::getDropdownTypeSchema(State::class);
+                $schemas[$schema_name]['properties']['status'] = self::getDropdownTypeSchema(class: State::class, full_schema: 'State');
             }
 
             if (in_array($asset_type, $CFG_GLPI['location_types'], true)) {
-                $schemas[$schema_name]['properties']['location'] = self::getDropdownTypeSchema(Location::class);
+                $schemas[$schema_name]['properties']['location'] = self::getDropdownTypeSchema(class: Location::class, full_schema: 'Location');
             }
 
             if ($asset->isEntityAssign()) {
@@ -124,14 +367,22 @@ final class AssetController extends AbstractController
 
             $type_class = $asset->getTypeClass();
             if ($type_class !== null) {
-                $schemas[$schema_name]['properties']['type'] = self::getDropdownTypeSchema($type_class);
+                $expected_schema_name = $type_class;
+                $schemas[$schema_name]['properties']['type'] = self::getDropdownTypeSchema(
+                    class: $type_class,
+                    full_schema: $schemas[$expected_schema_name] ?? null
+                );
             }
             if ($asset->isField('manufacturers_id')) {
-                $schemas[$schema_name]['properties']['manufacturer'] = self::getDropdownTypeSchema(Manufacturer::class);
+                $schemas[$schema_name]['properties']['manufacturer'] = self::getDropdownTypeSchema(class: Manufacturer::class, full_schema: 'Manufacturer');
             }
             $model_class = $asset->getModelClass();
             if ($model_class !== null) {
-                $schemas[$schema_name]['properties']['model'] = self::getDropdownTypeSchema($model_class);
+                $expected_schema_name = $type_class;
+                $schemas[$schema_name]['properties']['model'] = self::getDropdownTypeSchema(
+                    class: $model_class,
+                    full_schema: $schemas[$expected_schema_name] ?? null
+                );
             }
 
             if (in_array($asset_type, $CFG_GLPI['linkuser_tech_types'], true)) {
@@ -249,6 +500,7 @@ final class AssetController extends AbstractController
                     'description' => 'List of printer models that can use this cartridge',
                     'items' => [
                         'type' => Doc\Schema::TYPE_OBJECT,
+                        'x-full-schema' => 'PrinterModel',
                         'x-join' => [
                             'table' => \PrinterModel::getTable(),
                             'fkey' => 'printermodels_id',
@@ -390,9 +642,9 @@ final class AssetController extends AbstractController
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
                 'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                 'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
-                'location' => self::getDropdownTypeSchema(Location::class),
-                'category' => self::getDropdownTypeSchema(\SoftwareCategory::class),
-                'manufacturer' => self::getDropdownTypeSchema(Manufacturer::class),
+                'location' => self::getDropdownTypeSchema(class: Location::class, full_schema: 'Location'),
+                'category' => self::getDropdownTypeSchema(class: \SoftwareCategory::class, full_schema: 'SoftwareCategory'),
+                'manufacturer' => self::getDropdownTypeSchema(class: Manufacturer::class, full_schema: 'Manufacturer'),
                 'parent' => self::getDropdownTypeSchema(class: \Software::class, full_schema: 'Software'),
                 'is_helpdesk_visible' => ['type' => Doc\Schema::TYPE_BOOLEAN],
                 'user' => self::getDropdownTypeSchema(class: User::class, full_schema: 'User'),
@@ -422,8 +674,8 @@ final class AssetController extends AbstractController
                 'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                 'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
                 'software' => self::getDropdownTypeSchema(class: \Software::class, full_schema: 'Software'),
-                'state' => self::getDropdownTypeSchema(State::class),
-                'operating_system' => self::getDropdownTypeSchema(\OperatingSystem::class),
+                'state' => self::getDropdownTypeSchema(class: State::class, full_schema: 'State'),
+                'operating_system' => self::getDropdownTypeSchema(class: \OperatingSystem::class, full_schema: 'OperatingSystem'),
                 'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                 'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
             ]
@@ -442,13 +694,13 @@ final class AssetController extends AbstractController
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
                 'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                 'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
-                'location' => self::getDropdownTypeSchema(Location::class),
+                'location' => self::getDropdownTypeSchema(class: Location::class, full_schema: 'Location'),
                 'serial' => ['type' => Doc\Schema::TYPE_STRING],
                 'otherserial' => ['type' => Doc\Schema::TYPE_STRING],
-                'model' => self::getDropdownTypeSchema(\RackModel::class),
-                'manufacturer' => self::getDropdownTypeSchema(Manufacturer::class),
-                'type' => self::getDropdownTypeSchema(\RackType::class),
-                'state' => self::getDropdownTypeSchema(\State::class),
+                'model' => self::getDropdownTypeSchema(class: \RackModel::class, full_schema: 'RackModel'),
+                'manufacturer' => self::getDropdownTypeSchema(class: Manufacturer::class, full_schema: 'Manufacturer'),
+                'type' => self::getDropdownTypeSchema(class: \RackType::class, full_schema: 'RackType'),
+                'state' => self::getDropdownTypeSchema(class: \State::class, full_schema: 'State'),
                 'user_tech' => self::getDropdownTypeSchema(class: User::class, field: 'users_id_tech', full_schema: 'User'),
                 'group_tech' => self::getDropdownTypeSchema(class: Group::class, field: 'groups_id_tech', full_schema: 'Group'),
                 'width' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
@@ -456,7 +708,7 @@ final class AssetController extends AbstractController
                 'depth' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
                 'number_units' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
                 'is_deleted' => ['type' => Doc\Schema::TYPE_BOOLEAN],
-                'room' => self::getDropdownTypeSchema(\DCRoom::class),
+                'room' => self::getDropdownTypeSchema(class: \DCRoom::class, full_schema: 'DCRoom'),
                 'room_orientation' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
                 'position' => ['type' => Doc\Schema::TYPE_STRING],
                 'bgcolor' => ['type' => Doc\Schema::TYPE_STRING],
@@ -485,12 +737,12 @@ final class AssetController extends AbstractController
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
                 'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                 'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
-                'location' => self::getDropdownTypeSchema(Location::class),
+                'location' => self::getDropdownTypeSchema(class: Location::class, full_schema: 'Location'),
                 'serial' => ['type' => Doc\Schema::TYPE_STRING],
                 'otherserial' => ['type' => Doc\Schema::TYPE_STRING],
                 'model' => self::getDropdownTypeSchema(\EnclosureModel::class),
-                'manufacturer' => self::getDropdownTypeSchema(Manufacturer::class),
-                'state' => self::getDropdownTypeSchema(\State::class),
+                'manufacturer' => self::getDropdownTypeSchema(class: Manufacturer::class, full_schema: 'Manufacturer'),
+                'state' => self::getDropdownTypeSchema(class: \State::class, full_schema: 'State'),
                 'user_tech' => self::getDropdownTypeSchema(class: User::class, field: 'users_id_tech', full_schema: 'User'),
                 'group_tech' => self::getDropdownTypeSchema(class: Group::class, field: 'groups_id_tech', full_schema: 'Group'),
                 'is_deleted' => ['type' => Doc\Schema::TYPE_BOOLEAN],
@@ -514,13 +766,13 @@ final class AssetController extends AbstractController
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
                 'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                 'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
-                'location' => self::getDropdownTypeSchema(Location::class),
+                'location' => self::getDropdownTypeSchema(class: Location::class, full_schema: 'Location'),
                 'serial' => ['type' => Doc\Schema::TYPE_STRING],
                 'otherserial' => ['type' => Doc\Schema::TYPE_STRING],
-                'model' => self::getDropdownTypeSchema(\PDUModel::class),
-                'manufacturer' => self::getDropdownTypeSchema(Manufacturer::class),
-                'type' => self::getDropdownTypeSchema(\PDUType::class),
-                'state' => self::getDropdownTypeSchema(\State::class),
+                'model' => self::getDropdownTypeSchema(class: \PDUModel::class, full_schema: 'PDUModel'),
+                'manufacturer' => self::getDropdownTypeSchema(class: Manufacturer::class, full_schema: 'Manufacturer'),
+                'type' => self::getDropdownTypeSchema(class: \PDUType::class, full_schema: 'PDUType'),
+                'state' => self::getDropdownTypeSchema(class: \State::class, full_schema: 'State'),
                 'user_tech' => self::getDropdownTypeSchema(class: User::class, field: 'users_id_tech', full_schema: 'User'),
                 'group_tech' => self::getDropdownTypeSchema(class: Group::class, field: 'groups_id_tech', full_schema: 'Group'),
                 'is_deleted' => ['type' => Doc\Schema::TYPE_BOOLEAN],
@@ -542,13 +794,13 @@ final class AssetController extends AbstractController
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
                 'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                 'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
-                'location' => self::getDropdownTypeSchema(Location::class),
+                'location' => self::getDropdownTypeSchema(class: Location::class, full_schema: 'Location'),
                 'serial' => ['type' => Doc\Schema::TYPE_STRING],
                 'otherserial' => ['type' => Doc\Schema::TYPE_STRING],
-                'model' => self::getDropdownTypeSchema(\PassiveDCEquipmentModel::class),
-                'manufacturer' => self::getDropdownTypeSchema(Manufacturer::class),
-                'type' => self::getDropdownTypeSchema(\PassiveDCEquipmentType::class),
-                'state' => self::getDropdownTypeSchema(\State::class),
+                'model' => self::getDropdownTypeSchema(class: \PassiveDCEquipmentModel::class, full_schema: 'PassiveDCEquipmentModel'),
+                'manufacturer' => self::getDropdownTypeSchema(class: Manufacturer::class, full_schema: 'Manufacturer'),
+                'type' => self::getDropdownTypeSchema(class: \PassiveDCEquipmentType::class, full_schema: 'PassiveDCEquipmentType'),
+                'state' => self::getDropdownTypeSchema(class: \State::class, full_schema: 'State'),
                 'user_tech' => self::getDropdownTypeSchema(class: User::class, field: 'users_id_tech', full_schema: 'User'),
                 'group_tech' => self::getDropdownTypeSchema(class: Group::class, field: 'groups_id_tech', full_schema: 'Group'),
                 'is_deleted' => ['type' => Doc\Schema::TYPE_BOOLEAN],
@@ -571,16 +823,24 @@ final class AssetController extends AbstractController
                 'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                 'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
                 'otherserial' => ['type' => Doc\Schema::TYPE_STRING],
-                'state' => self::getDropdownTypeSchema(\State::class),
-                'user_tech' => self::getDropdownTypeSchema(User::class, 'users_id_tech'),
+                'state' => self::getDropdownTypeSchema(class: \State::class, full_schema: 'State'),
+                'user_tech' => self::getDropdownTypeSchema(class: User::class, field: 'users_id_tech', full_schema: 'User'),
                 'is_deleted' => ['type' => Doc\Schema::TYPE_BOOLEAN],
                 'itemtype_endpoint_a' => ['type' => Doc\Schema::TYPE_STRING],
                 'items_id_endpoint_a' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64],
-                'socketmodel_endpoint_a' => self::getDropdownTypeSchema(\Glpi\SocketModel::class, 'socketmodels_id_endpoint_a'),
+                'socketmodel_endpoint_a' => self::getDropdownTypeSchema(
+                    class: SocketModel::class,
+                    field: 'socketmodels_id_endpoint_a',
+                    full_schema: 'SocketModel'
+                ),
                 'sockets_id_endpoint_a' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64],
                 'itemtype_endpoint_b' => ['type' => Doc\Schema::TYPE_STRING],
                 'items_id_endpoint_b' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64],
-                'socketmodel_endpoint_b' => self::getDropdownTypeSchema(\Glpi\SocketModel::class, 'socketmodels_id_endpoint_b'),
+                'socketmodel_endpoint_b' => self::getDropdownTypeSchema(
+                    class: SocketModel::class,
+                    field: 'socketmodels_id_endpoint_b',
+                    full_schema: 'SocketModel'
+                ),
                 'sockets_id_endpoint_b' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64],
                 'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                 'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
@@ -588,7 +848,7 @@ final class AssetController extends AbstractController
         ];
 
         $schemas['Socket'] = [
-            'x-itemtype' => \Glpi\Socket::class,
+            'x-itemtype' => Socket::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
                 'id' => [
@@ -598,12 +858,12 @@ final class AssetController extends AbstractController
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
-                'location' => self::getDropdownTypeSchema(Location::class),
-                'model' => self::getDropdownTypeSchema(\Glpi\SocketModel::class),
+                'location' => self::getDropdownTypeSchema(class: Location::class, full_schema: 'Location'),
+                'model' => self::getDropdownTypeSchema(class: SocketModel::class, full_schema: 'SocketModel'),
                 'wiring_side' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
                 'itemtype' => ['type' => Doc\Schema::TYPE_STRING],
                 'items_id' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64],
-                'network_port' => self::getDropdownTypeSchema(\NetworkPort::class),
+                'network_port' => self::getDropdownTypeSchema(class: \NetworkPort::class, full_schema: 'NetworkPort'),
                 'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                 'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
             ]

--- a/src/Api/HL/Controller/AssetController.php
+++ b/src/Api/HL/Controller/AssetController.php
@@ -116,7 +116,7 @@ final class AssetController extends AbstractController
             }
 
             if ($asset->isEntityAssign()) {
-                $schemas[$schema_name]['properties']['entity'] = self::getDropdownTypeSchema(Entity::class);
+                $schemas[$schema_name]['properties']['entity'] = self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity');
                 // Add completename field
                 $schemas[$schema_name]['properties']['entity']['properties']['completename'] = ['type' => Doc\Schema::TYPE_STRING];
                 $schemas[$schema_name]['properties']['is_recursive'] = ['type' => Doc\Schema::TYPE_BOOLEAN];
@@ -135,16 +135,32 @@ final class AssetController extends AbstractController
             }
 
             if (in_array($asset_type, $CFG_GLPI['linkuser_tech_types'], true)) {
-                $schemas[$schema_name]['properties']['user_tech'] = self::getDropdownTypeSchema(User::class, 'users_id_tech');
+                $schemas[$schema_name]['properties']['user_tech'] = self::getDropdownTypeSchema(
+                    class: User::class,
+                    field: 'users_id_tech',
+                    full_schema: 'User'
+                );
             }
             if (in_array($asset_type, $CFG_GLPI['linkgroup_tech_types'], true)) {
-                $schemas[$schema_name]['properties']['group_tech'] = self::getDropdownTypeSchema(Group::class, 'groups_id_tech');
+                $schemas[$schema_name]['properties']['group_tech'] = self::getDropdownTypeSchema(
+                    class: Group::class,
+                    field: 'groups_id_tech',
+                    full_schema: 'Group'
+                );
             }
             if (in_array($asset_type, $CFG_GLPI['linkuser_types'], true)) {
-                $schemas[$schema_name]['properties']['user'] = self::getDropdownTypeSchema(User::class, 'users_id');
+                $schemas[$schema_name]['properties']['user'] = self::getDropdownTypeSchema(
+                    class: User::class,
+                    field: 'users_id',
+                    full_schema: 'User'
+                );
             }
             if (in_array($asset_type, $CFG_GLPI['linkgroup_types'], true)) {
-                $schemas[$schema_name]['properties']['group'] = self::getDropdownTypeSchema(Group::class, 'groups_id');
+                $schemas[$schema_name]['properties']['group'] = self::getDropdownTypeSchema(
+                    class: Group::class,
+                    field: 'groups_id',
+                    full_schema: 'Group'
+                );
             }
 
             if ($asset->isField('contact')) {
@@ -184,8 +200,8 @@ final class AssetController extends AbstractController
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
                     'x-readonly' => true,
                 ],
-                'entities_id' => self::getDropdownTypeSchema(Entity::class),
-                'cartridgeitems_id' => self::getDropdownTypeSchema(\CartridgeItem::class),
+                'entities_id' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
+                'cartridgeitems_id' => self::getDropdownTypeSchema(class: \CartridgeItem::class, full_schema: 'CartridgeItem'),
                 'pages' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
                 'date_in' => [
                     'type' => Doc\Schema::TYPE_STRING,
@@ -259,6 +275,7 @@ final class AssetController extends AbstractController
                     'description' => 'List of cartridges',
                     'items' => [
                         'type' => Doc\Schema::TYPE_OBJECT,
+                        'x-full-schema' => 'Cartridge',
                         'x-join' => [
                             'table' => \Cartridge::getTable(),
                             'fkey' => 'id',
@@ -291,8 +308,8 @@ final class AssetController extends AbstractController
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
                     'x-readonly' => true,
                 ],
-                'entities_id' => self::getDropdownTypeSchema(Entity::class),
-                'consumableitems_id' => self::getDropdownTypeSchema(\ConsumableItem::class),
+                'entities_id' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
+                'consumableitems_id' => self::getDropdownTypeSchema(class: \ConsumableItem::class, full_schema: 'ConsumableItem'),
                 'date_in' => [
                     'type' => Doc\Schema::TYPE_STRING,
                     'format' => Doc\Schema::FORMAT_STRING_DATE_TIME,
@@ -336,6 +353,7 @@ final class AssetController extends AbstractController
                     'description' => 'List of consumables',
                     'items' => [
                         'type' => Doc\Schema::TYPE_OBJECT,
+                        'x-full-schema' => 'Consumable',
                         'x-join' => [
                             'table' => \Consumable::getTable(),
                             'fkey' => 'id',
@@ -370,17 +388,17 @@ final class AssetController extends AbstractController
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
-                'entity' => self::getDropdownTypeSchema(Entity::class),
+                'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                 'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
                 'location' => self::getDropdownTypeSchema(Location::class),
                 'category' => self::getDropdownTypeSchema(\SoftwareCategory::class),
                 'manufacturer' => self::getDropdownTypeSchema(Manufacturer::class),
-                'parent' => self::getDropdownTypeSchema(\Software::class),
+                'parent' => self::getDropdownTypeSchema(class: \Software::class, full_schema: 'Software'),
                 'is_helpdesk_visible' => ['type' => Doc\Schema::TYPE_BOOLEAN],
-                'user' => self::getDropdownTypeSchema(User::class),
-                'group' => self::getDropdownTypeSchema(Group::class),
-                'user_tech' => self::getDropdownTypeSchema(User::class, 'users_id_tech'),
-                'group_tech' => self::getDropdownTypeSchema(Group::class, 'groups_id_tech'),
+                'user' => self::getDropdownTypeSchema(class: User::class, full_schema: 'User'),
+                'group' => self::getDropdownTypeSchema(class: Group::class, full_schema: 'Group'),
+                'user_tech' => self::getDropdownTypeSchema(class: User::class, field: 'users_id_tech', full_schema: 'User'),
+                'group_tech' => self::getDropdownTypeSchema(class: Group::class, field: 'groups_id_tech', full_schema: 'Group'),
                 'is_deleted' => ['type' => Doc\Schema::TYPE_BOOLEAN],
                 'is_update' => ['type' => Doc\Schema::TYPE_BOOLEAN],
                 'is_valid' => ['type' => Doc\Schema::TYPE_BOOLEAN],
@@ -401,9 +419,9 @@ final class AssetController extends AbstractController
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'arch' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
-                'entity' => self::getDropdownTypeSchema(Entity::class),
+                'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                 'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
-                'software' => self::getDropdownTypeSchema(\Software::class),
+                'software' => self::getDropdownTypeSchema(class: \Software::class, full_schema: 'Software'),
                 'state' => self::getDropdownTypeSchema(State::class),
                 'operating_system' => self::getDropdownTypeSchema(\OperatingSystem::class),
                 'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
@@ -422,7 +440,7 @@ final class AssetController extends AbstractController
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
-                'entity' => self::getDropdownTypeSchema(Entity::class),
+                'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                 'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
                 'location' => self::getDropdownTypeSchema(Location::class),
                 'serial' => ['type' => Doc\Schema::TYPE_STRING],
@@ -431,8 +449,8 @@ final class AssetController extends AbstractController
                 'manufacturer' => self::getDropdownTypeSchema(Manufacturer::class),
                 'type' => self::getDropdownTypeSchema(\RackType::class),
                 'state' => self::getDropdownTypeSchema(\State::class),
-                'user_tech' => self::getDropdownTypeSchema(User::class, 'users_id_tech'),
-                'group_tech' => self::getDropdownTypeSchema(Group::class, 'groups_id_tech'),
+                'user_tech' => self::getDropdownTypeSchema(class: User::class, field: 'users_id_tech', full_schema: 'User'),
+                'group_tech' => self::getDropdownTypeSchema(class: Group::class, field: 'groups_id_tech', full_schema: 'Group'),
                 'width' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
                 'height' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
                 'depth' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
@@ -465,7 +483,7 @@ final class AssetController extends AbstractController
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
-                'entity' => self::getDropdownTypeSchema(Entity::class),
+                'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                 'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
                 'location' => self::getDropdownTypeSchema(Location::class),
                 'serial' => ['type' => Doc\Schema::TYPE_STRING],
@@ -473,8 +491,8 @@ final class AssetController extends AbstractController
                 'model' => self::getDropdownTypeSchema(\EnclosureModel::class),
                 'manufacturer' => self::getDropdownTypeSchema(Manufacturer::class),
                 'state' => self::getDropdownTypeSchema(\State::class),
-                'user_tech' => self::getDropdownTypeSchema(User::class, 'users_id_tech'),
-                'group_tech' => self::getDropdownTypeSchema(Group::class, 'groups_id_tech'),
+                'user_tech' => self::getDropdownTypeSchema(class: User::class, field: 'users_id_tech', full_schema: 'User'),
+                'group_tech' => self::getDropdownTypeSchema(class: Group::class, field: 'groups_id_tech', full_schema: 'Group'),
                 'is_deleted' => ['type' => Doc\Schema::TYPE_BOOLEAN],
                 'orientation' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
                 'power_supplies' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
@@ -494,7 +512,7 @@ final class AssetController extends AbstractController
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
-                'entity' => self::getDropdownTypeSchema(Entity::class),
+                'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                 'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
                 'location' => self::getDropdownTypeSchema(Location::class),
                 'serial' => ['type' => Doc\Schema::TYPE_STRING],
@@ -503,8 +521,8 @@ final class AssetController extends AbstractController
                 'manufacturer' => self::getDropdownTypeSchema(Manufacturer::class),
                 'type' => self::getDropdownTypeSchema(\PDUType::class),
                 'state' => self::getDropdownTypeSchema(\State::class),
-                'user_tech' => self::getDropdownTypeSchema(User::class, 'users_id_tech'),
-                'group_tech' => self::getDropdownTypeSchema(Group::class, 'groups_id_tech'),
+                'user_tech' => self::getDropdownTypeSchema(class: User::class, field: 'users_id_tech', full_schema: 'User'),
+                'group_tech' => self::getDropdownTypeSchema(class: Group::class, field: 'groups_id_tech', full_schema: 'Group'),
                 'is_deleted' => ['type' => Doc\Schema::TYPE_BOOLEAN],
                 'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                 'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
@@ -522,7 +540,7 @@ final class AssetController extends AbstractController
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
-                'entity' => self::getDropdownTypeSchema(Entity::class),
+                'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                 'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
                 'location' => self::getDropdownTypeSchema(Location::class),
                 'serial' => ['type' => Doc\Schema::TYPE_STRING],
@@ -531,8 +549,8 @@ final class AssetController extends AbstractController
                 'manufacturer' => self::getDropdownTypeSchema(Manufacturer::class),
                 'type' => self::getDropdownTypeSchema(\PassiveDCEquipmentType::class),
                 'state' => self::getDropdownTypeSchema(\State::class),
-                'user_tech' => self::getDropdownTypeSchema(User::class, 'users_id_tech'),
-                'group_tech' => self::getDropdownTypeSchema(Group::class, 'groups_id_tech'),
+                'user_tech' => self::getDropdownTypeSchema(class: User::class, field: 'users_id_tech', full_schema: 'User'),
+                'group_tech' => self::getDropdownTypeSchema(class: Group::class, field: 'groups_id_tech', full_schema: 'Group'),
                 'is_deleted' => ['type' => Doc\Schema::TYPE_BOOLEAN],
                 'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                 'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
@@ -550,7 +568,7 @@ final class AssetController extends AbstractController
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
-                'entity' => self::getDropdownTypeSchema(Entity::class),
+                'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                 'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
                 'otherserial' => ['type' => Doc\Schema::TYPE_STRING],
                 'state' => self::getDropdownTypeSchema(\State::class),

--- a/src/Api/HL/Controller/ComponentController.php
+++ b/src/Api/HL/Controller/ComponentController.php
@@ -74,7 +74,7 @@ class ComponentController extends AbstractController
             'designation' => ['type' => Doc\Schema::TYPE_STRING],
             'comment' => ['type' => Doc\Schema::TYPE_STRING],
             'manufacturer' => self::getDropdownTypeSchema(\Manufacturer::class),
-            'entity' => self::getDropdownTypeSchema(\Entity::class),
+            'entity' => self::getDropdownTypeSchema(class: \Entity::class, full_schema: 'Entity'),
             'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
             'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
             'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
@@ -87,7 +87,7 @@ class ComponentController extends AbstractController
             ],
             'itemtype' => ['type' => Doc\Schema::TYPE_STRING],
             'items_id' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64],
-            'entity' => self::getDropdownTypeSchema(\Entity::class),
+            'entity' => self::getDropdownTypeSchema(class: \Entity::class, full_schema: 'Entity'),
             'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
             'serial' => ['type' => Doc\Schema::TYPE_STRING],
             'otherserial' => ['type' => Doc\Schema::TYPE_STRING],
@@ -272,7 +272,7 @@ class ComponentController extends AbstractController
                 'x-itemtype' => \Item_DeviceBattery::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
-                    'battery' => self::getDropdownTypeSchema(\DeviceBattery::class, null, 'designation'),
+                    'battery' => self::getDropdownTypeSchema(class: \DeviceBattery::class, name_field: 'designation', full_schema: 'Battery'),
                     'date_manufacture' => [
                         'type' => Doc\Schema::TYPE_STRING,
                         'format' => Doc\Schema::FORMAT_STRING_DATE,
@@ -285,21 +285,21 @@ class ComponentController extends AbstractController
                 'x-itemtype' => \Item_DeviceCamera::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => array_filter($common_item_device_properties + [
-                    'camera' => self::getDropdownTypeSchema(\DeviceCamera::class, null, 'designation'),
+                    'camera' => self::getDropdownTypeSchema(class: \DeviceCamera::class, name_field: 'designation', full_schema: 'Camera'),
                 ], static fn($key) => !in_array($key, ['status', 'location', 'serial', 'otherserial']), ARRAY_FILTER_USE_KEY) // Cameras don't follow the general schema of the others
             ],
             'CaseItem' => [
                 'x-itemtype' => \Item_DeviceCase::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
-                    'case' => self::getDropdownTypeSchema(\DeviceCase::class, null, 'designation'),
+                    'case' => self::getDropdownTypeSchema(class: \DeviceCase::class, name_field: 'designation', full_schema: 'Case'),
                 ]
             ],
             'ControllerItem' => [
                 'x-itemtype' => \Item_DeviceControl::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
-                    'controller' => self::getDropdownTypeSchema(\DeviceControl::class, null, 'designation'),
+                    'controller' => self::getDropdownTypeSchema(class: \DeviceControl::class, name_field: 'designation', full_schema: 'Controller'),
                     'busID' => ['type' => Doc\Schema::TYPE_STRING],
                 ]
             ],
@@ -307,7 +307,7 @@ class ComponentController extends AbstractController
                 'x-itemtype' => \Item_DeviceDrive::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
-                    'drive' => self::getDropdownTypeSchema(\DeviceDrive::class, null, 'designation'),
+                    'drive' => self::getDropdownTypeSchema(class: \DeviceDrive::class, name_field: 'designation', full_schema: 'Drive'),
                     'busID' => ['type' => Doc\Schema::TYPE_STRING],
                 ]
             ],
@@ -315,21 +315,21 @@ class ComponentController extends AbstractController
                 'x-itemtype' => \Item_DeviceFirmware::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
-                    'firmware' => self::getDropdownTypeSchema(\DeviceFirmware::class, null, 'designation'),
+                    'firmware' => self::getDropdownTypeSchema(class: \DeviceFirmware::class, name_field: 'designation', full_schema: 'Firmware'),
                 ]
             ],
             'GenericDeviceItem' => [
                 'x-itemtype' => \Item_DeviceGeneric::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
-                    'generic_device' => self::getDropdownTypeSchema(\DeviceGeneric::class, null, 'designation'),
+                    'generic_device' => self::getDropdownTypeSchema(class: \DeviceGeneric::class, name_field: 'designation', full_schema: 'GenericDevice'),
                 ]
             ],
             'GraphicCardItem' => [
                 'x-itemtype' => \Item_DeviceGraphicCard::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
-                    'graphic_card' => self::getDropdownTypeSchema(\DeviceGraphicCard::class, null, 'designation'),
+                    'graphic_card' => self::getDropdownTypeSchema(class: \DeviceGraphicCard::class, name_field: 'designation', full_schema: 'GraphicCard'),
                     'busID' => ['type' => Doc\Schema::TYPE_STRING],
                     'memory' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
                 ]
@@ -338,7 +338,7 @@ class ComponentController extends AbstractController
                 'x-itemtype' => \Item_DeviceHardDrive::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
-                    'hard_drive' => self::getDropdownTypeSchema(\DeviceHardDrive::class, null, 'designation'),
+                    'hard_drive' => self::getDropdownTypeSchema(class: \DeviceHardDrive::class, name_field: 'designation', full_schema: 'HardDrive'),
                     'busID' => ['type' => Doc\Schema::TYPE_STRING],
                     'capacity' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
                 ]
@@ -347,7 +347,7 @@ class ComponentController extends AbstractController
                 'x-itemtype' => \Item_DeviceMemory::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
-                    'memory' => self::getDropdownTypeSchema(\DeviceMemory::class, null, 'designation'),
+                    'memory' => self::getDropdownTypeSchema(class: \DeviceMemory::class, name_field: 'designation', full_schema: 'Memory'),
                     'busID' => ['type' => Doc\Schema::TYPE_STRING],
                     'size' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
                 ]
@@ -356,7 +356,7 @@ class ComponentController extends AbstractController
                 'x-itemtype' => \Item_DeviceNetworkCard::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
-                    'network_card' => self::getDropdownTypeSchema(\DeviceNetworkCard::class, null, 'designation'),
+                    'network_card' => self::getDropdownTypeSchema(class: \DeviceNetworkCard::class, name_field: 'designation', full_schema: 'NetworkCard'),
                     'busID' => ['type' => Doc\Schema::TYPE_STRING],
                     'mac' => ['type' => Doc\Schema::TYPE_STRING],
                 ]
@@ -365,7 +365,7 @@ class ComponentController extends AbstractController
                 'x-itemtype' => \Item_DevicePci::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
-                    'pci_device' => self::getDropdownTypeSchema(\DevicePci::class, null, 'designation'),
+                    'pci_device' => self::getDropdownTypeSchema(class: \DevicePci::class, name_field: 'designation', full_schema: 'PCIDevice'),
                     'busID' => ['type' => Doc\Schema::TYPE_STRING],
                 ]
             ],
@@ -373,14 +373,14 @@ class ComponentController extends AbstractController
                 'x-itemtype' => \Item_DevicePowerSupply::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
-                    'power_supply' => self::getDropdownTypeSchema(\DevicePowerSupply::class, null, 'designation'),
+                    'power_supply' => self::getDropdownTypeSchema(class: \DevicePowerSupply::class, name_field: 'designation', full_schema: 'PowerSupply'),
                 ]
             ],
             'ProcessorItem' => [
                 'x-itemtype' => \Item_DeviceProcessor::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
-                    'processor' => self::getDropdownTypeSchema(\DeviceProcessor::class, null, 'designation'),
+                    'processor' => self::getDropdownTypeSchema(class: \DeviceProcessor::class, name_field: 'designation', full_schema: 'Processor'),
                     'busID' => ['type' => Doc\Schema::TYPE_STRING],
                     'frequency' => ['type' => Doc\Schema::TYPE_STRING],
                     'nbcores' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
@@ -391,14 +391,14 @@ class ComponentController extends AbstractController
                 'x-itemtype' => \Item_DeviceSensor::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
-                    'sensor' => self::getDropdownTypeSchema(\DeviceSensor::class, null, 'designation'),
+                    'sensor' => self::getDropdownTypeSchema(class: \DeviceSensor::class, name_field: 'designation', full_schema: 'Sensor'),
                 ]
             ],
             'SIMCardItem' => [
                 'x-itemtype' => \Item_DeviceSimcard::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
-                    'sim_card' => self::getDropdownTypeSchema(\DeviceSimcard::class, null, 'designation'),
+                    'sim_card' => self::getDropdownTypeSchema(class: \DeviceSimcard::class, name_field: 'designation', full_schema: 'SIMCard'),
                     'pin' => ['type' => Doc\Schema::TYPE_STRING],
                     'pin2' => ['type' => Doc\Schema::TYPE_STRING],
                     'puk' => ['type' => Doc\Schema::TYPE_STRING],
@@ -413,7 +413,7 @@ class ComponentController extends AbstractController
                 'x-itemtype' => \Item_DeviceSoundCard::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
-                    'sound_card' => self::getDropdownTypeSchema(\DeviceSoundCard::class, null, 'designation'),
+                    'sound_card' => self::getDropdownTypeSchema(class: \DeviceSoundCard::class, name_field: 'designation', full_schema: 'SoundCard'),
                     'busID' => ['type' => Doc\Schema::TYPE_STRING],
                 ]
             ],
@@ -421,7 +421,7 @@ class ComponentController extends AbstractController
                 'x-itemtype' => \Item_DeviceMotherboard::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
-                    'systemboard' => self::getDropdownTypeSchema(\DeviceMotherboard::class, null, 'designation'),
+                    'systemboard' => self::getDropdownTypeSchema(class: \DeviceMotherboard::class, name_field: 'designation', full_schema: 'Systemboard'),
                 ]
             ],
         ];

--- a/src/Api/HL/Controller/ComponentController.php
+++ b/src/Api/HL/Controller/ComponentController.php
@@ -73,7 +73,7 @@ class ComponentController extends AbstractController
             ],
             'designation' => ['type' => Doc\Schema::TYPE_STRING],
             'comment' => ['type' => Doc\Schema::TYPE_STRING],
-            'manufacturer' => self::getDropdownTypeSchema(\Manufacturer::class),
+            'manufacturer' => self::getDropdownTypeSchema(class: \Manufacturer::class, full_schema: 'Manufacturer'),
             'entity' => self::getDropdownTypeSchema(class: \Entity::class, full_schema: 'Entity'),
             'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
             'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
@@ -91,21 +91,58 @@ class ComponentController extends AbstractController
             'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
             'serial' => ['type' => Doc\Schema::TYPE_STRING],
             'otherserial' => ['type' => Doc\Schema::TYPE_STRING],
-            'location' => self::getDropdownTypeSchema(\Location::class),
-            'status' => self::getDropdownTypeSchema(\State::class),
+            'location' => self::getDropdownTypeSchema(class: \Location::class, full_schema: 'Location'),
+            'status' => self::getDropdownTypeSchema(class: \State::class, full_schema: 'State'),
             'is_deleted' => ['type' => Doc\Schema::TYPE_BOOLEAN],
             'is_dynamic' => ['type' => Doc\Schema::TYPE_BOOLEAN],
         ];
+        $common_device_type_properties = [
+            'id' => [
+                'type' => Doc\Schema::TYPE_INTEGER,
+                'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                'x-readonly' => true,
+            ],
+            'name' => ['type' => Doc\Schema::TYPE_STRING],
+            'comment' => ['type' => Doc\Schema::TYPE_STRING],
+            'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+        ];
+        $common_device_model_properties = [
+            'id' => [
+                'type' => Doc\Schema::TYPE_INTEGER,
+                'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                'x-readonly' => true,
+            ],
+            'name' => ['type' => Doc\Schema::TYPE_STRING],
+            'comment' => ['type' => Doc\Schema::TYPE_STRING],
+            'product_number' => ['type' => Doc\Schema::TYPE_STRING],
+        ];
+
         return [
+            'BatteryType' => [
+                'x-itemtype' => \DeviceBatteryType::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => $common_device_type_properties
+            ],
+            'BatteryModel' => [
+                'x-itemtype' => \DeviceBatteryModel::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => $common_device_model_properties
+            ],
             'Battery' => [
                 'x-itemtype' => \DeviceBattery::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
                     'voltage' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
                     'capacity' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
-                    'type' => self::getDropdownTypeSchema(\DeviceBatteryType::class),
-                    'model' => self::getDropdownTypeSchema(\DeviceBatteryModel::class),
+                    'type' => self::getDropdownTypeSchema(class: \DeviceBatteryType::class, full_schema: 'BatteryType'),
+                    'model' => self::getDropdownTypeSchema(class: \DeviceBatteryModel::class, full_schema: 'BatteryModel'),
                 ]
+            ],
+            'CameraModel' => [
+                'x-itemtype' => \DeviceCameraModel::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => $common_device_model_properties
             ],
             'Camera' => [
                 'x-itemtype' => \DeviceCamera::class,
@@ -116,26 +153,46 @@ class ComponentController extends AbstractController
                     'orientation' => ['type' => Doc\Schema::TYPE_STRING],
                     'focal_length' => ['type' => Doc\Schema::TYPE_STRING, 'x-field' => 'focallength'],
                     'sensor_size' => ['type' => Doc\Schema::TYPE_STRING, 'x-field' => 'sensorsize'],
-                    'model' => self::getDropdownTypeSchema(\DeviceCameraModel::class),
+                    'model' => self::getDropdownTypeSchema(class: \DeviceCameraModel::class, full_schema: 'CameraModel'),
                     'support' => ['type' => Doc\Schema::TYPE_STRING],
                 ]
+            ],
+            'CaseType' => [
+                'x-itemtype' => \DeviceCaseType::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => $common_device_type_properties
+            ],
+            'CaseModel' => [
+                'x-itemtype' => \DeviceCaseModel::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => $common_device_model_properties
             ],
             'Case' => [
                 'x-itemtype' => \DeviceCase::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
-                    'type' => self::getDropdownTypeSchema(\DeviceCaseType::class),
-                    'model' => self::getDropdownTypeSchema(\DeviceCaseModel::class),
+                    'type' => self::getDropdownTypeSchema(class: \DeviceCaseType::class, full_schema: 'CaseType'),
+                    'model' => self::getDropdownTypeSchema(class: \DeviceCaseModel::class, full_schema: 'CaseModel'),
                 ]
+            ],
+            'ControllerModel' => [
+                'x-itemtype' => \DeviceControlModel::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => $common_device_model_properties
             ],
             'Controller' => [
                 'x-itemtype' => \DeviceControl::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
                     'is_raid' => ['type' => Doc\Schema::TYPE_BOOLEAN],
-                    'interface' => self::getDropdownTypeSchema(\InterfaceType::class),
-                    'model' => self::getDropdownTypeSchema(\DeviceControlModel::class),
+                    'interface' => self::getDropdownTypeSchema(class: \InterfaceType::class, full_schema: 'InterfaceType'),
+                    'model' => self::getDropdownTypeSchema(class: \DeviceControlModel::class, full_schema: 'ControllerModel'),
                 ]
+            ],
+            'DriveModel' => [
+                'x-itemtype' => \DeviceDriveModel::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => $common_device_model_properties
             ],
             'Drive' => [
                 'x-itemtype' => \DeviceDrive::class,
@@ -143,9 +200,19 @@ class ComponentController extends AbstractController
                 'properties' => $common_device_properties + [
                     'is_writer' => ['type' => Doc\Schema::TYPE_BOOLEAN],
                     'speed' => ['type' => Doc\Schema::TYPE_STRING],
-                    'interface' => self::getDropdownTypeSchema(\InterfaceType::class),
-                    'model' => self::getDropdownTypeSchema(\DeviceDriveModel::class),
+                    'interface' => self::getDropdownTypeSchema(class: \InterfaceType::class, full_schema: 'InterfaceType'),
+                    'model' => self::getDropdownTypeSchema(class: \DeviceDriveModel::class, full_schema: 'DriveModel'),
                 ]
+            ],
+            'FirmwareType' => [
+                'x-itemtype' => \DeviceFirmwareType::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => $common_device_type_properties
+            ],
+            'FirmwareModel' => [
+                'x-itemtype' => \DeviceFirmwareModel::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => $common_device_model_properties
             ],
             'Firmware' => [
                 'x-itemtype' => \DeviceFirmware::class,
@@ -153,19 +220,34 @@ class ComponentController extends AbstractController
                 'properties' => $common_device_properties + [
                     'date' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                     'version' => ['type' => Doc\Schema::TYPE_STRING],
-                    'type' => self::getDropdownTypeSchema(\DeviceFirmwareType::class),
-                    'model' => self::getDropdownTypeSchema(\DeviceFirmwareModel::class),
+                    'type' => self::getDropdownTypeSchema(class: \DeviceFirmwareType::class, full_schema: 'FirmwareType'),
+                    'model' => self::getDropdownTypeSchema(class: \DeviceFirmwareModel::class, full_schema: 'FirmwareModel'),
                 ]
+            ],
+            'GenericDeviceType' => [
+                'x-itemtype' => \DeviceGenericType::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => $common_device_type_properties
+            ],
+            'GenericDeviceModel' => [
+                'x-itemtype' => \DeviceGenericModel::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => $common_device_model_properties
             ],
             'GenericDevice' => [
                 'x-itemtype' => \DeviceGeneric::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
-                    'type' => self::getDropdownTypeSchema(\DeviceGenericType::class),
-                    'model' => self::getDropdownTypeSchema(\DeviceGenericModel::class),
-                    'location' => self::getDropdownTypeSchema(\Location::class),
-                    'state' => self::getDropdownTypeSchema(\State::class),
+                    'type' => self::getDropdownTypeSchema(class: \DeviceGenericType::class, full_schema: 'GenericDeviceType'),
+                    'model' => self::getDropdownTypeSchema(class: \DeviceGenericModel::class, full_schema: 'GenericDeviceModel'),
+                    'location' => self::getDropdownTypeSchema(class: \Location::class, full_schema: 'Location'),
+                    'state' => self::getDropdownTypeSchema(class: \State::class, full_schema: 'State'),
                 ]
+            ],
+            'GraphicCardModel' => [
+                'x-itemtype' => \DeviceGraphicCardModel::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => $common_device_model_properties
             ],
             'GraphicCard' => [
                 'x-itemtype' => \DeviceGraphicCard::class,
@@ -173,9 +255,14 @@ class ComponentController extends AbstractController
                 'properties' => $common_device_properties + [
                     'chipset' => ['type' => Doc\Schema::TYPE_STRING],
                     'memory_default' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
-                    'interface' => self::getDropdownTypeSchema(\InterfaceType::class),
-                    'model' => self::getDropdownTypeSchema(\DeviceGraphicCardModel::class),
+                    'interface' => self::getDropdownTypeSchema(class: \InterfaceType::class, full_schema: 'InterfaceType'),
+                    'model' => self::getDropdownTypeSchema(class: \DeviceGraphicCardModel::class, full_schema: 'GraphicCardModel'),
                 ]
+            ],
+            'HardDriveModel' => [
+                'x-itemtype' => \DeviceHardDriveModel::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => $common_device_model_properties
             ],
             'HardDrive' => [
                 'x-itemtype' => \DeviceHardDrive::class,
@@ -184,9 +271,24 @@ class ComponentController extends AbstractController
                     'rpm' => ['type' => Doc\Schema::TYPE_STRING],
                     'cache' => ['type' => Doc\Schema::TYPE_STRING],
                     'capacity_default' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
-                    'interface' => self::getDropdownTypeSchema(\InterfaceType::class),
-                    'model' => self::getDropdownTypeSchema(\DeviceHardDriveModel::class),
+                    'interface' => self::getDropdownTypeSchema(class: \InterfaceType::class, full_schema: 'InterfaceType'),
+                    'model' => self::getDropdownTypeSchema(class: \DeviceHardDriveModel::class, full_schema: 'HardDriveModel'),
                 ]
+            ],
+            'InterfaceType' => [
+                'x-itemtype' => \InterfaceType::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => $common_device_type_properties
+            ],
+            'MemoryType' => [
+                'x-itemtype' => \DeviceMemoryType::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => $common_device_type_properties
+            ],
+            'MemoryModel' => [
+                'x-itemtype' => \DeviceMemoryModel::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => $common_device_model_properties
             ],
             'Memory' => [
                 'x-itemtype' => \DeviceMemory::class,
@@ -194,9 +296,14 @@ class ComponentController extends AbstractController
                 'properties' => $common_device_properties + [
                     'frequency' => ['type' => Doc\Schema::TYPE_STRING, 'x-field' => 'frequence'],
                     'size_default' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
-                    'type' => self::getDropdownTypeSchema(\DeviceMemoryType::class),
-                    'model' => self::getDropdownTypeSchema(\DeviceMemoryModel::class),
+                    'type' => self::getDropdownTypeSchema(class: \DeviceMemoryType::class, full_schema: 'MemoryType'),
+                    'model' => self::getDropdownTypeSchema(class: \DeviceMemoryModel::class, full_schema: 'MemoryModel'),
                 ]
+            ],
+            'NetworkCardModel' => [
+                'x-itemtype' => \DeviceNetworkCardModel::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => $common_device_model_properties
             ],
             'NetworkCard' => [
                 'x-itemtype' => \DeviceNetworkCard::class,
@@ -204,15 +311,25 @@ class ComponentController extends AbstractController
                 'properties' => $common_device_properties + [
                     'bandwidth' => ['type' => Doc\Schema::TYPE_STRING],
                     'mac_default' => ['type' => Doc\Schema::TYPE_STRING],
-                    'model' => self::getDropdownTypeSchema(\DeviceNetworkCardModel::class),
+                    'model' => self::getDropdownTypeSchema(class: \DeviceNetworkCardModel::class, full_schema: 'NetworkCardModel'),
                 ]
+            ],
+            'PCIModel' => [
+                'x-itemtype' => \DevicePciModel::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => $common_device_model_properties
             ],
             'PCIDevice' => [
                 'x-itemtype' => \DevicePci::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
-                    'model' => self::getDropdownTypeSchema(\DevicePciModel::class),
+                    'model' => self::getDropdownTypeSchema(class: \DevicePciModel::class, full_schema: 'PCIModel'),
                 ]
+            ],
+            'PowerSupplyModel' => [
+                'x-itemtype' => \DevicePowerSupplyModel::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => $common_device_model_properties
             ],
             'PowerSupply' => [
                 'x-itemtype' => \DevicePowerSupply::class,
@@ -220,8 +337,13 @@ class ComponentController extends AbstractController
                 'properties' => $common_device_properties + [
                     'power' => ['type' => Doc\Schema::TYPE_STRING],
                     'is_atx' => ['type' => Doc\Schema::TYPE_BOOLEAN],
-                    'model' => self::getDropdownTypeSchema(\DevicePowerSupplyModel::class),
+                    'model' => self::getDropdownTypeSchema(class: \DevicePowerSupplyModel::class, full_schema: 'PowerSupplyModel'),
                 ]
+            ],
+            'ProcessorModel' => [
+                'x-itemtype' => \DeviceProcessorModel::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => $common_device_model_properties
             ],
             'Processor' => [
                 'x-itemtype' => \DeviceProcessor::class,
@@ -231,18 +353,33 @@ class ComponentController extends AbstractController
                     'frequency_default' => ['type' => Doc\Schema::TYPE_STRING],
                     'nbcores_default' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
                     'nbthreads_default' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
-                    'model' => self::getDropdownTypeSchema(\DeviceProcessorModel::class),
+                    'model' => self::getDropdownTypeSchema(class: \DeviceProcessorModel::class, full_schema: 'ProcessorModel'),
                 ]
+            ],
+            'SensorType' => [
+                'x-itemtype' => \DeviceSensorType::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => $common_device_type_properties
+            ],
+            'SensorModel' => [
+                'x-itemtype' => \DeviceSensorModel::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => $common_device_model_properties
             ],
             'Sensor' => [
                 'x-itemtype' => \DeviceSensor::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
-                    'type' => self::getDropdownTypeSchema(\DeviceSensorType::class),
-                    'model' => self::getDropdownTypeSchema(\DeviceSensorModel::class),
-                    'location' => self::getDropdownTypeSchema(\Location::class),
-                    'state' => self::getDropdownTypeSchema(\State::class),
+                    'type' => self::getDropdownTypeSchema(class: \DeviceSensorType::class, full_schema: 'SensorType'),
+                    'model' => self::getDropdownTypeSchema(class: \DeviceSensorModel::class, full_schema: 'SensorModel'),
+                    'location' => self::getDropdownTypeSchema(class: \Location::class, full_schema: 'Location'),
+                    'state' => self::getDropdownTypeSchema(class: \State::class, full_schema: 'State'),
                 ]
+            ],
+            'SIMCardType' => [
+                'x-itemtype' => \DeviceSimcardType::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => $common_device_type_properties
             ],
             'SIMCard' => [
                 'x-itemtype' => \DeviceSimcard::class,
@@ -250,14 +387,26 @@ class ComponentController extends AbstractController
                 'properties' => $common_device_properties + [
                     'voltage' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
                     'allow_voip' => ['type' => Doc\Schema::TYPE_BOOLEAN],
-                    'type' => self::getDropdownTypeSchema(\DeviceSimcardType::class),
+                    'type' => self::getDropdownTypeSchema(class: \DeviceSimcardType::class, full_schema: 'SIMCardType'),
                 ]
+            ],
+            'SoundCardModel' => [
+                'x-itemtype' => \DeviceSoundCardModel::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => $common_device_model_properties
             ],
             'SoundCard' => [
                 'x-itemtype' => \DeviceSoundCard::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
-                    'model' => self::getDropdownTypeSchema(\DeviceSoundCardModel::class),
+                    'model' => self::getDropdownTypeSchema(class: \DeviceSoundCardModel::class, full_schema: 'SoundCardModel'),
+                ]
+            ],
+            'SystemboardModel' => [
+                'x-itemtype' => \DeviceMotherboardModel::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => $common_device_model_properties + [
+                    'chipset' => ['type' => Doc\Schema::TYPE_STRING],
                 ]
             ],
             'Systemboard' => [
@@ -265,7 +414,7 @@ class ComponentController extends AbstractController
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
                     'chipset' => ['type' => Doc\Schema::TYPE_STRING],
-                    'model' => self::getDropdownTypeSchema(\DeviceMotherboardModel::class),
+                    'model' => self::getDropdownTypeSchema(class: \DeviceMotherboardModel::class, full_schema: 'SystemboardModel'),
                 ]
             ],
             'BatteryItem' => [
@@ -404,9 +553,9 @@ class ComponentController extends AbstractController
                     'puk' => ['type' => Doc\Schema::TYPE_STRING],
                     'puk2' => ['type' => Doc\Schema::TYPE_STRING],
                     'msin' => ['type' => Doc\Schema::TYPE_STRING],
-                    'line' => self::getDropdownTypeSchema(\Line::class),
-                    'user' => self::getDropdownTypeSchema(\User::class),
-                    'group' => self::getDropdownTypeSchema(\Group::class),
+                    'line' => self::getDropdownTypeSchema(class: \Line::class, full_schema: 'Line'),
+                    'user' => self::getDropdownTypeSchema(class: \User::class, full_schema: 'User'),
+                    'group' => self::getDropdownTypeSchema(class: \Group::class, full_schema: 'Group'),
                 ]
             ],
             'SoundCardItem' => [

--- a/src/Api/HL/Controller/DropdownController.php
+++ b/src/Api/HL/Controller/DropdownController.php
@@ -1,0 +1,195 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Api\HL\Controller;
+
+use AutoUpdateSystem;
+use Calendar;
+use CommonDBTM;
+use Entity;
+use Glpi\Api\HL\Doc as Doc;
+use Glpi\Api\HL\Middleware\ResultFormatterMiddleware;
+use Glpi\Api\HL\Route;
+use Glpi\Api\HL\Search;
+use Glpi\Http\JSONResponse;
+use Glpi\Http\Request;
+use Glpi\Http\Response;
+use Group;
+use Location;
+use Manufacturer;
+use Network;
+use State;
+use User;
+
+#[Route(path: '/Dropdowns', priority: 1, tags: ['Dropdowns'])]
+#[Doc\Route(
+    parameters: [
+        [
+            'name' => 'itemtype',
+            'description' => 'Dropdown type',
+            'location' => Doc\Parameter::LOCATION_PATH,
+            'schema' => ['type' => Doc\Schema::TYPE_STRING]
+        ],
+        [
+            'name' => 'id',
+            'description' => 'The ID of the dropdown item',
+            'location' => Doc\Parameter::LOCATION_PATH,
+            'schema' => ['type' => Doc\Schema::TYPE_INTEGER]
+        ]
+    ]
+)]
+final class DropdownController extends AbstractController
+{
+    use CRUDControllerTrait;
+
+    protected static function getRawKnownSchemas(): array
+    {
+        $schemas = [];
+
+        $schemas['Location'] = [
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'x-itemtype' => Location::class,
+            'description' => Location::getTypeName(1),
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'x-readonly' => true,
+                ],
+                'name' => ['type' => Doc\Schema::TYPE_STRING],
+                'completename' => ['type' => Doc\Schema::TYPE_STRING],
+                'code' => ['type' => Doc\Schema::TYPE_STRING],
+                'aliases' => ['type' => Doc\Schema::TYPE_STRING],
+                'comment' => ['type' => Doc\Schema::TYPE_STRING],
+                'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
+                'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'parent' => self::getDropdownTypeSchema(class: Location::class, full_schema: 'Location'),
+                'level' => ['type' => Doc\Schema::TYPE_INTEGER],
+                'room' => ['type' => Doc\Schema::TYPE_STRING],
+                'building' => ['type' => Doc\Schema::TYPE_STRING],
+                'address' => ['type' => Doc\Schema::TYPE_STRING],
+                'town' => ['type' => Doc\Schema::TYPE_STRING],
+                'postcode' => ['type' => Doc\Schema::TYPE_STRING],
+                'state' => ['type' => Doc\Schema::TYPE_STRING],
+                'country' => ['type' => Doc\Schema::TYPE_STRING],
+                'latitude' => ['type' => Doc\Schema::TYPE_STRING],
+                'longitude' => ['type' => Doc\Schema::TYPE_STRING],
+                'altitude' => ['type' => Doc\Schema::TYPE_STRING],
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ]
+        ];
+
+        $schemas['State'] = [
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'x-itemtype' => State::class,
+            'description' => State::getTypeName(1),
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'x-readonly' => true,
+                ],
+                'name' => ['type' => Doc\Schema::TYPE_STRING],
+                'completename' => ['type' => Doc\Schema::TYPE_STRING],
+                'comment' => ['type' => Doc\Schema::TYPE_STRING],
+                'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
+                'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'parent' => self::getDropdownTypeSchema(class: State::class, full_schema: 'State'),
+                'level' => ['type' => Doc\Schema::TYPE_INTEGER],
+                'is_visible_computer' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'is_visible_monitor' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'is_visible_network_equipment' => ['x-field' => 'is_visible_networkequipment','type' => Doc\Schema::TYPE_BOOLEAN],
+                'is_visible_peripheral' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'is_visible_phone' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'is_visible_printer' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'is_visible_software_version' => ['x-field' => 'is_visible_softwareversion','type' => Doc\Schema::TYPE_BOOLEAN],
+                'is_visible_software_license' => ['x-field' => 'is_visible_softwarelicense','type' => Doc\Schema::TYPE_BOOLEAN],
+                'is_visible_line' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'is_visible_certificate' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'is_visible_rack' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'is_visible_passive_dcequipment' => ['x-field' => 'is_visible_passivedcequipment', 'type' => Doc\Schema::TYPE_BOOLEAN],
+                'is_visible_enclosure' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'is_visible_pdu' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'is_visible_cluster' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'is_visible_contract' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'is_visible_appliance' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'is_visible_cable' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'is_visible_database_instance' => ['x-field' => 'is_visible_databaseinstance', 'type' => Doc\Schema::TYPE_BOOLEAN],
+                'is_visible_helpdesk' => ['x-field' => 'is_helpdesk_visible', 'type' => Doc\Schema::TYPE_BOOLEAN],
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ]
+        ];
+
+        $schemas['Manufacturer'] = [
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'x-itemtype' => Manufacturer::class,
+            'description' => Manufacturer::getTypeName(1),
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'x-readonly' => true,
+                ],
+                'name' => ['type' => Doc\Schema::TYPE_STRING],
+                'comment' => ['type' => Doc\Schema::TYPE_STRING],
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ]
+        ];
+
+        $schemas['Calendar'] = [
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'x-itemtype' => Calendar::class,
+            'description' => Calendar::getTypeName(1),
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'x-readonly' => true,
+                ],
+                'name' => ['type' => Doc\Schema::TYPE_STRING],
+                'comment' => ['type' => Doc\Schema::TYPE_STRING],
+                'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
+                'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ]
+        ];
+
+        return $schemas;
+    }
+}

--- a/src/Api/HL/Controller/ITILController.php
+++ b/src/Api/HL/Controller/ITILController.php
@@ -146,7 +146,7 @@ final class ITILController extends AbstractController
                     ],
                 ]
             ];
-            $schemas[$itil_type]['properties']['entity'] = self::getDropdownTypeSchema(Entity::class);
+            $schemas[$itil_type]['properties']['entity'] = self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity');
             // Add completename field
             $schemas[$itil_type]['properties']['entity']['properties']['completename'] = ['type' => Doc\Schema::TYPE_STRING];
 
@@ -230,8 +230,8 @@ final class ITILController extends AbstractController
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
                     'x-readonly' => true,
                 ],
-                'requester' => self::getDropdownTypeSchema(User::class),
-                'approver' => self::getDropdownTypeSchema(User::class, 'users_id_validate'),
+                'requester' => self::getDropdownTypeSchema(class: User::class, full_schema: 'User'),
+                'approver' => self::getDropdownTypeSchema(class: User::class, field: 'users_id_validate', full_schema: 'User'),
                 'requested_approver_type' => [
                     'type' => Doc\Schema::TYPE_STRING,
                     'x-field' => 'itemtype_target',
@@ -296,7 +296,7 @@ final class ITILController extends AbstractController
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
-                'entity' => self::getDropdownTypeSchema(Entity::class),
+                'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                 'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
                 'is_active' => ['type' => Doc\Schema::TYPE_BOOLEAN],
                 'template' => self::getDropdownTypeSchema(TicketTemplate::class),
@@ -334,7 +334,7 @@ final class ITILController extends AbstractController
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
-                'entity' => self::getDropdownTypeSchema(Entity::class),
+                'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                 'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
                 'is_active' => ['type' => Doc\Schema::TYPE_BOOLEAN],
                 'template' => self::getDropdownTypeSchema(ChangeTemplate::class),
@@ -374,10 +374,10 @@ final class ITILController extends AbstractController
                 'text' => ['type' => Doc\Schema::TYPE_STRING],
                 'template' => self::getDropdownTypeSchema(PlanningExternalEventTemplate::class),
                 'category' => self::getDropdownTypeSchema(PlanningEventCategory::class),
-                'entity' => self::getDropdownTypeSchema(Entity::class),
+                'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                 'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
-                'user' => self::getDropdownTypeSchema(User::class),
-                'group' => self::getDropdownTypeSchema(Group::class),
+                'user' => self::getDropdownTypeSchema(class: User::class, full_schema: 'User'),
+                'group' => self::getDropdownTypeSchema(class: Group::class, full_schema: 'Group'),
                 'date' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                 'date_begin' => [
                     'type' => Doc\Schema::TYPE_STRING,

--- a/src/Api/HL/Controller/ITILController.php
+++ b/src/Api/HL/Controller/ITILController.php
@@ -80,6 +80,54 @@ final class ITILController extends AbstractController
     {
         $schemas = [];
 
+        $schemas['ITILCategory'] = [
+            'x-itemtype' => 'ITILCategory',
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'x-readonly' => true,
+                ],
+                'name' => ['type' => Doc\Schema::TYPE_STRING],
+                'completename' => ['type' => Doc\Schema::TYPE_STRING],
+                'comment' => ['type' => Doc\Schema::TYPE_STRING],
+                'entity' => self::getDropdownTypeSchema(class: \Entity::class, full_schema: 'Entity'),
+                'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'parent' => self::getDropdownTypeSchema(class: \ITILCategory::class, full_schema: 'ITILCategory'),
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ]
+        ];
+
+        $common_itiltemplate_properties = [
+            'id' => [
+                'type' => Doc\Schema::TYPE_INTEGER,
+                'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                'x-readonly' => true,
+            ],
+            'name' => ['type' => Doc\Schema::TYPE_STRING],
+            'completename' => ['type' => Doc\Schema::TYPE_STRING],
+            'comment' => ['type' => Doc\Schema::TYPE_STRING],
+            'entity' => self::getDropdownTypeSchema(class: \Entity::class, full_schema: 'Entity'),
+            'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+        ];
+        $schemas['TicketTemplate'] = [
+            'x-itemtype' => 'TicketTemplate',
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'properties' => $common_itiltemplate_properties
+        ];
+        $schemas['ChangeTemplate'] = [
+            'x-itemtype' => 'ChangeTemplate',
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'properties' => $common_itiltemplate_properties
+        ];
+        $schemas['ProblemTemplate'] = [
+            'x-itemtype' => 'ProblemTemplate',
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'properties' => $common_itiltemplate_properties
+        ];
+
         $base_schema = [
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -91,8 +139,8 @@ final class ITILController extends AbstractController
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'content' => ['type' => Doc\Schema::TYPE_STRING],
                 'is_deleted' => ['type' => Doc\Schema::TYPE_BOOLEAN],
-                'category' => self::getDropdownTypeSchema(\ITILCategory::class),
-                'location' => self::getDropdownTypeSchema(\Location::class),
+                'category' => self::getDropdownTypeSchema(class: \ITILCategory::class, full_schema: 'ITILCategory'),
+                'location' => self::getDropdownTypeSchema(class: \Location::class, full_schema: 'Location'),
                 'urgency' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'enum' => [1, 2, 3, 4, 5]
@@ -152,6 +200,7 @@ final class ITILController extends AbstractController
 
             $schemas[$itil_type]['properties']['team'] = [
                 'type' => Doc\Schema::TYPE_ARRAY,
+                'x-full-schema' => 'TeamMember',
                 'items' => [
                     'x-mapped-from' => 'id',
                     'x-mapper' => function ($v) use ($itil_type) {
@@ -299,7 +348,7 @@ final class ITILController extends AbstractController
                 'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                 'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
                 'is_active' => ['type' => Doc\Schema::TYPE_BOOLEAN],
-                'template' => self::getDropdownTypeSchema(TicketTemplate::class),
+                'template' => self::getDropdownTypeSchema(class: TicketTemplate::class, full_schema: 'TicketTemplate'),
                 'date_begin' => [
                     'type' => Doc\Schema::TYPE_STRING,
                     'format' => Doc\Schema::FORMAT_STRING_DATE_TIME,
@@ -317,7 +366,7 @@ final class ITILController extends AbstractController
                     'format' => Doc\Schema::FORMAT_STRING_DATE_TIME,
                     'x-field' => 'next_creation_date',
                 ],
-                'calendar' => self::getDropdownTypeSchema(Calendar::class),
+                'calendar' => self::getDropdownTypeSchema(class: Calendar::class, full_schema: 'Calendar'),
                 'ticket_per_item' => ['type' => Doc\Schema::TYPE_BOOLEAN],
             ]
         ];
@@ -337,7 +386,7 @@ final class ITILController extends AbstractController
                 'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                 'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
                 'is_active' => ['type' => Doc\Schema::TYPE_BOOLEAN],
-                'template' => self::getDropdownTypeSchema(ChangeTemplate::class),
+                'template' => self::getDropdownTypeSchema(class: ChangeTemplate::class, full_schema: 'ChangeTemplate'),
                 'date_begin' => [
                     'type' => Doc\Schema::TYPE_STRING,
                     'format' => Doc\Schema::FORMAT_STRING_DATE_TIME,
@@ -355,14 +404,59 @@ final class ITILController extends AbstractController
                     'format' => Doc\Schema::FORMAT_STRING_DATE_TIME,
                     'x-field' => 'next_creation_date',
                 ],
-                'calendar' => self::getDropdownTypeSchema(Calendar::class),
+                'calendar' => self::getDropdownTypeSchema(class: Calendar::class, full_schema: 'Calendar'),
+            ]
+        ];
+
+        $schemas['ExternalEventTemplate'] = [
+            'x-itemtype' => \PlanningExternalEventTemplate::class,
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'description' => \PlanningExternalEventTemplate::getTypeName(1),
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'x-readonly' => true,
+                ],
+                'name' => ['type' => Doc\Schema::TYPE_STRING],
+                'text' => ['type' => Doc\Schema::TYPE_STRING],
+                'comment' => ['type' => Doc\Schema::TYPE_STRING],
+                'duration' => ['type' => Doc\Schema::TYPE_INTEGER],
+                'before_time' => ['type' => Doc\Schema::TYPE_INTEGER],
+                'rrule' => ['type' => Doc\Schema::TYPE_STRING],
+                'category' => self::getDropdownTypeSchema(class: PlanningEventCategory::class, full_schema: 'EventCategory'),
+                'state' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'enum' => [\Planning::INFO, \Planning::TODO, \Planning::DONE]
+                ],
+                'is_background' => ['x-field' => 'background', 'type' => Doc\Schema::TYPE_BOOLEAN],
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ]
+        ];
+
+        $schemas['EventCategory'] = [
+            'x-itemtype' => \PlanningEventCategory::class,
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'description' => \PlanningEventCategory::getTypeName(1),
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'x-readonly' => true,
+                ],
+                'name' => ['type' => Doc\Schema::TYPE_STRING],
+                'comment' => ['type' => Doc\Schema::TYPE_STRING],
+                'color' => ['type' => Doc\Schema::TYPE_STRING],
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
             ]
         ];
 
         $schemas['ExternalEvent'] = [
             'x-itemtype' => \PlanningExternalEvent::class,
             'type' => Doc\Schema::TYPE_OBJECT,
-            'description' => 'External event',
+            'description' => \PlanningExternalEvent::getTypeName(1),
             'properties' => [
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
@@ -372,8 +466,8 @@ final class ITILController extends AbstractController
                 'uuid' => ['type' => Doc\Schema::TYPE_STRING, 'pattern' => Doc\Schema::PATTERN_UUIDV4],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'text' => ['type' => Doc\Schema::TYPE_STRING],
-                'template' => self::getDropdownTypeSchema(PlanningExternalEventTemplate::class),
-                'category' => self::getDropdownTypeSchema(PlanningEventCategory::class),
+                'template' => self::getDropdownTypeSchema(class: PlanningExternalEventTemplate::class, full_schema: 'ExternalEventTemplate'),
+                'category' => self::getDropdownTypeSchema(class: PlanningEventCategory::class, full_schema: 'EventCategory'),
                 'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                 'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
                 'user' => self::getDropdownTypeSchema(class: User::class, full_schema: 'User'),

--- a/src/Api/HL/Controller/ManagementController.php
+++ b/src/Api/HL/Controller/ManagementController.php
@@ -124,7 +124,7 @@ final class ManagementController extends AbstractController
             }
 
             if ($item->isEntityAssign()) {
-                $schemas[$m_name]['properties']['entity'] = self::getDropdownTypeSchema(Entity::class);
+                $schemas[$m_name]['properties']['entity'] = self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity');
                 // Add completename field
                 $schemas[$m_name]['properties']['entity']['properties']['completename'] = ['type' => Doc\Schema::TYPE_STRING];
                 $schemas[$m_name]['properties']['is_recursive'] = ['type' => Doc\Schema::TYPE_BOOLEAN];
@@ -149,16 +149,16 @@ final class ManagementController extends AbstractController
             }
 
             if (in_array($m_class, $CFG_GLPI['linkuser_tech_types'], true)) {
-                $schemas[$m_name]['properties']['user_tech'] = self::getDropdownTypeSchema(User::class, 'users_id_tech');
+                $schemas[$m_name]['properties']['user_tech'] = self::getDropdownTypeSchema(class: User::class, field: 'users_id_tech', full_schema: 'User');
             }
             if (in_array($m_class, $CFG_GLPI['linkgroup_tech_types'], true)) {
-                $schemas[$m_name]['properties']['group_tech'] = self::getDropdownTypeSchema(Group::class, 'groups_id_tech');
+                $schemas[$m_name]['properties']['group_tech'] = self::getDropdownTypeSchema(class: Group::class, field: 'groups_id_tech', full_schema: 'Group');
             }
             if (in_array($m_class, $CFG_GLPI['linkuser_types'], true)) {
-                $schemas[$m_name]['properties']['user'] = self::getDropdownTypeSchema(User::class, 'users_id');
+                $schemas[$m_name]['properties']['user'] = self::getDropdownTypeSchema(class: User::class, full_schema: 'User');
             }
             if (in_array($m_class, $CFG_GLPI['linkgroup_types'], true)) {
-                $schemas[$m_name]['properties']['group'] = self::getDropdownTypeSchema(Group::class, 'groups_id');
+                $schemas[$m_name]['properties']['group'] = self::getDropdownTypeSchema(class: Group::class, full_schema: 'Group');
             }
 
             if ($item->isField('contact')) {

--- a/src/Api/HL/Controller/ManagementController.php
+++ b/src/Api/HL/Controller/ManagementController.php
@@ -116,11 +116,11 @@ final class ManagementController extends AbstractController
             }
 
             if (in_array($m_class, $CFG_GLPI['state_types'], true)) {
-                $schemas[$m_name]['properties']['status'] = self::getDropdownTypeSchema(State::class);
+                $schemas[$m_name]['properties']['status'] = self::getDropdownTypeSchema(class: State::class, full_schema: 'State');
             }
 
             if (in_array($m_class, $CFG_GLPI['location_types'], true)) {
-                $schemas[$m_name]['properties']['location'] = self::getDropdownTypeSchema(Location::class);
+                $schemas[$m_name]['properties']['location'] = self::getDropdownTypeSchema(class: Location::class, full_schema: 'Location');
             }
 
             if ($item->isEntityAssign()) {
@@ -137,7 +137,7 @@ final class ManagementController extends AbstractController
                 $schemas[$m_name]['properties']['type'] = self::getDropdownTypeSchema($type_class);
             }
             if ($item->isField('manufacturers_id')) {
-                $schemas[$m_name]['properties']['manufacturer'] = self::getDropdownTypeSchema(Manufacturer::class);
+                $schemas[$m_name]['properties']['manufacturer'] = self::getDropdownTypeSchema(class: Manufacturer::class, full_schema: 'Manufacturer');
             }
             $model_class = $item->getModelClass();
             if ($model_class !== null) {

--- a/src/Api/HL/Controller/ProjectController.php
+++ b/src/Api/HL/Controller/ProjectController.php
@@ -67,7 +67,7 @@ final class ProjectController extends AbstractController
                         'type' => Doc\Schema::TYPE_INTEGER,
                         'enum' => [1, 2, 3, 4, 5, 6],
                     ],
-                    'entity' => self::getDropdownTypeSchema(\Entity::class),
+                    'entity' => self::getDropdownTypeSchema(class: \Entity::class, full_schema: 'Entity'),
                     'tasks' => [
                         'type' => Doc\Schema::TYPE_ARRAY,
                         'items' => [

--- a/src/Api/HL/Controller/ProjectController.php
+++ b/src/Api/HL/Controller/ProjectController.php
@@ -72,6 +72,7 @@ final class ProjectController extends AbstractController
                         'type' => Doc\Schema::TYPE_ARRAY,
                         'items' => [
                             'type' => Doc\Schema::TYPE_OBJECT,
+                            'x-full-schema' => 'Task',
                             'x-join' => [
                                 'table' => 'glpi_projecttasks',
                                 'fkey' => 'id',
@@ -103,8 +104,8 @@ final class ProjectController extends AbstractController
                     'name' => ['type' => Doc\Schema::TYPE_STRING],
                     'comment' => ['type' => Doc\Schema::TYPE_STRING],
                     'content' => ['type' => Doc\Schema::TYPE_STRING],
-                    'project' => self::getDropdownTypeSchema(Project::class),
-                    'parent_task' => self::getDropdownTypeSchema(ProjectTask::class),
+                    'project' => self::getDropdownTypeSchema(class: Project::class, full_schema: 'Project'),
+                    'parent_task' => self::getDropdownTypeSchema(class: ProjectTask::class, full_schema: 'Task'),
                 ]
             ],
         ];

--- a/src/Api/HL/OpenAPIGenerator.php
+++ b/src/Api/HL/OpenAPIGenerator.php
@@ -78,7 +78,7 @@ final class OpenAPIGenerator
 
     private function getPublicVendorExtensions(): array
     {
-        return ['x-writeonly', 'x-readonly'];
+        return ['x-writeonly', 'x-readonly', 'x-full-schema'];
     }
 
     private function cleanVendorExtensions(array $schema, ?string $parent_key = null): array

--- a/src/Api/HL/OpenAPIGenerator.php
+++ b/src/Api/HL/OpenAPIGenerator.php
@@ -214,6 +214,8 @@ EOT;
     {
         global $CFG_GLPI;
 
+        $component_schemas = self::getComponentSchemas();
+        ksort($component_schemas);
         $schema = [
             'openapi' => self::OPENAPI_VERSION,
             'info' => $this->getInfo(),
@@ -225,7 +227,7 @@ EOT;
             ],
             'components' => [
                 'securitySchemes' => $this->getSecuritySchemeComponents(),
-                'schemas' => self::getComponentSchemas(),
+                'schemas' => $component_schemas,
             ]
         ];
 

--- a/src/Api/HL/Router.php
+++ b/src/Api/HL/Router.php
@@ -41,6 +41,7 @@ use Glpi\Api\HL\Controller\AssetController;
 use Glpi\Api\HL\Controller\ComponentController;
 use Glpi\Api\HL\Controller\CoreController;
 use Glpi\Api\HL\Controller\CRUDControllerTrait;
+use Glpi\Api\HL\Controller\DropdownController;
 use Glpi\Api\HL\Controller\ITILController;
 use Glpi\Api\HL\Controller\ManagementController;
 use Glpi\Api\HL\Controller\ProjectController;
@@ -162,6 +163,7 @@ EOT;
             $instance->registerController(new AdministrationController());
             $instance->registerController(new ManagementController());
             $instance->registerController(new ProjectController());
+            $instance->registerController(new DropdownController());
 
             // Register controllers from plugins
             if (isset($PLUGIN_HOOKS[Hooks::API_CONTROLLERS])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When a schema has related data like an entity or user, typically only the ID, name and a few other fields are shown; just enough to identify it. By tracking which schema represents the full object, it can improve user understanding of the type and also enable improved functionality on the server side.
For example, a potential GraphQL wrapper. Currently, the GraphQL wrapper dynamically generates a new object type for every single joined property. This is not only inefficient and a mess for users, but doesn't allow one of the benefits of GraphQL by letting the user get more of the fields than are exposed by default in the REST API. Knowing the full schema, we don't need to generate the extra object types and can enable the fetching of the extra fields.

The new OpenAPI extension field being used for this `x-full-schema` is configured to be shown in the Swagger UI.

To Do:
- [x] Add schemas for the other types being used in properties but lack a main schema currently