### PR TITLE
Fix maintenance text encoding issues

### DIFF
--- a/src/Console/Maintenance/EnableMaintenanceModeCommand.php
+++ b/src/Console/Maintenance/EnableMaintenanceModeCommand.php
@@ -37,6 +37,7 @@ namespace Glpi\Console\Maintenance;
 
 use Config;
 use Glpi\Console\AbstractCommand;
+use Glpi\Toolbox\Sanitizer;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -69,7 +70,7 @@ class EnableMaintenanceModeCommand extends AbstractCommand
             'maintenance_mode' => '1'
         ];
         if ($input->hasOption('text')) {
-            $values['maintenance_text'] = $input->getOption('text');
+            $values['maintenance_text'] = Sanitizer::sanitize($input->getOption('text'));
         }
         $config = new Config();
         $config->setConfigurationValues('core', $values);

--- a/templates/maintenance.html.twig
+++ b/templates/maintenance.html.twig
@@ -47,7 +47,7 @@
 
          {% if maintenance_text|length %}
             <div class="alert alert-warning mt-4">
-               {{ maintenance_text }}
+               {{ maintenance_text|verbatim_value }}
             </div>
          {% endif %}
          <div class="empty-action">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. `maintenance:enable` command was failing when `--text` option was used with a text containing single quotes.
2. Rendering of `<`, `&` or `>` chars was not correct.