### PR TITLE
Timeline performances: reuse already loaded user objects when possible

### DIFF
--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -100,10 +100,7 @@
 
       {# Cache keys are prefixed by "_" to avoid being converted to integer and thus renumbered #}
       {# Try to read user from cache #}
-      {% set entry_user = users_id is defined and users_id is not null ?
-         (user_cache["_" ~ users_id] ?? get_item('User', users_id)) :
-         null
-      %}
+      {% set entry_user = users_id is defined and users_id is not null ? (user_cache["_" ~ users_id] ?? get_item('User', users_id)) : null %}
       {# Update cache #}
       {% set user_cache = user_cache|merge({("_" ~ users_id): entry_user}) %}
 

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -42,6 +42,10 @@
     {% endif %}
 
    {% set status_closed = (item.fields['status'] in item.getClosedStatusArray()) %}
+
+   {# Keep track of loaded user to avoid reloading them from database if they appear multiple time in a ticket #}
+   {% set user_cache = {} %}
+
    {% for entry in timeline %}
       {% set entry_i = entry['item'] %}
       {% set entry_object = entry['object'] ?? get_item(entry['type'], entry_i['id']) %}
@@ -94,6 +98,15 @@
          {% endif %}
       {% endif %}
 
+      {# Cache keys are prefixed by "_" to avoid being converted to integer and thus renumbered #}
+      {# Try to read user from cache #}
+      {% set entry_user = users_id is defined and users_id is not null ?
+         (user_cache["_" ~ users_id] ?? get_item('User', users_id)) :
+         null
+      %}
+      {# Update cache #}
+      {% set user_cache = user_cache|merge({("_" ~ users_id): entry_user}) %}
+
       <div class="timeline-item mb-3 {{ itiltype }} {{ state_class }} {{ entry['class'] }} {{ 'right' in item_position ? 'ms-auto' : '' }}"
             data-itemtype="{{ entry['type'] }}" data-items-id="{{ entry_i['id'] }}"
             {% if entry['item_action'] is defined %}data-item-action="{{ entry['item_action'] }}"{% endif %}>
@@ -120,7 +133,6 @@
             <div class="col-auto d-flex flex-column user-part {{ 'right' in item_position ? 'ms-auto ms-0 order-sm-last' : 'order-first' }}">
                {% set avatar_rand = random() %}
                {# log entries have no users_id #}
-               {% set entry_user = users_id is defined and users_id is not null ? get_item('User', users_id) : null %}
                {% if entry_user is not null %}
                   {% set user_fields = entry_user.fields|merge({
                       user_name: entry_user.getFriendlyName()|verbatim_value,
@@ -129,6 +141,7 @@
                   <span id="timeline-avatar{{ avatar_rand }}">
                      {{ include('components/user/picture.html.twig', {
                         'users_id': users_id,
+                        'user_object': entry_user,
                         'enable_anonymization': anonym_user
                      }, with_context = false) }}
                   </span>
@@ -136,6 +149,7 @@
                      {% do call('Html::showToolTip', [
                         include('components/user/info_card.html.twig', {
                            'user': user_fields,
+                           'user_object': entry_user,
                            'enable_anonymization': false,
                         }, with_context = false), {
                            'applyto': 'timeline-avatar' ~ avatar_rand
@@ -148,7 +162,9 @@
             <div class="col-12 col-sm d-flex flex-column content-part">
                <div class="mt-2 timeline-content {{ solution_class }} flex-grow-1 {{ item_position }} card">
                   <div class="card-body px-1 px-xxl-3">
-                     {{ include('components/itilobject/timeline/timeline_item_header.html.twig') }}
+                     {{ include('components/itilobject/timeline/timeline_item_header.html.twig', {
+                           'user_object': entry_user,
+                     }) }}
 
                      {% if itiltype in timeline_itemtypes|column('type') %}
                         {% set matching_types = timeline_itemtypes|filter((v) => v.type == itiltype) %}

--- a/templates/components/itilobject/timeline/timeline_item_header.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header.html.twig
@@ -37,6 +37,7 @@
    <div class="d-flex creator">
       {{ include('components/itilobject/timeline/timeline_item_header_badges.html.twig', {
          'users_id': users_id,
+         'user_object': user_object,
          'date_creation': date_creation,
          'date_mod': date_mod,
          'users_id_editor': entry_i['users_id_editor'],

--- a/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
@@ -89,7 +89,7 @@
       {% set editor_span %}
          {{ include('components/user/link_with_tooltip.html.twig', {
             'users_id': users_id_editor,
-            'user_object': user_object,
+            'user_object': users_id == users_id_editor ? user_object : null,
             'enable_anonymization': anonym_editor
          }, with_context = false) }}
       {% endset %}

--- a/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
@@ -55,6 +55,7 @@
       {% set creator_span %}
          {{ include('components/user/link_with_tooltip.html.twig', {
             'users_id': users_id,
+            'user_object': user_object,
             'enable_anonymization': anonym_user
          }, with_context = false) }}
       {% endset %}
@@ -88,6 +89,7 @@
       {% set editor_span %}
          {{ include('components/user/link_with_tooltip.html.twig', {
             'users_id': users_id_editor,
+            'user_object': user_object,
             'enable_anonymization': anonym_editor
          }, with_context = false) }}
       {% endset %}

--- a/templates/components/user/info_card.html.twig
+++ b/templates/components/user/info_card.html.twig
@@ -39,6 +39,7 @@
          {% if user['id'] %}
             {{ include('components/user/picture.html.twig', {
                'users_id': user['id'],
+               'user_object': user_object,
                'enable_anonymization': enable_anonymization
             }) }}
          {% endif %}

--- a/templates/components/user/link_with_tooltip.html.twig
+++ b/templates/components/user/link_with_tooltip.html.twig
@@ -39,7 +39,7 @@
 </span>
 
 {% if not enable_anonymization %}
-    {% set user = get_item('User', users_id) %}
+    {% set user = user_object ?? get_item('User', users_id) %}
     {% if user is not null and user.canView() %}
         {% set user_fields = user.fields %}
         {% set user_fields = user_fields|merge({user_name: user.getFriendlyName()|verbatim_value}) %}
@@ -49,7 +49,10 @@
             [
                 include(
                     'components/user/info_card.html.twig',
-                    {'user': user_fields},
+                    {
+                        'user': user_fields,
+                        'user_object': user,
+                    },
                     with_context = false
                 ),
                 {

--- a/templates/components/user/picture.html.twig
+++ b/templates/components/user/picture.html.twig
@@ -34,7 +34,7 @@
 {% set enable_anonymization = enable_anonymization ?? false %}
 {% set avatar_size = avatar_size ?? "avatar-md" %}
 {% set anonymized = enable_anonymization and entity_config('anonymize_support_agents', session('glpiactive_entity')) != constant('Entity::ANONYMIZE_DISABLED') %}
-{% set user = get_item('User', users_id) %}
+{% set user = user_object ?? get_item('User', users_id) %}
 {% set with_link = with_link ?? true %}
 {% set user_thumbnail = user.getThumbnailPicturePath(enable_anonymization) %}
 {% if user_thumbnail == null and not entity_config('display_users_initials', session('glpiactive_entity')) %}


### PR DESCRIPTION
Part 1 of #15432.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
