### PR TITLE
Avoid deprecated warning when sync_field is null

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -1512,7 +1512,7 @@ class Auth extends CommonGLPI
                             'name' => 'force_ldap_resynch'
                         ]);
 
-                        if (strlen($authldap->fields['sync_field']) > 0) {
+                        if (strlen($authldap->fields['sync_field'] ?? "") > 0) {
                             echo Html::submit("<i class='fas fa-broom'></i><span>" . __s('Clean LDAP fields and force synchronisation') . "</span>", [
                                 'name' => 'clean_ldap_fields'
                             ]);


### PR DESCRIPTION
Avoid this deprecation warning:

> PHP Deprecated function (8192): strlen(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/glpi/src/Auth.php at line 1515

Since the `sync_field` allow null values, we should fallback to an empty string to avoid sending invalid parameters to `strlen()`.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
