### PR TITLE
HLAPI remove expanded route params

### DIFF
--- a/src/Api/HL/OpenAPIGenerator.php
+++ b/src/Api/HL/OpenAPIGenerator.php
@@ -262,13 +262,14 @@ EOT;
         foreach ($paths as $path_url => $path) {
             foreach ($path as $method => $route) {
                 $is_expanded = false;
-                foreach ($route['parameters'] as $param) {
+                foreach ($route['parameters'] as $param_key => $param) {
                     if (isset($param['schema']['pattern']) && preg_match('/^[\w+|]+$/', $param['schema']['pattern'])) {
                         $itemtypes = explode('|', $param['schema']['pattern']);
                         foreach ($itemtypes as $itemtype) {
                             $new_url = str_replace('{itemtype}', $itemtype, $path_url);
                             // Check there isn't already a route for this URL
                             if (!isset($paths[$new_url][$method])) {
+                                unset($route['parameters'][$param_key]);
                                 $expanded[$new_url][$method] = $route;
                                 $is_expanded = true;
                             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When an API path like `/Assistance/{itemtype}/` was expanded for the OpenAPI documentation to `/Assistance/Ticket/`, `/Assistance/Change/` and `/Assistance/Problem/`, the `itemtype` parameter was left in the documentation which is not necessary or valid.