### PR TITLE
Fix LDAP connection using certificate files

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -3090,12 +3090,6 @@ class AuthLDAP extends CommonDBTM
             LDAP_OPT_DEREF            => $deref_options,
             LDAP_OPT_NETWORK_TIMEOUT  => $timeout
         ];
-        if (!empty($tls_certfile) && file_exists($tls_certfile)) {
-            $ldap_options[LDAP_OPT_X_TLS_CERTFILE] = $tls_certfile;
-        }
-        if (!empty($tls_keyfile) && file_exists($tls_keyfile)) {
-            $ldap_options[LDAP_OPT_X_TLS_KEYFILE] = $tls_keyfile;
-        }
 
         foreach ($ldap_options as $option => $value) {
             if (!@ldap_set_option($ds, $option, $value)) {
@@ -3111,6 +3105,20 @@ class AuthLDAP extends CommonDBTM
                     E_USER_WARNING
                 );
             }
+        }
+        if (
+            !empty($tls_certfile)
+            && file_exists($tls_certfile)
+            && !@ldap_set_option(null, LDAP_OPT_X_TLS_CERTFILE, $tls_certfile)
+        ) {
+            trigger_error("Unable to set LDAP option `LDAP_OPT_X_TLS_CERTFILE`", E_USER_WARNING);
+        }
+        if (
+            !empty($tls_keyfile)
+            && file_exists($tls_keyfile)
+            && !@ldap_set_option(null, LDAP_OPT_X_TLS_KEYFILE, $tls_keyfile)
+        ) {
+            trigger_error("Unable to set LDAP option `LDAP_OPT_X_TLS_KEYFILE`", E_USER_WARNING);
         }
 
         if ($use_tls) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28885 !29035

Regression introduced in 10.0.8 (#14561).

First argument of `ldap_set_option` have to be `null` for `LDAP_OPT_X_TLS_CERTFILE`/`LDAP_OPT_X_TLS_KEYFILE`  to set it globally. I do not really understand why it does not work when setting it only for the current connection, but without this change, searching for LDAP users results in a `Insufficient access (50)` error.