### PR TITLE
fix(dashboard): tab is displayed without right

### DIFF
--- a/src/Central.php
+++ b/src/Central.php
@@ -73,7 +73,7 @@ class Central extends CommonGLPI
             ];
 
             $grid = new Glpi\Dashboard\Grid('central');
-            if ($grid::canViewOneDashboard('central')) {
+            if ($grid::canViewOneDashboard('core')) {
                 array_unshift($tabs, __('Dashboard'));
             }
 

--- a/src/Central.php
+++ b/src/Central.php
@@ -73,7 +73,7 @@ class Central extends CommonGLPI
             ];
 
             $grid = new Glpi\Dashboard\Grid('central');
-            if ($grid::canViewOneDashboard()) {
+            if ($grid::canViewOneDashboard('central')) {
                 array_unshift($tabs, __('Dashboard'));
             }
 


### PR DESCRIPTION
On the home page, the dashboard tab could be displayed even if the profile had no rights.

Rights:
![image](https://github.com/glpi-project/glpi/assets/8530352/79ebe8c2-f3ec-4464-b2b5-29a3e7ec0e21)


Before:
![image](https://github.com/glpi-project/glpi/assets/8530352/4651ea49-83b0-4252-bdde-077c308692c1)


After:
![image](https://github.com/glpi-project/glpi/assets/8530352/69184256-d45e-4354-a235-0711c3c4b04e)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29195
