### PR TITLE
main: unable to update replica config

### DIFF
--- a/templates/pages/setup/general/dbreplica_setup.html.twig
+++ b/templates/pages/setup/general/dbreplica_setup.html.twig
@@ -33,6 +33,7 @@
 
 {% extends "pages/setup/general/base_form.html.twig" %}
 {% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
 
 {% block config_fields %}
    {{ fields.textField('_dbreplicate_dbhost', replica_config['host'], __('SQL server (MariaDB or MySQL)')) }}
@@ -55,4 +56,6 @@
       no_label: true,
       full_width: true
    }) }}
+
+   {{ inputs.hidden('_dbslave_status', 1) }}
 {% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A

Since #15369 is not possible to update replica tab configuration (changes are not saved) because of a missing "_dbslave_status" hidden field.
