### PR TITLE
feat(user): add clean LDAP fields massive action

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -3417,6 +3417,8 @@ HTML;
                                                       _x('button', 'Change the authentication method');
             $actions[$prefix . 'force_user_ldap_update'] = "<i class='fas fa-sync'></i>" .
                                                       __('Force synchronization');
+            $actions[$prefix . 'clean_ldap_fields'] = "<i class='fas fa-broom'></i>" .
+                                                    __('Clean LDAP fields and force synchronisation');
         }
         return $actions;
     }
@@ -3451,13 +3453,14 @@ HTML;
 
         switch ($ma->getAction()) {
             case 'force_user_ldap_update':
+            case 'clean_ldap_fields':
                 foreach ($ids as $id) {
                     if ($item->can($id, UPDATE)) {
                         if (
                             ($item->fields["authtype"] == Auth::LDAP)
                             || ($item->fields["authtype"] == Auth::EXTERNAL)
                         ) {
-                            if (AuthLDAP::forceOneUserSynchronization($item, false, false)) {
+                            if (AuthLDAP::forceOneUserSynchronization($item, ($ma->getAction() == 'clean_ldap_fields'), false)) {
                                 $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
                             } else {
                                 $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes and no 😄
| New feature?  | yes and no 😄
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28961

It's possible to "Clean LDAP fields and force synchronisation" on "Synchronization" tab for each user, but not with a Massive Action.
