### PR TITLE
fix racks and room gridstack item width when draggin

### DIFF
--- a/css/includes/components/_racks.scss
+++ b/css/includes/components/_racks.scss
@@ -61,6 +61,10 @@
             cursor: grabbing;
         }
     }
+
+    &.ui-draggable-dragging {
+        min-width: 1% !important; /* fix %50 min-width when position is fixed (50% of body width) */
+    }
 }
 
 .grid-stack-item-content a {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Don't know since when (only on main), but while checking #15514 , I saw that while dragging a rack element (same in rooms) the width of the item was very wrong. Seems to come from the extra css of gridstack:
https://github.com/gridstack/gridstack.js/blob/master/src/gridstack-extra.scss
But I think this doesn't change since years, and I suspect another change (relative position maybe ?)
