### PR TITLE
Display pending reason in tickets details

### DIFF
--- a/templates/components/itilobject/fields/status.html.twig
+++ b/templates/components/itilobject/fields/status.html.twig
@@ -47,6 +47,10 @@
       {% if validation_class is not null %}
          {{ validation_class.alertValidation(item, 'status') }}
       {% endif %}
+
+      {{ include('components/itilobject/timeline/pending_reasons_messages.html.twig', {
+         'display_for_parent': true,
+      }) }}
    {% endset %}
 {% else %}
    {% set field_options = field_options|merge({'center': true}) %}

--- a/templates/components/itilobject/timeline/pending_reasons_messages.html.twig
+++ b/templates/components/itilobject/timeline/pending_reasons_messages.html.twig
@@ -42,7 +42,7 @@
 {% endif %}
 
 {% if pending_reason %}
-   <span class="badge bg-blue-lt {{ display_for_parent ? "mt-1" : ""}}" >
+   <span class="badge bg-blue-lt {{ display_for_parent ? "mt-1" : "" }}">
       <i class="fas fa-pause me-1"></i>
       {{ __("Pending: %s")|format(pending_reason.getLink())|raw }}
 

--- a/templates/components/itilobject/timeline/pending_reasons_messages.html.twig
+++ b/templates/components/itilobject/timeline/pending_reasons_messages.html.twig
@@ -32,16 +32,21 @@
  #}
 
 {% set pending_reason_item_parent = call("PendingReason_Item::getForItem", [item]) %}
-{% set pending_item = call(entry['type'] ~ "::getById", [entry_i['id']]) %}
-{% set pending_reason_item = pending_item ? call("PendingReason_Item::getForItem", [pending_item]) : false %}
-{% set pending_reason = pending_reason_item ? call("PendingReason::getById", [pending_reason_item.fields['pendingreasons_id']]) : false %}
 
-{% if pending_reason  %}
-   <span class="badge bg-blue-lt">
+{% if display_for_parent %}
+   {% set pending_reason = pending_reason_item_parent ? call("PendingReason::getById", [pending_reason_item_parent.fields['pendingreasons_id']]) : false %}
+{% else %}
+   {% set pending_item = pending_item ?? call(entry['type'] ~ "::getById", [entry_i['id']]) %}
+   {% set pending_reason_item = pending_item ? call("PendingReason_Item::getForItem", [pending_item]) : false %}
+   {% set pending_reason = pending_reason_item ? call("PendingReason::getById", [pending_reason_item.fields['pendingreasons_id']]) : false %}
+{% endif %}
+
+{% if pending_reason %}
+   <span class="badge bg-blue-lt {{ display_for_parent ? "mt-1" : ""}}" >
       <i class="fas fa-pause me-1"></i>
       {{ __("Pending: %s")|format(pending_reason.getLink())|raw }}
 
-      {% if call("PendingReason_Item::isLastPendingForItem", [
+      {% if display_for_parent or call("PendingReason_Item::isLastPendingForItem", [
          item,
          pending_item
       ]) %}


### PR DESCRIPTION
GLPI used to display the pending reason below the status field in the "main tickets details" section back in the official backport of the feature for GLPI 9.5.
This was lost when migrating to the new interface on the `main` branch.

Users that had beneficiated from the 9.5 backport are missing this feature and request that we correct it.
I think it's a good idea as it avoid scanning through the timeline to find the active pending reason (which may not be on the last followup).
With that in mind, displaying this information clearly under the status field seems good to me.

![image](https://github.com/glpi-project/glpi/assets/42734840/ef5265ef-ba85-4941-9001-d3164bc52c92)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29772
