### PR TITLE
try to keep the same url when a relative redirect is asked

### DIFF
--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -1619,10 +1619,10 @@ class Toolbox
                     }
                 }
 
-                // Redirect to relative url -> redirect with glpi url to prevent exploits
+                // Redirect to relative url
                 if ($decoded_where[0] == '/') {
-                    $redirect_to = $CFG_GLPI["url_base"] . $decoded_where;
-                   //echo $redirect_to; exit();
+                    // prevent exploit (//example.com) and force a redirect from glpi root
+                    $redirect_to = $CFG_GLPI["root_doc"] . "/" . ltrim($decoded_where, '/');
                     Html::redirect($redirect_to);
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29238

Context, one glpi with several url (case multi-structure or load balancing, etc)

Since https://github.com/glpi-project/glpi/security/advisories/GHSA-gxv6-xq9q-37hg, we force `url_base` (instead `root_doc` previously) when a `?redirect=` is asked with a relative url. This to prevent a malicious redirection (ex `?redirect=/\/example.com`)

Issue is with the above context, a cookie expiration will destroy session, and move to login page with a redirect parameter.
After a successful login, we are redirected to the url defined in setup general, where in some valid cases, we want to keep the current `server_name` .

To address the need and not re-open the case covered by the CVE, I suggest to prepend `$_SERVER['SERVER_NAME']` to ` $CFG_GLPI['root_doc']` to restore the previous behavior (aka keep the same domain)
