### PR TITLE
fix: horizontalField set class

### DIFF
--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -845,8 +845,6 @@
       'align_label_right': true,
       'mb': 'mb-2',
       'field_class': 'col-12 col-sm-6',
-      'label_class': 'col-xxl-5',
-      'input_class': 'col-xxl-7',
       'add_field_class': '',
       'add_field_attribs': {},
       'center': false,
@@ -858,19 +856,24 @@
       }) %}
 
       {% if options.full_width_adapt_column %}
-         {% set options = options|merge({
+         {% set options = {
             label_class: 'col-xxl-4',
             input_class: 'col-xxl-8',
-      }) %}
+      }|merge(options) %}
       {% endif %}
    {% endif %}
 
    {% if options.icon_label %}
-      {% set options = options|merge({
+      {% set options = {
          label_class: 'col-2',
          input_class: 'col-10',
-      }) %}
+      }|merge(options) %}
    {% endif %}
+
+   {% set options = {
+      label_class: 'col-xxl-5',
+      input_class: 'col-xxl-7',
+   }|merge(options) %}
 
    {% if options.align_label_right %}
       {% set options = options|merge({

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -845,6 +845,8 @@
       'align_label_right': true,
       'mb': 'mb-2',
       'field_class': 'col-12 col-sm-6',
+      'label_class': 'col-xxl-5',
+      'input_class': 'col-xxl-7',
       'add_field_class': '',
       'add_field_attribs': {},
       'center': false,
@@ -869,11 +871,6 @@
          input_class: 'col-10',
       }|merge(options) %}
    {% endif %}
-
-   {% set options = {
-      label_class: 'col-xxl-5',
-      input_class: 'col-xxl-7',
-   }|merge(options) %}
 
    {% if options.align_label_right %}
       {% set options = options|merge({


### PR DESCRIPTION
The "label_class" and "input_class" options could not be defined when the function was called, as they were systematically overwritten in the macro.

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !26302
