### PR TITLE
Add rotation on mail collectors

### DIFF
--- a/install/migrations/update_10.0.9_to_10.0.10/mailcollector.php
+++ b/install/migrations/update_10.0.9_to_10.0.10/mailcollector.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+/* Add `last_collect_date` to some glpi_mailcollectors */
+$migration->addField('glpi_mailcollectors', 'last_collect_date', 'timestamp');
+$migration->addKey('glpi_mailcollectors', 'last_collect_date', 'last_collect_date');
+$ADDTODISPLAYPREF['MailCollector'] = [23];

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -4167,6 +4167,7 @@ CREATE TABLE `glpi_mailcollectors` (
   `requester_field` int NOT NULL DEFAULT '0',
   `add_cc_to_observer` tinyint NOT NULL DEFAULT '0',
   `collect_only_unread` tinyint NOT NULL DEFAULT '0',
+  `last_collect_date` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `is_active` (`is_active`),

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -4172,7 +4172,8 @@ CREATE TABLE `glpi_mailcollectors` (
   KEY `name` (`name`),
   KEY `is_active` (`is_active`),
   KEY `date_mod` (`date_mod`),
-  KEY `date_creation` (`date_creation`)
+  KEY `date_creation` (`date_creation`),
+  KEY `last_collect_date` (`last_collect_date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -552,6 +552,15 @@ class MailCollector extends CommonDBTM
             'datatype'           => 'integer'
         ];
 
+        $tab[] = [
+            'id'                 => '23',
+            'table'              => $this->getTable(),
+            'field'              => 'last_collect_date',
+            'name'               => __('Date of last collection'),
+            'datatype'           => 'datetime',
+            'massiveaction'      => false
+        ];
+
         return $tab;
     }
 
@@ -959,6 +968,11 @@ class MailCollector extends CommonDBTM
                 foreach ($delete as $uid => $folder) {
                     $this->deleteMails($uid, $folder);
                 }
+
+                $this->update([
+                    'id' => $this->getID(),
+                    'last_collect_date' => $_SESSION["glpi_currenttime"],
+                ]);
 
               //TRANS: %1$d, %2$d, %3$d, %4$d %5$d and %6$d are number of messages
                 $msg = sprintf(
@@ -1873,7 +1887,9 @@ class MailCollector extends CommonDBTM
         NotImportedEmail::deleteLog();
         $iterator = $DB->request([
             'FROM'   => 'glpi_mailcollectors',
-            'WHERE'  => ['is_active' => 1]
+            'WHERE'  => ['is_active' => 1],
+            'ORDER'  => 'last_collect_date ASC',
+            'LIMIT'  => 100,
         ]);
 
         $max = $task->fields['param'];
@@ -1900,11 +1916,11 @@ class MailCollector extends CommonDBTM
 
         if ($max == $task->fields['param']) {
             return 0; // Nothin to do
-        } else if ($max > 0) {
-            return 1; // done
+        } else if ($max === 0 || count($iterator) < countElementsInTable('glpi_mailcollectors', ['is_active' => 1])) {
+            return -1; // still messages to retrieve
         }
 
-        return -1; // still messages to retrieve
+        return 1; // done
     }
 
 

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -712,6 +712,15 @@ class MailCollector extends CommonDBTM
                     false,
                     ERROR
                 );
+
+                // Update last collect date even if an error occurs.
+                // This will prevent collectors that are constantly errored to be stuck at the begin of the
+                // crontask process queue.
+                $this->update([
+                    'id' => $this->getID(),
+                    'last_collect_date' => $_SESSION["glpi_currenttime"],
+                ]);
+
                 return;
             }
 

--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -78,7 +78,8 @@ class MailCollector extends DbTestCase
                    'date_creation'        => '',
                    'requester_field'      => '',
                    'add_cc_to_observer'   => '',
-                   'collect_only_unread'  => ''
+                   'collect_only_unread'  => '',
+                   'last_collect_date'    => '',
                ]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29267

On a GLPI instance with 225 mail collectors, all connected to an Azure mail server with OAuth authentication, collect job fails everytime around the 100th collector processed. This is probably due to a connection rate limitation on Azure side, but IMAP error is not really clear and it is hard to be sure of that. Anyway, processing more than 100 collectors at once is probably not a good idea, for performances reasons.

The goal of current PR is to add some rotation on collect job, and limit to 100 collectors processing on each job run.