### PR TITLE
handle empty content before domdocument creation

### DIFF
--- a/src/RichText/UserMention.php
+++ b/src/RichText/UserMention.php
@@ -188,6 +188,10 @@ final class UserMention
     {
         $ids = [];
 
+        if (empty($content)) {
+            return $ids;
+        }
+
         try {
             $content = Sanitizer::getVerbatimValue($content);
             $dom = new DOMDocument();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In PHP 7.4 at least it seems like DOMDocument does not handle empty HTML content well.
From CLI:
Uncaught ValueError: DOMDocument::loadHTML(): Argument 1 ($source) must not be empty in php shell code:1

See https://github.com/glpi-project/glpi/actions/runs/5761634677/job/15619847811