### PR TITLE
Wrong status when adding a planned task

### DIFF
--- a/src/Features/ParentStatus.php
+++ b/src/Features/ParentStatus.php
@@ -135,7 +135,12 @@ trait ParentStatus
                     || $parentitem::isAllowedStatus($parentitem->fields["status"], CommonITILObject::ASSIGNED)
                 ) {
                     $needupdateparent = true;
-                    $update['status'] = CommonITILObject::ASSIGNED;
+                    // If begin date is defined, the status must be planned if it exists, rather than assigned.
+                    if (!empty($this->fields['begin']) && $parentitem->isStatusExists(CommonITILObject::PLANNED)) {
+                        $update['status'] = CommonITILObject::PLANNED;
+                    } else {
+                        $update['status'] = CommonITILObject::ASSIGNED;
+                    }
                 }
             } else {
                //check if lifecycle allowed new status
@@ -159,7 +164,8 @@ trait ParentStatus
         }
 
         if (
-            !empty($this->fields['begin'])
+            !$is_set_pending
+            && !empty($this->fields['begin'])
             && $parentitem->isStatusExists(CommonITILObject::PLANNED)
             && (($parentitem->fields["status"] == CommonITILObject::INCOMING)
               || ($parentitem->fields["status"] == CommonITILObject::ASSIGNED)

--- a/tests/functional/TicketTask.php
+++ b/tests/functional/TicketTask.php
@@ -401,4 +401,68 @@ class TicketTask extends DbTestCase
         $this->integer($task->fields['state'])->isEqualTo(\Planning::TODO);
         $this->integer($task->fields['is_private'])->isEqualTo(0);
     }
+
+    public function testUpdateParentStatus()
+    {
+        $this->login();
+        $ticket_id = $this->getNewTicket();
+        $task = new \TicketTask();
+
+        $uid = getItemByTypeName('User', TU_USER, true);
+        $date_begin = new \DateTime(); // ==> now
+        $date_begin_string = $date_begin->format('Y-m-d H:i:s');
+        $date_end = new \DateTime(); // ==> +2days
+        $date_end->add(new \DateInterval('P2D'));
+        $date_end_string = $date_end->format('Y-m-d H:i:s');
+
+        $this->integer($task->add([
+            'pending'            => 0,
+            'tickets_id'         => $ticket_id,
+            'content'            => "Task with schedule",
+            'state'              => \Planning::TODO,
+            'users_id_tech'      => $uid,
+            'begin'              => $date_begin_string,
+            'end'                => $date_end_string,
+        ]))->isGreaterThan(0);
+
+        $this->integer(\Ticket::getById($ticket_id)->fields['status'])->isEqualTo(\Ticket::PLANNED);
+
+        $date_begin = new \DateTime(); // ==> +3days
+        $date_begin->add(new \DateInterval('P3D'));
+        $date_begin_string = $date_begin->format('Y-m-d H:i:s');
+        $date_end = new \DateTime(); // ==> +4days
+        $date_end->add(new \DateInterval('P4D'));
+        $date_end_string = $date_end->format('Y-m-d H:i:s');
+
+        $this->integer($task->add([
+            'pending'            => 1,
+            'tickets_id'         => $ticket_id,
+            'content'            => "Task with schedule",
+            'state'              => \Planning::TODO,
+            'users_id_tech'      => $uid,
+            'begin'              => $date_begin_string,
+            'end'                => $date_end_string,
+        ]))->isGreaterThan(0);
+
+        $this->integer(\Ticket::getById($ticket_id)->fields['status'])->isEqualTo(\Ticket::WAITING);
+
+        $date_begin = new \DateTime(); // ==> +5days
+        $date_begin->add(new \DateInterval('P5D'));
+        $date_begin_string = $date_begin->format('Y-m-d H:i:s');
+        $date_end = new \DateTime(); // ==> +6days
+        $date_end->add(new \DateInterval('P6D'));
+        $date_end_string = $date_end->format('Y-m-d H:i:s');
+
+        $this->integer($task->add([
+            'pending'            => 0,
+            'tickets_id'         => $ticket_id,
+            'content'            => "Task with schedule",
+            'state'              => \Planning::TODO,
+            'users_id_tech'      => $uid,
+            'begin'              => $date_begin_string,
+            'end'                => $date_end_string,
+        ]))->isGreaterThan(0);
+
+        $this->integer(\Ticket::getById($ticket_id)->fields['status'])->isEqualTo(\Ticket::PLANNED);
+    }
 }


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15350 #15355 

There are several inconsistencies in the ticket status transition.
- First, when a planned task is performed on a ticket in "Pending" status and the "Pending" status is unchecked in the add task menu, the ticket status changes to "Processing (assigned)" instead of the expected "Processing (planned)" status.
- Second, if a planned task is added, and the ticket is set to "pending" at the same time, the ticket status will be "Processing (planned)" instead of "Pending".