### PR TITLE
Add missing hidden input for global_validation field

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -6469,6 +6469,11 @@ JAVASCRIPT;
                 }
             }
         }
+
+        // Add global validation
+        if (!$this->isNewItem() && !isset($input['global_validation'])) {
+            $input['global_validation'] = $this->fields['global_validation'];
+        }
     }
 
     /**

--- a/templates/components/itilobject/fields/status.html.twig
+++ b/templates/components/itilobject/fields/status.html.twig
@@ -70,8 +70,3 @@
    __('Status'),
    field_options
 ) }}
-
-{% if not item.isNewItem() %}
-   <input type="hidden" name="global_validation" value="{{ item.fields.global_validation }}">
-{% endif %}
-

--- a/templates/components/itilobject/fields/status.html.twig
+++ b/templates/components/itilobject/fields/status.html.twig
@@ -70,3 +70,8 @@
    __('Status'),
    field_options
 ) }}
+
+{% if not item.isNewItem() %}
+   <input type="hidden" name="global_validation" value="{{ item.fields.global_validation }}">
+{% endif %}
+

--- a/tests/DbTestCase.php
+++ b/tests/DbTestCase.php
@@ -262,4 +262,44 @@ class DbTestCase extends \GLPITestCase
 
         return $items;
     }
+
+    /**
+     * Helper method to avoid writting the same boilerplate code for rule creation
+     *
+     * @param RuleBuilder $builder RuleConfiguration
+     *
+     * @return Rule Created rule
+     */
+    protected function createRule(RuleBuilder $builder): Rule
+    {
+        $rule = $this->createItem(RuleTicket::class, [
+            'is_active'    => 1,
+            'sub_type'     => 'RuleTicket',
+            'name'         => $builder->getName(),
+            'match'        => $builder->getOperator(),
+            'condition'    => $builder->getCondition(),
+            'is_recursive' => $builder->isRecursive(),
+            'entities_id'  => $builder->getEntity(),
+        ]);
+
+        foreach ($builder->getCriteria() as $criterion) {
+            $this->createItem(RuleCriteria::class, [
+                'rules_id'  => $rule->getID(),
+                'criteria'  => $criterion['criteria'],
+                'condition' => $criterion['condition'],
+                'pattern'   => $criterion['pattern'],
+            ]);
+        }
+
+        foreach ($builder->getActions() as $criterion) {
+            $this->createItem(RuleAction::class, [
+                'rules_id'    => $rule->getID(),
+                'action_type' => $criterion['action_type'],
+                'field'       => $criterion['field'],
+                'value'       => $criterion['value'],
+            ]);
+        }
+
+        return $rule;
+    }
 }

--- a/tests/RuleBuilder.php
+++ b/tests/RuleBuilder.php
@@ -1,0 +1,247 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * Helper class to configurate rule creation in DbTestCase::createRule()
+ */
+class RuleBuilder
+{
+    /**
+     * @property string $name Rule name
+     */
+    protected string $name;
+
+    /**
+     * @property string $operator 'AND' or 'OR'
+     */
+    protected string $operator;
+
+    /**
+     * @property int $condition RuleTicket::ONADD and/or RuleTicket::ONUPDATE (bitmask)
+     */
+    protected int $condition;
+
+    /**
+     * @property bool $is_recursive
+     */
+    protected bool $is_recursive;
+
+    /**
+     * @property int $entities_id
+     */
+    protected int $entities_id;
+
+    /**
+     * @property array $criteria
+     */
+    protected array $criteria;
+
+    /**
+     * @property array $actions
+     */
+    protected array $actions;
+
+    /**
+     * @param string $name Rule name
+     */
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+
+        // Default values
+        $this->operator     = "AND";
+        $this->condition    = RuleTicket::ONADD | RuleTicket::ONUPDATE;
+        $this->is_recursive = true;
+        $this->entities_id  = getItemByTypeName(Entity::class, '_test_root_entity', true);
+        $this->criteria     = [];
+        $this->actions      = [];
+    }
+
+    /**
+     * Set condition
+     *
+     * @param string $operator 'AND' or 'OR'
+     *
+     * @return self
+     */
+    public function setOperator(string $operator): self
+    {
+        $this->operator = $operator;
+        return $this;
+    }
+
+    /**
+     * Set entity configuration
+     *
+     * @param bool $is_recursive
+     *
+     * @return self
+     */
+    public function setIsRecursive(int $is_recursive): self
+    {
+        $this->is_recursive = $is_recursive;
+        return $this;
+    }
+
+    /**
+     * Set entity configuration
+     *
+     * @param int $entities_id
+     *
+     * @return self
+     */
+    public function setEntity(int $entities_id): self
+    {
+        $this->entities_id = $entities_id;
+        return $this;
+    }
+
+    /**
+     * Add criteria
+     *
+     * @param string $criteria
+     * @param int $condition Rule::PATTERN_IS, ...
+     * @param mixed $pattern
+     *
+     * @return self
+     */
+    public function addCriteria(
+        string $criteria,
+        int $condition,
+        $pattern
+    ): self {
+        $this->criteria[] = [
+            'criteria'  => $criteria,
+            'condition' => $condition,
+            'pattern'   => $pattern,
+        ];
+        return $this;
+    }
+
+    /**
+     * Add action
+     *
+     * @param string $action_type
+     * @param string $field
+     * @param mixed $value
+     *
+     * @return self
+     */
+    public function addAction(
+        string $action_type,
+        string $field,
+        $value
+    ): self {
+        $this->actions[] = [
+            'action_type' => $action_type,
+            'field'       => $field,
+            'value'       => $value,
+        ];
+        return $this;
+    }
+
+
+    /**
+     * Get rule name
+     *
+     * @return string Rule name
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Get rule operator
+     *
+     * @return string 'AND' or 'OR'
+     */
+    public function getOperator(): string
+    {
+        return $this->operator;
+    }
+
+    /**
+     * Get rule condition
+     *
+     * @return int RuleTicket::ONADD and/or RuleTicket::ONUPDATE (bitmask)
+     */
+    public function getCondition(): int
+    {
+        return $this->condition;
+    }
+
+    /**
+     * Get rule entity configuration
+     *
+     * @return bool
+     */
+    public function isRecursive(): bool
+    {
+        return $this->is_recursive;
+    }
+
+    /**
+     * Get rule entity configuration
+     *
+     * @return int
+     */
+    public function getEntity(): int
+    {
+        return $this->entities_id;
+    }
+
+    /**
+     * Get rule criteria
+     *
+     * @return array
+     */
+    public function getCriteria(): array
+    {
+        return $this->criteria;
+    }
+
+    /**
+     * Get rule actions
+     *
+     * @return array
+     */
+    public function getActions(): array
+    {
+        return $this->actions;
+    }
+
+
+}

--- a/tests/RuleBuilder.php
+++ b/tests/RuleBuilder.php
@@ -242,6 +242,4 @@ class RuleBuilder
     {
         return $this->actions;
     }
-
-
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -93,6 +93,7 @@ include_once __DIR__ . '/DbTestCase.php';
 include_once __DIR__ . '/CsvTestCase.php';
 include_once __DIR__ . '/APIBaseClass.php';
 include_once __DIR__ . '/FrontBaseClass.php';
+include_once __DIR__ . '/RuleBuilder.php';
 include_once __DIR__ . '/InventoryTestCase.php';
 include_once __DIR__ . '/functional/CommonITILRecurrent.php';
 include_once __DIR__ . '/functional/Glpi/ContentTemplates/Parameters/AbstractParameters.php';


### PR DESCRIPTION
Add missing hidden input for the `global_validation` field, which is needed for our rule engine to work properly on this field.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28778