### PR TITLE
fix(RuleCriteria): unsanitize field when try to match

### DIFF
--- a/src/RuleCriteria.php
+++ b/src/RuleCriteria.php
@@ -411,7 +411,7 @@ class RuleCriteria extends CommonDBChild
                    //Perform comparison with fields in lower case
                     $field                        = Toolbox::strtolower($field);
                     $pattern                      = Toolbox::strtolower($pattern);
-                    if ($field == $pattern) {
+                    if (Sanitizer::unsanitize($field) == $pattern) {
                         $criterias_results[$criteria] = $pattern;
                         return true;
                     }
@@ -422,7 +422,7 @@ class RuleCriteria extends CommonDBChild
                //Perform comparison with fields in lower case
                 $field   = Toolbox::strtolower($field);
                 $pattern = Toolbox::strtolower($pattern);
-                if ($field != $pattern) {
+                if (Sanitizer::unsanitize($field) != $pattern) {
                     $criterias_results[$criteria] = $pattern;
                     return true;
                 }
@@ -449,7 +449,7 @@ class RuleCriteria extends CommonDBChild
                     return false;
                 }
 
-                if (str_ends_with(mb_strtolower($field), mb_strtolower($pattern))) {
+                if (str_ends_with(mb_strtolower(Sanitizer::unsanitize($field)), mb_strtolower($pattern))) {
                     $criterias_results[$criteria] = $pattern;
                     return true;
                 }
@@ -459,7 +459,7 @@ class RuleCriteria extends CommonDBChild
                 if (empty($pattern) || empty($field)) {
                     return false;
                 }
-                $value = mb_stripos($field, $pattern, 0, 'UTF-8');
+                $value = mb_stripos(Sanitizer::unsanitize($field), $pattern, 0, 'UTF-8');
                 if (($value !== false) && ($value == 0)) {
                     $criterias_results[$criteria] = $pattern;
                     return true;
@@ -470,7 +470,7 @@ class RuleCriteria extends CommonDBChild
                 if (empty($pattern) || empty($field)) {
                     return false;
                 }
-                $value = mb_stripos($field, $pattern, 0, 'UTF-8');
+                $value = mb_stripos(Sanitizer::unsanitize($field), $pattern, 0, 'UTF-8');
                 if (($value !== false) && ($value >= 0)) {
                     $criterias_results[$criteria] = $pattern;
                     return true;
@@ -481,7 +481,7 @@ class RuleCriteria extends CommonDBChild
                 if (empty($pattern)) {
                     return false;
                 }
-                $value = mb_stripos($field ?? '', $pattern, 0, 'UTF-8');
+                $value = mb_stripos(Sanitizer::unsanitize($field) ?? '', $pattern, 0, 'UTF-8');
                 if ($value === false) {
                     $criterias_results[$criteria] = $pattern;
                     return true;

--- a/tests/functional/Rule.php
+++ b/tests/functional/Rule.php
@@ -696,4 +696,129 @@ class Rule extends DbTestCase
             }
         }
     }
+
+
+    /**
+     * RuleCriteria data provider
+     *
+     * @return array
+     */
+    protected function ruleCriteriaDataProvider()
+    {
+        return [
+            [
+                'condition' => \Rule::PATTERN_BEGIN,
+                'pattern'   => "Besoin d'un ordinateur",
+                'field'     => "Besoin d'un ordinateur",
+                'result'    => true
+            ],
+            [
+                'condition' => \Rule::PATTERN_BEGIN,
+                'pattern'   => "Besoin d'un ordinateur",
+                'field'     => "Besoin d\'un ordinateur",
+                'result'    => true
+            ],
+            [
+                'condition' => \Rule::PATTERN_END,
+                'pattern'   => "Besoin d'un ordinateur",
+                'field'     => "Besoin d'un ordinateur",
+                'result'    => true
+            ],
+            [
+                'condition' => \Rule::PATTERN_END,
+                'pattern'   => "Besoin d'un ordinateur",
+                'field'     => "Besoin d\'un ordinateur",
+                'result'    => true
+            ],
+            [
+                'condition' => \Rule::PATTERN_CONTAIN,
+                'pattern'   => "d'un",
+                'field'     => "Besoin d'un ordinateur",
+                'result'    => true
+            ],
+            [
+                'condition' => \Rule::PATTERN_CONTAIN,
+                'pattern'   => "d'un",
+                'field'     => "Besoin d\'un ordinateur",
+                'result'    => true
+            ],
+            [
+                'condition' => \Rule::PATTERN_NOT_CONTAIN,
+                'pattern'   => "d'un",
+                'field'     => "Besoin d'un ordinateur",
+                'result'    => false
+            ],
+            [
+                'condition' => \Rule::PATTERN_NOT_CONTAIN,
+                'pattern'   => "d'un",
+                'field'     => "Besoin d\'un ordinateur",
+                'result'    => false
+            ],
+            [
+                'condition' => \Rule::PATTERN_IS,
+                'pattern'   => "d'un",
+                'field'     => "d'un",
+                'result'    => true
+            ],
+            [
+                'condition' => \Rule::PATTERN_IS,
+                'pattern'   => "d'un",
+                'field'     => "d\'un",
+                'result'    => true
+            ],
+            [
+                'condition' => \Rule::PATTERN_IS_NOT,
+                'pattern'   => "d'un",
+                'field'     => "d\'un",
+                'result'    => false
+            ],
+            [
+                'condition' => \Rule::PATTERN_IS_NOT,
+                'pattern'   => "d'un",
+                'field'     => "d'un",
+                'result'    => false
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider ruleCriteriaDataProvider
+    */
+    public function testPatternConditionWithSanitizeString($condition, $pattern, $field, $result)
+    {
+        $criteria = new \RuleCriteria();
+        $criteria->fields = ['id' => 1,
+            'rules_id'  => 1,
+            'criteria'  => 'name',
+            'condition' => $condition,
+            'pattern'   => $pattern
+        ];
+
+        $results      = [];
+        $regex_result = [];
+
+        if ($result) {
+            $this->boolean(
+                $criteria->match(
+                    $criteria,
+                    $field,
+                    $results,
+                    $regex_result
+                )
+            )->isTrue();
+        } else {
+            $this->boolean(
+                $criteria->match(
+                    $criteria,
+                    $field,
+                    $results,
+                    $regex_result
+                )
+            )->isFalse();
+        }
+
+
+
+
+    }
 }

--- a/tests/functional/Rule.php
+++ b/tests/functional/Rule.php
@@ -816,9 +816,5 @@ class Rule extends DbTestCase
                 )
             )->isFalse();
         }
-
-
-
-
     }
 }


### PR DESCRIPTION
```RuleCriteria``` does not work when the value of the field contains a ```quote```

This field can be ```sanitized``` and then passed to the rules 

Ex : 

Create a ticket with title :  ```"Besoin d'un ordinateur"```

```RuleCretieria``` receive  ```"Besoin d\'un ordinateur"``` 

This PR fix this

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29251
