### PR TITLE
fix(projecttask): Cloning and updating massive actions are now passed on to subtasks

### DIFF
--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -287,6 +287,14 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
             $this->getFromDB($this->fields['id']);
             NotificationEvent::raiseEvent("update", $this);
         }
+
+        // If task has changed of project, update all sub-tasks
+        if (in_array('projects_id', $this->updates)) {
+            foreach (self::getAllForProjectTask($this->getID()) as $task) {
+                $task['projects_id'] = $this->fields['projects_id'];
+                $a = self::getById($task['id'])->update($task);
+            }
+        }
     }
 
 
@@ -320,11 +328,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
     public function post_deleteItem()
     {
         // Delete all sub-tasks
-        foreach (
-            (new self())->find([
-                'projecttasks_id' => $this->getID()
-            ]) as $task
-        ) {
+        foreach (self::getAllForProjectTask($this->getID()) as $task) {
             self::getById($task['id'])->delete($task);
         }
     }
@@ -341,11 +345,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
         }
 
         // Restore all sub-tasks
-        foreach (
-            (new self())->find([
-                'projecttasks_id' => $this->getID()
-            ]) as $task
-        ) {
+        foreach (self::getAllForProjectTask($this->getID()) as $task) {
             self::getById($task['id'])->restore($task);
         }
     }
@@ -517,6 +517,16 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
         }
 
         return Project::checkPlanAndRealDates($input);
+    }
+
+    public function post_clone($source, $history)
+    {
+        // Clone all sub-tasks of the source and link them to the cloned task
+        foreach (self::getAllForProjectTask($source->getID()) as $task) {
+            self::getById($task['id'])->clone([
+                'projecttasks_id' => $this->getID()
+            ]);
+        }
     }
 
 

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -292,7 +292,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
         if (in_array('projects_id', $this->updates)) {
             foreach (self::getAllForProjectTask($this->getID()) as $task) {
                 $task['projects_id'] = $this->fields['projects_id'];
-                $a = self::getById($task['id'])->update($task);
+                self::getById($task['id'])->update($task);
             }
         }
     }

--- a/tests/functional/ProjectTask.php
+++ b/tests/functional/ProjectTask.php
@@ -295,4 +295,110 @@ class ProjectTask extends DbTestCase
         // Check if session has an error message
         $this->hasSessionMessages(ERROR, ['A linked project is mandatory']);
     }
+
+    public function testMoveTaskToAnotherProject()
+    {
+        // Create a project
+        $project1 = $this->createItem('Project', [
+            'name' => 'Project 1',
+        ]);
+
+        // Create a project task
+        $task = $this->createItem('ProjectTask', [
+            'projects_id' => $project1->getID(),
+            'name'        => 'Task 1',
+        ]);
+
+        // Create a subtask
+        $subtask = $this->createItem('ProjectTask', [
+            'projects_id'     => $project1->getID(),
+            'projecttasks_id' => $task->getID(),
+            'name'            => 'Subtask 1',
+        ]);
+
+        // Create a subtask of the subtask
+        $subtask2 = $this->createItem('ProjectTask', [
+            'projects_id'     => $project1->getID(),
+            'projecttasks_id' => $subtask->getID(),
+            'name'            => 'Subtask 2',
+        ]);
+
+        // Create another project
+        $project2 = $this->createItem('Project', [
+            'name' => 'Project 2',
+        ]);
+
+        // Move the task to another project
+        $this->updateItem('ProjectTask', $task->getID(), [
+            'projects_id' => $project2->getID(),
+        ]);
+
+        // Reload all items from DB
+        $task->getFromDB($task->getID());
+        $subtask->getFromDB($subtask->getID());
+        $subtask2->getFromDB($subtask2->getID());
+
+        // Check all tasks have been moved
+        $this->integer($task->fields['projects_id'])->isEqualTo($project2->getID());
+        $this->integer($subtask->fields['projects_id'])->isEqualTo($project2->getID());
+        $this->integer($subtask2->fields['projects_id'])->isEqualTo($project2->getID());
+    }
+
+    public function testCloneProjectTask()
+    {
+        // Create a project
+        $project = $this->createItem('Project', [
+            'name' => 'Project 1',
+        ]);
+
+        // Create a project task
+        $task = $this->createItem('ProjectTask', [
+            'projects_id' => $project->getID(),
+            'name'        => 'Task 1',
+        ]);
+
+        // Create a subtask
+        $subtask = $this->createItem('ProjectTask', [
+            'projects_id'     => $project->getID(),
+            'projecttasks_id' => $task->getID(),
+            'name'            => 'Subtask 1',
+        ]);
+
+        // Create a subtask of the subtask
+        $subtask2 = $this->createItem('ProjectTask', [
+            'projects_id'     => $project->getID(),
+            'projecttasks_id' => $subtask->getID(),
+            'name'            => 'Subtask 2',
+        ]);
+
+        // Clone the task
+        $clonedTaskId = $task->clone();
+        $clonedTask = \ProjectTask::getById($clonedTaskId);
+
+        // Check if the cloned task is in the same project with the same name
+        $this->integer($clonedTask->fields['projects_id'])->isEqualTo($project->getID());
+        $this->string($clonedTask->fields['name'])->isEqualTo($task->fields['name'] . ' (copy)');
+
+        // Check if the subtask has been cloned
+        $clonedSubtask = new \ProjectTask();
+        $clonedSubtask->getFromDBByCrit([
+            'projects_id'     => $project->getID(),
+            'projecttasks_id' => $clonedTaskId,
+        ]);
+
+        $this->integer($clonedSubtask->getID())->isGreaterThan(0);
+        $this->integer($clonedSubtask->fields['projects_id'])->isEqualTo($project->getID());
+        $this->string($clonedSubtask->fields['name'])->isEqualTo($subtask->fields['name'] . ' (copy)');
+
+        // Check if the subtask of the subtask has been cloned
+        $clonedSubtask2 = new \ProjectTask();
+        $clonedSubtask2->getFromDBByCrit([
+            'projects_id'     => $project->getID(),
+            'projecttasks_id' => $clonedSubtask->getID(),
+        ]);
+
+        $this->integer($clonedSubtask2->getID())->isGreaterThan(0);
+        $this->integer($clonedSubtask2->fields['projects_id'])->isEqualTo($project->getID());
+        $this->string($clonedSubtask2->fields['name'])->isEqualTo($subtask2->fields['name'] . ' (copy)');
+    }
 }


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28627

Currently, there are several inconsistencies in the execution of massive actions on project tasks.
Firstly, if a task is moved from one project to another, the sub-tasks of that task will not be moved to their new project.
Secondly, if a task is cloned, its associated sub-tasks will not be cloned.
