### PR TITLE
Prevent github autolink with copied system information

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -2083,6 +2083,14 @@ class Config extends CommonDBTM
 
         echo "</table>";
         Html::closeForm();
+        $cleaner_script = <<<JS
+        // Search all .section-content text content and Replace all instances of a '#' followed by a number so that there is a zero-width space between the # and the number
+        $('.section-content').each(function() {
+          $(this).text($(this).text().replace(/#(\d+)/g, '#\u200B$1'));
+        });
+JS;
+        echo Html::scriptBlock($cleaner_script);
+
 
         echo "<p>" . Telemetry::getViewLink() . "</p>";
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When people manually copy and paste the system info into a GitHub issue, there is a possibility it will contain a `#` followed by a number which triggers GitHub's auto-linking. Usually this occurs with the `php_uname` output. There are a lot of unrelated issues now linked to issue 1 at least.

When people use the preferred method of clicking the button that says "Copy to clipboard" this isn't an issue because it is converted to several HTML details elements.