### PR TITLE
fix(user): responsible dropdown

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -2853,10 +2853,12 @@ HTML;
                 echo "<td><label for='dropdown_users_id_supervisor_$userrand'>" .  __('Responsible') . "</label></td><td>";
 
                 User::dropdown(['name'   => 'users_id_supervisor',
-                    'value'  => $this->fields["users_id_supervisor"],
-                    'rand'   => $userrand,
-                    'entity' => $_SESSION["glpiactive_entity"],
-                    'right'  => 'all'
+                    'value'         => $this->fields["users_id_supervisor"],
+                    'rand'          => $userrand,
+                    'entity'        => $_SESSION["glpiactive_entity"],
+                    'entity_sons'   => true,
+                    'used'          => [$this->getID()],
+                    'right'         => 'all'
                 ]);
                 echo "</td></tr>";
             }


### PR DESCRIPTION
The responsible dropdown displays users according to the active entity of the session, but the list was incomplete, as it didn't take sub-entities into account.

In addition, it allowed the user being modified to be put in charge himself, which doesn't seem relevant.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29158
