### PR TITLE
Display preferences UX improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ The present file will list all changes made to the project; according to the
 - `PrinterLog::getMetrics()` method has been made final.
 - `SavedSearch::showSaveButton()` replaced with `pages/tools/savedsearch/save_button.html.twig` template.
 - `showSystemInformations` method for `$CFG_GLPI['systeminformations_types']` types renamed to `getSystemInformation` and should return an array with a label and content.
+- `DisplayPreference` config form POST handling moved to `ajax/displaypreference.php` script. The front file is for displaying the tabs only.
 
 #### Deprecated
 - Usage of `GLPI_USE_CSRF_CHECK` constant.
@@ -225,7 +226,13 @@ The present file will list all changes made to the project; according to the
 - Javascript file upload functions `dataURItoBlob`, `extractSrcFromImgTag`, `insertImgFromFile()`, `insertImageInTinyMCE`, `isImageBlobFromPaste`, `isImageFromPaste`.
 - `CommonDBTM::$fkfield` property.
 - `getHTML` action for `ajax/fuzzysearch.php` endpoint.
+<<<<<<< HEAD
 - `Config::showLibrariesInformation()`
+=======
+- `DisplayPreference::showFormGlobal` `target` parameter.
+- `DisplayPreference::showFormPerso` `target_id` parameter.
+
+>>>>>>> 9f421e80d2 (migrate display pref config to twig)
 
 ## [10.0.10] unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,9 +226,7 @@ The present file will list all changes made to the project; according to the
 - Javascript file upload functions `dataURItoBlob`, `extractSrcFromImgTag`, `insertImgFromFile()`, `insertImageInTinyMCE`, `isImageBlobFromPaste`, `isImageFromPaste`.
 - `CommonDBTM::$fkfield` property.
 - `getHTML` action for `ajax/fuzzysearch.php` endpoint.
-<<<<<<< HEAD
 - `Config::showLibrariesInformation()`
-=======
 - `DisplayPreference::showFormGlobal` `target` parameter.
 - `DisplayPreference::showFormPerso` `target_id` parameter.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,7 +230,6 @@ The present file will list all changes made to the project; according to the
 - `DisplayPreference::showFormGlobal` `target` parameter.
 - `DisplayPreference::showFormPerso` `target_id` parameter.
 
->>>>>>> 9f421e80d2 (migrate display pref config to twig)
 
 ## [10.0.10] unreleased
 

--- a/ajax/displaypreference.php
+++ b/ajax/displaypreference.php
@@ -52,18 +52,11 @@ if (isset($_POST["activate"])) {
             'itemtype' => $_POST['itemtype']
         ]);
     }
-} else if (isset($_POST["add"])) {
-    $setupdisplay->add($_POST);
-} else if ((isset($_POST["purge"]) || isset($_POST["purge_x"])) && isset($_POST['num'])) {
-    $setupdisplay->deleteByCriteria([
-        'itemtype' => $_POST['itemtype'],
-        'users_id' => $_POST['users_id'],
-        'num'      => $_POST['num']
-    ], true);
-} else if ((isset($_POST["up"]) || isset($_POST["up_x"])) && isset($_POST['num'])) {
-    $setupdisplay->orderItem($_POST, 'up');
-} else if ((isset($_POST["down"]) || isset($_POST["down_x"])) && isset($_POST['num'])) {
-    $setupdisplay->orderItem($_POST, 'down');
+} else if (isset($_POST['action']) && $_POST['action'] === 'update_order') {
+    if (!isset($_POST['itemtype'], $_POST['users_id'], $_POST['opts'])) {
+        die(400);
+    }
+    $setupdisplay->updateOrder($_POST['itemtype'], $_POST['users_id'], $_POST['opts']);
 } else {
     die(400);
 }

--- a/css/includes/_includes.scss
+++ b/css/includes/_includes.scss
@@ -62,6 +62,7 @@ $is-dark: false !default;
 @import "components/scrollbars";
 @import "components/search_input";
 @import "components/select2";
+@import "components/sortable";
 @import "components/tabs";
 @import "components/itilobject/footer";
 @import "components/itilobject/layout";

--- a/css/includes/components/_kanban.scss
+++ b/css/includes/components/_kanban.scss
@@ -452,20 +452,6 @@
         vertical-align: middle;
     }
 
-    .sortable-placeholder {
-        border: 2px dashed #dad55e;
-        background: #fff99038;
-        color: #777620;
-        height: 40px;
-        margin-top: 5px;
-
-        &.invalid-position {
-            border: 2px dashed #d3413c;
-            background: #ff7370;
-            color: #792220;
-        }
-    }
-
     .item-details-panel {
         width: 360px;
         position: absolute;

--- a/css/includes/components/_sortable.scss
+++ b/css/includes/components/_sortable.scss
@@ -1,0 +1,46 @@
+/*!
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+.sortable-placeholder {
+    border: 2px dashed #dad55e;
+    background: #fff99038;
+    color: #777620;
+    height: 40px;
+    margin-top: 5px;
+
+    &.invalid-position {
+        border: 2px dashed #d3413c;
+        background: #ff7370;
+        color: #792220;
+    }
+}

--- a/css/legacy/includes/_styles.scss
+++ b/css/legacy/includes/_styles.scss
@@ -1330,7 +1330,7 @@
       }
    }
 
-   .disabled {
+   .disabled:not(.list-group-item) {
       color: red !important;
    }
 

--- a/front/displaypreference.form.php
+++ b/front/displaypreference.form.php
@@ -46,7 +46,11 @@ $setupdisplay = new DisplayPreference();
 Html::popHeader(__('Setup'), $_SERVER['PHP_SELF'], true);
 // Datas may come from GET or POST : use REQUEST
 if (isset($_REQUEST["itemtype"])) {
-    $setupdisplay->display(['displaytype' => $_REQUEST['itemtype']]);
+    $setupdisplay->display([
+        'displaytype' => $_REQUEST['itemtype'],
+        'no_switch'   => $_REQUEST['no_switch'] ?? false,
+        'forced_tab'  => $_REQUEST['forcetab'] ?? null
+    ]);
 }
 
 Html::popFooter();

--- a/front/displaypreference.form.php
+++ b/front/displaypreference.form.php
@@ -49,7 +49,8 @@ if (isset($_REQUEST["itemtype"])) {
     $setupdisplay->display([
         'displaytype' => $_REQUEST['itemtype'],
         'no_switch'   => $_REQUEST['no_switch'] ?? false,
-        'forced_tab'  => $_REQUEST['forcetab'] ?? null
+        'forced_tab'  => $_REQUEST['forcetab'] ?? null,
+        'in_modal'    => true,
     ]);
 }
 

--- a/inc/define.php
+++ b/inc/define.php
@@ -570,12 +570,12 @@ $CFG_GLPI['javascript'] = [
         'dashboard' => ['dashboard'],
         'planning'  => ['clipboard', 'fullcalendar', 'tinymce', 'planning'],
         'ticket'    => ['rateit', 'tinymce', 'kanban', 'dashboard'],
-        'problem'   => ['tinymce', 'kanban', 'sortable'],
-        'change'    => ['tinymce', 'kanban', 'sortable', 'rateit'],
+        'problem'   => ['tinymce', 'kanban'],
+        'change'    => ['tinymce', 'kanban', 'rateit'],
         'stat'      => ['charts', 'rateit']
     ],
     'tools'     => [
-        'project'                 => ['kanban', 'tinymce', 'sortable'],
+        'project'                 => ['kanban', 'tinymce'],
         'knowbaseitem'            => ['tinymce'],
         'knowbaseitemtranslation' => ['tinymce'],
         'reminder'                => ['tinymce'],
@@ -604,7 +604,7 @@ $CFG_GLPI['javascript'] = [
         'config' => ['clipboard'],
         'webhook' => ['monaco', 'autocomplete'],
     ],
-    'admin'        => ['clipboard', 'sortable'],
+    'admin'        => ['clipboard'],
     'preference'   => ['clipboard'],
     'self-service' => array_merge(['tinymce'], $reservations_libs),
     'tickets'      => [

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -322,6 +322,10 @@ JAVASCRIPT;
                 $nav_width      = "";
             }
 
+            if (($options['in_modal'] ?? false)) {
+                $border = "border-0";
+            }
+
             echo "<div class='d-flex card-tabs $flex_container $orientation'>";
             echo "<ul class='nav nav-tabs $flex_tab' id='$tabdiv_id' $nav_width role='tablist'>";
             $html_tabs = "";
@@ -365,7 +369,7 @@ HTML;
             }
             echo $html_tabs;
             echo "</ul>";
-            echo "<select class='form-select border-2 border-secondary rounded-0 rounded-top d-md-none mb-2' id='$tabdiv_id-select'>$html_sele</select>";
+            echo "<select class='form-select border-2 rounded-0 rounded-top d-md-none mb-2' id='$tabdiv_id-select'>$html_sele</select>";
 
             echo "<div class='tab-content p-2 flex-grow-1 card $border' style='min-height: 150px'>";
             foreach ($tabs as $val) {

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -946,6 +946,10 @@ class CommonGLPI implements CommonGLPIInterface
             $tabs    = [];
 
             foreach ($onglets as $key => $val) {
+                if ($val === null) {
+                    // This is a placeholder tab
+                    continue;
+                }
                 $tabs[$key] = ['title'  => $val,
                     'url'    => $tabpage,
                     'params' => "_target=$target&amp;_itemtype=" . $this->getType() .

--- a/src/Config.php
+++ b/src/Config.php
@@ -135,6 +135,7 @@ class Config extends CommonDBTM
 
         $ong = [];
         $this->addStandardTab(__CLASS__, $ong, $options);
+        $this->addStandardTab(DisplayPreference::class, $ong, $options);
         $this->addStandardTab('GLPINetwork', $ong, $options);
         $this->addStandardTab('Log', $ong, $options);
 

--- a/src/DisplayPreference.php
+++ b/src/DisplayPreference.php
@@ -373,6 +373,9 @@ class DisplayPreference extends CommonDBTM
         }
         $entries = [];
         foreach ($fixed_columns as $key => $val) {
+            if (!isset($searchopt[$val])) {
+                continue;
+            }
             $entries[] = [
                 'id'   => $val,
                 'name' => $searchopt[$val]['name'],
@@ -381,6 +384,9 @@ class DisplayPreference extends CommonDBTM
             ];
         }
         foreach ($already_added as $key => $val) {
+            if (!isset($searchopt[$val])) {
+                continue;
+            }
             $entries[] = [
                 'id'   => $val,
                 'name' => $searchopt[$val]['name'],

--- a/src/DisplayPreference.php
+++ b/src/DisplayPreference.php
@@ -133,6 +133,7 @@ class DisplayPreference extends CommonDBTM
                 } else {
                     $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_KO);
                 }
+                return;
         }
         parent::processMassiveActionsForOneItemtype($ma, $item, $ids);
     }

--- a/src/DisplayPreference.php
+++ b/src/DisplayPreference.php
@@ -550,7 +550,6 @@ class DisplayPreference extends CommonDBTM
 
     public function defineTabs($options = [])
     {
-
         $ong = [];
         $this->addStandardTab(__CLASS__, $ong, $options);
         $ong['no_all_tab'] = true;
@@ -567,10 +566,14 @@ class DisplayPreference extends CommonDBTM
                 break;
 
             case __CLASS__:
+                $forced_tab = $_REQUEST['forcetab'] ?? null;
+                $allow_tab_switch = !isset($_REQUEST['no_switch']) || !$_REQUEST['no_switch'];
+                $global_only = $forced_tab === 'DisplayPreference$1' && !$allow_tab_switch;
+                $personal_only = $forced_tab === 'DisplayPreference$2' && !$allow_tab_switch;
                 $ong = [];
-                $ong[1] = __('Global View');
+                $ong[1] = $personal_only ? null : __('Global View');
                 if (Session::haveRight(self::$rightname, self::PERSONAL)) {
-                    $ong[2] = __('Personal View');
+                    $ong[2] = $global_only ? null : __('Personal View');
                 }
                 return $ong;
 

--- a/src/DisplayPreference.php
+++ b/src/DisplayPreference.php
@@ -402,7 +402,13 @@ class DisplayPreference extends CommonDBTM
     {
         global $DB;
 
-        $searchopt = Search::getCleanedOptions($itemtype);
+        if (class_exists($itemtype)) {
+            $searchopt = Search::getCleanedOptions($itemtype);
+            $available_itemtype = true;
+        } else {
+            $searchopt = [];
+            $available_itemtype = false;
+        }
         if (!is_array($searchopt)) {
             return false;
         }
@@ -470,6 +476,7 @@ class DisplayPreference extends CommonDBTM
             'entries' => $entries,
             'has_personal' => $has_personal,
             'is_global' => $global,
+            'available_itemtype' => $available_itemtype
         ]);
     }
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -1117,7 +1117,6 @@ HTML;
                 'gridstack',
                 'charts',
                 'clipboard',
-                'sortable'
             ]);
 
             if (in_array('planning', $jslibs)) {
@@ -1173,10 +1172,6 @@ HTML;
                 $tpl_vars['css_files'][] = ['path' => 'public/lib/prismjs.css'];
             }
 
-            if (in_array('sortable', $jslibs)) {
-                Html::requireJs('sortable');
-            }
-
             if (in_array('tinymce', $jslibs)) {
                 Html::requireJs('tinymce');
             }
@@ -1212,6 +1207,9 @@ HTML;
             $tpl_vars['css_files'][] = ['path' => 'public/lib/jquery.rateit.css'];
             Html::requireJs('rateit');
         }
+
+        // Sortable required for drag and drop of display preferences and some other things like dashboards, kanban, etc
+        Html::requireJs('sortable');
 
        //file upload is required... almost everywhere.
         Html::requireJs('fileupload');

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -1809,12 +1809,13 @@ class MassiveAction
      * Update the progress if necessary.
      *
      * @param string  $itemtype    the type of the item that has been done
-     * @param integer $id          id or array of ids of the item(s) that have been done.
+     * @param integer|array $id    id or array of ids of the item(s) that have been done.
      * @param integer $result
      *                self::NO_ACTION      in case of no specific action (used internally for older actions)
      *                MassiveAction::ACTION_OK      everything is OK for the action
      *                MassiveAction::ACTION_KO      something went wrong for the action
      *                MassiveAction::ACTION_NORIGHT not anough right for the action
+     * @phpstan-param array<integer>|integer $id
      **/
     public function itemDone($itemtype, $id, $result)
     {

--- a/src/Plugin/Hooks.php
+++ b/src/Plugin/Hooks.php
@@ -76,6 +76,7 @@ class Hooks
     const UNLOCK_FIELDS                 = 'unlock_fields';
     const UNDISCLOSED_CONFIG_VALUE      = 'undiscloseConfigValue';
     const FILTER_ACTORS                 = 'filter_actors';
+    const DEFAULT_DISPLAY_PREFS         = 'default_display_prefs';
 
    // Item hooks expecting an 'item' parameter
     const ADD_RECIPIENT_TO_TARGET   = 'add_recipient_to_target';

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -708,6 +708,9 @@ class Toolbox
 
         $params = [];
         foreach ($array as $k => $v) {
+            if ($v === null) {
+                continue;
+            }
             if (is_array($v)) {
                 $params[] = self::append_params(
                     $v,

--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -108,21 +108,10 @@
             <i class="ti fa-lg ti-tool"></i>
          </button>
          <template id="displaypreference_modal_template{{ rand }}">
-            <div id="displaypreference_modal{{ rand }}" class="modal fade" role="dialog">
-               <div class="modal-dialog modal-lg">
-                  <div class="modal-content">
-                     <div class="modal-header">
-                        <h4 class="modal-title">{{ __('Select default items to show') }}</h4>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ __('Close') }}"></button>
-                     </div>
-                     <div class="modal-body">
-                        <div class="ratio ratio-4x3">
-                           <iframe src="{{ path('/front/displaypreference.form.php?itemtype=' ~ itemtype|escape('url')) }}"></iframe>
-                        </div>
-                     </div>
-                  </div>
-               </div>
-            </div>
+            {{ include('components/search/displaypreference_modal.html.twig', {
+               rand: rand,
+               itemtype: itemtype,
+            }) }}
          </template>
       {% endif %}
 

--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -103,10 +103,27 @@
    <div class="d-inline-flex" role="group">
 
       {% if can_config and count > 0 %}
-      <button class="btn btn-sm btn-icon btn-ghost-secondary show_displaypreference_modal me-1 me-sm-2"
-             title="{{ __('Select default items to show') }}" data-bs-toggle="tooltip" data-bs-placement="bottom">
-         <i class="ti fa-lg ti-tool"></i>
-      </button>
+         <button class="btn btn-sm btn-icon btn-ghost-secondary show_displaypreference_modal me-1 me-sm-2"
+                title="{{ __('Select default items to show') }}" data-bs-toggle="tooltip" data-bs-placement="bottom">
+            <i class="ti fa-lg ti-tool"></i>
+         </button>
+         <template id="displaypreference_modal_template{{ rand }}">
+            <div id="displaypreference_modal{{ rand }}" class="modal fade" role="dialog">
+               <div class="modal-dialog modal-lg">
+                  <div class="modal-content">
+                     <div class="modal-header">
+                        <h4 class="modal-title">{{ __('Select default items to show') }}</h4>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ __('Close') }}"></button>
+                     </div>
+                     <div class="modal-body">
+                        <div class="ratio ratio-4x3">
+                           <iframe src="{{ path('/front/displaypreference.form.php?itemtype=' ~ itemtype|escape('url')) }}"></iframe>
+                        </div>
+                     </div>
+                  </div>
+               </div>
+            </div>
+         </template>
       {% endif %}
 
       {% if count > 0 %}
@@ -177,31 +194,29 @@ $(document).ready(function() {
    $('.show_displaypreference_modal').click(function(e) {
       e.preventDefault();
 
-      var modal = '<div class="modal fade" id="displayprefence_modal{{ rand }}" role="dialog">';
-      modal += '<div class="modal-dialog modal-lg">';
-      modal += '<div class="modal-content">';
-      modal += '<div class="modal-header">';
-      modal += '<h4 class="modal-title">{{ __('Select default items to show') }}</h4>';
-      modal += '<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ __('Close modal') }}"></button>';
-      modal += '</div>';
-      modal += '<div class="modal-body">';
-      modal += '<div class="ratio ratio-4x3">';
-      modal += '<iframe src="{{ path('front/displaypreference.form.php?itemtype=' ~ itemtype|escape('url')) }}"></iframe>'
-      modal += '</div>';
-      modal += '</div>';
-      modal += '</div>';
-      modal += '</div>';
-
       // remove old modal
       $('#displayprefence_modal{{ rand }}').remove();
 
       // create new one
-      $('body').append(modal);
-      $('#displayprefence_modal{{ rand }}').modal('show');
+      $('body').append($('#displaypreference_modal_template{{ rand }}').html());
+      const modal_el = $('#displaypreference_modal{{ rand }}');
+      modal_el.modal('show');
    });
 
-   $("body").on('hide.bs.modal', '#displayprefence_modal{{ rand }}', function() {
-      location.reload();
+   $("body").on('hide.bs.modal', '#displaypreference_modal{{ rand }}', function() {
+      // Try finding a fluid search instance
+      const search_display = $('.ajax-container.search-display-data');
+      try {
+          if (search_display.length === 1 && search_display.data('js_class') !== undefined) {
+              // Trigger a reload of just the results
+              search_display.data('js_class').view.refreshResults();
+          } else {
+              // There is no (or multiple) search results, reload the page
+              window.location.reload();
+          }
+      } catch (err) {
+          window.location.reload();
+      }
    });
 
    $('.fold-search').change(function(event) {

--- a/templates/components/search/displaypreference_config.html.twig
+++ b/templates/components/search/displaypreference_config.html.twig
@@ -1,0 +1,156 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2023 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
+<div id="tabsbody" class="m-n2 display_preference_config">
+   <input type="hidden" name="itemtype" value="{{ itemtype }}">
+   <input type="hidden" name="users_id" value="{{ users_id }}">
+   {% if not is_global and not has_personal %}
+      <div class="alert alert-info">
+         {{ __('No personal criteria. Create personal parameters?') }}
+      </div>
+      <button type="button" class="btn btn-primary" name="activate" value="1">{{ __('Create') }}</button>
+   {% else %}
+      <table class="table table-striped card-table m-n2">
+         <thead>
+            <tr>
+               <th colspan="4">
+                  {% if not is_global %}
+                     <button type="button" class="btn btn-danger" name="disable" value="1">{{ __('Delete') }}</button>
+                  {% endif %}
+               </th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr>
+               <td colspan="4">
+                  {% if available_to_add|length > 0 %}
+                     {% set add_opt_btn %}
+                        <button type="button" name="add_opt" class="btn btn-primary ms-1">{{ _x('button', 'Add') }}</button>
+                     {% endset %}
+                     {{ fields.dropdownArrayField('num', null, available_to_add, '', {
+                        no_label: true,
+                        add_field_html: add_opt_btn,
+                        used: entries|map(v => v['id']),
+                     }) }}
+                  {% endif %}
+               </td>
+            </tr>
+            {% for opt in entries|filter(v => v['fixed'] == true) %}
+               <tr data-opt-id="{{ opt['id'] }}">
+                  <td>{{ opt['name'] }}</td>
+                  <td colspan="3"></td>
+               </tr>
+            {% endfor %}
+            {% for opt in entries|filter(v => v['fixed'] != true) %}
+               {% set name_prefix = opt['group'] is not empty ? (opt['group']) : '' %}
+               <tr data-opt-id="{{ opt['id'] }}">
+                  <td>{{ name_prefix ~ opt['name'] }}</td>
+                  <td>
+                     <button type="button" name="move_up" class="btn btn-icon btn-sm btn-ghost-secondary" title="{{ __('Bring up') }}" {{ loop.first ? 'style="visibility: hidden"' : '' }}>
+                        <i class="ti ti-arrow-up"></i>
+                     </button>
+                     <button type="button" name="move_down" class="btn btn-icon btn-sm btn-ghost-secondary" title="{{ __('Bring down') }}" {{ loop.last ? 'style="visibility: hidden"' : '' }}>
+                        <i class="ti ti-arrow-down"></i>
+                     </button>
+                     {% if opt['noremove'] is not defined or opt['noremove'] != true %}
+                        <button type="button" name="remove_opt" class="btn btn-icon btn-sm btn-ghost-danger" title="{{ _x('button', 'Delete permanently') }}">
+                           <i class="ti ti-x"></i>
+                        </button>
+                     {% endif %}
+                  </td>
+               </tr>
+            {% endfor %}
+         </tbody>
+      </table>
+   {% endif %}
+</div>
+<script>
+   $(() => {
+       const config_forms = $(`#tabsbody.display_preference_config`);
+       const submitForm = (specific_form, data) => {
+           data['itemtype'] = specific_form.find(`input[name="itemtype"]`).val();
+           data['users_id'] = specific_form.find(`input[name="users_id"]`).val();
+           // Disable all buttons since there can only be one action done at a time
+           config_forms.find(`button`).prop('disabled', true);
+           $.ajax({
+               url: "{{ path('/ajax/displaypreference.php') }}",
+               type: 'POST',
+               data: data,
+           }).then(() => {
+               // This script is inside an iframe, so this only reloads the iframe
+               window.location.reload();
+           }, () => {
+               // This script is inside an iframe, so this only reloads the iframe
+               window.location.reload();
+           });
+       };
+       config_forms.find(`button[name="activate"]`).on(`click`, (e) => {
+          submitForm($(e.target).closest('.display_preference_config'), {activate: 1});
+       });
+
+       config_forms.find(`button[name="disable"]`).on(`click`, (e) => {
+          submitForm($(e.target).closest('.display_preference_config'), {disable: 1});
+       });
+
+       config_forms.find(`button[name="add_opt"]`).on(`click`, (e) => {
+           const specific_form = $(e.target).closest('.display_preference_config');
+           submitForm(specific_form, {
+               add: 1,
+               num: specific_form.find(`select[name="num"]`).val(),
+           });
+       });
+
+       config_forms.find(`button[name="move_up"]`).on(`click`, (e) => {
+          submitForm($(e.target).closest('.display_preference_config'), {
+             up: 1,
+             num: $(e.target).closest('tr').data('opt-id')
+          });
+       });
+
+       config_forms.find(`button[name="move_down"]`).on(`click`, (e) => {
+          submitForm($(e.target).closest('.display_preference_config'), {
+             down: 1,
+             num: $(e.target).closest('tr').data('opt-id')
+          });
+       });
+
+       config_forms.find(`button[name="remove_opt"]`).on(`click`, (e) => {
+          submitForm($(e.target).closest('.display_preference_config'), {
+             purge: 1,
+             num: $(e.target).closest('tr').data('opt-id')
+          });
+       });
+   });
+</script>

--- a/templates/components/search/displaypreference_config.html.twig
+++ b/templates/components/search/displaypreference_config.html.twig
@@ -36,6 +36,11 @@
 <div id="tabsbody" class="m-n2 display_preference_config">
    <input type="hidden" name="itemtype" value="{{ itemtype }}">
    <input type="hidden" name="users_id" value="{{ users_id }}">
+   {% if is_global %}
+      <div class="alert alert-info">
+         {{ __('These preferences are used by everyone that does not have a personal view configured.') }}
+      </div>
+   {% endif %}
    {% if not is_global and not has_personal %}
       <div class="alert alert-info">
          {{ __('No personal criteria. Create personal parameters?') }}

--- a/templates/components/search/displaypreference_config.html.twig
+++ b/templates/components/search/displaypreference_config.html.twig
@@ -42,25 +42,28 @@
         </div>
     {% else %}
         {% if is_global %}
-            <div class="alert alert-info">
-                {{ __('These preferences are used by everyone that does not have a personal view configured.') }}
+            <div class="my-1 me-1">
+                <div class="alert alert-secondary">
+                    <i class="ti ti-info-circle"></i>
+                    <i>{{ __('These preferences are used by everyone that does not have a personal view configured.') }}</i>
+                </div>
             </div>
         {% endif %}
         {% if not is_global and not has_personal %}
-            <div class="alert alert-info">
+            <div class="alert alert-warning mt-3">
                 {{ __('No personal criteria. Create personal parameters?') }}
+                <button type="button" class="btn btn-primary ms-3" name="activate" value="1">
+                    <i class="fas fa-plus"></i>
+                    <span>{{ __('Create') }}</span>
+                </button>
             </div>
-            <button type="button" class="btn btn-primary" name="activate" value="1">{{ __('Create') }}</button>
         {% else %}
-            <div class="p-3">
-                {% if not is_global %}
-                    <button type="button" class="btn btn-danger" name="disable" value="1">{{ __('Delete personal view') }}</button>
-                {% endif %}
+            <div class="pt-3">
                 {% if available_to_add|length > 0 %}
                     {% set add_opt_btn %}
                         <button type="button" name="add_opt" class="btn btn-primary ms-1 d-inline-block">
                             <i class="fas fa-plus"></i>
-                            {{ _x('button', 'Add') }}
+                            <span>{{ _x('button', 'Add') }}</span>
                         </button>
                     {% endset %}
                     {% set result_template_js %}
@@ -72,31 +75,40 @@
                         return opt.text;
                         }
                     {% endset %}
-                    {{ fields.dropdownArrayField('num', null, available_to_add, '', {
-                        field_class: 'col-12 col-sm-6 d-flex',
-                        no_label: true,
-                        add_field_html: add_opt_btn,
-                        templateResult: result_template_js,
-                    }) }}
+
+                    <div class="d-flex justify-content-between mb-2">
+                        {{ fields.dropdownArrayField('num', null, available_to_add, '', {
+                            field_class: 'col-12 col-sm-6 d-flex',
+                            no_label: true,
+                            add_field_html: add_opt_btn,
+                            templateResult: result_template_js,
+                            mb: '',
+                        }) }}
+
+                        {% if not is_global %}
+                            <button type="button" class="btn btn-ghost-danger me-1" name="disable" value="1">{{ __('Delete personal view') }}</button>
+                        {% endif %}
+                    </div>
                 {% endif %}
             </div>
             <ul class="list-group">
                 {% for opt in entries|filter(v => v['fixed'] == true) %}
-                    <li data-opt-id="{{ opt['id'] }}" data-fixed="true" class="list-group-item">
+                    <li data-opt-id="{{ opt['id'] }}" data-fixed="true" class="list-group-item disabled px-2">
+                        <i class="fa-fw d-inline-flex"></i>
                         <span>{{ opt['name'] }}</span>
                     </li>
                 {% endfor %}
                 {% for opt in entries|filter(v => v['fixed'] != true) %}
                     {% set name_prefix = opt['group'] is not empty ? (opt['group']) : '' %}
-                    <li data-opt-id="{{ opt['id'] }}" class="cursor-grab list-group-item d-flex justify-content-between">
-                        <span>{{ name_prefix ~ opt['name'] }}</span>
+                    <li data-opt-id="{{ opt['id'] }}" class="cursor-grab list-group-item d-flex px-2">
+                        <i class="ti ti-grip-vertical fa-fw"></i>
+                        <span class="flex-fill ms-1">{{ name_prefix ~ opt['name'] }}</span>
                         <span>
                             {% if opt['noremove'] is not defined or opt['noremove'] != true %}
                                 <button type="button" name="remove_opt" class="btn btn-icon btn-sm btn-ghost-danger" title="{{ _x('button', 'Delete permanently') }}">
                                     <i class="ti ti-x"></i>
                                 </button>
                             {% endif %}
-                            <i class="ti ti-grip-vertical"></i>
                         </span>
                     </li>
                 {% endfor %}

--- a/templates/components/search/displaypreference_config.html.twig
+++ b/templates/components/search/displaypreference_config.html.twig
@@ -34,194 +34,185 @@
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
 <div id="tabsbody" class="m-n2 display_preference_config">
-   <input type="hidden" name="itemtype" value="{{ itemtype }}">
-   <input type="hidden" name="users_id" value="{{ users_id }}">
-   {% if not available_itemtype %}
-      <div class="alert alert-danger">
-         {{ __('These preferences cannot be edited at this time. The item type no longer exists or is provided by a plugin that is not enabled.') }}
-      </div>
-   {% else %}
-      {% if is_global %}
-         <div class="alert alert-info">
-            {{ __('These preferences are used by everyone that does not have a personal view configured.') }}
-         </div>
-      {% endif %}
-      {% if not is_global and not has_personal %}
-         <div class="alert alert-info">
-            {{ __('No personal criteria. Create personal parameters?') }}
-         </div>
-         <button type="button" class="btn btn-primary" name="activate" value="1">{{ __('Create') }}</button>
-      {% else %}
-         <table class="table table-striped card-table m-n2">
-            <thead>
-            <tr>
-               <th colspan="4">
-                  {% if not is_global %}
-                     <button type="button" class="btn btn-danger" name="disable" value="1">{{ __('Delete') }}</button>
-                  {% endif %}
-               </th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-               <td colspan="4">
-                  {% if available_to_add|length > 0 %}
-                     {% set add_opt_btn %}
-                        <button type="button" name="add_opt" class="btn btn-primary ms-1">{{ _x('button', 'Add') }}</button>
-                     {% endset %}
-                     {% set result_template_js %}
+    <input type="hidden" name="itemtype" value="{{ itemtype }}">
+    <input type="hidden" name="users_id" value="{{ users_id }}">
+    {% if not available_itemtype %}
+        <div class="alert alert-danger">
+            {{ __('These preferences cannot be edited at this time. The item type no longer exists or is provided by a plugin that is not enabled.') }}
+        </div>
+    {% else %}
+        {% if is_global %}
+            <div class="alert alert-info">
+                {{ __('These preferences are used by everyone that does not have a personal view configured.') }}
+            </div>
+        {% endif %}
+        {% if not is_global and not has_personal %}
+            <div class="alert alert-info">
+                {{ __('No personal criteria. Create personal parameters?') }}
+            </div>
+            <button type="button" class="btn btn-primary" name="activate" value="1">{{ __('Create') }}</button>
+        {% else %}
+            <div class="p-3">
+                {% if not is_global %}
+                    <button type="button" class="btn btn-danger" name="disable" value="1">{{ __('Delete personal view') }}</button>
+                {% endif %}
+                {% if available_to_add|length > 0 %}
+                    {% set add_opt_btn %}
+                        <button type="button" name="add_opt" class="btn btn-primary ms-1 d-inline-block">{{ _x('button', 'Add') }}</button>
+                    {% endset %}
+                    {% set result_template_js %}
                         {# Select2 js function for templateResult that hides options already added to the table where the value matches the data-opt-id attr on the rows #}
                         (opt) => {
-                           if ($(`tr[data-opt-id="${opt.id}"]`).length > 0) {
-                              return null;
-                           }
-                           return opt.text;
+                        if ($(`tr[data-opt-id="${opt.id}"]`).length > 0) {
+                        return null;
                         }
-                     {% endset %}
-                     {{ fields.dropdownArrayField('num', null, available_to_add, '', {
+                        return opt.text;
+                        }
+                    {% endset %}
+                    {{ fields.dropdownArrayField('num', null, available_to_add, '', {
+                        field_class: 'col-12 col-sm-6 d-flex',
                         no_label: true,
                         add_field_html: add_opt_btn,
                         templateResult: result_template_js,
-                     }) }}
-                  {% endif %}
-               </td>
-            </tr>
-            {% for opt in entries|filter(v => v['fixed'] == true) %}
-               <tr data-opt-id="{{ opt['id'] }}" data-fixed="true">
-                  <td>{{ opt['name'] }}</td>
-                  <td colspan="3"></td>
-               </tr>
-            {% endfor %}
-            {% for opt in entries|filter(v => v['fixed'] != true) %}
-               {% set name_prefix = opt['group'] is not empty ? (opt['group']) : '' %}
-               <tr data-opt-id="{{ opt['id'] }}" class="cursor-grab">
-                  <td>{{ name_prefix ~ opt['name'] }}</td>
-                  <td>
-                     {% if opt['noremove'] is not defined or opt['noremove'] != true %}
-                        <button type="button" name="remove_opt" class="btn btn-icon btn-sm btn-ghost-danger" title="{{ _x('button', 'Delete permanently') }}">
-                           <i class="ti ti-x"></i>
-                        </button>
-                     {% endif %}
-                  </td>
-               </tr>
-            {% endfor %}
-            </tbody>
-         </table>
-      {% endif %}
-   {% endif %}
+                    }) }}
+                {% endif %}
+            </div>
+            <ul class="list-group">
+                {% for opt in entries|filter(v => v['fixed'] == true) %}
+                    <li data-opt-id="{{ opt['id'] }}" data-fixed="true" class="list-group-item">
+                        <span>{{ opt['name'] }}</span>
+                    </li>
+                {% endfor %}
+                {% for opt in entries|filter(v => v['fixed'] != true) %}
+                    {% set name_prefix = opt['group'] is not empty ? (opt['group']) : '' %}
+                    <li data-opt-id="{{ opt['id'] }}" class="cursor-grab list-group-item d-flex justify-content-between">
+                        <span>{{ name_prefix ~ opt['name'] }}</span>
+                        <span>
+                            {% if opt['noremove'] is not defined or opt['noremove'] != true %}
+                                <button type="button" name="remove_opt" class="btn btn-icon btn-sm btn-ghost-danger" title="{{ _x('button', 'Delete permanently') }}">
+                                    <i class="ti ti-x"></i>
+                                </button>
+                            {% endif %}
+                            <i class="ti ti-grip-vertical"></i>
+                        </span>
+                    </li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+    {% endif %}
 </div>
 <script>
-   $(() => {
-       const config_forms = $(`#tabsbody.display_preference_config`);
-       // Select nothing by default because select2 has no problem defaulting the selection to the first item even if it is filtered out
-       config_forms.find(`select[name="num"]`).val('').trigger('change');
-       // Make sure the table rows are sortable only once
-       const sortables = `#tabsbody.display_preference_config tbody`;
-       try {
-           sortable(sortables, 'destroy');
-       } catch (e) {}
-       sortable(sortables, {
-           acceptFrom: '#tabsbody.display_preference_config tbody',
-           items: 'tr:not([data-fixed])',
-       });
+    $(() => {
+        const config_forms = $(`#tabsbody.display_preference_config`);
+        // Select nothing by default because select2 has no problem defaulting the selection to the first item even if it is filtered out
+        config_forms.find(`select[name="num"]`).val('').trigger('change');
+        // Make sure the table rows are sortable only once
+        const sortables = `#tabsbody.display_preference_config ul.list-group`;
+        try {
+            sortable(sortables, 'destroy');
+        } catch (e) {}
+        sortable(sortables, {
+            acceptFrom: '#tabsbody.display_preference_config ul.list-group',
+            items: 'li:not([data-fixed])',
+        });
 
-       function updateOrder(element) {
-           const el = $(element);
-           const tbody = el.is('tbody') ? el : el.find('tbody');
+        function updateOrder(element) {
+            const el = $(element);
+            const ul = el.is('ul') ? el : el.find('ul');
 
-           const opts = [];
-           tbody.find('tr[data-opt-id]:not([data-fixed])').each((i, el) => {
-               opts.push($(el).data('opt-id'));
-           });
-           // disable sorting temporarily
-           sortable(sortables, 'disable');
-           $.ajax({
-               url: "{{ path('/ajax/displaypreference.php') }}",
-               type: 'POST',
-               data: {
-                   'action': 'update_order',
-                   'itemtype': config_forms.find(`input[name="itemtype"]`).val(),
-                   'users_id': config_forms.find(`input[name="users_id"]`).val(),
-                   'opts': opts,
-               },
-           }).then(() => {
-               sortable(sortables, 'enable');
-           }, () => {
-               // Failure. Move item back to original position
-               const dragged = e.detail.item;
-               const original_index = e.detail.origin.elementIndex;
-               if (original_index === 0) {
-                   $(dragged).insertBefore(dragged.parent().find(`tr:eq(${original_index})`));
-               } else {
-                   $(dragged).insertAfter(dragged.parent().find(`tr:eq(${original_index})`));
-               }
-               sortable(sortables, 'enable');
-           });
-       }
+            const opts = [];
+            ul.find('li[data-opt-id]:not([data-fixed])').each((i, el) => {
+                opts.push($(el).data('opt-id'));
+            });
+            // disable sorting temporarily
+            sortable(sortables, 'disable');
+            $.ajax({
+                url: "{{ path('/ajax/displaypreference.php') }}",
+                type: 'POST',
+                data: {
+                    'action': 'update_order',
+                    'itemtype': config_forms.find(`input[name="itemtype"]`).val(),
+                    'users_id': config_forms.find(`input[name="users_id"]`).val(),
+                    'opts': opts,
+                },
+            }).then(() => {
+                sortable(sortables, 'enable');
+            }, () => {
+                // Failure. Move item back to original position
+                const dragged = e.detail.item;
+                const original_index = e.detail.origin.elementIndex;
+                if (original_index === 0) {
+                    $(dragged).insertBefore(dragged.parent().find(`tr:eq(${original_index})`));
+                } else {
+                    $(dragged).insertAfter(dragged.parent().find(`tr:eq(${original_index})`));
+                }
+                sortable(sortables, 'enable');
+            });
+        }
 
-       $(sortables).off('sortupdate').on('sortupdate', (e) => {
-           updateOrder(e.target);
-       });
-       const submitForm = (specific_form, data) => {
-           data['itemtype'] = specific_form.find(`input[name="itemtype"]`).val();
-           data['users_id'] = specific_form.find(`input[name="users_id"]`).val();
-           // Disable all buttons since there can only be one action done at a time
-           config_forms.find(`button`).prop('disabled', true);
-           $.ajax({
-               url: "{{ path('/ajax/displaypreference.php') }}",
-               type: 'POST',
-               data: data,
-           }).then(() => {
-               // This script is inside an iframe, so this only reloads the iframe
-               window.location.reload();
-           }, () => {
-               // This script is inside an iframe, so this only reloads the iframe
-               window.location.reload();
-           });
-       };
-       config_forms.find(`button[name="activate"]`).on(`click`, (e) => {
-          submitForm($(e.target).closest('.display_preference_config'), {activate: 1});
-       });
+        $(sortables).off('sortupdate').on('sortupdate', (e) => {
+            updateOrder(e.target);
+        });
+        const submitForm = (specific_form, data) => {
+            data['itemtype'] = specific_form.find(`input[name="itemtype"]`).val();
+            data['users_id'] = specific_form.find(`input[name="users_id"]`).val();
+            // Disable all buttons since there can only be one action done at a time
+            config_forms.find(`button`).prop('disabled', true);
+            $.ajax({
+                url: "{{ path('/ajax/displaypreference.php') }}",
+                type: 'POST',
+                data: data,
+            }).then(() => {
+                // This script is inside an iframe, so this only reloads the iframe
+                window.location.reload();
+            }, () => {
+                // This script is inside an iframe, so this only reloads the iframe
+                window.location.reload();
+            });
+        };
+        config_forms.find(`button[name="activate"]`).on(`click`, (e) => {
+            submitForm($(e.target).closest('.display_preference_config'), {activate: 1});
+        });
 
-       config_forms.find(`button[name="disable"]`).on(`click`, (e) => {
-          submitForm($(e.target).closest('.display_preference_config'), {disable: 1});
-       });
+        config_forms.find(`button[name="disable"]`).on(`click`, (e) => {
+            submitForm($(e.target).closest('.display_preference_config'), {disable: 1});
+        });
 
-       config_forms.find(`button[name="add_opt"]`).on(`click`, (e) => {
-           const specific_form = $(e.target).closest('.display_preference_config');
-           const num_select = specific_form.find(`select[name="num"]`);
-           const num = num_select.val();
-           if (num === null) {
-               return;
-           }
-           // Label is the text of the selected option's optgroup + ' - ' + the text of the selected option
-           // unless it is in the first optgroup, then it is just the text of the selected option
-           const opt = num_select.find(`option[value="${num}"]`);
-           const label = opt.closest('optgroup').index() === 0 ? opt.text() : `${opt.closest('optgroup').attr('label')} - ${opt.text()}`;
+        config_forms.find(`button[name="add_opt"]`).on(`click`, (e) => {
+            const specific_form = $(e.target).closest('.display_preference_config');
+            const num_select = specific_form.find(`select[name="num"]`);
+            const num = num_select.val();
+            if (num === null) {
+                return;
+            }
+            // Label is the text of the selected option's optgroup + ' - ' + the text of the selected option
+            // unless it is in the first optgroup, then it is just the text of the selected option
+            const opt = num_select.find(`option[value="${num}"]`);
+            const label = opt.closest('optgroup').index() === 0 ? opt.text() : `${opt.closest('optgroup').attr('label')} - ${opt.text()}`;
 
-           const tbody = specific_form.find(`tbody`);
-           tbody.append(`
-               <tr data-opt-id="${num}" class="cursor-grab">
-                  <td>${label}</td>
-                  <td>
+            const tbody = specific_form.find(`ul.list-group`);
+            tbody.append(`
+               <li data-opt-id="${num}" class="cursor-grab list-group-item d-flex justify-content-between">
+                  <span>${label}</span>
+                  <span>
                         <button type="button" name="remove_opt" class="btn btn-icon btn-sm btn-ghost-danger" title="{{ _x('button', 'Delete permanently') }}">
                            <i class="ti ti-x"></i>
                         </button>
-                  </td>
-               </tr>
+                  </span>
+               </li>
            `);
-           // Reset selection to first item. templateResult will automatically hide the item, but it doesn't remove it as the active selection.
-           // New selection will be blank. Doesn't seem to be a good way to reset the selection to the first item that isn't hidden by the result template.
-           num_select.val('').trigger('change');
-           updateOrder(specific_form);
-       });
+            // Reset selection to first item. templateResult will automatically hide the item, but it doesn't remove it as the active selection.
+            // New selection will be blank. Doesn't seem to be a good way to reset the selection to the first item that isn't hidden by the result template.
+            num_select.val('').trigger('change');
+            updateOrder(specific_form);
+        });
 
-       config_forms.on(`click`, 'button[name="remove_opt"]', (e) => {
-           const tbody = $(e.target).closest('tbody');
-           $(e.target).closest('tr').remove();
-           // Trigger an update for the select to re-run the templateResult function
-           tbody.find(`select[name="num"]`).trigger('change');
-           updateOrder(tbody);
-       });
-   });
+        config_forms.on(`click`, 'button[name="remove_opt"]', (e) => {
+            const tbody = $(e.target).closest('tbody');
+            $(e.target).closest('tr').remove();
+            // Trigger an update for the select to re-run the templateResult function
+            tbody.find(`select[name="num"]`).trigger('change');
+            updateOrder(tbody);
+        });
+    });
 </script>

--- a/templates/components/search/displaypreference_config.html.twig
+++ b/templates/components/search/displaypreference_config.html.twig
@@ -59,31 +59,34 @@
                      {% set add_opt_btn %}
                         <button type="button" name="add_opt" class="btn btn-primary ms-1">{{ _x('button', 'Add') }}</button>
                      {% endset %}
+                     {% set result_template_js %}
+                        {# Select2 js function for templateResult that hides options already added to the table where the value matches the data-opt-id attr on the rows #}
+                        (opt) => {
+                           if ($(`tr[data-opt-id="${opt.id}"]`).length > 0) {
+                              return null;
+                           }
+                           return opt.text;
+                        }
+                     {% endset %}
                      {{ fields.dropdownArrayField('num', null, available_to_add, '', {
                         no_label: true,
                         add_field_html: add_opt_btn,
-                        used: entries|map(v => v['id']),
+                        templateResult: result_template_js,
                      }) }}
                   {% endif %}
                </td>
             </tr>
             {% for opt in entries|filter(v => v['fixed'] == true) %}
-               <tr data-opt-id="{{ opt['id'] }}">
+               <tr data-opt-id="{{ opt['id'] }}" data-fixed="true">
                   <td>{{ opt['name'] }}</td>
                   <td colspan="3"></td>
                </tr>
             {% endfor %}
             {% for opt in entries|filter(v => v['fixed'] != true) %}
                {% set name_prefix = opt['group'] is not empty ? (opt['group']) : '' %}
-               <tr data-opt-id="{{ opt['id'] }}">
+               <tr data-opt-id="{{ opt['id'] }}" class="cursor-grab">
                   <td>{{ name_prefix ~ opt['name'] }}</td>
                   <td>
-                     <button type="button" name="move_up" class="btn btn-icon btn-sm btn-ghost-secondary" title="{{ __('Bring up') }}" {{ loop.first ? 'style="visibility: hidden"' : '' }}>
-                        <i class="ti ti-arrow-up"></i>
-                     </button>
-                     <button type="button" name="move_down" class="btn btn-icon btn-sm btn-ghost-secondary" title="{{ __('Bring down') }}" {{ loop.last ? 'style="visibility: hidden"' : '' }}>
-                        <i class="ti ti-arrow-down"></i>
-                     </button>
                      {% if opt['noremove'] is not defined or opt['noremove'] != true %}
                         <button type="button" name="remove_opt" class="btn btn-icon btn-sm btn-ghost-danger" title="{{ _x('button', 'Delete permanently') }}">
                            <i class="ti ti-x"></i>
@@ -99,6 +102,53 @@
 <script>
    $(() => {
        const config_forms = $(`#tabsbody.display_preference_config`);
+       // Make sure the table rows are sortable only once
+       const sortables = `#tabsbody.display_preference_config tbody`;
+       try {
+           sortable(sortables, 'destroy');
+       } catch (e) {}
+       sortable(sortables, {
+           acceptFrom: '#tabsbody.display_preference_config tbody',
+           items: 'tr:not([data-fixed])',
+       });
+
+       function updateOrder(element) {
+           const el = $(element);
+           const tbody = el.is('tbody') ? el : el.find('tbody');
+
+           const opts = [];
+           tbody.find('tr[data-opt-id]:not([data-fixed])').each((i, el) => {
+               opts.push($(el).data('opt-id'));
+           });
+           // disable sorting temporarily
+           sortable(sortables, 'disable');
+           $.ajax({
+               url: "{{ path('/ajax/displaypreference.php') }}",
+               type: 'POST',
+               data: {
+                   'action': 'update_order',
+                   'itemtype': config_forms.find(`input[name="itemtype"]`).val(),
+                   'users_id': config_forms.find(`input[name="users_id"]`).val(),
+                   'opts': opts,
+               },
+           }).then(() => {
+               sortable(sortables, 'enable');
+           }, () => {
+               // Failure. Move item back to original position
+               const dragged = e.detail.item;
+               const original_index = e.detail.origin.elementIndex;
+               if (original_index === 0) {
+                   $(dragged).insertBefore(dragged.parent().find(`tr:eq(${original_index})`));
+               } else {
+                   $(dragged).insertAfter(dragged.parent().find(`tr:eq(${original_index})`));
+               }
+               sortable(sortables, 'enable');
+           });
+       }
+
+       $(sortables).off('sortupdate').on('sortupdate', (e) => {
+           updateOrder(e.target);
+       });
        const submitForm = (specific_form, data) => {
            data['itemtype'] = specific_form.find(`input[name="itemtype"]`).val();
            data['users_id'] = specific_form.find(`input[name="users_id"]`).val();
@@ -126,31 +176,39 @@
 
        config_forms.find(`button[name="add_opt"]`).on(`click`, (e) => {
            const specific_form = $(e.target).closest('.display_preference_config');
-           submitForm(specific_form, {
-               add: 1,
-               num: specific_form.find(`select[name="num"]`).val(),
-           });
+           const num_select = specific_form.find(`select[name="num"]`);
+           const num = num_select.val();
+           if (num === null) {
+               return;
+           }
+           // Label is the text of the selected option's optgroup + ' - ' + the text of the selected option
+           // unless it is in the first optgroup, then it is just the text of the selected option
+           const opt = num_select.find(`option[value="${num}"]`);
+           const label = opt.closest('optgroup').index() === 0 ? opt.text() : `${opt.closest('optgroup').attr('label')} - ${opt.text()}`;
+
+           const tbody = specific_form.find(`tbody`);
+           tbody.append(`
+               <tr data-opt-id="${num}" class="cursor-grab">
+                  <td>${label}</td>
+                  <td>
+                        <button type="button" name="remove_opt" class="btn btn-icon btn-sm btn-ghost-danger" title="{{ _x('button', 'Delete permanently') }}">
+                           <i class="ti ti-x"></i>
+                        </button>
+                  </td>
+               </tr>
+           `);
+           // Reset selection to first item. templateResult will automatically hide the item, but it doesn't remove it as the active selection.
+           // New selection will be blank. Doesn't seem to be a good way to reset the selection to the first item that isn't hidden by the result template.
+           num_select.val('').trigger('change');
+           updateOrder(specific_form);
        });
 
-       config_forms.find(`button[name="move_up"]`).on(`click`, (e) => {
-          submitForm($(e.target).closest('.display_preference_config'), {
-             up: 1,
-             num: $(e.target).closest('tr').data('opt-id')
-          });
-       });
-
-       config_forms.find(`button[name="move_down"]`).on(`click`, (e) => {
-          submitForm($(e.target).closest('.display_preference_config'), {
-             down: 1,
-             num: $(e.target).closest('tr').data('opt-id')
-          });
-       });
-
-       config_forms.find(`button[name="remove_opt"]`).on(`click`, (e) => {
-          submitForm($(e.target).closest('.display_preference_config'), {
-             purge: 1,
-             num: $(e.target).closest('tr').data('opt-id')
-          });
+       config_forms.on(`click`, 'button[name="remove_opt"]', (e) => {
+           const tbody = $(e.target).closest('tbody');
+           $(e.target).closest('tr').remove();
+           // Trigger an update for the select to re-run the templateResult function
+           tbody.find(`select[name="num"]`).trigger('change');
+           updateOrder(tbody);
        });
    });
 </script>

--- a/templates/components/search/displaypreference_config.html.twig
+++ b/templates/components/search/displaypreference_config.html.twig
@@ -58,7 +58,10 @@
                 {% endif %}
                 {% if available_to_add|length > 0 %}
                     {% set add_opt_btn %}
-                        <button type="button" name="add_opt" class="btn btn-primary ms-1 d-inline-block">{{ _x('button', 'Add') }}</button>
+                        <button type="button" name="add_opt" class="btn btn-primary ms-1 d-inline-block">
+                            <i class="fas fa-plus"></i>
+                            {{ _x('button', 'Add') }}
+                        </button>
                     {% endset %}
                     {% set result_template_js %}
                         {# Select2 js function for templateResult that hides options already added to the table where the value matches the data-opt-id attr on the rows #}

--- a/templates/components/search/displaypreference_config.html.twig
+++ b/templates/components/search/displaypreference_config.html.twig
@@ -36,19 +36,24 @@
 <div id="tabsbody" class="m-n2 display_preference_config">
    <input type="hidden" name="itemtype" value="{{ itemtype }}">
    <input type="hidden" name="users_id" value="{{ users_id }}">
-   {% if is_global %}
-      <div class="alert alert-info">
-         {{ __('These preferences are used by everyone that does not have a personal view configured.') }}
+   {% if not available_itemtype %}
+      <div class="alert alert-danger">
+         {{ __('These preferences cannot be edited at this time. The item type no longer exists or is provided by a plugin that is not enabled.') }}
       </div>
-   {% endif %}
-   {% if not is_global and not has_personal %}
-      <div class="alert alert-info">
-         {{ __('No personal criteria. Create personal parameters?') }}
-      </div>
-      <button type="button" class="btn btn-primary" name="activate" value="1">{{ __('Create') }}</button>
    {% else %}
-      <table class="table table-striped card-table m-n2">
-         <thead>
+      {% if is_global %}
+         <div class="alert alert-info">
+            {{ __('These preferences are used by everyone that does not have a personal view configured.') }}
+         </div>
+      {% endif %}
+      {% if not is_global and not has_personal %}
+         <div class="alert alert-info">
+            {{ __('No personal criteria. Create personal parameters?') }}
+         </div>
+         <button type="button" class="btn btn-primary" name="activate" value="1">{{ __('Create') }}</button>
+      {% else %}
+         <table class="table table-striped card-table m-n2">
+            <thead>
             <tr>
                <th colspan="4">
                   {% if not is_global %}
@@ -56,8 +61,8 @@
                   {% endif %}
                </th>
             </tr>
-         </thead>
-         <tbody>
+            </thead>
+            <tbody>
             <tr>
                <td colspan="4">
                   {% if available_to_add|length > 0 %}
@@ -100,8 +105,9 @@
                   </td>
                </tr>
             {% endfor %}
-         </tbody>
-      </table>
+            </tbody>
+         </table>
+      {% endif %}
    {% endif %}
 </div>
 <script>

--- a/templates/components/search/displaypreference_config.html.twig
+++ b/templates/components/search/displaypreference_config.html.twig
@@ -113,6 +113,8 @@
 <script>
    $(() => {
        const config_forms = $(`#tabsbody.display_preference_config`);
+       // Select nothing by default because select2 has no problem defaulting the selection to the first item even if it is filtered out
+       config_forms.find(`select[name="num"]`).val('').trigger('change');
        // Make sure the table rows are sortable only once
        const sortables = `#tabsbody.display_preference_config tbody`;
        try {

--- a/templates/components/search/displaypreference_config.html.twig
+++ b/templates/components/search/displaypreference_config.html.twig
@@ -93,14 +93,14 @@
             </div>
             <ul class="list-group">
                 {% for opt in entries|filter(v => v['fixed'] == true) %}
-                    <li data-opt-id="{{ opt['id'] }}" data-fixed="true" class="list-group-item disabled px-2">
+                    <li data-opt-id="{{ opt['id'] }}" data-fixed="true" class="list-group-item py-2 disabled px-2">
                         <i class="fa-fw d-inline-flex"></i>
                         <span>{{ opt['name'] }}</span>
                     </li>
                 {% endfor %}
                 {% for opt in entries|filter(v => v['fixed'] != true) %}
                     {% set name_prefix = opt['group'] is not empty ? (opt['group']) : '' %}
-                    <li data-opt-id="{{ opt['id'] }}" class="cursor-grab list-group-item d-flex px-2">
+                    <li data-opt-id="{{ opt['id'] }}" class="cursor-grab list-group-item py-2 d-flex px-2">
                         <i class="ti ti-grip-vertical fa-fw"></i>
                         <span class="flex-fill ms-1">{{ name_prefix ~ opt['name'] }}</span>
                         <span>

--- a/templates/components/search/displaypreference_list.html.twig
+++ b/templates/components/search/displaypreference_list.html.twig
@@ -52,7 +52,7 @@
                   {% endif %}
                </th>
                <th>{{ _n('Type', 'Types', 1) }}</th>
-               <th class="text-end">{{ __('Number of custom columns') }}</th>
+               <th class="text-end">{{ __('Number of modifiable columns') }}</th>
             </tr>
          </thead>
          <tbody>

--- a/templates/components/search/displaypreference_list.html.twig
+++ b/templates/components/search/displaypreference_list.html.twig
@@ -64,7 +64,7 @@
                         {% do call('Html::showMassiveActionCheckBox', ['DisplayPreference', pref['itemtype']]) %}
                      {% endif %}
                   </td>
-                  <td><button type="button" class="btn btn-link btn-itemtype-pref">{{ name }}</button></td>
+                  <td><button type="button" class="btn btn-link p-0 btn-itemtype-pref">{{ name }}</button></td>
                   <td class="text-end">{{ pref['nb'] }}</td>
                </tr>
             {% endfor %}

--- a/templates/components/search/displaypreference_list.html.twig
+++ b/templates/components/search/displaypreference_list.html.twig
@@ -34,73 +34,59 @@
 {% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
 
 {% if preferences|length > 0 %}
-   <div class="my-3">
-      {% if massiveactionparams['specific_actions']|length > 0 %}
-         <form id="massDisplayPreference{{ rand }}" method="get" action="{{ path('front/massiveaction.php') }}"
-            data-search-itemtype="DisplayPreference" data-submit-once>
-         {% do call('Html::showMassiveActions', [massiveactionparams]) %}
-      {% endif %}
-      {{ inputs.hidden('users_id', users_id, {
-         'data-glpicore-ma-tags': 'common'
-      }) }}
-      <table class="table table-striped display-prefs-list my-2">
-         <thead>
-            <tr>
-               <th style="width: 10px">
-                  {% if massiveactionparams['specific_actions']|length > 0 %}
-                     {{ call('Html::getCheckAllAsCheckbox', ['massDisplayPreference' ~ rand])|raw }}
-                  {% endif %}
-               </th>
-               <th>{{ _n('Type', 'Types', 1) }}</th>
-            </tr>
-         </thead>
-         <tbody>
-            {% for pref in preferences %}
-               {% set name = pref['itemtype']|itemtype_name(1)|default(pref['itemtype']) %}
-               <tr>
-                  <td style="width: 10px">
-                     {% if massiveactionparams['specific_actions']|length > 0 %}
+    <div class="my-3">
+        {% if massiveactionparams['specific_actions']|length > 0 %}
+        <form id="massDisplayPreference{{ rand }}" method="get" action="{{ path('front/massiveaction.php') }}"
+              data-search-itemtype="DisplayPreference" data-submit-once>
+            {% do call('Html::showMassiveActions', [massiveactionparams]) %}
+            {% endif %}
+            {{ inputs.hidden('users_id', users_id, {
+                'data-glpicore-ma-tags': 'common'
+            }) }}
+            <ul class="list-group display-prefs-list my-2">
+                {% for pref in preferences %}
+                    {% set name = pref['itemtype']|itemtype_name(1)|default(pref['itemtype']) %}
+                    <li class="list-group-item">
+                        {% if massiveactionparams['specific_actions']|length > 0 %}
+                            <span class="me-2">
                         {% do call('Html::showMassiveActionCheckBox', ['DisplayPreference', pref['itemtype']]) %}
-                     {% endif %}
-                  </td>
-                  <td><button type="button" class="btn btn-link p-0 btn-itemtype-pref" data-itemtype="{{ pref['itemtype'] }}">{{ name }}</button></td>
-               </tr>
-            {% endfor %}
-         </tbody>
-      </table>
-      {% if massiveactionparams['specific_actions']|length > 0 %}
-         {% do call('Html::showMassiveActions', [massiveactionparams|merge({
-            'ontop': false
-         })]) %}
-         </form>
-      {% endif %}
-   </div>
-   <template id="displaypreference_modal_template{{ rand }}">
-      {{ include('components/search/displaypreference_modal.html.twig', {
-         rand: rand,
-         itemtype: '__VALUE__',
-      }) }}
-   </template>
-   <script>
-       $(() => {
-           $('table.display-prefs-list tbody button.btn-itemtype-pref').on('click', (e) => {
-               const itemtype = $(e.currentTarget).attr('data-itemtype');
-               const itemtype_name = $(e.currentTarget).text();
-               $('#displayprefence_modal{{ rand }}').remove();
-               const modal = $($('#displaypreference_modal_template{{ rand }}').html());
-               const default_src = modal.find('iframe').attr('src');
-               const forced_tab = "{{ users_id > 0 ? 'DisplayPreference$2' : 'DisplayPreference$1' }}"
-               const replacement = `${itemtype}&forcetab=${forced_tab}&no_switch=1`;
-               modal.find('iframe').attr('src', default_src.replace('__VALUE__', replacement));
-               modal.find('.modal-header h4').text(modal.find('.modal-header h4').text() + ' - ' + itemtype_name);
-               modal.appendTo('body').modal('show');
-           });
-       });
-   </script>
+                     </span>
+                        {% endif %}
+                        <button type="button" class="btn btn-link p-0 btn-itemtype-pref" data-itemtype="{{ pref['itemtype'] }}">{{ name }}</button>
+                    </li>
+                {% endfor %}
+            </ul>
+            {% if massiveactionparams['specific_actions']|length > 0 %}
+            {% do call('Html::showMassiveActions', [massiveactionparams|merge({
+                'ontop': false
+            })]) %}
+        </form>
+        {% endif %}
+    </div>
+    <template id="displaypreference_modal_template{{ rand }}">
+        {{ include('components/search/displaypreference_modal.html.twig', {
+            rand: rand,
+            itemtype: '__VALUE__',
+        }) }}
+    </template>
+    <script>
+        $(() => {
+            $('ul.display-prefs-list button.btn-itemtype-pref').on('click', (e) => {
+                const itemtype = $(e.currentTarget).attr('data-itemtype');
+                const itemtype_name = $(e.currentTarget).text();
+                $('#displayprefence_modal{{ rand }}').remove();
+                const modal = $($('#displaypreference_modal_template{{ rand }}').html());
+                const default_src = modal.find('iframe').attr('src');
+                const forced_tab = "{{ users_id > 0 ? 'DisplayPreference$2' : 'DisplayPreference$1' }}"
+                const replacement = `${itemtype}&forcetab=${forced_tab}&no_switch=1`;
+                modal.find('iframe').attr('src', default_src.replace('__VALUE__', replacement));
+                modal.find('.modal-header h4').text(modal.find('.modal-header h4').text() + ' - ' + itemtype_name);
+                modal.appendTo('body').modal('show');
+            });
+        });
+    </script>
 {% else %}
-   <table class="table">
-      <tr>
-         <td class="text-center">{{ __('No item found') }}</td>
-      </tr>
-   </table>
+    <div class="alert alert-info">
+        {{ __('No item found') }}
+    </div>
 {% endif %}

--- a/templates/components/search/displaypreference_list.html.twig
+++ b/templates/components/search/displaypreference_list.html.twig
@@ -52,7 +52,6 @@
                   {% endif %}
                </th>
                <th>{{ _n('Type', 'Types', 1) }}</th>
-               <th class="text-end">{{ __('Number of modifiable columns') }}</th>
             </tr>
          </thead>
          <tbody>
@@ -65,7 +64,6 @@
                      {% endif %}
                   </td>
                   <td><button type="button" class="btn btn-link p-0 btn-itemtype-pref" data-itemtype="{{ pref['itemtype'] }}">{{ name }}</button></td>
-                  <td class="text-end">{{ pref['nb'] }}</td>
                </tr>
             {% endfor %}
          </tbody>

--- a/templates/components/search/displaypreference_list.html.twig
+++ b/templates/components/search/displaypreference_list.html.twig
@@ -34,7 +34,7 @@
 {% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
 
 {% if preferences|length > 0 %}
-   <div class="mb-3">
+   <div class="my-3">
       {% if massiveactionparams['specific_actions']|length > 0 %}
          <form id="massDisplayPreference{{ rand }}" method="get" action="{{ path('front/massiveaction.php') }}"
             data-search-itemtype="DisplayPreference" data-submit-once>
@@ -43,7 +43,7 @@
       {{ inputs.hidden('users_id', users_id, {
          'data-glpicore-ma-tags': 'common'
       }) }}
-      <table class="table table-striped display-prefs-list">
+      <table class="table table-striped display-prefs-list my-2">
          <thead>
             <tr>
                <th style="width: 10px">

--- a/templates/components/search/displaypreference_list.html.twig
+++ b/templates/components/search/displaypreference_list.html.twig
@@ -1,0 +1,86 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2023 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
+
+{% if preferences|length > 0 %}
+   <div class="mb-3">
+      {% if massiveactionparams['specific_actions']|length > 0 %}
+         <form id="massDisplayPreference{{ rand }}" method="get" action="{{ path('front/massiveaction.php') }}"
+            data-search-itemtype="DisplayPreference" data-submit-once>
+         {% do call('Html::showMassiveActions', [massiveactionparams]) %}
+      {% endif %}
+      {{ inputs.hidden('users_id', users_id, {
+         'data-glpicore-ma-tags': 'common'
+      }) }}
+      <table class="table table-striped">
+         <thead>
+            <tr>
+               <th style="width: 10px">
+                  {% if massiveactionparams['specific_actions']|length > 0 %}
+                     {{ call('Html::getCheckAllAsCheckbox', ['massDisplayPreference' ~ rand])|raw }}
+                  {% endif %}
+               </th>
+               <th>{{ _n('Type', 'Types', 1) }}</th>
+               <th class="text-end">{{ __('Number of custom columns') }}</th>
+            </tr>
+         </thead>
+         <tbody>
+            {% for pref in preferences %}
+               {% set name = pref['itemtype']|itemtype_name(1)|default(pref['itemtype']) %}
+               <tr>
+                  <td style="width: 10px">
+                     {% if massiveactionparams['specific_actions']|length > 0 %}
+                        {% do call('Html::showMassiveActionCheckBox', ['DisplayPreference', pref['itemtype']]) %}
+                     {% endif %}
+                  </td>
+                  <td>{{ name }}</td>
+                  <td class="text-end">{{ pref['nb'] }}</td>
+               </tr>
+            {% endfor %}
+         </tbody>
+      </table>
+      {% if massiveactionparams['specific_actions']|length > 0 %}
+         {% do call('Html::showMassiveActions', [massiveactionparams|merge({
+            'ontop': false
+         })]) %}
+         </form>
+      {% endif %}
+   </div>
+{% else %}
+   <table class="table">
+      <tr>
+         <td class="text-center">{{ __('No item found') }}</td>
+      </tr>
+   </table>
+{% endif %}

--- a/templates/components/search/displaypreference_list.html.twig
+++ b/templates/components/search/displaypreference_list.html.twig
@@ -64,7 +64,7 @@
                         {% do call('Html::showMassiveActionCheckBox', ['DisplayPreference', pref['itemtype']]) %}
                      {% endif %}
                   </td>
-                  <td><button type="button" class="btn btn-link p-0 btn-itemtype-pref">{{ name }}</button></td>
+                  <td><button type="button" class="btn btn-link p-0 btn-itemtype-pref" data-itemtype="{{ pref['itemtype'] }}">{{ name }}</button></td>
                   <td class="text-end">{{ pref['nb'] }}</td>
                </tr>
             {% endfor %}
@@ -86,13 +86,15 @@
    <script>
        $(() => {
            $('table.display-prefs-list tbody button.btn-itemtype-pref').on('click', (e) => {
-               const itemtype = $(e.currentTarget).text();
+               const itemtype = $(e.currentTarget).attr('data-itemtype');
+               const itemtype_name = $(e.currentTarget).text();
                $('#displayprefence_modal{{ rand }}').remove();
                const modal = $($('#displaypreference_modal_template{{ rand }}').html());
                const default_src = modal.find('iframe').attr('src');
                const forced_tab = "{{ users_id > 0 ? 'DisplayPreference$2' : 'DisplayPreference$1' }}"
                const replacement = `${itemtype}&forcetab=${forced_tab}&no_switch=1`;
                modal.find('iframe').attr('src', default_src.replace('__VALUE__', replacement));
+               modal.find('.modal-header h4').text(modal.find('.modal-header h4').text() + ' - ' + itemtype_name);
                modal.appendTo('body').modal('show');
            });
        });

--- a/templates/components/search/displaypreference_list.html.twig
+++ b/templates/components/search/displaypreference_list.html.twig
@@ -43,7 +43,7 @@
       {{ inputs.hidden('users_id', users_id, {
          'data-glpicore-ma-tags': 'common'
       }) }}
-      <table class="table table-striped">
+      <table class="table table-striped display-prefs-list">
          <thead>
             <tr>
                <th style="width: 10px">
@@ -64,7 +64,7 @@
                         {% do call('Html::showMassiveActionCheckBox', ['DisplayPreference', pref['itemtype']]) %}
                      {% endif %}
                   </td>
-                  <td>{{ name }}</td>
+                  <td><button type="button" class="btn btn-link btn-itemtype-pref">{{ name }}</button></td>
                   <td class="text-end">{{ pref['nb'] }}</td>
                </tr>
             {% endfor %}
@@ -77,6 +77,26 @@
          </form>
       {% endif %}
    </div>
+   <template id="displaypreference_modal_template{{ rand }}">
+      {{ include('components/search/displaypreference_modal.html.twig', {
+         rand: rand,
+         itemtype: '__VALUE__',
+      }) }}
+   </template>
+   <script>
+       $(() => {
+           $('table.display-prefs-list tbody button.btn-itemtype-pref').on('click', (e) => {
+               const itemtype = $(e.currentTarget).text();
+               $('#displayprefence_modal{{ rand }}').remove();
+               const modal = $($('#displaypreference_modal_template{{ rand }}').html());
+               const default_src = modal.find('iframe').attr('src');
+               const forced_tab = "{{ users_id > 0 ? 'DisplayPreference$2' : 'DisplayPreference$1' }}"
+               const replacement = `${itemtype}&forcetab=${forced_tab}&no_switch=1`;
+               modal.find('iframe').attr('src', default_src.replace('__VALUE__', replacement));
+               modal.appendTo('body').modal('show');
+           });
+       });
+   </script>
 {% else %}
    <table class="table">
       <tr>

--- a/templates/components/search/displaypreference_modal.html.twig
+++ b/templates/components/search/displaypreference_modal.html.twig
@@ -37,7 +37,11 @@
    <div class="modal-dialog modal-lg">
       <div class="modal-content">
          <div class="modal-header">
-            <h4 class="modal-title">{{ __('Select default items to show') }}</h4>
+            {% set header = __('Select default items to show') %}
+            {% if itemtype != '__VALUE__' %}
+               {% set header = header ~ ' - ' ~ itemtype|itemtype_name %}
+            {% endif %}
+            <h4 class="modal-title">{{ header }}</h4>
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ __('Close') }}"></button>
          </div>
          <div class="modal-body">

--- a/templates/components/search/displaypreference_modal.html.twig
+++ b/templates/components/search/displaypreference_modal.html.twig
@@ -1,0 +1,50 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2023 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% set rand = rand|default(random()) %}
+
+<div id="displaypreference_modal{{ rand }}" class="modal fade" role="dialog">
+   <div class="modal-dialog modal-lg">
+      <div class="modal-content">
+         <div class="modal-header">
+            <h4 class="modal-title">{{ __('Select default items to show') }}</h4>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ __('Close') }}"></button>
+         </div>
+         <div class="modal-body">
+            <div class="ratio ratio-4x3">
+               <iframe src="{{ path('/front/displaypreference.form.php?itemtype=' ~ itemtype|escape('url')) }}"></iframe>
+            </div>
+         </div>
+      </div>
+   </div>
+</div>

--- a/templates/components/search/displaypreference_modal.html.twig
+++ b/templates/components/search/displaypreference_modal.html.twig
@@ -45,7 +45,7 @@
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ __('Close') }}"></button>
          </div>
          <div class="modal-body">
-            <div class="ratio ratio-4x3">
+            <div class="ratio ratio-1x1">
                <iframe src="{{ path('/front/displaypreference.form.php?itemtype=' ~ itemtype|escape('url')) }}"></iframe>
             </div>
          </div>

--- a/tests/functional/Config.php
+++ b/tests/functional/Config.php
@@ -126,6 +126,7 @@ class Config extends DbTestCase
             'Config$7'      => "<span><i class='ti ti-dashboard me-2'></i>Performance</span>",
             'Config$8'      => "<span><i class='ti ti-api-app me-2'></i>API</span>",
             'Config$11'      => "<span><i class='ti ti-affiliate me-2'></i>Impact analysis</span>",
+            'DisplayPreference$1' => "<span><i class='ti ti-columns-3 me-2'></i>Search result display</span>",
             'GLPINetwork$1' => "<span><i class='ti ti-headset me-2'></i>GLPI Network</span>",
             'Log$1'         => "<span><i class='ti ti-history me-2'></i>Historical</span>",
         ];

--- a/tests/functional/Config.php
+++ b/tests/functional/Config.php
@@ -93,6 +93,7 @@ class Config extends DbTestCase
             'Config$3'      => "<span><i class='ti ti-package me-2'></i>Assets</span>",
             'Config$4'      => "<span><i class='ti ti-headset me-2'></i>Assistance</span>",
             'Config$12'     => "<span><i class='ti ti-wallet me-2'></i>Management</span>",
+            'DisplayPreference$1' => "<span><i class='ti ti-columns-3 me-2'></i>Search result display</span>",
             'GLPINetwork$1' => "<span><i class='ti ti-headset me-2'></i>GLPI Network</span>",
             'Log$1'         => "<span><i class='ti ti-history me-2'></i>Historical</span>",
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Notable changes/improvements:
- AJAX actions now use the itemtype, user, and num instead of the ID for ordering and removal.
- Closing the modal will now attempt to trigger the `refreshResults` method for the fluid search view and only reload the full page when a fluid search view cannot be found (or finds multiple) or an error occurs.
- De-duplicated code between global and personal config forms
- Options are now orderable by drag and drop instead of one... at... a... time... up and down controls. Adding and removing options now doesn't trigger a reload of the iframe either. Activating and deactivating personal preferences are still "synchronous" and require reloading the iframe in the modal.
- Added ability to view all global display preferences from the Config form in a new "Search result display" tab.
- Added ability to edit display preferences directly from the global/personal lists. Previously, it was only possible to do so from the search result page which could be problematic if someone added too many options or an option that otherwise breaks the search page.
- Added ability to reset global display preferences to the defaults specified in the `empty_data.php` script or provided by plugins via a new `default_display_prefs` hook.
- Added informational message to the global preference config form to make sure users are aware they would be changing the display for everyone that doesn't have a personal display configured, and not just changing their own display.