### PR TITLE
Remove indentation of heredoc closing tags

### DIFF
--- a/locales/en_GB.po
+++ b/locales/en_GB.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-15 06:29+0000\n"
-"PO-Revision-Date: 2023-09-15 06:29+0000\n"
+"POT-Creation-Date: 2023-09-19 07:06+0000\n"
+"PO-Revision-Date: 2023-09-19 07:06+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en_GB\n"
@@ -9730,8 +9730,8 @@ msgid_plural "External links"
 msgstr[0] "External link"
 msgstr[1] "External links"
 
-#: src/TicketSatisfaction.php:120 src/TicketSatisfaction.php:259
-#: src/TicketSatisfaction.php:309 src/Entity.php:3144 src/Entity.php:3883
+#: src/TicketSatisfaction.php:120 src/TicketSatisfaction.php:264
+#: src/TicketSatisfaction.php:314 src/Entity.php:3144 src/Entity.php:3883
 msgid "External survey"
 msgstr "External survey"
 
@@ -11988,7 +11988,7 @@ msgstr "Internal Time to resolve"
 msgid "Internal status"
 msgstr "Internal status"
 
-#: src/TicketSatisfaction.php:256 src/TicketSatisfaction.php:308
+#: src/TicketSatisfaction.php:261 src/TicketSatisfaction.php:313
 #: src/Entity.php:3143 src/Entity.php:3882
 msgid "Internal survey"
 msgstr "Internal survey"
@@ -24375,8 +24375,9 @@ msgid "Validation request answer"
 msgstr "Validation request answer"
 
 #: front/report.infocom.php:63 front/report.infocom.conso.php:62
-#: src/DropdownTranslation.php:426 src/Rule.php:1198 src/Rule.php:2260
-#: src/Blacklist.php:90 src/Blacklist.php:122 src/RuleCollection.php:1418
+#: src/DropdownTranslation.php:426 src/DropdownTranslation.php:573
+#: src/Rule.php:1198 src/Rule.php:2260 src/Blacklist.php:90
+#: src/Blacklist.php:122 src/RuleCollection.php:1418
 #: src/ITILTemplatePredefinedField.php:374 src/RuleAction.php:195
 #: src/Printer_CartridgeInfo.php:73 src/Config.php:3623
 #: src/Fieldblacklist.php:79 src/Fieldblacklist.php:121

--- a/locales/glpi.pot
+++ b/locales/glpi.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-15 06:29+0000\n"
+"POT-Creation-Date: 2023-09-19 07:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -9652,8 +9652,8 @@ msgid_plural "External links"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/TicketSatisfaction.php:120 src/TicketSatisfaction.php:259
-#: src/TicketSatisfaction.php:309 src/Entity.php:3144 src/Entity.php:3883
+#: src/TicketSatisfaction.php:120 src/TicketSatisfaction.php:264
+#: src/TicketSatisfaction.php:314 src/Entity.php:3144 src/Entity.php:3883
 msgid "External survey"
 msgstr ""
 
@@ -11876,7 +11876,7 @@ msgstr ""
 msgid "Internal status"
 msgstr ""
 
-#: src/TicketSatisfaction.php:256 src/TicketSatisfaction.php:308
+#: src/TicketSatisfaction.php:261 src/TicketSatisfaction.php:313
 #: src/Entity.php:3143 src/Entity.php:3882
 msgid "Internal survey"
 msgstr ""
@@ -24098,8 +24098,9 @@ msgid "Validation request answer"
 msgstr ""
 
 #: front/report.infocom.php:63 front/report.infocom.conso.php:62
-#: src/DropdownTranslation.php:426 src/Rule.php:1198 src/Rule.php:2260
-#: src/Blacklist.php:90 src/Blacklist.php:122 src/RuleCollection.php:1418
+#: src/DropdownTranslation.php:426 src/DropdownTranslation.php:573
+#: src/Rule.php:1198 src/Rule.php:2260 src/Blacklist.php:90
+#: src/Blacklist.php:122 src/RuleCollection.php:1418
 #: src/ITILTemplatePredefinedField.php:374 src/RuleAction.php:195
 #: src/Printer_CartridgeInfo.php:73 src/Config.php:3623
 #: src/Fieldblacklist.php:79 src/Fieldblacklist.php:121

--- a/src/Dashboard/Filters/AbstractFilter.php
+++ b/src/Dashboard/Filters/AbstractFilter.php
@@ -155,7 +155,7 @@ abstract class AbstractFilter
                         $('.dashboard .card.filter-{$id}').removeClass('filter-impacted');
                     });
                 });
- JAVASCRIPT;
+JAVASCRIPT;
          $js = Html::scriptBlock($js);
 
          $html  = <<<HTML

--- a/src/DropdownTranslation.php
+++ b/src/DropdownTranslation.php
@@ -566,7 +566,7 @@ class DropdownTranslation extends CommonDBChild
                         $("#dropdown_field$rand").trigger("change");
                     }
                 );
-    JAVASCRIPT
+JAVASCRIPT
             );
         }
         echo "</td>";

--- a/tests/units/DB.php
+++ b/tests/units/DB.php
@@ -482,7 +482,7 @@ OTHER EXPRESSION;"
                     `nameid` varchar(100) NOT NULL,
                     UNIQUE KEY (`nameid`)
                 )
-            SQL,
+SQL,
             'db_properties' => [],
             'warning' => null
         ];
@@ -505,7 +505,7 @@ OTHER EXPRESSION;"
                         `nameid` varchar(100) NOT NULL,
                         UNIQUE KEY (`nameid`)
                     ){$table_options}
-                SQL,
+SQL,
                 'db_properties' => [
                     'allow_myisam' => true
                 ],
@@ -518,7 +518,7 @@ OTHER EXPRESSION;"
                         `nameid` varchar(100) NOT NULL,
                         UNIQUE KEY (`nameid`)
                     ){$table_options}
-                SQL,
+SQL,
                 'db_properties' => [
                     'allow_myisam' => false
                 ],
@@ -534,7 +534,7 @@ OTHER EXPRESSION;"
                     `date` datetime NOT NULL,
                     UNIQUE KEY (`nameid`)
                 )
-            SQL,
+SQL,
             'db_properties' => [
                 'allow_datetime' => true
             ],
@@ -547,7 +547,7 @@ OTHER EXPRESSION;"
                     `date` datetime NOT NULL,
                     UNIQUE KEY (`nameid`)
                 )
-            SQL,
+SQL,
             'db_properties' => [
                 'allow_datetime' => false
             ],
@@ -561,7 +561,7 @@ OTHER EXPRESSION;"
                     `nameid` varchar(100) NOT NULL,
                     UNIQUE KEY (`nameid`)
                 ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = utf8 COLLATE = utf8_unicode_ci
-            SQL,
+SQL,
             'db_properties' => [
                 'use_utf8mb4' => false
             ],
@@ -573,7 +573,7 @@ OTHER EXPRESSION;"
                     `nameid` varchar(100) NOT NULL,
                     UNIQUE KEY (`nameid`)
                 ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci
-            SQL,
+SQL,
             'db_properties' => [
                 'use_utf8mb4' => false
             ],
@@ -587,7 +587,7 @@ OTHER EXPRESSION;"
                     `nameid` varchar(100) NOT NULL,
                     UNIQUE KEY (`nameid`)
                 ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = utf8 COLLATE = utf8_unicode_ci
-            SQL,
+SQL,
             'db_properties' => [
                 'use_utf8mb4' => true
             ],
@@ -599,7 +599,7 @@ OTHER EXPRESSION;"
                     `nameid` varchar(100) NOT NULL,
                     UNIQUE KEY (`nameid`)
                 ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci
-            SQL,
+SQL,
             'db_properties' => [
                 'use_utf8mb4' => true
             ],
@@ -627,7 +627,7 @@ OTHER EXPRESSION;"
                         {$int_declaration}
                         UNIQUE KEY (`nameid`)
                     )
-                SQL,
+SQL,
                 'db_properties' => [
                     'allow_signed_keys' => true
                 ],
@@ -640,7 +640,7 @@ OTHER EXPRESSION;"
                         {$int_declaration}
                         UNIQUE KEY (`nameid`)
                     )
-                SQL,
+SQL,
                 'db_properties' => [
                     'allow_signed_keys' => false
                 ],
@@ -665,7 +665,7 @@ OTHER EXPRESSION;"
                         `id` int NOT NULL AUTO_INCREMENT,
                         PRIMARY KEY (`id`)
                     )
-                SQL,
+SQL,
                 'db_properties' => [
                     'allow_signed_keys' => false
                 ],

--- a/tests/units/Glpi/RichText/RichText.php
+++ b/tests/units/Glpi/RichText/RichText.php
@@ -354,7 +354,7 @@ HTML,
         <img src="{$previous_prefix}/front/document.send.php?docid=180&amp;itemtype=Ticket&amp;items_id=515" alt="34c09468-b2d8e96f-64f991f5ce1660.58639912" width="248">
       </a>
     </p>
-    HTML,
+HTML,
                     'encode_output_entities' => false,
                     'expected_result'        => <<<HTML
     <p>
@@ -363,7 +363,7 @@ HTML,
         <img src="{$expected_prefix}/front/document.send.php?docid=180&amp;itemtype=Ticket&amp;items_id=515" alt="34c09468-b2d8e96f-64f991f5ce1660.58639912" width="248" />
       </a>
     </p>
-    HTML,
+HTML,
                 ];
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Due to https://savannah.gnu.org/bugs/?func=detailitem&item_id=62158, we should not indent heredoc ending marker.

I regenerated POT file. Missed translation (`src/DropdownTranslation.php:573`) was also present in other files, so it was still present in POT file.