### PR TITLE
Stop inventory process when main asset cannot be created

### DIFF
--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -695,6 +695,9 @@ abstract class MainAsset extends InventoryAsset
             unset($input['ap_port']);
             unset($input['firmware']);
             $items_id = $this->item->add(Sanitizer::sanitize($input));
+            if ($items_id === false) {
+                throw new \Exception('Unable to create item.');
+            }
             $this->setNew();
         }
 

--- a/src/Inventory/Conf.php
+++ b/src/Inventory/Conf.php
@@ -259,7 +259,11 @@ class Conf extends CommonGLPI
                 ];
             }
         } catch (\Throwable $e) {
-            throw $e;
+            $result = [
+                'success' => false,
+                'message' => sprintf(__('An error occurs during import: `%s`.'), $e->getMessage()),
+                'items'   => $inventory_request->getInventory()->getItems(),
+            ];
         }
 
         $result['request'] = $inventory_request;

--- a/tests/functional/Glpi/Inventory/Assets/Computer.php
+++ b/tests/functional/Glpi/Inventory/Assets/Computer.php
@@ -1613,4 +1613,51 @@ class Computer extends AbstractInventoryAsset
         $locks = $lockedfield->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
         $this->integer(count($locks))->isIdenticalTo(0);
     }
+
+    public function testErrorOnFieldUnicityChecks()
+    {
+        $root_entity_id = getItemByTypeName('Entity', '_test_root_entity', true);
+
+        $computer_name = __FUNCTION__;
+
+        $this->login();
+
+        $this->createItem(
+            \FieldUnicity::class,
+            [
+                'name'          => 'Unique computer name',
+                'entities_id'   => 0,
+                'is_recursive'  => 1,
+                'is_active'     => 1,
+                'itemtype'      => \Computer::class,
+                '_fields'       => ['name'],
+                'action_refuse' => 1,
+            ]
+        );
+
+        $this->createItem(\Computer::class, ['name' => $computer_name, 'entities_id' => $root_entity_id]);
+
+        $this->exception(
+            function () use ($computer_name) {
+                $inventory_request = new \Glpi\Inventory\Request();
+                $inventory_request->handleRequest(
+                    "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+                    <REQUEST>
+                    <CONTENT>
+                      <HARDWARE>
+                        <NAME>{$computer_name}</NAME>
+                        <UUID>5BCB-25C1BB60B18F-5404A6A534C4</UUID>
+                      </HARDWARE>
+                      <BIOS>
+                        <MSN>640HP72</MSN>
+                      </BIOS>
+                      <VERSIONCLIENT>FusionInventory-Inventory_v2.4.1-2.fc28</VERSIONCLIENT>
+                    </CONTENT>
+                    <DEVICEID>glpixps.teclib.infra-2018-10-03-08-42-36</DEVICEID>
+                    <QUERY>INVENTORY</QUERY>
+                    </REQUEST>"
+                );
+            }
+        )->hasMessage('Unable to create item.');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28571

When main asset cannot be created, for instance if it is blocked by unicity rules, or if a plugin invalidates the input, inventory process is not stopped and generates many errors.

1. First commit fixes handling of exceptions that may occurs during manual import.

2. Second commit permits to exit the inventory process as soon as the main asset cannot be created. It only patches this particular case.

![image](https://github.com/glpi-project/glpi/assets/33253653/ea44bb5c-6229-49c9-ad0c-7e4b7d57805b)


This PR focuses on main asset only, but this kind of issues could appear at many places in the inventory process. There is actually no way to fix this easilly with current code. Indeed, the `CommonDBTM::add/update/delete()` process is not designed to be able to store/retrieve labels/codes of the errors that blocked it, and, from the `InventoryAsset` context, it is not possible to transmit these potential errors to the `\Glpi\Inventory\Inventory` object that handles the request.

PHP Error log extract (just a subset of all errors that were trigerred):
```
[2023-07-27 11:53:43] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "id" in /usr/share/glpi/src/Inventory/Asset/MainAsset.php at line 701
  Backtrace :
  src/RuleImportAsset.php:988                        Glpi\Inventory\Asset\MainAsset->rulepassed()
  src/Rule.php:1525                                  RuleImportAsset->executeActions()
  src/RuleCollection.php:1640                        Rule->process()
  src/Inventory/Asset/MainAsset.php:573              RuleCollection->processAllRules()
  src/Inventory/Inventory.php:709                    Glpi\Inventory\Asset\MainAsset->handle()
  src/Inventory/Inventory.php:340                    Glpi\Inventory\Inventory->handleItem()
  src/Inventory/Request.php:360                      Glpi\Inventory\Inventory->doInventory()
  src/Inventory/Request.php:90                       Glpi\Inventory\Request->inventory()
  src/Agent/Communication/AbstractRequest.php:359    Glpi\Inventory\Request->handleAction()
  src/Agent/Communication/AbstractRequest.php:271    Glpi\Agent\Communication\AbstractRequest->handleJSONRequest()
  front/inventory.php:92                             Glpi\Agent\Communication\AbstractRequest->handleRequest()
  ...tplace/glpiinventory/front/communication.php:72 include_once()
  marketplace/glpiinventory/index.php:45             include_once()
  public/index.php:82                                require()
  
[2023-07-27 11:53:43] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "id" in /usr/share/glpi/src/Inventory/Asset/InventoryNetworkPort.php at line 113
  Backtrace :
  src/Inventory/Asset/MainAsset.php:823              Glpi\Inventory\Asset\MainAsset->handlePorts()
  src/RuleImportAsset.php:988                        Glpi\Inventory\Asset\MainAsset->rulepassed()
  src/Rule.php:1525                                  RuleImportAsset->executeActions()
  src/RuleCollection.php:1640                        Rule->process()
  src/Inventory/Asset/MainAsset.php:573              RuleCollection->processAllRules()
  src/Inventory/Inventory.php:709                    Glpi\Inventory\Asset\MainAsset->handle()
  src/Inventory/Inventory.php:340                    Glpi\Inventory\Inventory->handleItem()
  src/Inventory/Request.php:360                      Glpi\Inventory\Inventory->doInventory()
  src/Inventory/Request.php:90                       Glpi\Inventory\Request->inventory()
  src/Agent/Communication/AbstractRequest.php:359    Glpi\Inventory\Request->handleAction()
  src/Agent/Communication/AbstractRequest.php:271    Glpi\Agent\Communication\AbstractRequest->handleJSONRequest()
  front/inventory.php:92                             Glpi\Agent\Communication\AbstractRequest->handleRequest()
  ...tplace/glpiinventory/front/communication.php:72 include_once()
  marketplace/glpiinventory/index.php:45             include_once()
  public/index.php:82                                require()
  
[2023-07-27 11:53:43] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "id" in /usr/share/glpi/src/Inventory/Asset/Device.php at line 57
  Backtrace :
  src/Inventory/Asset/Device.php:86                  Glpi\Inventory\Asset\Device->getExisting()
  src/Inventory/Asset/Bios.php:77                    Glpi\Inventory\Asset\Device->handle()
  src/Inventory/Asset/MainAsset.php:933              Glpi\Inventory\Asset\Bios->handle()
  src/Inventory/Asset/MainAsset.php:848              Glpi\Inventory\Asset\MainAsset->handleAssets()
  src/RuleImportAsset.php:988                        Glpi\Inventory\Asset\MainAsset->rulepassed()
  src/Rule.php:1525                                  RuleImportAsset->executeActions()
  src/RuleCollection.php:1640                        Rule->process()
  src/Inventory/Asset/MainAsset.php:573              RuleCollection->processAllRules()
  src/Inventory/Inventory.php:709                    Glpi\Inventory\Asset\MainAsset->handle()
  src/Inventory/Inventory.php:340                    Glpi\Inventory\Inventory->handleItem()
  src/Inventory/Request.php:360                      Glpi\Inventory\Inventory->doInventory()
  src/Inventory/Request.php:90                       Glpi\Inventory\Request->inventory()
  src/Agent/Communication/AbstractRequest.php:359    Glpi\Inventory\Request->handleAction()
  src/Agent/Communication/AbstractRequest.php:271    Glpi\Agent\Communication\AbstractRequest->handleJSONRequest()
  front/inventory.php:92                             Glpi\Agent\Communication\AbstractRequest->handleRequest()
  ...tplace/glpiinventory/front/communication.php:72 include_once()
  marketplace/glpiinventory/index.php:45             include_once()
  public/index.php:82                                require()

..........

[2023-07-27 11:53:44] glpiphplog.ERROR:   *** PHP User Error (256): Column 'items_id' cannot be null in /usr/share/glpi/src/DBmysql.php at line 1998
  Backtrace :
  src/DBmysql.php:1998                               trigger_error()
  src/Inventory/Asset/Software.php:907               DBmysql->executeStatement()
  src/Inventory/Asset/Software.php:465               Glpi\Inventory\Asset\Software->storeAssetLink()
  src/Inventory/Asset/MainAsset.php:933              Glpi\Inventory\Asset\Software->handle()
  src/Inventory/Asset/MainAsset.php:848              Glpi\Inventory\Asset\MainAsset->handleAssets()
  src/RuleImportAsset.php:988                        Glpi\Inventory\Asset\MainAsset->rulepassed()
  src/Rule.php:1525                                  RuleImportAsset->executeActions()
  src/RuleCollection.php:1640                        Rule->process()
  src/Inventory/Asset/MainAsset.php:573              RuleCollection->processAllRules()
  src/Inventory/Inventory.php:709                    Glpi\Inventory\Asset\MainAsset->handle()
  src/Inventory/Inventory.php:340                    Glpi\Inventory\Inventory->handleItem()
  src/Inventory/Request.php:360                      Glpi\Inventory\Inventory->doInventory()
  src/Inventory/Request.php:90                       Glpi\Inventory\Request->inventory()
  src/Agent/Communication/AbstractRequest.php:359    Glpi\Inventory\Request->handleAction()
  src/Agent/Communication/AbstractRequest.php:271    Glpi\Agent\Communication\AbstractRequest->handleJSONRequest()
  front/inventory.php:92                             Glpi\Agent\Communication\AbstractRequest->handleRequest()
  ...tplace/glpiinventory/front/communication.php:72 include_once()
  marketplace/glpiinventory/index.php:45             include_once()
  public/index.php:82                                require()
```