### PR TITLE
Fix HLAPI entity test

### DIFF
--- a/src/Api/HL/Search.php
+++ b/src/Api/HL/Search.php
@@ -660,7 +660,14 @@ final class Search
                 }
             }
 
-            $internal_name = $prop['x-field'] ?? $prop_name;
+            // Field resolution priority: x-field -> x-join.fkey -> property name
+            if (isset($prop['x-field'])) {
+                $internal_name = $prop['x-field'];
+            } else if (isset($prop['x-join']['fkey'])) {
+                $internal_name = $prop['x-join']['fkey'] ?? $prop_name;
+            } else {
+                $internal_name = $prop_name;
+            }
             if (isset($request_params[$prop_name])) {
                 $params[$internal_name] = $request_params[$prop_name];
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When specifying the `parent` property when creating an entity via the API, the actual field name wasn't being resolved. There are no protections against this in the Entity class itself when creating a new one so it defaults to a parent entity ID of 0 but fails to calculate the complete name and caches. This noticed when suddenly the user didn't have permission to edit the new entity.

In a separate PR, this could probably be improved on the Entity class side to avoid this behavior.