### PR TITLE
Bump @tabler/icons-webfont from 2.30.0 to 2.34.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@fullcalendar/rrule": "^4.4.0",
                 "@fullcalendar/timegrid": "^4.4.0",
                 "@tabler/core": "^1.0.0-beta9",
-                "@tabler/icons-webfont": "^2.30.0",
+                "@tabler/icons-webfont": "^2.34.0",
                 "animate.css": "^4.1.1",
                 "bootstrap": "^5.1.1",
                 "chartist": "^0.11.4",
@@ -1894,20 +1894,20 @@
             }
         },
         "node_modules/@tabler/icons": {
-            "version": "2.30.0",
-            "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-2.30.0.tgz",
-            "integrity": "sha512-tvtmkI4ALjKThVVORh++sB9JnkFY7eGInKxNy+Df7WVQiF7T85tlvGADzlgX4Ic+CK5MIUzZ0jhOlQ/RRlgXpg==",
+            "version": "2.34.0",
+            "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-2.34.0.tgz",
+            "integrity": "sha512-65GsJsT4ZBETWcdrNxbsjsbRoZvbVk3CcU2SafaElrzP1wpOeuAn9aELVEbxhdyZyP9dg2SCfgH6iAArJgp7lw==",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/codecalm"
             }
         },
         "node_modules/@tabler/icons-webfont": {
-            "version": "2.30.0",
-            "resolved": "https://registry.npmjs.org/@tabler/icons-webfont/-/icons-webfont-2.30.0.tgz",
-            "integrity": "sha512-tGGKxeATvyHJBHl5FzY4oAShbAiR4ovstG62lqb2HGlOJwz4Io9TSk4eoB88nqxg3sT5no2YsAKXcr1UnlpnNQ==",
+            "version": "2.34.0",
+            "resolved": "https://registry.npmjs.org/@tabler/icons-webfont/-/icons-webfont-2.34.0.tgz",
+            "integrity": "sha512-1akLiJX4fiZEG6m2+7PGftmxtGPSVIGY/6vFQJCn0W/c9iOQLsowxfwjm1UwEEwiUYMbiXTU7gPBAgQRFYuEvQ==",
             "dependencies": {
-                "@tabler/icons": "2.30.0"
+                "@tabler/icons": "2.34.0"
             },
             "funding": {
                 "type": "github",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "@fullcalendar/rrule": "^4.4.0",
         "@fullcalendar/timegrid": "^4.4.0",
         "@tabler/core": "^1.0.0-beta9",
-        "@tabler/icons-webfont": "^2.30.0",
+        "@tabler/icons-webfont": "^2.34.0",
         "animate.css": "^4.1.1",
         "bootstrap": "^5.1.1",
         "chartist": "^0.11.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -