### PR TITLE
fix enable maintenance cli

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -680,6 +680,9 @@ class CommonDBTM extends CommonGLPI
                 unset($oldvalues[$field]);
             }
         }
+        if (count($tobeupdated) === 0) {
+            return true;
+        }
         $result = $DB->update(
             $this->getTable(),
             $tobeupdated,

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -680,9 +680,6 @@ class CommonDBTM extends CommonGLPI
                 unset($oldvalues[$field]);
             }
         }
-        if (count($tobeupdated) === 0) {
-            return true;
-        }
         $result = $DB->update(
             $this->getTable(),
             $tobeupdated,

--- a/src/Console/Maintenance/EnableMaintenanceModeCommand.php
+++ b/src/Console/Maintenance/EnableMaintenanceModeCommand.php
@@ -69,7 +69,7 @@ class EnableMaintenanceModeCommand extends AbstractCommand
         $values = [
             'maintenance_mode' => '1'
         ];
-        if ($input->hasOption('text')) {
+        if ($input->hasOption('text') && $input->getOption('text') !== null) {
             $values['maintenance_text'] = Sanitizer::sanitize($input->getOption('text'));
         }
         $config = new Config();

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -1421,6 +1421,9 @@ class DBmysql
         if (!count($clauses['WHERE'])) {
             throw new \RuntimeException('Cannot run an UPDATE query without WHERE clause!');
         }
+        if (!count($params)) {
+            throw new \RuntimeException('Cannot run an UPDATE query without parameters!');
+        }
 
         $query  = "UPDATE " . self::quoteName($table);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15543 (maybe)

The only way I was able to recreate the issue from #15543 was if I had the maintenance mode text set to something before running the CLI command to enable maintenance mode and I didn't specify any new text.
I added two fixes which both independently handle that case.

First, the `$input->hasOption('text')` is always true because it only checks if the option is defined rather than if the user specified a value for it. So, even if the user doesn't add `--text` to the command, it is still true. A null check was added as well. If the user wants to override the text already set and show nothing, they can specify an empty string `""`.

Second, in `CommonDBTM::updateInDB` the values that get updated in the DB are calculated. In certain cases, the array of changes may remain blank which `DBmysql::update` doesn't handle. It results in a SQL query with the `SET` added followed immediately by the `WHERE` criteria. When the SQL errors, the query that is shown isn't the one that was generated. A `count` check was added in `CommonDBTM::updateInDB` (if no updates, treated as success).

A check was also added in `DBmysql::update` to trigger an exception just like an empty criteria array does if it receives no parameters. This is just to hopefully identify future instances of this issue better than the MySQL error output indicates.