### PR TITLE
Use search engine to display consumables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The present file will list all changes made to the project; according to the
 
 ### Deprecated
 - Survey URL tags `TICKETCATEGORY_ID` and `TICKETCATEGORY_NAME` are deprecated and replaced by `ITILCATEGORY_ID` and `ITILCATEGORY_NAME` respectively.
+- `Consumable::showAddForm()` and `Consumable::showForConsumableItem()` are deprecated and replaced by `Consumable::displayConsumableList()`.
 
 ### Removed
 - XML-RPC API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ The present file will list all changes made to the project; according to the
 
 ### Deprecated
 - Survey URL tags `TICKETCATEGORY_ID` and `TICKETCATEGORY_NAME` are deprecated and replaced by `ITILCATEGORY_ID` and `ITILCATEGORY_NAME` respectively.
-- `Consumable::showAddForm()` and `Consumable::showForConsumableItem()` are deprecated and replaced by `Consumable::displayConsumableList()`.
 
 ### Removed
 - XML-RPC API.
@@ -117,6 +116,8 @@ The present file will list all changes made to the project; according to the
 - `CommonITILValidation::alreadyExists()`
 - `CommonITILValidation::getTicketStatusNumber()`
 - `Config::validatePassword()`
+- `Consumable::showAddForm()`
+- `Consumable::showForConsumableItem()`
 - `DBmysql::truncate()`
 - `DBmysql::truncateOrDie()`
 - `Glpi\Application\View\Extension::getVerbatimValue()`

--- a/css/includes/pages/_search.scss
+++ b/css/includes/pages/_search.scss
@@ -41,7 +41,16 @@
     background-color: $danger;
 }
 
+// Prevent search results from filling all available vertical space
+// Useful when displaying multipler search results on the same page
+.search-no-forced-height {
+    .search-container {
+        height: unset !important;
+    }
+}
+
 .search_page {
+
     @include media-breakpoint-up(lg) {
         display: flex;
         align-items: stretch;
@@ -53,6 +62,7 @@
 
         @include media-breakpoint-up(lg) {
             overflow: auto;
+            height: calc(100vh - #{$contextbar-height} - #{$content-margin});
             padding: 0;
             margin-left: calc(var(--tblr-gutter-x) / 2);
             margin-right: calc(var(--tblr-gutter-x) / 2);

--- a/css/includes/pages/_search.scss
+++ b/css/includes/pages/_search.scss
@@ -50,9 +50,9 @@
     .search-container {
         @include media-breakpoint-up(lg) {
             overflow: auto;
-            height: calc(100vh - #{$contextbar-height} - #{$content-margin});
             padding: 0;
             margin-left: calc(var(--tblr-gutter-x) / 2);
+            margin-right: calc(var(--tblr-gutter-x) / 2);
             width: 100%;
 
             .dashboard-card {

--- a/css/includes/pages/_search.scss
+++ b/css/includes/pages/_search.scss
@@ -50,7 +50,6 @@
 }
 
 .search_page {
-
     @include media-breakpoint-up(lg) {
         display: flex;
         align-items: stretch;

--- a/css/includes/pages/_search.scss
+++ b/css/includes/pages/_search.scss
@@ -48,6 +48,9 @@
     }
 
     .search-container {
+        border: var(--tblr-card-border-width) solid var(--tblr-card-border-color);
+        border-radius: var(--tblr-border-radius);
+
         @include media-breakpoint-up(lg) {
             overflow: auto;
             padding: 0;
@@ -90,6 +93,14 @@
         }
 
         .search-card {
+            &.card {
+                // Borders are unreliable here as they will scroll out of sight
+                // due to the sticky header behavior
+                // Its better to move it to a parent item that wont scroll like
+                // .search-container
+                border: unset;
+            }
+
             @include media-breakpoint-up(lg) {
                 min-width: 100%;
                 width: fit-content;

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -1985,6 +1985,7 @@ $empty_data_builder = new class
         $ADDTODISPLAYPREF[KnowbaseItem::class] = [79, 131, 13];
         $ADDTODISPLAYPREF[Webhook::class] = [3, 4, 5];
         $ADDTODISPLAYPREF[QueuedWebhook::class] = [80, 2, 22, 20, 21, 7, 30, 16];
+        $ADDTODISPLAYPREF[Consumable::class] = [2, 8, 3, 4, 5, 6, 7];
 
         foreach ($ADDTODISPLAYPREF as $type => $options) {
             $rank = 1;

--- a/install/migrations/update_10.0.x_to_10.1.0/consumable.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/consumable.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var array $ADDTODISPLAYPREF
+ */
+
+$ADDTODISPLAYPREF['Consumable'] = [2, 8, 3, 4, 5, 6, 7];

--- a/src/Consumable.php
+++ b/src/Consumable.php
@@ -543,6 +543,7 @@ class Consumable extends CommonDBChild
         Toolbox::deprecated('Replaced by Consumable::displayConsumableList()');
 
         $ID = $consitem->getField('id');
+
         if (!$consitem->can($ID, UPDATE)) {
             return;
         }
@@ -565,6 +566,7 @@ class Consumable extends CommonDBChild
             echo "</div>";
         }
     }
+
 
     /**
      * Print out the consumables of a defined type

--- a/src/Consumable.php
+++ b/src/Consumable.php
@@ -1164,7 +1164,7 @@ class Consumable extends CommonDBChild
             'field'              => 'id',
             'name'               => $infocom_label,
             // Content will be very short so using an icon here save space
-            'htmlname'           => "<i class=\"fa fa-coins\" title=\"$infocom_label\"></i>",
+            'htmlname'           => "<i class=\"ti ti-coins\" title=\"$infocom_label\"></i>",
             'massiveaction'      => false,
             'nosearch'           => true,
             'datatype'           => 'specific',

--- a/src/Consumable.php
+++ b/src/Consumable.php
@@ -1163,8 +1163,6 @@ class Consumable extends CommonDBChild
             'table'              => $this->getTable(),
             'field'              => 'id',
             'name'               => $infocom_label,
-            // Content will be very short so using an icon here save space
-            'htmlname'           => "<i class=\"ti ti-coins\" title=\"$infocom_label\"></i>",
             'massiveaction'      => false,
             'nosearch'           => true,
             'datatype'           => 'specific',

--- a/src/Consumable.php
+++ b/src/Consumable.php
@@ -1197,10 +1197,11 @@ class Consumable extends CommonDBChild
             case '6': // Given to
                 $itemtype = $values['itemtype'];
                 $items_id = $values['items_id'];
-                if (!is_null($itemtype)) {
+                if (is_a($itemtype, CommonDBTM::class, true)) {
                     $item = new $itemtype();
-                    $item->getFromDB($items_id);
-                    return $item->getLink();
+                    if ($item->getFromDB($items_id)) {
+                        return $item->getLink();
+                    }
                 }
 
                 // Must not be empty

--- a/src/Consumable.php
+++ b/src/Consumable.php
@@ -224,14 +224,25 @@ class Consumable extends CommonDBChild
         $input = $ma->getInput();
         switch ($ma->getAction()) {
             case 'give':
-                // Guess entity from first item
-                $consumable = current($input['items'][self::getType()]);
-                $entities_id = $consumable->fields['entities_id'];
+                // Retrieve entity restrict from consumable item
+                $consumable_id = current($input['items'][self::getType()]);
+                $consumable = new self();
+                if (
+                    $consumable_id === false
+                    || !$consumable->getFromDB($consumable_id)
+                    || ($consumable_item = $consumable->getItem()) === false
+                ) {
+                    // Cannot show form
+                    break;
+                }
+                $entity_restrict = $consumable_item->isRecursive()
+                    ? getSonsOf('glpi_entities', $consumable_item->getEntityID())
+                    : $consumable_item->getEntityID();
 
                 Dropdown::showSelectItemFromItemtypes([
                     'itemtype_name'   => 'give_itemtype',
                     'items_id_name'   => 'give_items_id',
-                    'entity_restrict' => $entities_id,
+                    'entity_restrict' => $entity_restrict,
                     'itemtypes'       => $CFG_GLPI["consumables_types"]
                 ]);
                 echo "<br><br>" . Html::submit(

--- a/src/Consumable.php
+++ b/src/Consumable.php
@@ -36,7 +36,6 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\Event;
-use Glpi\Search\SearchEngine;
 
 //!  Consumable Class
 /**

--- a/src/Consumable.php
+++ b/src/Consumable.php
@@ -766,7 +766,7 @@ class Consumable extends CommonDBChild
             'item'            => new self(),
             'parent'          => $parent,
             'itemtype'        => self::getType(),
-            'can_edit'        => $parent->canUpdateItem(),
+            'can_edit'        => $parent->canUpdate() && $parent->canUpdateItem(),
             'criteria_unused' => $criteria_unused,
             'criteria_used'   => $criteria_used,
             'count_unused'    => $count_unused,

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -835,6 +835,7 @@ class MassiveAction
         }
 
         Lock::getMassiveActionsForItemtype($actions, $itemtype, $is_deleted, $checkitem);
+        Consumable::getMassiveActionsForItemtype($actions, $itemtype, $is_deleted, $checkitem);
 
        // Manage forbidden actions : try complete action name or MassiveAction:action_name
         $forbidden_actions = $item->getForbiddenStandardMassiveAction();

--- a/src/Search/Input/QueryBuilder.php
+++ b/src/Search/Input/QueryBuilder.php
@@ -80,6 +80,7 @@ final class QueryBuilder implements SearchInputInterface
         $p['hide_controls']                 = false;
         $p['showmassiveactions']            = true;
         $p['extra_actions_templates']       = [];
+        $p['no_search']                     = $params['no_search'] ?? false;
 
         foreach ($params as $key => $val) {
             $p[$key] = $val;

--- a/src/Search/Input/QueryBuilder.php
+++ b/src/Search/Input/QueryBuilder.php
@@ -80,7 +80,7 @@ final class QueryBuilder implements SearchInputInterface
         $p['hide_controls']                 = false;
         $p['showmassiveactions']            = true;
         $p['extra_actions_templates']       = [];
-        $p['no_search']                     = $params['no_search'] ?? false;
+        $p['hide_criteria']                 = $params['hide_criteria'] ?? false;
 
         foreach ($params as $key => $val) {
             $p[$key] = $val;

--- a/src/Search/Output/HTMLSearchOutput.php
+++ b/src/Search/Output/HTMLSearchOutput.php
@@ -124,7 +124,7 @@ abstract class HTMLSearchOutput extends AbstractSearchOutput
             'posthref'            => $globallinkto,
             'push_history'        => $params['push_history'] ?? true,
             'hide_controls'       => $params['hide_controls'] ?? false,
-            'hide_search_toggle'  => $params['no_search'] ?? false,
+            'hide_search_toggle'  => $params['hide_criteria'] ?? false,
             'showmassiveactions'  => ($params['showmassiveactions'] ?? $search['showmassiveactions'] ?? true)
                 && $data['display_type'] != \Search::GLOBAL_SEARCH
                 && ($itemtype == \AllAssets::getType()

--- a/src/Search/Output/HTMLSearchOutput.php
+++ b/src/Search/Output/HTMLSearchOutput.php
@@ -106,10 +106,11 @@ abstract class HTMLSearchOutput extends AbstractSearchOutput
 
         \Session::initNavigateListItems($data['itemtype'], '', $href);
 
+        $rand = mt_rand();
         TemplateRenderer::getInstance()->display('components/search/display_data.html.twig', [
             'data'                => $data,
             'union_search_type'   => $CFG_GLPI["union_search_type"],
-            'rand'                => mt_rand(),
+            'rand'                => $rand,
             'no_sort'             => $search['no_sort'] ?? false,
             'order'               => $search['order'] ?? [],
             'sort'                => $search['sort'] ?? [],
@@ -123,6 +124,7 @@ abstract class HTMLSearchOutput extends AbstractSearchOutput
             'posthref'            => $globallinkto,
             'push_history'        => $params['push_history'] ?? true,
             'hide_controls'       => $params['hide_controls'] ?? false,
+            'hide_search_toggle'  => $params['no_search'] ?? false,
             'showmassiveactions'  => ($params['showmassiveactions'] ?? $search['showmassiveactions'] ?? true)
                 && $data['display_type'] != \Search::GLOBAL_SEARCH
                 && ($itemtype == \AllAssets::getType()
@@ -130,7 +132,7 @@ abstract class HTMLSearchOutput extends AbstractSearchOutput
                 ),
             'massiveactionparams' => $data['search']['massiveactionparams'] + [
                 'is_deleted' => $is_deleted,
-                'container'  => "massform$itemtype",
+                'container'  => "massform$itemtype$rand",
             ],
             'can_config'          => \Session::haveRightsOr('search_config', [
                 \DisplayPreference::PERSONAL,

--- a/src/Search/Provider/SQLProvider.php
+++ b/src/Search/Provider/SQLProvider.php
@@ -4309,7 +4309,6 @@ final class SQLProvider implements SearchProviderInterface
                     'itemtype'  => $data['itemtype'],
                     'id'        => $opt_id,
                     'name'      => $searchopt[$opt_id]["name"],
-                    'htmlname'  => $searchopt[$opt_id]["htmlname"] ?? false,
                     'meta'      => 0,
                     'searchopt' => $searchopt[$opt_id],
                 ];
@@ -4324,7 +4323,6 @@ final class SQLProvider implements SearchProviderInterface
                         'itemtype'  => $m_itemtype,
                         'id'        => $opt_id,
                         'name'      => $m_searchopt[$opt_id]["name"],
-                        'htmlname'  => $m_searchopt[$opt_id]["htmlname"] ?? false,
                         'meta'      => 1,
                         'searchopt' => $m_searchopt[$opt_id],
                         'groupname' => $m_itemtype,
@@ -4350,7 +4348,6 @@ final class SQLProvider implements SearchProviderInterface
                                 'itemtype'  => $metacriteria['itemtype'],
                                 'id'        => $metacriteria['field'],
                                 'name'      => $m_searchopt[$metacriteria['field']]["name"],
-                                'htmlname'  => $m_searchopt[$metacriteria['field']]["htmlname"] ?? false,
                                 'meta'      => 1,
                                 'searchopt' => $m_searchopt[$metacriteria['field']],
                                 'groupname' => $metacriteria['itemtype'],

--- a/src/Search/Provider/SQLProvider.php
+++ b/src/Search/Provider/SQLProvider.php
@@ -4309,6 +4309,7 @@ final class SQLProvider implements SearchProviderInterface
                     'itemtype'  => $data['itemtype'],
                     'id'        => $opt_id,
                     'name'      => $searchopt[$opt_id]["name"],
+                    'htmlname'  => $searchopt[$opt_id]["htmlname"] ?? false,
                     'meta'      => 0,
                     'searchopt' => $searchopt[$opt_id],
                 ];
@@ -4323,6 +4324,7 @@ final class SQLProvider implements SearchProviderInterface
                         'itemtype'  => $m_itemtype,
                         'id'        => $opt_id,
                         'name'      => $m_searchopt[$opt_id]["name"],
+                        'htmlname'  => $m_searchopt[$opt_id]["htmlname"] ?? false,
                         'meta'      => 1,
                         'searchopt' => $m_searchopt[$opt_id],
                         'groupname' => $m_itemtype,
@@ -4348,6 +4350,7 @@ final class SQLProvider implements SearchProviderInterface
                                 'itemtype'  => $metacriteria['itemtype'],
                                 'id'        => $metacriteria['field'],
                                 'name'      => $m_searchopt[$metacriteria['field']]["name"],
+                                'htmlname'  => $m_searchopt[$metacriteria['field']]["htmlname"] ?? false,
                                 'meta'      => 1,
                                 'searchopt' => $m_searchopt[$metacriteria['field']],
                                 'groupname' => $metacriteria['itemtype'],
@@ -4718,6 +4721,7 @@ final class SQLProvider implements SearchProviderInterface
             return self::giveItem($data["TYPE"], $ID, $data, $meta, $oparams, $itemtype);
         }
         $so = $searchopt[$ID];
+        $so['id'] = $ID; // Keep track of search option id so it can be used by functions using $so as a parameter
         $orig_id = $ID;
         $ID = ($orig_itemtype !== null ? $orig_itemtype : $itemtype) . '_' . $ID;
 

--- a/src/Search/SearchEngine.php
+++ b/src/Search/SearchEngine.php
@@ -578,13 +578,22 @@ final class SearchEngine
 
     /**
      * @param class-string<CommonGLPI> $itemtype
-     * @param array $params
+     * @param array $params Array of options:
+     *                       - (bool) init_session_data - default: false
      * @return void
      */
     public static function show(string $itemtype, array $params = []): void
     {
         Profiler::getInstance()->start('SearchEngine::show', Profiler::CATEGORY_SEARCH);
         Plugin::doHook(Hooks::PRE_ITEM_LIST, ['itemtype' => $itemtype, 'options' => []]);
+
+        if (($params['init_session_data'] ?? false) && isset($params['criteria'])) {
+            // Search engine need session data to display criteria properly.
+            // This parameter is needed when rendering multiple searches with
+            // different criteria from a twig template (as we can't set the
+            // session data from twig).
+            $_SESSION['glpisearch'][$itemtype]['criteria'] = $params['criteria'];
+        }
 
         /** @var SearchInputInterface $search_input_class */
         $search_input_class = self::getSearchInputClass($params);

--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -122,7 +122,7 @@
         'order': order,
         'start': start,
       }|url_encode ~ '&' ~ posthref %}
-      <ul class="dropdown-menu" style="z-index: 10001" aria-labelledby="dropdown-export{{ rand }}">
+      <ul class="dropdown-menu" style="z-index: 10001" aria-labelledby="dropdown-export-{{ rand }}">
          <li><a class="dropdown-item" href="{{ exporthref ~ '&display_type=' ~ constant('Search::PDF_OUTPUT_LANDSCAPE') }}">
             <i class="far fa-lg fa-file-pdf"></i>
             {{ __('Current page in landscape PDF') }}
@@ -165,7 +165,7 @@
       <script>
             // Ugly trick to fix z-index context issue by placing our dropdown at the end of the body
             $("#dropdown-export-{{ rand }}").on("show.bs.dropdown", function() {
-               $(document.body).append($("ul[aria-labelledby=dropdown-export{{ rand }}]").detach());
+               $(document.body).append($("ul[aria-labelledby=dropdown-export-{{ rand }}]").detach());
             });
       </script>
       {% endif %}

--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -110,7 +110,7 @@
       {% endif %}
 
       {% if count > 0 %}
-         <button class="dropdown-toggle btn btn-sm btn-icon btn-ghost-secondary me-1 me-sm-2" type="button" id="dropdown-export"
+         <button class="dropdown-toggle btn btn-sm btn-icon btn-ghost-secondary me-1 me-sm-2" type="button" id="dropdown-export-{{ rand }}"
                data-bs-toggle="dropdown" aria-expanded="false" data-bs-popper-config='{"strategy":"fixed"}'>
             <span class="py-1 px-2 my-n1 mx-n2"data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ _x('button', 'Export') }}">
                <i id="export_dropdown_icon" class="ti fa-lg ti-file-download"></i>
@@ -122,7 +122,7 @@
         'order': order,
         'start': start,
       }|url_encode ~ '&' ~ posthref %}
-      <ul class="dropdown-menu" aria-labelledby="dropdown-export">
+      <ul class="dropdown-menu move-to-end-of-body" style="z-index: 10001" aria-labelledby="dropdown-export{{ rand }}">
          <li><a class="dropdown-item" href="{{ exporthref ~ '&display_type=' ~ constant('Search::PDF_OUTPUT_LANDSCAPE') }}">
             <i class="far fa-lg fa-file-pdf"></i>
             {{ __('Current page in landscape PDF') }}
@@ -162,6 +162,12 @@
          </a></li>
          {% endif %}
       </ul>
+      <script>
+            // Ugly trick to fix z-index context issue by placing our dropdown at the end of the body
+            $("#dropdown-export-{{ rand }}").on("show.bs.dropdown", function() {
+               $(document.body).append($("ul[aria-labelledby=dropdown-export{{ rand }}]").detach());
+            });
+      </script>
       {% endif %}
    </div>
 </div>

--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -122,7 +122,7 @@
         'order': order,
         'start': start,
       }|url_encode ~ '&' ~ posthref %}
-      <ul class="dropdown-menu move-to-end-of-body" style="z-index: 10001" aria-labelledby="dropdown-export{{ rand }}">
+      <ul class="dropdown-menu" style="z-index: 10001" aria-labelledby="dropdown-export{{ rand }}">
          <li><a class="dropdown-item" href="{{ exporthref ~ '&display_type=' ~ constant('Search::PDF_OUTPUT_LANDSCAPE') }}">
             <i class="far fa-lg fa-file-pdf"></i>
             {{ __('Current page in landscape PDF') }}

--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -88,15 +88,17 @@
       </label>
    {% endif %}
 
-   <label class="form-check form-switch btn btn-sm btn-ghost-secondary me-1 me-sm-2 px-1 mb-0 flex-column-reverse flex-sm-row"
-          data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-trigger="hover"
-          title="{{ __('Toggle search filters') }}">
-      <input type="checkbox" class="form-check-input ms-0 me-1 mt-0 fold-search" role="button"
-             {{ session('glpifold_search') ? '' : 'checked' }} autocomplete="off" />
-      <span class="form-check-label mb-1 mb-sm-0">
-         <i class="ti fa-lg ti-search"></i>
-      </span>
-   </label>
+   {% if not hide_search_toggle %}
+      <label class="form-check form-switch btn btn-sm btn-ghost-secondary me-1 me-sm-2 px-1 mb-0 flex-column-reverse flex-sm-row"
+            data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-trigger="hover"
+            title="{{ __('Toggle search filters') }}">
+         <input type="checkbox" class="form-check-input ms-0 me-1 mt-0 fold-search" role="button"
+               {{ session('glpifold_search') ? '' : 'checked' }} autocomplete="off" />
+         <span class="form-check-label mb-1 mb-sm-0">
+            <i class="ti fa-lg ti-search"></i>
+         </span>
+      </label>
+   {% endif %}
 
    <div class="d-inline-flex" role="group">
 

--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -111,7 +111,7 @@
 
       {% if count > 0 %}
          <button class="dropdown-toggle btn btn-sm btn-icon btn-ghost-secondary me-1 me-sm-2" type="button" id="dropdown-export"
-               data-bs-toggle="dropdown" aria-expanded="false" >
+               data-bs-toggle="dropdown" aria-expanded="false" data-bs-popper-config='{"strategy":"fixed"}'>
             <span class="py-1 px-2 my-n1 mx-n2"data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ _x('button', 'Export') }}">
                <i id="export_dropdown_icon" class="ti fa-lg ti-file-download"></i>
             </span>

--- a/templates/components/search/display_data.html.twig
+++ b/templates/components/search/display_data.html.twig
@@ -42,7 +42,7 @@
 {# Remove namespace separators for use in HTML attributes #}
 {% set normalized_itemtype = itemtype|replace({'\\': ''}) %}
 
-<form id="massform{{ normalized_itemtype }}" method="get" action="{{ path('front/massiveaction.php') }}"
+<form id="massform{{ normalized_itemtype }}{{ rand }}" method="get" action="{{ path('front/massiveaction.php') }}"
       data-search-itemtype="{{ data['itemtype'] }}" data-start="{{ start }}" data-count="{{ count }}" data-limit="{{ limit }}" data-submit-once>
    <div class="card card-sm mt-0 search-card">
       {% if not hide_controls %}
@@ -86,30 +86,28 @@
 
    {% if data['search']['as_map'] == 0 %}
       <script>
-          if (typeof initFluidSearch !== "function") {
-             window.initFluidSearch = () => {
-                 const allowed_forced_params = ['hide_controls', 'usesession', 'forcetoview', 'criteria'];
-                 let forced_params = {};
-                 let all_params = {{ data['search']|default({})|json_encode|raw }};
+          window.initFluidSearch{{ rand }}  = () => {
+             const allowed_forced_params = ['hide_controls', 'usesession', 'forcetoview', 'criteria'];
+             let forced_params = {};
+             let all_params = {{ data['search']|default({})|json_encode|raw }};
 
-                 $.each(all_params, (k, v) => {
-                    if (allowed_forced_params.includes(k)) {
-                       forced_params[k] = v;
-                    }
-                 });
+             $.each(all_params, (k, v) => {
+                if (allowed_forced_params.includes(k)) {
+                   forced_params[k] = v;
+                }
+             });
 
-                 new GLPI.Search.ResultsView(
-                  "massform{{ normalized_itemtype }}",
-                  GLPI.Search.Table,
-                  {{ push_history ? "true" : "false" }},
-                  forced_params
-               );
-             };
-          }
+             new GLPI.Search.ResultsView(
+                "massform{{ normalized_itemtype }}{{ rand }}",
+                GLPI.Search.Table,
+                {{ push_history ? "true" : "false" }},
+                forced_params
+             );
+          };
           if (document.readyState === 'complete') {
-              initFluidSearch();
+              initFluidSearch{{ rand }}();
           } else {
-              $(document).on('ready', initFluidSearch);
+              $(document).on('ready', initFluidSearch{{ rand }});
           }
       </script>
    {% endif %}

--- a/templates/components/search/query_builder/main.html.twig
+++ b/templates/components/search/query_builder/main.html.twig
@@ -35,10 +35,11 @@
 {% set mainform = mainform is not defined ? true : mainform %}
 {% set main_block_class = mainform ? '' : 'sub_criteria' %}
 {% set card_class = mainform ? 'search-form card card-sm mb-4' : 'border d-inline-block ms-1' %}
+{% set no_search = not(p.no_search is defined and not p.no_search) %}
 {% set extra_actions_templates = p.extra_actions_templates|default([]) %}
 {% set hide_controls = p.hide_controls is defined and p.hide_controls %}
 {% set showmassiveactions = not p.showmassiveactions is defined or p.showmassiveactions %}
-{% set fold_search = session('glpifold_search') and not hide_controls %}
+{% set fold_search = (session('glpifold_search') or no_search) and not hide_controls %}
 
 {% if mainform and showaction %}
    <form name="searchform{{ normalized_itemtype }}" class="search-form-container" method="get" action="{{ p['target'] }}">
@@ -80,6 +81,7 @@
       {% endif %}
 
       {# Keep track of display params affecting the results, they must be kept on refresh #}
+      <input type="hidden" name="params[no_search]" value="{{ no_search ? "1" : "0" }}">
       <input type="hidden" name="params[hide_controls]" value="{{ hide_controls ? "1" : "0" }}">
       <input type="hidden" name="params[showmassiveactions]" value="{{ showmassiveactions ? "1" : "0" }}">
 
@@ -172,7 +174,7 @@
              });
          });
 
-         {% if mainform %}
+         {% if mainform and not no_search %}
             const toggle_fold_search = function(show_search) {
                 $('#searchcriteria{{ rand }}').closest('.search-form').toggle(show_search);
             };

--- a/templates/components/search/query_builder/main.html.twig
+++ b/templates/components/search/query_builder/main.html.twig
@@ -35,11 +35,11 @@
 {% set mainform = mainform is not defined ? true : mainform %}
 {% set main_block_class = mainform ? '' : 'sub_criteria' %}
 {% set card_class = mainform ? 'search-form card card-sm mb-4' : 'border d-inline-block ms-1' %}
-{% set no_search = not(p.no_search is defined and not p.no_search) %}
+{% set hide_criteria = not(p.hide_criteria is defined and not p.hide_criteria) %}
 {% set extra_actions_templates = p.extra_actions_templates|default([]) %}
 {% set hide_controls = p.hide_controls is defined and p.hide_controls %}
 {% set showmassiveactions = not p.showmassiveactions is defined or p.showmassiveactions %}
-{% set fold_search = (session('glpifold_search') or no_search) and not hide_controls %}
+{% set fold_search = (session('glpifold_search') or hide_criteria) and not hide_controls %}
 
 {% if mainform and showaction %}
    <form name="searchform{{ normalized_itemtype }}" class="search-form-container" method="get" action="{{ p['target'] }}">
@@ -81,7 +81,7 @@
       {% endif %}
 
       {# Keep track of display params affecting the results, they must be kept on refresh #}
-      <input type="hidden" name="params[no_search]" value="{{ no_search ? "1" : "0" }}">
+      <input type="hidden" name="params[hide_criteria]" value="{{ hide_criteria ? "1" : "0" }}">
       <input type="hidden" name="params[hide_controls]" value="{{ hide_controls ? "1" : "0" }}">
       <input type="hidden" name="params[showmassiveactions]" value="{{ showmassiveactions ? "1" : "0" }}">
 
@@ -174,7 +174,7 @@
              });
          });
 
-         {% if mainform and not no_search %}
+         {% if mainform and not hide_criteria %}
             const toggle_fold_search = function(show_search) {
                 $('#searchcriteria{{ rand }}').closest('.search-form').toggle(show_search);
             };

--- a/templates/components/search/table.html.twig
+++ b/templates/components/search/table.html.twig
@@ -67,7 +67,8 @@
                   {% endfor %}
                {% endif %}
 
-               {% set col_name = col['name'] %}
+               {# Use html name if defined #}
+               {% set col_name = col['htmlname'] is defined and col['htmlname'] ? col['htmlname'] : col['name'] %}
                {# prefix by group name (corresponding to optgroup in dropdown) if exists #}
                {% if col['groupname'] is defined %}
                   {% set groupname = (col['groupname']['name'] ?? col['groupname']) %}
@@ -82,7 +83,7 @@
                <th data-searchopt-id="{{ col['id'] }}" {% if not can_sort %}data-nosort="true"{% endif %} data-sort-order="{{ sort_order }}"
                   {% if sort_num is not empty %}data-sort-num="{{ sort_num - 1 }}"{% endif %}>
                   {% set sort_icon = sort_order == 'ASC' ? 'fas fa-sort-up' : (sort_order == 'DESC' ? 'fas fa-sort-down' : '') %}
-                  {{ col_name }}
+                  {{ col_name|raw }}
                   {% if can_sort %}
                      <span class="sort-indicator"><i class="{{ sort_icon }}"></i><span class="sort-num">{{ sorts|length > 1 ? sort_num : '' }}</span></span>
                   {% endif %}
@@ -135,7 +136,8 @@
                      {% if col['meta'] is defined and col['meta'] %}
                         {{ showItem(0, row[colkey]['displayname'], 0, 0,)|raw }}
                      {% else %}
-                        {{ showItem(0, row[colkey]['displayname'], 0, 0, call('Search::displayConfigItem', [itemtype, col['id'], row]))|raw }}
+                        {# Add a data-searchopt-content-id to each td to allow easy css selectors for a whole column #}
+                        {{ showItem(0, row[colkey]['displayname'], 0, 0, "data-searchopt-content-id=\"" ~ col['id'] ~ "\" " ~ call('Search::displayConfigItem', [itemtype, col['id'], row]))|raw }}
                      {% endif %}
                   {% endfor %}
 

--- a/templates/components/search/table.html.twig
+++ b/templates/components/search/table.html.twig
@@ -68,7 +68,7 @@
                {% endif %}
 
                {# Use html name if defined #}
-               {% set col_name = col['htmlname'] is defined and col['htmlname'] ? col['htmlname'] : col['name'] %}
+               {% set col_name = col['name'] %}
                {# prefix by group name (corresponding to optgroup in dropdown) if exists #}
                {% if col['groupname'] is defined %}
                   {% set groupname = (col['groupname']['name'] ?? col['groupname']) %}
@@ -83,7 +83,7 @@
                <th data-searchopt-id="{{ col['id'] }}" {% if not can_sort %}data-nosort="true"{% endif %} data-sort-order="{{ sort_order }}"
                   {% if sort_num is not empty %}data-sort-num="{{ sort_num - 1 }}"{% endif %}>
                   {% set sort_icon = sort_order == 'ASC' ? 'fas fa-sort-up' : (sort_order == 'DESC' ? 'fas fa-sort-down' : '') %}
-                  {{ col_name|raw }}
+                  {{ col_name }}
                   {% if can_sort %}
                      <span class="sort-indicator"><i class="{{ sort_icon }}"></i><span class="sort-num">{{ sorts|length > 1 ? sort_num : '' }}</span></span>
                   {% endif %}

--- a/templates/components/search/table.html.twig
+++ b/templates/components/search/table.html.twig
@@ -67,7 +67,6 @@
                   {% endfor %}
                {% endif %}
 
-               {# Use html name if defined #}
                {% set col_name = col['name'] %}
                {# prefix by group name (corresponding to optgroup in dropdown) if exists #}
                {% if col['groupname'] is defined %}

--- a/templates/pages/assets/consumable_list.html.twig
+++ b/templates/pages/assets/consumable_list.html.twig
@@ -134,3 +134,22 @@
     }
 
 </style>
+
+<script>
+    // Trigger search reload when infocom are updated
+    $('div.modal[id^="infocomConsumable"]').on('hide.bs.modal', () => {
+        // Try finding a fluid search instance
+        const search_display = $('.ajax-container.search-display-data');
+        try {
+            if (search_display.length === 1 && search_display.data('js_class') !== undefined) {
+                // Trigger a reload of just the results
+                search_display.data('js_class').view.refreshResults();
+            } else {
+                // There is no (or multiple) search results, reload the page
+                window.location.reload();
+            }
+        } catch (err) {
+            window.location.reload();
+        }
+    });
+</script>

--- a/templates/pages/assets/consumable_list.html.twig
+++ b/templates/pages/assets/consumable_list.html.twig
@@ -118,7 +118,7 @@
 
     /* Hack to display an icon as a column header */
     .unused-consumables th[data-searchopt-id="7"],
-    .used-consumables td[data-searchopt-id="7"]
+    .used-consumables th[data-searchopt-id="7"]
     {
         font-size: 0;
     }

--- a/templates/pages/assets/consumable_list.html.twig
+++ b/templates/pages/assets/consumable_list.html.twig
@@ -33,7 +33,7 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
-<div class="px-3 py-2">
+<div class="px-3 py-2 search-no-forced-height">
     <form method="POST" action="{{ item.getFormURL() }}">
         <h2 class="mb-4">
             <span class="me-2">

--- a/templates/pages/assets/consumable_list.html.twig
+++ b/templates/pages/assets/consumable_list.html.twig
@@ -75,7 +75,7 @@
                 'criteria'          : criteria_unused,
                 'push_history'      : false,
                 'showmassiveactions': can_edit,
-                'no_search'         : true,
+                'hide_criteria'     : true,
                 'init_session_data' : true,
             }]) %}
         </div>
@@ -88,7 +88,7 @@
                 'criteria'          : criteria_used,
                 'push_history'      : false,
                 'showmassiveactions': can_edit,
-                'no_search'         : true,
+                'hide_criteria'     : true,
                 'init_session_data' : true,
             }]) %}
         </div>

--- a/templates/pages/assets/consumable_list.html.twig
+++ b/templates/pages/assets/consumable_list.html.twig
@@ -31,6 +31,8 @@
  # ---------------------------------------------------------------------
  #}
 
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
 <div class="px-3 py-2">
     <form method="POST" action="{{ item.getFormURL() }}">
         <h2 class="mb-4">
@@ -42,18 +44,25 @@
                 )) }}
             </span>
             {% if can_edit %}
-                <input type="hidden" name="consumableitems_id" value="{{ parent.getID() }}">
-                {% do call('Dropdown::showNumber', ['to_add', {
-                    'value': 1,
-                    'min'  : 1,
-                    'max'  : 100,
-                }]) %}
+                <input type="hidden" name="consumableitems_id" value="{{ parent.getID() }}" />
+                {{ fields.dropdownNumberField(
+                    'to_add',
+                    1,
+                    '',
+                    {
+                        min: 1,
+                        max: 100,
+                        step: 1,
+                        include_field: false,
+                        width: '',
+                    }
+                ) }}
                 <input
                     type="submit"
                     name="add_several"
                     value="{{ _x('button', 'Add consumables') }}"
                     class='btn btn-primary'
-                >
+                />
                 <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
             {% endif %}
         </h2>

--- a/templates/pages/assets/consumable_list.html.twig
+++ b/templates/pages/assets/consumable_list.html.twig
@@ -1,0 +1,109 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2023 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+<div class="px-3 py-2">
+    <form method="POST" action="{{ item.getFormURL() }}">
+        <h2 class="mb-4">
+            <span class="me-2">
+                {{ __("Total: %s, New: %s, Used: %s"|format(
+                    count_unused + count_used,
+                    count_unused,
+                    count_used
+                )) }}
+            </span>
+            {% if can_edit %}
+                <input type="hidden" name="consumableitems_id" value="{{ parent.getID() }}">
+                {% do call('Dropdown::showNumber', ['to_add', {
+                    'value': 1,
+                    'min'  : 1,
+                    'max'  : 100,
+                }]) %}
+                <input
+                    type="submit"
+                    name="add_several"
+                    value="{{ _x('button', 'Add consumables') }}"
+                    class='btn btn-primary'
+                >
+                <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
+            {% endif %}
+        </h2>
+    </form>
+
+    {% if count_unused > 0 %}
+        <div class="unused-consumables mb-4">
+            <h3>{{ __("%s New consumables"|format(count_unused)) }}</h3>
+            {% do call('\\Glpi\\Search\\SearchEngine::show', [itemtype, {
+                'criteria'          : criteria_unused,
+                'push_history'      : false,
+                'showmassiveactions': can_edit,
+                'no_search'         : true,
+                'init_session_data' : true,
+            }]) %}
+        </div>
+    {% endif %}
+
+    {% if count_used > 0 %}
+        <div class="used-consumables mb-4">
+            <h3> {{ __("%s Used consumables"|format(count_used)) }} </h3>
+            {% do call('\\Glpi\\Search\\SearchEngine::show', [itemtype, {
+                'criteria'          : criteria_used,
+                'push_history'      : false,
+                'showmassiveactions': can_edit,
+                'no_search'         : true,
+                'init_session_data' : true,
+            }]) %}
+        </div>
+    {% endif %}
+</div>
+
+<style>
+    /* Hide "Use date" and "Give to" for unused consumables as they will have no
+     values for these fields */
+    .unused-consumables th[data-searchopt-id="5"],
+    .unused-consumables td[data-searchopt-content-id="5"],
+    .unused-consumables th[data-searchopt-id="6"],
+    .unused-consumables td[data-searchopt-content-id="6"]
+    {
+        display: none;
+    }
+
+    /* Hide "Consumable model" for all consumables as they all have the same
+     parent on this page*/
+    .unused-consumables th[data-searchopt-id="8"],
+    .unused-consumables td[data-searchopt-content-id="8"],
+    .used-consumables th[data-searchopt-id="8"],
+    .used-consumables td[data-searchopt-content-id="8"]
+    {
+        display: none;
+    }
+</style>

--- a/templates/pages/assets/consumable_list.html.twig
+++ b/templates/pages/assets/consumable_list.html.twig
@@ -115,4 +115,22 @@
     {
         display: none;
     }
+
+    /* Hack to display an icon as a column header */
+    .unused-consumables th[data-searchopt-id="7"],
+    .used-consumables td[data-searchopt-id="7"]
+    {
+        font-size: 0;
+    }
+    .unused-consumables th[data-searchopt-id="7"]::before,
+    .used-consumables th[data-searchopt-id="7"]::before
+    {
+        font-family: "tabler-icons" !important;
+        content: "\f65d";
+        font-size: 0.8rem;
+        font-style: normal;
+        font-weight: normal;
+        line-height: 2; /* Easiest way to deal with vertical align here */
+    }
+
 </style>


### PR DESCRIPTION
Rewrite the "Consumable" tab to use the search engine rendering.

The main goals with this change are to :
* Allow users to add custom columns to the results through display preferences
* Allow users to export data (e.g. CSV)

Before:

![image](https://github.com/glpi-project/glpi/assets/42734840/29cda862-f18a-4505-b600-f7a02fb4d88d)

![image](https://github.com/glpi-project/glpi/assets/42734840/6cf665ab-5445-44ef-9a9a-b9c28d30de66)

After:

![image](https://github.com/glpi-project/glpi/assets/42734840/761dbee1-4272-4dcc-9e89-d41b945dcf03)

![image](https://github.com/glpi-project/glpi/assets/42734840/8f962b44-db96-4e48-8797-dcbf4409933d)

The original layout of the page is conserved with two separate tables for unused and used items.

These changes required a few tweaks of the search engine to work properly:
* A new `no_search` parameter for `SearchEngine::show()` in order to display only search results (the search criteria section is hidden but still rendered as we need the criteria inputs defined in the page for results pagination to work properly)
* Add a rand to the `massform$itemtype` form to avoid conflicts when displaying multiple search results on the same page.
* Support a new `htmlname` option for searchoptions to display raw html (such as a an icon, which is very useful for the infocom column as it will only contain a single button so keeping a short icon as its header instead of a very long label save a lot of space).
* A new `init_session_data` parameter for `SearchEngine::show()` needed due to technical limitations of our search engine code. Explained in details in comments directly in the code.
* Added a new data property `data-searchopt-content-id` in the search engine results `<td>`, which allow to make some easy css selectors targetting a full column of results. This is useful in this case as the original page does not display the same columns for unused and used items so we can hide them accordingly using css).

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28730
