### PR TITLE
HLAPI Item-level restrictions in schema

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -5338,7 +5338,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'domain',
-                'rights' => READ | UPDATE | CREATE | PURGE,
+                'rights' => READ | UPDATE | CREATE | DELETE | PURGE,
             ], [
                 'profiles_id' => self::PROFILE_SELF_SERVICE,
                 'name' => 'profile',
@@ -6207,7 +6207,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'domain',
-                'rights' => READ | UPDATE | CREATE | PURGE,
+                'rights' => READ | UPDATE | CREATE | DELETE | PURGE,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'profile',
@@ -6506,7 +6506,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'domain',
-                'rights' => READ | UPDATE | CREATE | PURGE,
+                'rights' => READ | UPDATE | CREATE | DELETE | PURGE,
             ], [
                 'profiles_id' => self::PROFILE_HOTLINER,
                 'name' => 'profile',

--- a/src/Api/HL/Controller/AdministrationController.php
+++ b/src/Api/HL/Controller/AdministrationController.php
@@ -61,6 +61,26 @@ final class AdministrationController extends AbstractController
             'User' => [
                 'x-itemtype' => User::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
+                'x-rights-conditions' => [ // Object-level extra permissions
+                    'read' => static function () {
+                        if (!\Session::canViewAllEntities()) {
+                            return [
+                                'LEFT JOIN' => [
+                                    'glpi_profiles_users' => [
+                                        'ON' => [
+                                            'glpi_profiles_users' => 'users_id',
+                                            'glpi_users' => 'id'
+                                        ]
+                                    ]
+                                ],
+                                'WHERE' => [
+                                    'glpi_profiles_users.entities_id' => $_SESSION['glpiactiveentities']
+                                ]
+                            ];
+                        }
+                        return true;
+                    }
+                ],
                 'properties' => [
                     'id' => [
                         'type' => Doc\Schema::TYPE_INTEGER,

--- a/src/Api/HL/Controller/ITILController.php
+++ b/src/Api/HL/Controller/ITILController.php
@@ -221,6 +221,14 @@ final class ITILController extends AbstractController
 
         $base_task_schema = [
             'type' => Doc\Schema::TYPE_OBJECT,
+            'x-rights-conditions' => [ // Object-level extra permissions
+                'read' => static function () {
+                    if (!\Session::haveRight(\CommonITILTask::$rightname, \CommonITILTask::SEEPRIVATE)) {
+                        return ['WHERE' => ['is_private' => 0]];
+                    }
+                    return true; // Allow reading by default. No extra SQL conditions needed.
+                }
+            ],
             'properties' => [
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
@@ -245,8 +253,16 @@ final class ITILController extends AbstractController
         $schemas['ProblemTask']['properties'][Problem::getForeignKeyField()] = ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64];
 
         $schemas['Followup'] = [
-            'type' => Doc\Schema::TYPE_OBJECT,
             'x-itemtype' => \ITILFollowup::class,
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'x-rights-conditions' => [ // Object-level extra permissions
+                'read' => static function () {
+                    if (!\Session::haveRight(\ITILFollowup::$rightname, \ITILFollowup::SEEPRIVATE)) {
+                        return ['WHERE' => ['is_private' => 0]];
+                    }
+                    return true; // Allow reading by default. No extra SQL conditions needed.
+                }
+            ],
             'properties' => [
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,

--- a/src/Api/HL/Controller/ITILController.php
+++ b/src/Api/HL/Controller/ITILController.php
@@ -224,7 +224,14 @@ final class ITILController extends AbstractController
             'x-rights-conditions' => [ // Object-level extra permissions
                 'read' => static function () {
                     if (!\Session::haveRight(\CommonITILTask::$rightname, \CommonITILTask::SEEPRIVATE)) {
-                        return ['WHERE' => ['is_private' => 0]];
+                        return [
+                            'WHERE' => [
+                                'OR' => [
+                                    'is_private' => 0,
+                                    'users_id' => \Session::getLoginUserID()
+                                ]
+                            ]
+                        ];
                     }
                     return true; // Allow reading by default. No extra SQL conditions needed.
                 }
@@ -258,7 +265,14 @@ final class ITILController extends AbstractController
             'x-rights-conditions' => [ // Object-level extra permissions
                 'read' => static function () {
                     if (!\Session::haveRight(\ITILFollowup::$rightname, \ITILFollowup::SEEPRIVATE)) {
-                        return ['WHERE' => ['is_private' => 0]];
+                        return [
+                            'WHERE' => [
+                                'OR' => [
+                                    'is_private' => 0,
+                                    'users_id' => \Session::getLoginUserID()
+                                ]
+                            ]
+                        ];
                     }
                     return true; // Allow reading by default. No extra SQL conditions needed.
                 }

--- a/src/Api/HL/Middleware/CRUDRequestMiddleware.php
+++ b/src/Api/HL/Middleware/CRUDRequestMiddleware.php
@@ -80,7 +80,7 @@ class CRUDRequestMiddleware extends AbstractMiddleware implements RequestMiddlew
         if ($passed && $specific_item) {
             // Specific permission checks
             $passed = match ($input->request->getMethod()) {
-                'GET' => $item->canViewItem(),
+                // Specific item read permissions are checked at the API Search engine level to preserve pagination and allow filtering at the search operation level (getting multiple items)
                 'POST' => $item->canCreateItem(),
                 'PATCH' => $item->canUpdateItem(),
                 'DELETE' => $force ? $item->canPurgeItem() : $item->canDeleteItem()

--- a/src/Api/HL/Middleware/CRUDRequestMiddleware.php
+++ b/src/Api/HL/Middleware/CRUDRequestMiddleware.php
@@ -62,33 +62,7 @@ class CRUDRequestMiddleware extends AbstractMiddleware implements RequestMiddlew
                 $input->response = AbstractController::getNotFoundErrorResponse();
                 return;
             }
-            if (!$item->canViewItem()) {
-                $input->response = AbstractController::getAccessDeniedErrorResponse();
-                return;
-            }
             $input->request->setParameter('_item', $item);
-        }
-
-        $force = $input->request->hasParameter('force');
-        // Global permission checks
-        $passed = match ($input->request->getMethod()) {
-            'GET' => $itemtype::canView(),
-            'POST' => $itemtype::canCreate(),
-            'PATCH' => $itemtype::canUpdate(),
-            'DELETE' => $force ? $itemtype::canPurge() : $itemtype::canDelete()
-        };
-        if ($passed && $specific_item) {
-            // Specific permission checks
-            $passed = match ($input->request->getMethod()) {
-                // Specific item read permissions are checked at the API Search engine level to preserve pagination and allow filtering at the search operation level (getting multiple items)
-                'POST' => $item->canCreateItem(),
-                'PATCH' => $item->canUpdateItem(),
-                'DELETE' => $force ? $item->canPurgeItem() : $item->canDeleteItem()
-            };
-        }
-        if (!$passed) {
-            $input->response = AbstractController::getAccessDeniedErrorResponse();
-            return;
         }
 
         $next($input);

--- a/src/Api/HL/Search.php
+++ b/src/Api/HL/Search.php
@@ -608,7 +608,7 @@ final class Search
         if (isset($schema['x-subtypes'])) {
             // For this case, we need to filter out the schemas that the user doesn't have read rights on
             $schemas = $schema['x-subtypes'];
-            $schemas = array_filter($schemas, static function ($k, $v) {
+            $schemas = array_filter($schemas, static function ($v) {
                 $itemtype = $v['itemtype'];
                 if (class_exists($itemtype) && is_subclass_of($itemtype, CommonDBTM::class)) {
                     return $itemtype::canView();
@@ -800,7 +800,7 @@ final class Search
         /** @var CommonDBTM $item */
         $item = new $itemtype();
         $force = $request_params['force'] ?? false;
-        $input = [(int) $items_id];
+        $input = ['id' => (int) $items_id];
         if (!$item->can($item->getID(), $force ? PURGE : DELETE, $input)) {
             return AbstractController::getAccessDeniedErrorResponse();
         }

--- a/src/Api/HL/Search.php
+++ b/src/Api/HL/Search.php
@@ -780,7 +780,7 @@ final class Search
         $input['id'] = $items_id;
         /** @var CommonDBTM $item */
         $item = new $itemtype();
-        if (!$item->can($item->getID(), UPDATE, $input)) {
+        if (!$item->can($items_id, UPDATE, $input)) {
             return AbstractController::getAccessDeniedErrorResponse();
         }
         $result = $item->update($input);

--- a/tests/functional/Glpi/Api/HL/Controller/AdministrationController.php
+++ b/tests/functional/Glpi/Api/HL/Controller/AdministrationController.php
@@ -551,7 +551,7 @@ class AdministrationController extends \HLAPITestCase
 
     public function testCreateUpdateDeleteGroup()
     {
-        $this->login();
+        $this->login('glpi', 'glpi');
 
         $unique_id = __FUNCTION__;
 

--- a/tests/functional/Glpi/Api/HL/Controller/ComponentController.php
+++ b/tests/functional/Glpi/Api/HL/Controller/ComponentController.php
@@ -78,7 +78,7 @@ class ComponentController extends \HLAPITestCase
      */
     public function testCRUD(string $type)
     {
-        $this->login();
+        $this->login('glpi', 'glpi');
 
         $func_name = __FUNCTION__;
 

--- a/tests/functional/Glpi/Api/HL/Controller/ITILController.php
+++ b/tests/functional/Glpi/Api/HL/Controller/ITILController.php
@@ -539,17 +539,19 @@ class ITILController extends \HLAPITestCase
         // Create a document
         $this->integer($document_id = $document->add([
             'name' => __FUNCTION__,
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
         ]))->isGreaterThan(0);
 
         // Link the document to the ticket
         $this->integer($document_item_id = $document_item->add([
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
             'documents_id' => $document_id,
             'itemtype' => 'Ticket',
             'items_id' => $tickets_id,
         ]))->isGreaterThan(0);
 
         // Need to login to use the API
-        $this->login();
+        $this->login('glpi', 'glpi');
 
         // Try to change the parent of the followup
         $request = new Request('PATCH', "/Assistance/Ticket/$tickets_id/Timeline/Followup/$fup_id");

--- a/tests/functional/Glpi/Api/HL/Controller/ManagementController.php
+++ b/tests/functional/Glpi/Api/HL/Controller/ManagementController.php
@@ -57,7 +57,7 @@ class ManagementController extends \HLAPITestCase
             \Supplier::class => 'Supplier',
         ];
 
-        $this->login();
+        $this->login('glpi', 'glpi');
 
         foreach ($management_types as $m_class => $m_name) {
             $request = new Request('POST', '/Management/' . $m_name);


### PR DESCRIPTION
\| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Add a new optional extension property `x-rights-conditions`  to the schema definitions to specify, by access type, a callable that returns additional SQL criteria needed for the current user in order to restrict the results.

For example, a user without the ability to see private followups should have those followups filtered out.
A user without the ability to see all project should only see the ones they are a manager for or are in the project team for.

This keeps itemtype-specific restrictions out of the API's search code from the start and allows plugins to remove or modify the restrictions using the `redefine_api_schemas` hook. This also prevents the need to filter these items out of the results after they are already fetched from the DB which preserves pagination.

Example:
```php
function plugin_myplugin_redefine_api_schemas(array $data): array {
    foreach ($data['schemas'] as &$schema) {
        if (!$schema['x-itemtype'] !== 'Project') {
            continue;
        }
        // Remove read right restrictions
        if (isset($schema['x-rights-conditions']['read'])) {
            unset($schema['x-rights-conditions']['read']);
        }
        // Add more restrictions
        if (isset($schema['x-rights-conditions']['read'])) {
            $schema['x-rights-conditions']['read'] = function () {
                $existing = $schema['x-rights-conditions']['read']();
                // Modify existing array and then return the modified array
                // ...
            }
        }
    }
    return $data;
}
```