### PR TITLE
Disable errors output in test suites executed by atoum

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -88,6 +88,11 @@ if (file_exists(GLPI_CONFIG_DIR . DIRECTORY_SEPARATOR . CacheManager::CONFIG_FIL
 
 include_once __DIR__ . '/../inc/includes.php';
 
+// Errors that are not explicitely validated by `$this->error()` asserter will already make test fails,
+// and error log entries that not explicitely validated by `$this->has*LogRecord*()` asserters will also make test fails.
+// There is no need to pollute the output with error message.
+ErrorHandler::getInstance()->disableOutput();
+
 include_once __DIR__ . '/GLPITestCase.php';
 include_once __DIR__ . '/DbTestCase.php';
 include_once __DIR__ . '/CsvTestCase.php';

--- a/tests/functional/Item_OperatingSystem.php
+++ b/tests/functional/Item_OperatingSystem.php
@@ -100,11 +100,7 @@ class Item_OperatingSystem extends DbTestCase
         )->isIdenticalTo(1);
 
         $expected_error = "/Duplicate entry '{$computer->getID()}-Computer-{$objects['']->getID()}-{$objects['Architecture']->getID()}' for key '(glpi_items_operatingsystems\.)?unicity'/";
-        $this->output(
-            function () use ($ios, $input) {
-                $this->boolean($ios->add($input))->isFalse();
-            }
-        )->matches($expected_error);
+        $this->boolean($ios->add($input))->isFalse();
         $this->hasSqlLogRecordThatMatches($expected_error, LogLevel::ERROR);
 
         $this->integer(

--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -672,19 +672,15 @@ class MailCollector extends DbTestCase
         ];
 
         $msg = null;
-        $this->output(
+        $this->when(
             function () use (&$msg) {
-                $this->when(
-                    function () use (&$msg) {
-                        $msg = $this->collector->collect($this->mailgate_id);
-                    }
-                )
-                ->error()
-                    ->withType(E_USER_WARNING)
-                    ->withMessage('Invalid header "X-Invalid-Encoding"')
-                    ->exists();
+                $msg = $this->collector->collect($this->mailgate_id);
             }
-        )->matches('/^(.*\n){' . count($expected_logged_errors) . '}$/'); // Ensure that output has same count of lines than expected error count
+        )
+        ->error()
+            ->withType(E_USER_WARNING)
+            ->withMessage('Invalid header "X-Invalid-Encoding"')
+            ->exists();
 
         // Check error log and clean it (to prevent test failure, see GLPITestCase::afterTestMethod()).
         foreach ($expected_logged_errors as $error_message => $error_level) {

--- a/tests/units/DBmysqlIterator.php
+++ b/tests/units/DBmysqlIterator.php
@@ -68,11 +68,7 @@ class DBmysqlIterator extends DbTestCase
         global $DB;
 
         $expected_error = "Table '{$DB->dbdefault}.fakeTable' doesn't exist";
-        $this->output(
-            function () use ($DB) {
-                $DB->request('fakeTable');
-            }
-        )->contains($expected_error);
+        $DB->request('fakeTable');
         $this->hasSqlLogRecordThatContains($expected_error, LogLevel::ERROR);
     }
 

--- a/tests/units/Html.php
+++ b/tests/units/Html.php
@@ -68,11 +68,7 @@ class Html extends \GLPITestCase
         $this->string(\Html::convDate($mydate, 2))->isIdenticalTo($expected);
 
         $expected_error = 'Failed to parse time string (not a date) at position 0 (n): The timezone could not be found in the database';
-        $this->output(
-            function () {
-                $this->string(\Html::convDate('not a date', 2))->isIdenticalTo('not a date');
-            }
-        )->contains($expected_error);
+        $this->string(\Html::convDate('not a date', 2))->isIdenticalTo('not a date');
         $this->hasPhpLogRecordThatContains($expected_error, LogLevel::CRITICAL);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In our test suite, when an error is triggered:
1. the error is catched by atoum and make tests fail unless the `$this->error()` asserter is used to validate it exists;
2. the error is catched by the GLPI error handler and produce a log entry that make tests fail unless a `$this->has*LogRecord*()` asserter is used to validate it exists;
3. the error generates an output message.

The message pollutes the output, see image, and sometimes it confuses the developer that may think that the error has to be fixed.
![image](https://github.com/glpi-project/glpi/assets/33253653/4ec2be5b-94ea-4305-afaf-f92e799f4170)

A solution could be to catch the output using the `$this->output()` asserter, but it is redundant with the `$this->error()` asserter usage, see commit d28543712e4235b7bda39de632e7342ff9a7e0b9 .

I propose to disable the output of the error handler in test suite, as it seems useless, due to points 1 and 2.