### PR TITLE
Fix dashboard browser cache hash

### DIFF
--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -408,7 +408,7 @@ HTML;
         }
 
         $ajax_cards = GLPI_AJAX_DASHBOARD;
-        $cache_key  = sha1($_SESSION['glpiactiveentities_string '] ?? "");
+        $cache_key  = sha1($_SESSION['glpiactiveentities_string'] ?? "");
 
         $js_params = json_encode([
             'current'       => $this->current,


### PR DESCRIPTION
The cache key does not take current entities into account due to a typo that's probably here since the original implementation in GLPI 9.5.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15431
