### PR TITLE
Allow massive update of contracts `periodicity`, `billing` and `renewal`

### DIFF
--- a/src/Contract.php
+++ b/src/Contract.php
@@ -598,7 +598,6 @@ class Contract extends CommonDBTM
             'table'              => $this->getTable(),
             'field'              => 'periodicity',
             'name'               => __('Periodicity'),
-            'massiveaction'      => false,
             'datatype'           => 'number',
             'min'                => 12,
             'max'                => 60,
@@ -618,7 +617,6 @@ class Contract extends CommonDBTM
             'table'              => $this->getTable(),
             'field'              => 'billing',
             'name'               => __('Invoice period'),
-            'massiveaction'      => false,
             'datatype'           => 'number',
             'min'                => 12,
             'max'                => 60,
@@ -646,7 +644,6 @@ class Contract extends CommonDBTM
             'table'              => $this->getTable(),
             'field'              => 'renewal',
             'name'               => __('Renewal'),
-            'massiveaction'      => false,
             'datatype'           => 'specific',
             'searchtype'         => ['equals', 'notequals']
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15260

I do not see any reason that explains why these fields cannot be update by massive actions.