### PR TITLE
Fix empty exception output on test suite

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -39,7 +39,7 @@ use Glpi\Cache\SimpleCache;
 use Glpi\Socket;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
-ini_set('display_errors', 'On');
+ini_set('display_errors', 'On'); // Ensure errors happening during test suite bootstraping are always displayed
 error_reporting(E_ALL);
 
 define('GLPI_ROOT', __DIR__ . '/../');
@@ -88,10 +88,15 @@ if (file_exists(GLPI_CONFIG_DIR . DIRECTORY_SEPARATOR . CacheManager::CONFIG_FIL
 
 include_once __DIR__ . '/../inc/includes.php';
 
-// Errors that are not explicitely validated by `$this->error()` asserter will already make test fails,
-// and error log entries that not explicitely validated by `$this->has*LogRecord*()` asserters will also make test fails.
-// There is no need to pollute the output with error message.
+// Errors/exceptions that are not explicitely validated by `$this->error()` or `$this->exception` asserter will already make test fails.
+// There is no need to pollute the output with error messages.
+ini_set('display_errors', 'Off');
 ErrorHandler::getInstance()->disableOutput();
+// To ensure that errors/exceptions will be catched by `atoum`, unregister GLPI error/exception handlers.
+// Errors that are pushed directly to logs (SQL errors/warnings for instance) will still have to be explicitely
+// validated by `$this->has*LogRecord*()` asserters, otherwise it will make make test fails.
+set_error_handler(null);
+set_exception_handler(null);
 
 include_once __DIR__ . '/GLPITestCase.php';
 include_once __DIR__ . '/DbTestCase.php';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Since #15233 , I figured out that there was no output when an exception occurs during test suite execution. This PR aims to fix it by deactivating GLPI error and exception handlers during test suite, in order to ensure that atoum will be able to catch all errors/exceptions.

Before:
![image](https://github.com/glpi-project/glpi/assets/33253653/1f5eb989-0d12-43ec-a1ab-90292c4a6016)

After:
![image](https://github.com/glpi-project/glpi/assets/33253653/082f9667-7a0b-4ace-9f05-c5acf5c683f5)

The error handler is itself tested in a dedicated test, see https://github.com/glpi-project/glpi/blob/020c4a9b5abc66679bd2e16fa63f53270296e905/tests/units/Glpi/Application/ErrorHandler.php.