### PR TITLE
improve plugin support for vue

### DIFF
--- a/js/src/vue/app.js
+++ b/js/src/vue/app.js
@@ -33,9 +33,15 @@
 
 import { createApp } from 'vue/dist/vue.esm-bundler.js';
 import {defineAsyncComponent} from "vue";
+
+let existing_components = {};
+if (window.Vue !== undefined && window.Vue.components !== undefined) {
+    existing_components = window.Vue.components;
+}
 window.Vue = {
     createApp: createApp,
-    components: {},
+    defineAsyncComponent: defineAsyncComponent,
+    components: existing_components,
     getComponentsByName: (pattern) => {
         const components = {};
         Object.keys(window.Vue.components).forEach((component_name) => {

--- a/js/src/vue/app.js
+++ b/js/src/vue/app.js
@@ -32,7 +32,7 @@
  */
 
 import { createApp } from 'vue/dist/vue.esm-bundler.js';
-import {defineAsyncComponent} from "vue";
+import * as vue from "vue";
 
 let existing_components = {};
 if (window.Vue !== undefined && window.Vue.components !== undefined) {
@@ -40,7 +40,7 @@ if (window.Vue !== undefined && window.Vue.components !== undefined) {
 }
 window.Vue = {
     createApp: createApp,
-    defineAsyncComponent: defineAsyncComponent,
+    defineAsyncComponent: vue.defineAsyncComponent,
     components: existing_components,
     getComponentsByName: (pattern) => {
         const components = {};
@@ -50,7 +50,7 @@ window.Vue = {
             }
         });
         return components;
-    }
+    },
 };
 // Require all Vue SFCs in js/src directory
 const component_context = import.meta.webpackContext('.', {
@@ -64,8 +64,12 @@ component_context.keys().forEach((f) => {
     // Ex: ./Debug/Toolbar.vue => DebugToolbar
     const component_name = f.replace(/^\.\/(.+)\.vue$/, '$1');
     components[component_name] = {
-        component: defineAsyncComponent(() => component_context(f)),
+        component: vue.defineAsyncComponent(() => component_context(f)),
     };
 });
 // Save components in global scope
 window.Vue.components = Object.assign(window.Vue.components, components);
+
+// export vue module to be used in other webpack bundles as an external dependency without uselessly bundling it
+// For example, plugins can import from 'vue' as usual, but use the webpack externals option to map 'vue' to 'window _vue'
+window._vue = vue;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Add `defineAsyncComponent` on the `window.Vue` global so plugins can use it without needing to re-import it in their webpack entrypoints.
Add some logic to ensure components somehow loaded before the main Vue `app.js` is imported are preserved.
Set `window._vue` to the complete exports from the 'vue' library so it can be used in `externals` mappings in plugins.
Example option in a plugin's webpack:
```
externals: {
    vue: 'window _vue'
}
```
Plugins can then import from 'vue' as done normally, and have it actually map to `window._vue` to prevent useless duplicate code in the bundle.
I wasn't able to find a way to get this to work without the global variable.