### PR TITLE
Fix Kanban switcher

### DIFF
--- a/src/Features/Kanban.php
+++ b/src/Features/Kanban.php
@@ -169,7 +169,14 @@ trait Kanban
     public function getKanbanUrlWithID(int $items_id, bool $full = true): string
     {
         $tabs = $this->defineTabs();
-        $tab_id = array_search(__('Kanban'), $tabs);
+        $tab_id = null;
+        // search each value for one that contains "Kanban"
+        foreach ($tabs as $id => $tab) {
+            if (str_contains($tab, 'Kanban')) {
+                $tab_id = $id;
+                break;
+            }
+        }
         if (false === $tab_id || is_null($tab_id)) {
             Response::sendError(400, "Itemtype does not have a Kanban tab!", Response::CONTENT_TYPE_TEXT_HTML);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Since the addition of icons to the form tabs, the Kanban switcher has been broken due to the way it checked for the Kanban tab ID.