### PR TITLE
Prevent last super admin profile from changing interface

### DIFF
--- a/src/Profile.php
+++ b/src/Profile.php
@@ -4196,7 +4196,8 @@ class Profile extends CommonDBTM
                     'name'   => static::$rightname,
                     'rights' => ["&", UPDATE],
                 ]
-            ])
+            ]),
+            'interface' => 'central',
         ]);
 
         return array_column($super_admin_profiles, 'id');

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -417,6 +417,15 @@ class Profile extends CommonDBTM
             unset($input['_profile']);
         }
 
+        if (isset($input['interface']) && $input['interface'] == 'helpdesk' && $this->isLastSuperAdminProfile()) {
+            Session::addMessageAfterRedirect(
+                __("Can't change the interface on this profile as it is the only remaining profile with rights to modify profiles with this interface."),
+                false,
+                ERROR
+            );
+            unset($input['interface']);
+        }
+
         // KEEP AT THE END
         $this->profileRight = [];
         foreach (array_keys(ProfileRight::getAllPossibleRights()) as $right) {
@@ -757,7 +766,10 @@ class Profile extends CommonDBTM
         Dropdown::showFromArray(
             'interface',
             self::getInterfaces(),
-            ['value' => $this->fields["interface"]]
+            [
+                'value' => $this->fields["interface"],
+                'readonly' => $this->isLastSuperAdminProfile() && $this->fields['interface'] == 'central'
+            ]
         );
         echo "</td></tr>\n";
 

--- a/tests/functional/Profile.php
+++ b/tests/functional/Profile.php
@@ -213,9 +213,18 @@ class Profile extends DbTestCase
         $this->boolean($super_admin->isLastSuperAdminProfile())->isTrue();
         $this->boolean($super_admin_2->isLastSuperAdminProfile())->isFalse();
 
-        // Two super admin account, both can be deleted
+        // Two super admin account, can't be deleted because only one has central interface
         $this->updateItem("Profile", $super_admin_2->getID(), [
             '_profile' => [UPDATE . "_0" => true]
+        ]);
+        $this->boolean($super_admin->isLastSuperAdminProfile())->isTrue();
+        $this->boolean($super_admin->canPurgeItem())->isFalse();
+        $this->boolean($super_admin_2->isLastSuperAdminProfile())->isFalse();
+        $this->boolean($super_admin_2->canPurgeItem())->isTrue();
+
+        // Two super admin account, both can be deleted
+        $this->updateItem("Profile", $super_admin_2->getID(), [
+            'interface' => 'central'
         ]);
         $this->boolean($super_admin->isLastSuperAdminProfile())->isFalse();
         $this->boolean($super_admin->canPurgeItem())->isTrue();


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

It is possible for a user to switch all his "super-admin" profiles to a simplified interface, with the effect of losing the ability to modify the other profiles.
To prevent this, the "Profile's interface" field is set to "read-only" if the profile is the last "super-admin" profile.