### PR TITLE
fix(dashboard): suffix

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -847,7 +847,6 @@ class GLPIDashboard {
                 var count        = $(this);
                 var precision    = count.data('precision');
                 var number       = count.children('.number');
-                var suffix       = count.children('.suffix').text();
                 var targetNumber = number.text();
 
                 // Some custom formats may contain text in the number field, no animation in this case
@@ -859,10 +858,10 @@ class GLPIDashboard {
                     duration: 800,
                     easing: 'swing',
                     step: function () {
-                        number.text(this.Counter.toFixed(precision) + suffix);
+                        number.text(this.Counter.toFixed(precision));
                     },
                     complete: function () {
-                        number.text(targetNumber + suffix);
+                        number.text(targetNumber);
                     }
                 });
             });


### PR DESCRIPTION
The 'K' was duplicated since https://github.com/glpi-project/glpi/pull/15209.

![image](https://github.com/glpi-project/glpi/assets/8530352/ac1e6d1c-17b2-409f-87bb-641b1876ce81)

I don't know if this suffix has any other use? In this case, it seems unnecessary

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
