### PR TITLE
Show only the rack item form itself in modal

### DIFF
--- a/front/item_rack.form.php
+++ b/front/item_rack.form.php
@@ -81,7 +81,13 @@ if (isset($_GET['id'])) {
 $ajax = isset($_REQUEST['ajax']) ? true : false;
 
 if ($ajax) {
-    $ira->display($params);
+    $item = new Item_Rack();
+    $id = $params['id'] ?? 0;
+    if ($id > 0 && !$item->getFromDB($params['id'])) {
+        Html::displayNotFoundError();
+        return;
+    }
+    $item->showForm($id, $params);
 } else {
     $menus = ["assets", "rack"];
     Item_Rack::displayFullPageForItem($params['id'] ?? 0, $menus, $params);

--- a/js/rack.js
+++ b/js/rack.js
@@ -81,6 +81,18 @@ var initRack = function() {
                 }
             });
         })
+        .on('click', 'a.edit_rack_item', (e) => {
+            e.preventDefault();
+            const href = $(e.currentTarget).attr('href');
+            glpi_ajax_dialog({
+                url : href,
+                method : 'get',
+                dialogclass: 'modal-xl',
+                params: {
+                    ajax: true
+                }
+            });
+        })
 
         .on("click", "#add_pdu", function(event) {
             event.preventDefault();

--- a/src/Item_Rack.php
+++ b/src/Item_Rack.php
@@ -880,7 +880,7 @@ JAVASCRIPT;
                (!empty($gs_item['url'])
                   ? "<a href='{$gs_item['url']}' class='itemrack_name' style='$fg_color_s'>{$gs_item['name']}</a>"
                   : "<span class='itemrack_name'>" . $gs_item['name'] . "</span>") . "
-               <a href='{$gs_item['rel_url']}'>
+               <a href='{$gs_item['rel_url']}' class='edit_rack_item'>
                   <i class='fa fa-pencil-alt rel-link'
                      style='$fg_color_s'
                      title='" . __("Edit rack relation") . "'></i>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Currently, the entire rack item form, including tabs, are being displayed in the modal when adding an item to the rack. This causes an issue as the new tabs share the same ID as the panel on the page. Before the "All" tab was reworked, this didn't seem to be an issue, but now the tabs on the page are hidden when the modal is opened (and an error trying to redefine a function).

Since the modal will only ever be used for a new item, it makes sense to just show the form itself without the extra tab stuff. Currently, the only way to have multiple tabbed forms loaded at once would be to load the others in an iframe. Randomizing the IDs and function names isn't a clean solution as many places simple call `reloadTab` and we wouldn't know which set of tabs it is referring to. The calling script wouldn't know if it is on the main page or a modal either.