### PR TITLE
Better check for `replysatisfaction` notification sending

### DIFF
--- a/src/TicketSatisfaction.php
+++ b/src/TicketSatisfaction.php
@@ -200,9 +200,14 @@ class TicketSatisfaction extends CommonDBTM
         global $CFG_GLPI;
 
         if (!isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"]) {
+            // Send notification only if fields related to reply are updated.
+            $answer_updates = array_filter(
+                $this->updates,
+                fn ($field) => in_array($field, ['satisfaction', 'comment'])
+            );
+
             $ticket = new Ticket();
-            // date_answer is always updated even if the comment or rate does not change
-            if (count($this->updates) > 1 && $ticket->getFromDB($this->fields['tickets_id'])) {
+            if (count($answer_updates) > 1 && $ticket->getFromDB($this->fields['tickets_id'])) {
                 NotificationEvent::raiseEvent("replysatisfaction", $ticket);
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Follows #15478.

An update on something else than `satisfaction` or `comment` should probably ignored too. For instance, updating the `type` filed from API/plugin/whatever should not trigger a `replysatisfaction` notification.