### PR TITLE
Allow query string in plugins CSS added by hooks

### DIFF
--- a/src/Application/View/Extension/FrontEndAssetsExtension.php
+++ b/src/Application/View/Extension/FrontEndAssetsExtension.php
@@ -49,6 +49,17 @@ use Twig\TwigFunction;
  */
 class FrontEndAssetsExtension extends AbstractExtension
 {
+    /**
+     * GLPI root dir.
+     * @var string
+     */
+    private $root_dir;
+
+    public function __construct(string $root_dir = GLPI_ROOT)
+    {
+        $this->root_dir = $root_dir;
+    }
+
     public function getFunctions(): array
     {
         return [
@@ -84,20 +95,34 @@ class FrontEndAssetsExtension extends AbstractExtension
     {
         $is_debug = isset($_SESSION['glpi_use_mode']) && $_SESSION['glpi_use_mode'] === Session::DEBUG_MODE;
 
-        if (preg_match('/\.scss$/', $path)) {
-            $compiled_file = Html::getScssCompilePath($path);
+        $file_path = parse_url($path, PHP_URL_PATH); // Strip potential quey string from path
+
+        $extra_params = parse_url($path, PHP_URL_QUERY) ?: '';
+
+        if (preg_match('/\.scss$/', $file_path)) {
+            $compiled_file = Html::getScssCompilePath($file_path, $this->root_dir);
 
             if (!$is_debug && file_exists($compiled_file)) {
-                $path = str_replace(GLPI_ROOT, '', $compiled_file);
+                $path = str_replace($this->root_dir, '', $compiled_file);
             } else {
-                $path = '/front/css.php?file=' . $path . ($is_debug ? '&debug=1' : '');
+                $path = '/front/css.php?file=' . $file_path;
+                if ($is_debug) {
+                    $extra_params .= ($extra_params !== '' ? '&' : '') . 'debug=1';
+                }
             }
         } else {
-            $minified_path = str_replace('.css', '.min.css', $path);
+            $minified_path = str_replace('.css', '.min.css', $file_path);
 
-            if (!$is_debug && file_exists(GLPI_ROOT . '/' . $minified_path)) {
+            if (!$is_debug && file_exists($this->root_dir . '/' . $minified_path)) {
                 $path = $minified_path;
+            } else {
+                $path = $file_path;
             }
+        }
+
+        if ($extra_params !== '') {
+            // Append query string from initial path, if any
+            $path .= (str_contains($path, '?') ? '&' : '?') . $extra_params;
         }
 
         $path = Html::getPrefixedUrl($path);
@@ -120,7 +145,7 @@ class FrontEndAssetsExtension extends AbstractExtension
 
         $minified_path = str_replace('.js', '.min.js', $path);
 
-        if (!$is_debug && file_exists(GLPI_ROOT . '/' . $minified_path)) {
+        if (!$is_debug && file_exists($this->root_dir . '/' . $minified_path)) {
             $path = $minified_path;
         }
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -6908,23 +6908,29 @@ CSS;
     /**
      * Get scss compilation path for given file.
      *
+     * @param string $root_dir
+     *
      * @return array
+     *
+     * @TODO GLPI 10.1 Handle SCSS compiled directory in plugins.
      */
-    public static function getScssCompilePath($file)
+    public static function getScssCompilePath($file, string $root_dir = GLPI_ROOT)
     {
         $file = preg_replace('/\.scss$/', '', $file);
 
-        return self::getScssCompileDir() . '/' . str_replace('/', '_', $file) . '.min.css';
+        return self::getScssCompileDir($root_dir) . '/' . str_replace('/', '_', $file) . '.min.css';
     }
 
     /**
      * Get scss compilation directory.
      *
+     * @param string $root_dir
+     *
      * @return string
      */
-    public static function getScssCompileDir()
+    public static function getScssCompileDir(string $root_dir = GLPI_ROOT)
     {
-        return GLPI_ROOT . '/css_compiled';
+        return $root_dir . '/css_compiled';
     }
 
     /**

--- a/tests/units/Glpi/Application/View/Extension/FrontEndAssetsExtension.php
+++ b/tests/units/Glpi/Application/View/Extension/FrontEndAssetsExtension.php
@@ -1,0 +1,234 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Application\View\Extension;
+
+use Glpi\Toolbox\FrontEnd;
+use org\bovigo\vfs\vfsStream;
+
+class FrontEndAssetsExtension extends \GLPITestCase
+{
+    protected function cssPathProvider(): iterable
+    {
+        global $CFG_GLPI;
+
+        vfsStream::setup(
+            'glpi',
+            null,
+            [
+                'css' => [
+                    'static_1.css'     => '/* Source CSS file */',
+                    'static_2.css'     => '/* Source CSS file */',
+                    'static_2.min.css' => '/* Minified CSS file */',
+                    'styles_1.scss'    => '/* SCSS file to compile */',
+                    'styles_2.scss'    => '/* SCSS file to compile */',
+                ],
+                'css_compiled' => [
+                    'css_styles_1.min.css' => '/* Compiled and minified SCSS */',
+                ],
+                'marketplace' => [
+                    'myplugin' => [
+                        'css' => [
+                            'styles_1.scss' => '/* SCSS file to compile */',
+                            'styles_2.scss' => '/* SCSS file to compile */',
+                        ],
+                    ]
+                ],
+                'plugins' => [
+                    'anotherplugin' => [
+                        'css' => [
+                            'static_1.css'     => '/* Source CSS file */',
+                            'static_2.css'     => '/* Source CSS file */',
+                            'static_1.min.css' => '/* Minified CSS file */',
+                        ],
+                    ]
+                ],
+            ]
+        );
+
+        $v_default = FrontEnd::getVersionCacheKey(GLPI_VERSION);
+        $v_1_2_5   = FrontEnd::getVersionCacheKey('1.2.5');
+
+        // Static CSS files
+        $path_mapping = [
+            // Core file, with minified file provided
+            'css/static_2.css' => 'css/static_2.min.css',
+            'css/static_2.css?param=value&a=5' => 'css/static_2.min.css?param=value&a=5',
+
+            // Core file, NO minified file provided
+            'css/static_1.css' => 'css/static_1.css',
+            'css/static_1.css?param=value' => 'css/static_1.css?param=value',
+
+            // Plugin file, with minified file provided
+            'plugins/anotherplugin/css/static_1.css' => 'plugins/anotherplugin/css/static_1.min.css',
+            'plugins/anotherplugin/css/static_1.css?foo=bar&bar=foo' => 'plugins/anotherplugin/css/static_1.min.css?foo=bar&bar=foo',
+
+            // Plugin files, NO minified file provided
+            'plugins/anotherplugin/css/static_2.css' => 'plugins/anotherplugin/css/static_2.css',
+            'plugins/anotherplugin/css/static_2.css?p' => 'plugins/anotherplugin/css/static_2.css?p',
+        ];
+        foreach ($path_mapping as $source_path => $optimized_path) {
+            // in debug mode -> get source file
+            yield [
+                'path'       => $source_path,
+                'options'    => [],
+                'debug_mode' => true,
+                'expected'   => sprintf(
+                    '%s/%s%sv=%s',
+                    $CFG_GLPI['root_doc'],
+                    $source_path,
+                    str_contains($source_path, '?') ? '&' : '?',
+                    $v_default
+                ),
+            ];
+            yield [
+                'path'       => $source_path,
+                'options'    => ['version' => '1.2.5'],
+                'debug_mode' => true,
+                'expected'   => sprintf(
+                    '%s/%s%sv=%s',
+                    $CFG_GLPI['root_doc'],
+                    $source_path,
+                    str_contains($source_path, '?') ? '&' : '?',
+                    $v_1_2_5
+                ),
+            ];
+
+            // NOT in debug mode -> get minified file, if any
+            yield [
+                'path'       => $source_path,
+                'options'    => [],
+                'debug_mode' => false,
+                'expected'   => sprintf(
+                    '%s/%s%sv=%s',
+                    $CFG_GLPI['root_doc'],
+                    $optimized_path,
+                    str_contains($optimized_path, '?') ? '&' : '?',
+                    $v_default
+                ),
+            ];
+            yield [
+                'path'       => $source_path,
+                'options'    => ['version' => '1.2.5'],
+                'debug_mode' => false,
+                'expected'   => sprintf(
+                    '%s/%s%sv=%s',
+                    $CFG_GLPI['root_doc'],
+                    $optimized_path,
+                    str_contains($optimized_path, '?') ? '&' : '?',
+                    $v_1_2_5
+                ),
+            ];
+        }
+
+        // SCSS files
+        $path_mapping = [
+            // Core files, no params in URL
+            'css/styles_1.scss' => 'css_compiled/css_styles_1.min.css',
+            'css/styles_2.scss' => 'front/css.php?file=css/styles_2.scss',
+
+            // Core files, with params in URL
+            'css/styles_1.scss?param=value'     => 'css_compiled/css_styles_1.min.css?param=value',
+            'css/styles_2.scss?param=value&a=5' => 'front/css.php?file=css/styles_2.scss&param=value&a=5',
+
+            // Plugin files, NO minified file provided
+            'marketplace/myplugin/css/styles_1.scss' => 'front/css.php?file=marketplace/myplugin/css/styles_1.scss',
+            'marketplace/myplugin/css/styles_1.scss?p' => 'front/css.php?file=marketplace/myplugin/css/styles_1.scss&p',
+            'marketplace/myplugin/css/styles_1.scss?foo=bar&bar=foo' => 'front/css.php?file=marketplace/myplugin/css/styles_1.scss&foo=bar&bar=foo',
+        ];
+        foreach ($path_mapping as $source_path => $optimized_path) {
+            // in debug mode -> get source file
+            yield [
+                'path'       => $source_path,
+                'options'    => [],
+                'debug_mode' => true,
+                'expected'   => sprintf(
+                    '%s/front/css.php?file=%s&debug=1&v=%s',
+                    $CFG_GLPI['root_doc'],
+                    str_replace('?', '&', $source_path),
+                    $v_default
+                ),
+            ];
+            yield [
+                'path'       => $source_path,
+                'options'    => ['version' => '1.2.5'],
+                'debug_mode' => true,
+                'expected'   => sprintf(
+                    '%s/front/css.php?file=%s&debug=1&v=%s',
+                    $CFG_GLPI['root_doc'],
+                    str_replace('?', '&', $source_path),
+                    $v_1_2_5
+                ),
+            ];
+
+            // NOT in debug mode -> get minified file, if any
+            yield [
+                'path'       => $source_path,
+                'options'    => [],
+                'debug_mode' => false,
+                'expected'   => sprintf(
+                    '%s/%s%sv=%s',
+                    $CFG_GLPI['root_doc'],
+                    $optimized_path,
+                    str_contains($optimized_path, '?') ? '&' : '?',
+                    $v_default
+                ),
+            ];
+            yield [
+                'path'       => $source_path,
+                'options'    => ['version' => '1.2.5'],
+                'debug_mode' => false,
+                'expected'   => sprintf(
+                    '%s/%s%sv=%s',
+                    $CFG_GLPI['root_doc'],
+                    $optimized_path,
+                    str_contains($optimized_path, '?') ? '&' : '?',
+                    $v_1_2_5
+                ),
+            ];
+        }
+    }
+
+    /**
+     * @dataProvider cssPathProvider
+     */
+    public function testCssPath(string $path, array $options, bool $debug_mode, string $expected): void
+    {
+        $_SESSION['glpi_use_mode'] = $debug_mode ? \Session::DEBUG_MODE : \Session::NORMAL_MODE;
+
+        $this->newTestedInstance(vfsStream::url('glpi'));
+        $this->string($this->testedInstance->cssPath($path, $options))->isEqualTo($expected);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When a quey string is present in a SCSS file added by a plugin using the `add_css` hook, the resulting CSS href is broken.