### PR TITLE
Feature : rewriting satisfaction form in twig

### DIFF
--- a/templates/components/itilobject/itilsatisfaction.html.twig
+++ b/templates/components/itilobject/itilsatisfaction.html.twig
@@ -1,0 +1,128 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2023 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% import "components/form/fields_macros.html.twig" as fields %}
+
+{% block more_fields %}
+    {% if url is defined %}
+        {{ fields.htmlField(
+            '',
+            '<a href="' ~ url|e('html_attr') ~ '">' ~ url ~ '</a>',
+            __('External survey'),
+            {
+                'input_class' : 'col-xxl-9',
+                'label_class' : 'col-xxl-3'
+            }
+        ) }}
+
+    {% else %}
+        <div class="alert alert-info d-flex align-items-center" role="alert">
+            <div class="text-dark">
+                <span class="ms-2">
+                    <i class="fas fa-xl fa-info-circle"></i>
+                    {{ __('After 12 hours, you can no longer modify your notice.') }}
+                </span>
+            </div>
+        </div>
+
+        {{ fields.hiddenField(
+            parent_item.getForeignKeyField(),
+            parent_item.fields['id'],
+            '',
+            {
+                'full_width': true,
+            }
+        ) }}
+
+        {% set select_dom %}
+            <select id="satisfaction_data" name="satisfaction">
+                {% for i in range(0, max_rate) %}
+                    <option value="{{ i }}" {% if i == item.fields['satisfaction'] %} selected {% endif %}>{{ i }}</option>
+                {% endfor %}
+            </select>
+            <div class="rateit" id="stars"></div>
+        {% endset %}
+
+        {{ fields.htmlField(
+            'satisfaction',
+            select_dom,
+            __('Satisfaction with the resolution of the %s')|format(parent_item.getTypeName(1)),
+            {
+                'full_width': true,
+                'full_width_adapt_column': false,
+                'label_class': 'col-xxl-4',
+                'input_class': 'col-xxl-8 text-start',
+            }
+        ) }}
+
+        {{ fields.textareaField(
+            'comment',
+            item.fields['comment'],
+            _n('Comment', 'Comments', get_plural_number()),
+            {
+                'full_width': true,
+            }
+        ) }}
+
+        {% if item.fields['date_answered'] > 0 %}
+
+            {{ fields.datetimeField(
+                'date_answered',
+                item.fields['date_answered'],
+                __('Response date to the satisfaction survey.'),
+                {
+                    'full_width': true,
+                    'readonly' : true
+                }
+            ) }}
+
+        {% endif %}
+
+        <script>
+            $(function() {
+                $('#stars').rateit({
+                    value: {{ item.fields['satisfaction'] }},
+                    min: 0,
+                    max: {{ max_rate }},
+                    step: 1,
+                    backingfld: '#satisfaction_data',
+                    ispreset: true,
+                    resetable: false
+                });
+            });
+        </script>
+
+        {{ include('components/form/buttons.html.twig') }}
+    {% endif %}
+
+{% endblock %}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 889e1ae</samp>

Refactored the satisfaction form rendering for ITIL tickets to use the Twig template engine. Added a new Twig template file `ticketsatisfaction.html.twig` with the HTML code for the form and the rating widget.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
