### PR TITLE
Fix handling of `integer` search option datatype

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -3569,7 +3569,7 @@ JAVASCRIPT;
                 case "count":
                 case "mio":
                 case "number":
-                // FIXME Should also apply to integer
+                case "integer":
                 case "decimal":
                 case "timestamp":
                     // FIXME Negative search are not supported. For instance, `>-10` result in a `LIKE '%>-10%'` SQL criterion.
@@ -5296,7 +5296,7 @@ JAVASCRIPT;
                 case "count":
                 case "mio":
                 case "number":
-                // FIXME Should also apply to integer
+                case "integer":
                 case "decimal":
                 case "timestamp":
                 case "progressbar":
@@ -7623,7 +7623,7 @@ JAVASCRIPT;
 
                 case "count":
                 case "number":
-                // FIXME Should also apply to integer
+                case "integer":
                 case "mio":
                     $out           = "";
                     $count_display = 0;
@@ -8424,7 +8424,7 @@ HTML;
                 switch ($searchopt[$field_num]['datatype']) {
                     case 'mio':
                     case 'count':
-                    // FIXME Should also apply to integer
+                    case "integer":
                     case 'number':
                         $opt = [
                             'contains'    => __('contains'),

--- a/tests/functional/Search.php
+++ b/tests/functional/Search.php
@@ -3295,8 +3295,8 @@ class Search extends DbTestCase
             'itemtype'          => \AuthLDAP::class,
             'search_option'     => 4, // port
             'value'             => '123',
-            'expected_and'      => "(`glpi_authldaps`.`port` LIKE '%123%')",
-            'expected_and_not'  => "(`glpi_authldaps`.`port` NOT LIKE '%123%' OR `glpi_authldaps`.`port` IS NULL)",
+            'expected_and'      => "(`glpi_authldaps`.`port` = 123)",
+            'expected_and_not'  => "(`glpi_authldaps`.`port` <> 123)",
         ];
 
         // datatype=number
@@ -4220,8 +4220,8 @@ class Search extends DbTestCase
                         'itemtype'          => \AuthLDAP::class,
                         'search_option'     => 4, // port
                         'value'             => $searched_value,
-                        'expected_and'      => "(`glpi_authldaps`.`port` LIKE '%{$searched_value}%')",
-                        'expected_and_not'  => "(`glpi_authldaps`.`port` NOT LIKE '%{$searched_value}%' OR `glpi_authldaps`.`port` IS NULL)",
+                        'expected_and'      => "(`glpi_authldaps`.`port` {$operator} {$int_value})",
+                        'expected_and_not'  => "(`glpi_authldaps`.`port` {$not_operator} {$int_value})",
                     ];
 
                     // datatype=number


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Fix SQL criteria applied when searching for numeric values.
2. Fix search form `is`/`is_not` inputs when min/max values are defined.

before:
![Capture d’écran du 2023-07-25 14-39-17](https://github.com/glpi-project/glpi/assets/33253653/6bb7d04c-88b5-4d3b-a998-c5243eac05d1)
after:
![Capture d’écran du 2023-07-25 14-40-07](https://github.com/glpi-project/glpi/assets/33253653/b7d6efb2-8ec6-4b8b-a66f-57a77407ec33)
![Capture d’écran du 2023-07-25 14-40-41](https://github.com/glpi-project/glpi/assets/33253653/77a62976-8214-47ac-bcff-d08573046956)
