### PR TITLE
force id attribute when disclosable or copyable

### DIFF
--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -54,6 +54,12 @@
         {% set options = options|merge({'readonly': true}) %}
     {% endif %}
 
+   {% if (options.is_disclosable or options.is_copyable) and id is null %}
+      {% set options = options|merge({
+         id: name|slug ~ '_' ~ random()
+      }) %}
+   {% endif %}
+
     {% set input %}
         <input type="{{ options.type }}" {{ options.id != null ? 'id=' ~ options.id : '' }}
                class="form-control {{ options.input_addclass }}"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Issue noticed with the client secret field for OAuth Clients. When a password field has no ID specified, the JS for the disclose and copy buttons is not valid. This PR forces the generation of an ID if none is specified and the options for disclosable or copyable are set to true.