### PR TITLE
fix(saved search): 404 error

### DIFF
--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -658,6 +658,8 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
 
         $itemtype = $this->fields['itemtype'];
         $url = $itemtype::getSearchURL();
+
+        // Prevents parameter duplication
         $parse_url = parse_url($url);
         if (isset($parse_url['query'])) {
             parse_str($parse_url['query'], $url_params);

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -656,7 +656,14 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
             return;
         }
 
-        $url = Toolbox::getItemTypeSearchURL($this->fields['itemtype']);
+        $itemtype = $this->fields['itemtype'];
+        $url = $itemtype::getSearchURL();
+        $parse_url = parse_url($url);
+        if (isset($parse_url['query'])) {
+            parse_str($parse_url['query'], $url_params);
+            $url = $parse_url['path'];
+            $params = array_merge($url_params, $params);
+        }
         $url .= "?" . Toolbox::append_params($params);
 
        // keep last loaded to set an active state on saved search panel


### PR DESCRIPTION
Some saved searches gave a 404 error when trying to load them.

For example, **Device Camera Models**, which tried to load the URL `front/devicecameramodel.php?itemtype=DeviceCameraModel` instead of `front/devicemodel.php?itemtype=DeviceCameraModel`

Same case with GenericObject plugin objects

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28884
