### PR TITLE
fix(inventory): fix inventory / GLPI mapping

### DIFF
--- a/src/Inventory/Asset/Simcard.php
+++ b/src/Inventory/Asset/Simcard.php
@@ -43,8 +43,9 @@ class Simcard extends Device
     public function prepare(): array
     {
         $mapping = [
-            'imsi' => 'serial'
+            'subscriber_id' => 'msin'
         ];
+
         foreach ($this->data as $k => &$val) {
             foreach ($mapping as $origin => $dest) {
                 if (property_exists($val, $origin)) {

--- a/src/Inventory/Asset/Simcard.php
+++ b/src/Inventory/Asset/Simcard.php
@@ -37,13 +37,14 @@ namespace Glpi\Inventory\Asset;
 
 use CommonDBTM;
 use Glpi\Inventory\Conf;
+use Toolbox;
 
 class Simcard extends Device
 {
     public function prepare(): array
     {
         $mapping = [
-            'subscriber_id' => 'msin'
+            'subscriber_id' => 'msin',
         ];
 
         foreach ($this->data as $k => &$val) {
@@ -53,6 +54,7 @@ class Simcard extends Device
                 }
             }
         }
+
         return $this->data;
     }
 

--- a/src/Item_DeviceSimcard.php
+++ b/src/Item_DeviceSimcard.php
@@ -139,8 +139,9 @@ class Item_DeviceSimcard extends Item_Devices
     public function getImportCriteria(): array
     {
         return [
-            'serial' => 'equal',
-            'msin' => 'equal',
+            'itemtype' => 'equal',
+            'items_id' => 'equal',
+            'is_dynamic' => 'equal',
         ];
     }
 }

--- a/src/Item_DeviceSimcard.php
+++ b/src/Item_DeviceSimcard.php
@@ -139,9 +139,8 @@ class Item_DeviceSimcard extends Item_Devices
     public function getImportCriteria(): array
     {
         return [
-            'itemtype' => 'equal',
-            'items_id' => 'equal',
-            'is_dynamic' => 'equal',
+            'serial' => 'equal',
+            'msin' => 'equal',
         ];
     }
 }

--- a/tests/functional/Glpi/Inventory/Inventory.php
+++ b/tests/functional/Glpi/Inventory/Inventory.php
@@ -4819,6 +4819,127 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
             ->integer['size']->isIdenticalTo(55000);
     }
 
+
+    public function testImportPhoneSimCardNoReset()
+    {
+        global $DB;
+
+        $xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<REQUEST>
+  <CONTENT>
+    <SIMCARDS>
+        <COUNTRY>fr</COUNTRY>
+        <OPERATOR_CODE>2081</OPERATOR_CODE>
+        <OPERATOR_NAME>Orange F</OPERATOR_NAME>
+        <SERIAL>89330126162002971850</SERIAL>
+        <STATE>SIM_STATE_READY</STATE>
+        <LINE_NUMBER></LINE_NUMBER>
+        <SUBSCRIBER_ID>1</SUBSCRIBER_ID>
+    </SIMCARDS>
+    <HARDWARE>
+      <NAME>pc002</NAME>
+    </HARDWARE>
+    <BIOS>
+      <SSN>ggheb7ne7</SSN>
+    </BIOS>
+    <VERSIONCLIENT>FusionInventory-Agent_v2.3.19</VERSIONCLIENT>
+  </CONTENT>
+  <DEVICEID>test-pc002</DEVICEID>
+  <QUERY>INVENTORY</QUERY>
+  <ITEMTYPE>Phone</ITEMTYPE>
+</REQUEST>";
+
+        $this->doInventory($xml, true);
+        $agents = $DB->request(['FROM' => \Agent::getTable()]);
+        $this->integer(count($agents))->isIdenticalTo(1);
+        $agent = $agents->current();
+
+
+        //check created computer
+        $phone = new \Phone();
+        $this->boolean($phone->getFromDB($agent['items_id']))->isTrue();
+
+        //check for components
+        $item_devicesimcard = new \Item_DeviceSimcard();
+        $simcards_first = $item_devicesimcard->find(['itemtype' => 'Phone' , 'items_id' => $agent['items_id']]);
+        $this->integer(count($simcards_first))->isIdenticalTo(1);
+
+        //re run inventory to check if item_simcard ID is changed
+        $json = json_decode(file_get_contents(self::INV_FIXTURES . 'phone_1.json'));
+
+        $this->doInventory($json);
+        $item_devicesimcard = new \Item_DeviceSimcard();
+        $simcards_second = $item_devicesimcard->find(['itemtype' => 'Phone' , 'items_id' => $agent['items_id']]);
+        $this->integer(count($simcards_second))->isIdenticalTo(1);
+
+        $this->array($simcards_first)->isIdenticalTo($simcards_second);
+    }
+
+    public function testImportPhoneMultiSimCardNoReset()
+    {
+        global $DB;
+
+        $xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<REQUEST>
+  <CONTENT>
+    <SIMCARDS>
+        <COUNTRY>fr</COUNTRY>
+        <OPERATOR_CODE>2081</OPERATOR_CODE>
+        <OPERATOR_NAME>Orange F</OPERATOR_NAME>
+        <SERIAL>89330126162002971850</SERIAL>
+        <STATE>SIM_STATE_READY</STATE>
+        <LINE_NUMBER></LINE_NUMBER>
+        <SUBSCRIBER_ID>1</SUBSCRIBER_ID>
+    </SIMCARDS>
+    <SIMCARDS>
+        <COUNTRY>fr</COUNTRY>
+        <OPERATOR_CODE>2081</OPERATOR_CODE>
+        <OPERATOR_NAME>Orange F</OPERATOR_NAME>
+        <SERIAL>23168441316812316511</SERIAL>
+        <STATE>SIM_STATE_READY</STATE>
+        <LINE_NUMBER></LINE_NUMBER>
+        <SUBSCRIBER_ID>2</SUBSCRIBER_ID>
+    </SIMCARDS>
+    <HARDWARE>
+      <NAME>pc002</NAME>
+    </HARDWARE>
+    <BIOS>
+      <SSN>ggheb7ne7</SSN>
+    </BIOS>
+    <VERSIONCLIENT>FusionInventory-Agent_v2.3.19</VERSIONCLIENT>
+  </CONTENT>
+  <DEVICEID>test-pc002</DEVICEID>
+  <QUERY>INVENTORY</QUERY>
+  <ITEMTYPE>Phone</ITEMTYPE>
+</REQUEST>";
+
+        $this->doInventory($xml, true);
+        $agents = $DB->request(['FROM' => \Agent::getTable()]);
+        $this->integer(count($agents))->isIdenticalTo(1);
+        $agent = $agents->current();
+
+
+        //check created computer
+        $phone = new \Phone();
+        $this->boolean($phone->getFromDB($agent['items_id']))->isTrue();
+
+        //check for components
+        $item_devicesimcard = new \Item_DeviceSimcard();
+        $simcards_first = $item_devicesimcard->find(['itemtype' => 'Phone' , 'items_id' => $agent['items_id']]);
+        $this->integer(count($simcards_first))->isIdenticalTo(2);
+
+        //re run inventory to check if item_simcard ID is changed
+        $json = json_decode(file_get_contents(self::INV_FIXTURES . 'phone_1.json'));
+
+        $this->doInventory($json);
+        $item_devicesimcard = new \Item_DeviceSimcard();
+        $simcards_second = $item_devicesimcard->find(['itemtype' => 'Phone' , 'items_id' => $agent['items_id']]);
+        $this->integer(count($simcards_second))->isIdenticalTo(2);
+
+        $this->array($simcards_first)->isIdenticalTo($simcards_second);
+    }
+
+
     public function testImportPhone()
     {
         global $DB, $CFG_GLPI;


### PR DESCRIPTION
Try to fix https://github.com/glpi-project/glpi/issues/15435

The reconciliation (to know whether to add or update the SIM card) is done on the ```serial``` / ```msin``` field which (in the latest versions of Android due to Google restrictions) are empty.

So GLPI deletes the SIM card and adds a new one at each inventory.

This first draft consists of basing the reconciliation on the link (```imtes_id```, ```itemtype```, ```is_dynamic```) to the asset

This work if asset have only one SIM card.

But  could cause problems if the asset has several simcards.

It may be necessary to generate a ```UUID``` to be used as the serial number (from ```android-inventory-library```).



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15435
