### PR TITLE
Fix encoding of groups fields fetched from LDAP

### DIFF
--- a/install/migrations/update_10.0.9_to_10.0.10/groups.php
+++ b/install/migrations/update_10.0.9_to_10.0.10/groups.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+use Glpi\Toolbox\Sanitizer;
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+/** Fix non encoded LDAP fields in groups */
+$groups = getAllDataFromTable('glpi_groups');
+foreach ($groups as $group) {
+    $updated = [];
+    foreach (['name', 'ldap_group_dn', 'ldap_value'] as $ldap_field) {
+        if ($group[$ldap_field] !== null && preg_match('/(<|>|(&(?!#?[a-z0-9]+;)))/i', $group[$ldap_field]) === 1) {
+            $updated[$ldap_field] = Sanitizer::sanitize($group[$ldap_field]);
+        }
+    }
+    if (count($updated) > 0) {
+        $migration->addPostQuery(
+            $DB->buildUpdate(
+                'glpi_groups',
+                $updated,
+                [
+                    'id' => $group['id'],
+                ]
+            )
+        );
+    }
+}
+/** /Fix non encoded LDAP fields in groups */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Before #15017, some fields were not properly encoded when groups were imported from LDAP. These fields encoding have to be fixed to prevent issues during LDAP sync.

For instance, a group in DB with `ldap_group_dn=R&D` will not be found anymore as now we are searching for the encoded value `ldap_group_dn=R&#38;D`