### PR TITLE
Search Option widget for Debug Bar

### DIFF
--- a/ajax/debug.php
+++ b/ajax/debug.php
@@ -72,7 +72,16 @@ if (isset($_GET['action'])) {
     if ($action === 'get_itemtypes') {
         $loaded = get_declared_classes();
         $glpi_classes = array_filter($loaded, static function ($class) {
-            return is_subclass_of($class, 'CommonDBTM');
+            if (!is_subclass_of($class, 'CommonDBTM')) {
+                return false;
+            }
+
+            $reflection_class = new ReflectionClass($class);
+            if ($reflection_class->isAbstract()) {
+                return false;
+            }
+
+            return true;
         });
         sort($glpi_classes);
         header('Content-Type: application/json');

--- a/ajax/debug.php
+++ b/ajax/debug.php
@@ -91,6 +91,17 @@ if (isset($_GET['action'])) {
         die();
     }
     if ($action === 'get_search_options' && isset($_GET['itemtype'])) {
+        header('Content-Type: application/json');
+        $class = $_GET['itemtype'];
+        if (!class_exists($class) || !is_subclass_of($class, 'CommonDBTM')) {
+            echo '[]';
+            die();
+        }
+        $reflection_class = new ReflectionClass($class);
+        if ($reflection_class->isAbstract()) {
+            echo '[]';
+            die();
+        }
         // In some cases, a class that isn't a proper itemtype may show in the selection box and this would trigger a SQL error that cannot be caught.
         ErrorHandler::getInstance()->disableOutput();
         try {
@@ -103,7 +114,6 @@ if (isset($_GET['action'])) {
         $options = array_filter($options, static function ($k) {
             return is_numeric($k);
         }, ARRAY_FILTER_USE_KEY);
-        header('Content-Type: application/json');
         echo json_encode($options);
         die();
     }

--- a/js/src/vue/Debug/Toolbar.vue
+++ b/js/src/vue/Debug/Toolbar.vue
@@ -111,6 +111,14 @@
             }
         },
         {
+            id: 'search_options',
+            title: 'Search Options',
+            icon: 'ti ti-list-search',
+            main_widget: true, // This widget shows directly in the toolbar
+            component_registered_name: 'widget-search-options',
+            refreshButton: (button) => {}
+        },
+        {
             id: 'globals',
             main_widget: false,
             component_registered_name: 'widget-globals',

--- a/js/src/vue/Debug/Widget/SearchOptions.vue
+++ b/js/src/vue/Debug/Widget/SearchOptions.vue
@@ -89,6 +89,8 @@
     watch(current_itemtype, () => {
         updateSearchOptions();
     });
+
+    const itemtype_input_mode = ref('select');
 </script>
 
 <template>
@@ -97,10 +99,16 @@
             <div class="form-group row">
                 <label class="col-5" :for="`itemtype${rand}`">Itemtype</label>
                 <div class="col-7">
-                    <select class="form-select" :id="`itemtype${rand}`" v-model="current_itemtype">
-                        <option value="">-----</option>
-                        <option v-for="itemtype in all_itemtypes" :value="itemtype" v-text="itemtype"></option>
-                    </select>
+                    <div class="input-group">
+                        <select v-if="itemtype_input_mode === 'select'" class="form-select" :id="`itemtype${rand}`" v-model="current_itemtype">
+                            <option value="">-----</option>
+                            <option v-for="itemtype in all_itemtypes" :value="itemtype" v-text="itemtype"></option>
+                        </select>
+                        <input v-else class="form-control" :id="`itemtype${rand}`" v-model.lazy="current_itemtype">
+                        <button class="btn btn-sm btn-outline-secondary" @click="itemtype_input_mode = itemtype_input_mode === 'select' ? 'input' : 'select'">
+                            <i class="ti ti-switch-horizontal"></i>
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/js/src/vue/Debug/Widget/SearchOptions.vue
+++ b/js/src/vue/Debug/Widget/SearchOptions.vue
@@ -1,0 +1,147 @@
+<script setup>
+    import {computed, onMounted, ref, watch} from "vue";
+
+    const rand = Math.floor(Math.random() * 1000000000);
+
+    const all_itemtypes = ref([]);
+    const current_itemtype = ref('');
+    const search_options = ref({});
+
+    const sorted_col = ref('opt_id');
+    const sort_dir = ref('asc');
+    const sorted_search_options = computed(() => {
+        let sorted = [];
+
+        $.each(search_options.value, (opt_id, data) => {
+            sorted.push({
+                opt_id: opt_id,
+                table: data['table'],
+                field: data['field'],
+                name: data['name'],
+                linkfield: data['linkfield'],
+                datatype: data['datatype'] || '',
+                nosearch: data['nosearch'] || false,
+                massiveaction: data['massiveaction'] || true,
+            });
+        });
+
+        // Sort by column
+        sorted.sort((a, b) => {
+            let a_val = a[sorted_col.value];
+            let b_val = b[sorted_col.value];
+            // if the sorted_col is the opt_id, need to sort the numbers properly instead of as strings
+            if (sorted_col.value === 'opt_id') {
+                a_val = parseInt(a_val);
+                b_val = parseInt(b_val);
+            }
+            if (a_val === b_val) {
+                return 0;
+            }
+            if (sort_dir.value === 'asc') {
+                return a_val < b_val ? -1 : 1;
+            } else {
+                return a_val > b_val ? -1 : 1;
+            }
+        });
+        return sorted;
+    });
+
+    function setSortedCol(col) {
+        if (sorted_col.value === col) {
+            if (sort_dir.value === 'asc') {
+                sort_dir.value = 'desc';
+            } else {
+                sort_dir.value = 'asc';
+            }
+        } else {
+            sorted_col.value = col;
+            sort_dir.value = 'asc';
+        }
+    }
+
+    function updateSearchOptions() {
+        if (current_itemtype.value === null || current_itemtype.value === '') {
+            return;
+        }
+        $.ajax({
+            url: CFG_GLPI.root_doc + '/ajax/debug.php',
+            data: {
+                action: 'get_search_options',
+                itemtype: current_itemtype.value
+            },
+        }).then((data) => {
+            search_options.value = data;
+        });
+    }
+
+    onMounted(() => {
+        $.ajax({
+            url: CFG_GLPI.root_doc + '/ajax/debug.php',
+            data: {
+                action: 'get_itemtypes'
+            },
+        }).then((data) => {
+            all_itemtypes.value = data;
+        });
+        updateSearchOptions();
+    });
+
+    watch(current_itemtype, () => {
+        updateSearchOptions();
+    });
+</script>
+
+<template>
+    <div class="py-2 px-3 col-12">
+        <div class="d-flex">
+            <div class="form-group row">
+                <label class="col-5" :for="`itemtype${rand}`">Itemtype</label>
+                <div class="col-7">
+                    <select class="form-select" :id="`itemtype${rand}`" v-model="current_itemtype">
+                        <option value="">-----</option>
+                        <option v-for="itemtype in all_itemtypes" :value="itemtype" v-text="itemtype"></option>
+                    </select>
+                </div>
+            </div>
+        </div>
+        <table class="table search-opts-table" v-if="current_itemtype !== null && current_itemtype !== ''">
+            <thead>
+                <tr>
+                    <th colspan="8" class="text-center">Search Options</th>
+                </tr>
+                <tr>
+                    <th @click="setSortedCol('opt_id')">Search ID</th>
+                    <th @click="setSortedCol('table')">Table</th>
+                    <th @click="setSortedCol('field')">Field</th>
+                    <th @click="setSortedCol('name')">Name</th>
+                    <th @click="setSortedCol('linkfield')">Link Field</th>
+                    <th @click="setSortedCol('datatype')">Datatype</th>
+                    <th @click="setSortedCol('nosearch')">Searchable</th>
+                    <th @click="setSortedCol('massiveaction')">Massive Action</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr v-if="sorted_search_options.length" v-for="opt in sorted_search_options" :key="opt.opt_id">
+                    <td v-text="opt.opt_id"></td>
+                    <td v-text="opt.table"></td>
+                    <td v-text="opt.field"></td>
+                    <td v-text="opt.name"></td>
+                    <td v-text="opt.linkfield"></td>
+                    <td v-if="opt.datatype" v-text="opt.datatype"></td>
+                    <td v-else><span class="fst-italic">Not specified</span></td>
+                    <td v-text="opt.nosearch !== true ? 'Yes' : 'No'"></td>
+                    <td v-text="opt.massiveaction !== false ? 'Yes' : 'No'"></td>
+                </tr>
+                <tr v-else>
+                    <td colspan="8" class="text-center">No Search Options</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</template>
+
+<style scoped>
+    .search-opts-table thead tr:nth-of-type(2) th {
+        cursor: pointer;
+    }
+</style>

--- a/js/src/vue/Debug/WidgetButton.vue
+++ b/js/src/vue/Debug/WidgetButton.vue
@@ -17,10 +17,12 @@
 
 <template>
   <li class="debug-toolbar-widget d-inline-block p-2" :data-glpi-debug-widget-id="id">
-    <button type="button" class="btn btn-icon border-0 p-1" :title="title" data-bs-toggle="tab">
-      <i v-if="icon" :class="icon + ' me-1'"></i>
-      <span class="debug-text"></span>
-    </button>
+      <div :title="title" data-bs-toggle="tooltip" data-bs-placement="top">
+          <button type="button" class="btn btn-icon border-0 p-1" data-bs-toggle="tab">
+              <i v-if="icon" :class="icon + ' me-1'"></i>
+              <span class="debug-text"></span>
+          </button>
+      </div>
   </li>
 </template>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Proposal to migrate search option viewer from `dev` plugin to new debug bar. This allows seeing an overview of all of the search options for an itemtype at runtime in one place regardless of how they are added (inheritance, directly in class, plugins, etc). Could be useful to identify available search option IDs too.

Relies on #15274

![Selection_158](https://github.com/glpi-project/glpi/assets/17678637/a9ae794d-fe0e-4191-b8bf-c9bc615c77b3)
