### PR TITLE
Fix invalid search options datatypes

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -3775,6 +3775,8 @@ class CommonDBTM extends CommonGLPI
         $options[$type] = [];
 
         foreach ($this->rawSearchOptions() as $opt) {
+            // FIXME In GLPI 10.1, trigger a warning on invalid datatype (see `tests\units\Search::testSearchOptionsDatatype()`)
+
             $missingFields = [];
             if (!isset($opt['id'])) {
                 $missingFields[] = 'id';
@@ -3895,6 +3897,8 @@ class CommonDBTM extends CommonGLPI
         }
 
         foreach ($classname::$method_name($itemtype) as $opt) {
+            // FIXME In GLPI 10.1, trigger a warning on invalid datatype (see `tests\units\Search::testSearchOptionsDatatype()`)
+
             if (!isset($opt['id'])) {
                 throw new \Exception(get_called_class() . ': invalid search option! ' . print_r($opt, true));
             }

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -761,7 +761,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             'table'              => $this->getTable(),
             'field'              => 'actiontime',
             'name'               => __('Total duration'),
-            'datatype'           => 'actiontime',
+            'datatype'           => 'timestamp',
             'massiveaction'      => false
         ];
 

--- a/src/DeviceCamera.php
+++ b/src/DeviceCamera.php
@@ -117,7 +117,7 @@ class DeviceCamera extends CommonDevice
             'table'              => $this->getTable(),
             'field'              => 'flashunit',
             'name'               => __('Flashunit'),
-            'datatype'           => 'boolean',
+            'datatype'           => 'bool',
         ];
 
         $tab[] = [

--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -1672,6 +1672,7 @@ class Infocom extends CommonDBChild
             'field'              => 'itemtype',
             'name'               => _n('Type', 'Types', 1),
             'datatype'           => 'itemtypename',
+            'itemtype_list'      => 'infocom_types',
             'massiveaction'      => false
         ];
 

--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -1671,7 +1671,7 @@ class Infocom extends CommonDBChild
             'table'              => $this->getTable(),
             'field'              => 'itemtype',
             'name'               => _n('Type', 'Types', 1),
-            'datatype'           => 'itemtype',
+            'datatype'           => 'itemtypename',
             'massiveaction'      => false
         ];
 

--- a/src/NetworkName.php
+++ b/src/NetworkName.php
@@ -162,7 +162,7 @@ class NetworkName extends FQDNLabel
             'table'              => $this->getTable(),
             'field'              => 'itemtype',
             'name'               => _n('Type', 'Types', 1),
-            'datatype'           => 'itemtype',
+            'datatype'           => 'itemtypename',
             'massiveaction'      => false
         ];
 

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1630,6 +1630,7 @@ class NetworkPort extends CommonDBChild
             'field'              => 'itemtype',
             'name'               => _n('Type', 'Types', 1),
             'datatype'           => 'itemtypename',
+            'itemtype_list'      => 'networkport_types',
             'massiveaction'      => false
         ];
 

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1629,7 +1629,7 @@ class NetworkPort extends CommonDBChild
             'table'              => $this->getTable(),
             'field'              => 'itemtype',
             'name'               => _n('Type', 'Types', 1),
-            'datatype'           => 'itemtype',
+            'datatype'           => 'itemtypename',
             'massiveaction'      => false
         ];
 

--- a/src/ProjectTaskTemplate.php
+++ b/src/ProjectTaskTemplate.php
@@ -144,7 +144,7 @@ class ProjectTaskTemplate extends CommonDropdown
             'name'     => __('Percent done'),
             'field'    => 'percent_done',
             'table'    => $this->getTable(),
-            'datatype' => 'percent',
+            'datatype' => 'progressbar',
         ];
 
         $tab[] = [
@@ -192,7 +192,7 @@ class ProjectTaskTemplate extends CommonDropdown
             'name'     => __('Planned duration'),
             'field'    => 'planned_duration',
             'table'    => $this->getTable(),
-            'datatype' => 'actiontime',
+            'datatype' => 'timestamp',
         ];
 
         $tab[] = [
@@ -200,7 +200,7 @@ class ProjectTaskTemplate extends CommonDropdown
             'name'     => __('Effective duration'),
             'field'    => 'effective_duration',
             'table'    => $this->getTable(),
-            'datatype' => 'actiontime',
+            'datatype' => 'timestamp',
         ];
 
         $tab[] = [
@@ -208,7 +208,8 @@ class ProjectTaskTemplate extends CommonDropdown
             'name'     => __('Description'),
             'field'    => 'description',
             'table'    => $this->getTable(),
-            'datatype' => 'textarea',
+            'datatype' => 'text',
+            'htmltext' => true,
         ];
 
         return $tab;

--- a/src/QueuedNotification.php
+++ b/src/QueuedNotification.php
@@ -358,7 +358,7 @@ class QueuedNotification extends CommonDBTM
             'table'              => $this->getTable(),
             'field'              => 'itemtype',
             'name'               => _n('Type', 'Types', 1),
-            'datatype'           => 'itemtype',
+            'datatype'           => 'itemtypename',
             'massiveaction'      => false
         ];
 

--- a/src/TaskTemplate.php
+++ b/src/TaskTemplate.php
@@ -144,7 +144,7 @@ class TaskTemplate extends AbstractITILChildTemplate
             'table'              => $this->getTable(),
             'field'              => 'actiontime',
             'name'               => __('Total duration'),
-            'datatype'           => 'actiontime',
+            'datatype'           => 'timestamp',
             'massiveaction'      => false
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

While working on #14875, I figured out that some search options were not correctly declared.

As I am not completely sure of the exact list that we are supposed to support, I decided to not add a warning yet, to prevent introducing warnings on legitimate usages in plugins in a bugfixes version, so I added a check in test suite to prevent future issues.
This check should be moved into the search class itself in GLPI 10.1.