### PR TITLE
fix(notification): private timeline items visible

### DIFF
--- a/src/NotificationTemplate.php
+++ b/src/NotificationTemplate.php
@@ -268,6 +268,10 @@ class NotificationTemplate extends CommonDBTM
             $bak_language = $_SESSION["glpilanguage"];
             $_SESSION["glpilanguage"] = $language;
 
+            // Switch to the user's ID
+            $bak_glpiID = $_SESSION['glpiID'];
+            $_SESSION['glpiID'] = $user_infos['users_id'];
+
            //If event is raised by a plugin, load it in order to get the language file available
             if ($plug = isPluginItemType(get_class($target->obj))) {
                 Plugin::loadLang(strtolower($plug['plugin']), $language);
@@ -333,6 +337,7 @@ class NotificationTemplate extends CommonDBTM
             }
 
            // Restore default language
+            $_SESSION['glpiID'] = $bak_glpiID;
             $_SESSION["glpilanguage"] = $bak_language;
             Session::loadLanguage();
             if ($bak_dropdowntranslations !== null) {


### PR DESCRIPTION
In the case of a notification template using "FOREACHtimelineitems".

In a ticket, if a technician adds a private follow-up, other actors who don't have the right to see private follow-ups don't receive a notification (this is normal). If the same technician then adds a public follow-up, the other actors receive a notification containing the new follow-up (normal), but also the previous private follow-ups written by the same technician, even though they don't have access to them.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28943
