### PR TITLE
Forms: AJAX controller

### DIFF
--- a/ajax/common_ajax_controller.php
+++ b/ajax/common_ajax_controller.php
@@ -7,7 +7,7 @@
  *
  * http://glpi-project.org
  *
- * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2015-2024 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *

--- a/ajax/common_ajax_controller.php
+++ b/ajax/common_ajax_controller.php
@@ -7,7 +7,7 @@
  *
  * http://glpi-project.org
  *
- * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2015-2023 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
@@ -33,28 +33,13 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\Form\Form;
+use Glpi\Controller\CommonAjaxController;
 
-include('../../inc/includes.php');
+include('../inc/includes.php');
 
-// Only super admins for now - TODO add specific rights
-Session::checkRight("config", UPDATE);
-
-// Read parameters
-$id = $_REQUEST['id'] ?? null;
-
-if (isset($_POST["add"])) {
-    // Create form
-    $form = new Form();
-    $form->check($id, CREATE);
-
-    if ($form->add($_POST)) {
-        if ($_SESSION['glpibackcreated']) {
-            Html::redirect($form->getLinkURL());
-        }
-    }
-    Html::back();
-} else {
-    // Show requested form
-    Form::displayFullPageForItem($id, ['admin', Form::getType()], []);
-}
+/**
+ * AJAX endpoint used to update, delete, restore or purge a CommonDBTM item
+ */
+$controller = new CommonAjaxController();
+$response = $controller->handleRequest($_POST);
+$response->send();

--- a/css/includes/components/_asset-form.scss
+++ b/css/includes/components/_asset-form.scss
@@ -105,6 +105,12 @@
         }
     }
 
+    &:not(.asset-deleted) {
+        #header-is-deleted {
+            display: none;
+        }
+    }
+
     .main-header {
         padding-top: 0;
         padding-bottom: 0;

--- a/css/includes/components/_content-editable-inputs.scss
+++ b/css/includes/components/_content-editable-inputs.scss
@@ -50,6 +50,7 @@ $inline-input-padding: 2px 4px;
     padding: $inline-input-padding;
     margin-bottom: 1rem;
     background-color: transparent;
+    box-shadow: none;
 
     &:hover {
         box-shadow: 0 0 0 0.25rem rgba(var(--tblr-primary-rgb), 0.20);

--- a/css/includes/components/_content-editable-inputs.scss
+++ b/css/includes/components/_content-editable-inputs.scss
@@ -41,9 +41,9 @@
 // Must not be too high as content-editable is usually done without padding
 $inline-input-padding: 2px 4px;
 
-.content-editable-h2 {
+.content-editable-h1 {
     // Copy h2 styles
-    font-size: 1.2rem !important;
+    font-size: 1.6rem !important;
     line-height: 1.5rem;
     font-weight: var(--tblr-font-weight-medium);
     border: 0;
@@ -51,22 +51,13 @@ $inline-input-padding: 2px 4px;
     margin-bottom: 1rem;
     background-color: transparent;
     box-shadow: none;
-
-    &:hover {
-        box-shadow: 0 0 0 0.25rem rgba(var(--tblr-primary-rgb), 0.20);
-    }
 }
-
 
 .content-editable-tinymce {
     // Remove default border and padding, add similar hover style used on our inputs
     .tox-tinymce {
         border-color: transparent !important;
         padding: $inline-input-padding;
-
-        &:hover {
-            box-shadow: 0 0 0 0.25rem rgba(var(--tblr-primary-rgb), 0.20);
-        }
     }
 
     // Status bar is empty here, do not display to gain some vertical space

--- a/js/common.js
+++ b/js/common.js
@@ -1671,4 +1671,5 @@ function waitForElement(selector) {
 }
 
 // Init the AJAX controller
+/* global GlpiCommonAjaxController */
 new GlpiCommonAjaxController();

--- a/js/common.js
+++ b/js/common.js
@@ -1672,4 +1672,6 @@ function waitForElement(selector) {
 
 // Init the AJAX controller
 /* global GlpiCommonAjaxController */
-new GlpiCommonAjaxController();
+if (typeof GlpiCommonAjaxController == "function") {
+    new GlpiCommonAjaxController();
+}

--- a/js/common.js
+++ b/js/common.js
@@ -1669,3 +1669,6 @@ function waitForElement(selector) {
         });
     });
 }
+
+// Init the AJAX controller
+new GlpiCommonAjaxController();

--- a/js/common_ajax_controller.js
+++ b/js/common_ajax_controller.js
@@ -5,7 +5,7 @@
  *
  * http://glpi-project.org
  *
- * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2015-2024 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *

--- a/js/common_ajax_controller.js
+++ b/js/common_ajax_controller.js
@@ -134,12 +134,12 @@ $(() => {
 
         // Toggle "is_deleted" badge
         if (response.is_deleted) {
-            $('#header-is-deleted').removeClass("d-none");
+            $('#navigationheader').addClass("asset-deleted");
             form.find('button[name=delete]').addClass("d-none");
             form.find('button[name=purge]').removeClass("d-none");
             form.find('button[name=restore]').removeClass("d-none");
         } else {
-            $('#header-is-deleted').addClass("d-none");
+            $('#navigationheader').removeClass("asset-deleted");
             form.find('button[name=delete]').removeClass("d-none");
             form.find('button[name=purge]').addClass("d-none");
             form.find('button[name=restore]').addClass("d-none");

--- a/js/common_ajax_controller.js
+++ b/js/common_ajax_controller.js
@@ -173,7 +173,7 @@ class GlpiCommonAjaxController
     /**
      * Handle thrashin status updates found in the response
      *
-     * @param {jQuery} response
+     * @param {Object} response
      * @param {jQuery} form
      * @returns {void}
      */

--- a/js/common_ajax_controller.js
+++ b/js/common_ajax_controller.js
@@ -132,18 +132,11 @@ $(() => {
             return;
         }
 
-        // Toggle "is_deleted" badge
-        if (response.is_deleted) {
-            $('#navigationheader').addClass("asset-deleted");
-            form.find('button[name=delete]').addClass("d-none");
-            form.find('button[name=purge]').removeClass("d-none");
-            form.find('button[name=restore]').removeClass("d-none");
-        } else {
-            $('#navigationheader').removeClass("asset-deleted");
-            form.find('button[name=delete]').removeClass("d-none");
-            form.find('button[name=purge]').addClass("d-none");
-            form.find('button[name=restore]').addClass("d-none");
-        }
+        // Update UX to show deleted state and relevant actions
+        $('#navigationheader').toggleClass("asset-deleted", response.is_deleted);
+        form.find('button[name=delete]').toggleClass("d-none", response.is_deleted);
+        form.find('button[name=purge]').toggleClass("d-none", !response.is_deleted);
+        form.find('button[name=restore]').toggleClass("d-none", !response.is_deleted);
     };
 
     /**

--- a/js/common_ajax_controller.js
+++ b/js/common_ajax_controller.js
@@ -177,7 +177,7 @@ class GlpiCommonAjaxController
      * @param {jQuery} form
      * @returns {void}
      */
-    #handleTrashbinStatus = function (response, form) {
+    #handleTrashbinStatus(response, form) {
         if (response.is_deleted === undefined) {
             return;
         }
@@ -187,7 +187,7 @@ class GlpiCommonAjaxController
         form.find('button[name=delete]').toggleClass("d-none", response.is_deleted);
         form.find('button[name=purge]').toggleClass("d-none", !response.is_deleted);
         form.find('button[name=restore]').toggleClass("d-none", !response.is_deleted);
-    };
+    }
 
     /**
      * Handle redirect instructions found in the response
@@ -195,7 +195,7 @@ class GlpiCommonAjaxController
      * @param {Object} response
      * @returns {void}
      */
-    #handleRedirect = function (response) {
+    #handleRedirect(response) {
         if (response.redirect === undefined) {
             return;
         }

--- a/js/common_ajax_controller.js
+++ b/js/common_ajax_controller.js
@@ -55,8 +55,20 @@ $(() => {
         // Try to get submit button info
         const active_element = document.activeElement;
         let action = null;
-        if (active_element.tagName.toLowerCase() == "button") {
-            // Form submitted by presssing a button, get value from button
+
+        if (
+            // Submitted using the submit button
+            active_element.tagName.toLowerCase() == "button"
+            || (
+                // Submitted using a "submit" or "button" input
+                active_element.tagName.toLowerCase() == "input"
+                && (
+                    $(active_element).attr("type") == "submit"
+                    || $(active_element).attr("type") == "button"
+                )
+            )
+        ) {
+            // Get value from active element name
             action = $(active_element).prop('name');
         } else {
             // Form submitted by shift + enter, default to "update"

--- a/js/common_ajax_controller.js
+++ b/js/common_ajax_controller.js
@@ -176,15 +176,17 @@ $(() => {
             handleTrashbinStatus(response, form);
             handleRedirect(response);
         } catch (error) {
-            // Handle backend errors
-            const response = error.responseJSON;
-
-            // Add minimal error message if server provided no feedback
-            if (response.messages === undefined) {
-                response.messages = {error: __("Unexpected error")};
+            // Handle known backend errors
+            if (
+                error.responseJSON !== undefined
+                && error.responseJSON.messages !== undefined
+            ) {
+                handleFeedbackMessages(error.responseJSON.messages);
+            } else {
+                // We don't know how to handle this error
+                console.error(error);
+                handleFeedbackMessages({error: __("Unexpected error")});
             }
-
-            handleFeedbackMessages(response);
         }
     });
 });

--- a/js/common_ajax_controller.js
+++ b/js/common_ajax_controller.js
@@ -1,0 +1,185 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * Client code to handle AJAX updates orchestrated by the CommonAjaxController class
+ */
+
+/* global glpi_toast_info */
+/* global glpi_toast_warning */
+/* global glpi_toast_error */
+
+// Isolate functions and run when document is ready
+$(() => {
+    /**
+     * Build form data from the submitted form data + some extra params like
+     * the expected action and the target itemtype.
+     *
+     * @param {Object} form
+     * @returns {string}
+     */
+    const buildFormData = function (form) {
+        // Parse raw form data
+        const data = form.serializeArray();
+
+        // Try to get submit button info
+        const active_element = document.activeElement;
+        let action = null;
+        if (active_element.tagName.toLowerCase() == "button") {
+            // Form submitted by presssing a button, get value from button
+            action = $(active_element).prop('name');
+        } else {
+            // Form submitted by shift + enter, default to "update"
+            action = "update";
+        }
+
+        // Add submit button info to the form data
+        data.push({'name': '_action', 'value': action});
+
+        // Also keep action as a "direct" parameter as some internal code will
+        // look for it that way
+        data.push({'name': action, 'value': true});
+
+        // Add target itemtype
+        data.push({'name': 'itemtype', 'value': form.data('ajaxSubmitItemtype')});
+
+        return $.param(data);
+    };
+
+    /**
+     * Handle feedback message found in the reponse
+     *
+     * @param {Object} response
+     * @returns {void}
+     */
+    const handleFeedbackMessages = function (response) {
+        if (!response.messages) {
+            return;
+        }
+
+        // Display feedback messages as a toast
+        response.messages.info.forEach(message => glpi_toast_info(message));
+        response.messages.warning.forEach(message => glpi_toast_warning(message));
+        response.messages.error.forEach(message => glpi_toast_error(message));
+    };
+
+    /**
+     * Handle friendly name updates found in the reponse
+     *
+     * @param {Object} response
+     * @returns {void}
+     */
+    const handleFriendlyNameUpdate = function (response) {
+        if (!response.friendlyname || !$('#header-friendlyname').length) {
+            return;
+        }
+
+        // Update friendlyname
+        $('#header-friendlyname').text(response.friendlyname);
+    };
+
+    /**
+     * Handle thrashin status updates found in the reponse
+     *
+     * @param {Object} response
+     * @param {Object} form
+     * @returns {void}
+     */
+    const handleTrashbinStatus = function (response, form) {
+        if (response.is_deleted === undefined) {
+            return;
+        }
+
+        // Toggle "is_deleted" badge
+        if (response.is_deleted) {
+            $('#header-is-deleted').removeClass("d-none");
+            form.find('button[name=delete]').addClass("d-none");
+            form.find('button[name=purge]').removeClass("d-none");
+            form.find('button[name=restore]').removeClass("d-none");
+        } else {
+            $('#header-is-deleted').addClass("d-none");
+            form.find('button[name=delete]').removeClass("d-none");
+            form.find('button[name=purge]').addClass("d-none");
+            form.find('button[name=restore]').addClass("d-none");
+        }
+    };
+
+    /**
+     * Handle redirect instructions found in the reponse
+     *
+     * @param {Object} response
+     * @returns {void}
+     */
+    const handleRedirect = function (response) {
+        if (response.redirect === undefined) {
+            return;
+        }
+
+        // Redirect to specified page
+        window.location = response.redirect;
+    };
+
+    // Event handler on ajax form submit
+    $(document).on('submit', 'form[data-ajax-submit]', async function(e) {
+        e.preventDefault();
+
+        // Build form data
+        const form = $(e.target).closest('form');
+        const data = buildFormData(form);
+
+        // Send AJAX request
+        try {
+            const response = await $.post({
+                url: CFG_GLPI.root_doc + '/ajax/common_ajax_controller.php',
+                data: data,
+            });
+
+            // Response might contain specific content dependign on the action type
+            // This extra content will be handled by the functions below
+            handleFeedbackMessages(response);
+            handleFriendlyNameUpdate(response);
+            handleTrashbinStatus(response, form);
+            handleRedirect(response);
+        } catch (error) {
+            // Handle backend errors
+            const response = error.responseJSON;
+
+            // Add minimal error message if server provided no feedback
+            if (response.messages === undefined) {
+                response.messages = {error: __("Unexpected error")};
+            }
+
+            handleFeedbackMessages(response);
+        }
+    });
+});

--- a/js/common_ajax_controller.js
+++ b/js/common_ajax_controller.js
@@ -77,7 +77,7 @@ $(() => {
     };
 
     /**
-     * Handle feedback message found in the reponse
+     * Handle feedback message found in the response
      *
      * @param {Object} response
      * @returns {void}
@@ -94,7 +94,7 @@ $(() => {
     };
 
     /**
-     * Handle friendly name updates found in the reponse
+     * Handle friendly name updates found in the response
      *
      * @param {Object} response
      * @returns {void}
@@ -109,7 +109,7 @@ $(() => {
     };
 
     /**
-     * Handle thrashin status updates found in the reponse
+     * Handle thrashin status updates found in the response
      *
      * @param {Object} response
      * @param {Object} form
@@ -135,7 +135,7 @@ $(() => {
     };
 
     /**
-     * Handle redirect instructions found in the reponse
+     * Handle redirect instructions found in the response
      *
      * @param {Object} response
      * @returns {void}
@@ -164,7 +164,7 @@ $(() => {
                 data: data,
             });
 
-            // Response might contain specific content dependign on the action type
+            // Response might contain specific content depending on the action type
             // This extra content will be handled by the functions below
             handleFeedbackMessages(response);
             handleFriendlyNameUpdate(response);

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1932,6 +1932,23 @@ class CommonDBTM extends CommonGLPI
         }
     }
 
+    /**
+     * Standard formatting for session message relative to an item update
+     *
+     * @param string $message Feedback message
+     *
+     * @return string Formatted message
+     */
+    public function formatSessionMessageAfterAction(string $message): string
+    {
+        if (isset($this->input['_no_message_link'])) {
+            $display = $this->getNameID();
+        } else {
+            $display = $this->getLink();
+        }
+
+        return sprintf(__('%1$s: %2$s'), $message, $display);
+    }
 
     /**
      * Add a message on update action
@@ -1967,13 +1984,8 @@ class CommonDBTM extends CommonGLPI
                 );
             }
 
-            if (isset($this->input['_no_message_link'])) {
-                $display = $this->getNameID();
-            } else {
-                $display = $this->getLink();
-            }
-           //TRANS : %s is the description of the updated item
-            Session::addMessageAfterRedirect(sprintf(__('%1$s: %2$s'), __('Item successfully updated'), $display));
+            $message = $this->formatSessionMessageAfterAction(__('Item successfully updated'));
+            Session::addMessageAfterRedirect($message);
         }
     }
 
@@ -2204,13 +2216,8 @@ class CommonDBTM extends CommonGLPI
         }
 
         if ($addMessAfterRedirect) {
-            if (isset($this->input['_no_message_link'])) {
-                $display = $this->getNameID();
-            } else {
-                $display = $this->getLink();
-            }
-           //TRANS : %s is the description of the updated item
-            Session::addMessageAfterRedirect(sprintf(__('%1$s: %2$s'), __('Item successfully deleted'), $display));
+            $message = $this->formatSessionMessageAfterAction(__('Item successfully deleted'));
+            Session::addMessageAfterRedirect($message);
         }
     }
 
@@ -2244,17 +2251,8 @@ class CommonDBTM extends CommonGLPI
         }
 
         if ($addMessAfterRedirect) {
-            if (isset($this->input['_no_message_link'])) {
-                $display = $this->getNameID();
-            } else {
-                $display = $this->getLink();
-            }
-           //TRANS : %s is the description of the updated item
-            Session::addMessageAfterRedirect(sprintf(
-                __('%1$s: %2$s'),
-                __('Item successfully purged'),
-                $display
-            ));
+            $message = $this->formatSessionMessageAfterAction(__('Item successfully purged'));
+            Session::addMessageAfterRedirect($message);
         }
     }
 
@@ -2364,13 +2362,8 @@ class CommonDBTM extends CommonGLPI
         }
 
         if ($addMessAfterRedirect) {
-            if (isset($this->input['_no_message_link'])) {
-                $display = $this->getNameID();
-            } else {
-                $display = $this->getLink();
-            }
-           //TRANS : %s is the description of the updated item
-            Session::addMessageAfterRedirect(sprintf(__('%1$s: %2$s'), __('Item successfully restored'), $display));
+            $message = $this->formatSessionMessageAfterAction(__('Item successfully restored'));
+            Session::addMessageAfterRedirect($message);
         }
     }
 
@@ -3029,6 +3022,24 @@ class CommonDBTM extends CommonGLPI
         return false;
     }
 
+    /**
+     * Check if submitted id match an existing item or indicate a new item
+     *
+     * @param int $id Given id
+     *
+     * @return bool
+     */
+    public function checkIfExistOrNew($id): bool
+    {
+        return
+            $this->isNewID($id)
+            || (
+                isset($this->fields['id'])
+                && $this->fields['id'] == $id
+            )
+            || $this->getFromDB($id)
+        ;
+    }
 
     /**
      * Check right on an item with block
@@ -3041,13 +3052,8 @@ class CommonDBTM extends CommonGLPI
      **/
     public function check($ID, $right, array &$input = null)
     {
-
-       // Check item exists
-        if (
-            !$this->isNewID($ID)
-            && (!isset($this->fields['id']) || $this->fields['id'] != $ID)
-            && !$this->getFromDB($ID)
-        ) {
+        // Check item exists
+        if (!$this->checkIfExistOrNew($ID)) {
            // Gestion timeout session
             Session::redirectIfNotLoggedIn();
             Html::displayNotFoundError();
@@ -3063,7 +3069,6 @@ class CommonDBTM extends CommonGLPI
             }
         }
     }
-
 
     /**
      * Check if have right on this entity

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -3029,13 +3029,13 @@ class CommonDBTM extends CommonGLPI
      *
      * @return bool
      */
-    public function checkIfExistOrNew($id): bool
+    final public function checkIfExistOrNew($id): bool
     {
         return
             $this->isNewID($id)
             || (
                 isset($this->fields['id'])
-                && $this->fields['id'] == $id
+                && $this->fields['id'] === $id
             )
             || $this->getFromDB($id)
         ;

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1939,7 +1939,7 @@ class CommonDBTM extends CommonGLPI
      *
      * @return string Formatted message
      */
-    public function formatSessionMessageAfterAction(string $message): string
+    final public function formatSessionMessageAfterAction(string $message): string
     {
         if (isset($this->input['_no_message_link'])) {
             $display = $this->getNameID();

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -1083,7 +1083,7 @@ class CommonGLPI implements CommonGLPIInterface
             }
             $cleantarget = Html::cleanParametersURL($target);
             $is_deleted = $this instanceof CommonDBTM && $this->isField('is_deleted') && $this->fields['is_deleted'];
-            echo "<div class='navigationheader justify-content-sm-between " . ($is_deleted ? 'asset-deleted' : '') . "'>";
+            echo "<div id='navigationheader' class='navigationheader justify-content-sm-between " . ($is_deleted ? 'asset-deleted' : '') . "'>";
 
             // First set of header pagination actions, displayed on the left side of the page
             echo "<div class='left-icons'>";

--- a/src/Controller/CommonAjaxController.php
+++ b/src/Controller/CommonAjaxController.php
@@ -7,7 +7,7 @@
  *
  * http://glpi-project.org
  *
- * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2015-2024 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *

--- a/src/Controller/CommonAjaxController.php
+++ b/src/Controller/CommonAjaxController.php
@@ -1,0 +1,363 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Controller;
+
+use CommonDBTM;
+use Glpi\Http\Response;
+
+/**
+ * Ajax controller for handling "update", "delete", "restore" and "purge"
+ * actions on CommonDBTM objects
+ */
+class CommonAjaxController
+{
+    /**
+     * Object to update, delete, restore or purge
+     * @var CommonDBTM
+     */
+    protected CommonDBTM $item;
+
+    /**
+     * Handle a given POST request
+     *
+     * @param array $post POST data
+     *
+     * @return Response
+     */
+    final public function handleRequest(array $post): Response
+    {
+        // Validate id as soon as possible so all sub-methods can assume
+        // $post['id'] exist
+        if (!isset($post['id'])) {
+            return $this->errorReponse(400, __("Invalid id"));
+        }
+
+        // Validate and instanciate item from supplied itemtype
+        $itemtype = $post['itemtype'] ?? "";
+        if (!$this->isClassWhitelisted($itemtype)) {
+            return $this->errorReponse(403, __("Forbidden itemtype"));
+        }
+        $this->item = new $itemtype();
+
+        // Handle requested action
+        return $this->handleAction($post);
+    }
+
+    /**
+     * Handle the requested action ("update", "delete", "restore" or "purge")
+     * Can be overloaded by potential children classes to add new actions
+     *
+     * @param array $post POST data
+     *
+     * @return Response
+     */
+    protected function handleAction(array $post): Response
+    {
+        switch ($post['_action'] ?? "") {
+            default:
+                return $this->errorReponse(400, __("Invalid action"));
+
+            case "update":
+                return $this->handleUpdateAction($post);
+
+            case "delete":
+                return $this->handleDeleteAction($post);
+
+            case "restore":
+                return $this->handleRestoreAction($post);
+
+            case "purge":
+                return $this->handlePurgeAction($post);
+        }
+    }
+
+    /**
+     * Create an error response when the controller wasn't able to handle
+     * the request (lack or rights, invalid paramters, ...)
+     *
+     * @param int    $code    HTTP status code
+     * @param string $message Error message
+     *
+     * @return Response
+     */
+    final protected function errorReponse(int $code, string $message): Response
+    {
+        $body = [
+            'messages' => ['error' => [$message]]
+        ];
+        $body = $this->insertSessionMessages($body);
+        return $this->jsonResponse($code, $body);
+    }
+
+    /**
+     * Create a success response when the controller handled the request
+     * succesfully
+     *
+     * @param int   $code HTTP status code
+     * @param array $body Response's body
+     *
+     * @return Response
+     */
+    final protected function successResponse(int $code, array $body): Response
+    {
+        // TODO: we probably also need to insert the updated `date_mod` field to
+        // the response so it can be applied in the UX but its not yet displayed
+        // for Forms so there is no way to test it right now
+        $body = $this->insertSessionMessages($body);
+        return $this->jsonResponse($code, $body);
+    }
+
+    /**
+     * Build a simple JSON response
+     *
+     * @param int   $code HTTP status code
+     * @param array $body Response's body
+     *
+     * @return Response
+     */
+    final protected function jsonResponse(int $code, array $body): Response
+    {
+        return new Response(
+            $code,
+            ['Content-Type' => 'application/json'],
+            json_encode($body),
+        );
+    }
+
+    /**
+     * Insert session messages into the body of a response
+     *
+     * @param array $body
+     *
+     * @return array Updated body
+     */
+    final protected function insertSessionMessages(array $body): array
+    {
+        // Session messages are already handled by GLPI in case of a redirection
+        if (isset($body['redirect'])) {
+            return $body;
+        }
+
+        // Get each message types
+        $info    = $body['messages']['info'] ?? [];
+        $warning = $body['messages']['warning'] ?? [];
+        $error   = $body['messages']['error'] ?? [];
+
+        // Add session messages to body
+        $messages = $_SESSION['MESSAGE_AFTER_REDIRECT'] ?? [];
+        if (isset($messages[INFO])) {
+            array_push($info, ...$messages[INFO]);
+        }
+        if (isset($messages[WARNING])) {
+            array_push($warning, ...$messages[WARNING]);
+        }
+        if (isset($messages[ERROR])) {
+            array_push($error, ...$messages[ERROR]);
+        }
+
+        // Clear session
+        $_SESSION['MESSAGE_AFTER_REDIRECT'] = [];
+
+        // Update body
+        $body['messages'] = [
+            'info'    => $info,
+            'warning' => $warning,
+            'error'   => $error,
+        ];
+        return $body;
+    }
+
+    /**
+     * Handle "update" action
+     *
+     * @param array $post POST data
+     *
+     * @return Response
+     */
+    final protected function handleUpdateAction(array $post): Response
+    {
+        // Validate rights
+        $error_response = $this->check((int) $post['id'], UPDATE, $post);
+        if ($error_response instanceof Response) {
+            return $error_response;
+        }
+
+        if ($this->item->update($post)) {
+            // Successfull update
+            // Feedback message is already handled by CommonDBTM::addMessageOnUpdateAction
+            return $this->successResponse(200, [
+                "friendlyname" => $this->item->getFriendlyName(),
+            ]);
+        } else {
+            // Failed update
+            $error = $this->item->formatSessionMessageAfterAction(
+                __("Failed to udpate item")
+            );
+            return $this->errorReponse(422, $error);
+        }
+    }
+
+    /**
+     * Handle "delete" action
+     *
+     * @param array $post POST data
+     *
+     * @return Response
+     */
+    final protected function handleDeleteAction(array $post): Response
+    {
+        // Validate rights
+        $error_response = $this->check((int) $post['id'], DELETE, $post);
+        if ($error_response instanceof Response) {
+            return $error_response;
+        }
+
+        if ($this->item->delete($post)) {
+            // Successfull deletion
+            // Feedback message is already handled by CommonDBTM::addMessageOnDeleteAction
+            return $this->successResponse(200, [
+                "is_deleted" => true,
+            ]);
+        } else {
+            // Failed deletion
+            $error = $this->item->formatSessionMessageAfterAction(
+                __("Failed to delete item")
+            );
+            return $this->errorReponse(422, $error);
+        }
+    }
+
+    /**
+     * Handle "restore" action
+     *
+     * @param array $post POST data
+     *
+     * @return Response
+     */
+    final protected function handleRestoreAction(array $post): Response
+    {
+        // Validate rights
+        $error_response = $this->check((int) $post['id'], DELETE, $post);
+        if ($error_response instanceof Response) {
+            return $error_response;
+        }
+
+        if ($this->item->restore($post)) {
+            // Successfull restoration
+            // Feedback message is already handled by CommonDBTM::addMessageOnRestoreAction
+            return $this->successResponse(200, [
+                "is_deleted" => false,
+            ]);
+        } else {
+            // Failed to restore
+            $error = $this->item->formatSessionMessageAfterAction(
+                __("Failed to restore item")
+            );
+            return $this->errorReponse(422, $error);
+        }
+    }
+
+    /**
+     * Handle "purge" action
+     *
+     * @param array $post POST data
+     *
+     * @return Response
+     */
+    final protected function handlePurgeAction(array $post): Response
+    {
+        // Validate rights
+        $error_response = $this->check((int) $post['id'], PURGE, $post);
+        if ($error_response instanceof Response) {
+            return $error_response;
+        }
+
+        if ($this->item->delete($post, true)) {
+            // Successfull purge
+            // Feedback message is already handled by CommonDBTM::addMessageOnPurgeAction
+            return $this->successResponse(200, [
+                "redirect" => $this->item->getSearchURL(),
+            ]);
+        } else {
+            // Failed purge
+            $error = $this->item->formatSessionMessageAfterAction(
+                __("Failed to purge item")
+            );
+            return $this->errorReponse(422, $error);
+        }
+    }
+
+    /**
+     * Similar checks than done in CommonDBTM::check() without parts that aren't
+     * compatible with an AJAX response
+     *
+     * If a check fail, an error reponse will be returned
+     * If everything is OK, `null` is returned
+     *
+     * @param int   $id     Target item's id
+     * @param int   $right  Specific right to check
+     * @param array $post   POST data
+     *
+     * @return Response|null
+     */
+    final protected function check(int $id, int $right, array $post): ?Response
+    {
+        if (!$this->item->checkIfExistOrNew($id)) {
+            return $this->errorReponse(403, __("Item not found"));
+        } elseif (!$this->item->can($id, $right, $input)) {
+            return $this->errorReponse(
+                403,
+                __("You don't have permission to perform this action.")
+            );
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Check that the given class is whitelisted for ajax updates
+     * This is needed as we don't want others controllers to be bypassed by this
+     * endpoint
+     *
+     * @param string $class Given class
+     *
+     * @return bool
+     */
+    final protected function isClassWhitelisted(string $class): bool
+    {
+        return in_array($class, CommonAjaxControllerWhitelist::getClasses());
+    }
+}

--- a/src/Controller/CommonAjaxController.php
+++ b/src/Controller/CommonAjaxController.php
@@ -51,56 +51,56 @@ class CommonAjaxController
     protected CommonDBTM $item;
 
     /**
-     * Handle a given POST request
+     * Handle a given HTTP request
      *
-     * @param array $post POST data
+     * @param array $input request data
      *
      * @return Response
      */
-    final public function handleRequest(array $post): Response
+    final public function handleRequest(array $input): Response
     {
         // Validate id as soon as possible so all sub-methods can assume
-        // $post['id'] exist
-        if (!isset($post['id'])) {
+        // $input['id'] exist
+        if (!isset($input['id'])) {
             return $this->errorReponse(400, __("Invalid id"));
         }
 
         // Validate and instanciate item from supplied itemtype
-        $itemtype = $post['itemtype'] ?? "";
+        $itemtype = $input['itemtype'] ?? "";
         if (!$this->isClassWhitelisted($itemtype)) {
             return $this->errorReponse(403, __("Forbidden itemtype"));
         }
         $this->item = new $itemtype();
 
         // Handle requested action
-        return $this->handleAction($post);
+        return $this->handleAction($input);
     }
 
     /**
      * Handle the requested action ("update", "delete", "restore" or "purge")
      * Can be overloaded by potential children classes to add new actions
      *
-     * @param array $post POST data
+     * @param array $input Input data
      *
      * @return Response
      */
-    protected function handleAction(array $post): Response
+    protected function handleAction(array $input): Response
     {
-        switch ($post['_action'] ?? "") {
+        switch ($input['_action'] ?? "") {
             default:
                 return $this->errorReponse(400, __("Invalid action"));
 
             case "update":
-                return $this->handleUpdateAction($post);
+                return $this->handleUpdateAction($input);
 
             case "delete":
-                return $this->handleDeleteAction($post);
+                return $this->handleDeleteAction($input);
 
             case "restore":
-                return $this->handleRestoreAction($post);
+                return $this->handleRestoreAction($input);
 
             case "purge":
-                return $this->handlePurgeAction($post);
+                return $this->handlePurgeAction($input);
         }
     }
 
@@ -203,19 +203,19 @@ class CommonAjaxController
     /**
      * Handle "update" action
      *
-     * @param array $post POST data
+     * @param array $input Input data
      *
      * @return Response
      */
-    final protected function handleUpdateAction(array $post): Response
+    final protected function handleUpdateAction(array $input): Response
     {
         // Validate rights
-        $error_response = $this->check((int) $post['id'], UPDATE, $post);
+        $error_response = $this->check((int) $input['id'], UPDATE, $input);
         if ($error_response instanceof Response) {
             return $error_response;
         }
 
-        if ($this->item->update($post)) {
+        if ($this->item->update($input)) {
             // Successfull update
             // Feedback message is already handled by CommonDBTM::addMessageOnUpdateAction
             return $this->successResponse(200, [
@@ -233,19 +233,19 @@ class CommonAjaxController
     /**
      * Handle "delete" action
      *
-     * @param array $post POST data
+     * @param array $input Input data
      *
      * @return Response
      */
-    final protected function handleDeleteAction(array $post): Response
+    final protected function handleDeleteAction(array $input): Response
     {
         // Validate rights
-        $error_response = $this->check((int) $post['id'], DELETE, $post);
+        $error_response = $this->check((int) $input['id'], DELETE, $input);
         if ($error_response instanceof Response) {
             return $error_response;
         }
 
-        if ($this->item->delete($post)) {
+        if ($this->item->delete($input)) {
             // Successfull deletion
             // Feedback message is already handled by CommonDBTM::addMessageOnDeleteAction
             return $this->successResponse(200, [
@@ -263,19 +263,19 @@ class CommonAjaxController
     /**
      * Handle "restore" action
      *
-     * @param array $post POST data
+     * @param array $input Input data
      *
      * @return Response
      */
-    final protected function handleRestoreAction(array $post): Response
+    final protected function handleRestoreAction(array $input): Response
     {
         // Validate rights
-        $error_response = $this->check((int) $post['id'], DELETE, $post);
+        $error_response = $this->check((int) $input['id'], DELETE, $input);
         if ($error_response instanceof Response) {
             return $error_response;
         }
 
-        if ($this->item->restore($post)) {
+        if ($this->item->restore($input)) {
             // Successfull restoration
             // Feedback message is already handled by CommonDBTM::addMessageOnRestoreAction
             return $this->successResponse(200, [
@@ -293,19 +293,19 @@ class CommonAjaxController
     /**
      * Handle "purge" action
      *
-     * @param array $post POST data
+     * @param array $input Input data
      *
      * @return Response
      */
-    final protected function handlePurgeAction(array $post): Response
+    final protected function handlePurgeAction(array $input): Response
     {
         // Validate rights
-        $error_response = $this->check((int) $post['id'], PURGE, $post);
+        $error_response = $this->check((int) $input['id'], PURGE, $input);
         if ($error_response instanceof Response) {
             return $error_response;
         }
 
-        if ($this->item->delete($post, true)) {
+        if ($this->item->delete($input, true)) {
             // Successfull purge
             // Feedback message is already handled by CommonDBTM::addMessageOnPurgeAction
             return $this->successResponse(200, [
@@ -329,11 +329,11 @@ class CommonAjaxController
      *
      * @param int   $id     Target item's id
      * @param int   $right  Specific right to check
-     * @param array $post   POST data
+     * @param array $input  Input data
      *
      * @return Response|null
      */
-    final protected function check(int $id, int $right, array $post): ?Response
+    final protected function check(int $id, int $right, array $input): ?Response
     {
         if (!$this->item->checkIfExistOrNew($id)) {
             return $this->errorReponse(403, __("Item not found"));

--- a/src/Controller/CommonAjaxController.php
+++ b/src/Controller/CommonAjaxController.php
@@ -74,6 +74,9 @@ class CommonAjaxController
 
         // Handle requested action
         try {
+            // READ right is historically always checked no matter the action
+            $this->check((int) $input['id'], READ, $input);
+
             return $this->handleAction($input);
         } catch (\Glpi\Controller\RequestException $e) {
             return $this->errorReponse($e->getHttpCode(), $e->getMessage());

--- a/src/Controller/CommonAjaxController.php
+++ b/src/Controller/CommonAjaxController.php
@@ -81,7 +81,7 @@ class CommonAjaxController
         } catch (\Glpi\Controller\RequestException $e) {
             return $this->errorReponse($e->getHttpCode(), $e->getMessage());
         } catch (\Throwable $e) {
-            return $this->errorReponse(500, __('An unexpected error occured.'));
+            return $this->errorReponse(500, __('An unexpected error occurred.'));
         }
     }
 

--- a/src/Controller/CommonAjaxController.php
+++ b/src/Controller/CommonAjaxController.php
@@ -67,7 +67,7 @@ class CommonAjaxController
 
         // Validate and instanciate item from supplied itemtype
         $itemtype = $input['itemtype'] ?? "";
-        if (!$this->isClassWhitelisted($itemtype)) {
+        if (!$this->isClassAllowed($itemtype)) {
             return $this->errorReponse(403, __("Forbidden itemtype"));
         }
         $this->item = new $itemtype();
@@ -344,16 +344,20 @@ class CommonAjaxController
     }
 
     /**
-     * Check that the given class is whitelisted for ajax updates
+     * Check that the given class is allowed for ajax updates
      * This is needed as we don't want others controllers to be bypassed by this
-     * endpoint
+     * endpoint.
+     *
+     * Temporary method, this check should be deleted once we are confident
+     * that our rights management is good enough to allow all classes to access
+     * this endpoint.
      *
      * @param string $class Given class
      *
      * @return bool
      */
-    final protected function isClassWhitelisted(string $class): bool
+    final protected function isClassAllowed(string $class): bool
     {
-        return in_array($class, CommonAjaxControllerWhitelist::getClasses());
+        return in_array($class, CommonAjaxControllerAllowedClassesList::getClasses());
     }
 }

--- a/src/Controller/CommonAjaxControllerAllowedClassesList.php
+++ b/src/Controller/CommonAjaxControllerAllowedClassesList.php
@@ -7,7 +7,7 @@
  *
  * http://glpi-project.org
  *
- * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2015-2024 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *

--- a/src/Controller/CommonAjaxControllerAllowedClassesList.php
+++ b/src/Controller/CommonAjaxControllerAllowedClassesList.php
@@ -38,9 +38,12 @@ namespace Glpi\Controller;
 use Glpi\Form\Form;
 
 /**
- * Whitelist for classes allowed to be used with the CommonAjaxController class
+ * List of classes that are allowed to be used with the CommonAjaxController class
+ *
+ * Temporary class, will be deleted once we are confident that our rights
+ * management is good enough to allow all classes to access this endpoint.
  */
-final class CommonAjaxControllerWhitelist
+final class CommonAjaxControllerAllowedClassesList
 {
     /**
      * Return allowed classes list
@@ -49,7 +52,6 @@ final class CommonAjaxControllerWhitelist
      */
     public static function getClasses(): array
     {
-        // TOOD: add a hook so plugins can whitelist their classes
         return [
             Form::class,
         ];

--- a/src/Controller/CommonAjaxControllerWhitelist.php
+++ b/src/Controller/CommonAjaxControllerWhitelist.php
@@ -7,7 +7,7 @@
  *
  * http://glpi-project.org
  *
- * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2015-2023 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
@@ -33,28 +33,25 @@
  * ---------------------------------------------------------------------
  */
 
+namespace Glpi\Controller;
+
 use Glpi\Form\Form;
 
-include('../../inc/includes.php');
-
-// Only super admins for now - TODO add specific rights
-Session::checkRight("config", UPDATE);
-
-// Read parameters
-$id = $_REQUEST['id'] ?? null;
-
-if (isset($_POST["add"])) {
-    // Create form
-    $form = new Form();
-    $form->check($id, CREATE);
-
-    if ($form->add($_POST)) {
-        if ($_SESSION['glpibackcreated']) {
-            Html::redirect($form->getLinkURL());
-        }
+/**
+ * Whitelist for classes allowed to be used with the CommonAjaxController class
+ */
+final class CommonAjaxControllerWhitelist
+{
+    /**
+     * Return allowed classes list
+     *
+     * @return array
+     */
+    public static function getClasses(): array
+    {
+        // TOOD: add a hook so plugins can whitelist their classes
+        return [
+            Form::class,
+        ];
     }
-    Html::back();
-} else {
-    // Show requested form
-    Form::displayFullPageForItem($id, ['admin', Form::getType()], []);
 }

--- a/src/Controller/RequestException.php
+++ b/src/Controller/RequestException.php
@@ -7,7 +7,7 @@
  *
  * http://glpi-project.org
  *
- * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2015-2024 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *

--- a/src/Controller/RequestException.php
+++ b/src/Controller/RequestException.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Controller;
+
+use Exception;
+
+final class RequestException extends Exception
+{
+    protected int $http_code;
+
+    public function __construct($http_code, $message, $code = 0, $previous = null)
+    {
+        $this->http_code = $http_code;
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getHttpCode(): int
+    {
+        return $this->http_code;
+    }
+}

--- a/src/Html.php
+++ b/src/Html.php
@@ -1289,8 +1289,8 @@ HTML;
         $tpl_vars['js_files'][] = ['path' => 'public/lib/base.js'];
         $tpl_vars['js_files'][] = ['path' => 'js/webkit_fix.js'];
         $tpl_vars['js_modules'][] = ['path' => 'public/build/vue/app.js'];
-        $tpl_vars['js_files'][] = ['path' => 'js/common.js'];
         $tpl_vars['js_files'][] = ['path' => 'js/common_ajax_controller.js'];
+        $tpl_vars['js_files'][] = ['path' => 'js/common.js'];
 
        // Search
         $tpl_vars['js_modules'][] = ['path' => 'js/modules/Search/ResultsView.js'];

--- a/src/Html.php
+++ b/src/Html.php
@@ -1290,6 +1290,7 @@ HTML;
         $tpl_vars['js_files'][] = ['path' => 'js/webkit_fix.js'];
         $tpl_vars['js_modules'][] = ['path' => 'public/build/vue/app.js'];
         $tpl_vars['js_files'][] = ['path' => 'js/common.js'];
+        $tpl_vars['js_files'][] = ['path' => 'js/common_ajax_controller.js'];
 
        // Search
         $tpl_vars['js_modules'][] = ['path' => 'js/modules/Search/ResultsView.js'];

--- a/src/Session.php
+++ b/src/Session.php
@@ -1466,7 +1466,6 @@ class Session
         $message_type = INFO,
         $reset = false
     ) {
-
         if (!empty($msg)) {
             if (self::isCron()) {
                 // We are in cron mode

--- a/templates/components/form/header_content.html.twig
+++ b/templates/components/form/header_content.html.twig
@@ -96,7 +96,7 @@
          {% if withtemplate == 1 and item.id > 0 %}
             {{ _n('Template', 'Templates', 1) }} - {{ nametype }} - {{ template_name }}
          {% elseif not item.isNewItem() %}
-            {{ nametype }} - {{ friendlyname }}
+            {{ nametype }} - <span id="header-friendlyname"> {{ friendlyname }} </span>
          {% else %}
             {{ nametype }}
          {% endif %}
@@ -106,9 +106,14 @@
          <i class="{{ call('Agent::getIcon') }}"></i>
       </span>
       {% endif %}
-      {% if in_navheader and item.isField('is_deleted') and item.fields['is_deleted'] %}
+      {% if in_navheader and item.isField('is_deleted') %}
       {% set title = item.isField('date_mod') ? __('Item has been deleted on %s')|format(item.fields['date_mod']) : __('Deleted') %}
-      <span class="mx-1 status rounded-1" title="{{ title }}" data-bs-toggle="tooltip">
+      <span
+         id="header-is-deleted"
+         class="mx-1 text-white status rounded-1 {{ item.fields['is_deleted'] ? "" : "d-none" }}"
+         title="{{ title }}"
+         data-bs-toggle="tooltip"
+      >
          <i class="ti ti-trash"></i>
          {{ __('Deleted') }}
       </span>

--- a/templates/components/form/header_content.html.twig
+++ b/templates/components/form/header_content.html.twig
@@ -89,7 +89,7 @@
             <i class="{{ icon }} fa-2x"></i>
          </div>
       {% endif %}
-      <span {% if in_navheader %} class="status rounded-1" {% endif %}>
+      <span {% if in_navheader %} class="status rounded-1 me-1" {% endif %}>
          {% if in_navheader %}
             <i class="{{ icon }}"></i>
          {% endif %}
@@ -110,7 +110,7 @@
       {% set title = item.isField('date_mod') ? __('Item has been deleted on %s')|format(item.fields['date_mod']) : __('Deleted') %}
       <span
          id="header-is-deleted"
-         class="mx-1 text-white status rounded-1 {{ item.fields['is_deleted'] ? "" : "d-none" }}"
+         class="mx-1 status rounded-1"
          title="{{ title }}"
          data-bs-toggle="tooltip"
       >

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -52,6 +52,10 @@
     "
     method="POST"
     action="{{ item.getFormURL() }}"
+    {% if not item.isNewItem() %}
+        data-ajax-submit {# Form will be submitted using AJAX #}
+        data-ajax-submit-itemtype="Glpi\Form\Form" {# Target itemtype #}
+    {% endif %}
 >
     {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::PRE_ITEM_FORM'), {'item': item, 'options': params}) }}
 
@@ -168,7 +172,7 @@
             </button>
         {% endif %}
 
-        {% if item.isNewItem() %}
+        {% if item.isNewItem() and item.canCreate() %}
             {# Add action #}
             <button
                 class="btn btn-primary"
@@ -199,8 +203,10 @@
     {# Form id #}
     <input type="hidden" name="id" value="{{ item.fields.id }}">
 
-    {# CSRF #}
-    <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
+    {% if item.isNewItem() %}
+        {# CSRF #}
+        <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
+    {% endif %}
 
     {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::POST_ITEM_FORM'), {'item': item, 'options': params}) }}
 </form>

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -73,15 +73,16 @@
 
                     {# Card containing the main form data: title, header and status #}
                     <div class="card form-details">
-                        <div class="card-status-top bg-primary"></div>
+
+                        <div class="card-status-start bg-primary"></div>
                         <div class="card-body">
 
                             {# Header #}
-                            <div class="d-flex mt-2">
+                            <div class="d-flex">
                                 {# Form's name #}
                                 <input
                                     type="text"
-                                    class="form-control content-editable-h2"
+                                    class="form-control content-editable-h1"
                                     name="name"
                                     value="{{ item.fields.name }}"
                                 >

--- a/tests/functional/Computer.php
+++ b/tests/functional/Computer.php
@@ -831,4 +831,66 @@ class Computer extends DbTestCase
         $this->object($printer1_agent)->isInstanceOf(\Agent::class);
         $this->array($computer_agent->fields)->isEqualTo($printer1_agent->fields);
     }
+
+    /**
+     * Data provider for the testFormatSessionMessageAfterAction method
+     *
+     * @return iterable
+     */
+    protected function testFormatSessionMessageAfterActionProvider(): iterable
+    {
+        $this->login();
+
+        $entity = $this->getTestRootEntity();
+
+        list (
+            $c1,
+            $c2,
+            $c3,
+        ) = $this->createItems(\Computer::class, [
+            ['name' => 'Computer 1', 'entities_id' => $entity->fields['id']],
+            ['name' => 'Computer 2', 'entities_id' => $entity->fields['id']],
+            ['name' => 'Computer 3', 'entities_id' => $entity->fields['id']],
+        ]);
+
+        // Test message with link to item
+        yield [
+            $c1,
+            "Test",
+            "Test: <a  href='/glpi/front/computer.form.php?id={$c1->getId()}'  title=\"Computer 1\">Computer 1</a>"
+        ];
+        yield [
+            $c2,
+            "Test",
+            "Test: <a  href='/glpi/front/computer.form.php?id={$c2->getId()}'  title=\"Computer 2\">Computer 2</a>"
+        ];
+
+        // Test message without link
+        $c3->input["_no_message_link"] = true;
+        yield [
+            $c3,
+            "Test",
+            "Test: Computer 3"
+        ];
+    }
+
+    /**
+     * Test the formatSessionMessageAfterAction method
+     *
+     * @dataProvider testFormatSessionMessageAfterActionProvider
+     *
+     * @param \Computer $item                        Test subject
+     * @param string    $raw_message                 Raw message to format
+     * @param string    $expected_formatted_message  Expected formatted message
+     *
+     * @return void
+     */
+    public function testFormatSessionMessageAfterAction(
+        \Computer $item,
+        string $raw_message,
+        string $expected_formatted_message
+    ): void {
+        $message = $item->formatSessionMessageAfterAction($raw_message);
+        $this->string($message)->isEqualTo($expected_formatted_message);
+    }
 }


### PR DESCRIPTION
Allow update on Forms through AJAX.

This is an important feature because Forms will be complex items to configure and thus we want to avoid any page reload while dealing with them (which would make the user lose its curent "context" on the page).

Rather than implement the feature specifically for Forms, a generic `CommonAJAXController` controller has been created that will be able to handle AJAX updates on any `CommonDBTM` items.

This "ajax update" feature will only be enabled for Forms at this moment but could be easily enabled on others items later if we want to.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
