### PR TITLE
Fix actor dropdown infinite loading

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -4183,7 +4183,7 @@ JAVASCRIPT;
             'results' => $results,
             'count'   => count($results),
         ];
-        if ($total_results > count($results)) {
+        if (count($results) >= $post['page_limit']) {
             $return['pagination'] = [
                 'more' => true,
             ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15256

The returned `more` parameter was being returned as `true` under the wrong conditions leading to the actor dropdown always thinking there was more to load. This caused it to repeatedly send back-to-back requests to `ajax/actors.php` and, if debug mode was enabled, that meant many debug profile sessions being created and fetched from the server in a second `ajax/debug.php` request each time.