### PR TITLE
fix: remove 9.5 from security fixes

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,7 +23,7 @@ Thank you for improving the security of glpi.
 | Version | Supported          |
 | ------- | ------------------ |
 | 10.0.x  | :heavy_check_mark: |
-| 9.5.x   | :heavy_check_mark: (only for critical issues) |
+| 9.5.x   | :x:                |
 | 9.4.x   | :x:                |
 | 9.3.x   | :x:                |
 | 9.2.x   | :x:                |


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A

The end of support for GLPI 9.5 has been announced, and ended on 06/30/2023.
