### PR TITLE
fix(group): restore cloning

### DIFF
--- a/src/Group.php
+++ b/src/Group.php
@@ -38,12 +38,19 @@
  **/
 class Group extends CommonTreeDropdown
 {
+    use Glpi\Features\Clonable;
+
     public $dohistory       = true;
 
     public static $rightname       = 'group';
 
     protected $usenotepad  = true;
 
+
+    public function getCloneRelations(): array
+    {
+        return [];
+    }
 
     public static function getTypeName($nb = 0)
     {


### PR DESCRIPTION
Since 10.0, it was no longer possible to clone a group.

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28979
