### PR TITLE
Fix LDAP delete/restore conditions

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -2179,11 +2179,11 @@ class AuthLDAP extends CommonDBTM
                    // Only manage deleted user if ALL (because of entity visibility in delegated mode)
 
                     if ($user['auths_id'] == $options['authldaps_id']) {
-                        if (!$user['is_deleted']) {
+                        if (!$userfound && $user['is_deleted_ldap'] == 0) {
                              //If user is marked as coming from LDAP, but is not present in it anymore
                              User::manageDeletedUserInLdap($user['id']);
                              $results[self::USER_DELETED_LDAP]++;
-                        } else {
+                        } elseif ($userfound && $user['is_deleted_ldap'] == 1) {
                            // User is marked as coming from LDAP, but was previously deleted
                             User::manageRestoredUserInLdap($user['id']);
                             $results[self::USER_RESTORED_LDAP]++;

--- a/src/User.php
+++ b/src/User.php
@@ -5182,12 +5182,19 @@ HTML;
             return;
         }
 
+        $myuser = new self();
+        if (
+            !$myuser->getFromDB($users_id) // invalid user
+            || $myuser->fields['is_deleted_ldap'] == 1 // user already considered as deleted from LDAP
+        ) {
+            return;
+        }
+
        //User is present in DB but not in the directory : it's been deleted in LDAP
         $tmp = [
             'id'              => $users_id,
             'is_deleted_ldap' => 1,
         ];
-        $myuser = new self();
 
         switch ($CFG_GLPI['user_deleted_ldap']) {
            //DO nothing
@@ -5256,18 +5263,19 @@ HTML;
             return;
         }
 
+        $myuser = new self();
+        if (
+            !$myuser->getFromDB($users_id) // invalid user
+            || $myuser->fields['is_deleted_ldap'] == 0 // user already considered as restored from LDAP
+        ) {
+            return;
+        }
+
        //User is present in DB and in the directory but 'is_ldap_deleted' was true : it's been restored in LDAP
         $tmp = [
             'id'              => $users_id,
             'is_deleted_ldap' => 0,
         ];
-        $myuser = new self();
-        $myuser->getFromDB($users_id);
-
-       // User is already considered as restored from ldap
-        if ($myuser->fields['is_deleted_ldap'] == 0) {
-            return;
-        }
 
        // Calling the update function for the user will reapply dynamic rights {@see User::post_updateItem()}
         switch ($CFG_GLPI['user_restored_ldap']) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29585

I do not know why we did not had a bug on it before. Maybe something changed, or maybe noone ever detect it (the restore feature is recent).

Problem is simple: a user was previously imported from LDAP into GLPI and then was removed from the LDAP.
On even synchronization, `$user['is_deleted']` was false, so the `User::manageDeletedUserInLdap();` method was called.
On odd synchronization, `$user['is_deleted']` was true, so the `User::manageRestoredUserInLdap();` method was called.

I added some conditions to prevent this to happen.