### PR TITLE
Avoid empty update queries

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -669,6 +669,9 @@ class CommonDBTM extends CommonGLPI
                 unset($oldvalues[$field]);
             }
         }
+        if (count($tobeupdated) === 0) {
+            return true;
+        }
         $result = $DB->update(
             $this->getTable(),
             $tobeupdated,

--- a/tests/functional/Config.php
+++ b/tests/functional/Config.php
@@ -829,4 +829,18 @@ class Config extends DbTestCase
             $this->boolean($infocom_exists)->isFalse();
         }
     }
+
+    public function testEmptyUpdate()
+    {
+        \Config::setConfigurationValues('core', ['maintenance_text' => 'test']);
+        // If not handled, this second call would trigger an exception if handled at the DBAL level as the params array would be empty.
+        // If not handled by GLPI at all, it will trigger a SQL syntax error.
+        // Need to specify a field to get the execution to the point the error could occur.
+        // The null value will cause the entry to be removed and an empty array to be passed to the DBAL.
+        \Config::setConfigurationValues('core', ['maintenance_text' => null]);
+
+        // Make sure atoum doesn't feel left out by the lack of assertions in this test
+        // Doing ->exception(...)->isNull() around the previous code would cause a complaint that null is not an exception
+        $this->boolean(true)->isTrue();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Adds count check to field updates array in `CommonDBTM::updateInDB` to avoid sending an empty array to the DB update method which would either create a bad SQL query in current releases, or since #15693 would throw an exception.