### PR TITLE
Fix handling of unquoted images src in mail collector

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -6189,16 +6189,18 @@ JAVASCRIPT;
      **/
     public static function convertContentForTicket($html, $files, $tags)
     {
-
-        preg_match_all("/src\s*=\s*['|\"](.+?)['|\"]/", $html, $matches, PREG_PATTERN_ORDER);
-        if (isset($matches[1]) && count($matches[1])) {
-           // Get all image src
-
-            foreach ($matches[1] as $src) {
+        $src_patterns = [
+            'src\s*=\s*"[^"]+"',    // src="image.png"
+            "src\s*=\s*'[^']+'",    // src='image.png'
+            'src\s*=[^\s>]+',       // src=image.png
+        ];
+        $matches = [];
+        if (preg_match_all('/(' . implode('|', $src_patterns) . ')/', $html, $matches, PREG_PATTERN_ORDER) > 0) {
+            foreach ($matches[0] as $src_attr) {
                 // Set tag if image matches
                 foreach ($files as $data => $filename) {
-                    if (preg_match("/" . $data . "/i", $src)) {
-                        $html = preg_replace("/<img[^>]*src=['|\"]" . preg_quote($src, '/') . "['|\"][^>]*\>/s", "<p>" . Document::getImageTag($tags[$filename]) . "</p>", $html);
+                    if (preg_match("/" . $data . "/i", $src_attr)) {
+                        $html = preg_replace("/<img[^>]*" . preg_quote($src_attr, '/') . "[^>]*>/s", "<p>" . Document::getImageTag($tags[$filename]) . "</p>", $html);
                     }
                 }
             }

--- a/tests/emails-tests/41-image-src-with-no-quote.eml
+++ b/tests/emails-tests/41-image-src-with-no-quote.eml
@@ -1,0 +1,41 @@
+Date: Thu, 1 Dec 2022 11:23:48 +0200 (CEST)
+From: Normal User <normal@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>
+Subject: 41 - Image src without quotes
+MIME-Version: 1.0
+Content-Type: multipart/alternative; 
+    boundary="----=_Part_1757883_1359581901.1528365951028"
+
+------=_Part_1757883_1359581901.1528365951028
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+Image:
+
+------=_Part_1757883_1359581901.1528365951028
+Content-Type: multipart/related; 
+    boundary="----=_Part_1757884_1267006027.1528365951028"
+
+------=_Part_1757884_1267006027.1528365951028
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+<html>
+<body>
+Image: <img src=cid:image001.png@01D90577.61DCAEC0>
+</body>
+</html>
+------=_Part_1757884_1267006027.1528365951028
+Content-Type: image/png; name=41-blue-dot.png
+Content-Disposition: attachment; filename=41-blue-dot.png
+Content-Transfer-Encoding: base64
+Content-ID: <image001.png@01D90577.61DCAEC0>
+
+iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAL
+EwAACxMBAJqcGAAAAANQTFRFAAD/injSVwAAAApJREFUeJxjYAAAAAIAAUivpHEAAAAASUVORK5C
+YII=
+------=_Part_1757884_1267006027.1528365951028--
+
+------=_Part_1757883_1359581901.1528365951028--
+
+

--- a/tests/functional/Ticket.php
+++ b/tests/functional/Ticket.php
@@ -4230,51 +4230,74 @@ HTML
             'expected' => '',
         ];
 
-       // Content with embedded image.
-        yield [
-            'content'  => <<<HTML
+        foreach (['"', "'", ''] as $quote_style) {
+            // `img` of embedded image that has only a `src` attribute.
+            yield [
+                'content'  => <<<HTML
 Here is the screenshot:
-<img src="screenshot.png" />
+<img src={$quote_style}screenshot.png{$quote_style}>
 blabla
 HTML
-         ,
-            'files'    => [
-                'screenshot.png' => 'screenshot.png',
-            ],
-            'tags'     => [
-                'screenshot.png' => '9faff0a6-f37490bd-60e2af9721f420.96500246',
-            ],
-            'expected' => <<<HTML
+                ,
+                'files'    => [
+                    'screenshot.png' => 'screenshot.png',
+                ],
+                'tags'     => [
+                    'screenshot.png' => '9faff0a6-f37490bd-60e2af9721f420.96500246',
+                ],
+                'expected' => <<<HTML
 Here is the screenshot:
 <p>#9faff0a6-f37490bd-60e2af9721f420.96500246#</p>
 blabla
 HTML
-         ,
-        ];
-
-       // Content with leading external image that will not be replaced by a tag.
-        yield [
-            'content'  => <<<HTML
-<img src="http://test.glpi-project.org/logo.png" />
+                ,
+            ];
+            // `img` of embedded image that has multiple attributes.
+            yield [
+                'content'  => <<<HTML
 Here is the screenshot:
-<img src="img.jpg" />
+<img id="img-id" src={$quote_style}screenshot.png{$quote_style} height="150" width="100" />
 blabla
 HTML
-         ,
-            'files'    => [
-                'img.jpg' => 'img.jpg',
-            ],
-            'tags'     => [
-                'img.jpg' => '3eaff0a6-f37490bd-60e2a59721f420.96500246',
-            ],
-            'expected' => <<<HTML
-<img src="http://test.glpi-project.org/logo.png" />
+                ,
+                'files'    => [
+                    'screenshot.png' => 'screenshot.png',
+                ],
+                'tags'     => [
+                    'screenshot.png' => '9faff0a6-f37490bd-60e2af9721f420.96500246',
+                ],
+                'expected' => <<<HTML
+Here is the screenshot:
+<p>#9faff0a6-f37490bd-60e2af9721f420.96500246#</p>
+blabla
+HTML
+                ,
+            ];
+
+            // Content with leading external image that will not be replaced by a tag.
+            yield [
+                'content'  => <<<HTML
+<img src={$quote_style}http://test.glpi-project.org/logo.png{$quote_style} />
+Here is the screenshot:
+<img src={$quote_style}img.jpg{$quote_style} />
+blabla
+HTML
+                ,
+                'files'    => [
+                    'img.jpg' => 'img.jpg',
+                ],
+                'tags'     => [
+                    'img.jpg' => '3eaff0a6-f37490bd-60e2a59721f420.96500246',
+                ],
+                'expected' => <<<HTML
+<img src={$quote_style}http://test.glpi-project.org/logo.png{$quote_style} />
 Here is the screenshot:
 <p>#3eaff0a6-f37490bd-60e2a59721f420.96500246#</p>
 blabla
 HTML
-         ,
-        ];
+                ,
+            ];
+        }
     }
 
     /**

--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -791,6 +791,7 @@ class MailCollector extends DbTestCase
                     '40.1 - Empty content (multipart)',
                     '40.2 - Empty content (html)',
                     '40.3 - Empty content (plain text)',
+                    '41 - Image src without quotes',
                 ]
             ],
          // Mails having "normal" user as observer (add_cc_to_observer = true)
@@ -943,6 +944,7 @@ PLAINTEXT,
             '1234567890_2' => 'text/plain',
             '1234567890_3' => 'text/plain',
             '37-red-dot.png' => 'image/png',
+            '41-blue-dot.png' => 'image/png',
         ];
 
         $iterator = $DB->request(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15578

Lack of quotes in embedded images (e.g. `<img src=cid:xxx>`) was not handled by the mail collector.