### PR TITLE
Computers: Add search option for reservations

### DIFF
--- a/src/Computer.php
+++ b/src/Computer.php
@@ -580,6 +580,18 @@ class Computer extends CommonDBTM
             'datatype'           => 'dropdown'
         ];
 
+        $tab[] = [
+            'id'                 => '81',
+            'table'              => 'glpi_reservationitems',
+            'name'               => __('Reservable'),
+            'field'              => 'is_active',
+            'joinparams'         => [
+                'jointype' => 'itemtype_item'
+            ],
+            'datatype'           => 'bool',
+            'massiveaction'      => false
+        ];
+
        // add operating system search options
         $tab = array_merge($tab, Item_OperatingSystem::rawSearchOptionsToAdd(get_class($this)));
 


### PR DESCRIPTION
This was a feature added for my team's use - I've opened this PR in case the wider community would benefit.

This allows users to search whether a computer is available for reservation or not:

![Screenshot from 2023-08-21 17-13-26](https://github.com/glpi-project/glpi/assets/56094214/6912c019-faa1-4b5d-b162-f11a7b2d2bd3)


Computers marked as unavailable will be marked as "No", computers marked as available will be marked as "Yes", and computers that are not authorized for reservation can be searched under "contains NULL"

One question I have is about the 'id' of the search option. I picked 81 at random, let me know if I have this wrong and if there's a better way to determine a search option's id number.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
