### PR TITLE
Prevent tickets creation SQL to use `id=0`

### DIFF
--- a/templates/components/itilobject/mainform_open.html.twig
+++ b/templates/components/itilobject/mainform_open.html.twig
@@ -50,7 +50,9 @@
 
 <form method="POST" action="{{ form_path }}" enctype="{{ enctype }}"
       data-track-changes="{{ track_changes }}" id="itil-form" class="{{ new_cls }}" data-submit-once>
-   <input type="hidden" name="id" value="{{ item.fields['id'] ?? 0 }}" />
+   {% if not item.isNewItem() %}
+       <input type="hidden" name="id" value="{{ item.fields['id'] }}" />
+   {% endif %}
    <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
    <input type="hidden" name="_skip_default_actor" value="1" />
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15458
