### PR TITLE
Fix entity restriction in ticket item add form

### DIFF
--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -286,7 +286,7 @@
          </h2>
          <div id="items" class="accordion-collapse collapse {{ items_show ? "show" : "" }}" aria-labelledby="items-heading">
             <div class="accordion-body accordion-items row m-0 mt-n2">
-               {{ item_ticket.itemAddForm(item, params|default({})) }}
+               {{ item_ticket.itemAddForm(item, params|default({})|merge({entities_id: entities_id})) }}
             </div>
          </div>
       </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Replace #15450 .

I do not know why and if it is correct, but `$params['entities_id']` passed to `components/itilobject/layout.html.twig` correspond to the active entity, while `$entities_id` corresponds to the ticket entity.

This `entities_id` variable is already used to retrict actors fields.