### PR TITLE
fix(Group): prevent SQL error when 'name' field not exist

### DIFF
--- a/src/Group.php
+++ b/src/Group.php
@@ -747,10 +747,13 @@ class Group extends CommonTreeDropdown
                     'SELECT' => 'id',
                     'FROM'   => $item->getTable(),
                     'WHERE'  => $restrict[$itemtype],
-                    'ORDER'  => 'name',
                     'LIMIT'  => $max,
                     'START'  => $start
                 ];
+
+                if ($item->isField('name')) {
+                    $request['ORDER'] = 'name';
+                };
 
                 if ($itemtype == 'Consumable') {
                     $request['SELECT'] = 'glpi_consumableitems.id';


### PR DESCRIPTION
Prevent SQL error

```sql
*** MySQL query error:
  SQL: SELECT `id` FROM `glpi_items_devicesimcards` WHERE `groups_id` IN ('1') AND `is_deleted` = '0' ORDER BY `` LIMIT 100
  Error: Unknown column '' in 'order clause'
  Backtrace :
  src/DBmysqlIterator.php:112                        
  src/DBmysql.php:1078                               DBmysqlIterator->execute()
  src/Group.php:767                                  DBmysql->request()
  src/Group.php:857                                  Group->getDataItems()
  src/Group.php:167                                  Group->showItems()
  src/CommonGLPI.php:691                             Group::displayTabContentForItem()
  ajax/common.tabs.php:114                           CommonGLPI::displayStandardTab()
```

When we display item list from ```Group```

```glpi_items_devicesimcards``` have no column ```name``` 



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29403
