### PR TITLE
Notifications triggered by email followups don't mention tickets documents added after the initial ticket creation

### DIFF
--- a/src/NotificationTargetCommonITILObject.php
+++ b/src/NotificationTargetCommonITILObject.php
@@ -1423,7 +1423,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                     ]
                 ],
                 'WHERE'     => [
-                    $item->getAssociatedDocumentsCriteria(),
+                    $item->getAssociatedDocumentsCriteria(Session::isCron()),
                     'timeline_position' => ['>', CommonITILObject::NO_TIMELINE], // skip inlined images
                 ]
             ]);


### PR DESCRIPTION
When a followup is retrieved by an mail collector, existing session does not set "canView" to yes. So  itil obejcts' documents are not added to the notification template data. On the other hand, as the same function is used during itil followups creations from the user interface, rights checks should not be bypassed all the time...

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 1
