### PR TITLE
Fix cartridge icon

### DIFF
--- a/src/Cartridge.php
+++ b/src/Cartridge.php
@@ -1402,6 +1402,6 @@ class Cartridge extends CommonDBRelation
 
     public static function getIcon()
     {
-        return "ti ti-droplet-filled-2";
+        return "ti ti-droplet-half-2-filled";
     }
 }


### PR DESCRIPTION
The icon used for cartridge seems to no longer exist:

![image](https://github.com/glpi-project/glpi/assets/42734840/3404fa54-5b91-4487-af4c-72ce88e6ccce)

Suggested replacement:

![image](https://github.com/glpi-project/glpi/assets/42734840/9a4729ce-b1b3-4bdb-a934-e719f9e858b2)

Other possible choices:
![image](https://github.com/glpi-project/glpi/assets/42734840/66ae2507-9abb-414a-b748-c4b52ee9fc79)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
