### PR TITLE
Fix/debug bar zindex

### DIFF
--- a/js/src/vue/Debug/Toolbar.vue
+++ b/js/src/vue/Debug/Toolbar.vue
@@ -398,7 +398,7 @@
         z-index: 1030
     }
     #debug-toolbar {
-        z-index: 9999;
+        z-index: 1030; /* bootstrap $zindex-fixed (if this need to upped, keep it under 1040) */
         outline: none;
     }
     .debug-toolbar-badge button {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Fix a z-index issue found will checking #15474, its tooltips were under the bar.
Anyway, regarding [z-index variables](https://getbootstrap.com/docs/5.2/layout/z-index/) in bootstrap, as our bar is fixed, we should have 1030 (and at most < 1040).
If superposition are found later, check the other component use a correct z-index value according to boostrap reference.
