### PR TITLE
Fix escalation levels computation

### DIFF
--- a/src/CalendarSegment.php
+++ b/src/CalendarSegment.php
@@ -191,41 +191,95 @@ class CalendarSegment extends CommonDBChild
      * @param integer $day             day number
      * @param string  $begin_time      begin time
      * @param integer $delay           timestamp delay to add
+     * @param bool    $negative_delay  are we adding or removing time ?
      *
      * @return string|false Ending timestamp (HH:mm:dd) of delay or false if not applicable.
      **/
-    public static function addDelayInDay($calendars_id, $day, $begin_time, $delay)
-    {
+    public static function addDelayInDay(
+        $calendars_id,
+        $day,
+        $begin_time,
+        $delay,
+        bool $negative_delay = false
+    ) {
+        // TODO: unit test this method with complex calendars using multiple
+        // disconnected segments per day
         global $DB;
 
-       // Do not check hour if day before the end day of after the begin day
-        $iterator = $DB->request([
-            'SELECT' => [
-                new \QueryExpression(
-                    "GREATEST(" . $DB->quoteName('begin') . ", " . $DB->quoteValue($begin_time)  . ") AS " . $DB->quoteName('BEGIN')
+        // Common SELECT for both modes
+        $SELECT = [
+            new \QueryExpression(
+                sprintf(
+                    "TIMEDIFF(
+                        %s,
+                        GREATEST(%s, %s)
+                    ) AS %s",
+                    $DB->quoteName('end'),
+                    $DB->quoteName('begin'),
+                    $DB->quoteValue($begin_time),
+                    $DB->quoteName('TDIFF')
                 ),
-                new \QueryExpression(
-                    "TIMEDIFF(" . $DB->quoteName('end') . ", GREATEST(" . $DB->quoteName('begin') . ", " . $DB->quoteValue($begin_time) . ")) AS " . $DB->quoteName('TDIFF')
+            )
+        ];
+
+        // Common WHERE for both modes
+        $WHERE = [
+            'calendars_id' => $calendars_id,
+            'day'          => $day,
+        ];
+
+        // Add specific SELECT and WHERE clauses
+        if (!$negative_delay) {
+            $SELECT[] = new \QueryExpression(
+                sprintf("GREATEST(%s, %s) AS %s", ...[
+                    $DB->quoteName('begin'),
+                    $DB->quoteValue($begin_time),
+                    $DB->quoteName('BEGIN'),
+                ])
+            );
+            $WHERE['end'] = ['>', $begin_time];
+        } else {
+            // When counting back time, "00:00:00" can't be used for some comparison
+            // as it is supposed to represent the end of the day
+            // (e.g. finding calendar segments that start before 00:00:00 would always
+            // return no results but using 23:59:59 get us the correct behavior).
+            $adjusted_time_for_comparaison_in_negative_delay_mode = $begin_time == "00:00:00" ? "23:59:59" : $begin_time;
+
+            $SELECT[] = new \QueryExpression(
+                sprintf(
+                    "LEAST(%s, %s) AS %s",
+                    $DB->quoteName('end'),
+                    $DB->quoteValue($adjusted_time_for_comparaison_in_negative_delay_mode),
+                    $DB->quoteName('END'),
                 )
-            ],
-            'FROM'   => 'glpi_calendarsegments',
-            'WHERE'  => [
-                'calendars_id' => $calendars_id,
-                'day'          => $day,
-                'end'          => ['>', $begin_time]
-            ],
-            'ORDER'  => 'begin'
+            );
+            $WHERE['begin'] = ['<', $adjusted_time_for_comparaison_in_negative_delay_mode];
+        }
+
+        $iterator = $DB->request([
+            'SELECT' => $SELECT,
+            'FROM'   => self::getTable(),
+            'WHERE'  => $WHERE,
+            'ORDER'  => !$negative_delay ? 'begin' : 'end DESC'
         ]);
 
         foreach ($iterator as $data) {
             list($hour, $minute, $second) = explode(':', $data['TDIFF']);
             $tstamp = $hour * HOUR_TIMESTAMP + $minute * MINUTE_TIMESTAMP + $second;
 
-           // Delay is completed
+            // Delay is completed
             if ($delay <= $tstamp) {
-                list($begin_hour, $begin_minute, $begin_second) = explode(':', $data['BEGIN']);
-                $beginstamp = $begin_hour * HOUR_TIMESTAMP + $begin_minute * MINUTE_TIMESTAMP + $begin_second;
-                $endstamp   = $beginstamp + $delay;
+                if (!$negative_delay) {
+                    // Add time
+                    list($begin_hour, $begin_minute, $begin_second) = explode(':', $data['BEGIN']);
+                    $beginstamp = $begin_hour * HOUR_TIMESTAMP + $begin_minute * MINUTE_TIMESTAMP + $begin_second;
+                    $endstamp = $beginstamp + $delay;
+                } else {
+                    // Substract time
+                    list($begin_hour, $begin_minute, $begin_second) = explode(':', $data['END']);
+                    $beginstamp = $begin_hour * HOUR_TIMESTAMP + $begin_minute * MINUTE_TIMESTAMP + $begin_second;
+                    $endstamp = $beginstamp - $delay;
+                }
                 $units      = Toolbox::getTimestampTimeUnits($endstamp);
                 return str_pad($units['hour'], 2, '0', STR_PAD_LEFT) . ':' .
                      str_pad($units['minute'], 2, '0', STR_PAD_LEFT) . ':' .

--- a/src/LevelAgreement.php
+++ b/src/LevelAgreement.php
@@ -903,7 +903,7 @@ abstract class LevelAgreement extends CommonDBChild
                                 $this->fields['end_of_working_day']
                             );
 
-                            // Take waiting duration time which give us the final date
+                            // Take waiting duration time into account
                             $date_with_waiting_time = $cal->computeEndDate(
                                 $date_with_sla,
                                 $additional_delay,

--- a/src/LevelAgreementLevel.php
+++ b/src/LevelAgreementLevel.php
@@ -407,4 +407,16 @@ abstract class LevelAgreementLevel extends RuleTicket
         }
         return true;
     }
+
+    /**
+     * Should calculation on this LA Level target date be done using
+     * the "work_in_day" parameter set to true ?
+     *
+     * @return bool
+     */
+    public function shouldUseWorkInDayMode(): bool
+    {
+        // No definition time here so we must guess the unit from the raw seconds value
+        return abs($this->fields['execution_time']) >= DAY_TIMESTAMP;
+    }
 }

--- a/tests/functional/CommonITILRecurrent.php
+++ b/tests/functional/CommonITILRecurrent.php
@@ -44,7 +44,7 @@ abstract class CommonITILRecurrent extends DbTestCase
     abstract protected function getChildClass();
 
     /**
-     * Data provider for self::testConvertTagToImage().
+     * Data provider for self::testComputeNextCreationDate().
      */
     protected function computeNextCreationDateProvider()
     {

--- a/tests/functional/SLM.php
+++ b/tests/functional/SLM.php
@@ -35,8 +35,10 @@
 
 namespace tests\units;
 
+use CommonITILObject;
 use DbTestCase;
 use OlaLevel_Ticket;
+use Rule;
 use SlaLevel_Ticket;
 
 class SLM extends DbTestCase
@@ -935,6 +937,16 @@ class SLM extends DbTestCase
 
     protected function laProvider(): iterable
     {
+        // WARNING: dates must be in the future or escalation levels will be
+        // computed immediately and removed from the database (and thus wont be able
+        // to be tested properly)
+
+        // Note: while it is possible to add multiple escalation levels,
+        // only one at a time is set in the database so we can only
+        // really test one level here
+        // With that in mind, escalation_time and escalation_target_date will be
+        // individual parameters instead of an array that could support multiple levels
+
         foreach ([\OLA::class, \SLA::class] as $la_class) {
             foreach ([\SLM::TTO, \SLM::TTR] as $la_type) {
                 // 30 minutes LA without pauses
@@ -945,13 +957,16 @@ class SLM extends DbTestCase
                         'number_time'     => 30,
                         'definition_time' => 'minute',
                     ],
-                    'begin_date'        => '2023-06-09 08:46:12',
-                    'pauses'            => [],
-                    'target_date'       => '2023-06-09 09:16:12',
-                    'waiting_duration'  => 0,
+                    'begin_date'             => '2034-06-09 08:46:12',
+                    'pauses'                 => [],
+                    'target_date'            => '2034-06-09 09:16:12',
+                    'waiting_duration'       => 0,
+                    // Negative 10 minutes escalation level
+                    'escalation_time'        => - 10 * MINUTE_TIMESTAMP,
+                    'target_escalation_date' => '2034-06-09 09:06:12',
                 ];
 
-                // 30 hours LA with many pauses within the same day
+                // 30 minutes LA with many pauses within the same day
                 yield [
                     'la_class'          => $la_class,
                     'la_params'         => [
@@ -959,33 +974,39 @@ class SLM extends DbTestCase
                         'number_time'     => 30,
                         'definition_time' => 'minute',
                     ],
-                    'begin_date'        => '2023-06-09 08:46:12',
+                    'begin_date'        => '2034-06-09 08:46:12',
                     'pauses'            => [
                         [
                             // pause: 1 h 18 m 12 s (4692 s)
-                            'from' => '2023-06-09 08:47:42',
-                            'to'   => '2023-06-09 10:05:54',
+                            'from' => '2034-06-09 08:47:42',
+                            'to'   => '2034-06-09 10:05:54',
                         ],
                         [
                             // pause: 25 m 25 s (1525 s)
-                            'from' => '2023-06-09 10:09:13',
-                            'to'   => '2023-06-09 10:34:38',
+                            'from' => '2034-06-09 10:09:13',
+                            'to'   => '2034-06-09 10:34:38',
                         ],
                         [
                             // pause: 45 m 36 s (2736 s)
-                            'from' => '2023-06-09 10:43:41',
-                            'to'   => '2023-06-09 11:29:17',
+                            'from' => '2034-06-09 10:43:41',
+                            'to'   => '2034-06-09 11:29:17',
                         ],
                     ],
                     'target_date'       => $la_type == \SLM::TTR
-                        // 2023-06-09 08:46:12 + 30 m (LA time) + 2 h 29 m 13 s (waiting time)
-                        ? '2023-06-09 11:45:25'
+                        // 2034-06-09 08:46:12 + 30 m (LA time) + 2 h 29 m 13 s (waiting time)
+                        ? '2034-06-09 11:45:25'
                         // TTO does is not impacted by waiting times
-                        : '2023-06-09 09:16:12'
+                        : '2034-06-09 09:16:12'
                     ,
                     'waiting_duration'  => $la_type == \SLM::TTR
                         ? 8953 // 4692 + 1525 + 2736
                         : 0,
+                    // Negative 5 minutes escalation level
+                    'escalation_time'        => - 5 * MINUTE_TIMESTAMP,
+                    'target_escalation_date' => $la_type == \SLM::TTR
+                        // 5 minutes before each target date
+                        ? '2034-06-09 11:40:25'
+                        : '2034-06-09 09:11:12'
                 ];
 
                 // 4 hours LA without pauses
@@ -996,10 +1017,13 @@ class SLM extends DbTestCase
                         'number_time'     => 4,
                         'definition_time' => 'hour',
                     ],
-                    'begin_date'        => '2023-06-09 08:46:12',
+                    'begin_date'        => '2034-06-09 08:46:12',
                     'pauses'            => [],
-                    'target_date'       => '2023-06-09 12:46:12',
+                    'target_date'       => '2034-06-09 12:46:12',
                     'waiting_duration'  => 0,
+                    // Positive 1 hour escalation level
+                    'escalation_time'   => HOUR_TIMESTAMP,
+                    'target_escalation_date' => '2034-06-09 13:46:12',
                 ];
 
                 // 4 hours LA with a pause within the same day
@@ -1010,21 +1034,40 @@ class SLM extends DbTestCase
                         'number_time'     => 4,
                         'definition_time' => 'hour',
                     ],
-                    'begin_date'        => '2023-06-09 08:46:12',
+                    'begin_date'        => '2034-06-09 08:46:12',
                     'pauses'            => [
                         [
                             // pause: 2 h 8 m 22 s (7702 s)
-                            'from' => '2023-06-09 09:15:27',
-                            'to'   => '2023-06-09 11:23:49',
+                            'from' => '2034-06-09 09:15:27',
+                            'to'   => '2034-06-09 11:23:49',
                         ],
                     ],
                     'target_date'       => $la_type == \SLM::TTR
-                        // 2023-06-09 08:46:12 + 4 h (LA time) + 2h 8 m 22 s (waiting time)
-                        ? '2023-06-09 14:54:34'
+                        // 2034-06-09 08:46:12 + 4 h (LA time) + 2h 8 m 22 s (waiting time)
+                        ? '2034-06-09 14:54:34'
                         // TTO does is not impacted by waiting times
-                        : '2023-06-09 12:46:12'
+                        : '2034-06-09 12:46:12'
                     ,
                     'waiting_duration'  => $la_type == \SLM::TTR ? 7702 : 0,
+                    // Positive 10 hour escalation level
+                    'escalation_time'   => 10 * HOUR_TIMESTAMP,
+                    'target_escalation_date' => $la_type == \SLM::TTR
+                        // Start on 2034-06-09 14:54:34 (target TTR date) - 10 hours to add
+                        // 4h06 to reach end of day (19h)
+                        // There is still 5h54 remaining hours to add
+                        // 2034-06-10 is outside our calendar (saturday)
+                        // 2034-06-11 is outside our calendar (sunday)
+                        // Start again on 2034-06-12 on 10h30 (monday)
+                        // Add the remaining 5h54 hours -> 16h24
+                        ? '2034-06-12 16:24:34'
+                        // Start on 2034-06-09 12:46:12 (target TTO date) - 10 hours to add
+                        // 6h14 to reach end of day (19h)
+                        // There is still 3h46 remaining hours to add
+                        // 2034-06-10 is outside our calendar (saturday)
+                        // 2034-06-11 is outside our calendar (sunday)
+                        // Start again on 2034-06-12 on 10h30 (monday)
+                        // Add the remaining 3h46 hours -> 14h16
+                        : '2034-06-12 14:16:12'
                 ];
 
                 // 4 hours LA with pauses accross multiple days
@@ -1035,33 +1078,43 @@ class SLM extends DbTestCase
                         'number_time'     => 4,
                         'definition_time' => 'hour',
                     ],
-                    'begin_date'        => '2023-06-05 10:00:00', // LA will start at 10:30
+                    'begin_date'        => '2034-06-05 10:00:00', // LA will start at 10:30
                     'pauses'            => [
                         [
                             // From calendar POV, pause is
-                            // from 11:00:00 to 19:00:00 on 2023-06-05 (8 h),
-                            // from 08:30:00 to 19:00:00 on 2023-06-06 (10 h 30 m),
-                            // from 08:30:00 to 09:30:00 on 2023-06-07 (1 h).
+                            // from 11:00:00 to 19:00:00 on 2034-06-05 (8 h),
+                            // from 08:30:00 to 19:00:00 on 2034-06-06 (10 h 30 m),
+                            // from 08:30:00 to 09:30:00 on 2034-06-07 (1 h).
                             // pause: 8 h + 10 h 30 m + 1 h = 19 h 30 m (70 200 s)
-                            'from' => '2023-06-05 11:00:00',
-                            'to'   => '2023-06-07 09:30:00',
+                            'from' => '2034-06-05 11:00:00',
+                            'to'   => '2034-06-07 09:30:00',
                         ],
                         [
                             // From calendar POV, pause is
-                            // from 10:00:00 to 19:00:00 on 2023-06-07 (9 h),
-                            // from 08:30:00 to 09:00:00 on 2023-06-08 (30 m).
+                            // from 10:00:00 to 19:00:00 on 2034-06-07 (9 h),
+                            // from 08:30:00 to 09:00:00 on 2034-06-08 (30 m).
                             // pause: 9 h + 30 m = 9 h 30 m (34 200 s)
-                            'from' => '2023-06-07 10:00:00',
-                            'to'   => '2023-06-08 09:00:00',
+                            'from' => '2034-06-07 10:00:00',
+                            'to'   => '2034-06-08 09:00:00',
                         ],
                     ],
                     'target_date'       => $la_type == \SLM::TTR
-                        // 2023-06-05 10:30:00 + 4 h (LA time) + 29 h (waiting time) + non-working hours
-                        ? '2023-06-08 12:00:00'
-                        // TTO does is not impacted by waiting times
-                        : '2023-06-05 14:30:00'
+                        // 2034-06-05 10:30:00 + 4 h (LA time) + 29 h (waiting time) + non-working hours
+                        ? '2034-06-08 12:00:00'
+                        // TTO is not impacted by waiting times
+                        : '2034-06-05 14:30:00'
                     ,
                     'waiting_duration'  => $la_type == \SLM::TTR ? 104400 : 0,
+                    // Positive 3 days escalation level
+                    'escalation_time'   => 3 * DAY_TIMESTAMP,
+                    'target_escalation_date' => $la_type == \SLM::TTR
+                         // 3 days after TTR
+                         // Skip saturday and sunday (2034-06-10 and 2034-06-11)
+                         // The fact that monday start later (+ 2 hours) SHOULD NOT
+                         // be taken into account as we work in days not in hours
+                         ? '2034-06-13 12:00:00'
+                         // 3 day after TTO
+                         : '2034-06-08 14:30:00'
                 ];
 
                 // 5 days LA over a week-end without pauses
@@ -1072,10 +1125,18 @@ class SLM extends DbTestCase
                         'number_time'     => 5,
                         'definition_time' => 'day',
                     ],
-                    'begin_date'        => '2023-06-09 08:46:12',
+                    'begin_date'        => '2034-06-09 08:46:12',
                     'pauses'            => [],
-                    'target_date'       => '2023-06-16 08:46:12',
+                    'target_date'       => '2034-06-16 08:46:12',
                     'waiting_duration'  => 0,
+                    // Negative 8 hours escalation level
+                    'escalation_time'   => - 8 * HOUR_TIMESTAMP,
+                    // Count back from 2034-06-16 08:46:12 (friday) - 8 hours to remove
+                    // 16m to reach start of day (8h30)
+                    // 7h44 hours remaining
+                    // Start counting back again from 2034-06-15 19h00 (thurday)
+                    // Remove the remaining 7h44 hours -> 11h16
+                    'target_escalation_date' =>  '2034-06-15 11:16:12'
                 ];
 
                 // 5 days LA over a week-end without pauses
@@ -1088,10 +1149,14 @@ class SLM extends DbTestCase
                         'definition_time'    => 'day',
                         'end_of_working_day' => 1,
                     ],
-                    'begin_date'        => '2023-06-09 08:46:12',
+                    'begin_date'        => '2034-06-09 08:46:12',
                     'pauses'            => [],
-                    'target_date'       => '2023-06-16 19:00:00',
+                    'target_date'       => '2034-06-16 19:00:00',
                     'waiting_duration'  => 0,
+                    // Negative 2 days escalation level
+                    'escalation_time'   => - 2 * DAY_TIMESTAMP,
+                    // Remove two days
+                    'target_escalation_date' =>  '2034-06-14 19:00:00'
                 ];
 
                 // 5 days LA with multiple pauses, including a pause of multiple days over a week-end
@@ -1102,35 +1167,40 @@ class SLM extends DbTestCase
                         'number_time'     => 5,
                         'definition_time' => 'day',
                     ],
-                    'begin_date'        => '2023-06-07 10:00:00',
+                    'begin_date'        => '2034-06-07 10:00:00',
                     'pauses'            => [
                         [
                             // From calendar POV, pause is
-                            // from 11:00:00 to 19:00:00 on 2023-06-07 (8 h),
-                            // from 08:30:00 to 19:00:00 on 2023-06-08 (10 h 30 m),
-                            // from 08:30:00 to 19:00:00 on 2023-06-09 (10 h 30 m),
-                            // not counted on 2023-06-10 as it is not a working day,
-                            // not counted on 2023-06-11 as it is not a working day,
-                            // from 10:30:00 to 19:00:00 on 2023-06-12 (08 h 30 m),
-                            // from 08:30:00 to 11:00:00 on 2023-06-13 (2 h 30 m).
+                            // from 11:00:00 to 19:00:00 on 2034-06-07 (8 h),
+                            // from 08:30:00 to 19:00:00 on 2034-06-08 (10 h 30 m),
+                            // from 08:30:00 to 19:00:00 on 2034-06-09 (10 h 30 m),
+                            // not counted on 2034-06-10 as it is not a working day,
+                            // not counted on 2034-06-11 as it is not a working day,
+                            // from 10:30:00 to 19:00:00 on 2034-06-12 (08 h 30 m),
+                            // from 08:30:00 to 11:00:00 on 2034-06-13 (2 h 30 m).
                             // pause: 8 h + 10 h 30 m + 10 h 30 m + 10 h 30 m + 2 h 30 m = 40 h (144 000 s)
-                            'from' => '2023-06-07 11:00:00',
-                            'to'   => '2023-06-13 11:00:00',
+                            'from' => '2034-06-07 11:00:00',
+                            'to'   => '2034-06-13 11:00:00',
                         ],
                         [
-                            // From calendar POV, pause is from 08:30:00 to 18:00:00 on 2023-06-07 (9 h 30 m),
+                            // From calendar POV, pause is from 08:30:00 to 18:00:00 on 2034-06-07 (9 h 30 m),
                             // pause: 9 h 30 m (34 200 s)
-                            'from' => '2023-06-14 07:00:00',
-                            'to'   => '2023-06-14 18:00:00',
+                            'from' => '2034-06-14 07:00:00',
+                            'to'   => '2034-06-14 18:00:00',
                         ],
                     ],
                     'target_date'       => $la_type == \SLM::TTR
-                        // 2023-06-07 10:00:00 + 5 days (LA time)
-                        // -> 2023-06-14 10:00:00 + 49 h 30 m (waiting time) + non-working hours
-                        ? '2023-06-21 09:00:00'
-                        : '2023-06-14 10:00:00' // TTO does is not impacted by waiting times
+                        // 2034-06-07 10:00:00 + 5 days (LA time)
+                        // -> 2034-06-14 10:00:00 + 49 h 30 m (waiting time) + non-working hours
+                        ? '2034-06-21 09:00:00'
+                        : '2034-06-14 10:00:00' // TTO does is not impacted by waiting times
                     ,
                     'waiting_duration'  => $la_type == \SLM::TTR ? 178200 : 0,
+                    // Positive 3 week escalation level
+                    'escalation_time'   => 15 * DAY_TIMESTAMP,
+                    'target_escalation_date' => $la_type == \SLM::TTR
+                        ? '2034-07-12 09:00:00'
+                        : '2034-07-05 10:00:00'
                 ];
 
                 // 5 days LA with multiple pauses, including a pause of multiple days over a week-end
@@ -1143,36 +1213,42 @@ class SLM extends DbTestCase
                         'definition_time'    => 'day',
                         'end_of_working_day' => 1,
                     ],
-                    'begin_date'        => '2023-06-07 10:00:00',
+                    'begin_date'        => '2034-06-07 10:00:00',
                     'pauses'            => [
                         [
                             // From calendar POV, pause is
-                            // from 11:00:00 to 19:00:00 on 2023-06-07 (8 h),
-                            // from 08:30:00 to 19:00:00 on 2023-06-08 (10 h 30 m),
-                            // from 08:30:00 to 19:00:00 on 2023-06-09 (10 h 30 m),
-                            // not counted on 2023-06-10 as it is not a working day,
-                            // not counted on 2023-06-11 as it is not a working day,
-                            // from 10:30:00 to 19:00:00 on 2023-06-12 (08 h 30 m),
-                            // from 08:30:00 to 11:00:00 on 2023-06-13 (2 h 30 m).
+                            // from 11:00:00 to 19:00:00 on 2034-06-07 (8 h),
+                            // from 08:30:00 to 19:00:00 on 2034-06-08 (10 h 30 m),
+                            // from 08:30:00 to 19:00:00 on 2034-06-09 (10 h 30 m),
+                            // not counted on 2034-06-10 as it is not a working day,
+                            // not counted on 2034-06-11 as it is not a working day,
+                            // from 10:30:00 to 19:00:00 on 2034-06-12 (08 h 30 m),
+                            // from 08:30:00 to 11:00:00 on 2034-06-13 (2 h 30 m).
                             // pause: 8 h + 10 h 30 m + 10 h 30 m + 10 h 30 m + 2 h 30 m = 40 h (144 000 s)
-                            'from' => '2023-06-07 11:00:00',
-                            'to'   => '2023-06-13 11:00:00',
+                            'from' => '2034-06-07 11:00:00',
+                            'to'   => '2034-06-13 11:00:00',
                         ],
                         [
-                            // From calendar POV, pause is from 08:30:00 to 18:00:00 on 2023-06-07 (9 h 30 m),
+                            // From calendar POV, pause is from 08:30:00 to 18:00:00 on 2034-06-07 (9 h 30 m),
                             // pause: 9 h 30 m (34 200 s)
-                            'from' => '2023-06-14 07:00:00',
-                            'to'   => '2023-06-14 18:00:00',
+                            'from' => '2034-06-14 07:00:00',
+                            'to'   => '2034-06-14 18:00:00',
                         ],
                     ],
                     'target_date'       => $la_type == \SLM::TTR
-                        // 2023-06-07 10:00:00 + 5 days/end of working day(LA time)
-                        // -> 2023-06-14 19:00:00 + 49 h 30 m (waiting time) + non-working hours
-                        ? '2023-06-21 18:00:00'
+                        // 2034-06-07 10:00:00 + 5 days/end of working day(LA time)
+                        // -> 2034-06-14 19:00:00 + 49 h 30 m (waiting time) + non-working hours
+                        ? '2034-06-21 18:00:00'
                         // TTO does is not impacted by waiting times
-                        : '2023-06-14 19:00:00'
+                        : '2034-06-14 19:00:00'
                     ,
                     'waiting_duration'  => $la_type == \SLM::TTR ? 178200 : 0,
+                    // Positive 2 hours escalation level
+                    'escalation_time'   => 2 * HOUR_TIMESTAMP,
+                    'target_escalation_date' => $la_type == \SLM::TTR
+                        // Must be two hours after their respetive target date
+                        ? '2034-06-22 09:30:00'
+                        : '2034-06-15 10:30:00'
                 ];
             }
         }
@@ -1187,7 +1263,9 @@ class SLM extends DbTestCase
         string $begin_date,
         array $pauses,
         string $target_date,
-        int $waiting_duration
+        int $waiting_duration,
+        int $escalation_time,
+        string $target_escalation_date
     ): void {
         $this->login(); // must be logged in to be able to change ticket status
 
@@ -1223,6 +1301,16 @@ class SLM extends DbTestCase
             ] + $la_params
         );
 
+        // Create escalation level
+        $this->createItem($la->getLevelClass(), [
+            'name'                          => 'Test escalation level',
+            'execution_time'                => $escalation_time,
+            'is_active'                     => 1,
+            'is_recursive'                  => 1,
+            'match'                         => "OR",
+            $la_class::getForeignKeyField() => $la->getID(),
+        ]);
+
         // Create a ticket
         $_SESSION['glpi_currenttime'] = $begin_date;
 
@@ -1250,5 +1338,14 @@ class SLM extends DbTestCase
 
         $this->integer($ticket->fields[$la_class::getWaitingFieldName()])->isEqualTo($waiting_duration);
         $this->string($ticket->fields[$la_date_field])->isEqualTo($target_date);
+
+        // Check escalation date
+        $la_level_class = $la->getLevelTicketClass();
+        $la_level_ticket = (new $la_level_class())->find([
+            'tickets_id' => $ticket->getID(),
+        ]);
+        $this->array($la_level_ticket)->hasSize(1);
+        $escalation_data = array_pop($la_level_ticket)["date"];
+        $this->string($escalation_data)->isEqualTo($target_escalation_date);
     }
 }


### PR DESCRIPTION
Escalation levels are not computed correctly.
I'm supposed to have a 10 day threshold for the escalation date but it end up being on the same date as the SLA:

![image](https://github.com/glpi-project/glpi/assets/42734840/31b92b2f-5927-4a90-b1b3-c9e612d849ec)

![image](https://github.com/glpi-project/glpi/assets/42734840/624eab05-0eee-4e4b-b721-6326b4bfb5d6)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28778