### PR TITLE
Use header for hlapi translation test

### DIFF
--- a/src/Api/HL/Router.php
+++ b/src/Api/HL/Router.php
@@ -659,7 +659,9 @@ EOT;
         $auth->user = new \User();
         $auth->user->getFromDB($data['user_id']);
         Session::init($auth);
-        if (!empty($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
+        if ($request->getHeaderLine('Accept-Language')) {
+            // Make sure language header is set in SERVER superglobal so that Session::getPreferredLanguage() works
+            $_SERVER['HTTP_ACCEPT_LANGUAGE'] = $request->getHeaderLine('Accept-Language');
             $_SESSION['glpilanguage'] = Session::getPreferredLanguage();
             $_SESSION['glpi_dropdowntranslations'] = DropdownTranslation::getAvailableTranslations($_SESSION["glpilanguage"]);
         }

--- a/tests/functional/Glpi/Api/HL/Controller/AssetController.php
+++ b/tests/functional/Glpi/Api/HL/Controller/AssetController.php
@@ -360,8 +360,10 @@ class AssetController extends \HLAPITestCase
                 });
         });
         // Change language and verify
-        $_SESSION['glpilanguage'] = 'fr_FR';
-        $this->api->call(new Request('GET', '/Assets/Computer/' . $computer_id), function ($call) use ($state_id) {
+        $request = new Request('GET', '/Assets/Computer/' . $computer_id, [
+            'Accept-Language' => 'fr_FR',
+        ]);
+        $this->api->call($request, function ($call) use ($state_id) {
             /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

With the removal of all "stateful" login methods for the new API, the language must be specified in a header instead of directly in the `$_SESSION` global. I also fixed detection of the language header in cases where the request is made directly with the router, instead of separate requests made through the web server.