### PR TITLE
fix(LockedField): do not save value for global lockedfield

### DIFF
--- a/install/migrations/update_10.0.10_to_10.0.11/lockedfield.php
+++ b/install/migrations/update_10.0.10_to_10.0.11/lockedfield.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+//lockedfield previous value must be null for global lock
+$migration->addPostQuery(
+    $DB->buildUpdate(
+        'glpi_lockedfields',
+        [
+            'value' => null
+        ],
+        [
+            'is_global' => 1
+        ]
+    )
+);

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1752,7 +1752,6 @@ class CommonDBTM extends CommonGLPI
                 }
 
                 if (array_key_exists($lock, $this->input)) {
-                    $lockedfield->setLastValue($this->getType(), 0, $lock, $this->input[$lock]);
                     unset($this->input[$lock]);
                 }
             }
@@ -1781,15 +1780,19 @@ class CommonDBTM extends CommonGLPI
             && $this->input['is_dynamic'] == true)
         ) {
             $lockedfield = new Lockedfield();
-            $locks = $lockedfield->getLockedNames($this->getType(), $this->fields['id']);
+            $locks = $lockedfield->getFullLockedFields($this->getType(), $this->fields['id']);
             foreach ($locks as $lock) {
-                $idx = array_search($lock, $this->updates);
+                $lock_field = $lock['field'];
+                $idx = array_search($lock_field, $this->updates);
                 if ($idx !== false) {
-                    $lockedfield->setLastValue($this->getType(), $this->fields['id'], $lock, $this->input[$lock]);
+                    //do not update global lock value
+                    if (!$lock['is_global']) {
+                        $lockedfield->setLastValue($this->getType(), $this->fields['id'], $lock_field, $this->input[$lock_field]);
+                    }
                     unset($this->updates[$idx]);
-                    unset($this->input[$lock]);
-                    $this->fields[$lock] = $this->oldvalues[$lock];
-                    unset($this->oldvalues[$lock]);
+                    unset($this->input[$lock_field]);
+                    $this->fields[$lock_field] = $this->oldvalues[$lock_field];
+                    unset($this->oldvalues[$lock_field]);
                 }
             }
             $this->updates = array_values($this->updates);

--- a/src/Lockedfield.php
+++ b/src/Lockedfield.php
@@ -172,7 +172,7 @@ class Lockedfield extends CommonDBTM
      *
      * return array
      */
-    public function getFullLockedFields($itemtype, $items_id)
+    final public function getFullLockedFields($itemtype, $items_id): array
     {
         global $DB;
 

--- a/src/Lockedfield.php
+++ b/src/Lockedfield.php
@@ -163,6 +163,39 @@ class Lockedfield extends CommonDBTM
         return $this->getLocks($itemtype, $items_id, false);
     }
 
+
+    /**
+     * Get locked fields
+     *
+     * @param string  $itemtype Item type
+     * @param integer $items_id Item ID
+     *
+     * return array
+     */
+    public function getFullLockedFields($itemtype, $items_id)
+    {
+        global $DB;
+
+        $iterator = $DB->request([
+            'FROM'   => $this->getTable(),
+            'WHERE'  => [
+                'itemtype'  => $itemtype,
+                [
+                    'OR' => [
+                        'items_id'  => $items_id,
+                        'is_global' => 1
+                    ]
+                ]
+            ]
+        ]);
+
+        $locks = [];
+        foreach ($iterator as $row) {
+            $locks[$row['id']] = $row;
+        }
+        return $locks;
+    }
+
     /**
      * Get locked fields
      *

--- a/tests/functional/Lockedfield.php
+++ b/tests/functional/Lockedfield.php
@@ -187,7 +187,8 @@ class Lockedfield extends DbTestCase
         $this->variable($computer->fields['otherserial'])->isEqualTo('');
 
         $this->boolean($lockedfield->isHandled($computer))->isTrue();
-        $this->array($lockedfield->getLockedValues($computer->getType(), $cid))->isIdenticalTo(['otherserial' => '789012']);
+        //lockedfield value must be null because it's a global lock
+        $this->array($lockedfield->getLockedValues($computer->getType(), $cid))->isIdenticalTo(['otherserial' => null]);
 
         //ensure new dynamic update does not override otherserial again
         $this->boolean(
@@ -200,7 +201,8 @@ class Lockedfield extends DbTestCase
 
         $this->boolean($computer->getFromDB($cid))->isTrue();
         $this->variable($computer->fields['otherserial'])->isEqualTo('');
-        $this->array($lockedfield->getLockedValues($computer->getType(), $cid))->isIdenticalTo(['otherserial' => '789012']);
+        //lockedfield must be null because it's a global lock
+        $this->array($lockedfield->getLockedValues($computer->getType(), $cid))->isIdenticalTo(['otherserial' => null]);
 
         //ensure new dynamic update do not set new lock on regular update
         $this->boolean(
@@ -213,7 +215,8 @@ class Lockedfield extends DbTestCase
 
         $this->boolean($computer->getFromDB($cid))->isTrue();
         $this->variable($computer->fields['name'])->isEqualTo('Computer name changed');
-        $this->array($lockedfield->getLockedValues($computer->getType(), $cid))->isIdenticalTo(['otherserial' => '789012']);
+        //lockedfield must be null because it's a global lock
+        $this->array($lockedfield->getLockedValues($computer->getType(), $cid))->isIdenticalTo(['otherserial' => null]);
 
         //ensure regular update do work on locked field
         $this->boolean(


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 98ba44f</samp>

This pull request fixes and improves the global lock feature for `CommonDBTM` items. It changes the database schema and the logic for detecting and applying locked fields. It also updates the tests and adds a migration script for the new schema.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15591
