### PR TITLE
Fix project tasks rich text images handling

### DIFF
--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -221,6 +221,16 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
     {
         global $DB, $CFG_GLPI;
 
+        // Handle rich-text images
+        $this->input = $this->addFiles(
+            $this->input,
+            [
+                'force_update'  => true,
+                'name'          => 'content',
+                'content_field' => 'content',
+            ]
+        );
+
         if (in_array('plan_start_date', $this->updates) || in_array('plan_end_date', $this->updates)) {
            //dates has changed, check for planning conflicts on attached team
             $team = ProjectTaskTeam::getTeamFor($this->fields['id']);
@@ -297,6 +307,16 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
     public function post_addItem()
     {
         global $CFG_GLPI;
+
+        // Handle rich-text images
+        $this->input = $this->addFiles(
+            $this->input,
+            [
+                'force_update'  => true,
+                'name'          => 'content',
+                'content_field' => 'content',
+            ]
+        );
 
        // ADD Documents
         $document_items = Document_Item::getItemsAssociatedTo($this->getType(), $this->fields['id']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Inline images from project task description were not converted into documents, and were stored as base64 images into DB.