### PR TITLE
fix(user): used items list

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -4851,7 +4851,7 @@ HTML;
 
         $iterator = $DB->request([
             'SELECT'    => [
-                'glpi_groups_users.groups_id',
+                'glpi_groups.id',
                 'glpi_groups.name'
             ],
             'FROM'      => 'glpi_groups',
@@ -4869,8 +4869,8 @@ HTML;
 
         $group_where = [];
         foreach ($iterator as $data) {
-            $group_where[$field_group][] = $data['groups_id'];
-            $groups[$data["groups_id"]] = $data["name"];
+            $group_where[$field_group][] = $data['id'];
+            $groups[$data["id"]] = $data["name"];
         }
 
         echo "<div class='spaced'><table class='tab_cadre_fixehov'>";

--- a/src/User.php
+++ b/src/User.php
@@ -4855,7 +4855,7 @@ HTML;
                 'glpi_groups.name'
             ],
             'FROM'      => 'glpi_groups',
-            'JOIN' => [
+            'LEFT JOIN' => [
                 'glpi_groups_users' => [
                     'FKEY' => [
                         'glpi_groups_users'  => 'groups_id',

--- a/src/User.php
+++ b/src/User.php
@@ -4854,9 +4854,9 @@ HTML;
                 'glpi_groups_users.groups_id',
                 'glpi_groups.name'
             ],
-            'FROM'      => 'glpi_groups_users',
-            'LEFT JOIN' => [
-                'glpi_groups' => [
+            'FROM'      => 'glpi_groups',
+            'JOIN' => [
+                'glpi_groups_users' => [
                     'FKEY' => [
                         'glpi_groups_users'  => 'groups_id',
                         'glpi_groups'        => 'id'


### PR DESCRIPTION
In the "used items" tab, if the user is linked to group ID = 0 (a group that doesn't exist), the result displayed all assets with no group entered in their file, because in this case the value of `groups_id = 0`.

Same in the "managed items" tab.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28923
