### PR TITLE
Fix reminder documents entity

### DIFF
--- a/templates/components/form/header.html.twig
+++ b/templates/components/form/header.html.twig
@@ -61,7 +61,9 @@
 
 {% if open_form and item.canEdit(item.fields['id']) %}
 <form name="asset_form" method="post" action="{{ target }}" {{ formoptions|raw }} enctype="multipart/form-data" data-submit-once>
-   <input type="hidden" name="entities_id" value="{{ entity_id }}" />
+   {% if item.isField("entities_id") %}
+       <input type="hidden" name="entities_id" value="{{ entity_id }}" />
+   {% endif %}
    {% if _request['_in_modal'] is defined and _request['_in_modal'] == "1" %}
       <input type="hidden" name="_in_modal" value="1"/>
    {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15001

In GLPI 9.5, the `entities_id` field was only present in form header when the corresponding item has this field in its database table. This PR reproduces this behaviour.

Problem here is that the `0` value was passed due to https://github.com/glpi-project/glpi/blob/afbf1f6b93d9b7006a593c53480a33e5c7fe392a/templates/components/form/header.html.twig#L41-L53 and then used by document attachement logic due to `else if (isset($input['entities_id']))` case in https://github.com/glpi-project/glpi/blob/afbf1f6b93d9b7006a593c53480a33e5c7fe392a/src/CommonDBTM.php#L5484-L5491. With proposed change, the default `$entities_id = isset($_SESSION['glpiactive_entity']) ? $_SESSION['glpiactive_entity'] : 0;` case will be used, so the document will be attached to active entity when the related item has no `entities_id` field.

Recursivity assignment will be fixed by #15287.