### PR TITLE
Fix : Duplicate mail notification

### DIFF
--- a/src/TicketSatisfaction.php
+++ b/src/TicketSatisfaction.php
@@ -201,7 +201,7 @@ class TicketSatisfaction extends CommonDBTM
 
         if (!isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"]) {
             $ticket = new Ticket();
-            // date_answer is always set when updating
+            // date_answer is always updated even if the comment or rate does not change
             if (count($this->updates) > 1 && $ticket->getFromDB($this->fields['tickets_id'])) {
                 NotificationEvent::raiseEvent("replysatisfaction", $ticket);
             }

--- a/src/TicketSatisfaction.php
+++ b/src/TicketSatisfaction.php
@@ -201,8 +201,10 @@ class TicketSatisfaction extends CommonDBTM
 
         if (!isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"]) {
             $ticket = new Ticket();
-            if ($ticket->getFromDB($this->fields['tickets_id'])) {
-                NotificationEvent::raiseEvent("replysatisfaction", $ticket);
+            if (count($this->updates) > 1) {
+                if ($ticket->getFromDB($this->fields['tickets_id'])) {
+                    NotificationEvent::raiseEvent("replysatisfaction", $ticket);
+                }
             }
         }
     }

--- a/src/TicketSatisfaction.php
+++ b/src/TicketSatisfaction.php
@@ -201,10 +201,9 @@ class TicketSatisfaction extends CommonDBTM
 
         if (!isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"]) {
             $ticket = new Ticket();
-            if (count($this->updates) > 1) {
-                if ($ticket->getFromDB($this->fields['tickets_id'])) {
-                    NotificationEvent::raiseEvent("replysatisfaction", $ticket);
-                }
+            // date_answer is always set when updating
+            if (count($this->updates) > 1 && $ticket->getFromDB($this->fields['tickets_id'])) {
+                NotificationEvent::raiseEvent("replysatisfaction", $ticket);
             }
         }
     }


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9c3ab02</samp>

Fix notification issue for satisfaction surveys. Prevent sending a notification when only the `date_answered` field of a `TicketSatisfaction` object is updated by the system.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number