### PR TITLE
Ensure cache is clear when a plugin is activated/deactivated

### DIFF
--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -1075,12 +1075,16 @@ HTML;
      *
      * @return string
      */
-    public static function getAllDashboardCardsCacheKey(): string
+    public static function getAllDashboardCardsCacheKey(?string $language = null): string
     {
+        if ($language === null) {
+            $language = Session::getLanguage() ?? '';
+        }
+
         return sprintf(
             'getAllDashboardCards_%s_%s',
             sha1(json_encode(Filter::getRegisteredFilterClasses())),
-            Session::getLanguage() ?? ''
+            $language
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

While working on #15109, I figured out that some caching issues may happens due to the fact that cache entries thay may be affected by plugins are not cleaned/rebuild when a plugin is installed/updated/activated/deactivated/uninstalled.

Some examples:
- A plugin installation may register a new right, resulting in a stale `all_possible_rights` cache entry. For the same reason, deinstallation of a plugin may have the same effect.
- If a plugin add its own entries in `$CFG_GLPI['itemdevices']`, `$CFG_GLPI['device_types']` or `$CFG_GLPI['asset_types']`, or if the result of a `AbstractFilter::canBeApplied()` method of an implementation of its own returns a different result than in a previous version, the `getAllDashboardCards_%s_%s` cache entry will be stale.
- If a plugin has a new class in its new version, the `itemtype-case-mapping-%s` corresponding to this plugin will be stale.
- If a plugin registers a new itemtype in a `itemdevice*_types` entry, the `item_device_affinities` cache entry will be stale.

There are many solutions to handle this:
1. Clearing the whole cache everytime a plugin is activated/deactivated. It is the easier way to ensure there is no stale cache entry.
2. Ask for plugins to clean/rebuild cache entries on their side, using hooks related to plugins operations. This is probably a bad idea, as some plugin developers may not be aware of the cache entries impacted by their plugins.
3. Maintain, on our side, a list of cache entries that may be affected by plugins, and clear only these entries. It may be hard to maintain and should only be used as a short term solution.
4. Use [cache entries tags](https://symfony.com/doc/current/components/cache/cache_invalidation.html#using-cache-tags) to be able to make cleaning operations less aggressive (for instance we would not clear the CSS cache nor the marketplace cache on plugin activation). It could be a good idea, but the list would have to be documented somewhere and would have to be stable over GLPI versions, to be able to be used by plugins.

For now, I propose to use solution 3, as the target branch is 10.0/bugfixes. The solution 4 could be implemented in GLPI 10.1, if everyone agrees for this.