### PR TITLE
Fix undefined properties

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -1459,7 +1459,7 @@ abstract class CommonITILObject extends CommonDBTM
         $type = null;
         if (isset($input['type'])) {
             $type = $input['type'];
-        } else if (isset($this->field['type'])) {
+        } else if (isset($this->fields['type'])) {
             $type = $this->fields['type'];
         }
 

--- a/src/NotificationTemplate.php
+++ b/src/NotificationTemplate.php
@@ -613,7 +613,7 @@ class NotificationTemplate extends CommonDBTM
         $mailing_options['items_id']     = method_exists($target->obj, "getField")
          ? $target->obj->getField('id')
          : 0;
-        if (isset($target->obj->documents)) {
+        if (property_exists($target, 'documents') && isset($target->obj->documents)) {
             $mailing_options['documents'] = $target->obj->documents;
         }
 

--- a/templates/components/itilobject/layout.html.twig
+++ b/templates/components/itilobject/layout.html.twig
@@ -56,13 +56,13 @@
 
 <div id="itil-object-container" class="mt-n1 {{ collapsed_cls }} {{ expanded_cls }}">
 
-   {% if item.isNewItem and not params['template_preview'] %}
+   {% if item.isNewItem() and not params['template_preview'] %}
       {{ include('components/itilobject/mainform_open.html.twig') }}
    {% endif %}
 
    <div class="row d-flex flex-column alin-items-stretch itil-object">
       {% set is_timeline_reversed = user_pref('timeline_order') == constant('CommonITILObject::TIMELINE_ORDER_REVERSE') %}
-      {% set fl_direction = (item.isNewItem or is_timeline_reversed ? 'flex-column' : 'flex-column-reverse') %}
+      {% set fl_direction = (item.isNewItem() or is_timeline_reversed ? 'flex-column' : 'flex-column-reverse') %}
       <div class="itil-left-side col-12 {{ left_side_cls }} order-last order-lg-first pt-2 pe-2 pe-lg-4 d-flex {{ fl_direction }} border-top border-4">
          {% if item.isNewItem() %}
             {{ include('components/itilobject/timeline/new_form.html.twig') }}

--- a/templates/components/itilobject/mainform_open.html.twig
+++ b/templates/components/itilobject/mainform_open.html.twig
@@ -35,7 +35,7 @@
 {% set new_cls = item.isNewItem() ? 'new-itil-object' : '' %}
 
 {% set form_path = item.getFormURL() %}
-{% if not item.isNewItem %}
+{% if not item.isNewItem() %}
    {% set form_path = form_path ~ '?id=' ~ item.fields['id'] %}
 {% endif %}
 
@@ -44,7 +44,7 @@
 {% endif %}
 
 {% set track_changes = 'true' %}
-{% if item.isNewItem %}
+{% if item.isNewItem() %}
    {% set track_changes = 'false' %}
 {% endif %}
 

--- a/templates/components/itilobject/service_levels.html.twig
+++ b/templates/components/itilobject/service_levels.html.twig
@@ -163,7 +163,7 @@
                {% endif %}
 
                {% if la_displayed %}
-                  <div class="{{ item.isNewItem ? '' : 'collapsed' }} w-100 mt-1 d-none" id="dropdown_{{ assign_la_id }}">
+                  <div class="{{ item.isNewItem() ? '' : 'collapsed' }} w-100 mt-1 d-none" id="dropdown_{{ assign_la_id }}">
                      {{ fields.dropdownField(
                         la_field.la.getType(),
                         la_field.lafieldname,

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -359,7 +359,7 @@
                               rand_group: {{ random() }},
                               itemtype: "{{ subitem.type }}",
                               items_id: {{ subitem.fields['id']|default(-1) }},
-                              parent_itemtype: "{{ item.type }}",
+                              parent_itemtype: "{{ item.getType() }}",
                               parent_items_id: {{ item.fields['id'] }},
                               parent_fk_field: "{{ item.getForeignKeyField() }}",
                               begin: "{{ subitem.fields['begin'] }}",


### PR DESCRIPTION
Fix call to undefined properties to avoid triggering the `__get` magic method that will be added in #15388.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
