### PR TITLE
Clear old escalation levels on SLA/OLA change

### DIFF
--- a/src/LevelAgreement.php
+++ b/src/LevelAgreement.php
@@ -1164,4 +1164,39 @@ abstract class LevelAgreement extends CommonDBChild
     {
         return static::$levelticketclass;
     }
+
+    /**
+     * Remove level of previously assigned level agreements
+     *
+     * @return void
+     */
+    public function clearInvalidLevels(): void
+    {
+        // CLear levels of others LA of the same type
+        // e.g. if a new LA TTR was assigned, clear levels from others (= previous) LA TTR
+        $level_ticket_class = $this->getLevelTicketClass();
+        $level_class = $this->getLevelClass();
+        $levels = (new $level_ticket_class())->find([
+            [$level_class::getForeignKeyField() => ['!=', $this->getID()]],
+            [
+                $level_class::getForeignKeyField() => new QuerySubQuery([
+                    'SELECT' => 'id',
+                    'FROM' => $level_class::getTable(),
+                    'WHERE' => [
+                        static::getForeignKeyField() => new QuerySubQuery([
+                            'SELECT' => 'id',
+                            'FROM' => static::getTable(),
+                            'WHERE' => ['type' => $this->fields['type']],
+                        ])
+                    ]
+                ]),
+            ]
+        ]);
+
+        // Delete invalid levels
+        foreach ($levels as $level) {
+            $em = new $level_ticket_class();
+            $em->delete(['id' => $level['id']]);
+        }
+    }
 }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1538,6 +1538,7 @@ class Ticket extends CommonITILObject
 
         $sla = new SLA();
         if ($sla->getFromDB($slas_id)) {
+            $sla->clearInvalidLevels();
             $calendars_id = Entity::getUsedConfig(
                 'calendars_strategy',
                 $this->fields['entities_id'],
@@ -1565,6 +1566,7 @@ class Ticket extends CommonITILObject
 
         $ola = new OLA();
         if ($ola->getFromDB($slas_id)) {
+            $ola->clearInvalidLevels();
             $calendars_id = Entity::getUsedConfig(
                 'calendars_strategy',
                 $this->fields['entities_id'],

--- a/tests/RuleBuilder.php
+++ b/tests/RuleBuilder.php
@@ -92,6 +92,19 @@ class RuleBuilder
     /**
      * Set condition
      *
+     * @param string $operator RuleTicket::ONADD and/or RuleTicket::ONUPDATE
+     *
+     * @return self
+     */
+    public function setCondtion(int $condition): self
+    {
+        $this->condition = $condition;
+        return $this;
+    }
+
+    /**
+     * Set operator
+     *
      * @param string $operator 'AND' or 'OR'
      *
      * @return self

--- a/tests/functional/SLM.php
+++ b/tests/functional/SLM.php
@@ -37,9 +37,13 @@ namespace tests\units;
 
 use CommonITILObject;
 use DbTestCase;
+use OlaLevel;
 use OlaLevel_Ticket;
 use Rule;
+use RuleBuilder;
+use RuleTicket;
 use SlaLevel_Ticket;
+use Ticket;
 
 class SLM extends DbTestCase
 {
@@ -1347,5 +1351,180 @@ class SLM extends DbTestCase
         $this->array($la_level_ticket)->hasSize(1);
         $escalation_data = array_pop($la_level_ticket)["date"];
         $this->string($escalation_data)->isEqualTo($target_escalation_date);
+    }
+
+    /**
+     * Assign SLA and OLA to a ticket then change them with a rule
+     * The ticket should only have the escalation level of the second set of SLA / OLA
+     *
+     * @return void
+     */
+    public function testLaChange(): void
+    // public function testLaChange(string $la_class, string $la_type): void
+    {
+        $this->login();
+        $entity = getItemByTypeName('Entity', '_test_root_entity', true);
+        $test_ticket_name = "Test ticket with multiple LA assignation " . mt_rand();
+
+        // OLA change are recomputed from the current date so we need to set
+        // glpi_currenttime to get predictable results
+        $calendar = getItemByTypeName('Calendar', 'Default', true);
+        $_SESSION['glpi_currenttime'] = '2034-08-16 13:00:00';
+
+        // Create test SLM
+        $slm = $this->createItem(\SLM::class, [
+            'name'                => 'SLM',
+            'entities_id'         => $entity,
+            'is_recursive'        => true,
+            'use_ticket_calendar' => false,
+            'calendars_id'        => $calendar,
+        ]);
+
+        // Create rules to set full SLA and OLA on ticket creation and to change them on ticket update
+        foreach ([\OLA::class, \SLA::class] as $la_class) {
+            foreach ([\SLM::TTO, \SLM::TTR] as $la_type) {
+                $la = new $la_class();
+                list($la_date_field, $la_fk_field) = $la->getFieldNames($la_type);
+
+                // Create two LA with one escalation level
+                list($la1, $la2) = $this->createItems($la_class, [
+                    [
+                        'name'                => "$la_class $la_type 1",
+                        'entities_id'         => $entity,
+                        'is_recursive'        => true,
+                        'type'                => $la_type,
+                        'number_time'         => 4,
+                        'calendars_id'        => $calendar,
+                        'definition_time'     => 'hour',
+                        'end_of_working_day'  => false,
+                        'slms_id'             => $slm->getID(),
+                        'use_ticket_calendar' => false,
+                    ],
+                    [
+                        'name'                => "$la_class $la_type 2",
+                        'entities_id'         => $entity,
+                        'is_recursive'        => true,
+                        'type'                => $la_type,
+                        'number_time'         => 2,
+                        'calendars_id'        => $calendar,
+                        'definition_time'     => 'hour',
+                        'end_of_working_day'  => false,
+                        'slms_id'             => $slm->getID(),
+                        'use_ticket_calendar' => false,
+                    ],
+                ]);
+                foreach ([$la1, $la2] as $created_la) {
+                    $this->createItem($created_la->getLevelClass(), [
+                        'name'                          => $created_la->fields['name'] . ' level',
+                        $la_class::getForeignKeyField() => $created_la->getID(),
+                        'execution_time'                => - HOUR_TIMESTAMP,
+                        'is_active'                     => true,
+                        'entities_id'                   => $entity,
+                        'is_recursive'                  => true,
+                        'match'                         => 'AND',
+                    ]);
+                }
+
+                // First OLA is added on creation
+                $builder = new RuleBuilder('Add first LA on creation');
+                $builder->setEntity($entity)
+                    ->setCondtion(RuleTicket::ONADD)
+                    ->addCriteria('name', Rule::PATTERN_IS, $test_ticket_name)
+                    ->addCriteria('entities_id', Rule::PATTERN_IS, $entity)
+                    ->addAction('assign', $la_fk_field, $la1->getID());
+                $this->createRule($builder);
+
+                // First OLA is added on update
+                $builder = new RuleBuilder('Add second LA on update');
+                $builder->setEntity($entity)
+                    ->setCondtion(RuleTicket::ONUPDATE)
+                    ->addCriteria('name', Rule::PATTERN_IS, $test_ticket_name)
+                    ->addCriteria('urgency', Rule::PATTERN_IS, 5)
+                    ->addAction('assign', $la_fk_field, $la2->getID());
+                $this->createRule($builder);
+            }
+        }
+
+        // Create a ticket
+        $ticket = $this->createItem(Ticket::class, [
+            'entities_id' => $entity,
+            'name'        => $test_ticket_name,
+            'content'     => '',
+        ]);
+
+        // Check that each LA TTO and TTR are set as expected
+        foreach ([\OLA::class, \SLA::class] as $la_class) {
+            $la = new $la_class();
+            $level_class = $la->getLevelClass();
+            $expected_la_levels = [];
+
+            foreach ([\SLM::TTO, \SLM::TTR] as $la_type) {
+                list($la_date_field, $la_fk_field) = $la->getFieldNames($la_type);
+
+                // Check that the correct LA is assigned to the ticket
+                $expected_la = getItemByTypeName($la_class, "$la_class $la_type 1", true);
+                $expected_la_levels[] = getItemByTypeName($level_class, "$la_class $la_type 1 level", true);
+                $this->integer($ticket->fields[$la_fk_field])->isEqualTo($expected_la);
+
+                // Check that the target date is correct (+ 4 hours)
+                $this->string($ticket->fields[$la_date_field])->isEqualTo('2034-08-16 17:00:00');
+            }
+
+            // Check that all escalations levels are sets
+            $level_ticket_class = $la->getLevelTicketClass();
+            $sa_levels_ticket = (new $level_ticket_class())->find(['tickets_id' => $ticket->getID()]);
+            $this->array($sa_levels_ticket)->hasSize(2); // One TTO and one TTR
+
+            // Check that they match the expected la levels
+            $this->array(
+                array_column($sa_levels_ticket, $level_class::getForeignKeyField())
+            )->isEqualTo($expected_la_levels);
+
+            // Check that they match the expected date (- 1 hour)
+            $this->array(
+                array_unique(array_column($sa_levels_ticket, 'date'))
+            )->isEqualTo(['2034-08-16 16:00:00']);
+        }
+
+        // Update ticket, triggering an LA change
+        $this->updateItem(Ticket::class, $ticket->getID(), [
+            'urgency' => 5,
+            'name' => $test_ticket_name, // Name is not updated but we need to be in the input for the rule
+        ]);
+        $ticket->getFromDB($ticket->getID());
+
+        // Check that each LA TTO and TTR have been modified as expected
+        foreach ([\OLA::class, \SLA::class] as $la_class) {
+            $la = new $la_class();
+            $level_class = $la->getLevelClass();
+            $expected_la_levels = [];
+
+            foreach ([\SLM::TTO, \SLM::TTR] as $la_type) {
+                list($la_date_field, $la_fk_field) = $la->getFieldNames($la_type);
+
+                // Check that the correct LA is assigned to the ticket
+                $expected_la = getItemByTypeName($la_class, "$la_class $la_type 2", true);
+                $expected_la_levels[] = getItemByTypeName($level_class, "$la_class $la_type 2 level", true);
+                $this->integer($ticket->fields[$la_fk_field])->isEqualTo($expected_la);
+
+                // Check that the target date is correct (+ 2 hours)
+                $this->string($ticket->fields[$la_date_field])->isEqualTo('2034-08-16 15:00:00');
+            }
+
+            // Check that all escalations levels have been modifieds
+            $level_ticket_class = $la->getLevelTicketClass();
+            $sa_levels_ticket = (new $level_ticket_class())->find(['tickets_id' => $ticket->getID()]);
+            $this->array($sa_levels_ticket)->hasSize(2); // One TTO and one TTR
+
+            // Check that they match the expected la levels
+            $this->array(
+                array_column($sa_levels_ticket, $level_class::getForeignKeyField())
+            )->isEqualTo($expected_la_levels);
+
+            // Check that they match the expected date (- 1 hour)
+            $this->array(
+                array_unique(array_column($sa_levels_ticket, 'date'))
+            )->isEqualTo(['2034-08-16 14:00:00']);
+        }
     }
 }


### PR DESCRIPTION
When a ticket is created, it's SLA/OLA escalation's date is computed properly:

![image](https://github.com/glpi-project/glpi/assets/42734840/5f23344e-9a07-477e-b114-003b440e1912)

However, if the SLA and/or OLA are changed through a rule, the escalation date does not change and keep the previous value:

![image](https://github.com/glpi-project/glpi/assets/42734840/75c9d8cc-58fc-44a9-8fca-3014a2a666e5)
_Escalation date should be 11h33, not 13h33_

This happens because we do not clear the data from the `glpi_slalevels_tickets` / `glpi_olalevels_tickets` tables when the SLA/OLA are updated.
This mean the old escalation level is kept in the database and shown in the tickets.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28778
