### PR TITLE
Fix private followups/tasks filtering in notifications

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -6790,16 +6790,17 @@ abstract class CommonITILObject extends CommonDBTM
             $params['hide_private_items']
             || ($params['check_view_rights'] && !Session::haveRight("followup", ITILFollowup::SEEPRIVATE))
         ) {
-            if (Session::getLoginUserID() !== false && Session::getCurrentInterface() === "central") {
+            if (!$params['check_view_rights']) {
+                // notification case, we cannot rely on session
+                $restrict_fup = [
+                    'is_private' => 0,
+                ];
+            } else {
                 $restrict_fup = [
                     'OR' => [
                         'is_private' => 0,
                         'users_id'   => Session::getCurrentInterface() === "central" ? (int)Session::getLoginUserID() : 0,
                     ]
-                ];
-            } else {
-                $restrict_fup = [
-                    'is_private' => 0,
                 ];
             }
         }
@@ -6816,16 +6817,17 @@ abstract class CommonITILObject extends CommonDBTM
                 || ($params['check_view_rights'] && !Session::haveRight($task_obj::$rightname, CommonITILTask::SEEPRIVATE))
             )
         ) {
-            if (Session::getLoginUserID() !== false && Session::getCurrentInterface() === "central") {
+            if (!$params['check_view_rights']) {
+                // notification case, we cannot rely on session
+                $restrict_task = [
+                    'is_private' => 0,
+                ];
+            } else {
                 $restrict_task = [
                     'OR' => [
                         'is_private' => 0,
                         'users_id'   => Session::getCurrentInterface() === "central" ? (int)Session::getLoginUserID() : 0,
                     ]
-                ];
-            } else {
-                $restrict_task = [
-                    'is_private' => 0,
                 ];
             }
         }

--- a/tests/functional/Ticket.php
+++ b/tests/functional/Ticket.php
@@ -5933,43 +5933,45 @@ HTML
             ],
         ];
 
-        // sessionless call with private items (used for notifications)
-        yield [
-            'login'              => null,
-            'pass'               => null,
-            'ticket_id'          => $ticket->getID(),
-            'options'            => [
-                'check_view_rights'  => false,
-                'hide_private_items' => false,
-            ],
-            'expected_followups' => [
-                'private followup of normal user',
-                'private followup of tech user',
-                'public followup',
-            ],
-            'expected_tasks'     => [
-                'private task of normal user',
-                'private task of tech user',
-                'public task',
-            ],
-        ];
+        foreach ([null => null, 'post-only' => 'postonly', 'tech' => 'tech'] as $login => $pass) {
+            // usage of `check_view_rights` should produce the same result whoever is logged-in (used for notifications)
+            yield [
+                'login'              => $login,
+                'pass'               => $pass,
+                'ticket_id'          => $ticket->getID(),
+                'options'            => [
+                    'check_view_rights'  => false,
+                    'hide_private_items' => false,
+                ],
+                'expected_followups' => [
+                    'private followup of normal user',
+                    'private followup of tech user',
+                    'public followup',
+                ],
+                'expected_tasks'     => [
+                    'private task of normal user',
+                    'private task of tech user',
+                    'public task',
+                ],
+            ];
 
-        // sessionless call without private items (used for notifications)
-        yield [
-            'login'              => null,
-            'pass'               => null,
-            'ticket_id'          => $ticket->getID(),
-            'options'            => [
-                'check_view_rights'  => false,
-                'hide_private_items' => true,
-            ],
-            'expected_followups' => [
-                'public followup',
-            ],
-            'expected_tasks'     => [
-                'public task',
-            ],
-        ];
+            // usage of `check_view_rights` should produce the same result whoever is logged-in (used for notifications)
+            yield [
+                'login'              => $login,
+                'pass'               => $pass,
+                'ticket_id'          => $ticket->getID(),
+                'options'            => [
+                    'check_view_rights'  => false,
+                    'hide_private_items' => true,
+                ],
+                'expected_followups' => [
+                    'public followup',
+                ],
+                'expected_tasks'     => [
+                    'public task',
+                ],
+            ];
+        }
     }
 
     /**
@@ -5983,7 +5985,7 @@ HTML
         array $expected_followups,
         array $expected_tasks
     ): void {
-        if ($login !== null) {
+        if ($pass !== null) {
             $this->login($login, $pass);
         } else {
             $this->resetSession();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28943

The `getTimelineItems()` design is prone to mistakes. When `check_view_rights` option is `false`, we should not us the session to filter private items.