### PR TITLE
Add tests on `contains` search operator

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -3535,6 +3535,8 @@ JAVASCRIPT;
 
             switch ($searchopt[$ID]["datatype"]) {
                 case "datetime":
+                    // FIXME `addHaving` should produce same kind of criterion as `addWhere`
+                    //  (i.e. using a comparison with `ADDDATE(NOW(), INTERVAL {$val} MONTH)`).
                     if (in_array($searchtype, ['contains', 'notcontains'])) {
                         break;
                     }
@@ -3567,8 +3569,11 @@ JAVASCRIPT;
                 case "count":
                 case "mio":
                 case "number":
+                // FIXME Should also apply to integer
                 case "decimal":
                 case "timestamp":
+                    // FIXME Negative search are not supported. For instance, `>-10` result in a `LIKE '%>-10%'` SQL criterion.
+
                     $val = Sanitizer::decodeHtmlSpecialChars($val); // Decode "<" and ">" operators
                     if (preg_match("/([<>])([=]*)[[:space:]]*([0-9]+)/", $val, $regs)) {
                         if ($NOT) {
@@ -4676,6 +4681,23 @@ JAVASCRIPT;
                 $nott = !$nott;
                //negated, use contains case
             case "contains":
+                // FIXME
+                // `field LIKE '%test%'` condition is not supposed to be relevant, and can sometimes result in SQL performances issues/warnings/errors,
+                // or at least to unexpected results, when following datatype are used:
+                //  - integer
+                //  - number
+                //  - decimal
+                //  - count
+                //  - mio
+                //  - percentage
+                //  - timestamp
+                //  - datetime
+                //  - date_delay
+                //  - mac
+                //  - color
+                //  - language
+                // Values should be filtered to accept only valid pattern according to given datatype.
+
                 if (isset($searchopt[$ID]["datatype"]) && ($searchopt[$ID]["datatype"] === 'decimal')) {
                     $matches = [];
                     if (preg_match('/^(\d+.?\d?)/', $val, $matches)) {
@@ -5196,6 +5218,7 @@ JAVASCRIPT;
                         $date_computation = $tocompute;
                     }
                     if (in_array($searchtype, ["contains", "notcontains"])) {
+                        // FIXME `CONVERT` operation should not be necessary if we only allow legitimate date/time chars
                         $default_charset = DBConnection::getDefaultCharset();
                         $date_computation = "CONVERT($date_computation USING {$default_charset})";
                     }
@@ -5223,6 +5246,7 @@ JAVASCRIPT;
                     $val = Sanitizer::decodeHtmlSpecialChars($val); // Decode "<" and ">" operators
                     if (preg_match("/^\s*([<>=]+)(.*)/", $val, $regs)) {
                         if (is_numeric($regs[2])) {
+                            // FIXME Comparison operator should be "reversed" whne `$nott === true`.
                             return $link . " $date_computation " . $regs[1] . "
                             ADDDATE(NOW(), INTERVAL " . $regs[2] . " $search_unit) ";
                         }
@@ -5272,6 +5296,7 @@ JAVASCRIPT;
                 case "count":
                 case "mio":
                 case "number":
+                // FIXME Should also apply to integer
                 case "decimal":
                 case "timestamp":
                 case "progressbar":
@@ -7595,6 +7620,7 @@ JAVASCRIPT;
 
                 case "count":
                 case "number":
+                // FIXME Should also apply to integer
                 case "mio":
                     $out           = "";
                     $count_display = 0;
@@ -8395,6 +8421,7 @@ HTML;
                 switch ($searchopt[$field_num]['datatype']) {
                     case 'mio':
                     case 'count':
+                    // FIXME Should also apply to integer
                     case 'number':
                         $opt = [
                             'contains'    => __('contains'),
@@ -9112,6 +9139,23 @@ HTML;
        // mange empty field (string with length = 0)
         $sql_or = "";
         if (strtolower($val) == "null") {
+            // FIXME Should operator be `<>` when `$not === true`?
+
+            // FIXME
+            // `OR field = ''` condition is not supposed to be relevant, and can sometimes result in SQL performances issues/warnings/errors,
+            // when following datatype are used:
+            //  - integer
+            //  - number
+            //  - decimal
+            //  - count
+            //  - mio
+            //  - percentage
+            //  - timestamp
+            //  - datetime
+            //  - date_delay
+            //
+            // Removing this condition requires, at least, to use the `int`/`float`/`double`/`timestamp`/`date` types in DB,
+            // to ensure that the `''` value will not be stored in DB.
             $sql_or = "OR $field = ''";
         }
 

--- a/tests/GLPITestCase.php
+++ b/tests/GLPITestCase.php
@@ -91,12 +91,23 @@ class GLPITestCase extends atoum
 
         if (!$this->has_failed) {
             foreach ([$this->php_log_handler, $this->sql_log_handler] as $log_handler) {
-                $this->array($log_handler->getRecords())->isEmpty(
+                $this->array($log_handler->getRecords());
+                $clean_logs = array_map(
+                    static function (array $entry): array {
+                        return [
+                            'channel' => $entry['channel'],
+                            'level'   => $entry['level_name'],
+                            'message' => $entry['message'],
+                        ];
+                    },
+                    $log_handler->getRecords()
+                );
+                $this->array($clean_logs)->isEmpty(
                     sprintf(
                         "Unexpected entries in log in %s::%s:\n%s",
                         static::class,
                         $method,
-                        print_r(array_column($log_handler->getRecords(), 'message'), true)
+                        print_r($clean_logs, true)
                     )
                 );
             }

--- a/tests/functional/Search.php
+++ b/tests/functional/Search.php
@@ -40,6 +40,7 @@ use CommonITILActor;
 use DBConnection;
 use DbTestCase;
 use Glpi\Toolbox\Sanitizer;
+use Psr\Log\LogLevel;
 use Ticket;
 
 /* Test for inc/search.class.php */
@@ -3204,6 +3205,1195 @@ class Search extends DbTestCase
 
         // Validate results
         $this->array($names)->isEqualTo($expected);
+    }
+
+    protected function containsCriterionProvider(): iterable
+    {
+        // Note:
+        // Following datatypes are not tested as they do not support `contains` search operator:
+        //  - bool
+        //  - itemtypename
+        //  - right
+        // Some other datatypes are not tested for the `usehaving=true` case, or when a `computation` is
+        // required, because there is no search option that corresponds to it yet.
+
+        global $DB;
+        $version_string = $DB->getVersion();
+        $server  = preg_match('/-MariaDB/', $version_string) ? 'MariaDB' : 'MySQL';
+        $version = preg_replace('/^((\d+\.?)+).*$/', '$1', $version_string);
+        $is_mariadb      = $server === 'MariaDB';
+        $is_mariadb_10_2 = $is_mariadb && version_compare($version, '10.3', '<');
+        $is_mysql_5_7    = $server === 'MySQL' && version_compare($version, '8.0', '<');
+
+
+        // Check simple values search.
+        // Usage is only relevant for textual fields, so it is not tested on other fields.
+
+        // datatype=dropdown
+        yield [
+            'itemtype'          => \Computer::class,
+            'search_option'     => 4, // type
+            'value'             => 'test',
+            'expected_and'      => "(`glpi_computertypes`.`name` LIKE '%test%')",
+            'expected_and_not'  => "(`glpi_computertypes`.`name` NOT LIKE '%test%' OR `glpi_computertypes`.`name` IS NULL)",
+        ];
+
+        // datatype=dropdown (usehaving=true)
+        yield [
+            'itemtype'          => \Ticket::class,
+            'search_option'     => 142, // document name
+            'value'             => 'test',
+            'expected_and'      => "(`ITEM_Ticket_142` LIKE '%test%')",
+            'expected_and_not'  => "(`ITEM_Ticket_142` NOT LIKE '%test%' OR `ITEM_Ticket_142` IS NULL)",
+        ];
+
+        // datatype=itemlink
+        yield [
+            'itemtype'          => \Computer::class,
+            'search_option'     => 1, // name
+            'value'             => 'test',
+            'expected_and'      => "(`glpi_computers`.`name` LIKE '%test%')",
+            'expected_and_not'  => "(`glpi_computers`.`name` NOT LIKE '%test%' OR `glpi_computers`.`name` IS NULL)",
+        ];
+
+        // datatype=itemlink (usehaving=true)
+        yield [
+            'itemtype'          => \Ticket::class,
+            'search_option'     => 50, // parent tickets
+            'value'             => 'test',
+            'expected_and'      => "(`ITEM_Ticket_50` LIKE '%test%')",
+            'expected_and_not'  => "(`ITEM_Ticket_50` NOT LIKE '%test%' OR `ITEM_Ticket_50` IS NULL)",
+        ];
+
+        // datatype=string
+        yield [
+            'itemtype'          => \Computer::class,
+            'search_option'     => 47, // uuid
+            'value'             => 'test',
+            'expected_and'      => "(`glpi_computers`.`uuid` LIKE '%test%')",
+            'expected_and_not'  => "(`glpi_computers`.`uuid` NOT LIKE '%test%' OR `glpi_computers`.`uuid` IS NULL)",
+        ];
+
+        // datatype=text
+        yield [
+            'itemtype'          => \Computer::class,
+            'search_option'     => 16, // comment
+            'value'             => 'test',
+            'expected_and'      => "(`glpi_computers`.`comment` LIKE '%test%')",
+            'expected_and_not'  => "(`glpi_computers`.`comment` NOT LIKE '%test%' OR `glpi_computers`.`comment` IS NULL)",
+        ];
+
+        // datatype=integer
+        yield [
+            'itemtype'          => \AuthLDAP::class,
+            'search_option'     => 4, // port
+            'value'             => 'test',
+            'expected_and'      => "(`glpi_authldaps`.`port` LIKE '%test%')",
+            'expected_and_not'  => "(`glpi_authldaps`.`port` NOT LIKE '%test%' OR `glpi_authldaps`.`port` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \AuthLDAP::class,
+            'search_option'     => 4, // port
+            'value'             => '123',
+            'expected_and'      => "(`glpi_authldaps`.`port` LIKE '%123%')",
+            'expected_and_not'  => "(`glpi_authldaps`.`port` NOT LIKE '%123%' OR `glpi_authldaps`.`port` IS NULL)",
+        ];
+
+        // datatype=number
+        yield [
+            'itemtype'          => \AuthLDAP::class,
+            'search_option'     => 32, // timeout
+            'value'             => 'test',
+            'expected_and'      => "(`glpi_authldaps`.`timeout` LIKE '%test%')",
+            'expected_and_not'  => "(`glpi_authldaps`.`timeout` NOT LIKE '%test%' OR `glpi_authldaps`.`timeout` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \AuthLDAP::class,
+            'search_option'     => 32, // timeout
+            'value'             => '30',
+            'expected_and'      => "(`glpi_authldaps`.`timeout` = 30)",
+            'expected_and_not'  => "(`glpi_authldaps`.`timeout` <> 30)",
+        ];
+
+        // datatype=number (usehaving=true)
+        yield [
+            'itemtype'          => \Computer::class,
+            'search_option'     => 115, // harddrive capacity
+            'value'             => 'test',
+            'expected_and'      => "(`ITEM_Computer_115` LIKE '%test%')",
+            'expected_and_not'  => "(`ITEM_Computer_115` NOT LIKE '%test%' OR `ITEM_Computer_115` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Computer::class,
+            'search_option'     => 115, // harddrive capacity
+            'value'             => '512',
+            'expected_and'      => "(`ITEM_Computer_115` < 1512 AND `ITEM_Computer_115` > -488)",
+            'expected_and_not'  => "(`ITEM_Computer_115` > 1512 OR `ITEM_Computer_115` < -488)",
+        ];
+
+        // datatype=decimal
+        yield [
+            'itemtype'          => \Budget::class,
+            'search_option'     => 7, // value
+            'value'             => 'test',
+            'expected_and'      => "(`glpi_budgets`.`value` LIKE '%test%')",
+            'expected_and_not'  => "(`glpi_budgets`.`value` NOT LIKE '%test%' OR `glpi_budgets`.`value` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Budget::class,
+            'search_option'     => 7, // value
+            'value'             => '1500',
+            'expected_and'      => "(`glpi_budgets`.`value` LIKE '%1500.%')",
+            'expected_and_not'  => "(`glpi_budgets`.`value` NOT LIKE '%1500.%' OR `glpi_budgets`.`value` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Budget::class,
+            'search_option'     => 7, // value
+            'value'             => '10.25',
+            'expected_and'      => "(`glpi_budgets`.`value` LIKE '%10.2%')",
+            'expected_and_not'  => "(`glpi_budgets`.`value` NOT LIKE '%10.2%' OR `glpi_budgets`.`value` IS NULL)",
+        ];
+
+        // datatype=decimal (usehaving=true)
+        yield [
+            'itemtype'          => \Contract::class,
+            'search_option'     => 11, // totalcost
+            'value'             => 'test',
+            'expected_and'      => "(`ITEM_Contract_11` LIKE '%test%')",
+            'expected_and_not'  => "(`ITEM_Contract_11` NOT LIKE '%test%' OR `ITEM_Contract_11` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Contract::class,
+            'search_option'     => 11, // totalcost
+            'value'             => '250',
+            'expected_and'      => "(`ITEM_Contract_11` = 250)",
+            'expected_and_not'  => "(`ITEM_Contract_11` <> 250)",
+        ];
+
+        // datatype=count (usehaving=true)
+        yield [
+            'itemtype'          => \Ticket::class,
+            'search_option'     => 27, // number of followups
+            'value'             => 'test',
+            'expected_and'      => "(`ITEM_Ticket_27` LIKE '%test%')",
+            'expected_and_not'  => "(`ITEM_Ticket_27` NOT LIKE '%test%' OR `ITEM_Ticket_27` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Ticket::class,
+            'search_option'     => 27, // number of followups
+            'value'             => '10',
+            'expected_and'      => "(`ITEM_Ticket_27` = 10)",
+            'expected_and_not'  => "(`ITEM_Ticket_27` <> 10)",
+        ];
+
+        // datatype=mio (usehaving=true)
+        yield [
+            'itemtype'          => \Computer::class,
+            'search_option'     => 111, // memory size
+            'value'             => 'test',
+            'expected_and'      => "(`ITEM_Computer_111` LIKE '%test%')",
+            'expected_and_not'  => "(`ITEM_Computer_111` NOT LIKE '%test%' OR `ITEM_Computer_111` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Computer::class,
+            'search_option'     => 111, // memory size
+            'value'             => '512',
+            'expected_and'      => "(`ITEM_Computer_111` < 612 AND `ITEM_Computer_111` > 412)",
+            'expected_and_not'  => "(`ITEM_Computer_111` > 612 OR `ITEM_Computer_111` < 412)",
+        ];
+
+        // datatype=progressbar (with computation)
+        yield [
+            'itemtype'          => \Computer::class,
+            'search_option'     => 152, // harddrive freepercent
+            'value'             => 'test',
+            'expected_and'      => "(LPAD(ROUND(100*`glpi_items_disks`.freesize/NULLIF(`glpi_items_disks`.totalsize, 0)), 3, 0) LIKE '%test%')",
+            'expected_and_not'  => "(LPAD(ROUND(100*`glpi_items_disks`.freesize/NULLIF(`glpi_items_disks`.totalsize, 0)), 3, 0) NOT LIKE '%test%' OR LPAD(ROUND(100*`glpi_items_disks`.freesize/NULLIF(`glpi_items_disks`.totalsize, 0)), 3, 0) IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Computer::class,
+            'search_option'     => 152, // harddrive freepercent
+            'value'             => '50',
+            'expected_and'      => "(LPAD(ROUND(100*`glpi_items_disks`.freesize/NULLIF(`glpi_items_disks`.totalsize, 0)), 3, 0) >= 48 AND LPAD(ROUND(100*`glpi_items_disks`.freesize/NULLIF(`glpi_items_disks`.totalsize, 0)), 3, 0) <= 52)",
+            'expected_and_not'  => "(LPAD(ROUND(100*`glpi_items_disks`.freesize/NULLIF(`glpi_items_disks`.totalsize, 0)), 3, 0) < 48 OR LPAD(ROUND(100*`glpi_items_disks`.freesize/NULLIF(`glpi_items_disks`.totalsize, 0)), 3, 0) > 52 OR LPAD(ROUND(100*`glpi_items_disks`.freesize/NULLIF(`glpi_items_disks`.totalsize, 0)), 3, 0) IS NULL)",
+        ];
+
+        // datatype=timestamp
+        yield [
+            'itemtype'          => \CronTask::class,
+            'search_option'     => 6, // frequency
+            'value'             => 'test',
+            'expected_and'      => "(`glpi_crontasks`.`frequency` LIKE '%test%')",
+            'expected_and_not'  => "(`glpi_crontasks`.`frequency` NOT LIKE '%test%' OR `glpi_crontasks`.`frequency` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \CronTask::class,
+            'search_option'     => 6, // frequency
+            'value'             => '3600',
+            'expected_and'      => "(`glpi_crontasks`.`frequency` = 3600)",
+            'expected_and_not'  => "(`glpi_crontasks`.`frequency` <> 3600)",
+        ];
+
+        // datatype=timestamp (usehaving=true)
+        yield [
+            'itemtype'          => \Ticket::class,
+            'search_option'     => 49, // actiontime
+            'value'             => 'test',
+            'expected_and'      => "(`ITEM_Ticket_49` LIKE '%test%')",
+            'expected_and_not'  => "(`ITEM_Ticket_49` NOT LIKE '%test%' OR `ITEM_Ticket_49` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Ticket::class,
+            'search_option'     => 49, // actiontime
+            'value'             => '3600',
+            'expected_and'      => "(`ITEM_Ticket_49` = 3600)",
+            'expected_and_not'  => "(`ITEM_Ticket_49` <> 3600)",
+        ];
+
+        // datatype=datetime
+        yield [
+            'itemtype'          => \Computer::class,
+            'search_option'     => 9, // last_inventory_update
+            'value'             => 'test',
+            'expected_and'      => "(CONVERT(`glpi_computers`.`last_inventory_update` USING utf8mb4) LIKE '%test%')",
+            'expected_and_not'  => "(CONVERT(`glpi_computers`.`last_inventory_update` USING utf8mb4) NOT LIKE '%test%' OR CONVERT(`glpi_computers`.`last_inventory_update` USING utf8mb4) IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Computer::class,
+            'search_option'     => 9, // last_inventory_update
+            'value'             => '2023-06',
+            'expected_and'      => "(CONVERT(`glpi_computers`.`last_inventory_update` USING utf8mb4) LIKE '%2023-06%')",
+            'expected_and_not'  => "(CONVERT(`glpi_computers`.`last_inventory_update` USING utf8mb4) NOT LIKE '%2023-06%' OR CONVERT(`glpi_computers`.`last_inventory_update` USING utf8mb4) IS NULL)",
+        ];
+
+        // datatype=datetime (usehaving=true)
+        yield [
+            'itemtype'          => \Ticket::class,
+            'search_option'     => 188, // next_escalation_level
+            'value'             => 'test',
+            'expected_and'      => "(`ITEM_Ticket_188` LIKE '%test%')",
+            'expected_and_not'  => "(`ITEM_Ticket_188` NOT LIKE '%test%' OR `ITEM_Ticket_188` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Ticket::class,
+            'search_option'     => 188, // next_escalation_level
+            'value'             => '2023-06',
+            'expected_and'      => "(`ITEM_Ticket_188` LIKE '%2023-06%')",
+            'expected_and_not'  => "(`ITEM_Ticket_188` NOT LIKE '%2023-06%' OR `ITEM_Ticket_188` IS NULL)",
+        ];
+
+        // datatype=date
+        yield [
+            'itemtype'          => \Budget::class,
+            'search_option'     => 5, // begin_date
+            'value'             => 'test',
+            'expected_and'      => "(CONVERT(`glpi_budgets`.`begin_date` USING utf8mb4) LIKE '%test%')",
+            'expected_and_not'  => "(CONVERT(`glpi_budgets`.`begin_date` USING utf8mb4) NOT LIKE '%test%' OR CONVERT(`glpi_budgets`.`begin_date` USING utf8mb4) IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Budget::class,
+            'search_option'     => 5, // begin_date
+            'value'             => '2023',
+            'expected_and'      => "(CONVERT(`glpi_budgets`.`begin_date` USING utf8mb4) LIKE '%2023%')",
+            'expected_and_not'  => "(CONVERT(`glpi_budgets`.`begin_date` USING utf8mb4) NOT LIKE '%2023%' OR CONVERT(`glpi_budgets`.`begin_date` USING utf8mb4) IS NULL)",
+        ];
+
+        // datatype=date_delay
+        yield [
+            'itemtype'          => \Contract::class,
+            'search_option'     => 20, // end_date
+            'value'             => 'test',
+            'expected_and'      => "(ADDDATE(`glpi_contracts`.begin_date, INTERVAL (`glpi_contracts`.duration) MONTH) LIKE '%test%')",
+            'expected_and_not'  => "(ADDDATE(`glpi_contracts`.begin_date, INTERVAL (`glpi_contracts`.duration) MONTH) NOT LIKE '%test%' OR ADDDATE(`glpi_contracts`.begin_date, INTERVAL (`glpi_contracts`.duration) MONTH) IS NULL)",
+        ];
+        if ($is_mysql_5_7) {
+            // log for both AND and AND NOT cases
+            $this->hasSqlLogRecordThatContains("Truncated incorrect date value: '%test%'", LogLevel::WARNING);
+            $this->hasSqlLogRecordThatContains("Truncated incorrect date value: '%test%'", LogLevel::WARNING);
+        }
+        yield [
+            'itemtype'          => \Contract::class,
+            'search_option'     => 20, // end_date
+            'value'             => '2023-12',
+            'expected_and'      => "(ADDDATE(`glpi_contracts`.begin_date, INTERVAL (`glpi_contracts`.duration) MONTH) LIKE '%2023-12%')",
+            'expected_and_not'  => "(ADDDATE(`glpi_contracts`.begin_date, INTERVAL (`glpi_contracts`.duration) MONTH) NOT LIKE '%2023-12%' OR ADDDATE(`glpi_contracts`.begin_date, INTERVAL (`glpi_contracts`.duration) MONTH) IS NULL)",
+        ];
+        if ($is_mysql_5_7) {
+            // log for both AND and AND NOT cases
+            $this->hasSqlLogRecordThatContains("Truncated incorrect date value: '%2023-12%'", LogLevel::WARNING);
+            $this->hasSqlLogRecordThatContains("Truncated incorrect date value: '%2023-12%'", LogLevel::WARNING);
+        }
+
+        // datatype=email
+        yield [
+            'itemtype'          => \Contact::class,
+            'search_option'     => 6, // email
+            'value'             => 'test',
+            'expected_and'      => "(`glpi_contacts`.`email` LIKE '%test%')",
+            'expected_and_not'  => "(`glpi_contacts`.`email` NOT LIKE '%test%' OR `glpi_contacts`.`email` IS NULL)",
+        ];
+
+        // datatype=weblink
+        yield [
+            'itemtype'          => \Document::class,
+            'search_option'     => 4, // link
+            'value'             => 'test',
+            'expected_and'      => "(`glpi_documents`.`link` LIKE '%test%')",
+            'expected_and_not'  => "(`glpi_documents`.`link` NOT LIKE '%test%' OR `glpi_documents`.`link` IS NULL)",
+        ];
+
+        // datatype=mac
+        yield [
+            'itemtype'          => \DeviceNetworkCard::class,
+            'search_option'     => 11, // mac_default
+            'value'             => 'test',
+            'expected_and'      => "(`glpi_devicenetworkcards`.`mac_default` LIKE '%test%')",
+            'expected_and_not'  => "(`glpi_devicenetworkcards`.`mac_default` NOT LIKE '%test%' OR `glpi_devicenetworkcards`.`mac_default` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \DeviceNetworkCard::class,
+            'search_option'     => 11, // mac_default
+            'value'             => 'a2:ef:00',
+            'expected_and'      => "(`glpi_devicenetworkcards`.`mac_default` LIKE '%a2:ef:00%')",
+            'expected_and_not'  => "(`glpi_devicenetworkcards`.`mac_default` NOT LIKE '%a2:ef:00%' OR `glpi_devicenetworkcards`.`mac_default` IS NULL)",
+        ];
+
+        // datatype=color
+        yield [
+            'itemtype'          => \Cable::class,
+            'search_option'     => 15, // color
+            'value'             => 'test',
+            'expected_and'      => "(`glpi_cables`.`color` LIKE '%test%')",
+            'expected_and_not'  => "(`glpi_cables`.`color` NOT LIKE '%test%' OR `glpi_cables`.`color` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Cable::class,
+            'search_option'     => 15, // color
+            'value'             => '#ffffff',
+            'expected_and'      => "(`glpi_cables`.`color` LIKE '%#ffffff%')",
+            'expected_and_not'  => "(`glpi_cables`.`color` NOT LIKE '%#ffffff%' OR `glpi_cables`.`color` IS NULL)",
+        ];
+
+        // datatype=language
+        yield [
+            'itemtype'          => \User::class,
+            'search_option'     => 17, // language
+            'value'             => 'test',
+            'expected_and'      => "(`glpi_users`.`language` LIKE '%test%')",
+            'expected_and_not'  => "(`glpi_users`.`language` NOT LIKE '%test%' OR `glpi_users`.`language` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \User::class,
+            'search_option'     => 17, // language
+            'value'             => 'en_',
+            'expected_and'      => "(`glpi_users`.`language` LIKE '%en\_%')",
+            'expected_and_not'  => "(`glpi_users`.`language` NOT LIKE '%en\_%' OR `glpi_users`.`language` IS NULL)",
+        ];
+
+        // Check `NULL` special value
+        foreach (['NULL', 'null'] as $null_value) {
+            // datatype=dropdown
+            yield [
+                'itemtype'          => \Computer::class,
+                'search_option'     => 4, // type
+                'value'             => $null_value,
+                'expected_and'      => "(`glpi_computertypes`.`name` IS NULL OR `glpi_computertypes`.`name` = '')",
+                'expected_and_not'  => "(`glpi_computertypes`.`name` IS NOT NULL OR `glpi_computertypes`.`name` = '')",
+            ];
+
+            // datatype=dropdown (usehaving=true)
+            yield [
+                'itemtype'          => \Ticket::class,
+                'search_option'     => 142, // document name
+                'value'             => $null_value,
+                'expected_and'      => "(`ITEM_Ticket_142` IS NULL OR `ITEM_Ticket_142` = '')",
+                'expected_and_not'  => "(`ITEM_Ticket_142` IS NOT NULL OR `ITEM_Ticket_142` = '')",
+            ];
+
+            // datatype=itemlink
+            yield [
+                'itemtype'          => \Computer::class,
+                'search_option'     => 1, // name
+                'value'             => $null_value,
+                'expected_and'      => "(`glpi_computers`.`name` IS NULL OR `glpi_computers`.`name` = '')",
+                'expected_and_not'  => "(`glpi_computers`.`name` IS NOT NULL OR `glpi_computers`.`name` = '')",
+            ];
+
+            // datatype=itemlink (usehaving=true)
+            yield [
+                'itemtype'          => \Ticket::class,
+                'search_option'     => 50, // parent tickets
+                'value'             => $null_value,
+                'expected_and'      => "(`ITEM_Ticket_50` IS NULL OR `ITEM_Ticket_50` = '')",
+                'expected_and_not'  => "(`ITEM_Ticket_50` IS NOT NULL OR `ITEM_Ticket_50` = '')",
+            ];
+
+            // datatype=string
+            yield [
+                'itemtype'          => \Computer::class,
+                'search_option'     => 47, // uuid
+                'value'             => $null_value,
+                'expected_and'      => "(`glpi_computers`.`uuid` IS NULL OR `glpi_computers`.`uuid` = '')",
+                'expected_and_not'  => "(`glpi_computers`.`uuid` IS NOT NULL OR `glpi_computers`.`uuid` = '')",
+            ];
+
+            // datatype=text
+            yield [
+                'itemtype'          => \Computer::class,
+                'search_option'     => 16, // comment
+                'value'             => $null_value,
+                'expected_and'      => "(`glpi_computers`.`comment` IS NULL OR `glpi_computers`.`comment` = '')",
+                'expected_and_not'  => "(`glpi_computers`.`comment` IS NOT NULL OR `glpi_computers`.`comment` = '')",
+            ];
+
+            // datatype=integer
+            yield [
+                'itemtype'          => \AuthLDAP::class,
+                'search_option'     => 4, // port
+                'value'             => $null_value,
+                'expected_and'      => "(`glpi_authldaps`.`port` IS NULL OR `glpi_authldaps`.`port` = '')",
+                'expected_and_not'  => "(`glpi_authldaps`.`port` IS NOT NULL OR `glpi_authldaps`.`port` = '')",
+            ];
+            if ($is_mariadb_10_2) {
+                $this->hasSqlLogRecordThatContains("Truncated incorrect DOUBLE value: ''", LogLevel::WARNING);
+            } elseif ($is_mariadb) {
+                $this->hasSqlLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
+            }
+
+            // datatype=number
+            yield [
+                'itemtype'          => \AuthLDAP::class,
+                'search_option'     => 32, // timeout
+                'value'             => $null_value,
+                'expected_and'      => "(`glpi_authldaps`.`timeout` IS NULL OR `glpi_authldaps`.`timeout` = '')",
+                'expected_and_not'  => "(`glpi_authldaps`.`timeout` IS NOT NULL OR `glpi_authldaps`.`timeout` = '')",
+            ];
+            if ($is_mariadb_10_2) {
+                $this->hasSqlLogRecordThatContains("Truncated incorrect DOUBLE value: ''", LogLevel::WARNING);
+            } elseif ($is_mariadb) {
+                $this->hasSqlLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
+            }
+
+            // datatype=number (usehaving=true)
+            yield [
+                'itemtype'          => \Computer::class,
+                'search_option'     => 115, // harddrive capacity
+                'value'             => $null_value,
+                'expected_and'      => "(`ITEM_Computer_115` IS NULL OR `ITEM_Computer_115` = '')",
+                'expected_and_not'  => "(`ITEM_Computer_115` IS NOT NULL OR `ITEM_Computer_115` = '')",
+            ];
+
+            // datatype=decimal
+            yield [
+                'itemtype'          => \Budget::class,
+                'search_option'     => 7, // value
+                'value'             => $null_value,
+                'expected_and'      => "(`glpi_budgets`.`value` IS NULL OR `glpi_budgets`.`value` = '')",
+                'expected_and_not'  => "(`glpi_budgets`.`value` IS NOT NULL OR `glpi_budgets`.`value` = '')",
+            ];
+            $this->hasSqlLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
+
+            // datatype=decimal (usehaving=true)
+            yield [
+                'itemtype'          => \Contract::class,
+                'search_option'     => 11, // totalcost
+                'value'             => $null_value,
+                'expected_and'      => "(`ITEM_Contract_11` IS NULL OR `ITEM_Contract_11` = '')",
+                'expected_and_not'  => "(`ITEM_Contract_11` IS NOT NULL OR `ITEM_Contract_11` = '')",
+            ];
+
+            // datatype=count (usehaving=true)
+            yield [
+                'itemtype'          => \Ticket::class,
+                'search_option'     => 27, // number of followups
+                'value'             => $null_value,
+                'expected_and'      => "(`ITEM_Ticket_27` IS NULL OR `ITEM_Ticket_27` = '')",
+                'expected_and_not'  => "(`ITEM_Ticket_27` IS NOT NULL OR `ITEM_Ticket_27` = '')",
+            ];
+            if ($is_mariadb_10_2) {
+                $this->hasSqlLogRecordThatContains("Truncated incorrect DOUBLE value: ''", LogLevel::WARNING);
+            } elseif ($is_mariadb) {
+                $this->hasSqlLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
+            }
+
+            // datatype=mio (usehaving=true)
+            yield [
+                'itemtype'          => \Computer::class,
+                'search_option'     => 111, // memory size
+                'value'             => $null_value,
+                'expected_and'      => "(`ITEM_Computer_111` IS NULL OR `ITEM_Computer_111` = '')",
+                'expected_and_not'  => "(`ITEM_Computer_111` IS NOT NULL OR `ITEM_Computer_111` = '')",
+            ];
+
+            // datatype=progressbar (with computation)
+            yield [
+                'itemtype'          => \Computer::class,
+                'search_option'     => 152, // harddrive freepercent
+                'value'             => $null_value,
+                'expected_and'      => "(LPAD(ROUND(100*`glpi_items_disks`.freesize/NULLIF(`glpi_items_disks`.totalsize, 0)), 3, 0) IS NULL OR LPAD(ROUND(100*`glpi_items_disks`.freesize/NULLIF(`glpi_items_disks`.totalsize, 0)), 3, 0) = '')",
+                'expected_and_not'  => "(LPAD(ROUND(100*`glpi_items_disks`.freesize/NULLIF(`glpi_items_disks`.totalsize, 0)), 3, 0) IS NOT NULL OR LPAD(ROUND(100*`glpi_items_disks`.freesize/NULLIF(`glpi_items_disks`.totalsize, 0)), 3, 0) = '')",
+            ];
+
+            // datatype=timestamp
+            yield [
+                'itemtype'          => \CronTask::class,
+                'search_option'     => 6, // frequency
+                'value'             => $null_value,
+                'expected_and'      => "(`glpi_crontasks`.`frequency` IS NULL OR `glpi_crontasks`.`frequency` = '')",
+                'expected_and_not'  => "(`glpi_crontasks`.`frequency` IS NOT NULL OR `glpi_crontasks`.`frequency` = '')",
+            ];
+            if ($is_mariadb_10_2) {
+                $this->hasSqlLogRecordThatContains("Truncated incorrect DOUBLE value: ''", LogLevel::WARNING);
+            } elseif ($is_mariadb) {
+                $this->hasSqlLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
+            }
+
+            // datatype=timestamp (usehaving=true)
+            yield [
+                'itemtype'          => \Ticket::class,
+                'search_option'     => 49, // actiontime
+                'value'             => $null_value,
+                'expected_and'      => "(`ITEM_Ticket_49` IS NULL OR `ITEM_Ticket_49` = '')",
+                'expected_and_not'  => "(`ITEM_Ticket_49` IS NOT NULL OR `ITEM_Ticket_49` = '')",
+            ];
+
+            // datatype=datetime
+            yield [
+                'itemtype'          => \Computer::class,
+                'search_option'     => 9, // last_inventory_update
+                'value'             => $null_value,
+                'expected_and'      => "(CONVERT(`glpi_computers`.`last_inventory_update` USING utf8mb4) IS NULL OR CONVERT(`glpi_computers`.`last_inventory_update` USING utf8mb4) = '')",
+                'expected_and_not'  => "(CONVERT(`glpi_computers`.`last_inventory_update` USING utf8mb4) IS NOT NULL OR CONVERT(`glpi_computers`.`last_inventory_update` USING utf8mb4) = '')",
+            ];
+
+            // datatype=datetime computed field
+            yield [
+                'itemtype'          => \Ticket::class,
+                'search_option'     => 188, // next_escalation_level
+                'value'             => $null_value,
+                'expected_and'      => "(`ITEM_Ticket_188` IS NULL OR `ITEM_Ticket_188` = '')",
+                'expected_and_not'  => "(`ITEM_Ticket_188` IS NOT NULL OR `ITEM_Ticket_188` = '')",
+            ];
+
+            // datatype=date
+            yield [
+                'itemtype'          => \Budget::class,
+                'search_option'     => 5, // begin_date
+                'value'             => $null_value,
+                'expected_and'      => "(CONVERT(`glpi_budgets`.`begin_date` USING utf8mb4) IS NULL OR CONVERT(`glpi_budgets`.`begin_date` USING utf8mb4) = '')",
+                'expected_and_not'  => "(CONVERT(`glpi_budgets`.`begin_date` USING utf8mb4) IS NOT NULL OR CONVERT(`glpi_budgets`.`begin_date` USING utf8mb4) = '')",
+            ];
+
+            // datatype=date_delay
+            /*
+             * FIXME Following search fails due to the following SQL error: `Error: Incorrect DATE value: ''`.
+            yield [
+                'itemtype'          => \Contract::class,
+                'search_option'     => 20, // end_date
+                'value'             => $null_value,
+                'expected_and'      => "(ADDDATE(`glpi_contracts`.begin_date, INTERVAL (`glpi_contracts`.duration ) MONTH) IS  NULL  OR ADDDATE(`glpi_contracts`.begin_date, INTERVAL (`glpi_contracts`.duration ) MONTH) = '')",
+                'expected_and_not'  => "(ADDDATE(`glpi_contracts`.begin_date, INTERVAL (`glpi_contracts`.duration ) MONTH) IS NOT NULL  OR ADDDATE(`glpi_contracts`.begin_date, INTERVAL (`glpi_contracts`.duration ) MONTH) = '')",
+            ];
+            */
+
+            // datatype=email
+            yield [
+                'itemtype'          => \Contact::class,
+                'search_option'     => 6, // email
+                'value'             => $null_value,
+                'expected_and'      => "(`glpi_contacts`.`email` IS NULL OR `glpi_contacts`.`email` = '')",
+                'expected_and_not'  => "(`glpi_contacts`.`email` IS NOT NULL OR `glpi_contacts`.`email` = '')",
+            ];
+
+            // datatype=weblink
+            yield [
+                'itemtype'          => \Document::class,
+                'search_option'     => 4, // link
+                'value'             => $null_value,
+                'expected_and'      => "(`glpi_documents`.`link` IS NULL OR `glpi_documents`.`link` = '')",
+                'expected_and_not'  => "(`glpi_documents`.`link` IS NOT NULL OR `glpi_documents`.`link` = '')",
+            ];
+
+            // datatype=mac
+            yield [
+                'itemtype'          => \DeviceNetworkCard::class,
+                'search_option'     => 11, // mac_default
+                'value'             => $null_value,
+                'expected_and'      => "(`glpi_devicenetworkcards`.`mac_default` IS NULL OR `glpi_devicenetworkcards`.`mac_default` = '')",
+                'expected_and_not'  => "(`glpi_devicenetworkcards`.`mac_default` IS NOT NULL OR `glpi_devicenetworkcards`.`mac_default` = '')",
+            ];
+
+            // datatype=color
+            yield [
+                'itemtype'          => \Cable::class,
+                'search_option'     => 15, // color
+                'value'             => $null_value,
+                'expected_and'      => "(`glpi_cables`.`color` IS NULL OR `glpi_cables`.`color` = '')",
+                'expected_and_not'  => "(`glpi_cables`.`color` IS NOT NULL OR `glpi_cables`.`color` = '')",
+            ];
+
+            // datatype=language
+            yield [
+                'itemtype'          => \User::class,
+                'search_option'     => 17, // language
+                'value'             => $null_value,
+                'expected_and'      => "(`glpi_users`.`language` IS NULL OR `glpi_users`.`language` = '')",
+                'expected_and_not'  => "(`glpi_users`.`language` IS NOT NULL OR `glpi_users`.`language` = '')",
+            ];
+        }
+
+        // Check `^` and `$` operators.
+        // Usage is only relevant for textual fields, so it is not tested on other fields.
+
+        // datatype=dropdown
+        yield [
+            'itemtype'          => \Computer::class,
+            'search_option'     => 4, // type
+            'value'             => '^test',
+            'expected_and'      => "(`glpi_computertypes`.`name` LIKE 'test%')",
+            'expected_and_not'  => "(`glpi_computertypes`.`name` NOT LIKE 'test%' OR `glpi_computertypes`.`name` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Computer::class,
+            'search_option'     => 4, // type
+            'value'             => 'test$',
+            'expected_and'      => "(`glpi_computertypes`.`name` LIKE '%test')",
+            'expected_and_not'  => "(`glpi_computertypes`.`name` NOT LIKE '%test' OR `glpi_computertypes`.`name` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Computer::class,
+            'search_option'     => 4, // type
+            'value'             => '^test$',
+            'expected_and'      => "(`glpi_computertypes`.`name` LIKE 'test')",
+            'expected_and_not'  => "(`glpi_computertypes`.`name` NOT LIKE 'test' OR `glpi_computertypes`.`name` IS NULL)",
+        ];
+
+        // datatype=dropdown (usehaving=true)
+        yield [
+            'itemtype'          => \Ticket::class,
+            'search_option'     => 142, // document name
+            'value'             => '^test',
+            'expected_and'      => "(`ITEM_Ticket_142` LIKE 'test%')",
+            'expected_and_not'  => "(`ITEM_Ticket_142` NOT LIKE 'test%' OR `ITEM_Ticket_142` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Ticket::class,
+            'search_option'     => 142, // document name
+            'value'             => 'test$',
+            'expected_and'      => "(`ITEM_Ticket_142` LIKE '%test')",
+            'expected_and_not'  => "(`ITEM_Ticket_142` NOT LIKE '%test' OR `ITEM_Ticket_142` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Ticket::class,
+            'search_option'     => 142, // document name
+            'value'             => '^test$',
+            'expected_and'      => "(`ITEM_Ticket_142` LIKE 'test')",
+            'expected_and_not'  => "(`ITEM_Ticket_142` NOT LIKE 'test' OR `ITEM_Ticket_142` IS NULL)",
+        ];
+
+        // datatype=itemlink
+        yield [
+            'itemtype'          => \Computer::class,
+            'search_option'     => 1, // name
+            'value'             => '^test',
+            'expected_and'      => "(`glpi_computers`.`name` LIKE 'test%')",
+            'expected_and_not'  => "(`glpi_computers`.`name` NOT LIKE 'test%' OR `glpi_computers`.`name` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Computer::class,
+            'search_option'     => 1, // name
+            'value'             => 'test$',
+            'expected_and'      => "(`glpi_computers`.`name` LIKE '%test')",
+            'expected_and_not'  => "(`glpi_computers`.`name` NOT LIKE '%test' OR `glpi_computers`.`name` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Computer::class,
+            'search_option'     => 1, // name
+            'value'             => '^test$',
+            'expected_and'      => "(`glpi_computers`.`name` LIKE 'test')",
+            'expected_and_not'  => "(`glpi_computers`.`name` NOT LIKE 'test' OR `glpi_computers`.`name` IS NULL)",
+        ];
+
+        // datatype=itemlink (usehaving=true)
+        yield [
+            'itemtype'          => \Ticket::class,
+            'search_option'     => 50, // parent tickets
+            'value'             => '^test',
+            'expected_and'      => "(`ITEM_Ticket_50` LIKE 'test%')",
+            'expected_and_not'  => "(`ITEM_Ticket_50` NOT LIKE 'test%' OR `ITEM_Ticket_50` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Ticket::class,
+            'search_option'     => 50, // parent tickets
+            'value'             => 'test$',
+            'expected_and'      => "(`ITEM_Ticket_50` LIKE '%test')",
+            'expected_and_not'  => "(`ITEM_Ticket_50` NOT LIKE '%test' OR `ITEM_Ticket_50` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Ticket::class,
+            'search_option'     => 50, // parent tickets
+            'value'             => '^test$',
+            'expected_and'      => "(`ITEM_Ticket_50` LIKE 'test')",
+            'expected_and_not'  => "(`ITEM_Ticket_50` NOT LIKE 'test' OR `ITEM_Ticket_50` IS NULL)",
+        ];
+
+        // datatype=string
+        yield [
+            'itemtype'          => \Computer::class,
+            'search_option'     => 47, // uuid
+            'value'             => '^test',
+            'expected_and'      => "(`glpi_computers`.`uuid` LIKE 'test%')",
+            'expected_and_not'  => "(`glpi_computers`.`uuid` NOT LIKE 'test%' OR `glpi_computers`.`uuid` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Computer::class,
+            'search_option'     => 47, // uuid
+            'value'             => 'test$',
+            'expected_and'      => "(`glpi_computers`.`uuid` LIKE '%test')",
+            'expected_and_not'  => "(`glpi_computers`.`uuid` NOT LIKE '%test' OR `glpi_computers`.`uuid` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Computer::class,
+            'search_option'     => 47, // uuid
+            'value'             => '^test$',
+            'expected_and'      => "(`glpi_computers`.`uuid` LIKE 'test')",
+            'expected_and_not'  => "(`glpi_computers`.`uuid` NOT LIKE 'test' OR `glpi_computers`.`uuid` IS NULL)",
+        ];
+
+        // datatype=text
+        yield [
+            'itemtype'          => \Computer::class,
+            'search_option'     => 16, // comment
+            'value'             => '^test',
+            'expected_and'      => "(`glpi_computers`.`comment` LIKE 'test%')",
+            'expected_and_not'  => "(`glpi_computers`.`comment` NOT LIKE 'test%' OR `glpi_computers`.`comment` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Computer::class,
+            'search_option'     => 16, // comment
+            'value'             => 'test$',
+            'expected_and'      => "(`glpi_computers`.`comment` LIKE '%test')",
+            'expected_and_not'  => "(`glpi_computers`.`comment` NOT LIKE '%test' OR `glpi_computers`.`comment` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Computer::class,
+            'search_option'     => 16, // comment
+            'value'             => '^test$',
+            'expected_and'      => "(`glpi_computers`.`comment` LIKE 'test')",
+            'expected_and_not'  => "(`glpi_computers`.`comment` NOT LIKE 'test' OR `glpi_computers`.`comment` IS NULL)",
+        ];
+
+        // datatype=email
+        yield [
+            'itemtype'          => \Contact::class,
+            'search_option'     => 6, // email
+            'value'             => '^myname@',
+            'expected_and'      => "(`glpi_contacts`.`email` LIKE 'myname@%')",
+            'expected_and_not'  => "(`glpi_contacts`.`email` NOT LIKE 'myname@%' OR `glpi_contacts`.`email` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Contact::class,
+            'search_option'     => 6, // email
+            'value'             => '@domain.tld$',
+            'expected_and'      => "(`glpi_contacts`.`email` LIKE '%@domain.tld')",
+            'expected_and_not'  => "(`glpi_contacts`.`email` NOT LIKE '%@domain.tld' OR `glpi_contacts`.`email` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Contact::class,
+            'search_option'     => 6, // email
+            'value'             => '^myname@domain.tld$',
+            'expected_and'      => "(`glpi_contacts`.`email` LIKE 'myname@domain.tld')",
+            'expected_and_not'  => "(`glpi_contacts`.`email` NOT LIKE 'myname@domain.tld' OR `glpi_contacts`.`email` IS NULL)",
+        ];
+
+        // datatype=weblink
+        yield [
+            'itemtype'          => \Document::class,
+            'search_option'     => 4, // link
+            'value'             => '^ftp://',
+            'expected_and'      => "(`glpi_documents`.`link` LIKE 'ftp://%')",
+            'expected_and_not'  => "(`glpi_documents`.`link` NOT LIKE 'ftp://%' OR `glpi_documents`.`link` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Document::class,
+            'search_option'     => 4, // link
+            'value'             => '.pdf$',
+            'expected_and'      => "(`glpi_documents`.`link` LIKE '%.pdf')",
+            'expected_and_not'  => "(`glpi_documents`.`link` NOT LIKE '%.pdf' OR `glpi_documents`.`link` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Document::class,
+            'search_option'     => 4, // link
+            'value'             => '^ftp://domain.tld/document.pdf$',
+            'expected_and'      => "(`glpi_documents`.`link` LIKE 'ftp://domain.tld/document.pdf')",
+            'expected_and_not'  => "(`glpi_documents`.`link` NOT LIKE 'ftp://domain.tld/document.pdf' OR `glpi_documents`.`link` IS NULL)",
+        ];
+
+        // datatype=mac
+        yield [
+            'itemtype'          => \DeviceNetworkCard::class,
+            'search_option'     => 11, // mac_default
+            'value'             => '^a2:e5:aa',
+            'expected_and'      => "(`glpi_devicenetworkcards`.`mac_default` LIKE 'a2:e5:aa%')",
+            'expected_and_not'  => "(`glpi_devicenetworkcards`.`mac_default` NOT LIKE 'a2:e5:aa%' OR `glpi_devicenetworkcards`.`mac_default` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \DeviceNetworkCard::class,
+            'search_option'     => 11, // mac_default
+            'value'             => 'a2:e5:aa$',
+            'expected_and'      => "(`glpi_devicenetworkcards`.`mac_default` LIKE '%a2:e5:aa')",
+            'expected_and_not'  => "(`glpi_devicenetworkcards`.`mac_default` NOT LIKE '%a2:e5:aa' OR `glpi_devicenetworkcards`.`mac_default` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \DeviceNetworkCard::class,
+            'search_option'     => 11, // mac_default
+            'value'             => '^15:f4:q4:a2:e5:aa$',
+            'expected_and'      => "(`glpi_devicenetworkcards`.`mac_default` LIKE '15:f4:q4:a2:e5:aa')",
+            'expected_and_not'  => "(`glpi_devicenetworkcards`.`mac_default` NOT LIKE '15:f4:q4:a2:e5:aa' OR `glpi_devicenetworkcards`.`mac_default` IS NULL)",
+        ];
+
+        // datatype=color
+        yield [
+            'itemtype'          => \Cable::class,
+            'search_option'     => 15, // color
+            'value'             => '^#00',
+            'expected_and'      => "(`glpi_cables`.`color` LIKE '#00%')",
+            'expected_and_not'  => "(`glpi_cables`.`color` NOT LIKE '#00%' OR `glpi_cables`.`color` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Cable::class,
+            'search_option'     => 15, // color
+            'value'             => 'ff$',
+            'expected_and'      => "(`glpi_cables`.`color` LIKE '%ff')",
+            'expected_and_not'  => "(`glpi_cables`.`color` NOT LIKE '%ff' OR `glpi_cables`.`color` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \Cable::class,
+            'search_option'     => 15, // color
+            'value'             => '^#00aaff$',
+            'expected_and'      => "(`glpi_cables`.`color` LIKE '#00aaff')",
+            'expected_and_not'  => "(`glpi_cables`.`color` NOT LIKE '#00aaff' OR `glpi_cables`.`color` IS NULL)",
+        ];
+
+        // datatype=language
+        yield [
+            'itemtype'          => \User::class,
+            'search_option'     => 17, // language
+            'value'             => '^en_',
+            'expected_and'      => "(`glpi_users`.`language` LIKE 'en\_%')",
+            'expected_and_not'  => "(`glpi_users`.`language` NOT LIKE 'en\_%' OR `glpi_users`.`language` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \User::class,
+            'search_option'     => 17, // language
+            'value'             => '_GB$',
+            'expected_and'      => "(`glpi_users`.`language` LIKE '%\_GB')",
+            'expected_and_not'  => "(`glpi_users`.`language` NOT LIKE '%\_GB' OR `glpi_users`.`language` IS NULL)",
+        ];
+        yield [
+            'itemtype'          => \User::class,
+            'search_option'     => 17, // language
+            'value'             => '^en_GB$',
+            'expected_and'      => "(`glpi_users`.`language` LIKE 'en\_GB')",
+            'expected_and_not'  => "(`glpi_users`.`language` NOT LIKE 'en\_GB' OR `glpi_users`.`language` IS NULL)",
+        ];
+
+        // Check `>`, `>=`, `<` and `<=` operators on textual fields.
+        // Operator has no meaning and is considered as a term to search for.
+        foreach (['>', '>=', '<', '<='] as $operator) {
+            foreach (['', ' '] as $spacing) {
+                $searched_value = "{$operator}{$spacing}15";
+
+                // datatype=dropdown
+                yield [
+                    'itemtype'          => \Computer::class,
+                    'search_option'     => 4, // type
+                    'value'             => $searched_value,
+                    'expected_and'      => "(`glpi_computertypes`.`name` LIKE '%{$searched_value}%')",
+                    'expected_and_not'  => "(`glpi_computertypes`.`name` NOT LIKE '%{$searched_value}%' OR `glpi_computertypes`.`name` IS NULL)",
+                ];
+
+                // datatype=dropdown (usehaving=true)
+                yield [
+                    'itemtype'          => \Ticket::class,
+                    'search_option'     => 142, // document name
+                    'value'             => $searched_value,
+                    'expected_and'      => "(`ITEM_Ticket_142` LIKE '%{$searched_value}%')",
+                    'expected_and_not'  => "(`ITEM_Ticket_142` NOT LIKE '%{$searched_value}%' OR `ITEM_Ticket_142` IS NULL)",
+                ];
+
+                // datatype=itemlink
+                yield [
+                    'itemtype'          => \Computer::class,
+                    'search_option'     => 1, // name
+                    'value'             => $searched_value,
+                    'expected_and'      => "(`glpi_computers`.`name` LIKE '%{$searched_value}%')",
+                    'expected_and_not'  => "(`glpi_computers`.`name` NOT LIKE '%{$searched_value}%' OR `glpi_computers`.`name` IS NULL)",
+                ];
+
+                // datatype=itemlink (usehaving=true)
+                yield [
+                    'itemtype'          => \Ticket::class,
+                    'search_option'     => 50, // parent tickets
+                    'value'             => $searched_value,
+                    'expected_and'      => "(`ITEM_Ticket_50` LIKE '%{$searched_value}%')",
+                    'expected_and_not'  => "(`ITEM_Ticket_50` NOT LIKE '%{$searched_value}%' OR `ITEM_Ticket_50` IS NULL)",
+                ];
+
+                // datatype=string
+                yield [
+                    'itemtype'          => \Computer::class,
+                    'search_option'     => 47, // uuid
+                    'value'             => $searched_value,
+                    'expected_and'      => "(`glpi_computers`.`uuid` LIKE '%{$searched_value}%')",
+                    'expected_and_not'  => "(`glpi_computers`.`uuid` NOT LIKE '%{$searched_value}%' OR `glpi_computers`.`uuid` IS NULL)",
+                ];
+
+                // datatype=text
+                yield [
+                    'itemtype'          => \Computer::class,
+                    'search_option'     => 16, // comment
+                    'value'             => $searched_value,
+                    'expected_and'      => "(`glpi_computers`.`comment` LIKE '%{$searched_value}%')",
+                    'expected_and_not'  => "(`glpi_computers`.`comment` NOT LIKE '%{$searched_value}%' OR `glpi_computers`.`comment` IS NULL)",
+                ];
+
+                // datatype=email
+                yield [
+                    'itemtype'          => \Contact::class,
+                    'search_option'     => 6, // email
+                    'value'             => $searched_value,
+                    'expected_and'      => "(`glpi_contacts`.`email` LIKE '%{$searched_value}%')",
+                    'expected_and_not'  => "(`glpi_contacts`.`email` NOT LIKE '%{$searched_value}%' OR `glpi_contacts`.`email` IS NULL)",
+                ];
+
+                // datatype=weblink
+                yield [
+                    'itemtype'          => \Document::class,
+                    'search_option'     => 4, // link
+                    'value'             => $searched_value,
+                    'expected_and'      => "(`glpi_documents`.`link` LIKE '%{$searched_value}%')",
+                    'expected_and_not'  => "(`glpi_documents`.`link` NOT LIKE '%{$searched_value}%' OR `glpi_documents`.`link` IS NULL)",
+                ];
+
+                // datatype=mac
+                yield [
+                    'itemtype'          => \DeviceNetworkCard::class,
+                    'search_option'     => 11, // mac_default
+                    'value'             => $searched_value,
+                    'expected_and'      => "(`glpi_devicenetworkcards`.`mac_default` LIKE '%{$searched_value}%')",
+                    'expected_and_not'  => "(`glpi_devicenetworkcards`.`mac_default` NOT LIKE '%{$searched_value}%' OR `glpi_devicenetworkcards`.`mac_default` IS NULL)",
+                ];
+
+                // datatype=color
+                yield [
+                    'itemtype'          => \Cable::class,
+                    'search_option'     => 15, // color
+                    'value'             => $searched_value,
+                    'expected_and'      => "(`glpi_cables`.`color` LIKE '%{$searched_value}%')",
+                    'expected_and_not'  => "(`glpi_cables`.`color` NOT LIKE '%{$searched_value}%' OR `glpi_cables`.`color` IS NULL)",
+                ];
+
+                // datatype=language
+                yield [
+                    'itemtype'          => \User::class,
+                    'search_option'     => 17, // language
+                    'value'             => $searched_value,
+                    'expected_and'      => "(`glpi_users`.`language` LIKE '%{$searched_value}%')",
+                    'expected_and_not'  => "(`glpi_users`.`language` NOT LIKE '%{$searched_value}%' OR `glpi_users`.`language` IS NULL)",
+                ];
+            }
+        }
+
+        // Check `>`, `>=`, `<` and `<=` operators on numeric fields.
+        // It should result in usage of the corresponding SQL operator.
+
+        foreach (['>', '>=', '<', '<='] as $operator) {
+            foreach (['', ' '] as $spacing) {
+                foreach ([15, 2.3, 1.125] as $value) {
+                    $searched_value = "{$operator}{$spacing}{$value}";
+                    $int_value      = round($value);
+                    $not_operator   = str_contains($operator, '>') ? str_replace('>', '<', $operator) : str_replace('<', '>', $operator);
+
+                    // datatype=integer
+                    yield [
+                        'itemtype'          => \AuthLDAP::class,
+                        'search_option'     => 4, // port
+                        'value'             => $searched_value,
+                        'expected_and'      => "(`glpi_authldaps`.`port` LIKE '%{$searched_value}%')",
+                        'expected_and_not'  => "(`glpi_authldaps`.`port` NOT LIKE '%{$searched_value}%' OR `glpi_authldaps`.`port` IS NULL)",
+                    ];
+
+                    // datatype=number
+                    yield [
+                        'itemtype'          => \AuthLDAP::class,
+                        'search_option'     => 32, // timeout
+                        'value'             => $searched_value,
+                        'expected_and'      => "(`glpi_authldaps`.`timeout` {$operator} {$int_value})",
+                        'expected_and_not'  => "(`glpi_authldaps`.`timeout` {$not_operator} {$int_value})",
+                    ];
+
+                    // datatype=number (usehaving=true)
+                    yield [
+                        'itemtype'          => \Computer::class,
+                        'search_option'     => 115, // harddrive capacity
+                        'value'             => $searched_value,
+                        'expected_and'      => "(`ITEM_Computer_115` {$operator} {$int_value})",
+                        'expected_and_not'  => "(`ITEM_Computer_115` {$not_operator} {$int_value})",
+                    ];
+
+                    // datatype=decimal
+                    yield [
+                        'itemtype'          => \Budget::class,
+                        'search_option'     => 7, // value
+                        'value'             => $searched_value,
+                        'expected_and'      => "(`glpi_budgets`.`value` {$operator} {$int_value})",
+                        'expected_and_not'  => "(`glpi_budgets`.`value` {$not_operator} {$int_value})",
+                    ];
+
+                    // datatype=decimal (usehaving=true)
+                    yield [
+                        'itemtype'          => \Contract::class,
+                        'search_option'     => 11, // totalcost
+                        'value'             => $searched_value,
+                        'expected_and'      => "(`ITEM_Contract_11` {$operator} {$int_value})",
+                        'expected_and_not'  => "(`ITEM_Contract_11` {$not_operator} {$int_value})",
+                    ];
+
+                    // datatype=count (usehaving=true)
+                    yield [
+                        'itemtype'          => \Ticket::class,
+                        'search_option'     => 27, // number of followups
+                        'value'             => $searched_value,
+                        'expected_and'      => "(`ITEM_Ticket_27` {$operator} {$int_value})",
+                        'expected_and_not'  => "(`ITEM_Ticket_27` {$not_operator} {$int_value})",
+                    ];
+
+                    // datatype=mio (usehaving=true)
+                    yield [
+                        'itemtype'          => \Computer::class,
+                        'search_option'     => 111, // memory size
+                        'value'             => $searched_value,
+                        'expected_and'      => "(`ITEM_Computer_111` {$operator} {$int_value})",
+                        'expected_and_not'  => "(`ITEM_Computer_111` {$not_operator} {$int_value})",
+                    ];
+
+                    // datatype=progressbar (with computation)
+                    yield [
+                        'itemtype'          => \Computer::class,
+                        'search_option'     => 152, // harddrive freepercent
+                        'value'             => $searched_value,
+                        'expected_and'      => "(LPAD(ROUND(100*`glpi_items_disks`.freesize/NULLIF(`glpi_items_disks`.totalsize, 0)), 3, 0) {$operator} {$int_value})",
+                        'expected_and_not'  => "(LPAD(ROUND(100*`glpi_items_disks`.freesize/NULLIF(`glpi_items_disks`.totalsize, 0)), 3, 0) {$not_operator} {$int_value})",
+                    ];
+
+                    // datatype=timestamp
+                    yield [
+                        'itemtype'          => \CronTask::class,
+                        'search_option'     => 6, // frequency
+                        'value'             => $searched_value,
+                        'expected_and'      => "(`glpi_crontasks`.`frequency` {$operator} {$int_value})",
+                        'expected_and_not'  => "(`glpi_crontasks`.`frequency` {$not_operator} {$int_value})",
+                    ];
+
+                    // datatype=timestamp (usehaving=true)
+                    yield [
+                        'itemtype'          => \Ticket::class,
+                        'search_option'     => 49, // actiontime
+                        'value'             => $searched_value,
+                        'expected_and'      => "(`ITEM_Ticket_49` {$operator} {$int_value})",
+                        'expected_and_not'  => "(`ITEM_Ticket_49` {$not_operator} {$int_value})",
+                    ];
+                }
+            }
+        }
+
+        // Check `>`, `>=`, `<` and `<=` operators on date and datetime fields.
+        // It should result in a criterion based on a relative date expressed in months, and using the corresponding SQL operator.
+
+        foreach (['>', '>=', '<', '<='] as $operator) {
+            foreach (['', ' '] as $spacing) {
+                foreach ([-3, 6] as $value) {
+                    $searched_value = "{$operator}{$spacing}{$value}";
+                    $not_operator   = $operator;
+
+                    // datatype=datetime
+                    yield [
+                        'itemtype'          => \Computer::class,
+                        'search_option'     => 9, // last_inventory_update
+                        'value'             => $searched_value,
+                        'expected_and'      => "(CONVERT(`glpi_computers`.`last_inventory_update` USING utf8mb4) {$operator} ADDDATE(NOW(), INTERVAL {$value} MONTH))",
+                        'expected_and_not'  => "(CONVERT(`glpi_computers`.`last_inventory_update` USING utf8mb4) {$not_operator} ADDDATE(NOW(), INTERVAL {$value} MONTH))",
+                    ];
+
+                    // datatype=datetime computed field
+                    yield [
+                        'itemtype'          => \Ticket::class,
+                        'search_option'     => 188, // next_escalation_level
+                        'value'             => $searched_value,
+                        'expected_and'      => "(`ITEM_Ticket_188` LIKE '%{$searched_value}%')",
+                        'expected_and_not'  => "(`ITEM_Ticket_188` NOT LIKE '%{$searched_value}%' OR `ITEM_Ticket_188` IS NULL)",
+                    ];
+
+                    // datatype=date
+                    yield [
+                        'itemtype'          => \Budget::class,
+                        'search_option'     => 5, // begin_date
+                        'value'             => $searched_value,
+                        'expected_and'      => "(CONVERT(`glpi_budgets`.`begin_date` USING utf8mb4) {$operator} ADDDATE(NOW(), INTERVAL {$value} MONTH))",
+                        'expected_and_not'  => "(CONVERT(`glpi_budgets`.`begin_date` USING utf8mb4) {$not_operator} ADDDATE(NOW(), INTERVAL {$value} MONTH))",
+                    ];
+
+                    // datatype=date_delay
+                    yield [
+                        'itemtype'          => \Contract::class,
+                        'search_option'     => 20, // end_date
+                        'value'             => $searched_value,
+                        'expected_and'      => "(ADDDATE(`glpi_contracts`.begin_date, INTERVAL (`glpi_contracts`.duration) MONTH) {$operator} ADDDATE(NOW(), INTERVAL {$value} MONTH))",
+                        'expected_and_not'  => "(ADDDATE(`glpi_contracts`.begin_date, INTERVAL (`glpi_contracts`.duration) MONTH) {$not_operator} ADDDATE(NOW(), INTERVAL {$value} MONTH))",
+                    ];
+                }
+            }
+        }
+    }
+
+    /**
+     * @dataprovider containsCriterionProvider
+     */
+    public function testContainsCriterion(
+        string $itemtype,
+        int $search_option,
+        string $value,
+        string $expected_and,
+        string $expected_and_not
+    ): void {
+        $cases = [
+            'AND'       => $expected_and,
+            'AND NOT'   => $expected_and_not,
+        ];
+
+        foreach ($cases as $link => $expected_where) {
+            $search_params = [
+                'is_deleted' => 0,
+                'start'      => 0,
+                'criteria'   => [
+                    0 => [
+                        'link'       => $link,
+                        'field'      => $search_option,
+                        'searchtype' => 'contains',
+                        'value'      => $value,
+                    ]
+                ],
+            ];
+
+            $data = $this->doSearch($itemtype, $search_params);
+
+            $this->array($data)->hasKey('sql');
+            $this->array($data['sql'])->hasKey('search');
+            $this->string($data['sql']['search']);
+
+            $this->string($this->cleanSQL($data['sql']['search']))->contains($expected_where);
+        }
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Add many tests using the `contains` search operator.

Aim to validate advanced usages described in https://glpi-user-documentation.readthedocs.io/fr/latest/first-steps/search.html?highlight=search#perform-an-advanced-search for all valid search options datatypes.

While adding tests, I figured out that some cases are not working as expected, but I did not fix them yet, I just added some `FIXME` comments in the `Search` class code. I propose to fix them in separated PRs, as all of them are not easy to fix.