### PR TITLE
HLAPI Expand endpoint docs

### DIFF
--- a/src/Api/HL/Controller/AbstractController.php
+++ b/src/Api/HL/Controller/AbstractController.php
@@ -81,6 +81,29 @@ abstract class AbstractController
         ]
     ];
 
+    protected const PARAMETER_START = [
+        'name' => 'start',
+        'description' => 'The first item to return',
+        'location' => 'query',
+        'schema' => [
+            'type' => Doc\Schema::TYPE_INTEGER,
+            'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+            'minimum' => 0,
+            'default' => 0,
+        ]
+    ];
+
+    protected const PARAMETER_LIMIT = [
+        'name' => 'limit',
+        'description' => 'The maximum number of items to return',
+        'location' => 'query',
+        'schema' => [
+            'type' => Doc\Schema::TYPE_INTEGER,
+            'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+            'minimum' => 0,
+        ]
+    ];
+
     /**
      * @return array<string, Doc\Schema>
      */

--- a/src/Api/HL/Controller/AbstractController.php
+++ b/src/Api/HL/Controller/AbstractController.php
@@ -72,6 +72,15 @@ abstract class AbstractController
     public const CRUD_ACTION_RESTORE = 'restore';
     public const CRUD_ACTION_LIST = 'list';
 
+    protected const PARAMETER_RSQL_FILTER = [
+        'name' => 'filter',
+        'description' => 'RSQL query string',
+        'location' => 'query',
+        'schema' => [
+            'type' => Doc\Schema::TYPE_STRING,
+        ]
+    ];
+
     /**
      * @return array<string, Doc\Schema>
      */

--- a/src/Api/HL/Controller/AdministrationController.php
+++ b/src/Api/HL/Controller/AdministrationController.php
@@ -330,6 +330,7 @@ final class AdministrationController extends AbstractController
     #[Route(path: '/User', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search users',
+        parameters: [self::PARAMETER_RSQL_FILTER],
         responses: [
             ['schema' => 'User[]']
         ]
@@ -342,6 +343,7 @@ final class AdministrationController extends AbstractController
     #[Route(path: '/Group', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search groups',
+        parameters: [self::PARAMETER_RSQL_FILTER],
         responses: [
             ['schema' => 'Group[]']
         ]
@@ -354,6 +356,7 @@ final class AdministrationController extends AbstractController
     #[Route(path: '/Entity', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search entities',
+        parameters: [self::PARAMETER_RSQL_FILTER],
         responses: [
             ['schema' => 'Entity[]']
         ]
@@ -366,6 +369,7 @@ final class AdministrationController extends AbstractController
     #[Route(path: '/Profile', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search profiles',
+        parameters: [self::PARAMETER_RSQL_FILTER],
         responses: [
             ['schema' => 'Profile[]']
         ]

--- a/src/Api/HL/Controller/AdministrationController.php
+++ b/src/Api/HL/Controller/AdministrationController.php
@@ -330,7 +330,7 @@ final class AdministrationController extends AbstractController
     #[Route(path: '/User', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search users',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'User[]']
         ]
@@ -343,7 +343,7 @@ final class AdministrationController extends AbstractController
     #[Route(path: '/Group', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search groups',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'Group[]']
         ]
@@ -356,7 +356,7 @@ final class AdministrationController extends AbstractController
     #[Route(path: '/Entity', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search entities',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'Entity[]']
         ]
@@ -369,7 +369,7 @@ final class AdministrationController extends AbstractController
     #[Route(path: '/Profile', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search profiles',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'Profile[]']
         ]

--- a/src/Api/HL/Controller/AdministrationController.php
+++ b/src/Api/HL/Controller/AdministrationController.php
@@ -550,7 +550,6 @@ final class AdministrationController extends AbstractController
         [
             'name' => '_',
             'location' => Doc\Parameter::LOCATION_BODY,
-            'type' => Doc\Schema::TYPE_OBJECT,
             'schema' => 'User',
         ]
     ])]
@@ -682,7 +681,6 @@ final class AdministrationController extends AbstractController
         [
             'name' => '_',
             'location' => Doc\Parameter::LOCATION_BODY,
-            'type' => Doc\Schema::TYPE_OBJECT,
             'schema' => 'Group',
         ]
     ])]
@@ -735,7 +733,6 @@ final class AdministrationController extends AbstractController
         [
             'name' => '_',
             'location' => Doc\Parameter::LOCATION_BODY,
-            'type' => Doc\Schema::TYPE_OBJECT,
             'schema' => 'Entity',
         ]
     ])]
@@ -788,7 +785,6 @@ final class AdministrationController extends AbstractController
         [
             'name' => '_',
             'location' => Doc\Parameter::LOCATION_BODY,
-            'type' => Doc\Schema::TYPE_OBJECT,
             'schema' => 'Profile',
         ]
     ])]

--- a/src/Api/HL/Controller/AssetController.php
+++ b/src/Api/HL/Controller/AssetController.php
@@ -977,6 +977,7 @@ final class AssetController extends AbstractController
     #[Route(path: '/Global', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search assets of all types',
+        parameters: [self::PARAMETER_RSQL_FILTER],
         responses: [
             ['schema' => 'CommonAsset[]']
         ]
@@ -990,7 +991,8 @@ final class AssetController extends AbstractController
         'itemtype' => [self::class, 'getAssetTypes']
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
-        description: 'List or search assets of a specific type'
+        description: 'List or search assets of a specific type',
+        parameters: [self::PARAMETER_RSQL_FILTER],
     )]
     public function search(Request $request): Response
     {
@@ -1051,7 +1053,8 @@ final class AssetController extends AbstractController
 
     #[Route(path: '/Cartridge', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
-        description: 'List or search cartridges models'
+        description: 'List or search cartridges models',
+        parameters: [self::PARAMETER_RSQL_FILTER],
     )]
     public function searchCartridgeItems(Request $request): Response
     {
@@ -1144,7 +1147,8 @@ final class AssetController extends AbstractController
 
     #[Route(path: '/Consumable', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
-        description: 'List or search consumables models'
+        description: 'List or search consumables models',
+        parameters: [self::PARAMETER_RSQL_FILTER],
     )]
     public function searchConsumableItems(Request $request): Response
     {
@@ -1237,7 +1241,8 @@ final class AssetController extends AbstractController
 
     #[Route(path: '/Software', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
-        description: 'List or search software'
+        description: 'List or search software',
+        parameters: [self::PARAMETER_RSQL_FILTER],
     )]
     public function searchSoftware(Request $request): Response
     {
@@ -1288,7 +1293,8 @@ final class AssetController extends AbstractController
 
     #[Route(path: '/Rack', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
-        description: 'List or search racks'
+        description: 'List or search racks',
+        parameters: [self::PARAMETER_RSQL_FILTER],
     )]
     public function searchRack(Request $request): Response
     {
@@ -1339,7 +1345,8 @@ final class AssetController extends AbstractController
 
     #[Route(path: '/Enclosure', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
-        description: 'List or search enclosure'
+        description: 'List or search enclosure',
+        parameters: [self::PARAMETER_RSQL_FILTER],
     )]
     public function searchEnclosure(Request $request): Response
     {
@@ -1390,7 +1397,8 @@ final class AssetController extends AbstractController
 
     #[Route(path: '/PDU', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
-        description: 'List or search PDUs'
+        description: 'List or search PDUs',
+        parameters: [self::PARAMETER_RSQL_FILTER],
     )]
     public function searchPDU(Request $request): Response
     {
@@ -1441,7 +1449,8 @@ final class AssetController extends AbstractController
 
     #[Route(path: '/PassiveDCEquipment', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
-        description: 'List or search passive DC equipment'
+        description: 'List or search passive DC equipment',
+        parameters: [self::PARAMETER_RSQL_FILTER],
     )]
     public function searchPassiveDCEquipment(Request $request): Response
     {
@@ -1492,7 +1501,8 @@ final class AssetController extends AbstractController
 
     #[Route(path: '/Cable', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
-        description: 'List or search cables'
+        description: 'List or search cables',
+        parameters: [self::PARAMETER_RSQL_FILTER],
     )]
     public function searchCables(Request $request): Response
     {
@@ -1543,7 +1553,8 @@ final class AssetController extends AbstractController
 
     #[Route(path: '/Socket', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
-        description: 'List or search sockets'
+        description: 'List or search sockets',
+        parameters: [self::PARAMETER_RSQL_FILTER],
     )]
     public function searchSockets(Request $request): Response
     {
@@ -1596,7 +1607,8 @@ final class AssetController extends AbstractController
         'software_id' => '\d+',
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
-        description: 'List or search software versions'
+        description: 'List or search software versions',
+        parameters: [self::PARAMETER_RSQL_FILTER],
     )]
     public function searchSoftwareVersions(Request $request): Response
     {

--- a/src/Api/HL/Controller/AssetController.php
+++ b/src/Api/HL/Controller/AssetController.php
@@ -993,6 +993,9 @@ final class AssetController extends AbstractController
     #[Doc\Route(
         description: 'List or search assets of a specific type',
         parameters: [self::PARAMETER_RSQL_FILTER],
+        responses: [
+            ['schema' => '{itemtype}[]']
+        ]
     )]
     public function search(Request $request): Response
     {
@@ -1006,6 +1009,9 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get an asset of a specific type by ID',
+        responses: [
+            ['schema' => '{itemtype}']
+        ]
     )]
     public function getItem(Request $request): Response
     {
@@ -1018,6 +1024,13 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'])]
     #[Doc\Route(
         description: 'Create an asset of a specific type',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => '{itemtype}',
+            ]
+        ]
     )]
     public function createItem(Request $request): Response
     {
@@ -1031,6 +1044,13 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'])]
     #[Doc\Route(
         description: 'Update an asset of a specific type by ID',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => '{itemtype}',
+            ]
+        ]
     )]
     public function updateItem(Request $request): Response
     {

--- a/src/Api/HL/Controller/AssetController.php
+++ b/src/Api/HL/Controller/AssetController.php
@@ -977,7 +977,7 @@ final class AssetController extends AbstractController
     #[Route(path: '/Global', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search assets of all types',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'CommonAsset[]']
         ]
@@ -992,7 +992,7 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search assets of a specific type',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => '{itemtype}[]']
         ]
@@ -1074,7 +1074,7 @@ final class AssetController extends AbstractController
     #[Route(path: '/Cartridge', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search cartridge models',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'CartridgeItem[]']
         ]
@@ -1205,7 +1205,7 @@ final class AssetController extends AbstractController
     #[Route(path: '/Consumable', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search consumables models',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'ConsumableItem[]']
         ]
@@ -1336,7 +1336,7 @@ final class AssetController extends AbstractController
     #[Route(path: '/Software', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search software',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'Software[]']
         ]
@@ -1408,7 +1408,7 @@ final class AssetController extends AbstractController
     #[Route(path: '/Rack', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search racks',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'Rack[]']
         ]
@@ -1480,7 +1480,7 @@ final class AssetController extends AbstractController
     #[Route(path: '/Enclosure', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search enclosure',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'Enclosure[]']
         ]
@@ -1552,7 +1552,7 @@ final class AssetController extends AbstractController
     #[Route(path: '/PDU', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search PDUs',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'PDU[]']
         ]
@@ -1624,7 +1624,7 @@ final class AssetController extends AbstractController
     #[Route(path: '/PassiveDCEquipment', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search passive DC equipment',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'PassiveDCEquipment[]']
         ]
@@ -1696,7 +1696,7 @@ final class AssetController extends AbstractController
     #[Route(path: '/Cable', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search cables',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'Cable[]']
         ]
@@ -1768,7 +1768,7 @@ final class AssetController extends AbstractController
     #[Route(path: '/Socket', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search sockets',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'Socket[]']
         ]
@@ -1842,7 +1842,7 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search software versions',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'SoftwareVersion[]']
         ]

--- a/src/Api/HL/Controller/AssetController.php
+++ b/src/Api/HL/Controller/AssetController.php
@@ -1053,8 +1053,11 @@ final class AssetController extends AbstractController
 
     #[Route(path: '/Cartridge', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
-        description: 'List or search cartridges models',
+        description: 'List or search cartridge models',
         parameters: [self::PARAMETER_RSQL_FILTER],
+        responses: [
+            ['schema' => 'CartridgeItem[]']
+        ]
     )]
     public function searchCartridgeItems(Request $request): Response
     {
@@ -1066,6 +1069,9 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a cartridge model by ID',
+        responses: [
+            ['schema' => 'CartridgeItem']
+        ]
     )]
     public function getCartridgeItem(Request $request): Response
     {
@@ -1075,6 +1081,13 @@ final class AssetController extends AbstractController
     #[Route(path: '/Cartridge', methods: ['POST'], tags: ['Assets'])]
     #[Doc\Route(
         description: 'Create a cartridge model',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'CartridgeItem',
+            ]
+        ]
     )]
     public function createCartridgeItems(Request $request): Response
     {
@@ -1086,6 +1099,13 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'])]
     #[Doc\Route(
         description: 'Update a cartridge model by ID',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'CartridgeItem',
+            ]
+        ]
     )]
     public function updateCartridgeItems(Request $request): Response
     {
@@ -1108,6 +1128,9 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a cartridge by ID',
+        responses: [
+            ['schema' => 'Cartridge']
+        ]
     )]
     public function getCartridge(Request $request): Response
     {
@@ -1117,6 +1140,13 @@ final class AssetController extends AbstractController
     #[Route(path: '/Cartridge/{cartridgeitems_id}', methods: ['POST'], tags: ['Assets'])]
     #[Doc\Route(
         description: 'Create a cartridge',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'Cartridge',
+            ]
+        ]
     )]
     public function createCartridges(Request $request): Response
     {
@@ -1128,6 +1158,13 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'])]
     #[Doc\Route(
         description: 'Update a cartridge by ID',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'Cartridge',
+            ]
+        ]
     )]
     public function updateCartridges(Request $request): Response
     {
@@ -1149,6 +1186,9 @@ final class AssetController extends AbstractController
     #[Doc\Route(
         description: 'List or search consumables models',
         parameters: [self::PARAMETER_RSQL_FILTER],
+        responses: [
+            ['schema' => 'ConsumableItem[]']
+        ]
     )]
     public function searchConsumableItems(Request $request): Response
     {
@@ -1160,6 +1200,9 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a consumable model by ID',
+        responses: [
+            ['schema' => 'ConsumableItem']
+        ]
     )]
     public function getConsumableItem(Request $request): Response
     {
@@ -1169,6 +1212,13 @@ final class AssetController extends AbstractController
     #[Route(path: '/Consumable', methods: ['POST'], tags: ['Assets'])]
     #[Doc\Route(
         description: 'Create a consumable model',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'ConsumableItem',
+            ]
+        ]
     )]
     public function createConsumableItems(Request $request): Response
     {
@@ -1180,6 +1230,13 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'])]
     #[Doc\Route(
         description: 'Update a consumable model by ID',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'ConsumableItem',
+            ]
+        ]
     )]
     public function updateConsumableItems(Request $request): Response
     {
@@ -1202,6 +1259,9 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a consumable by ID',
+        responses: [
+            ['schema' => 'Consumable']
+        ]
     )]
     public function getConsumable(Request $request): Response
     {
@@ -1211,6 +1271,13 @@ final class AssetController extends AbstractController
     #[Route(path: '/Consumable/{consumableitems_id}', methods: ['POST'], tags: ['Assets'])]
     #[Doc\Route(
         description: 'Create a consumable',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'Consumable',
+            ]
+        ]
     )]
     public function createConsumables(Request $request): Response
     {
@@ -1222,6 +1289,13 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'])]
     #[Doc\Route(
         description: 'Update a consumable by ID',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'Consumable',
+            ]
+        ]
     )]
     public function updateConsumable(Request $request): Response
     {
@@ -1243,6 +1317,9 @@ final class AssetController extends AbstractController
     #[Doc\Route(
         description: 'List or search software',
         parameters: [self::PARAMETER_RSQL_FILTER],
+        responses: [
+            ['schema' => 'Software[]']
+        ]
     )]
     public function searchSoftware(Request $request): Response
     {
@@ -1254,6 +1331,9 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a software by ID',
+        responses: [
+            ['schema' => 'Software']
+        ]
     )]
     public function getSoftware(Request $request): Response
     {
@@ -1263,6 +1343,13 @@ final class AssetController extends AbstractController
     #[Route(path: '/Software', methods: ['POST'], tags: ['Assets'])]
     #[Doc\Route(
         description: 'Create a software',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'Software',
+            ]
+        ]
     )]
     public function createSoftware(Request $request): Response
     {
@@ -1274,6 +1361,13 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'])]
     #[Doc\Route(
         description: 'Update a software by ID',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'Software',
+            ]
+        ]
     )]
     public function updateSoftware(Request $request): Response
     {
@@ -1295,6 +1389,9 @@ final class AssetController extends AbstractController
     #[Doc\Route(
         description: 'List or search racks',
         parameters: [self::PARAMETER_RSQL_FILTER],
+        responses: [
+            ['schema' => 'Rack[]']
+        ]
     )]
     public function searchRack(Request $request): Response
     {
@@ -1306,6 +1403,9 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a rack by ID',
+        responses: [
+            ['schema' => 'Rack']
+        ]
     )]
     public function getRack(Request $request): Response
     {
@@ -1315,6 +1415,13 @@ final class AssetController extends AbstractController
     #[Route(path: '/Rack', methods: ['POST'], tags: ['Assets'])]
     #[Doc\Route(
         description: 'Create a rack',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'Rack',
+            ]
+        ]
     )]
     public function createRack(Request $request): Response
     {
@@ -1326,6 +1433,13 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'])]
     #[Doc\Route(
         description: 'Update a rack by ID',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'Rack',
+            ]
+        ]
     )]
     public function updateRack(Request $request): Response
     {
@@ -1347,6 +1461,9 @@ final class AssetController extends AbstractController
     #[Doc\Route(
         description: 'List or search enclosure',
         parameters: [self::PARAMETER_RSQL_FILTER],
+        responses: [
+            ['schema' => 'Enclosure[]']
+        ]
     )]
     public function searchEnclosure(Request $request): Response
     {
@@ -1358,6 +1475,9 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a enclosure by ID',
+        responses: [
+            ['schema' => 'Enclosure']
+        ]
     )]
     public function getEnclosure(Request $request): Response
     {
@@ -1367,6 +1487,13 @@ final class AssetController extends AbstractController
     #[Route(path: '/Enclosure', methods: ['POST'], tags: ['Assets'])]
     #[Doc\Route(
         description: 'Create a enclosure',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'Enclosure',
+            ]
+        ]
     )]
     public function createEnclosure(Request $request): Response
     {
@@ -1378,6 +1505,13 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'])]
     #[Doc\Route(
         description: 'Update a enclosure by ID',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'Enclosure',
+            ]
+        ]
     )]
     public function updateEnclosure(Request $request): Response
     {
@@ -1399,6 +1533,9 @@ final class AssetController extends AbstractController
     #[Doc\Route(
         description: 'List or search PDUs',
         parameters: [self::PARAMETER_RSQL_FILTER],
+        responses: [
+            ['schema' => 'PDU[]']
+        ]
     )]
     public function searchPDU(Request $request): Response
     {
@@ -1410,6 +1547,9 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a PDU by ID',
+        responses: [
+            ['schema' => 'PDU']
+        ]
     )]
     public function getPDU(Request $request): Response
     {
@@ -1419,6 +1559,13 @@ final class AssetController extends AbstractController
     #[Route(path: '/PDU', methods: ['POST'], tags: ['Assets'])]
     #[Doc\Route(
         description: 'Create a PDU',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'PDU',
+            ]
+        ]
     )]
     public function createPDU(Request $request): Response
     {
@@ -1430,6 +1577,13 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'])]
     #[Doc\Route(
         description: 'Update a PDU by ID',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'PDU',
+            ]
+        ]
     )]
     public function updatePDU(Request $request): Response
     {
@@ -1451,6 +1605,9 @@ final class AssetController extends AbstractController
     #[Doc\Route(
         description: 'List or search passive DC equipment',
         parameters: [self::PARAMETER_RSQL_FILTER],
+        responses: [
+            ['schema' => 'PassiveDCEquipment[]']
+        ]
     )]
     public function searchPassiveDCEquipment(Request $request): Response
     {
@@ -1462,6 +1619,9 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a passive DC equipment by ID',
+        responses: [
+            ['schema' => 'PassiveDCEquipment']
+        ]
     )]
     public function getPassiveDCEquipment(Request $request): Response
     {
@@ -1471,6 +1631,13 @@ final class AssetController extends AbstractController
     #[Route(path: '/PassiveDCEquipment', methods: ['POST'], tags: ['Assets'])]
     #[Doc\Route(
         description: 'Create a passive DC equipment',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'PassiveDCEquipment',
+            ]
+        ]
     )]
     public function createPassiveDCEquipment(Request $request): Response
     {
@@ -1482,6 +1649,13 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'])]
     #[Doc\Route(
         description: 'Update a passive DC equipment by ID',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'PassiveDCEquipment',
+            ]
+        ]
     )]
     public function updatePassiveDCEquipment(Request $request): Response
     {
@@ -1503,6 +1677,9 @@ final class AssetController extends AbstractController
     #[Doc\Route(
         description: 'List or search cables',
         parameters: [self::PARAMETER_RSQL_FILTER],
+        responses: [
+            ['schema' => 'Cable[]']
+        ]
     )]
     public function searchCables(Request $request): Response
     {
@@ -1514,6 +1691,9 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a cable by ID',
+        responses: [
+            ['schema' => 'Cable']
+        ]
     )]
     public function getCable(Request $request): Response
     {
@@ -1523,6 +1703,13 @@ final class AssetController extends AbstractController
     #[Route(path: '/Cable', methods: ['POST'], tags: ['Assets'])]
     #[Doc\Route(
         description: 'Create a cable',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'Cable',
+            ]
+        ]
     )]
     public function createCable(Request $request): Response
     {
@@ -1533,7 +1720,14 @@ final class AssetController extends AbstractController
         'id' => '\d+'
     ], tags: ['Assets'])]
     #[Doc\Route(
-        description: 'Update a software by ID',
+        description: 'Update a cable by ID',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'Cable',
+            ]
+        ]
     )]
     public function updateCable(Request $request): Response
     {
@@ -1555,6 +1749,9 @@ final class AssetController extends AbstractController
     #[Doc\Route(
         description: 'List or search sockets',
         parameters: [self::PARAMETER_RSQL_FILTER],
+        responses: [
+            ['schema' => 'Socket[]']
+        ]
     )]
     public function searchSockets(Request $request): Response
     {
@@ -1566,6 +1763,9 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a socket by ID',
+        responses: [
+            ['schema' => 'Socket']
+        ]
     )]
     public function getSocket(Request $request): Response
     {
@@ -1575,6 +1775,13 @@ final class AssetController extends AbstractController
     #[Route(path: '/Socket', methods: ['POST'], tags: ['Assets'])]
     #[Doc\Route(
         description: 'Create a socket',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'Socket',
+            ]
+        ]
     )]
     public function createSocket(Request $request): Response
     {
@@ -1586,6 +1793,13 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'])]
     #[Doc\Route(
         description: 'Update a socket by ID',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'Socket',
+            ]
+        ]
     )]
     public function updateSocket(Request $request): Response
     {
@@ -1609,6 +1823,9 @@ final class AssetController extends AbstractController
     #[Doc\Route(
         description: 'List or search software versions',
         parameters: [self::PARAMETER_RSQL_FILTER],
+        responses: [
+            ['schema' => 'SoftwareVersion[]']
+        ]
     )]
     public function searchSoftwareVersions(Request $request): Response
     {
@@ -1623,6 +1840,9 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a software version by ID',
+        responses: [
+            ['schema' => 'SoftwareVersion']
+        ]
     )]
     public function getSoftwareVersion(Request $request): Response
     {
@@ -1637,6 +1857,13 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'])]
     #[Doc\Route(
         description: 'Create a software version',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'SoftwareVersion',
+            ]
+        ]
     )]
     public function createSoftwareVersion(Request $request): Response
     {
@@ -1655,6 +1882,13 @@ final class AssetController extends AbstractController
     ], tags: ['Assets'])]
     #[Doc\Route(
         description: 'Update a software version by ID',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'SoftwareVersion',
+            ]
+        ]
     )]
     public function updateSoftwareVersion(Request $request): Response
     {

--- a/src/Api/HL/Controller/ComponentController.php
+++ b/src/Api/HL/Controller/ComponentController.php
@@ -625,7 +625,7 @@ class ComponentController extends AbstractController
     ], tags: ['Components'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get the component definitions of the specified type',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
     )]
     public function getComponentTypes(Request $request): Response
     {
@@ -666,7 +666,7 @@ class ComponentController extends AbstractController
     ], tags: ['Components'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get the components of a specific component definition',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
     )]
     public function getComponentsOfType(Request $request): Response
     {
@@ -740,7 +740,7 @@ class ComponentController extends AbstractController
     ], tags: ['Assets', 'Components'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get all components for an asset',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
     )]
     public function getAssetComponentsByType(Request $request): Response
     {

--- a/src/Api/HL/Controller/ComponentController.php
+++ b/src/Api/HL/Controller/ComponentController.php
@@ -734,7 +734,7 @@ class ComponentController extends AbstractController
     }
 
     #[Route(path: '/Assets/{itemtype}/{id}/Component/{component_type}', methods: ['GET'], requirements: [
-        'itemtype' => '\w*',
+        'itemtype' => [AssetController::class, 'getAssetTypes'],
         'component_type' => '\w*',
         'id' => '\d+'
     ], tags: ['Assets', 'Components'], middlewares: [ResultFormatterMiddleware::class])]

--- a/src/Api/HL/Controller/ComponentController.php
+++ b/src/Api/HL/Controller/ComponentController.php
@@ -625,6 +625,7 @@ class ComponentController extends AbstractController
     ], tags: ['Components'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get the component definitions of the specified type',
+        parameters: [self::PARAMETER_RSQL_FILTER],
     )]
     public function getComponentTypes(Request $request): Response
     {
@@ -665,6 +666,7 @@ class ComponentController extends AbstractController
     ], tags: ['Components'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get the components of a specific component definition',
+        parameters: [self::PARAMETER_RSQL_FILTER],
     )]
     public function getComponentsOfType(Request $request): Response
     {
@@ -738,6 +740,7 @@ class ComponentController extends AbstractController
     ], tags: ['Assets', 'Components'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get all components for an asset',
+        parameters: [self::PARAMETER_RSQL_FILTER],
     )]
     public function getAssetComponentsByType(Request $request): Response
     {

--- a/src/Api/HL/Controller/CoreController.php
+++ b/src/Api/HL/Controller/CoreController.php
@@ -160,11 +160,6 @@ final class CoreController extends AbstractController
                 'schema' => ['type' => 'string']
             ]
         ],
-        responses: [
-            [
-
-            ]
-        ]
     )]
     public function showDocumentation(Request $request): Response
     {
@@ -312,10 +307,6 @@ HTML;
             ],
             '404' => [
                 'description' => 'No route found for the requested path',
-                'schema' => [
-                    'type' => Doc\Schema::TYPE_OBJECT,
-                    'properties' => []
-                ]
             ]
         ]
     )]
@@ -586,7 +577,6 @@ HTML;
             [
                 'name' => '_',
                 'location' => Doc\Parameter::LOCATION_BODY,
-                'type' => Doc\Schema::TYPE_OBJECT,
                 'schema' => 'EntityTransferRecord[]'
             ]
         ]

--- a/src/Api/HL/Controller/ITILController.php
+++ b/src/Api/HL/Controller/ITILController.php
@@ -570,7 +570,7 @@ final class ITILController extends AbstractController
     #[Route(path: '/{itemtype}/', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search Tickets, Changes or Problems',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => '{itemtype}[]']
         ]
@@ -1160,7 +1160,7 @@ final class ITILController extends AbstractController
     #[Route(path: '/RecurringTicket', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search recurring tickets',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'RecurringTicket[]']
         ]
@@ -1232,7 +1232,7 @@ final class ITILController extends AbstractController
     #[Route(path: '/RecurringChange', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search recurring changes',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'RecurringChange[]']
         ]
@@ -1304,7 +1304,7 @@ final class ITILController extends AbstractController
     #[Route(path: '/ExternalEvent', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search external events',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'ExternalEvent[]']
         ]

--- a/src/Api/HL/Controller/ITILController.php
+++ b/src/Api/HL/Controller/ITILController.php
@@ -569,7 +569,8 @@ final class ITILController extends AbstractController
 
     #[Route(path: '/{itemtype}/', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
-        description: 'List or search Tickets, Changes or Problems'
+        description: 'List or search Tickets, Changes or Problems',
+        parameters: [self::PARAMETER_RSQL_FILTER],
     )]
     public function search(Request $request): Response
     {
@@ -1134,7 +1135,8 @@ final class ITILController extends AbstractController
 
     #[Route(path: '/RecurringTicket', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
-        description: 'List or search recurring tickets'
+        description: 'List or search recurring tickets',
+        parameters: [self::PARAMETER_RSQL_FILTER],
     )]
     public function searchRecurringTickets(Request $request): Response
     {
@@ -1185,7 +1187,8 @@ final class ITILController extends AbstractController
 
     #[Route(path: '/RecurringChange', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
-        description: 'List or search recurring changes'
+        description: 'List or search recurring changes',
+        parameters: [self::PARAMETER_RSQL_FILTER],
     )]
     public function searchRecurringChanges(Request $request): Response
     {
@@ -1236,7 +1239,8 @@ final class ITILController extends AbstractController
 
     #[Route(path: '/ExternalEvent', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
-        description: 'List or search external evenst'
+        description: 'List or search external events',
+        parameters: [self::PARAMETER_RSQL_FILTER],
     )]
     public function searchExternalEvent(Request $request): Response
     {

--- a/src/Api/HL/Controller/ITILController.php
+++ b/src/Api/HL/Controller/ITILController.php
@@ -1006,7 +1006,13 @@ final class ITILController extends AbstractController
 
     #[Route(path: '/{itemtype}/{id}/TeamMember', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
-        description: 'Get the team members for a specific Ticket, Change or Problem by ID'
+        description: 'Get the team members for a specific Ticket, Change or Problem by ID',
+        responses: [
+            [
+                'description' => 'The team members',
+                'schema' => 'TeamMember[]'
+            ]
+        ]
     )]
     public function getTeamMembers(Request $request): Response
     {
@@ -1137,6 +1143,9 @@ final class ITILController extends AbstractController
     #[Doc\Route(
         description: 'List or search recurring tickets',
         parameters: [self::PARAMETER_RSQL_FILTER],
+        responses: [
+            ['schema' => 'RecurringTicket[]']
+        ]
     )]
     public function searchRecurringTickets(Request $request): Response
     {
@@ -1148,6 +1157,9 @@ final class ITILController extends AbstractController
     ], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a recurring ticket by ID',
+        responses: [
+            ['schema' => 'RecurringTicket']
+        ]
     )]
     public function getRecurringTicket(Request $request): Response
     {
@@ -1157,6 +1169,13 @@ final class ITILController extends AbstractController
     #[Route(path: '/RecurringTicket', methods: ['POST'])]
     #[Doc\Route(
         description: 'Create a recurring ticket',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'RecurringTicket',
+            ]
+        ]
     )]
     public function createRecurringTicket(Request $request): Response
     {
@@ -1168,6 +1187,13 @@ final class ITILController extends AbstractController
     ])]
     #[Doc\Route(
         description: 'Update a recurring ticket by ID',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'RecurringTicket',
+            ]
+        ]
     )]
     public function updateRecurringTicket(Request $request): Response
     {
@@ -1189,6 +1215,9 @@ final class ITILController extends AbstractController
     #[Doc\Route(
         description: 'List or search recurring changes',
         parameters: [self::PARAMETER_RSQL_FILTER],
+        responses: [
+            ['schema' => 'RecurringChange[]']
+        ]
     )]
     public function searchRecurringChanges(Request $request): Response
     {
@@ -1200,6 +1229,9 @@ final class ITILController extends AbstractController
     ], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a recurring change by ID',
+        responses: [
+            ['schema' => 'RecurringChange']
+        ]
     )]
     public function getRecurringChange(Request $request): Response
     {
@@ -1209,6 +1241,13 @@ final class ITILController extends AbstractController
     #[Route(path: '/RecurringChange', methods: ['POST'])]
     #[Doc\Route(
         description: 'Create a recurring change',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'RecurringChange',
+            ]
+        ]
     )]
     public function createRecurringChange(Request $request): Response
     {
@@ -1220,6 +1259,13 @@ final class ITILController extends AbstractController
     ])]
     #[Doc\Route(
         description: 'Update a recurring change by ID',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'RecurringChange',
+            ]
+        ]
     )]
     public function updateRecurringChange(Request $request): Response
     {
@@ -1241,6 +1287,9 @@ final class ITILController extends AbstractController
     #[Doc\Route(
         description: 'List or search external events',
         parameters: [self::PARAMETER_RSQL_FILTER],
+        responses: [
+            ['schema' => 'ExternalEvent[]']
+        ]
     )]
     public function searchExternalEvent(Request $request): Response
     {
@@ -1251,7 +1300,10 @@ final class ITILController extends AbstractController
         'id' => '\d+'
     ], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
-        description: 'Get a recurring change by ID',
+        description: 'Get an external event by ID',
+        responses: [
+            ['schema' => 'ExternalEvent']
+        ]
     )]
     public function getExternalEvent(Request $request): Response
     {
@@ -1261,6 +1313,13 @@ final class ITILController extends AbstractController
     #[Route(path: '/ExternalEvent', methods: ['POST'])]
     #[Doc\Route(
         description: 'Create an external event',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'ExternalEvent',
+            ]
+        ]
     )]
     public function createExternalEvent(Request $request): Response
     {
@@ -1272,6 +1331,13 @@ final class ITILController extends AbstractController
     ])]
     #[Doc\Route(
         description: 'Update an external event by ID',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => 'ExternalEvent',
+            ]
+        ]
     )]
     public function updateExternalEvent(Request $request): Response
     {

--- a/src/Api/HL/Controller/ITILController.php
+++ b/src/Api/HL/Controller/ITILController.php
@@ -571,6 +571,9 @@ final class ITILController extends AbstractController
     #[Doc\Route(
         description: 'List or search Tickets, Changes or Problems',
         parameters: [self::PARAMETER_RSQL_FILTER],
+        responses: [
+            ['schema' => '{itemtype}[]']
+        ]
     )]
     public function search(Request $request): Response
     {
@@ -588,6 +591,9 @@ final class ITILController extends AbstractController
                 'location' => Doc\Parameter::LOCATION_PATH,
                 'schema' => ['type' => Doc\Schema::TYPE_INTEGER]
             ]
+        ],
+        responses: [
+            ['schema' => '{itemtype}']
         ]
     )]
     public function getItem(Request $request): Response
@@ -598,7 +604,14 @@ final class ITILController extends AbstractController
 
     #[Route(path: '/{itemtype}/', methods: ['POST'])]
     #[Doc\Route(
-        description: 'Create a new Ticket, Change or Problem'
+        description: 'Create a new Ticket, Change or Problem',
+        parameters: [
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => '{itemtype}',
+            ]
+        ]
     )]
     public function createItem(Request $request): Response
     {
@@ -615,6 +628,11 @@ final class ITILController extends AbstractController
                 'description' => 'The ID of the Ticket, Change, or Problem',
                 'location' => Doc\Parameter::LOCATION_PATH,
                 'schema' => ['type' => Doc\Schema::TYPE_INTEGER]
+            ],
+            [
+                'name' => '_',
+                'location' => Doc\Parameter::LOCATION_BODY,
+                'schema' => '{itemtype}',
             ]
         ]
     )]

--- a/src/Api/HL/Controller/ManagementController.php
+++ b/src/Api/HL/Controller/ManagementController.php
@@ -279,7 +279,6 @@ final class ManagementController extends AbstractController
         [
             'name' => '_',
             'location' => Doc\Parameter::LOCATION_BODY,
-            'type' => Doc\Schema::TYPE_OBJECT,
             'schema' => 'Budget',
         ]
     ])]
@@ -337,7 +336,6 @@ final class ManagementController extends AbstractController
         [
             'name' => '_',
             'location' => Doc\Parameter::LOCATION_BODY,
-            'type' => Doc\Schema::TYPE_OBJECT,
             'schema' => 'License',
         ]
     ])]
@@ -395,7 +393,6 @@ final class ManagementController extends AbstractController
         [
             'name' => '_',
             'location' => Doc\Parameter::LOCATION_BODY,
-            'type' => Doc\Schema::TYPE_OBJECT,
             'schema' => 'Supplier',
         ]
     ])]
@@ -461,7 +458,6 @@ final class ManagementController extends AbstractController
         [
             'name' => '_',
             'location' => Doc\Parameter::LOCATION_BODY,
-            'type' => Doc\Schema::TYPE_OBJECT,
             'schema' => 'Contact',
         ]
     ])]
@@ -519,7 +515,6 @@ final class ManagementController extends AbstractController
         [
             'name' => '_',
             'location' => Doc\Parameter::LOCATION_BODY,
-            'type' => Doc\Schema::TYPE_OBJECT,
             'schema' => 'Contract',
         ]
     ])]
@@ -588,7 +583,6 @@ final class ManagementController extends AbstractController
         [
             'name' => '_',
             'location' => Doc\Parameter::LOCATION_BODY,
-            'type' => Doc\Schema::TYPE_OBJECT,
             'schema' => 'Document',
         ]
     ])]
@@ -646,7 +640,6 @@ final class ManagementController extends AbstractController
         [
             'name' => '_',
             'location' => Doc\Parameter::LOCATION_BODY,
-            'type' => Doc\Schema::TYPE_OBJECT,
             'schema' => 'Line',
         ]
     ])]
@@ -704,7 +697,6 @@ final class ManagementController extends AbstractController
         [
             'name' => '_',
             'location' => Doc\Parameter::LOCATION_BODY,
-            'type' => Doc\Schema::TYPE_OBJECT,
             'schema' => 'Certificate',
         ]
     ])]
@@ -762,7 +754,6 @@ final class ManagementController extends AbstractController
         [
             'name' => '_',
             'location' => Doc\Parameter::LOCATION_BODY,
-            'type' => Doc\Schema::TYPE_OBJECT,
             'schema' => 'DataCenter',
         ]
     ])]
@@ -820,7 +811,6 @@ final class ManagementController extends AbstractController
         [
             'name' => '_',
             'location' => Doc\Parameter::LOCATION_BODY,
-            'type' => Doc\Schema::TYPE_OBJECT,
             'schema' => 'Cluster',
         ]
     ])]
@@ -878,7 +868,6 @@ final class ManagementController extends AbstractController
         [
             'name' => '_',
             'location' => Doc\Parameter::LOCATION_BODY,
-            'type' => Doc\Schema::TYPE_OBJECT,
             'schema' => 'Domain',
         ]
     ])]
@@ -936,7 +925,6 @@ final class ManagementController extends AbstractController
         [
             'name' => '_',
             'location' => Doc\Parameter::LOCATION_BODY,
-            'type' => Doc\Schema::TYPE_OBJECT,
             'schema' => 'Appliance',
         ]
     ])]
@@ -994,7 +982,6 @@ final class ManagementController extends AbstractController
         [
             'name' => '_',
             'location' => Doc\Parameter::LOCATION_BODY,
-            'type' => Doc\Schema::TYPE_OBJECT,
             'schema' => 'Database',
         ]
     ])]

--- a/src/Api/HL/Controller/ManagementController.php
+++ b/src/Api/HL/Controller/ManagementController.php
@@ -252,7 +252,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/Budget', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search budgets',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'Budget[]']
         ]
@@ -309,7 +309,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/License', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search licenses',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'License[]']
         ]
@@ -366,7 +366,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/Supplier', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search suppliers',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'Supplier[]']
         ]
@@ -431,7 +431,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/Contact', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search contacts',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'Contact[]']
         ]
@@ -488,7 +488,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/Contract', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search contracts',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'Contract[]']
         ]
@@ -545,7 +545,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/Document', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search documents',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'Document[]']
         ]
@@ -613,7 +613,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/Line', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search lines',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'Line[]']
         ]
@@ -670,7 +670,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/Certificate', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search certificates',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'Certificate[]']
         ]
@@ -727,7 +727,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/DataCenter', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search data centers',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'DataCenter[]']
         ]
@@ -784,7 +784,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/Cluster', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search clusters',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'Cluster[]']
         ]
@@ -841,7 +841,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/Domain', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search domains',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'Domain[]']
         ]
@@ -898,7 +898,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/Appliance', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search appliances',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'Appliance[]']
         ]
@@ -955,7 +955,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/Database', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search databases',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'Database[]']
         ]

--- a/src/Api/HL/Controller/ManagementController.php
+++ b/src/Api/HL/Controller/ManagementController.php
@@ -252,6 +252,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/Budget', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search budgets',
+        parameters: [self::PARAMETER_RSQL_FILTER],
         responses: [
             ['schema' => 'Budget[]']
         ]
@@ -309,6 +310,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/License', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search licenses',
+        parameters: [self::PARAMETER_RSQL_FILTER],
         responses: [
             ['schema' => 'License[]']
         ]
@@ -366,6 +368,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/Supplier', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search suppliers',
+        parameters: [self::PARAMETER_RSQL_FILTER],
         responses: [
             ['schema' => 'Supplier[]']
         ]
@@ -431,6 +434,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/Contact', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search contacts',
+        parameters: [self::PARAMETER_RSQL_FILTER],
         responses: [
             ['schema' => 'Contact[]']
         ]
@@ -488,6 +492,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/Contract', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search contracts',
+        parameters: [self::PARAMETER_RSQL_FILTER],
         responses: [
             ['schema' => 'Contract[]']
         ]
@@ -545,6 +550,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/Document', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search documents',
+        parameters: [self::PARAMETER_RSQL_FILTER],
         responses: [
             ['schema' => 'Document[]']
         ]
@@ -613,6 +619,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/Line', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search lines',
+        parameters: [self::PARAMETER_RSQL_FILTER],
         responses: [
             ['schema' => 'Line[]']
         ]
@@ -670,6 +677,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/Certificate', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search certificates',
+        parameters: [self::PARAMETER_RSQL_FILTER],
         responses: [
             ['schema' => 'Certificate[]']
         ]
@@ -727,6 +735,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/DataCenter', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search data centers',
+        parameters: [self::PARAMETER_RSQL_FILTER],
         responses: [
             ['schema' => 'DataCenter[]']
         ]
@@ -784,6 +793,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/Cluster', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search clusters',
+        parameters: [self::PARAMETER_RSQL_FILTER],
         responses: [
             ['schema' => 'Cluster[]']
         ]
@@ -841,6 +851,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/Domain', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search domains',
+        parameters: [self::PARAMETER_RSQL_FILTER],
         responses: [
             ['schema' => 'Domain[]']
         ]
@@ -898,6 +909,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/Appliance', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search appliances',
+        parameters: [self::PARAMETER_RSQL_FILTER],
         responses: [
             ['schema' => 'Appliance[]']
         ]
@@ -955,6 +967,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/Database', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search databases',
+        parameters: [self::PARAMETER_RSQL_FILTER],
         responses: [
             ['schema' => 'Database[]']
         ]

--- a/src/Api/HL/Controller/ProjectController.php
+++ b/src/Api/HL/Controller/ProjectController.php
@@ -219,6 +219,7 @@ final class ProjectController extends AbstractController
     #[Route(path: '/', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search projects',
+        parameters: [self::PARAMETER_RSQL_FILTER],
         responses: [
             ['schema' => 'Project[]']
         ]
@@ -276,6 +277,7 @@ final class ProjectController extends AbstractController
     #[Route(path: '/Task', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search project tasks',
+        parameters: [self::PARAMETER_RSQL_FILTER],
         responses: [
             ['schema' => 'Task[]']
         ]
@@ -333,6 +335,7 @@ final class ProjectController extends AbstractController
     #[Route(path: '/{project_id}/Task', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search project tasks',
+        parameters: [self::PARAMETER_RSQL_FILTER],
         responses: [
             ['schema' => 'Task[]']
         ]

--- a/src/Api/HL/Controller/ProjectController.php
+++ b/src/Api/HL/Controller/ProjectController.php
@@ -219,7 +219,7 @@ final class ProjectController extends AbstractController
     #[Route(path: '/', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search projects',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'Project[]']
         ]
@@ -276,7 +276,7 @@ final class ProjectController extends AbstractController
     #[Route(path: '/Task', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search project tasks',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'Task[]']
         ]
@@ -333,7 +333,7 @@ final class ProjectController extends AbstractController
     #[Route(path: '/{project_id}/Task', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search project tasks',
-        parameters: [self::PARAMETER_RSQL_FILTER],
+        parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
         responses: [
             ['schema' => 'Task[]']
         ]

--- a/src/Api/HL/Controller/ProjectController.php
+++ b/src/Api/HL/Controller/ProjectController.php
@@ -246,7 +246,6 @@ final class ProjectController extends AbstractController
         [
             'name' => '_',
             'location' => Doc\Parameter::LOCATION_BODY,
-            'type' => Doc\Schema::TYPE_OBJECT,
             'schema' => 'Project',
         ]
     ])]
@@ -304,7 +303,6 @@ final class ProjectController extends AbstractController
         [
             'name' => '_',
             'location' => Doc\Parameter::LOCATION_BODY,
-            'type' => Doc\Schema::TYPE_OBJECT,
             'schema' => 'Task',
         ]
     ])]
@@ -355,7 +353,6 @@ final class ProjectController extends AbstractController
         [
             'name' => '_',
             'location' => Doc\Parameter::LOCATION_BODY,
-            'type' => Doc\Schema::TYPE_OBJECT,
             'schema' => 'Task',
         ]
     ])]

--- a/src/Api/HL/OpenAPIGenerator.php
+++ b/src/Api/HL/OpenAPIGenerator.php
@@ -681,6 +681,27 @@ EOT;
                     ],
                 ];
             }
+            // Language can always be specified, even if it may not always be respected if no temporary session is started
+            $path_schema['parameters']['Accept-Language'] = [
+                'name' => 'Accept-Language',
+                'in' => 'header',
+                'description' => 'The language to use for the response. If not specified, the default language for the user is used.',
+                'schema' => ['type' => Schema::TYPE_STRING],
+                'examples' => [
+                    'English_GB' => [
+                        'value' => 'en_GB',
+                        'summary' => 'English (United Kingdom)'
+                    ],
+                    'French_FR' => [
+                        'value' => 'fr_FR',
+                        'summary' => 'French (France)'
+                    ],
+                    'Portuguese_BR' => [
+                        'value' => 'pt_BR',
+                        'summary' => 'Portuguese (Brazil)'
+                    ],
+                ]
+            ];
 
             if (strcasecmp($method, 'delete') && $request_body !== null) {
                 $path_schema['requestBody'] = $request_body;

--- a/src/Api/HL/OpenAPIGenerator.php
+++ b/src/Api/HL/OpenAPIGenerator.php
@@ -599,22 +599,19 @@ EOT;
             }
 
             $requirements = $route_path->getRouteRequirements();
-            if (count($requirements)) {
-                $path_schema['parameters'] = [];
-                if ($route_doc !== null) {
-                    $route_params = $route_doc->getParameters();
-                    if (count($route_params) > 0) {
-                        foreach ($route_params as $route_param) {
-                            if (!array_key_exists($route_param->getName(), $requirements)) {
-                                continue;
-                            }
-                            $location = $route_param->getLocation();
-                            if ($location !== Doc\Parameter::LOCATION_BODY) {
-                                $path_schema['parameters'][$route_param->getName()] = $this->getPathParameterSchema($route_param);
-                            }
+            $path_schema['parameters'] = [];
+            if ($route_doc !== null) {
+                $route_params = $route_doc->getParameters();
+                if (count($route_params) > 0) {
+                    foreach ($route_params as $route_param) {
+                        $location = $route_param->getLocation();
+                        if ($location !== Doc\Parameter::LOCATION_BODY && $location !== Doc\Parameter::LOCATION_PATH) {
+                            $path_schema['parameters'][$route_param->getName()] = $this->getPathParameterSchema($route_param);
                         }
                     }
                 }
+            }
+            if (count($requirements)) {
                 foreach ($requirements as $name => $requirement) {
                     if (!str_contains($route_path->getRoutePath(), '{' . $name . '}')) {
                         continue;

--- a/src/Api/HL/OpenAPIGenerator.php
+++ b/src/Api/HL/OpenAPIGenerator.php
@@ -556,6 +556,30 @@ EOT;
                     $path_schema['parameters'][$param['name']]['schema'] = $combined_schema;
                 }
             }
+            // Inject global headers
+            if ($route_path->getRouteSecurityLevel() !== Route::SECURITY_NONE) {
+                $path_schema['parameters']['GLPI-Entity'] = [
+                    'name' => 'GLPI-Entity',
+                    'in' => 'header',
+                    'description' => 'The ID of the entity to use. If not specified, the default entity for the user is used.',
+                    'schema' => ['type' => Schema::TYPE_INTEGER]
+                ];
+                $path_schema['parameters']['GLPI-Profile'] = [
+                    'name' => 'GLPI-Profile',
+                    'in' => 'header',
+                    'description' => 'The ID of the profile to use. If not specified, the default profile for the user is used.',
+                    'schema' => ['type' => Schema::TYPE_INTEGER]
+                ];
+                $path_schema['parameters']['GLPI-Entity-Recursive'] = [
+                    'name' => 'GLPI-Entity-Recursive',
+                    'in' => 'header',
+                    'description' => '"true" if the entity access should include child entities. This is false by default.',
+                    'schema' => [
+                        'type' => Schema::TYPE_STRING,
+                        'enum' => ['true', 'false']
+                    ],
+                ];
+            }
 
             if (strcasecmp($method, 'delete') && $request_body !== null) {
                 $path_schema['requestBody'] = $request_body;

--- a/src/Api/HL/OpenAPIGenerator.php
+++ b/src/Api/HL/OpenAPIGenerator.php
@@ -354,6 +354,7 @@ EOT;
         foreach ($paths as $path_url => $path) {
             foreach ($path as $method => $route) {
                 $is_expanded = false;
+                $new_urls = [];
                 foreach ($route['parameters'] as $param_key => $param) {
                     if (isset($param['schema']['pattern']) && preg_match('/^[\w+|]+$/', $param['schema']['pattern'])) {
                         $itemtypes = explode('|', $param['schema']['pattern']);
@@ -379,11 +380,17 @@ EOT;
                                         $route['x-controller']
                                     );
                                 }
+                                // Remove the itemtype path parameter now that it is a static value
+                                unset($expanded[$new_url][$method]['parameters'][$param_key]);
+                                $new_urls[] = $new_url;
                                 $is_expanded = true;
-                                unset($route['parameters'][$param_key]);
                             }
                         }
                     }
+                }
+                foreach ($new_urls as $new_url) {
+                    // fix parameter array indexing. should not be associative, but unsetting the path parameter causes a gap and breaks openapi.
+                    $expanded[$new_url][$method]['parameters'] = array_values($expanded[$new_url][$method]['parameters']);
                 }
                 if (!$is_expanded) {
                     $expanded[$path_url][$method] = $route;

--- a/src/Api/HL/OpenAPIGenerator.php
+++ b/src/Api/HL/OpenAPIGenerator.php
@@ -37,6 +37,7 @@ namespace Glpi\Api\HL;
 
 use Glpi\Api\HL\Controller\ProjectController;
 use Glpi\Api\HL\Doc\Response;
+use Glpi\Api\HL\Doc\Schema;
 use Glpi\Api\HL\Doc\SchemaReference;
 
 /**
@@ -156,6 +157,10 @@ EOT;
                         $other_calculated_name = str_replace('Controller', '', $other_short_name) . ' - ' . $schema_name;
                         $schemas[$other_calculated_name] = $schemas[$schema_name];
                         unset($schemas[$schema_name]);
+                    }
+                    if (!isset($known_schema['description']) && isset($known_schema['x-itemtype'])) {
+                        $itemtype = $known_schema['x-itemtype'];
+                        $known_schema['description'] = method_exists($itemtype, 'getTypeName') ? $itemtype::getTypeName(1) : 'No description available';
                     }
                     $schemas[$calculated_name] = $known_schema;
                     $schemas[$calculated_name]['x-controller'] = $controller::class;

--- a/src/Api/HL/OpenAPIGenerator.php
+++ b/src/Api/HL/OpenAPIGenerator.php
@@ -269,14 +269,14 @@ EOT;
             }
             foreach ($response['content'] as $content_type => &$content) {
                 foreach ($placeholders as $placeholder_name => $placeholder_value) {
-                    if (isset($content['schema']['$ref']) && $content['schema']['$ref'] === '#/components/schemas/{' .$placeholder_name . '}') {
+                    if (isset($content['schema']['$ref']) && $content['schema']['$ref'] === '#/components/schemas/{' . $placeholder_name . '}') {
                         $new_schema = $this->getComponentReference($placeholder_value, $controller);
                         if ($new_schema !== null) {
                             $content['schema']['$ref'] = $new_schema['$ref'];
                         }
                     }
                     // Handle array types
-                    if (isset($content['schema']['items']['$ref']) && $content['schema']['items']['$ref'] === '#/components/schemas/{' .$placeholder_name . '}') {
+                    if (isset($content['schema']['items']['$ref']) && $content['schema']['items']['$ref'] === '#/components/schemas/{' . $placeholder_name . '}') {
                         $new_schema = $this->getComponentReference($placeholder_value, $controller);
                         if ($new_schema !== null) {
                             $content['schema']['items']['$ref'] = $new_schema['$ref'];
@@ -295,14 +295,14 @@ EOT;
         $new_parameters = $parameters;
         foreach ($new_parameters as &$parameter) {
             foreach ($placeholders as $placeholder_name => $placeholder_value) {
-                if (isset($parameter['schema']['$ref']) && $parameter['schema']['$ref'] === '#/components/schemas/{' .$placeholder_name . '}') {
+                if (isset($parameter['schema']['$ref']) && $parameter['schema']['$ref'] === '#/components/schemas/{' . $placeholder_name . '}') {
                     $new_schema = $this->getComponentReference($placeholder_value, $controller);
                     if ($new_schema !== null) {
                         $parameter['schema']['$ref'] = $new_schema['$ref'];
                     }
                 }
                 // Handle array types
-                if (isset($parameter['schema']['items']['$ref']) && $parameter['schema']['items']['$ref'] === '#/components/schemas/{' .$placeholder_name . '}') {
+                if (isset($parameter['schema']['items']['$ref']) && $parameter['schema']['items']['$ref'] === '#/components/schemas/{' . $placeholder_name . '}') {
                     $new_schema = $this->getComponentReference($placeholder_value, $controller);
                     if ($new_schema !== null) {
                         $parameter['schema']['items']['$ref'] = $new_schema['$ref'];
@@ -322,14 +322,14 @@ EOT;
         }
         foreach ($new_request_body['content'] as $content_type => &$content) {
             foreach ($placeholders as $placeholder_name => $placeholder_value) {
-                if (isset($content['schema']['$ref']) && $content['schema']['$ref'] === '#/components/schemas/{' .$placeholder_name . '}') {
+                if (isset($content['schema']['$ref']) && $content['schema']['$ref'] === '#/components/schemas/{' . $placeholder_name . '}') {
                     $new_schema = $this->getComponentReference($placeholder_value, $controller);
                     if ($new_schema !== null) {
                         $content['schema']['$ref'] = $new_schema['$ref'];
                     }
                 }
                 // Handle array types
-                if (isset($content['schema']['items']['$ref']) && $content['schema']['items']['$ref'] === '#/components/schemas/{' .$placeholder_name . '}') {
+                if (isset($content['schema']['items']['$ref']) && $content['schema']['items']['$ref'] === '#/components/schemas/{' . $placeholder_name . '}') {
                     $new_schema = $this->getComponentReference($placeholder_value, $controller);
                     if ($new_schema !== null) {
                         $content['schema']['items']['$ref'] = $new_schema['$ref'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Changes should affect Swagger UI documentation only.

- Added valid parameters for search endpoints (RSQL query, start, and limit)
- When a component schema has no description but has an itemtype associated, the fallback description is the itemtype's name
- GLPI-Entity, GLPI-Entity-Recursive and GLPI-Profile headers available in Swagger UI as parameters
- Added missing parameters and responses to route docs
- Added Accept-Langauge header parameter for every endpoint along with some examples for quick testing and to show the user the required format. Examples can be selected to pre-fill the value, but can also be entered manually.
- Added placeholder support for cases where generic endpoints are expanded in the documentation. For example, `/Assistance/{itemtype}` expands to endpoints specific for Ticket, Change and Problem as `itemtype` is specified that it can only ever be Ticket, Change or Problem. Placeholders can now be used in the schema property for the parameters and responses for the documentation on the `/Assistance/{itemtype}` endpoint. A schema of `{itemtype}` is resolved to the expanded value. `{itemtype}[]` is similarly resolved, but as an array type.