### PR TITLE
fix php warnings

### DIFF
--- a/src/Item_Ticket.php
+++ b/src/Item_Ticket.php
@@ -506,9 +506,9 @@ class Item_Ticket extends CommonItilObject_Item
                     $item->getFromDB($data["id"]);
                     echo "<td class='center'>" . $item->getKBLinks() . "</td>";
                     echo "<td class='center'>";
-                    echo Dropdown::getDropdownName("glpi_states", $data['states_id']) . "</td>";
+                    echo (isset($data["otherserial"]) ? Dropdown::getDropdownName("glpi_states", $data['states_id']) : '') . "</td>";
                     echo "<td class='center'>";
-                    echo Dropdown::getDropdownName("glpi_locations", $data['locations_id']) . "</td>";
+                    echo (isset($data['locations_id']) ? Dropdown::getDropdownName("glpi_locations", $data['locations_id']) : ''). "</td>";
                     echo "</tr>";
                 }
                 $totalnb += $nb;


### PR DESCRIPTION
Fix php warnings when showing items linked to a ticket, not having status or location.

To reproduce : 

- Use Formcreator and generate a ticket from a form.
- In your profile, tab assistance, add Form answers to items likable to tickets
- open the ticket previously created, go in tab "Items"
- The for manswer should show and in debug mode, there are 2 warnings
![image](https://github.com/glpi-project/glpi/assets/14139801/e18e465a-b58f-4917-8ddf-2ce31e2d9578)


After the fix, no error appears
![image](https://github.com/glpi-project/glpi/assets/14139801/cc901c17-55ab-4815-b8ee-9d53fcde4008)



| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/pluginsGLPI/formcreator/issues/3336
