### PR TITLE
fix(fuzzy): main entries before subentries and dashboards

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -6621,6 +6621,15 @@ HTML;
                         }
                     }
 
+                    if (isset($firstlvl['default_dashboard'])) {
+                        if (strlen($firstlvl['title']) > 0) {
+                            $fuzzy_entries[] = [
+                                'url'   => $firstlvl['default_dashboard'],
+                                'title' => $firstlvl['title'] . " > " . _n('Dashboard', 'Dashboards', 1)
+                            ];
+                        }
+                    }
+
                     if (isset($firstlvl['content'])) {
                         foreach ($firstlvl['content'] as $menu) {
                             if (isset($menu['title']) && strlen($menu['title']) > 0) {

--- a/src/Html.php
+++ b/src/Html.php
@@ -6625,7 +6625,7 @@ HTML;
                         if (strlen($firstlvl['title']) > 0) {
                             $fuzzy_entries[] = [
                                 'url'   => $firstlvl['default_dashboard'],
-                                'title' => $firstlvl['title'] . " > " . _n('Dashboard', 'Dashboards', 1)
+                                'title' => $firstlvl['title'] . " > " . __('Dashboard')
                             ];
                         }
                     }

--- a/src/Html.php
+++ b/src/Html.php
@@ -6612,6 +6612,15 @@ HTML;
 
                // retrieve menu
                 foreach ($_SESSION['glpimenu'] as $firstlvl) {
+                    if (isset($firstlvl['default'])) {
+                        if (strlen($firstlvl['title']) > 0) {
+                            $fuzzy_entries[] = [
+                                'url'   => $firstlvl['default'],
+                                'title' => $firstlvl['title']
+                            ];
+                        }
+                    }
+
                     if (isset($firstlvl['content'])) {
                         foreach ($firstlvl['content'] as $menu) {
                             if (isset($menu['title']) && strlen($menu['title']) > 0) {
@@ -6633,15 +6642,6 @@ HTML;
                                     }
                                 }
                             }
-                        }
-                    }
-
-                    if (isset($firstlvl['default'])) {
-                        if (strlen($firstlvl['title']) > 0) {
-                            $fuzzy_entries[] = [
-                                'url'   => $firstlvl['default'],
-                                'title' => $firstlvl['title']
-                            ];
                         }
                     }
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A

- Display main menu entries befores submenu entries ("Assets", before "Assets > Computers").
- Also add default dashboards entries
