### PR TITLE
Wrong status when adding a planned task with pending

### DIFF
--- a/src/Features/ParentStatus.php
+++ b/src/Features/ParentStatus.php
@@ -159,7 +159,8 @@ trait ParentStatus
         }
 
         if (
-            !empty($this->fields['begin'])
+            !$is_set_pending
+            && !empty($this->fields['begin'])
             && $parentitem->isStatusExists(CommonITILObject::PLANNED)
             && (($parentitem->fields["status"] == CommonITILObject::INCOMING)
               || ($parentitem->fields["status"] == CommonITILObject::ASSIGNED)


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15355 

There is an inconsistency in the transition of ticket statuses. Currently, if a planned task is added, and the ticket is set to "pending" at the same time, the ticket status will be "Processing (planned)" instead of "Pending".