### PR TITLE
fix(dropdown): sort by entity

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -2728,7 +2728,14 @@ JAVASCRIPT;
             if (isset($post['condition']['WHERE'])) {
                 $where = array_merge($where, $post['condition']['WHERE']);
             } else {
-                $where = array_merge($where, $post['condition']);
+                foreach ($post['condition'] as $key => $value) {
+                    if (strpos($key, '.') === false) {
+                        // Ensure condition contains table name to prevent ambiguity with fields from `glpi_entities` table
+                        $where["$table.$key"] = $value;
+                    } else {
+                        $where[$key] = $value;
+                    }
+                }
             }
         }
 
@@ -2835,7 +2842,13 @@ JAVASCRIPT;
                 }
 
                 if ($multi) {
-                    array_unshift($order, "$table.entities_id");
+                    $ljoin['glpi_entities'] = [
+                        'ON' => [
+                            'glpi_entities' => 'id',
+                            $table          => 'entities_id'
+                        ]
+                    ];
+                    array_unshift($order, "glpi_entities.completename");
                 }
             }
 


### PR DESCRIPTION
In a dropdown of locations (for example), in multi-entities, locations are grouped by entity, but these entities were sorted by ID and not by completename.

Entities ID:
![image](https://github.com/glpi-project/glpi/assets/8530352/cbb1376f-c1b3-47d1-b0a3-e06f81a333f6)

Before:
![image](https://github.com/glpi-project/glpi/assets/8530352/4e4e0d80-78f7-46f3-99e1-d8d673433180)

After:
![image](https://github.com/glpi-project/glpi/assets/8530352/45c1269e-5389-441c-91aa-0fe296866f3a)


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28931
