### PR TITLE
feat(search): use keyboard arrows for pagination

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -2091,6 +2091,8 @@ class AuthLDAP extends CommonDBTM
                 $filter = $values['ldap_filter'];
             }
 
+            d("LDAP filter: $filter");
+
             if ($values['script'] && !empty($values['begin_date'])) {
                 $filter_timestamp = self::addTimestampRestrictions(
                     $values['begin_date'],

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -2091,8 +2091,6 @@ class AuthLDAP extends CommonDBTM
                 $filter = $values['ldap_filter'];
             }
 
-            d("LDAP filter: $filter");
-
             if ($values['script'] && !empty($values['begin_date'])) {
                 $filter_timestamp = self::addTimestampRestrictions(
                     $values['begin_date'],

--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -243,5 +243,46 @@ $(document).ready(function() {
          navigator.clipboard.writeText(data).then(copy_success, copy_error);
       }).fail(copy_error);
    });
+
+   // Keyboard navigation shortcuts (left/right arrows)
+   var page_link_start = $(".page-link-start");
+   var page_link_prev  = $(".page-link-prev");
+   var page_link_next  = $(".page-link-next");
+   var page_link_last  = $(".page-link-last");
+   document.onkeydown = function(e) {
+      // Ctrl + ArrowLeft for first page
+      if (page_link_start.length > 0
+            && (e.ctrlKey || e.metaKey)
+            && (e.keyCode == 37 || e.key == 'ArrowLeft')
+            && !page_link_start.parent().hasClass('disabled')
+         ){
+         page_link_start.click();
+      }
+
+      // ArrowLeft for previous page
+      if (page_link_prev.length > 0
+            && (e.keyCode == 37 || e.key == 'ArrowLeft')
+            && !page_link_prev.parent().hasClass('disabled')
+         ){
+         page_link_prev.click();
+      }
+
+      // ArrowRight for next page
+      if (page_link_next.length > 0
+            && (e.keyCode == 39 || e.key == 'ArrowRight')
+            && !page_link_next.parent().hasClass('disabled')
+         ){
+         page_link_next.click();
+      }
+
+      // Ctrl + ArrowRight for last page
+      if (page_link_last.length > 0
+            && (e.ctrlKey || e.metaKey)
+            && (e.keyCode == 39 || e.key == 'ArrowRight')
+            && !page_link_last.parent().hasClass('disabled')
+         ){
+         page_link_last.click();
+      }
+   }
 });
 </script>

--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -250,6 +250,11 @@ $(document).ready(function() {
    var page_link_next  = $(".page-link-next");
    var page_link_last  = $(".page-link-last");
    document.onkeydown = function(e) {
+      // Ignore if focus is on an input
+      if ($("input, textarea").is(":focus") === true) {
+         return;
+      }
+
       // Ctrl + ArrowLeft for first page
       if (page_link_start.length > 0
             && (e.ctrlKey || e.metaKey)

--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -255,9 +255,10 @@ $(document).ready(function() {
          return;
       }
 
-      // Home for first page
+      // Ctrl+Left for first page
       if (page_link_start.length > 0
-            && (e.keyCode == 36 || e.key == 'Home')
+            && (e.ctrlKey || e.metaKey)
+            && (e.keyCode == 37 || e.key == 'ArrowLeft')
             && !page_link_start.parent().hasClass('disabled')
          ){
          page_link_start.click();
@@ -279,9 +280,10 @@ $(document).ready(function() {
          page_link_next.click();
       }
 
-      // End for last page
+      // Ctrl+Right for last page
       if (page_link_last.length > 0
-            && (e.keyCode == 35 || e.key == 'End')
+            && (e.ctrlKey || e.metaKey)
+            && (e.keyCode == 39 || e.key == 'ArrowRight')
             && !page_link_last.parent().hasClass('disabled')
          ){
          page_link_last.click();

--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -264,17 +264,17 @@ $(document).ready(function() {
          page_link_start.click();
       }
 
-      // ArrowLeft for previous page
+      // ArrowLeft or j for previous page
       if (page_link_prev.length > 0
-            && (e.keyCode == 37 || e.key == 'ArrowLeft')
+            && (e.keyCode == 37 || e.key == 'ArrowLeft' || e.keyCode == 74 || e.key == 'j')
             && !page_link_prev.parent().hasClass('disabled')
          ){
          page_link_prev.click();
       }
 
-      // ArrowRight for next page
+      // ArrowRight or k for next page
       if (page_link_next.length > 0
-            && (e.keyCode == 39 || e.key == 'ArrowRight')
+            && (e.keyCode == 39 || e.key == 'ArrowRight' || e.keyCode == 75 || e.key == 'k')
             && !page_link_next.parent().hasClass('disabled')
          ){
          page_link_next.click();

--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -255,10 +255,9 @@ $(document).ready(function() {
          return;
       }
 
-      // Ctrl + ArrowLeft for first page
+      // Home for first page
       if (page_link_start.length > 0
-            && (e.ctrlKey || e.metaKey)
-            && (e.keyCode == 37 || e.key == 'ArrowLeft')
+            && (e.keyCode == 36 || e.key == 'Home')
             && !page_link_start.parent().hasClass('disabled')
          ){
          page_link_start.click();
@@ -280,10 +279,9 @@ $(document).ready(function() {
          page_link_next.click();
       }
 
-      // Ctrl + ArrowRight for last page
+      // End for last page
       if (page_link_last.length > 0
-            && (e.ctrlKey || e.metaKey)
-            && (e.keyCode == 39 || e.key == 'ArrowRight')
+            && (e.keyCode == 35 || e.key == 'End')
             && !page_link_last.parent().hasClass('disabled')
          ){
          page_link_last.click();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8004de3</samp>

Add keyboard navigation shortcuts for search pagination. The change modifies the `templates/components/search/controls.html.twig` file to include a JavaScript code block that listens for keypress events and triggers the appropriate page link.
