### PR TITLE
fix(ticket): FAQ article sliders

### DIFF
--- a/css/includes/components/_richtext.scss
+++ b/css/includes/components/_richtext.scss
@@ -54,6 +54,8 @@ body.mce-content-body {
 }
 
 .rich_text_container {
+    white-space: initial;
+
     thead,
     tbody,
     tfoot,

--- a/css/legacy/includes/_styles.scss
+++ b/css/legacy/includes/_styles.scss
@@ -702,7 +702,6 @@
       bottom: 0;
       left: 0;
       right: 0;
-      white-space: initial;
    }
 
    .faqadd_entries,

--- a/css/legacy/includes/_styles.scss
+++ b/css/legacy/includes/_styles.scss
@@ -702,6 +702,7 @@
       bottom: 0;
       left: 0;
       right: 0;
+      white-space: initial;
    }
 
    .faqadd_entries,


### PR DESCRIPTION
The content of the article was displayed without line breaks in the paragraphs, so there was always a vertical and horizontal scrollbar.

Before:
![image](https://github.com/glpi-project/glpi/assets/8530352/be8d4e8b-a700-4bec-bb8a-c3981df43a9e)

After:
![image](https://github.com/glpi-project/glpi/assets/8530352/a210955c-caf2-47d0-ab86-5275a2bec4ec)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28974
