### PR TITLE
fix(reservation): itemtype list empty

### DIFF
--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -512,7 +512,7 @@ class ReservationItem extends CommonDBChild
         ]);
 
         foreach ($iterator as $data) {
-            if (is_a($data['itemtype'], CommonDBTM::class, true) && $data['itemtype']::canView()) {
+            if (is_a($data['itemtype'], CommonDBTM::class, true)) {
                 $values[$data['itemtype']] = $data['itemtype']::getTypeName();
             }
         }


### PR DESCRIPTION
When we searched for a free item for a specific period, we found items of different types, but the itemtype dropdown was empty, which made it impossible to filter by this field.

After:
![image](https://github.com/glpi-project/glpi/assets/8530352/0e21a14c-68d1-40ac-b4c4-31354279cbb2)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28083
