### PR TITLE
Fix/project task prevent no project linked

### DIFF
--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -446,6 +446,15 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
             }
         }
 
+        if (isset($input['projects_id']) && $input['projects_id'] <= 0) {
+            Session::addMessageAfterRedirect(
+                __('A linked project is mandatory'),
+                false,
+                ERROR
+            );
+            unset($input['projects_id']);
+        }
+
         if (isset($input['projecttasks_id']) && $input['projecttasks_id'] > 0) {
             if (self::checkCircularRelation($input['id'], $input['projecttasks_id'])) {
                 Session::addMessageAfterRedirect(

--- a/tests/functional/ProjectTask.php
+++ b/tests/functional/ProjectTask.php
@@ -267,4 +267,32 @@ class ProjectTask extends DbTestCase
         $this->integer($team[0]['items_id'])->isEqualTo(5);
         $this->integer($team[0]['role'])->isEqualTo(Team::ROLE_MEMBER);
     }
+
+    public function testTaskMustHaveLinkedProject()
+    {
+        // Create a project
+        $project = $this->createItem('Project', [
+            'name' => 'Project 1',
+        ]);
+
+        // Create a task
+        $task = $this->createItem('ProjectTask', [
+            'name' => 'Task 1',
+            'projects_id' => $project->getID(),
+        ]);
+
+        // Update the task with a projects_id at 0
+        $this->updateItem('ProjectTask', $task->getID(), [
+            'projects_id' => 0,
+        ], ['projects_id']);
+
+        // Reload task from DB
+        $task->getFromDB($task->getID());
+
+        // Check that the task is still linked to the project
+        $this->integer($task->fields['projects_id'])->isEqualTo($project->getID());
+
+        // Check if session has an error message
+        $this->hasSessionMessages(ERROR, ['A linked project is mandatory']);
+    }
 }


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

With the addition of mass actions for project tasks (#15337), it is now possible to modify the project of one or more tasks, enabling tasks to be moved between projects. However, it is also possible to define no project (see below).
Once a task has no project, it cannot be recovered.

![image](https://github.com/glpi-project/glpi/assets/42278610/7e4c8aaf-1b63-4877-be38-f4f102e4c927)

This fix prevents a task's project ID from being modified by an invalid project.