### PR TITLE
Add `sub_type` search option to rules

### DIFF
--- a/src/Rule.php
+++ b/src/Rule.php
@@ -791,6 +791,14 @@ class Rule extends CommonDBTM
         ];
 
         $tab[] = [
+            'id'                 => '122',
+            'table'              => $this->getTable(),
+            'field'              => 'sub_type',
+            'name'               => __('Subtype'),
+            'datatype'           => 'text'
+        ];
+
+        $tab[] = [
             'id'                 => '80',
             'table'              => 'glpi_entities',
             'field'              => 'completename',

--- a/tests/functional/Rule.php
+++ b/tests/functional/Rule.php
@@ -195,7 +195,7 @@ class Rule extends DbTestCase
     public function testGetSearchOptionsNew()
     {
         $rule = new \Rule();
-        $this->array($rule->rawSearchOptions())->hasSize(11);
+        $this->array($rule->rawSearchOptions())->hasSize(12);
     }
 
     public function testGetRuleWithCriteriasAndActions()


### PR DESCRIPTION
Add search option to be able to filter rules by subtype using RestAPI.

I just don't know hopw to choose the ID of this searchOption :/
