### PR TITLE
Avoid costly calls to Toolbox::getAvailableTabs()

### DIFF
--- a/ajax/common.tabs.php
+++ b/ajax/common.tabs.php
@@ -97,10 +97,7 @@ if (isset($_GET['_target'])) {
     $_GET['_target'] = Toolbox::cleanTarget($_GET['_target']);
 }
 
-$tabs = Toolbox::getAvailablesTabs($_GET['_itemtype'], $_GET['id'] ?? null);
-if (isset($tabs[$_GET['_glpi_tab']])) {
-    Session::setActiveTab($_GET['_itemtype'], $_GET['_glpi_tab']);
-}
+Session::setActiveTab($_GET['_itemtype'], $_GET['_glpi_tab']);
 
 $notvalidoptions = ['_glpi_tab', '_itemtype', 'sort', 'order', 'withtemplate', 'formoptions'];
 $options         = $_GET;

--- a/ajax/updatecurrenttab.php
+++ b/ajax/updatecurrenttab.php
@@ -50,7 +50,7 @@ if (
     )
 ) {
     if (isset($_GET['tab_key'])) {
-        // Prefered way, load tab key directly - avoid unneeded call to Toolbox::getAvailablesTabs
+        // Prefered way, load tab key directly, avoid unneeded call to Toolbox::getAvailablesTabs
         Session::setActiveTab($_UGET['itemtype'], $_UGET['tab_key']);
     } else {
         // Deprecated, use tab_key if possible
@@ -66,5 +66,4 @@ if (
             $current++;
         }
     }
-
 }

--- a/ajax/updatecurrenttab.php
+++ b/ajax/updatecurrenttab.php
@@ -42,14 +42,29 @@ if (!basename($_SERVER['SCRIPT_NAME']) == "helpdesk.faq.php") {
 /** @global array $_UGET */
 
 // Manage tabs
-if (isset($_GET['tab']) && isset($_GET['itemtype'])) {
-    $tabs = Toolbox::getAvailablesTabs($_UGET['itemtype'], $_GET['id'] ?? null);
-    $current      = 0;
-    foreach (array_keys($tabs) as $key) {
-        if ($current == $_GET['tab']) {
-            Session::setActiveTab($_UGET['itemtype'], $key);
-            break;
+if (
+    isset($_GET['itemtype'])
+    && (
+        isset($_GET['tab'])
+        || isset($_GET['tab_key'])
+    )
+) {
+    if (isset($_GET['tab_key'])) {
+        // Prefered way, load tab key directly - avoid unneeded call to Toolbox::getAvailablesTabs
+        Session::setActiveTab($_UGET['itemtype'], $_UGET['tab_key']);
+    } else {
+        // Deprecated, use tab_key if possible
+        Toolbox::deprecated("'tab' parameter is deprecated, use 'tab_key' instead");
+
+        $tabs = Toolbox::getAvailablesTabs($_UGET['itemtype'], $_GET['id'] ?? null);
+        $current      = 0;
+        foreach (array_keys($tabs) as $key) {
+            if ($current == $_GET['tab']) {
+                Session::setActiveTab($_UGET['itemtype'], $key);
+                break;
+            }
+            $current++;
         }
-        $current++;
     }
+
 }

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -358,6 +358,7 @@ JAVASCRIPT;
             echo "</div>"; // .container-fluid
             $js = "
          var loadTabContents = function (tablink, force_reload = false) {
+            const href_url_params = new URLSearchParams($(tablink).prop('href'));
             var url = tablink.attr('href');
             var target = tablink.attr('data-bs-target');
             var index = tablink.closest('.nav-item').index();
@@ -368,7 +369,7 @@ JAVASCRIPT;
                   {
                      itemtype: '" . addslashes($type) . "',
                      id: '$ID',
-                     tab: index,
+                     tab_key: href_url_params.get('_glpi_tab'),
                      withtemplate: " . (int)($_GET['withtemplate'] ?? 0) . "
                   }
                );

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -361,7 +361,6 @@ JAVASCRIPT;
             const href_url_params = new URLSearchParams($(tablink).prop('href'));
             var url = tablink.attr('href');
             var target = tablink.attr('data-bs-target');
-            var index = tablink.closest('.nav-item').index();
 
             const updateCurrentTab = () => {
                 $.get(


### PR DESCRIPTION
Remove unneeded calls to `Toolbox::getAvailablesTabs()` as they may be costly in performances.

In the case of tickets, this function will trigger the following chain : `Ticket::defineAllTabs()` -> `Ticket::addDefaultFormTab()` -> `Ticket::getTimelineItems()` -> lot of SQL requests to load the timeline content.

This was really bad because `Toolbox::getAvailablesTabs()` was called 4 times when opening the ticket page and once on each tab change (any tab change, even to an already loaded one).
Going back and forth on some tabs and you may end up calling it 10+ times, triggering huge amount of requests.

After the changes, `Toolbox::getAvailablesTabs()` is only called twice :
* Once when opening the timeline tab (load timeline content)
* Once when loading the ticket page (load tabs name with count of timeline items)

For `ajax/updatecurrenttab.php`, we were computing the tab ID from all the possible tabs instead of sending its value directly from the client.

For `ajax/common.tabs.php`, it was a safety check to ensure the tab name is valid, which I think it can be safely removed as this data is sent by GLPI internal framework and can be trusted.
If needed we can always add a safety somewhere else (defaulting to another value is the session is incorrect).

I've tested the changes on different pages and we end up saving between 25% to 50% SQL requests on average.

Examples :

1\) Ticket with 11 followups:

Before:
![image](https://github.com/glpi-project/glpi/assets/42734840/e8d87ca0-243a-4185-ae49-f4f5f1057ac7)

After (-25%): 
![image](https://github.com/glpi-project/glpi/assets/42734840/aa7364ed-f6c2-49af-9144-75b8b04d6487)

2\) Computer main tab:

Before:
![image](https://github.com/glpi-project/glpi/assets/42734840/e2454670-1cc5-4b12-a788-e1d3a7d85ad7)

After (-40%):
![image](https://github.com/glpi-project/glpi/assets/42734840/1c9e364f-2ba0-4b22-ba80-0ec662540ec2)

I've got more changes coming in another pull request specifically targeting the ticket timeline tab which should hopefully reduce its requests count by another 50%.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29020
