### PR TITLE
fix(user): authorization cloning

### DIFF
--- a/src/Features/Clonable.php
+++ b/src/Features/Clonable.php
@@ -117,7 +117,7 @@ trait Clonable
             $override_input[$classname::getItemField($this->getType())] = $this->getID();
 
            // Force entity / recursivity based on cloned parent, with fallback on session values
-            if ($classname !== 'Profile_User') {
+            if ($classname::$disableAutoEntityForwarding !== false) {
                 $override_input['entities_id'] = $this->isEntityAssign() ? $this->getEntityID() : Session::getActiveEntity();
                 $override_input['is_recursive'] = $this->maybeRecursive() ? $this->isRecursive() : Session::getIsActiveEntityRecursive();
             }

--- a/src/Features/Clonable.php
+++ b/src/Features/Clonable.php
@@ -117,8 +117,10 @@ trait Clonable
             $override_input[$classname::getItemField($this->getType())] = $this->getID();
 
            // Force entity / recursivity based on cloned parent, with fallback on session values
-            $override_input['entities_id'] = $this->isEntityAssign() ? $this->getEntityID() : Session::getActiveEntity();
-            $override_input['is_recursive'] = $this->maybeRecursive() ? $this->isRecursive() : Session::getIsActiveEntityRecursive();
+            if ($classname !== 'Profile_User') {
+                $override_input['entities_id'] = $this->isEntityAssign() ? $this->getEntityID() : Session::getActiveEntity();
+                $override_input['is_recursive'] = $this->maybeRecursive() ? $this->isRecursive() : Session::getIsActiveEntityRecursive();
+            }
 
             $cloned = []; // Link between old and new ID
             $relation_newitems = [];

--- a/src/Features/Clonable.php
+++ b/src/Features/Clonable.php
@@ -117,7 +117,7 @@ trait Clonable
             $override_input[$classname::getItemField($this->getType())] = $this->getID();
 
            // Force entity / recursivity based on cloned parent, with fallback on session values
-            if ($classname::$disableAutoEntityForwarding !== false) {
+            if ($classname::$disableAutoEntityForwarding !== true) {
                 $override_input['entities_id'] = $this->isEntityAssign() ? $this->getEntityID() : Session::getActiveEntity();
                 $override_input['is_recursive'] = $this->maybeRecursive() ? $this->isRecursive() : Session::getIsActiveEntityRecursive();
             }

--- a/tests/functional/User.php
+++ b/tests/functional/User.php
@@ -631,12 +631,37 @@ class User extends \DbTestCase
     {
         $this->login();
 
-        $user = getItemByTypeName('User', TU_USER);
+        $user = $this->newTestedInstance;
+
+        // Create user with profile
+        $uid = (int)$user->add([
+            'name'         => 'create_user',
+            '_profiles_id' => (int)getItemByTypeName('Profile', 'Self-Service', true)
+        ]);
+        $this->integer($uid)->isGreaterThan(0);
 
         $this->setEntity('_test_root_entity', true);
 
         $date = date('Y-m-d H:i:s');
         $_SESSION['glpi_currenttime'] = $date;
+
+        // Add authorizations
+        $puser = new \Profile_User();
+        $this->integer($puser->add([
+            'users_id'      => $uid,
+            'profiles_id'   => (int)getItemByTypeName('Profile', 'Technician', true),
+            'entities_id'   => (int)getItemByTypeName('Entity', '_test_child_1', true),
+            'is_recursive'  => 0,
+        ]))->isGreaterThan(0);
+
+        $this->integer($puser->add([
+            'users_id'      => $uid,
+            'profiles_id'   => (int)getItemByTypeName('Profile', 'Admin', true),
+            'entities_id'   => (int)getItemByTypeName('Entity', '_test_child_2', true),
+            'is_recursive'  => 1,
+        ]))->isGreaterThan(0);
+
+        $puser_original = $puser->find(['users_id' => $uid]);
 
        // Test item cloning
         $added = $user->clone();
@@ -651,7 +676,6 @@ class User extends \DbTestCase
         foreach ($fields as $k => $v) {
             switch ($k) {
                 case 'id':
-                case 'name':
                     $this->variable($clonedUser->getField($k))->isNotEqualTo($user->getField($k));
                     break;
                 case 'date_mod':
@@ -661,11 +685,22 @@ class User extends \DbTestCase
                     $this->dateTime($dateClone)->isEqualTo($expectedDate);
                     break;
                 case 'name':
-                    $this->variable($clonedUser->getField($k))->isEqualTo("_test_user-copy");
+                    $this->variable($clonedUser->getField($k))->isEqualTo("create_user-copy");
                     break;
                 default:
                     $this->variable($clonedUser->getField($k))->isEqualTo($user->getField($k));
             }
+        }
+
+        // Check authorizations
+        foreach ($puser_original as $row) {
+            $this->boolean($puser->getFromDBByCrit([
+                'users_id'      => $added,
+                'profiles_id'   => $row['profiles_id'],
+                'entities_id'   => $row['entities_id'],
+                'is_recursive'  => $row['is_recursive'],
+                'is_dynamic'    => $row['is_dynamic'],
+            ]))->isTrue();
         }
     }
 


### PR DESCRIPTION
When cloning a user, the new user's authorization entities did not match the original one.

Original user:
![image](https://github.com/glpi-project/glpi/assets/8530352/bbb09d8b-9c6b-4f8f-adff-f8863ece04f9)

Clone before:
![image](https://github.com/glpi-project/glpi/assets/8530352/2d84834d-c416-4cc3-90c2-9ef6496786b7)

Clone after:
![image](https://github.com/glpi-project/glpi/assets/8530352/878d6af4-5ef5-406f-8d32-9f3eaa06c38f)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
