### PR TITLE
Fix images upload

### DIFF
--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -178,6 +178,11 @@
       'rows': 3,
    }|merge(options) %}
 
+   {% if options.id is not defined %}
+       {# `id` is mandatory at this point to correctly handle file uploads #}
+       {% set options = {id: name ~ '_' ~ options.rand}|merge(options) %}
+   {% endif %}
+
    {% set field %}
         {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
         {{ _inputs.textarea(name, value, options) }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Since #14852, file upload was partially broken. Images were correctly added as document, but rich text was not update to replace base64 source by href to created document.