### PR TITLE
Bump @tabler/icons-webfont from 2.21.0 to 2.30.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@fullcalendar/rrule": "^4.4.0",
                 "@fullcalendar/timegrid": "^4.4.0",
                 "@tabler/core": "^1.0.0-beta9",
-                "@tabler/icons-webfont": "^2.21.0",
+                "@tabler/icons-webfont": "^2.30.0",
                 "animate.css": "^4.1.1",
                 "bootstrap": "^5.1.1",
                 "chartist": "^0.11.4",
@@ -1903,20 +1903,20 @@
             }
         },
         "node_modules/@tabler/icons": {
-            "version": "2.21.0",
-            "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-2.21.0.tgz",
-            "integrity": "sha512-XKrTEHMX6XzCOwcOU8ZNA+Xqm51sI+0abn2jk1fyQUpWeFnGsOEiC+fpQ4EISc+v+U9jqgTSbh8bZ6JBuKU5sw==",
+            "version": "2.30.0",
+            "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-2.30.0.tgz",
+            "integrity": "sha512-tvtmkI4ALjKThVVORh++sB9JnkFY7eGInKxNy+Df7WVQiF7T85tlvGADzlgX4Ic+CK5MIUzZ0jhOlQ/RRlgXpg==",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/codecalm"
             }
         },
         "node_modules/@tabler/icons-webfont": {
-            "version": "2.21.0",
-            "resolved": "https://registry.npmjs.org/@tabler/icons-webfont/-/icons-webfont-2.21.0.tgz",
-            "integrity": "sha512-WCa57zYBjD9NF3/g96WKePgKUkKKD95Y+mo27/fzXOGxuoP9lGRjd01UCeLTGVxdEPErwlCjHXSi8HoDX2jevg==",
+            "version": "2.30.0",
+            "resolved": "https://registry.npmjs.org/@tabler/icons-webfont/-/icons-webfont-2.30.0.tgz",
+            "integrity": "sha512-tGGKxeATvyHJBHl5FzY4oAShbAiR4ovstG62lqb2HGlOJwz4Io9TSk4eoB88nqxg3sT5no2YsAKXcr1UnlpnNQ==",
             "dependencies": {
-                "@tabler/icons": "2.21.0"
+                "@tabler/icons": "2.30.0"
             },
             "funding": {
                 "type": "github",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "@fullcalendar/rrule": "^4.4.0",
         "@fullcalendar/timegrid": "^4.4.0",
         "@tabler/core": "^1.0.0-beta9",
-        "@tabler/icons-webfont": "^2.21.0",
+        "@tabler/icons-webfont": "^2.30.0",
         "animate.css": "^4.1.1",
         "bootstrap": "^5.1.1",
         "chartist": "^0.11.4",


### PR DESCRIPTION
#15312 backported on 10.0/bugfixes branch.