### PR TITLE
fix(document): recursivity when added from knowbase

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5498,6 +5498,11 @@ class CommonDBTM extends CommonGLPI
                 $is_recursive = $input['is_recursive'];
             } else if (isset($input['_job']->fields['is_recursive'])) {
                 $is_recursive = $input['_job']->fields['is_recursive'];
+            } else if ($this instanceof CommonDBVisible) {
+                // CommonDBVisible visibility restriction is unpredictable as
+                // it may change over time, and can be related to dynamic profiles assignation.
+                // Related documents have to be available on all entities.
+                $is_recursive = 1;
             }
 
            // Check for duplicate and availability (e.g. file deleted in _files)


### PR DESCRIPTION
When a document is added from the kb, it was created on the root entity, but not recursively.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28932
