### PR TITLE
fix group formats in API listSearchOptions

### DIFF
--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -1433,6 +1433,9 @@ abstract class API
                     $option
                 );
             } else {
+                if (is_string($option)) {
+                    $option = ['name' => $option];
+                }
                 $cleaned_soptions[$sID] = $option;
             }
         }

--- a/src/Search.php
+++ b/src/Search.php
@@ -8197,7 +8197,7 @@ HTML;
                 Session::getLoginUserID()
                 && in_array($itemtype, $CFG_GLPI["ticket_types"])
             ) {
-                self::$search[$itemtype]['tracking']          = __('Assistance');
+                self::$search[$itemtype]['tracking']          = ['name' => __('Assistance')];
 
                 self::$search[$itemtype][60]['table']         = 'glpi_tickets';
                 self::$search[$itemtype][60]['field']         = 'id';
@@ -8287,9 +8287,9 @@ HTML;
             }
 
             if (in_array($itemtype, $CFG_GLPI["link_types"])) {
-                self::$search[$itemtype]['link'] = Link::getTypeName(Session::getPluralNumber());
+                self::$search[$itemtype]['link'] = ['name' => Link::getTypeName(Session::getPluralNumber())];
                 self::$search[$itemtype] += Link::getSearchOptionsToAdd($itemtype);
-                self::$search[$itemtype]['manuallink'] = ManualLink::getTypeName(Session::getPluralNumber());
+                self::$search[$itemtype]['manuallink'] = ['name' => ManualLink::getTypeName(Session::getPluralNumber())];
                 self::$search[$itemtype] += ManualLink::getSearchOptionsToAdd($itemtype);
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15593

Standardize search option group entries as being an array with the label in a "name" property. When getting the search options from the legacy API, this wasn't consistent.