### PR TITLE
Replace `E_USER_ERROR` by exceptions

### DIFF
--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -2063,7 +2063,7 @@ class DBmysql
     public function executeStatement(mysqli_stmt $stmt): void
     {
         if (!$stmt->execute()) {
-            trigger_error($stmt->error, E_USER_ERROR);
+            throw new \RuntimeException($stmt->error);
         }
     }
 

--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -242,7 +242,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
                     $this->sql .= "" . DBmysql::quoteName($field);
                 } else {
                     if ($distinct) {
-                        trigger_error("With COUNT and DISTINCT, you must specify exactly one field, or use 'COUNT DISTINCT'", E_USER_ERROR);
+                        throw new \LogicException("With COUNT and DISTINCT, you must specify exactly one field, or use 'COUNT DISTINCT'.");
                     }
                     $this->sql .= "*";
                 }
@@ -277,7 +277,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
                     $table = array_map([DBmysql::class, 'quoteName'], $table);
                     $this->sql .= ' FROM ' . implode(", ", $table);
                 } else {
-                    trigger_error("Missing table name", E_USER_ERROR);
+                    throw new \LogicException("Missing table name.");
                 }
             } else if ($table) {
                 if ($table instanceof \AbstractQuery) {
@@ -293,7 +293,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
                 * TODO filter with if ($where || !empty($crit)) {
                 * but not usefull for now, as we CANNOT write something like "SELECT NOW()"
                 */
-                trigger_error("Missing table name", E_USER_ERROR);
+                throw new \LogicException("Missing table name.");
             }
 
            // JOIN
@@ -320,7 +320,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
                     $groupby = array_map([DBmysql::class, 'quoteName'], $groupby);
                     $this->sql .= ' GROUP BY ' . implode(", ", $groupby);
                 } else {
-                    trigger_error("Missing group by field", E_USER_ERROR);
+                    throw new \LogicException("Missing group by field.");
                 }
             } else if ($groupby) {
                 $groupby = DBmysql::quoteName($groupby);
@@ -376,7 +376,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
             } else if ($o instanceof QueryExpression) {
                 $cleanorderby[] = $o->getValue();
             } else {
-                trigger_error("Invalid order clause", E_USER_ERROR);
+                throw new \LogicException("Invalid order clause.");
             }
         }
 
@@ -656,7 +656,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
         $query = '';
         foreach ($joinarray as $jointype => $jointables) {
             if (!in_array($jointype, ['JOIN', 'LEFT JOIN', 'INNER JOIN', 'RIGHT JOIN'])) {
-                throw new \RuntimeException('BAD JOIN');
+                throw new \LogicException(sprintf('Invalid JOIN type `%s`.', $jointype));
             }
 
             if ($jointype == 'JOIN') {
@@ -664,7 +664,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
             }
 
             if (!is_array($jointables)) {
-                trigger_error("BAD JOIN, value must be [ table => criteria ]", E_USER_ERROR);
+                throw new \LogicException("BAD JOIN, value must be [ table => criteria ].");
                 continue;
             }
 
@@ -680,7 +680,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
                     $jointablekey = $jointablecrit['TABLE'];
                     unset($jointablecrit['TABLE']);
                 } else if (is_numeric($jointablekey) || $jointablekey == 'FKEY' || $jointablekey == 'ON') {
-                    throw new \RuntimeException('BAD JOIN');
+                    throw new \LogicException('BAD JOIN');
                 }
 
                 if ($jointablekey instanceof \QuerySubQuery) {
@@ -724,7 +724,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
                 return $fkey . ' ' . key($condition) . ' ' . $this->analyseCrit(current($condition));
             }
         }
-        trigger_error("BAD FOREIGN KEY, should be [ table1 => key1, table2 => key2 ] or [ table1 => key1, table2 => key2, [criteria]]", E_USER_ERROR);
+        throw new \LogicException('BAD FOREIGN KEY, should be [ table1 => key1, table2 => key2 ] or [ table1 => key1, table2 => key2, [criteria]].');
     }
 
     /**

--- a/src/Inventory/Asset/NetworkPort.php
+++ b/src/Inventory/Asset/NetworkPort.php
@@ -493,7 +493,7 @@ class NetworkPort extends InventoryAsset
                         $reference
                     );
                     if (!$this->vlan_stmt = $DB->prepare($insert_query)) {
-                           trigger_error("Error preparing query $insert_query", E_USER_ERROR);
+                        throw new \RuntimeException(sprintf('Error preparing query `%s`.', $insert_query));
                     }
                 }
 
@@ -523,7 +523,7 @@ class NetworkPort extends InventoryAsset
                     $reference
                 );
                 if (!$this->pvlan_stmt = $DB->prepare($insert_query)) {
-                     trigger_error("Error preparing query $insert_query", E_USER_ERROR);
+                    throw new \RuntimeException(sprintf('Error preparing query `%s`.', $insert_query));
                 }
             }
 

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -273,7 +273,7 @@ class Migration
                     } else if (in_array($default_value, ['0', '1'])) {
                         $format .= " DEFAULT '$default_value'";
                     } else {
-                        trigger_error(__('default_value must be 0 or 1'), E_USER_ERROR);
+                        throw new \LogicException('Default value must be 0 or 1.');
                     }
                 }
                 break;
@@ -311,7 +311,7 @@ class Migration
                     } else if (is_numeric($default_value)) {
                         $format .= " DEFAULT '$default_value'";
                     } else {
-                        trigger_error(__('default_value must be numeric'), E_USER_ERROR);
+                        throw new \LogicException('Default value must be numeric.');
                     }
                 }
                 break;

--- a/src/Notification_NotificationTemplate.php
+++ b/src/Notification_NotificationTemplate.php
@@ -531,7 +531,7 @@ class Notification_NotificationTemplate extends CommonDBRelation
             $classname = 'Notification' . ucfirst($mode) . 'Setting';
         } else {
             if ($extratype != '') {
-                trigger_error("Unknown type $extratype", E_USER_ERROR);
+                throw new \LogicException(sprintf('Unknown type `%s`.', $extratype));
             }
             $classname = 'Notification' . ucfirst($mode);
         }

--- a/src/Plugin/HookManager.php
+++ b/src/Plugin/HookManager.php
@@ -87,7 +87,7 @@ class HookManager
         // Check if the given hook is a valid file hook
         $allowed_file_hooks = Hooks::getFileHooks();
         if (!in_array($hook, $allowed_file_hooks)) {
-            trigger_error("Invalid file hook: '$hook'", E_USER_ERROR);
+            throw new \LogicException(sprintf('Invalid file hook `%s`.', $hook));
         }
 
         // Init target array if needed
@@ -114,7 +114,7 @@ class HookManager
         // Check if the given hook is a valid functional hook
         $allowed_file_hooks = Hooks::getFunctionalHooks();
         if (!in_array($hook, $allowed_file_hooks)) {
-            trigger_error("Invalid functional hook: '$hook'", E_USER_ERROR);
+            throw new \LogicException(sprintf('Invalid functional hook `%s`.', $hook));
         }
 
         $PLUGIN_HOOKS[$hook][$this->plugin] = $function;
@@ -137,7 +137,7 @@ class HookManager
         // Check if the given hook is a valid item hook
         $allowed_file_hooks = Hooks::getItemHooks();
         if (!in_array($hook, $allowed_file_hooks)) {
-            trigger_error("Invalid item hook: '$hook'", E_USER_ERROR);
+            throw new \LogicException(sprintf('Invalid item hook `%s`.', $hook));
         }
 
         $PLUGIN_HOOKS[$hook][$this->plugin][$itemtype] = $function;

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -591,7 +591,7 @@ class Rule extends CommonDBTM
             $parent = get_parent_class($parent);
         } while ($parent !== 'CommonDBTM' && $parent !== false && !class_exists($collection_class));
         if ($collection_class === null) {
-            trigger_error('Unable to find collection class for ' . static::getType(), E_USER_ERROR);
+            throw new \LogicException(sprintf('Unable to find collection class for `%s`.', static::getType()));
         }
         return $collection_class;
     }

--- a/tests/units/DBmysqlIterator.php
+++ b/tests/units/DBmysqlIterator.php
@@ -92,15 +92,13 @@ class DBmysqlIterator extends DbTestCase
      */
     public function testNoTableWithWhere()
     {
-        $this->when(
+        $this->exception(
             function () {
                 $it = $this->it->execute('', ['foo' => 1]);
                 $this->string($it->getSql())->isIdenticalTo('SELECT * WHERE `foo` = \'1\'');
             }
-        )->error()
-         ->withType(E_USER_ERROR)
-         ->withMessage('Missing table name')
-         ->exists();
+        )->isInstanceOf(\LogicException::class)
+         ->hasMessage('Missing table name.');
     }
 
 
@@ -109,15 +107,13 @@ class DBmysqlIterator extends DbTestCase
      */
     public function testNoTableWithoutWhere()
     {
-        $this->when(
+        $this->exception(
             function () {
                 $it = $this->it->execute('');
                 $this->string($it->getSql())->isIdenticalTo('SELECT *');
             }
-        )->error()
-         ->withType(E_USER_ERROR)
-         ->withMessage('Missing table name')
-         ->exists();
+        )->isInstanceOf(\LogicException::class)
+         ->hasMessage('Missing table name.');
     }
 
 
@@ -126,15 +122,13 @@ class DBmysqlIterator extends DbTestCase
      */
     public function testNoTableWithoutWhereBis()
     {
-        $this->when(
+        $this->exception(
             function () {
                 $it = $this->it->execute(['FROM' => []]);
                 $this->string('SELECT *', $it->getSql(), 'No table');
             }
-        )->error()
-         ->withType(E_USER_ERROR)
-         ->withMessage('Missing table name')
-         ->exists();
+        )->isInstanceOf(\LogicException::class)
+         ->hasMessage('Missing table name.');
     }
 
 
@@ -269,14 +263,12 @@ class DBmysqlIterator extends DbTestCase
         $it = $this->it->execute('foo', ['ORDER' => [new \QueryExpression("CASE WHEN `foo` LIKE 'test%' THEN 0 ELSE 1 END"), 'bar ASC', 'baz DESC']]);
         $this->string($it->getSql())->isIdenticalTo("SELECT * FROM `foo` ORDER BY CASE WHEN `foo` LIKE 'test%' THEN 0 ELSE 1 END, `bar` ASC, `baz` DESC");
 
-        $this->when(
+        $this->exception(
             function () {
-                $it = $this->it->execute('foo', ['ORDER' => [new \stdClass()]]);
+                $this->it->execute('foo', ['ORDER' => [new \stdClass()]]);
             }
-        )->error()
-         ->withType(E_USER_ERROR)
-         ->withMessage('Invalid order clause')
-         ->exists();
+        )->isInstanceOf(\LogicException::class)
+         ->hasMessage('Invalid order clause.');
     }
 
 
@@ -327,14 +319,12 @@ class DBmysqlIterator extends DbTestCase
         $it = $this->it->execute('foo', ['FIELDS' => 'bar', 'COUNT' => 'cpt', 'DISTINCT' => true]);
         $this->string($it->getSql())->isIdenticalTo('SELECT COUNT(DISTINCT `bar`) AS cpt FROM `foo`');
 
-        $this->when(
+        $this->exception(
             function () {
-                $it = $this->it->execute('foo', ['COUNT' => 'cpt', 'DISTINCT' => true]);
+                $this->it->execute('foo', ['COUNT' => 'cpt', 'DISTINCT' => true]);
             }
-        )->error()
-         ->withType(E_USER_ERROR)
-         ->withMessage("With COUNT and DISTINCT, you must specify exactly one field, or use 'COUNT DISTINCT'")
-         ->exists();
+        )->isInstanceOf(\LogicException::class)
+         ->hasMessage("With COUNT and DISTINCT, you must specify exactly one field, or use 'COUNT DISTINCT'.");
     }
 
 
@@ -394,29 +384,25 @@ class DBmysqlIterator extends DbTestCase
 
         $this->exception(
             function () {
-                $it = $this->it->execute('foo', ['LEFT JOIN' => ['ON' => ['a' => 'id', 'b' => 'a_id']]]);
+                $this->it->execute('foo', ['LEFT JOIN' => ['ON' => ['a' => 'id', 'b' => 'a_id']]]);
             }
-        )
-         ->isInstanceOf('RuntimeException')
+        )->isInstanceOf(\LogicException::class)
          ->hasMessage('BAD JOIN');
 
-        $this->when(
-            function () {
-                $it = $this->it->execute('foo', ['LEFT JOIN' => 'bar']);
-            }
-        )->error()
-         ->withType(E_USER_ERROR)
-         ->withMessage('BAD JOIN, value must be [ table => criteria ]')
-         ->exists();
 
-        $this->when(
+        $this->exception(
             function () {
-                $it = $this->it->execute('foo', ['INNER JOIN' => ['bar' => ['FKEY' => 'akey']]]);
+                $this->it->execute('foo', ['LEFT JOIN' => 'bar']);
             }
-        )->error()
-         ->withType(E_USER_ERROR)
-         ->withMessage('BAD FOREIGN KEY, should be [ table1 => key1, table2 => key2 ] or [ table1 => key1, table2 => key2, [criteria]]')
-         ->exists();
+        )->isInstanceOf(\LogicException::class)
+         ->hasMessage('BAD JOIN, value must be [ table => criteria ].');
+
+        $this->exception(
+            function () {
+                $this->it->execute('foo', ['INNER JOIN' => ['bar' => ['FKEY' => 'akey']]]);
+            }
+        )->isInstanceOf(\LogicException::class)
+         ->hasMessage('BAD FOREIGN KEY, should be [ table1 => key1, table2 => key2 ] or [ table1 => key1, table2 => key2, [criteria]].');
 
        //test conditions
         $it = $this->it->execute(
@@ -484,11 +470,10 @@ class DBmysqlIterator extends DbTestCase
 
         $this->exception(
             function () {
-                $it = $this->it->analyseJoins(['LEFT OUTER JOIN' => ['ON' => ['a' => 'id', 'b' => 'a_id']]]);
+                $this->it->analyseJoins(['LEFT OUTER JOIN' => ['ON' => ['a' => 'id', 'b' => 'a_id']]]);
             }
-        )
-         ->isInstanceOf('RuntimeException')
-         ->hasMessage('BAD JOIN');
+        )->isInstanceOf(\LogicException::class)
+         ->hasMessage('Invalid JOIN type `LEFT OUTER JOIN`.');
 
         // QueryExpression
         $expression = "LEFT JOIN xxxx";
@@ -623,25 +608,21 @@ class DBmysqlIterator extends DbTestCase
 
     public function testNoFieldGroupBy()
     {
-        $this->when(
+        $this->exception(
             function () {
                 $it = $this->it->execute(['foo'], ['GROUPBY' => []]);
                 $this->string('SELECT * FROM `foo`', $it->getSql(), 'No group by field');
             }
-        )->error()
-         ->withType(E_USER_ERROR)
-         ->withMessage('Missing group by field')
-         ->exists();
+        )->isInstanceOf(\LogicException::class)
+         ->hasMessage('Missing group by field.');
 
-        $this->when(
+        $this->exception(
             function () {
                 $it = $this->it->execute(['foo'], ['GROUP' => []]);
                 $this->string('SELECT * FROM `foo`', $it->getSql(), 'No group by field');
             }
-        )->error()
-         ->withType(E_USER_ERROR)
-         ->withMessage('Missing group by field')
-         ->exists();
+        )->isInstanceOf(\LogicException::class)
+         ->hasMessage('Missing group by field.');
     }
 
     public function testRange()

--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -632,7 +632,7 @@ class Migration extends \GLPITestCase
         $this->calling($this->db)->fieldExists = false;
         $this->queries = [];
 
-        $this->when(
+        $this->exception(
             function () {
                 $this->migration->addField('my_table', 'my_field', 'bool', ['value' => 2]);
 
@@ -642,10 +642,8 @@ class Migration extends \GLPITestCase
                     }
                 )->isEqualTo('Change of the database layout - my_tableTask completed.');
             }
-        )->error()
-         ->withType(E_USER_ERROR)
-         ->withMessage('default_value must be 0 or 1')
-         ->exists();
+        )->isInstanceOf(\LogicException::class)
+         ->hasMessage('Default value must be 0 or 1.');
     }
 
     public function testFormatIntegerBadDefault()
@@ -655,7 +653,7 @@ class Migration extends \GLPITestCase
         $this->calling($this->db)->fieldExists = false;
         $this->queries = [];
 
-        $this->when(
+        $this->exception(
             function () {
                 $this->migration->addField('my_table', 'my_field', 'integer', ['value' => 'foo']);
 
@@ -665,10 +663,8 @@ class Migration extends \GLPITestCase
                     }
                 )->isEqualTo('Change of the database layout - my_tableTask completed.');
             }
-        )->error()
-         ->withType(E_USER_ERROR)
-         ->withMessage('default_value must be numeric')
-         ->exists();
+        )->isInstanceOf(\LogicException::class)
+         ->hasMessage('Default value must be numeric.');
     }
 
     public function testAddRight()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Usring `trigger_error()` with `E_USER_ERROR` level generates a fatal error that cannot be catched. Throwing an exception will permit to catch the error.