### PR TITLE
fix(ticket): ticket reopening with template

### DIFF
--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -351,6 +351,9 @@ const setRichTextEditorContent = function(editor_id, content) {
         editor.execCommand('mceInsertClipboardContent', false, {
             html: content
         });
+        // force trigger of event handlers that will save editor contents
+        // and remove "required" state
+        editor.fire('keyup');
     }
 };
 


### PR DESCRIPTION
When a ticket is reopened, a follow-up is mandatory. If an attempt is made to save this empty follow-up, a warning is displayed and the follow-up is not created. In the case where the user uses the content of a template, the text modification was not detected, and the warning was displayed even though the content is not empty.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29302
