### PR TITLE
fix(knowbase): load category from URL

### DIFF
--- a/src/Knowbase.php
+++ b/src/Knowbase.php
@@ -152,7 +152,7 @@ class Knowbase extends CommonGLPI
         $ajax_url    = $CFG_GLPI["root_doc"] . "/ajax/knowbase.php";
         $loading_txt = __s('Loading...');
         $start       = (int)($_REQUEST['start'] ?? 0);
-        $cat_id      = (int)($_GET["knowbaseitemcategories_id"] ?? ($_SESSION['kb_cat_id'] ?? 0));
+        $cat_id      = (int)($_GET["knowbaseitemcategories_id"] ?? $_SESSION['kb_cat_id'] ?? 0);
 
         $category_list = json_encode(self::getTreeCategoryList());
         $no_cat_found  = __s("No category found");

--- a/src/Knowbase.php
+++ b/src/Knowbase.php
@@ -152,7 +152,7 @@ class Knowbase extends CommonGLPI
         $ajax_url    = $CFG_GLPI["root_doc"] . "/ajax/knowbase.php";
         $loading_txt = __s('Loading...');
         $start       = (int)($_REQUEST['start'] ?? 0);
-        $cat_id      = (int)($_SESSION['kb_cat_id'] ?? 0);
+        $cat_id      = (int)($_GET["knowbaseitemcategories_id"] ?? ($_SESSION['kb_cat_id'] ?? 0));
 
         $category_list = json_encode(self::getTreeCategoryList());
         $no_cat_found  = __s("No category found");


### PR DESCRIPTION
The category was not loaded from the URL parameters, when it is present. The last category displayed was always loaded.

![image](https://github.com/glpi-project/glpi/assets/8530352/c43a932e-d1a7-48db-8a37-90101e3d96d0)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28580
