### PR TITLE
fix(knowbase): translations not editable

### DIFF
--- a/src/KnowbaseItemTranslation.php
+++ b/src/KnowbaseItemTranslation.php
@@ -125,7 +125,7 @@ class KnowbaseItemTranslation extends CommonDBChild
                     break;
 
                 case 3:
-                    $item->showForm($item->getID());
+                    $item->showForm($item->getID(), ['parent' => $item]);
                     break;
             }
         } else if (self::canBeTranslated($item)) {


### PR DESCRIPTION
Translations could no longer be modified with an error visible in debug mode:

![image](https://github.com/glpi-project/glpi/assets/8530352/beb26315-dcf0-410d-99aa-66bd1ad9471b)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29252
