### PR TITLE
Equipment collision in rack due to model modification

### DIFF
--- a/src/CommonDCModelDropdown.php
+++ b/src/CommonDCModelDropdown.php
@@ -309,7 +309,7 @@ abstract class CommonDCModelDropdown extends CommonDropdown
      */
     private function checkForRackIssues(array $input)
     {
-        // Check if t
+        // Checks whether any fields that might be causing a problem have been modified
         if (
             (!isset($input['required_units'])
                 || $input['required_units'] <= $this->fields['required_units']
@@ -337,6 +337,7 @@ abstract class CommonDCModelDropdown extends CommonDropdown
             $hpos = $input['is_half_rack'] ?? $this->fields['is_half_rack'] ? $item_rack['hpos'] : Rack::POS_NONE;
             $depth = $input['depth'] ?? $this->fields['depth'];
 
+            // Collect the positions to check
             for ($i = 0; $i < $requiredUnits; $i++) {
                 $positionsToCheck[] = $item_rack['position'] + $i;
 
@@ -348,6 +349,7 @@ abstract class CommonDCModelDropdown extends CommonDropdown
                 }
             }
 
+            // Check if any of the positions to check are filled or out of bounds
             foreach ($positionsToCheck as $position) {
                 if (
                     isset($filled[$position]) && $this->isCellFilled($filled[$position], $orientation, $hpos, $depth)

--- a/src/CommonDCModelDropdown.php
+++ b/src/CommonDCModelDropdown.php
@@ -212,28 +212,69 @@ abstract class CommonDCModelDropdown extends CommonDropdown
         return parent::getSpecificValueToDisplay($field, $values, $options);
     }
 
-    public function getItemRackForModel(): array
+    /**
+     * Get the itemtype for this model
+     *
+     * @return string
+     */
+    public function getItemtypeForModel(): string
     {
-        $itemtype = str_replace('Model', '', get_called_class());
+        return str_replace('Model', '', get_called_class());
+    }
+
+    /**
+     * Get the items in racks that are using this model
+     *
+     * @return array
+     */
+    public function getItemsRackForModel(): array
+    {
+        $itemtype = $this->getItemtypeForModel();
         return array_filter(
             (new Item_Rack())->find([
                 'itemtype' => $itemtype,
+                'items_id' => new QuerySubQuery([
+                    'SELECT' => 'id',
+                    'FROM'   => $itemtype::getTable(),
+                    'WHERE'  => [
+                        $this->getForeignKeyField() => $this->fields['id'],
+                    ]
+                ])
             ]),
             // Filter out items that are not using the model
             fn ($item_rack) => $itemtype::getById($item_rack['items_id'])->fields[strtolower(get_called_class()) . 's_id'] == $this->fields['id']
         );
     }
 
-    private function checkCellFilled(array $cell, int $orientation, int $hpos, float $depth): bool
+    /**
+     * Check if a cell is filled for a specific orientations, hpos and depth
+     *
+     * @param array $cell
+     * @param int $orientation front or rear
+     * @param int $hpos left, right or full
+     * @param float $depth
+     *
+     * @return bool
+     */
+    private function isCellFilled(array $cell, int $orientation, int $hpos, float $depth): bool
     {
+        // If hpos is full, check if both left and right are filled
         if ($hpos == Rack::POS_NONE) {
-            return $this->checkCellFilled($cell, $orientation, Rack::POS_LEFT, $depth)
-                || $this->checkCellFilled($cell, $orientation, Rack::POS_RIGHT, $depth);
+            return $this->isCellFilled($cell, $orientation, Rack::POS_LEFT, $depth)
+                || $this->isCellFilled($cell, $orientation, Rack::POS_RIGHT, $depth);
         }
 
         if (isset($cell[$hpos])) {
-            $accurateCell = array_slice($orientation ? array_reverse($cell[$hpos]) : $cell[$hpos], 0, $depth * 4);
+            // Get the first $depth * 4 units of the cell to check if they are filled
+            $accurateCell = array_slice(
+                $orientation ?
+                    array_reverse($cell[$hpos]) // If orientation is rear, reverse the array
+                    : $cell[$hpos],
+                0,
+                $depth * 4
+            );
 
+            // Check if any of the units is filled
             if (in_array(1, $accurateCell)) {
                 return true;
             }
@@ -250,82 +291,98 @@ abstract class CommonDCModelDropdown extends CommonDropdown
     public function prepareInputForUpdate($input)
     {
         $input = $this->managePictures($input);
-
-        // Check if the model is used by an asset in a rack
-        // If so, check whether the new units required fit into the rack without modifying the positions
-        if (
-            isset($input['required_units']) && $input['required_units'] > $this->fields['required_units']
-            || isset($input['is_half_rack']) && $input['is_half_rack'] != $this->fields['is_half_rack']
-            || isset($input['depth']) && $input['depth'] != $this->fields['depth']
-        ) {
-            $errors = [];
-            $itemtype = str_replace('Model', '', get_called_class());
-            foreach ($this->getItemRackForModel() as $item_rack) {
-                $rack = Rack::getById($item_rack['racks_id']);
-                $filled = $rack->getFilled($itemtype, $item_rack['items_id']);
-                $requiredUnits = $input['required_units'] ?? $this->fields['required_units'];
-                $orientation = $item_rack['orientation'];
-                $hpos = $input['is_half_rack'] ?? $this->fields['is_half_rack'] ? $item_rack['hpos'] : Rack::POS_NONE;
-                $depth = $input['depth'] ?? $this->fields['depth'];
-
-                for ($i = 0; $i < $requiredUnits; $i++) {
-                    $position = $item_rack['position'] + $i;
-
-                    if (isset($filled[$position]) && $this->checkCellFilled($filled[$position], $orientation, $hpos, $depth)) {
-                        $errors = [
-                            sprintf(
-                                __(
-                                    'Unable to update model because it is used by an asset in a rack %s and the new required units do not fit into the rack'
-                                ),
-                                $rack->getLink()
-                            )
-                        ];
-                        break;
-                    }
-
-                    if ($position > $rack->fields['number_units']) {
-                        for ($j = 1; $j <= $requiredUnits - $i; $j++) {
-                            $position = $item_rack['position'] - $j;
-                            if (
-                                isset($filled[$position]) && $this->checkCellFilled($filled[$position], $orientation, $hpos, $depth)
-                                || $position < 1
-                            ) {
-                                $errors = [
-                                    sprintf(
-                                        __(
-                                            'Unable to update model because it is used by an asset in a rack %s and the new required units do not fit into the rack'
-                                        ),
-                                        $rack->getLink()
-                                    )
-                                ];
-                                break 2;
-                            }
-                        }
-                        break;
-                    }
-                }
-            }
-
-            if (!empty($errors)) {
-                foreach ($errors as $error) {
-                    Session::addMessageAfterRedirect(
-                        $error,
-                        true,
-                        ERROR
-                    );
-                }
-                return false;
-            }
-        }
+        $input = $this->checkForRackIssues($input);
 
         return $input;
     }
 
     public function post_updateItem($history = 1)
     {
+        $this->updateRackItemsHorizontalPosition();
+    }
+
+    /**
+     * Check if the racks items using this model can be updated without issues
+     *
+     * @param array $input
+     * @return array|false
+     */
+    private function checkForRackIssues(array $input)
+    {
+        // Check if t
+        if (
+            (!isset($input['required_units'])
+                || $input['required_units'] <= $this->fields['required_units']
+            )
+            && (!isset($input['is_half_rack'])
+                || $input['is_half_rack'] == $this->fields['is_half_rack']
+            )
+            && (!isset($input['depth'])
+                || $input['depth'] == $this->fields['depth']
+            )
+        ) {
+            return $input;
+        }
+
+        // Check if the model is used by an asset in a rack
+        // If so, check whether the new units required fit into the rack without modifying the positions
+        $hasIssues = false;
+        $itemtype = $this->getItemtypeForModel();
+        $positionsToCheck = [];
+        foreach ($this->getItemsRackForModel() as $item_rack) {
+            $rack = Rack::getById($item_rack['racks_id']);
+            $filled = $rack->getFilled($itemtype, $item_rack['items_id']);
+            $requiredUnits = $input['required_units'] ?? $this->fields['required_units'];
+            $orientation = $item_rack['orientation'];
+            $hpos = $input['is_half_rack'] ?? $this->fields['is_half_rack'] ? $item_rack['hpos'] : Rack::POS_NONE;
+            $depth = $input['depth'] ?? $this->fields['depth'];
+
+            for ($i = 0; $i < $requiredUnits; $i++) {
+                $positionsToCheck[] = $item_rack['position'] + $i;
+
+                if ($positionsToCheck[array_key_last($positionsToCheck)] > $rack->fields['number_units']) {
+                    for ($j = 1; $j <= $requiredUnits - $i; $j++) {
+                        $positionsToCheck[] = $item_rack['position'] - $j;
+                    }
+                    break;
+                }
+            }
+
+            foreach ($positionsToCheck as $position) {
+                if (
+                    isset($filled[$position]) && $this->isCellFilled($filled[$position], $orientation, $hpos, $depth)
+                    || $position < 1
+                ) {
+                    $hasIssues = true;
+                    Session::addMessageAfterRedirect(
+                        sprintf(
+                            __(
+                                'Unable to update model because it is used by an asset in the "%s" rack and the new required units do not fit into the rack'
+                            ),
+                            $rack->getLink()
+                        ),
+                        true,
+                        ERROR
+                    );
+                    break 2;
+                }
+            }
+        }
+
+        return $hasIssues ? false : $input;
+    }
+
+    /**
+     * Update the horizontal positions of the items in racks using this model
+     *
+     * @return void
+     */
+    private function updateRackItemsHorizontalPosition()
+    {
         if (!$this->fields['is_half_rack']) {
+            // If the model is not half rack, set the hpos to none for all rack items using this model
             $item_rack = new Item_Rack();
-            foreach ($this->getItemRackForModel() as $item) {
+            foreach ($this->getItemsRackForModel() as $item) {
                 if ($item['hpos'] == Rack::POS_NONE) {
                     continue;
                 }
@@ -333,6 +390,19 @@ abstract class CommonDCModelDropdown extends CommonDropdown
                 $item_rack->update([
                     'id' => $item['id'],
                     'hpos' => Rack::POS_NONE,
+                ]);
+            }
+        } else {
+            // If the model is half rack, set the hpos to left for all rack items using this model and having hpos none
+            $item_rack = new Item_Rack();
+            foreach ($this->getItemsRackForModel() as $item) {
+                if ($item['hpos'] != Rack::POS_NONE) {
+                    continue;
+                }
+
+                $item_rack->update([
+                    'id' => $item['id'],
+                    'hpos' => Rack::POS_LEFT,
                 ]);
             }
         }

--- a/tests/functional/Item_Rack.php
+++ b/tests/functional/Item_Rack.php
@@ -493,293 +493,343 @@ class Item_Rack extends DbTestCase
     }
 
     /**
-     * Test for update items models into rack
+     * Test for rack issues when updating models
      */
-    public function testAlterModels()
+    public function testRackIssues()
     {
         // Create a ComputerModel
-        $model1 = new \ComputerModel();
-        $this->integer(
-            (int)$model1->add([
+        $model1 = $this->createItem(
+            'ComputerModel',
+            [
                 'required_units'  => 1,
                 'depth'           => 1,
-                'is_half_rack'    => 0,
-                'entities_id'     => 0,
-            ])
-        )->isGreaterThan(0);
+                'is_half_rack'    => 0
+            ]
+        );
 
         // Create a Computer
-        $computer = new \Computer();
-        $this->integer(
-            (int)$computer->add([
+        $computer = $this->createItem(
+            'Computer',
+            [
                 'computermodels_id' => $model1->getID(),
-                'entities_id'  => 0,
-            ])
-        )->isGreaterThan(0);
+                'entities_id'       => 0,
+            ]
+        );
 
         // Create a 10u rack
-        $rack = new \Rack();
-        $this->integer(
-            (int)$rack->add([
+        $rack = $this->createItem(
+            'Rack',
+            [
                 'name'         => 'Test rack',
                 'number_units' => 10,
                 'dcrooms_id'   => 0,
                 'position'     => 0,
                 'entities_id'  => 0,
-            ])
-        )->isGreaterThan(0);
+            ]
+        );
 
         // Create an Item_Rack
-        $itemRack1 = new \Item_Rack();
-        $this->integer(
-            (int)$itemRack1->add([
+        $itemRack1 = $this->createItem(
+            'Item_Rack',
+            [
                 'racks_id'    => $rack->getID(),
                 'position'    => 2,
                 'orientation' => 0,
                 'itemtype'    => 'Computer',
                 'items_id'    => $computer->getID()
-            ])
-        )->isGreaterThan(0);
+            ]
+        );
 
         // Update the ComputerModel
         for ($i = 1; $i < 15; $i++) {
-            $this->boolean(
-                $model1->update([
-                    'id'              => $model1->getID(),
-                    'required_units'  => $i,
-                ])
-            )->isEqualTo($i <= 10);
+            $this->boolean($model1->update([
+                'id'              => $model1->getID(),
+                'required_units'  => $i,
+            ]))->isEqualTo($i <= 10);
         }
 
-        $this->hasSessionMessages(ERROR, ['Unable to update model because it is used by an asset in a rack Test rack and the new required units do not fit into the rack']);
+        $this->hasSessionMessages(ERROR, ['Unable to update model because it is used by an asset in the "Test rack" rack and the new required units do not fit into the rack']);
 
         // Update the ComputerModel
-        $this->boolean(
-            $model1->update([
-                'id'              => $model1->getID(),
-                'required_units'  => 1,
-            ])
-        )->isTrue();
+        $this->boolean($model1->update([
+            'id'              => $model1->getID(),
+            'required_units'  => 1,
+        ]))->isTrue();
 
         // Add a new Computer with a new ComputerModel
-        $model2 = new \ComputerModel();
-        $this->integer(
-            (int)$model2->add([
+        $model2 = $this->createItem(
+            'ComputerModel',
+            [
                 'required_units'  => 1,
                 'depth'           => 1,
                 'is_half_rack'    => 0,
-                'entities_id'     => 0,
-            ])
-        )->isGreaterThan(0);
+            ]
+        );
 
-        $computer2 = new \Computer();
-        $this->integer(
-            (int)$computer2->add([
+        $computer2 = $this->createItem(
+            'Computer',
+            [
                 'computermodels_id' => $model2->getID(),
-                'entities_id'  => 0,
-            ])
-        )->isGreaterThan(0);
+                'entities_id'       => 0,
+            ]
+        );
 
         // Add the new Computer into the rack
-        $itemRack2 = new \Item_Rack();
-        $this->integer(
-            (int)$itemRack2->add([
+        $itemRack2 = $this->createItem(
+            'Item_Rack',
+            [
                 'racks_id'    => $rack->getID(),
                 'position'    => 4,
                 'orientation' => 0,
                 'itemtype'    => 'Computer',
                 'items_id'    => $computer2->getID()
-            ])
-        )->isGreaterThan(0);
+            ]
+        );
 
         // Update the ComputerModel
         for ($i = 1; $i < 15; $i++) {
-            $this->boolean(
-                $model2->update([
-                    'id'              => $model2->getID(),
-                    'required_units'  => $i,
-                ])
-            )->isEqualTo($i <= 8);
+            $this->boolean($model2->update([
+                'id'              => $model2->getID(),
+                'required_units'  => $i,
+            ]))->isEqualTo($i <= 8);
         }
 
-        $this->hasSessionMessages(ERROR, ['Unable to update model because it is used by an asset in a rack Test rack and the new required units do not fit into the rack']);
+        $this->hasSessionMessages(ERROR, ['Unable to update model because it is used by an asset in the "Test rack" rack and the new required units do not fit into the rack']);
 
         // Update the ComputerModel
-        $this->boolean(
-            $model2->update([
-                'id'              => $model2->getID(),
-                'required_units'  => 1,
-            ])
-        )->isTrue();
+        $this->boolean($model2->update([
+            'id'              => $model2->getID(),
+            'required_units'  => 1,
+        ]))->isTrue();
 
         // Update the ComputerModel
-        $this->boolean(
-            $model1->update([
-                'id'              => $model1->getID(),
-                'is_half_rack'    => 1,
-            ])
-        )->isTrue();
+        $this->boolean($model1->update([
+            'id'              => $model1->getID(),
+            'is_half_rack'    => 1,
+        ]))->isTrue();
 
-        $this->boolean(
-            $model2->update([
-                'id'              => $model2->getID(),
-                'is_half_rack'    => 1,
-            ])
-        )->isTrue();
+        $this->boolean($model2->update([
+            'id'              => $model2->getID(),
+            'is_half_rack'    => 1,
+        ]))->isTrue();
 
         // Update the Item_Rack
-        $this->boolean(
-            $itemRack1->update([
-                'id'   => $itemRack1->getID(),
-                'hpos' => 1,
-            ])
-        )->isTrue();
+        $this->boolean($itemRack1->update([
+            'id'   => $itemRack1->getID(),
+            'hpos' => 1,
+        ]))->isTrue();
 
-        $this->boolean(
-            $itemRack2->update([
-                'id'   => $itemRack2->getID(),
-                'hpos' => 2,
-            ])
-        )->isTrue();
+        $this->boolean($itemRack2->update([
+            'id'   => $itemRack2->getID(),
+            'hpos' => 2,
+        ]))->isTrue();
 
         // Update the ComputerModel
         for ($i = 1; $i <= 10; $i++) {
-            $this->boolean(
-                $model1->update([
-                    'id'              => $model1->getID(),
-                    'required_units'  => $i,
-                ])
-            )->isTrue();
+            $this->boolean($model1->update([
+                'id'              => $model1->getID(),
+                'required_units'  => $i,
+            ]))->isTrue();
 
-            $this->boolean(
-                $model2->update([
-                    'id'              => $model2->getID(),
-                    'required_units'  => $i,
-                ])
-            )->isTrue();
+            $this->boolean($model2->update([
+                'id'              => $model2->getID(),
+                'required_units'  => $i,
+            ]))->isTrue();
         }
 
         // Update the ComputerModel
-        $this->boolean(
-            $model1->update([
-                'id'              => $model1->getID(),
-                'required_units'  => 1,
-            ])
-        )->isTrue();
+        $this->boolean($model1->update([
+            'id'              => $model1->getID(),
+            'required_units'  => 1,
+        ]))->isTrue();
 
-        $this->boolean(
-            $model2->update([
-                'id'              => $model2->getID(),
-                'is_half_rack'    => 0,
-                'required_units'  => 1,
-            ])
-        )->isTrue();
+        $this->boolean($model2->update([
+            'id'              => $model2->getID(),
+            'is_half_rack'    => 0,
+            'required_units'  => 1,
+        ]))->isTrue();
 
         // Update the ComputerModel
         for ($i = 1; $i <= 5; $i++) {
-            $this->boolean(
-                $model1->update([
-                    'id'              => $model1->getID(),
-                    'required_units'  => $i,
-                ])
-            )->isEqualTo($i < 3);
+            $this->boolean($model1->update([
+                'id'              => $model1->getID(),
+                'required_units'  => $i,
+            ]))->isEqualTo($i < 3);
         }
 
-        $this->hasSessionMessages(ERROR, ['Unable to update model because it is used by an asset in a rack Test rack and the new required units do not fit into the rack']);
+        $this->hasSessionMessages(ERROR, ['Unable to update model because it is used by an asset in the "Test rack" rack and the new required units do not fit into the rack']);
 
         // Update the ComputerModel
-        $this->boolean(
-            $model1->update([
-                'id'              => $model1->getID(),
-                'required_units'  => 1,
-            ])
-        )->isTrue();
+        $this->boolean($model1->update([
+            'id'              => $model1->getID(),
+            'required_units'  => 1,
+        ]))->isTrue();
 
         // Test orientation
-        $this->boolean(
-            $itemRack1->update([
-                'id'   => $itemRack1->getID(),
-                'orientation' => Rack::REAR,
-                'hpos' => Rack::POS_LEFT,
-            ])
-        )->isTrue();
+        $this->boolean($itemRack1->update([
+            'id'   => $itemRack1->getID(),
+            'orientation' => Rack::REAR,
+            'hpos' => Rack::POS_LEFT,
+        ]))->isTrue();
 
-        $this->boolean(
-            $itemRack2->update([
-                'id'   => $itemRack2->getID(),
-                'orientation' => Rack::FRONT,
-                'is_half_rack' => 0,
-            ])
-        )->isTrue();
+        $this->boolean($itemRack2->update([
+            'id'   => $itemRack2->getID(),
+            'orientation' => Rack::FRONT,
+            'is_half_rack' => 0,
+        ]))->isTrue();
 
         for ($i = 1; $i <= 10; $i++) {
-            $this->boolean(
-                $model1->update([
-                    'id'              => $model1->getID(),
-                    'required_units'  => $i,
-                ])
-            )->isEqualTo($i < 3);
+            $this->boolean($model1->update([
+                'id'              => $model1->getID(),
+                'required_units'  => $i,
+            ]))->isEqualTo($i < 3);
         }
 
-        $this->hasSessionMessages(ERROR, ['Unable to update model because it is used by an asset in a rack Test rack and the new required units do not fit into the rack']);
+        $this->hasSessionMessages(ERROR, ['Unable to update model because it is used by an asset in the "Test rack" rack and the new required units do not fit into the rack']);
 
         // Test depth
-        $this->boolean(
-            $model1->update([
-                'id'              => $model1->getID(),
-                'required_units'  => 1,
-                'depth'           => 0.5,
-            ])
-        )->isTrue();
+        $this->boolean($model1->update([
+            'id'              => $model1->getID(),
+            'required_units'  => 1,
+            'depth'           => 0.5,
+        ]))->isTrue();
 
-        $this->boolean(
-            $model2->update([
-                'id'              => $model2->getID(),
-                'depth'           => 0.5,
-            ])
-        )->isTrue();
+        $this->boolean($model2->update([
+            'id'              => $model2->getID(),
+            'depth'           => 0.5,
+        ]))->isTrue();
 
         for ($i = 1; $i <= 10; $i++) {
-            $this->boolean(
-                $model1->update([
-                    'id'              => $model1->getID(),
-                    'required_units'  => $i,
-                ])
-            )->isTrue();
+            $this->boolean($model1->update([
+                'id'              => $model1->getID(),
+                'required_units'  => $i,
+            ]))->isTrue();
 
-            $this->boolean(
-                $model2->update([
-                    'id'              => $model2->getID(),
-                    'required_units'  => $i,
-                ])
-            )->isTrue();
+            $this->boolean($model2->update([
+                'id'              => $model2->getID(),
+                'required_units'  => $i,
+            ]))->isTrue();
         }
 
-        $this->boolean(
-            $model1->update([
-                'id'              => $model1->getID(),
-                'required_units'  => 1,
-                'depth'           => 0.5,
-            ])
-        )->isTrue();
+        $this->boolean($model1->update([
+            'id'              => $model1->getID(),
+            'required_units'  => 1,
+            'depth'           => 0.5,
+        ]))->isTrue();
 
-        $this->boolean(
-            $model2->update([
-                'id'              => $model2->getID(),
+        $this->boolean($model2->update([
+            'id'              => $model2->getID(),
+            'required_units'  => 1,
+            'depth'           => 1,
+        ]))->isTrue();
+
+        for ($i = 1; $i <= 10; $i++) {
+            $this->boolean($model1->update([
+                'id'              => $model1->getID(),
+                'required_units'  => $i,
+            ]))->isEqualTo($i < 3);
+        }
+
+        $this->hasSessionMessages(ERROR, ['Unable to update model because it is used by an asset in the "Test rack" rack and the new required units do not fit into the rack']);
+    }
+
+    /**
+     * Test for updating horizontal position of items rack
+     */
+    public function testUpdateItemHorizontalPosition()
+    {
+        // Create a ComputerModel
+        $model = $this->createItem(
+            'ComputerModel',
+            [
                 'required_units'  => 1,
                 'depth'           => 1,
-            ])
-        )->isTrue();
+                'is_half_rack'    => 0
+            ]
+        );
 
-        for ($i = 1; $i <= 10; $i++) {
-            $this->boolean(
-                $model1->update([
-                    'id'              => $model1->getID(),
-                    'required_units'  => $i,
-                ])
-            )->isEqualTo($i < 3);
-        }
+        // Create a Computer
+        $computer = $this->createItem(
+            'Computer',
+            [
+                'computermodels_id' => $model->getID(),
+                'entities_id'       => 0,
+            ]
+        );
 
-        $this->hasSessionMessages(ERROR, ['Unable to update model because it is used by an asset in a rack Test rack and the new required units do not fit into the rack']);
+        // Create a 10u rack
+        $rack = $this->createItem(
+            'Rack',
+            [
+                'name'         => 'Test rack',
+                'number_units' => 10,
+                'dcrooms_id'   => 0,
+                'position'     => 0,
+                'entities_id'  => 0,
+            ]
+        );
+
+        // Create an Item_Rack
+        $itemRack = $this->createItem(
+            'Item_Rack',
+            [
+                'racks_id'    => $rack->getID(),
+                'position'    => 2,
+                'orientation' => 0,
+                'itemtype'    => 'Computer',
+                'items_id'    => $computer->getID()
+            ]
+        );
+
+        // Check horizontal position
+        $this->integer($itemRack->fields['hpos'])->isEqualTo(Rack::POS_NONE);
+
+        // Update model
+        $this->updateItem(
+            'ComputerModel',
+            $model->getID(),
+            [
+                'is_half_rack'    => 1,
+            ]
+        );
+        $itemRack->getFromDB($itemRack->getID());
+
+        // Check horizontal position
+        $this->integer($itemRack->fields['hpos'])->isEqualTo(Rack::POS_LEFT);
+
+        // Update model
+        $this->updateItem(
+            'ComputerModel',
+            $model->getID(),
+            [
+                'is_half_rack'    => 0,
+            ]
+        );
+        $itemRack->getFromDB($itemRack->getID());
+
+        // Check horizontal position
+        $this->integer($itemRack->fields['hpos'])->isEqualTo(Rack::POS_NONE);
+
+        // Update item rack
+        $this->updateItem(
+            'Item_Rack',
+            $itemRack->getID(),
+            [
+                'hpos'    => Rack::POS_RIGHT,
+            ]
+        );
+
+        // Update model
+        $this->updateItem(
+            'ComputerModel',
+            $model->getID(),
+            [
+                'is_half_rack'    => 1,
+            ]
+        );
+        $itemRack->getFromDB($itemRack->getID());
+
+        // Check horizontal position
+        $this->integer($itemRack->fields['hpos'])->isEqualTo(Rack::POS_RIGHT);
     }
 }

--- a/tests/functional/Item_Rack.php
+++ b/tests/functional/Item_Rack.php
@@ -36,6 +36,7 @@
 namespace tests\units;
 
 use DbTestCase;
+use Rack;
 
 /* Test for inc/item_rack.class.php */
 
@@ -489,5 +490,296 @@ class Item_Rack extends DbTestCase
                 'hpos'      => $rack::POS_RIGHT
             ])
         )->isGreaterThan(0);
+    }
+
+    /**
+     * Test for update items models into rack
+     */
+    public function testAlterModels()
+    {
+        // Create a ComputerModel
+        $model1 = new \ComputerModel();
+        $this->integer(
+            (int)$model1->add([
+                'required_units'  => 1,
+                'depth'           => 1,
+                'is_half_rack'    => 0,
+                'entities_id'     => 0,
+            ])
+        )->isGreaterThan(0);
+
+        // Create a Computer
+        $computer = new \Computer();
+        $this->integer(
+            (int)$computer->add([
+                'computermodels_id' => $model1->getID(),
+                'entities_id'  => 0,
+            ])
+        )->isGreaterThan(0);
+
+        // Create a 10u rack
+        $rack = new \Rack();
+        $this->integer(
+            (int)$rack->add([
+                'name'         => 'Test rack',
+                'number_units' => 10,
+                'dcrooms_id'   => 0,
+                'position'     => 0,
+                'entities_id'  => 0,
+            ])
+        )->isGreaterThan(0);
+
+        // Create an Item_Rack
+        $itemRack1 = new \Item_Rack();
+        $this->integer(
+            (int)$itemRack1->add([
+                'racks_id'    => $rack->getID(),
+                'position'    => 2,
+                'orientation' => 0,
+                'itemtype'    => 'Computer',
+                'items_id'    => $computer->getID()
+            ])
+        )->isGreaterThan(0);
+
+        // Update the ComputerModel
+        for ($i = 1; $i < 15; $i++) {
+            $this->boolean(
+                $model1->update([
+                    'id'              => $model1->getID(),
+                    'required_units'  => $i,
+                ])
+            )->isEqualTo($i <= 10);
+        }
+
+        $this->hasSessionMessages(ERROR, ['Unable to update model because it is used by an asset in a rack Test rack and the new required units do not fit into the rack']);
+
+        // Update the ComputerModel
+        $this->boolean(
+            $model1->update([
+                'id'              => $model1->getID(),
+                'required_units'  => 1,
+            ])
+        )->isTrue();
+
+        // Add a new Computer with a new ComputerModel
+        $model2 = new \ComputerModel();
+        $this->integer(
+            (int)$model2->add([
+                'required_units'  => 1,
+                'depth'           => 1,
+                'is_half_rack'    => 0,
+                'entities_id'     => 0,
+            ])
+        )->isGreaterThan(0);
+
+        $computer2 = new \Computer();
+        $this->integer(
+            (int)$computer2->add([
+                'computermodels_id' => $model2->getID(),
+                'entities_id'  => 0,
+            ])
+        )->isGreaterThan(0);
+
+        // Add the new Computer into the rack
+        $itemRack2 = new \Item_Rack();
+        $this->integer(
+            (int)$itemRack2->add([
+                'racks_id'    => $rack->getID(),
+                'position'    => 4,
+                'orientation' => 0,
+                'itemtype'    => 'Computer',
+                'items_id'    => $computer2->getID()
+            ])
+        )->isGreaterThan(0);
+
+        // Update the ComputerModel
+        for ($i = 1; $i < 15; $i++) {
+            $this->boolean(
+                $model2->update([
+                    'id'              => $model2->getID(),
+                    'required_units'  => $i,
+                ])
+            )->isEqualTo($i <= 8);
+        }
+
+        $this->hasSessionMessages(ERROR, ['Unable to update model because it is used by an asset in a rack Test rack and the new required units do not fit into the rack']);
+
+        // Update the ComputerModel
+        $this->boolean(
+            $model2->update([
+                'id'              => $model2->getID(),
+                'required_units'  => 1,
+            ])
+        )->isTrue();
+
+        // Update the ComputerModel
+        $this->boolean(
+            $model1->update([
+                'id'              => $model1->getID(),
+                'is_half_rack'    => 1,
+            ])
+        )->isTrue();
+
+        $this->boolean(
+            $model2->update([
+                'id'              => $model2->getID(),
+                'is_half_rack'    => 1,
+            ])
+        )->isTrue();
+
+        // Update the Item_Rack
+        $this->boolean(
+            $itemRack1->update([
+                'id'   => $itemRack1->getID(),
+                'hpos' => 1,
+            ])
+        )->isTrue();
+
+        $this->boolean(
+            $itemRack2->update([
+                'id'   => $itemRack2->getID(),
+                'hpos' => 2,
+            ])
+        )->isTrue();
+
+        // Update the ComputerModel
+        for ($i = 1; $i <= 10; $i++) {
+            $this->boolean(
+                $model1->update([
+                    'id'              => $model1->getID(),
+                    'required_units'  => $i,
+                ])
+            )->isTrue();
+
+            $this->boolean(
+                $model2->update([
+                    'id'              => $model2->getID(),
+                    'required_units'  => $i,
+                ])
+            )->isTrue();
+        }
+
+        // Update the ComputerModel
+        $this->boolean(
+            $model1->update([
+                'id'              => $model1->getID(),
+                'required_units'  => 1,
+            ])
+        )->isTrue();
+
+        $this->boolean(
+            $model2->update([
+                'id'              => $model2->getID(),
+                'is_half_rack'    => 0,
+                'required_units'  => 1,
+            ])
+        )->isTrue();
+
+        // Update the ComputerModel
+        for ($i = 1; $i <= 5; $i++) {
+            $this->boolean(
+                $model1->update([
+                    'id'              => $model1->getID(),
+                    'required_units'  => $i,
+                ])
+            )->isEqualTo($i < 3);
+        }
+
+        $this->hasSessionMessages(ERROR, ['Unable to update model because it is used by an asset in a rack Test rack and the new required units do not fit into the rack']);
+
+        // Update the ComputerModel
+        $this->boolean(
+            $model1->update([
+                'id'              => $model1->getID(),
+                'required_units'  => 1,
+            ])
+        )->isTrue();
+
+        // Test orientation
+        $this->boolean(
+            $itemRack1->update([
+                'id'   => $itemRack1->getID(),
+                'orientation' => Rack::REAR,
+                'hpos' => Rack::POS_LEFT,
+            ])
+        )->isTrue();
+
+        $this->boolean(
+            $itemRack2->update([
+                'id'   => $itemRack2->getID(),
+                'orientation' => Rack::FRONT,
+                'is_half_rack' => 0,
+            ])
+        )->isTrue();
+
+        for ($i = 1; $i <= 10; $i++) {
+            $this->boolean(
+                $model1->update([
+                    'id'              => $model1->getID(),
+                    'required_units'  => $i,
+                ])
+            )->isEqualTo($i < 3);
+        }
+
+        $this->hasSessionMessages(ERROR, ['Unable to update model because it is used by an asset in a rack Test rack and the new required units do not fit into the rack']);
+
+        // Test depth
+        $this->boolean(
+            $model1->update([
+                'id'              => $model1->getID(),
+                'required_units'  => 1,
+                'depth'           => 0.5,
+            ])
+        )->isTrue();
+
+        $this->boolean(
+            $model2->update([
+                'id'              => $model2->getID(),
+                'depth'           => 0.5,
+            ])
+        )->isTrue();
+
+        for ($i = 1; $i <= 10; $i++) {
+            $this->boolean(
+                $model1->update([
+                    'id'              => $model1->getID(),
+                    'required_units'  => $i,
+                ])
+            )->isTrue();
+
+            $this->boolean(
+                $model2->update([
+                    'id'              => $model2->getID(),
+                    'required_units'  => $i,
+                ])
+            )->isTrue();
+        }
+
+        $this->boolean(
+            $model1->update([
+                'id'              => $model1->getID(),
+                'required_units'  => 1,
+                'depth'           => 0.5,
+            ])
+        )->isTrue();
+
+        $this->boolean(
+            $model2->update([
+                'id'              => $model2->getID(),
+                'required_units'  => 1,
+                'depth'           => 1,
+            ])
+        )->isTrue();
+
+        for ($i = 1; $i <= 10; $i++) {
+            $this->boolean(
+                $model1->update([
+                    'id'              => $model1->getID(),
+                    'required_units'  => $i,
+                ])
+            )->isEqualTo($i < 3);
+        }
+
+        $this->hasSessionMessages(ERROR, ['Unable to update model because it is used by an asset in a rack Test rack and the new required units do not fit into the rack']);
     }
 }


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29207

Modifying an asset's model (by increasing its height, width or depth) can lead to overlapping with other assets in the rack.

![image](https://github.com/glpi-project/glpi/assets/42278610/9444ecbd-60ec-4288-a3bd-2b956c000cbf)
For example, if I increase the height of my network equipment model to 5, the display becomes inconsistent (we can no longer interact with the computer).
