### PR TITLE
Fix encoding of users fields fetched from LDAP

### DIFF
--- a/install/migrations/update_10.0.9_to_10.0.10/ldap_fields.php
+++ b/install/migrations/update_10.0.9_to_10.0.10/ldap_fields.php
@@ -44,7 +44,7 @@ use Glpi\Toolbox\Sanitizer;
 $groups = getAllDataFromTable('glpi_groups');
 foreach ($groups as $group) {
     $updated = [];
-    foreach (['name', 'ldap_group_dn', 'ldap_value'] as $ldap_field) {
+    foreach (['ldap_group_dn', 'ldap_value'] as $ldap_field) {
         if ($group[$ldap_field] !== null && preg_match('/(<|>|(&(?!#?[a-z0-9]+;)))/i', $group[$ldap_field]) === 1) {
             $updated[$ldap_field] = Sanitizer::sanitize($group[$ldap_field]);
         }
@@ -56,6 +56,29 @@ foreach ($groups as $group) {
                 $updated,
                 [
                     'id' => $group['id'],
+                ]
+            )
+        );
+    }
+}
+/** /Fix non encoded LDAP fields in groups */
+
+/** Fix non encoded LDAP fields in users */
+$users = getAllDataFromTable('glpi_users', ['authtype' => 3]);
+foreach ($users as $user) {
+    $updated = [];
+    foreach (['user_dn', 'sync_field'] as $ldap_field) {
+        if ($user[$ldap_field] !== null && preg_match('/(<|>|(&(?!#?[a-z0-9]+;)))/i', $user[$ldap_field]) === 1) {
+            $updated[$ldap_field] = Sanitizer::sanitize($user[$ldap_field]);
+        }
+    }
+    if (count($updated) > 0) {
+        $migration->addPostQuery(
+            $DB->buildUpdate(
+                'glpi_users',
+                $updated,
+                [
+                    'id' => $user['id'],
                 ]
             )
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Follows #15622 .

Before #15017, some fields were not properly encoded when groups were imported from LDAP. These fields encoding have to be fixed to prevent issues during LDAP sync.

For instance, a user in DB with `user_dn=CN=TEST,OU=R&D,DC=glpi` will not be found anymore as now we are searching for the encoded value `user_dn=CN=TEST,OU=R&#38;D,DC=glpi`.