### PR TITLE
fix(Item_DeviceXXX) restrict visibility even if not linked to an asset

### DIFF
--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -802,6 +802,10 @@ class Item_Devices extends CommonDBRelation
                     ]
                 ];
                 $criteria['WHERE'] = $criteria['WHERE'] + getEntitiesRestrictCriteria(getTableForItemType($peer_type));
+            } else {
+                //peer_type not defined is related to Item_DeviceXXX without associated assets
+                //so restrict entity criteria to current Item_DeviceXXX
+                $criteria['WHERE'] = $criteria['WHERE'] + getEntitiesRestrictCriteria($ctable);
             }
         } else {
             $fk = $this->getDeviceForeignKey();


### PR DESCRIPTION

```Item_DeviceXXX``` from ```Component``` form are visible (and editable) even if they are attach to another entity

![image](https://github.com/glpi-project/glpi/assets/7335054/335b0b1d-a965-4593-81d1-e10e9804c859)

Entity restriction is only added when item_DeviceXXX is linked to an asset.

PS : 

Even with this fix, using this URL is still possible 

```/front/item_devicesimcard.form.php?id=20```

![image](https://github.com/glpi-project/glpi/assets/7335054/04083284-7d5b-4da4-945e-5c7677d2b8e8)

I am unable to correct this point 


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29354
