### PR TITLE
Fix images URLs when document root has change

### DIFF
--- a/tests/units/Glpi/RichText/RichText.php
+++ b/tests/units/Glpi/RichText/RichText.php
@@ -339,6 +339,34 @@ HTML,
             'encode_output_entities' => false,
             'expected_result'        => '<table width="0" align="left" cellspacing="10" style="width: 100%;"><tr><td>Test</td></tr></table>',
         ];
+
+        // Images path should be corrected when root doc changed
+        // see #15113
+        foreach (['', '/glpi', '/path/to/glpi'] as $expected_prefix) {
+            global $CFG_GLPI;
+            $CFG_GLPI['root_doc'] = $expected_prefix;
+            foreach (['/previous/glpi/path', '', '/glpi'] as $previous_prefix) {
+                yield [
+                    'content'                => <<<HTML
+    <p>
+      Images path should be corrected when root doc changed:
+      <a href="{$previous_prefix}/front/document.send.php?docid=180&amp;itemtype=Ticket&amp;items_id=515" target="_blank">
+        <img src="{$previous_prefix}/front/document.send.php?docid=180&amp;itemtype=Ticket&amp;items_id=515" alt="34c09468-b2d8e96f-64f991f5ce1660.58639912" width="248">
+      </a>
+    </p>
+    HTML,
+                    'encode_output_entities' => false,
+                    'expected_result'        => <<<HTML
+    <p>
+      Images path should be corrected when root doc changed:
+      <a href="{$expected_prefix}/front/document.send.php?docid=180&amp;itemtype=Ticket&amp;items_id=515" target="_blank">
+        <img src="{$expected_prefix}/front/document.send.php?docid=180&amp;itemtype=Ticket&amp;items_id=515" alt="34c09468-b2d8e96f-64f991f5ce1660.58639912" width="248" />
+      </a>
+    </p>
+    HTML,
+                ];
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15113

When GLPI document root is changed, all images URLs stored in rich text content are broken. We could probably use the change of `base_url` config as a trigger to update rich text contents, but it would probably result in a too long update procedure on large databases, so would not be a good idea.

I propose to fix paths on rich text rendering.