### PR TITLE
fix(calendar input): week number not visible

### DIFF
--- a/css/includes/components/_flatpickr.scss
+++ b/css/includes/components/_flatpickr.scss
@@ -226,6 +226,11 @@ body {
         box-shadow: 1px 0 0 $picker-shadow-color;
     }
 
+    .flatpickr-weekwrapper span.flatpickr-day,
+    .flatpickr-weekwrapper span.flatpickr-day:hover {
+        color: $picker-text-faded-color;
+    }
+
     .flatpickr-time .numInputWrapper span.arrowUp::after {
         border-bottom-color: $picker-text-color;
     }


### PR DESCRIPTION
The week number was not visible, as it was written in white on white.

Before:
![image](https://github.com/glpi-project/glpi/assets/8530352/accec78e-9ad4-4228-93b5-8e0a5b864482)


After:
![image](https://github.com/glpi-project/glpi/assets/8530352/f0d0f35b-3fe8-4648-928d-45574cba1f1a)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28914
