### PR TITLE
fix(PendingReason): restore previous status

### DIFF
--- a/install/migrations/update_10.0.10_to_10.0.11/pendingreason.php
+++ b/install/migrations/update_10.0.10_to_10.0.11/pendingreason.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+ /* Add `previous_status` to glpi_pendingreasons_items */
+if (!$DB->fieldExists('glpi_pendingreasons_items', 'previous_status')) {
+    $migration->addField('glpi_pendingreasons_items', 'previous_status', "int DEFAULT NULL");
+}

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9098,6 +9098,7 @@ CREATE TABLE `glpi_pendingreasons_items` (
   `followups_before_resolution` int NOT NULL DEFAULT '0',
   `bump_count` int NOT NULL DEFAULT '0',
   `last_bump_date` timestamp NULL DEFAULT NULL,
+  `previous_status` int DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`items_id`,`itemtype`),
   KEY `pendingreasons_id` (`pendingreasons_id`),

--- a/src/Features/ParentStatus.php
+++ b/src/Features/ParentStatus.php
@@ -65,6 +65,7 @@ trait ParentStatus
                     'pendingreasons_id'           => $input['pendingreasons_id'] ?? 0,
                     'followup_frequency'          => $input['followup_frequency'] ?? 0,
                     'followups_before_resolution' => $input['followups_before_resolution'] ?? 0,
+                    'previous_status'             => $parentitem->fields['status'],
                 ]);
                 PendingReason_Item::createForItem($this, [
                     'pendingreasons_id'           => $input['pendingreasons_id'] ?? 0,


### PR DESCRIPTION
When modifying a ```ITILfollowup```, if the ```PendingReason``` is removed, the status of the parent element is set to ```ASSIGN```

But this status does not exist for changes (for example)

Here, I propose to save the parent's previous status (```Ticket```, ```Change```, ```Problem```) so that it can be restored if the user removes the  ```PendingReason```.


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29347
