### PR TITLE
Fix and enhance date search

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -5244,11 +5244,21 @@ JAVASCRIPT;
                         return " $link ($date_computation " . $SEARCH . ') ';
                     }
                     $val = Sanitizer::decodeHtmlSpecialChars($val); // Decode "<" and ">" operators
-                    if (preg_match("/^\s*([<>=]+)(.*)/", $val, $regs)) {
-                        if (is_numeric($regs[2])) {
-                            // FIXME Comparison operator should be "reversed" whne `$nott === true`.
-                            return $link . " $date_computation " . $regs[1] . "
-                            ADDDATE(NOW(), INTERVAL " . $regs[2] . " $search_unit) ";
+                    if (preg_match("/^\s*([<>])(=?)(.+)$/", $val, $regs)) {
+                        $numeric_matches = [];
+                        if (preg_match('/^\s*(-?)\s*([0-9]+(.[0-9]+)?)\s*$/', $regs[3], $numeric_matches)) {
+                            if ($searchtype === "notcontains") {
+                                $nott = !$nott;
+                            }
+                            if ($nott) {
+                                if ($regs[1] == '<') {
+                                    $regs[1] = '>';
+                                } else {
+                                    $regs[1] = '<';
+                                }
+                            }
+                            return $link . " $date_computation " . $regs[1] . $regs[2] . "
+                            ADDDATE(NOW(), INTERVAL " . $numeric_matches[1] . $numeric_matches[2] . " $search_unit) ";
                         }
                        // ELSE Reformat date if needed
                         $regs[2] = preg_replace(

--- a/src/Search.php
+++ b/src/Search.php
@@ -5261,17 +5261,17 @@ JAVASCRIPT;
                             ADDDATE(NOW(), INTERVAL " . $numeric_matches[1] . $numeric_matches[2] . " $search_unit) ";
                         }
                        // ELSE Reformat date if needed
-                        $regs[2] = preg_replace(
+                        $regs[3] = preg_replace(
                             '@(\d{1,2})(-|/)(\d{1,2})(-|/)(\d{4})@',
                             '\5-\3-\1',
-                            $regs[2]
+                            $regs[3]
                         );
-                        if (preg_match('/[0-9]{2,4}-[0-9]{1,2}-[0-9]{1,2}/', $regs[2])) {
+                        if (preg_match('/[0-9]{2,4}-[0-9]{1,2}-[0-9]{1,2}/', $regs[3])) {
                              $ret = $link;
                             if ($nott) {
                                 $ret .= " NOT(";
                             }
-                             $ret .= " $date_computation {$regs[1]} '{$regs[2]}'";
+                             $ret .= " $date_computation {$regs[1]}{$regs[2]} '{$regs[3]}'";
                             if ($nott) {
                                 $ret .= ")";
                             }

--- a/tests/functional/Search.php
+++ b/tests/functional/Search.php
@@ -4312,27 +4312,37 @@ class Search extends DbTestCase
         // It should result in a criterion based on a relative date expressed in months, and using the corresponding SQL operator.
 
         foreach (['>', '>=', '<', '<='] as $operator) {
-            foreach (['', ' '] as $spacing) {
-                foreach ([-3, 6] as $value) {
-                    $searched_value = "{$operator}{$spacing}{$value}";
-                    $not_operator   = $operator;
+            foreach ([3, 6.5] as $value) {
+                $searched_values = [
+                    // positive values, with or without spaces
+                    "{$operator}{$value}"       => "{$value}",
+                    " {$operator}  {$value} "   => "{$value}",
 
+                    // negative values, with or without spaces
+                    "{$operator}-{$value}"      => "-{$value}",
+                    " {$operator} -{$value} "   => "-{$value}",
+                    "{$operator} - {$value} "   => "-{$value}",
+                ];
+                $not_operator   = str_contains($operator, '>') ? str_replace('>', '<', $operator) : str_replace('<', '>', $operator);
+
+                foreach ($searched_values as $searched_value => $signed_value) {
                     // datatype=datetime
                     yield [
                         'itemtype'          => \Computer::class,
                         'search_option'     => 9, // last_inventory_update
                         'value'             => $searched_value,
-                        'expected_and'      => "(CONVERT(`glpi_computers`.`last_inventory_update` USING utf8mb4) {$operator} ADDDATE(NOW(), INTERVAL {$value} MONTH))",
-                        'expected_and_not'  => "(CONVERT(`glpi_computers`.`last_inventory_update` USING utf8mb4) {$not_operator} ADDDATE(NOW(), INTERVAL {$value} MONTH))",
+                        'expected_and'      => "(CONVERT(`glpi_computers`.`last_inventory_update` USING utf8mb4) {$operator} ADDDATE(NOW(), INTERVAL {$signed_value} MONTH))",
+                        'expected_and_not'  => "(CONVERT(`glpi_computers`.`last_inventory_update` USING utf8mb4) {$not_operator} ADDDATE(NOW(), INTERVAL {$signed_value} MONTH))",
                     ];
 
                     // datatype=datetime computed field
+                    $like_value = trim(str_replace('  ', ' ', $searched_value));
                     yield [
                         'itemtype'          => \Ticket::class,
                         'search_option'     => 188, // next_escalation_level
                         'value'             => $searched_value,
-                        'expected_and'      => "(`ITEM_Ticket_188` LIKE '%{$searched_value}%')",
-                        'expected_and_not'  => "(`ITEM_Ticket_188` NOT LIKE '%{$searched_value}%' OR `ITEM_Ticket_188` IS NULL)",
+                        'expected_and'      => "(`ITEM_Ticket_188` LIKE '%{$like_value}%')",
+                        'expected_and_not'  => "(`ITEM_Ticket_188` NOT LIKE '%{$like_value}%' OR `ITEM_Ticket_188` IS NULL)",
                     ];
 
                     // datatype=date
@@ -4340,8 +4350,8 @@ class Search extends DbTestCase
                         'itemtype'          => \Budget::class,
                         'search_option'     => 5, // begin_date
                         'value'             => $searched_value,
-                        'expected_and'      => "(CONVERT(`glpi_budgets`.`begin_date` USING utf8mb4) {$operator} ADDDATE(NOW(), INTERVAL {$value} MONTH))",
-                        'expected_and_not'  => "(CONVERT(`glpi_budgets`.`begin_date` USING utf8mb4) {$not_operator} ADDDATE(NOW(), INTERVAL {$value} MONTH))",
+                        'expected_and'      => "(CONVERT(`glpi_budgets`.`begin_date` USING utf8mb4) {$operator} ADDDATE(NOW(), INTERVAL {$signed_value} MONTH))",
+                        'expected_and_not'  => "(CONVERT(`glpi_budgets`.`begin_date` USING utf8mb4) {$not_operator} ADDDATE(NOW(), INTERVAL {$signed_value} MONTH))",
                     ];
 
                     // datatype=date_delay
@@ -4349,8 +4359,8 @@ class Search extends DbTestCase
                         'itemtype'          => \Contract::class,
                         'search_option'     => 20, // end_date
                         'value'             => $searched_value,
-                        'expected_and'      => "(ADDDATE(`glpi_contracts`.begin_date, INTERVAL (`glpi_contracts`.duration) MONTH) {$operator} ADDDATE(NOW(), INTERVAL {$value} MONTH))",
-                        'expected_and_not'  => "(ADDDATE(`glpi_contracts`.begin_date, INTERVAL (`glpi_contracts`.duration) MONTH) {$not_operator} ADDDATE(NOW(), INTERVAL {$value} MONTH))",
+                        'expected_and'      => "(ADDDATE(`glpi_contracts`.begin_date, INTERVAL (`glpi_contracts`.duration) MONTH) {$operator} ADDDATE(NOW(), INTERVAL {$signed_value} MONTH))",
+                        'expected_and_not'  => "(ADDDATE(`glpi_contracts`.begin_date, INTERVAL (`glpi_contracts`.duration) MONTH) {$not_operator} ADDDATE(NOW(), INTERVAL {$signed_value} MONTH))",
                     ];
                 }
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Fix handling of `AND NOT` operator in date searches.
2. Support floats in date searches (e.g. `>= 10.5` -> `>= ADDDATE(NOW(), INTERVAL 10.5 MONTH)`).