### PR TITLE
Fix relative path for themes stored outside of GLPI_ROOT + cache on last update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,7 @@
         "symfony/console": "^6.3",
         "symfony/css-selector": "^6.3",
         "symfony/dom-crawler": "^6.3",
+        "symfony/filesystem": "^6.3",
         "symfony/html-sanitizer": "^6.3",
         "symfony/mailer": "^6.3",
         "symfony/mime": "^6.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8eed5bf22715616da1009259f556ff64",
+    "content-hash": "7b6f83fbddf268da10657e07bf04956d",
     "packages": [
         {
             "name": "apereo/phpcas",
@@ -5467,6 +5467,69 @@
             "time": "2023-05-23T14:45:45+00:00"
         },
         {
+            "name": "symfony/filesystem",
+            "version": "v6.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "edd36776956f2a6fcf577edb5b05eb0e3bdc52ae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/edd36776956f2a6fcf577edb5b05eb0e3bdc52ae",
+                "reference": "edd36776956f2a6fcf577edb5b05eb0e3bdc52ae",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v6.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-06-01T08:30:39+00:00"
+        },
+        {
             "name": "symfony/html-sanitizer",
             "version": "v6.3.4",
             "source": {
@@ -7638,69 +7701,6 @@
                 }
             ],
             "time": "2023-02-14T08:44:56+00:00"
-        },
-        {
-            "name": "symfony/filesystem",
-            "version": "v6.0.13",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "3adca49133bd055ebe6011ed1e012be3c908af79"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/3adca49133bd055ebe6011ed1e012be3c908af79",
-                "reference": "3adca49133bd055ebe6011ed1e012be3c908af79",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.2",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.8"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Filesystem\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides basic utilities for the filesystem",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.0.13"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-09-21T20:25:27+00:00"
         },
         {
             "name": "symfony/finder",

--- a/src/Config.php
+++ b/src/Config.php
@@ -954,6 +954,9 @@ class Config extends CommonDBTM
             [ 'name'    => 'symfony/console',
                 'check'   => 'Symfony\\Component\\Console\\Application'
             ],
+            [ 'name'    => 'symfony/filesystem',
+                'check'   => 'Symfony\\Component\\Filesystem\\Filesystem'
+            ],
             [ 'name'    => 'scssphp/scssphp',
                 'check'   => 'ScssPhp\ScssPhp\Compiler'
             ],

--- a/src/Html.php
+++ b/src/Html.php
@@ -1253,7 +1253,13 @@ HTML;
                 }
             }
         }
-        $tpl_vars['css_files'][] = ['path' => $theme->getPath()];
+
+        $theme_path = $theme->getPath();
+        if ($theme->isCustomTheme()) {
+            // Custom theme files might be modified by external source
+            $theme_path .= "?lastupdate=" . filemtime($theme->getPath(false));
+        }
+        $tpl_vars['css_files'][] = ['path' => $theme_path];
 
         $tpl_vars['js_files'][] = ['path' => 'public/lib/base.js'];
         $tpl_vars['js_files'][] = ['path' => 'js/webkit_fix.js'];

--- a/src/UI/Theme.php
+++ b/src/UI/Theme.php
@@ -34,6 +34,7 @@
  */
 
 namespace Glpi\UI;
+
 use Symfony\Component\Filesystem\Filesystem;
 
 /**

--- a/src/UI/Theme.php
+++ b/src/UI/Theme.php
@@ -34,6 +34,7 @@
  */
 
 namespace Glpi\UI;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Class that represents a theme/palette.
@@ -81,7 +82,8 @@ final class Theme
     {
         $path = $this->is_custom ? ThemeManager::getInstance()->getCustomThemesDirectory() : ThemeManager::CORE_THEME_ROOT;
         if ($relative) {
-            $path = str_replace(GLPI_ROOT, '', $path);
+            $filesystem = new Filesystem();
+            $path = $filesystem->makePathRelative($path, GLPI_ROOT);
         }
         return $path;
     }


### PR DESCRIPTION
`str_replace(GLPI_ROOT, '', $path);` won't work if `GLPI_THEMES` is outside `GLPI_ROOT`.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28015
