### PR TITLE
Avoid transform rotate when collapsing kanban cols

### DIFF
--- a/css/includes/components/_kanban.scss
+++ b/css/includes/components/_kanban.scss
@@ -191,7 +191,7 @@
 
                             .kanban-column-title,
                             .kanban_nb {
-                                writing-mode: tb;
+                                writing-mode: vertical-lr;
                                 margin-top: 10px;
                                 margin-left: 0;
                                 padding: 12px 3px;

--- a/css/includes/components/_kanban.scss
+++ b/css/includes/components/_kanban.scss
@@ -181,14 +181,20 @@
                         .kanban-column-header-content {
                             flex-direction: column;
 
-                            .kanban-collapse-column,
-                            .kanban-column-title,
-                            .kanban_nb {
+                            .kanban-collapse-column {
                                 transform: rotate(90deg);
                                 transform-origin: center;
                                 display: inline-block;
                                 margin: calc(50% - 8px) 0;
                                 white-space: nowrap;
+                            }
+
+                            .kanban-column-title,
+                            .kanban_nb {
+                                writing-mode: tb;
+                                margin-top: 10px;
+                                margin-left: 0;
+                                padding: 12px 3px;
                             }
 
                             .kanban-collapse-column {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15254

When using a rotate transform in CSS, it doesn't rotate the layout (width, height, margin, padding, etc). A long Kanban header like "Processing (Assigned)" would overlap the surrounding columns when collapsed and block the user from being able to interact with the buttons in the other columns to expand them.

An alternative could be to change the writing mode to `tb` and then manually "rotate" the margins and padding.