### PR TITLE
Allow dynamic properties on `CommonITILObject`

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -236,6 +236,17 @@ abstract class CommonITILObject extends CommonDBTM
                 // TODO 10.1: throw exception instead
                 trigger_error("Readonly field: '$property_name'", E_USER_WARNING);
                 break;
+
+            default:
+                if (version_compare(PHP_VERSION, '8.2.0', '<')) {
+                    // Trigger same deprecation notice as the one triggered by PHP 8.2+
+                    trigger_error(
+                        sprintf('Creation of dynamic property %s::$%s is deprecated', get_called_class(), $property_name),
+                        E_USER_DEPRECATED
+                    );
+                }
+                $this->$property_name = $value;
+                break;
         }
     }
 

--- a/tests/functional/Ticket.php
+++ b/tests/functional/Ticket.php
@@ -6328,4 +6328,21 @@ HTML
         $this->array($simplied_actors[Group::class])->isEqualTo($expected_groups);
         $this->array($simplied_actors[Supplier::class])->isEqualTo($expected_suppliers);
     }
+
+    public function testDynamicProperties(): void
+    {
+        $ticket = new \Ticket();
+
+        $this->when(
+            function () use ($ticket) {
+                $ticket->plugin_xxx_data = 'test';
+            }
+        )
+         ->error
+         ->withMessage('Creation of dynamic property Ticket::$plugin_xxx_data is deprecated')
+         ->exists();
+
+        $this->boolean(property_exists($ticket, 'plugin_xxx_data'))->isTrue();
+        $this->string($ticket->plugin_xxx_data)->isEqualTo('test');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

While trying to fix a bug on `fields`  pugin, I figured out that dynamic properties defined on `CommonITILObject` are not anymore working since #15388.
For instance,
```php
$change = new Change();
$change->plugin_fields_data = [];
var_dump($change->plugin_fields_data);
```
will produce a `*** PHP User Warning (512): Unknown field: 'plugin_fields_data' in /var/www/glpi/src/CommonITILObject.php at line 221` error.

We should preserve current behaviour , to not affect plugins in a bugfixes version. Maybe we should deprecate dynamic property settings in GLPI 10.1.