### PR TITLE
Fix API upload handler

### DIFF
--- a/src/Api/APIRest.php
+++ b/src/Api/APIRest.php
@@ -61,7 +61,12 @@ class APIRest extends API
         foreach (array_keys($_FILES) as $filename) {
            // Randomize files names
             $rand_name = uniqid('', true);
-            foreach ($_FILES[$filename]['name'] as &$name) {
+            if( is_array($_FILES[$filename]['name'])) {
+                foreach ($_FILES[$filename]['name'] as &$name) {
+                    $name = $rand_name . $name;
+                }
+            } else {
+                $name = &$_FILES[$filename]['name'];
                 $name = $rand_name . $name;
             }
 

--- a/src/Api/APIRest.php
+++ b/src/Api/APIRest.php
@@ -61,7 +61,7 @@ class APIRest extends API
         foreach (array_keys($_FILES) as $filename) {
            // Randomize files names
             $rand_name = uniqid('', true);
-            if( is_array($_FILES[$filename]['name'])) {
+            if (is_array($_FILES[$filename]['name'])) {
                 foreach ($_FILES[$filename]['name'] as &$name) {
                     $name = $rand_name . $name;
                 }

--- a/src/Api/APIRest.php
+++ b/src/Api/APIRest.php
@@ -62,10 +62,28 @@ class APIRest extends API
            // Randomize files names
             $rand_name = uniqid('', true);
             if (is_array($_FILES[$filename]['name'])) {
+                // Input name was suffixed by `[]`. This results in each `$_FILES[$filename]` element being an array.
+                // e.g.
+                // [
+                //     'name' => [
+                //         0 => 'image.jpg',
+                //         1 => 'document.pdf',
+                //     ],
+                //     'type' => [
+                //         0 => 'image/jpeg',
+                //         1 => 'application/pdf',
+                //     ]
+                // ]
                 foreach ($_FILES[$filename]['name'] as &$name) {
                     $name = $rand_name . $name;
                 }
             } else {
+                // Input name was NOT suffixed by `[]`. This results in each `$_FILES[$filename]` element being a single entry.
+                // e.g.
+                // [
+                //     'name' => 'image.jpg',
+                //     'type' => 'image/jpeg',
+                // ]
                 $name = &$_FILES[$filename]['name'];
                 $name = $rand_name . $name;
             }

--- a/src/Api/APIRest.php
+++ b/src/Api/APIRest.php
@@ -62,7 +62,7 @@ class APIRest extends API
            // Randomize files names
             $rand_name = uniqid('', true);
             if (is_array($_FILES[$filename]['name'])) {
-                // Input name was suffixed by `[]`. This results in each `$_FILES[$filename]` element being an array.
+                // Input name was suffixed by `[]`. This results in each `$_FILES[$filename]` property being an array.
                 // e.g.
                 // [
                 //     'name' => [
@@ -78,7 +78,7 @@ class APIRest extends API
                     $name = $rand_name . $name;
                 }
             } else {
-                // Input name was NOT suffixed by `[]`. This results in each `$_FILES[$filename]` element being a single entry.
+                // Input name was NOT suffixed by `[]`. This results in each `$_FILES[$filename]` property being a single entry.
                 // e.g.
                 // [
                 //     'name' => 'image.jpg',


### PR DESCRIPTION
Description
Currently when a file is uploaded through Rest API the file name is threated as an array. Thereby the random generated string wont be attached to the filename and so the whole filename later will be threated as PREFIX. This leds to a uploaded file which is not chained to the created document.

Fix
My fix checks if $_FILES[]['name'] is an array or not. And if not handles the random name in a different way. I have not removed the legacy array part but I do think this can ever work because $_FILES[]['name'] will never be an array in my opinion.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
