### PR TITLE
Use DOMDocument when parsing user mentions

### DIFF
--- a/src/RichText/UserMention.php
+++ b/src/RichText/UserMention.php
@@ -41,10 +41,10 @@ use CommonITILObject;
 use CommonITILTask;
 use CommonITILValidation;
 use Glpi\Toolbox\Sanitizer;
+use DOMDocument;
 use ITILFollowup;
 use ITILSolution;
 use NotificationEvent;
-use SimpleXMLElement;
 use User;
 
 final class UserMention
@@ -190,8 +190,10 @@ final class UserMention
 
         try {
             $content = Sanitizer::getVerbatimValue($content);
+            $dom = new DOMDocument();
+            $dom->loadHTML($content);
             libxml_use_internal_errors(true);
-            $content_as_xml = new SimpleXMLElement('<div>' . $content . '</div>');
+            $content_as_xml = simplexml_import_dom($dom);
         } catch (\Throwable $e) {
            // Sanitize process does not handle correctly `<` and `>` chars that are not surrounding html tags.
            // This generates invalid HTML that cannot be loaded by `SimpleXMLElement`.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Ref: https://forum.glpi-project.org/viewtopic.php?pid=503789

The SimpleXMLElement class expects valid XML when constructed, but rich text content is HTML which could contain self-closing HTML tags like `<br>` which is not valid XML. This causes GLPI to fail to find user mentions in some cases. We need to load the content as a DOMDocument first and then use `simplexml_import_dom` to create a valid `SimpleXMLElement` instance.