### PR TITLE
Wrong status when adding a planned task with deactivation of waiting status

### DIFF
--- a/src/Features/ParentStatus.php
+++ b/src/Features/ParentStatus.php
@@ -135,7 +135,12 @@ trait ParentStatus
                     || $parentitem::isAllowedStatus($parentitem->fields["status"], CommonITILObject::ASSIGNED)
                 ) {
                     $needupdateparent = true;
-                    $update['status'] = CommonITILObject::ASSIGNED;
+                    // If begin date is defined, the status must be planned if it exists, rather than assigned.
+                    if (!empty($this->fields['begin']) && $parentitem->isStatusExists(CommonITILObject::PLANNED)) {
+                        $update['status'] = CommonITILObject::PLANNED;
+                    } else {
+                        $update['status'] = CommonITILObject::ASSIGNED;
+                    }
                 }
             } else {
                //check if lifecycle allowed new status


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15350 

There is an inconsistency in the transition of ticket statuses. Currently, when a planned task is performed on a ticket in "Pending" status and the "Pending" status is unchecked in the add task menu, the ticket status changes to "Processing (assigned)" instead of the expected "Processing (planned)" status.