### PR TITLE
expired session message

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -821,6 +821,7 @@ class Html
         TemplateRenderer::getInstance()->display('display_and_die.html.twig', [
             'title'   => __('Access denied'),
             'message' => $message,
+            'link'    => Html::getBackUrl(),
         ]);
 
         self::nullFooter();

--- a/src/Session.php
+++ b/src/Session.php
@@ -1592,9 +1592,9 @@ class Session
     {
 
         $message = __("The action you have requested is not allowed.");
-        $requestToken = $data['_glpi_csrf_token'];
         if (
-            isset($_SESSION['glpicsrftokens'][$requestToken])
+            ($requestToken = $data['_glpi_csrf_token'] ?? null) !== null
+            && isset($_SESSION['glpicsrftokens'][$requestToken])
             && ($_SESSION['glpicsrftokens'][$requestToken] < time())
         ) {
             $message = __("Your session has expired.");

--- a/src/Session.php
+++ b/src/Session.php
@@ -1597,9 +1597,7 @@ class Session
             isset($_SESSION['glpicsrftokens'][$requestToken])
             && ($_SESSION['glpicsrftokens'][$requestToken] < time())
         ) {
-            $link = $_SERVER['HTTP_REFERER'] ?? '';
             $message = __("Your session has expired.") . "<br>";
-            $message .= sprintf(__("<a href='%s'>Click here</a> to go back to the previous page."), $link);
         }
 
         if (

--- a/src/Session.php
+++ b/src/Session.php
@@ -1591,6 +1591,17 @@ class Session
     public static function checkCSRF($data)
     {
 
+        $message = __("The action you have requested is not allowed.");
+        $requestToken = $data['_glpi_csrf_token'];
+        if (
+            isset($_SESSION['glpicsrftokens'][$requestToken])
+            && ($_SESSION['glpicsrftokens'][$requestToken] < time())
+        ) {
+            $link = $_SERVER['HTTP_REFERER'] ?? '';
+            $message = __("Your session has expired.") . "<br>";
+            $message .= sprintf(__("<a href='%s'>Click here</a> to go back to the previous page."), $link);
+        }
+
         if (
             GLPI_USE_CSRF_CHECK
             && (!Session::validateCSRF($data))
@@ -1601,10 +1612,10 @@ class Session
             // Output JSON if requested by client
             if (strpos($_SERVER['HTTP_ACCEPT'] ?? '', 'application/json') !== false) {
                 http_response_code(403);
-                die(json_encode(["message" => __("The action you have requested is not allowed.")]));
+                die(json_encode(["message" => $message]));
             }
 
-            Html::displayErrorAndDie(__("The action you have requested is not allowed."), true);
+            Html::displayErrorAndDie($message, true);
         }
     }
 

--- a/src/Session.php
+++ b/src/Session.php
@@ -1597,7 +1597,7 @@ class Session
             isset($_SESSION['glpicsrftokens'][$requestToken])
             && ($_SESSION['glpicsrftokens'][$requestToken] < time())
         ) {
-            $message = __("Your session has expired.") . "<br>";
+            $message = __("Your session has expired.");
         }
 
         if (

--- a/templates/display_and_die.html.twig
+++ b/templates/display_and_die.html.twig
@@ -37,7 +37,7 @@
          <i class="fas fa-exclamation-triangle fa-2x"></i>
       </div>
       <div>
-         {{ message }}
+         {{ message|safe_html }}
       </div>
    </div>
 </div>

--- a/templates/display_and_die.html.twig
+++ b/templates/display_and_die.html.twig
@@ -37,7 +37,8 @@
          <i class="fas fa-exclamation-triangle fa-2x"></i>
       </div>
       <div>
-         {{ message|safe_html }}
+         {{ message }}<br>
+         <a href="{{ link }}">{{ __(Return to previous page) }}</a>
       </div>
    </div>
 </div>

--- a/templates/display_and_die.html.twig
+++ b/templates/display_and_die.html.twig
@@ -38,7 +38,7 @@
       </div>
       <div>
          {{ message }}<br>
-         <a href="{{ link }}">{{ __(Return to previous page) }}</a>
+         <a href="{{ link }}">{{ __('Return to previous page') }}</a>
       </div>
    </div>
 </div>


### PR DESCRIPTION
When the session expires and an action is attempted, the error message was too generic.

Before:
![image](https://github.com/glpi-project/glpi/assets/8530352/5bbd5562-56f8-4c11-9cb2-6c17c5d51380)

After:
![image](https://github.com/glpi-project/glpi/assets/8530352/d27a48ea-756e-4e26-ab19-55b974cc10c0)


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28748
