### PR TITLE
fix(rule criteria): regex match with carriage return

### DIFF
--- a/src/RuleCriteria.php
+++ b/src/RuleCriteria.php
@@ -495,7 +495,7 @@ class RuleCriteria extends CommonDBChild
 
             case Rule::REGEX_MATCH:
                 $results = [];
-                $match_result = @preg_match_all($pattern . "i", $field, $results);
+                $match_result = @preg_match_all($pattern . "si", $field, $results);
                 if ($match_result === false) {
                     trigger_error(
                         sprintf('Invalid regular expression `%s`.', $pattern),
@@ -518,7 +518,7 @@ class RuleCriteria extends CommonDBChild
                 return false;
 
             case Rule::REGEX_NOT_MATCH:
-                $match_result = @preg_match($pattern . "i", $field);
+                $match_result = @preg_match($pattern . "si", $field);
                 if ($match_result === false) {
                     trigger_error(
                         sprintf('Invalid regular expression `%s`.', $pattern),

--- a/tests/functional/RuleCriteria.php
+++ b/tests/functional/RuleCriteria.php
@@ -1045,6 +1045,18 @@ class RuleCriteria extends DbTestCase
                     'value'     => $value_sanitized ? Sanitizer::sanitize("\o/") : "\o/",
                     'matches'   => true
                 ];
+                yield [
+                    'condition' => \Rule::REGEX_MATCH,
+                    'pattern'   => $pattern_sanitized ? Sanitizer::sanitize("/line1.*line2/") : "/line1.*line2/",
+                    'value'     => $value_sanitized ? Sanitizer::sanitize("line1\nline2") : "line1\nline2",
+                    'matches'   => true
+                ];
+                yield [
+                    'condition' => \Rule::REGEX_MATCH,
+                    'pattern'   => $pattern_sanitized ? Sanitizer::sanitize("/line1.*line3/") : "/line1.*line3/",
+                    'value'     => $value_sanitized ? Sanitizer::sanitize("line1\n<p>line2<p>\nline3") : "line1\n<p>line2</p>\nline3",
+                    'matches'   => true
+                ];
             }
         }
     }


### PR DESCRIPTION
Since 10.0.10, this case no longer works when there are carriage returns in a `/(.*)/`, whereas it did in 10.0.9:

Criteria:
![image_paste5077265](https://github.com/glpi-project/glpi/assets/8530352/0eff941c-ecbd-4df4-8b29-f1dc5a2f35ad)

Description code:
```
<div>CATEGORIE : POSTE DE TRAVAIL</div>
<div>Catégorie secondaire : Dysfonctionnement-panne</div>
<div>---</div>
<div>DESCRIPTION :
<p>cambrai</p>
<br>Il s'agit d'un matériel neuf</div>
<div>---</div>
<div>Site de rattachement : Autres sites - Cambrai  </div>
<div>:</div>
<div> </div>
<div>---</div>
<div>Fin de la saisie - merci d'avoir utilisé notre plate-forme ; nos équipes vous répondront dans les meilleurs délais. </div>
<div>Information technique (réservée aux intervenants helpdesk) : Vers Qui Escalader</div>
<div> </div>
```


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29827
