### PR TITLE
FIX: always considerd domain_items even if deleted

### DIFF
--- a/src/Domain.php
+++ b/src/Domain.php
@@ -266,7 +266,18 @@ class Domain extends CommonDBTM
                     'joinparams'         => [
                         'beforejoin' => [
                             'table'      => Domain_Item::getTable(),
-                            'joinparams' => ['jointype' => 'itemtype_item']
+                            'joinparams' => [
+                                'jointype' => 'itemtype_item',
+                                'condition'          => [
+                                    'OR'  => [
+                                        'AND' => [
+                                            'NEWTABLE.is_deleted' => 0,
+                                            'NEWTABLE.is_dynamic' => 1
+                                        ],
+                                        'NEWTABLE.is_dynamic' => 0
+                                    ]
+                                ]
+                            ]
                         ]
                     ]
                 ];
@@ -285,7 +296,18 @@ class Domain extends CommonDBTM
                             'joinparams'         => [
                                 'beforejoin' => [
                                     'table'      => Domain_Item::getTable(),
-                                    'joinparams' => ['jointype' => 'itemtype_item']
+                                    'joinparams' => [
+                                        'jointype' => 'itemtype_item',
+                                        'condition'          => [
+                                            'OR'  => [
+                                                'AND' => [
+                                                    'NEWTABLE.is_deleted' => 0,
+                                                    'NEWTABLE.is_dynamic' => 1
+                                                ],
+                                                'NEWTABLE.is_dynamic' => 0
+                                            ]
+                                        ]
+                                    ]
                                 ]
                             ]
                         ]

--- a/src/Domain.php
+++ b/src/Domain.php
@@ -160,7 +160,16 @@ class Domain extends CommonDBTM
             'name'               => _n('Associated item', 'Associated items', Session::getPluralNumber()),
             'forcegroupby'       => true,
             'joinparams'         => [
-                'jointype'           => 'child'
+                'jointype'           => 'child',
+                'condition'          => [
+                    'OR'  => [
+                        'AND' => [
+                            'NEWTABLE.is_deleted' => 0,
+                            'NEWTABLE.is_dynamic' => 1
+                        ],
+                        'NEWTABLE.is_dynamic' => 0
+                    ]
+                ]
             ]
         ];
 

--- a/src/Domain_Item.php
+++ b/src/Domain_Item.php
@@ -104,7 +104,14 @@ class Domain_Item extends CommonDBRelation
             'glpi_domains_items',
             [
                 "domains_id"   => $item->getID(),
-                "itemtype"     => $types
+                "itemtype"     => $types,
+                'OR'  => [
+                    'AND' => [
+                        'is_deleted' => 0,
+                        'is_dynamic' => 1
+                    ],
+                    'is_dynamic' => 0
+                ]
             ]
         );
     }
@@ -113,11 +120,27 @@ class Domain_Item extends CommonDBRelation
     {
         $criteria = [];
         if ($item instanceof DomainRelation) {
-            $criteria = ['domainrelations_id' => $item->fields['id']];
+            $criteria = [
+                'domainrelations_id' => $item->fields['id'],
+                'OR'  => [
+                    'AND' => [
+                        'is_deleted' => 0,
+                        'is_dynamic' => 1
+                    ],
+                    'is_dynamic' => 0
+                ]
+            ];
         } else {
             $criteria = [
                 'itemtype'  => $item->getType(),
-                'items_id'  => $item->fields['id']
+                'items_id'  => $item->fields['id'],
+                'OR'  => [
+                    'AND' => [
+                        'is_deleted' => 0,
+                        'is_dynamic' => 1
+                    ],
+                    'is_dynamic' => 0
+                ]
             ];
         }
 
@@ -132,11 +155,27 @@ class Domain_Item extends CommonDBRelation
         $criteria = ['domains_id' => $domains_id];
         $item = new $itemtype();
         if ($item instanceof DomainRelation) {
-            $criteria += ['domainrelations_id' => $items_id];
+            $criteria += [
+                'domainrelations_id' => $items_id,
+                'OR'  => [
+                    'AND' => [
+                        'is_deleted' => 0,
+                        'is_dynamic' => 1
+                    ],
+                    'is_dynamic' => 0
+                ]
+            ];
         } else {
             $criteria += [
                 'itemtype'  => $itemtype,
-                'items_id'  => $items_id
+                'items_id'  => $items_id,
+                'OR'  => [
+                    'AND' => [
+                        'is_deleted' => 0,
+                        'is_dynamic' => 1
+                    ],
+                    'is_dynamic' => 0
+                ]
             ];
         }
 
@@ -182,7 +221,16 @@ class Domain_Item extends CommonDBRelation
             'SELECT'    => 'itemtype',
             'DISTINCT'  => true,
             'FROM'      => self::getTable(),
-            'WHERE'     => ['domains_id' => $instID],
+            'WHERE'     => [
+                'domains_id' => $instID,
+                'OR'  => [
+                    'AND' => [
+                        'is_deleted' => 0,
+                        'is_dynamic' => 1
+                    ],
+                    'is_dynamic' => 0
+                ]
+            ],
             'ORDER'     => 'itemtype',
             'LIMIT'     => count(Domain::getTypes(true))
         ]);
@@ -289,7 +337,14 @@ class Domain_Item extends CommonDBRelation
                     ],
                     'WHERE'        => [
                         self::getTable() . '.itemtype'   => $itemtype,
-                        self::getTable() . '.domains_id' => $instID
+                        self::getTable() . '.domains_id' => $instID,
+                        'OR'  => [
+                            'AND' => [
+                                self::getTable() . '.is_deleted' => 0,
+                                self::getTable() . '.is_dynamic' => 1
+                            ],
+                            self::getTable() . '.is_dynamic' => 0
+                        ]
                     ] + getEntitiesRestrictCriteria($itemTable, '', '', $item->maybeRecursive())
                 ];
 


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Domain items were always shown and counted even if they had the is_deleted flag set. This is now fixed and is consistent with the showForItem function in Domain_Item.php. So all domain items are shown and counted if they are created dynamically and not deleted or created manually. 