### PR TITLE
Fix project kanban

### DIFF
--- a/src/Project.php
+++ b/src/Project.php
@@ -2008,7 +2008,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
             }
 
             // sort by name ASC
-            usort($result, function ($a, $b) {
+            uasort($result, function ($a, $b) {
                 return strnatcasecmp($a['name'], $b['name']);
             });
         }


### PR DESCRIPTION
Blank page on project kanban after #15118.

I've compared the data returned by `Project::getAllKanbanColumns()` before and after the changes and found some differences in array keys.

Before #15118:

![image](https://github.com/glpi-project/glpi/assets/42734840/4f756d8b-3055-4d54-b51d-50b390267027)

After #15118:
![image](https://github.com/glpi-project/glpi/assets/42734840/e7700077-3fbf-4655-92de-ad5c68b209cc)

Using `uasort` to preserve keys seems to fix the issue.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
