### PR TITLE
fix(planning external event): prevent errors

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -4813,8 +4813,7 @@ JAVASCRIPT
 
        // manage multiple select (with multiple values)
         if ($params['multiple']) {
-            $min = min(count($params['values']), count($params['valuesnames']));
-            $values = array_combine(array_slice($params['values'], 0, $min), array_slice($params['valuesnames'], 0, $min));
+            $values = array_combine($params['values'], $params['valuesnames']);
             $options['multiple'] = 'multiple';
             $options['selected'] = $params['values'];
         } else {

--- a/src/Html.php
+++ b/src/Html.php
@@ -4813,7 +4813,8 @@ JAVASCRIPT
 
        // manage multiple select (with multiple values)
         if ($params['multiple']) {
-            $values = array_combine($params['values'], $params['valuesnames']);
+            $min = min(count($params['values']), count($params['valuesnames']));
+            $values = array_combine(array_slice($params['values'], 0, $min), array_slice($params['valuesnames'], 0, $min));
             $options['multiple'] = 'multiple';
             $options['selected'] = $params['values'];
         } else {

--- a/src/PlanningExternalEvent.php
+++ b/src/PlanningExternalEvent.php
@@ -157,7 +157,7 @@ class PlanningExternalEvent extends CommonDBTM implements CalDAVCompatibleItemIn
         $this->showFormHeader($options);
 
         $is_ajax  = isset($options['from_planning_edit_ajax']) && $options['from_planning_edit_ajax'];
-        $is_rrule = strlen($this->fields['rrule']) > 0;
+        $is_rrule = strlen($this->fields['rrule'] ?? '') > 0;
 
        // set event for another user
         if (

--- a/src/User.php
+++ b/src/User.php
@@ -4565,6 +4565,9 @@ HTML;
         // Make a select box with all glpi users
         $view_users = self::canView();
 
+        $default = '';
+        $valuesnames = [];
+
         if (!$p['multiple']) {
             $user = getUserName($p['value'], 2, true);
 
@@ -4585,7 +4588,6 @@ HTML;
             }
         } else {
             // get multiple values name
-            $valuesnames = [];
             foreach ($p['values'] as $value) {
                 if (!empty($value) && ($value > 0)) {
                     $user = getUserName($value, 2);

--- a/src/User.php
+++ b/src/User.php
@@ -4590,6 +4590,8 @@ HTML;
                 if (!empty($value) && ($value > 0)) {
                     $user = getUserName($value, 2);
                     $valuesnames[] = $user["name"];
+                } else {
+                    unset($p['values'][$value]);
                 }
             }
 


### PR DESCRIPTION
Prevent 2 errors message on planningexternalevent form

`PHP Deprecated function (8192): strlen(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/glpi/src/PlanningExternalEvent.php at line 160`

`Uncaught Exception ValueError: array_combine(): Argument #1 ($keys) and argument #2 ($values) must have the same number of elements in /var/www/glpi/src/Html.php at line 4816`

![image](https://github.com/glpi-project/glpi/assets/8530352/12b3d2c9-2737-434e-8ba4-ad157bdd26a9)

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
