### PR TITLE
Files integrity check

### DIFF
--- a/src/Console/Build/GenerateCodeBaselineCommand.php
+++ b/src/Console/Build/GenerateCodeBaselineCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Console\Build;
+
+use GLPI;
+use Glpi\System\Diagnostic\SourceCodeIntegrityChecker;
+use Glpi\Toolbox\VersionParser;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class GenerateCodeBaselineCommand extends Command
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $this->setName('build:generate_code_baseline');
+        $this->setDescription(__('Generate hashes of GLPI source code files and store them in the version file in the versions folder.'));
+        $this->addOption(
+            'algorithm',
+            'a',
+            InputOption::VALUE_OPTIONAL,
+            __('Hash algorithm to use. Defaults to CRC32c'),
+            'CRC32c'
+        );
+        $this->setHidden(GLPI_ENVIRONMENT_TYPE !== GLPI::ENV_DEVELOPMENT);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $algorithm = $input->getOption('algorithm');
+
+        try {
+            $this->generateManifest($algorithm, $output);
+        } catch (\Throwable $e) {
+            $output->writeln('<error>' . sprintf('Failed to generate manifest. Error was: %s', PHP_EOL . $e->getMessage()) . '</error>');
+            return 1;
+        }
+        return 0;
+    }
+
+    private function generateManifest(string $algorithm, OutputInterface $output): void
+    {
+        $manifest_output = GLPI_ROOT . '/version/' . VersionParser::getNormalizedVersion(GLPI_VERSION, false);
+        $checker = new SourceCodeIntegrityChecker();
+        $manifest = $checker->generateManifest($algorithm);
+        $manifest_json = json_encode($manifest, JSON_PRETTY_PRINT);
+        $manifest_length = strlen($manifest_json);
+        if (file_put_contents($manifest_output, $manifest_json) !== $manifest_length) {
+            throw new \RuntimeException(sprintf('Failed to write manifest to %s', $manifest_output));
+        }
+        $output->writeln(sprintf('Manifest of %d files generated', count($manifest['files'])));
+    }
+}

--- a/src/Console/Build/GenerateCodeManifestCommand.php
+++ b/src/Console/Build/GenerateCodeManifestCommand.php
@@ -67,7 +67,7 @@ class GenerateCodeManifestCommand extends Command
 
         try {
             $this->generateManifest($algorithm, $output);
-            $output->writeln(__('Manifest successfully generated'));
+            $output->writeln('<info>' . __('Manifest successfully generated.') . '</info>');
         } catch (\Throwable $e) {
             $output->writeln('<error>' . sprintf(__('Failed to generate manifest. Error was: %s'), $e->getMessage()) . '</error>');
             return 1;

--- a/src/Console/Build/GenerateCodeManifestCommand.php
+++ b/src/Console/Build/GenerateCodeManifestCommand.php
@@ -43,19 +43,19 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class GenerateCodeBaselineCommand extends Command
+class GenerateCodeManifestCommand extends Command
 {
     protected function configure()
     {
         parent::configure();
 
-        $this->setName('build:generate_code_baseline');
-        $this->setDescription(__('Generate hashes of GLPI source code files and store them in the version file in the versions folder.'));
+        $this->setName('build:generate_code_manifest');
+        $this->setDescription(__('Generate GLPI source code manifest that could be used to validate source code integrity.'));
         $this->addOption(
             'algorithm',
             'a',
             InputOption::VALUE_OPTIONAL,
-            __('Hash algorithm to use. Defaults to CRC32c'),
+            __('Hash algorithm to use'),
             'CRC32c'
         );
         $this->setHidden(GLPI_ENVIRONMENT_TYPE !== GLPI::ENV_DEVELOPMENT);
@@ -67,8 +67,9 @@ class GenerateCodeBaselineCommand extends Command
 
         try {
             $this->generateManifest($algorithm, $output);
+            $output->writeln(__('Manifest successfully generated'));
         } catch (\Throwable $e) {
-            $output->writeln('<error>' . sprintf('Failed to generate manifest. Error was: %s', PHP_EOL . $e->getMessage()) . '</error>');
+            $output->writeln('<error>' . sprintf(__('Failed to generate manifest. Error was: %s'), $e->getMessage()) . '</error>');
             return 1;
         }
         return 0;
@@ -84,6 +85,5 @@ class GenerateCodeBaselineCommand extends Command
         if (file_put_contents($manifest_output, $manifest_json) !== $manifest_length) {
             throw new \RuntimeException(sprintf('Failed to write manifest to %s', $manifest_output));
         }
-        $output->writeln(sprintf('Manifest of %d files generated', count($manifest['files'])));
     }
 }

--- a/src/Console/Diagnostic/CheckSourceCodeIntegrityCommand.php
+++ b/src/Console/Diagnostic/CheckSourceCodeIntegrityCommand.php
@@ -1,0 +1,166 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Console\Diagnostic;
+
+use Glpi\Console\AbstractCommand;
+use Glpi\System\Diagnostic\SourceCodeIntegrityChecker;
+use Glpi\Toolbox\VersionParser;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+class CheckSourceCodeIntegrityCommand extends AbstractCommand
+{
+    protected $requires_db = false;
+
+    protected function configure()
+    {
+        parent::configure();
+
+        $this->setName('diagnostic:check_source_code_integrity');
+        $this->setDescription(__('Check GLPI source code file integrity'));
+        $this->addOption(
+            'diff',
+            'd',
+            InputOption::VALUE_NONE,
+            __('Show diff of altered files.'),
+        );
+        $this->addOption(
+            'allow-download',
+            null,
+            InputOption::VALUE_NONE,
+            __('Allow downloading the GLPI release if needed'),
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $diff = $input->getOption('diff');
+        $checker = new SourceCodeIntegrityChecker();
+        $allow_download = $input->getOption('allow-download');
+
+        // create temporary output buffer to capture output
+        $output_buffer = fopen('php://memory', 'r+b');
+        $temp_output = new StreamOutput($output_buffer);
+        try {
+            $summary = $checker->getSummary();
+        } catch (\Exception $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+            return 1;
+        }
+        $all_ok = true;
+        if (count(array_filter($summary, static fn($status) => $status === SourceCodeIntegrityChecker::STATUS_ALTERED)) > 0) {
+            $all_ok = false;
+        }
+        if (count(array_filter($summary, static fn($status) => $status === SourceCodeIntegrityChecker::STATUS_MISSING)) > 0) {
+            $all_ok = false;
+        }
+        if (count(array_filter($summary, static fn($status) => $status === SourceCodeIntegrityChecker::STATUS_ADDED)) > 0) {
+            $all_ok = false;
+        }
+        if ($all_ok) {
+            $temp_output->writeln('<info>' . __('GLPI source code integrity is validated.') . '</info>');
+        } else {
+            $temp_output->writeln('<error>' . __('GLPI source code integrity is not validated.') . '</error>');
+            $table = new Table($temp_output);
+            $table->setHeaders(['File', 'Status']);
+            foreach ($summary as $file => $status) {
+                $status_label = match ($status) {
+                    SourceCodeIntegrityChecker::STATUS_ALTERED => 'Altered',
+                    SourceCodeIntegrityChecker::STATUS_MISSING => 'Missing',
+                    SourceCodeIntegrityChecker::STATUS_ADDED => 'Added',
+                };
+                $table->addRow([
+                    $file,
+                    $status_label
+                ]);
+            }
+            $table->render();
+        }
+        if (!$diff) {
+            // copy lines from the temporary output buffer to the real output
+            rewind($output_buffer);
+            while (!feof($output_buffer)) {
+                $output->write(fread($output_buffer, 4096));
+            }
+        } else {
+            $errors = [];
+            if (VersionParser::isDevVersion(GLPI_VERSION)) {
+                $output->writeln('<error>' . __('Cannot generate a diff on a development version.') . '</error>');
+            } else {
+                $diff = '';
+                // enumerate lines of the temporary output buffer and add them to the diff prefixed with a # to make them comments
+                rewind($output_buffer);
+                while (!feof($output_buffer)) {
+                    $diff .= '# ' . fgets($output_buffer);
+                }
+                $diff .= "\n" . $checker->getDiff($errors, $allow_download);
+                // Output with escaping so that style tags like <error> are shown as-is without being interpreted
+                $output->write(OutputFormatter::escape($diff));
+
+                if (count($errors) > 0) {
+                    $output->writeln('<error>' . __('Errors:') . '</error>');
+                    foreach ($errors as $error) {
+                        $output->writeln('<error>' . $error . '</error>');
+                    }
+                    return 1;
+                }
+            }
+        }
+        //cleanup temporary output buffer
+        fclose($output_buffer);
+        return 0;
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        // If --allow-download missing, ask if it is OK
+        if ($input->getOption('diff') && !$input->getOption('allow-download')) {
+            $helper = $this->getHelper('question');
+            $question = new ConfirmationQuestion(
+                __('Generating the source code diff could require downloading the GLPI release archive. Do you want to allow this operation?'),
+                false
+            );
+            if ($helper->ask($input, $output, $question)) {
+                $input->setOption('allow-download', true);
+            }
+        }
+    }
+}

--- a/src/System/Diagnostic/SourceCodeIntegrityChecker.php
+++ b/src/System/Diagnostic/SourceCodeIntegrityChecker.php
@@ -1,0 +1,243 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\System\Diagnostic;
+
+use FilesystemIterator;
+use Glpi\Toolbox\VersionParser;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SebastianBergmann\Diff\Differ;
+use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
+
+/**
+ * @since 10.1.0
+ */
+class SourceCodeIntegrityChecker
+{
+    public const STATUS_OK = 0;
+    public const STATUS_ALTERED = 1;
+    public const STATUS_MISSING = 2;
+    public const STATUS_ADDED = 3;
+
+    /**
+     * @note Only exists to be able to mock it in tests
+     */
+    public function getCheckRootDir(): string
+    {
+        return GLPI_ROOT;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPathsToCheck(): array
+    {
+        return [
+            'ajax', 'css', 'front', 'inc', 'install', 'js', 'lib', 'locales', 'pics',
+            'public', 'resources', 'sound', 'src', 'templates', 'vendor',
+            'api.php', 'apirest.md', 'apirest.php', 'caldav.php', 'index.php', 'status.php'
+        ];
+    }
+
+    /**
+     * @return array|null
+     * @phpstan-return array{algorithm: string, files: array<string, string>}|null
+     * @throws \JsonException
+     */
+    private function getBaselineManifest(): ?array
+    {
+        $version = VersionParser::getNormalizedVersion(GLPI_VERSION, false);
+        $manifest = file_get_contents($this->getCheckRootDir() . '/version/' . $version);
+        try {
+            $content = json_decode($manifest, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\Throwable $e) {
+            throw new \RuntimeException('The source code file manifest is invalid', previous: $e);
+        }
+        if (!isset($content['algorithm'], $content['files']) || !is_string($content['algorithm']) || !is_array($content['files'])) {
+            throw new \RuntimeException('The source code file manifest is invalid');
+        }
+        return $content;
+    }
+
+    /**
+     * @param string $algorithm
+     * @return array {algorithm: string, files: array<string, string>}
+     */
+    public function generateManifest(string $algorithm): array
+    {
+        $to_scan = $this->getPathsToCheck();
+
+        $files_to_check = [];
+        $hashes = [];
+        foreach ($to_scan as $item) {
+            $path = $this->getCheckRootDir() . '/' . $item;
+            if (is_dir($path)) {
+                $iterator = new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS);
+                // flatten the iterator
+                $iterator = new RecursiveIteratorIterator($iterator, RecursiveIteratorIterator::SELF_FIRST);
+                foreach ($iterator as $file) {
+                    if ($file->isFile()) {
+                        $files_to_check[] = $file->getPathname();
+                    }
+                }
+            } else {
+                $files_to_check[] = $path;
+            }
+        }
+        sort($files_to_check);
+        foreach ($files_to_check as $file) {
+            $key = preg_replace('/^' . preg_quote($this->getCheckRootDir() . '/', '/') . '/', '', $file);
+            $hashes[$key] = hash_file($algorithm, $file);
+        }
+        return [
+            'algorithm' => $algorithm,
+            'files' => $hashes
+        ];
+    }
+
+    public function getSummary(): array
+    {
+        $baseline = $this->getBaselineManifest();
+        $current = $this->generateManifest($baseline['algorithm']);
+
+        // Get files missing from the current manifest
+        $missing = array_diff_key($baseline['files'], $current['files']);
+        // Get files added to the current manifest
+        $added = array_diff_key($current['files'], $baseline['files']);
+        // Get files altered
+        $altered = [];
+        foreach ($baseline['files'] as $file => $hash) {
+            if (isset($current['files'][$file]) && $current['files'][$file] !== $hash) {
+                $altered[$file] = $current['files'][$file];
+            }
+        }
+        // Summary where the key is the file and the value is the status. Ignore OK files
+        $summary = [];
+        foreach ($altered as $file => $hash) {
+            $summary[$file] = self::STATUS_ALTERED;
+        }
+        foreach ($added as $file => $hash) {
+            $summary[$file] = self::STATUS_ADDED;
+        }
+        foreach ($missing as $file => $hash) {
+            $summary[$file] = self::STATUS_MISSING;
+        }
+
+        return $summary;
+    }
+
+    private function getGLPIRelease(&$errors = []): string|null
+    {
+        $version_to_get = VersionParser::getNormalizedVersion(GLPI_VERSION);
+        $gh_releases_endpoint = 'https://api.github.com/repos/glpi-project/glpi/releases/tags/' . $version_to_get;
+        $client = new Client();
+        $dest = null;
+        try {
+            $response = $client->request('GET', $gh_releases_endpoint);
+            $release = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+            foreach ($release['assets'] as $asset) {
+                if (str_starts_with($asset['name'], 'glpi-' . $version_to_get)) {
+                    $dest = GLPI_TMP_DIR . '/' . $asset['name'];
+                    // Check if the file already exists in the tmp dir
+                    if (file_exists($dest)) {
+                        break;
+                    }
+                    $url = $asset['browser_download_url'];
+                    $client->request('GET', $url, ['sink' => $dest]);
+                    break;
+                }
+            }
+        } catch (GuzzleException $e) {
+            $errors[] = $e->getMessage();
+        }
+        return $dest;
+    }
+
+    public function getDiff(array &$errors = [], bool $allow_download = false): string
+    {
+        $summary = $this->getSummary();
+        // ignore OK files in case they are present
+        $summary = array_filter($summary, static fn ($status) => $status !== self::STATUS_OK);
+        // Ensure the release is downloaded
+        $release_path = GLPI_TMP_DIR . '/glpi-' . VersionParser::getNormalizedVersion(GLPI_VERSION) . '.tgz';
+        if (!file_exists($release_path)) {
+            if ($allow_download) {
+                $release_path = $this->getGLPIRelease($errors);
+                if ($release_path === null) {
+                    $errors[] = 'An error occurred while downloading the release';
+                    return '';
+                }
+            } else {
+                $errors[] = 'The release is not downloaded and downloading it was not allowed';
+                return '';
+            }
+        }
+
+        $diff = '';
+
+        foreach ($summary as $file => $status) {
+            // print diff --git line for the file
+            $diff .= 'diff --git a/' . $file . ' b/' . $file . "\n";
+            $original_file = 'a/' . $file;
+            $current_file = 'b/' . $file;
+            $original_content = '';
+            $current_content = '';
+            if ($status === self::STATUS_ADDED || !file_exists('phar://' . $release_path . '/glpi/' . $file)) {
+                $original_file = '/dev/null';
+            } else {
+                $original_content = file_get_contents('phar://' . $release_path . '/glpi/' . $file);
+            }
+            if ($status === self::STATUS_MISSING || !file_exists($this->getCheckRootDir() . '/' . $file)) {
+                $current_file = '/dev/null';
+            } else {
+                $current_content = file_get_contents($this->getCheckRootDir() . '/' . $file);
+            }
+            try {
+                $differ = new Differ(new UnifiedDiffOutputBuilder("--- $original_file\n+++ $current_file\n", true));
+                $diff .= $differ->diff(
+                    $original_content,
+                    $current_content
+                );
+                $diff .= "\n";
+            } catch (\Exception $e) {
+                $errors[] = $e->getMessage();
+            }
+        }
+        return $diff;
+    }
+}

--- a/tests/functional/Glpi/System/Diagnostic/SourceCodeIntegrityChecker.php
+++ b/tests/functional/Glpi/System/Diagnostic/SourceCodeIntegrityChecker.php
@@ -66,6 +66,7 @@ class SourceCodeIntegrityChecker extends \GLPITestCase
 line1
 line2
 line3
+
 EOL,
             ],
             'templates' => [],
@@ -104,7 +105,7 @@ EOL,
                 'caldav.php' => '71938259',
                 'index.php' => '4475f8b1',
                 'src/test.php' => '53fe1f55',
-                'src/test2.php' => 'c779eae1',
+                'src/test2.php' => '2803299a',
                 'status.php' => '82d603ce',
             ]
         ]);
@@ -121,12 +122,14 @@ EOL,
 
         file_put_contents(vfsStream::url('check_root_dir/src/test.php'), 'changed');
         file_put_contents(vfsStream::url('check_root_dir/src/test3.php'), 'added');
+        file_put_contents(vfsStream::url('check_root_dir/src/test4.php'), 'added (with EOL)' . "\n");
         unlink(vfsStream::url('check_root_dir/src/test2.php'));
 
         $this->array($checker->getSummary())->isEqualTo([
             'src/test.php' => 1, // 1 = STATUS_ALTERED
             'src/test2.php' => 2, // 2 = STATUS_MISSING
             'src/test3.php' => 3, // 3 = STATUS_ADDED
+            'src/test4.php' => 3, // 3 = STATUS_ADDED
         ]);
     }
 
@@ -164,9 +167,11 @@ EOL,
 line1
 lineb
 line3
+
 EOL
         );
         file_put_contents(vfsStream::url('check_root_dir/src/test3.php'), 'added');
+        file_put_contents(vfsStream::url('check_root_dir/src/test4.php'), 'added (with EOL)' . "\n");
 
         $errors = [];
         $diff = $checker->getDiff(false, $errors);
@@ -183,16 +188,27 @@ diff --git a/src/test2.php b/src/test2.php
  line3
 
 diff --git a/src/test3.php b/src/test3.php
+new file mode 100666
 --- /dev/null
 +++ b/src/test3.php
 @@ -1,0 +1 @@
 +added
+\ No newline at end of file
+
+diff --git a/src/test4.php b/src/test4.php
+new file mode 100666
+--- /dev/null
++++ b/src/test4.php
+@@ -1,0 +1 @@
++added (with EOL)
 
 diff --git a/src/test.php b/src/test.php
+deleted file mode 100644
 --- a/src/test.php
 +++ /dev/null
 @@ -1 +1,0 @@
 -test1
+\ No newline at end of file
 EOL
         );
     }

--- a/tests/functional/Glpi/System/Diagnostic/SourceCodeIntegrityChecker.php
+++ b/tests/functional/Glpi/System/Diagnostic/SourceCodeIntegrityChecker.php
@@ -1,0 +1,199 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\System\Diagnostic;
+
+use Glpi\Toolbox\VersionParser;
+use org\bovigo\vfs\vfsStream;
+use wapmorgan\UnifiedArchive\UnifiedArchive;
+
+class SourceCodeIntegrityChecker extends \GLPITestCase
+{
+    private function setupVFS()
+    {
+        $version = VersionParser::getNormalizedVersion(GLPI_VERSION, false);
+        vfsStream::setup('check_root_dir', null, [
+            'ajax' => [],
+            'css' => [],
+            'front' => [],
+            'files' => [
+                '_tmp' => []
+            ],
+            'inc' => [],
+            'install' => [],
+            'js' => [],
+            'lib' => [],
+            'locales' => [],
+            'pics' => [],
+            'public' => [],
+            'resources' => [],
+            'sound' => [],
+            'src' => [
+                'test.php' => 'test1',
+                'test2.php' => <<<EOL
+line1
+line2
+line3
+EOL,
+            ],
+            'templates' => [],
+            'vendor' => [],
+            'version' => [
+                $version => ''
+            ],
+            'api.php' => 'api',
+            'apirest.md' => 'apirest',
+            'apirest.php' => 'apirest',
+            'caldav.php' => 'caldav',
+            'index.php' => 'index',
+            'status.php' => 'status',
+        ]);
+    }
+
+    public function beforeTestMethod($method)
+    {
+        parent::beforeTestMethod($method);
+        $this->setupVFS();
+    }
+
+    public function testGenerateManifest()
+    {
+        /** @var \Glpi\System\Diagnostic\SourceCodeIntegrityChecker $checker */
+        $checker = new \mock\Glpi\System\Diagnostic\SourceCodeIntegrityChecker();
+        $this->calling($checker)->getCheckRootDir = static fn() => vfsStream::url('check_root_dir');
+        $this->string($checker->getCheckRootDir())->isEqualTo(vfsStream::url('check_root_dir'));
+        $manifest = $checker->generateManifest('CRC32c');
+        $this->array($manifest)->isEqualTo([
+            'algorithm' => 'CRC32c',
+            'files' => [
+                'api.php' => '4529d6e0',
+                'apirest.md' => '04202f8b',
+                'apirest.php' => '04202f8b',
+                'caldav.php' => '71938259',
+                'index.php' => '4475f8b1',
+                'src/test.php' => '53fe1f55',
+                'src/test2.php' => 'c779eae1',
+                'status.php' => '82d603ce',
+            ]
+        ]);
+    }
+
+    public function testGetSummary()
+    {
+        $version = VersionParser::getNormalizedVersion(GLPI_VERSION, false);
+        /** @var \Glpi\System\Diagnostic\SourceCodeIntegrityChecker $checker */
+        $checker = new \mock\Glpi\System\Diagnostic\SourceCodeIntegrityChecker();
+        $this->calling($checker)->getCheckRootDir = static fn() => vfsStream::url('check_root_dir');
+        $this->string($checker->getCheckRootDir())->isEqualTo(vfsStream::url('check_root_dir'));
+        file_put_contents(vfsStream::url('check_root_dir/version/' . $version), json_encode($checker->generateManifest('CRC32c'), JSON_THROW_ON_ERROR));
+
+        file_put_contents(vfsStream::url('check_root_dir/src/test.php'), 'changed');
+        file_put_contents(vfsStream::url('check_root_dir/src/test3.php'), 'added');
+        unlink(vfsStream::url('check_root_dir/src/test2.php'));
+
+        $this->array($checker->getSummary())->isEqualTo([
+            'src/test.php' => 1, // 1 = STATUS_ALTERED
+            'src/test2.php' => 2, // 2 = STATUS_MISSING
+            'src/test3.php' => 3, // 3 = STATUS_ADDED
+        ]);
+    }
+
+    public function testGetDiff()
+    {
+        $version = VersionParser::getNormalizedVersion(GLPI_VERSION, false);
+        $version_full = VersionParser::getNormalizedVersion(GLPI_VERSION);
+        /** @var \Glpi\System\Diagnostic\SourceCodeIntegrityChecker $checker */
+        $checker = new \mock\Glpi\System\Diagnostic\SourceCodeIntegrityChecker();
+        $this->calling($checker)->getCheckRootDir = static fn() => vfsStream::url('check_root_dir');
+        $this->string($checker->getCheckRootDir())->isEqualTo(vfsStream::url('check_root_dir'));
+        file_put_contents(vfsStream::url('check_root_dir/version/' . $version), json_encode($checker->generateManifest('CRC32c'), JSON_THROW_ON_ERROR));
+
+        // Create tgz file from the vfs directory and save it to files/_tmp/ in the vfs.
+        // No, it cannot be created from a stream or saved directly to a stream.
+        if (file_exists(GLPI_TMP_DIR . '/glpi-' . $version_full . '.tar.gz')) {
+            unlink(GLPI_TMP_DIR . '/glpi-' . $version_full . '.tar.gz');
+        }
+        $phar = new \PharData(GLPI_TMP_DIR . '/glpi-' . $version_full . '.tgz');
+        // recursively iterate through the files in the vfs and manually add to phar using addFromString
+        $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator(vfsStream::url('check_root_dir')));
+        $path_pattern = '/^' . preg_quote(vfsStream::url('check_root_dir') . '/', '/') . '/';
+        foreach ($iterator as $file) {
+            if ($file->isDir() || str_ends_with($file->getPathname(), '.tgz')) {
+                continue;
+            }
+            $path = preg_replace($path_pattern, '', $file->getPathname());
+            $phar->addFromString('glpi/' . $path, file_get_contents($file->getPathname()));
+        }
+        $phar->compress(\Phar::GZ);
+        $this->boolean(rename(GLPI_TMP_DIR . '/glpi-' . $version_full . '.tar.gz', GLPI_TMP_DIR . '/glpi-' . $version_full . '.tgz'))->isTrue();
+
+        unlink(vfsStream::url('check_root_dir/src/test.php'));
+        file_put_contents(vfsStream::url('check_root_dir/src/test2.php'), <<<EOL
+line1
+lineb
+line3
+EOL
+        );
+        file_put_contents(vfsStream::url('check_root_dir/src/test3.php'), 'added');
+
+        $errors = [];
+        $diff = $checker->getDiff($errors, false);
+        // Why not isEmpty? Because then atoum will not tell you what the contents are when this fails.
+        $this->array($errors)->isEqualTo([]);
+        $this->string(trim($diff))->isEqualTo(<<<EOL
+diff --git a/src/test2.php b/src/test2.php
+--- a/src/test2.php
++++ b/src/test2.php
+@@ -1,3 +1,3 @@
+ line1
+-line2
++lineb
+ line3
+
+diff --git a/src/test3.php b/src/test3.php
+--- /dev/null
++++ b/src/test3.php
+@@ -1,0 +1 @@
++added
+
+diff --git a/src/test.php b/src/test.php
+--- a/src/test.php
++++ /dev/null
+@@ -1 +1,0 @@
+-test1
+EOL
+        );
+    }
+}

--- a/tests/functional/Glpi/System/Diagnostic/SourceCodeIntegrityChecker.php
+++ b/tests/functional/Glpi/System/Diagnostic/SourceCodeIntegrityChecker.php
@@ -169,7 +169,7 @@ EOL
         file_put_contents(vfsStream::url('check_root_dir/src/test3.php'), 'added');
 
         $errors = [];
-        $diff = $checker->getDiff($errors, false);
+        $diff = $checker->getDiff(false, $errors);
         // Why not isEmpty? Because then atoum will not tell you what the contents are when this fails.
         $this->array($errors)->isEqualTo([]);
         $this->string(trim($diff))->isEqualTo(<<<EOL

--- a/tools/build_glpi.sh
+++ b/tools/build_glpi.sh
@@ -93,4 +93,4 @@ do
 done
 
 echo "Generating file manifest..."
-$WORKING_DIR/bin/console build:generate_code_baseline -a crc32c
+$WORKING_DIR/bin/console build:generate_code_manifest -a crc32c

--- a/tools/build_glpi.sh
+++ b/tools/build_glpi.sh
@@ -91,3 +91,6 @@ for node in "${dev_nodes[@]}"
 do
     rm -rf $WORKING_DIR/$node
 done
+
+echo "Generating file manifest..."
+$WORKING_DIR/bin/console build:generate_code_baseline -a crc32c


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

- `bin/console diagnostic:source_code_integrity --baseline` - (Re-)Generate the baseline file manifest in the `version/X.Y.Z` file based on the current files. This is what is used when building the release archive.
- `bin/console diagnostic:source_code_integrity` - Display a summary of differences between the baseline file manifest and the current files. This is just a table of relative paths and the status (missing, added, or altered). Specific differences are not displayed.
-  `bin/console diagnostic:source_code_integrity --diff` - Outputs a diff of changes between the release archive and the current files. Does not work with development versions. The summary is added to the start of the diff as a comment.

When generating the baseline, you can use the `-a`/`--algorithm` option to specify the hashing function. Could be used to change the algorithm in the future if needed.