### PR TITLE
Display pending reason in tickets details 2

### DIFF
--- a/templates/components/itilobject/timeline/pending_reasons_messages.html.twig
+++ b/templates/components/itilobject/timeline/pending_reasons_messages.html.twig
@@ -42,7 +42,7 @@
 {% endif %}
 
 {% if pending_reason %}
-   <span class="badge bg-blue-lt {{ display_for_parent ? "mt-1" : "" }}">
+   <span class="badge bg-blue-lt {{ display_for_parent ? "mt-1 w-100 text-truncate" : "" }}">
       <i class="fas fa-pause me-1"></i>
       {{ __("Pending: %s")|format(pending_reason.getLink())|raw }}
 


### PR DESCRIPTION
Followup for https://github.com/glpi-project/glpi/pull/15696, improve display for long labels.

Before:

![image](https://github.com/glpi-project/glpi/assets/42734840/00940fd7-d051-4f43-92c8-e05bd53d6394)

After:

![image](https://github.com/glpi-project/glpi/assets/42734840/a9326e47-9135-428f-83d1-9e1e7550cd7d)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29772
