### PR TITLE
fix(Datetime): fix number of week

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4675,9 +4675,9 @@
             }
         },
         "node_modules/flatpickr": {
-            "version": "4.6.11",
-            "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.11.tgz",
-            "integrity": "sha512-/rnbE/hu5I5zndLEyYfYvqE4vPDvI5At0lFcQA5eOPfjquZLcQ0HMKTL7rv5/+DvbPM3/vJcXpXjB/DjBh+1jw=="
+            "version": "4.6.13",
+            "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.13.tgz",
+            "integrity": "sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw=="
         },
         "node_modules/flatted": {
             "version": "3.2.4",


### PR DESCRIPTION
Fix bad computation of the week number for all date fields using ```flatpickr```

Today (28/09/2023) We are in week 39, not 38

Before (with flatpickr to 4.6.11) : 
![image](https://github.com/glpi-project/glpi/assets/7335054/f79c573a-238c-41ab-845c-48630dbc012c)

After  (with flatpickr to 4.6.13) : 
![image](https://github.com/glpi-project/glpi/assets/7335054/593317cd-51ed-4036-b971-0360869b406f)

See : 

![image](https://github.com/glpi-project/glpi/assets/7335054/de64d58d-f584-4f78-b3c9-17c4684b942d)

Fixed by

https://github.com/flatpickr/flatpickr/commit/b0ac85233140dc672dc564ce692dcf4d3dbfb540
https://github.com/flatpickr/flatpickr/commit/42723a251f5c1c206f189ea49892620e374a5ec1

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29751
