### PR TITLE
Allow pending reason edition from new fup/task form

### DIFF
--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -634,6 +634,8 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             NotificationEvent::raiseEvent('add_task', $this->input["_job"], $options);
         }
 
+        PendingReason_Item::handlePendingReasonUpdateFromNewTimelineItem($this);
+
        // Add log entry in the ITIL object
         $changes = [
             0,

--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -284,6 +284,8 @@ class ITILFollowup extends CommonDBChild
             NotificationEvent::raiseEvent("add_followup", $parentitem, $options);
         }
 
+        PendingReason_Item::handlePendingReasonUpdateFromNewTimelineItem($this);
+
        // Add log entry in the ITILObject
         $changes = [
             0,

--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -216,7 +216,7 @@
             {# Fixed min-height ensure no height increase when toggling the pending reason button, as select 2 dropdown are a bit higher than the default footer height #}
             <div class="d-flex card-footer mx-n3 mb-n3 flex-wrap" style="row-gap: 10px; min-height: 79px">
                {% set pending_reasons %}
-                  {% set show_pending_reasons_actions = item.fields['status'] == constant('CommonITILObject::WAITING') and not has_pending_reason and not add_reopen %}
+                  {% set show_pending_reasons_actions = item.fields['status'] == constant('CommonITILObject::WAITING') and not add_reopen %}
                   {% if get_current_interface() == 'central' and item.isAllowedStatus(item.fields['status'], constant('CommonITILObject::WAITING')) %}
                      <span
                         class="input-group-text bg-yellow-lt py-0 pe-0 {{ show_pending_reasons_actions ? 'flex-fill' : '' }}"
@@ -235,15 +235,13 @@
                            </label>
                         </span>
 
-                        {% if not has_pending_reason %}
-                           <div
-                              class="collapse ps-2 py-1 flex-fill {{ show_pending_reasons_actions ? 'show' : '' }}"
-                              aria-expanded="{{ show_pending_reasons_actions ? 'true' : 'false' }}"
-                              id="pending-reasons-setup-{{ rand }}"
-                           >
-                              {{ include('components/itilobject/timeline/pending_reasons.html.twig') }}
-                           </div>
-                        {% endif %}
+                        <div
+                           class="collapse ps-2 py-1 flex-fill {{ show_pending_reasons_actions ? 'show' : '' }}"
+                           aria-expanded="{{ show_pending_reasons_actions ? 'true' : 'false' }}"
+                           id="pending-reasons-setup-{{ rand }}"
+                        >
+                           {{ include('components/itilobject/timeline/pending_reasons.html.twig') }}
+                        </div>
                      </span>
                   {% endif %}
                {% endset %}

--- a/templates/components/itilobject/timeline/pending_reasons.html.twig
+++ b/templates/components/itilobject/timeline/pending_reasons.html.twig
@@ -34,6 +34,8 @@
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
 {% set pending_item = call('PendingReason_Item::getForItem', [subitem, true]) %}
+{% set pending_item_parent = call('PendingReason_Item::getForItem', [item, true]) %}
+{% set pendingreasons_id = pending_item.fields['pendingreasons_id'] ?? pending_item_parent.fields['pendingreasons_id'] ?? 0 %}
 {% if subitem.isNewItem() or pending_item or call('PendingReason_Item::isLastTimelineItem', [subitem])  %}
    <div class="row">
       <div class="col-12 col-sm-4" title="{{ "PendingReason"|itemtype_name }}"
@@ -55,7 +57,7 @@
          {{ fields.dropdownField(
             'PendingReason',
             'pendingreasons_id',
-            subitem.fields['pendingreasons_id'],
+            pendingreasons_id,
             pendingreasons_lbl,
             {
                'label_class': 'col-1',
@@ -96,12 +98,12 @@
          </script>
       </div>
 
-      <div class="collapse col-12 col-sm-8" id="pending-reasons-more_options_{{ rand }}">
+      <div class="collapse col-12 col-sm-8 {{ pendingreasons_id ? "show" : "" }}" id="pending-reasons-more_options_{{ rand }}">
          <div class="row">
             <div class="col-12 col-sm-6" title="{{ __('Automatic follow-up') }}"
                   data-bs-toggle="tooltip" data-bs-placement="top">
                {% set pendingreasons_frequency_field = call('PendingReason::displayFollowupFrequencyfield', [
-                  pending_item.fields["followup_frequency"],
+                  pending_item ? pending_item.fields['followup_frequency'] : pending_item_parent.fields['followup_frequency'],
                   "",
                   {
                      'rand': rand
@@ -127,7 +129,7 @@
             <div class="col-12 col-sm-6" title="{{ __('Automatic resolution') }}"
                  data-bs-toggle="tooltip" data-bs-placement="top">
                {% set pendingreasons_resolution_field = call('PendingReason::displayFollowupsNumberBeforeResolutionField', [
-                     pending_item.fields["followups_before_resolution"],
+                     pending_item ? pending_item.fields['followups_before_resolution'] : pending_item_parent.fields['followups_before_resolution'],
                      "",
                      {
                         'rand': rand

--- a/tests/functional/PendingReason.class.php
+++ b/tests/functional/PendingReason.class.php
@@ -456,7 +456,7 @@ class PendingReason extends DbTestCase
      *
      * @return iterable
      */
-    public function testUpdatesFromNewTimelineItemProvider(): iterable
+    protected function testUpdatesFromNewTimelineItemProvider(): iterable
     {
         $this->login();
         $entity = getItemByTypeName('Entity', '_test_root_entity', true);

--- a/tests/functional/PendingReason.class.php
+++ b/tests/functional/PendingReason.class.php
@@ -450,4 +450,280 @@ class PendingReason extends DbTestCase
             $this->integer($item->fields['status'])->isEqualTo($status);
         }
     }
+
+    /**
+     * Data provider for testHandlePendingReasonUpdateFromNewTimelineItem
+     *
+     * @return iterable
+     */
+    public function testUpdatesFromNewTimelineItemProvider(): iterable
+    {
+        $this->login();
+        $entity = getItemByTypeName('Entity', '_test_root_entity', true);
+
+        // Create a set of pending reasons that will be reused in our test cases
+        list(
+            $pending_reason1,
+            $pending_reason2
+        ) = $this->createItems(\PendingReason::class, [
+            ['entities_id' => $entity, 'is_recursive' => true, 'name' => 'Pending 1'],
+            ['entities_id' => $entity, 'is_recursive' => true, 'name' => 'Pending 2'],
+        ]);
+
+        // Case 1: ticket without any pending data
+        yield [
+            'timeline' => [
+                ['type' => ITILFollowup::class, 'pending' => 0],
+                ['type' => TicketTask::class, 'pending' => 0],
+            ],
+            'expected' => [
+                'status' => CommonITILObject::INCOMING,
+            ],
+        ];
+
+        // Case 2: ticket with a single pending data
+        yield [
+            'timeline' => [
+                [
+                    'type'                        => ITILFollowup::class,
+                    'pending'                     => 1,
+                    'pendingreasons_id'           => $pending_reason1->getID(),
+                    'followup_frequency'          => 3 * DAY_TIMESTAMP,
+                    'followups_before_resolution' => 2,
+                ],
+            ],
+            'expected' => [
+                'status'                      => CommonITILObject::WAITING,
+                'pendingreasons_id'           => $pending_reason1->getID(),
+                'followup_frequency'          => 3 * DAY_TIMESTAMP,
+                'followups_before_resolution' => 2,
+                // Pending reason is attached to the first followup
+                'pending_timeline_index'      => 0,
+            ]
+        ];
+
+        // Case 3: ticket with two tasks (of which the first is pending)
+        yield [
+            'timeline' => [
+                [
+                    'type'                        => TicketTask::class,
+                    'pending'                     => 1,
+                    'pendingreasons_id'           => $pending_reason1->getID(),
+                    'followup_frequency'          => 3 * DAY_TIMESTAMP,
+                    'followups_before_resolution' => 2,
+                ],
+                ['type' => TicketTask::class],
+
+            ],
+            'expected' => [
+                'status'                      => CommonITILObject::WAITING,
+                'pendingreasons_id'           => $pending_reason1->getID(),
+                'followup_frequency'          => 3 * DAY_TIMESTAMP,
+                'followups_before_resolution' => 2,
+                // Pending reason is attached to the first task
+                'pending_timeline_index'      => 0,
+            ]
+        ];
+
+        // Case 4: ticket with two followups
+        // The first set the pending data and the second change it
+        yield [
+            'timeline' => [
+                [
+                    'type'                        => ITILFollowup::class,
+                    'pending'                     => 1,
+                    'pendingreasons_id'           => $pending_reason1->getID(),
+                    'followup_frequency'          => 3 * DAY_TIMESTAMP,
+                    'followups_before_resolution' => 2,
+                ],
+                [
+                    'type'                        => ITILFollowup::class,
+                    'pending'                     => 1,
+                    'pendingreasons_id'           => $pending_reason2->getID(),
+                    'followup_frequency'          => 2 * DAY_TIMESTAMP,
+                    'followups_before_resolution' => 1,
+                ],
+
+            ],
+            'expected' => [
+                'status'                      => CommonITILObject::WAITING,
+                'pendingreasons_id'           => $pending_reason2->getID(),
+                'followup_frequency'          => 2 * DAY_TIMESTAMP,
+                'followups_before_resolution' => 1,
+                // Pending reason is still attached to the first followup, the second one only edited its value
+                'pending_timeline_index'      => 0,
+            ]
+        ];
+
+        // Case 5: ticket with two followups
+        // The first set the pending data and the second remove it
+        yield [
+            'timeline' => [
+                [
+                    'type'                        => ITILFollowup::class,
+                    'pending'                     => 1,
+                    'pendingreasons_id'           => $pending_reason1->getID(),
+                    'followup_frequency'          => 3 * DAY_TIMESTAMP,
+                    'followups_before_resolution' => 2,
+                ],
+                [
+                    'type'    => ITILFollowup::class,
+                    'pending' => 0,
+                ],
+
+            ],
+            'expected' => [
+                'status' => CommonITILObject::INCOMING,
+            ]
+        ];
+
+        // Case 6: ticket with 3 timeline items
+        // The first set the pending data, the second remove it and the third add a new pending reason
+        yield [
+            'timeline' => [
+                [
+                    'type'                        => ITILFollowup::class,
+                    'pending'                     => 1,
+                    'pendingreasons_id'           => $pending_reason1->getID(),
+                    'followup_frequency'          => 3 * DAY_TIMESTAMP,
+                    'followups_before_resolution' => 2,
+                ],
+                [
+                    'type'    => TicketTask::class,
+                    'pending' => 0,
+                ],
+                [
+                    'type'                        => ITILFollowup::class,
+                    'pending'                     => 1,
+                    'pendingreasons_id'           => $pending_reason2->getID(),
+                    'followup_frequency'          => 0,
+                    'followups_before_resolution' => 0,
+                ],
+            ],
+            'expected' => [
+                'status'                      => CommonITILObject::WAITING,
+                'pendingreasons_id'           => $pending_reason2->getID(),
+                'followup_frequency'          => 0 * DAY_TIMESTAMP,
+                'followups_before_resolution' => 0,
+                // Pending reason is attached to the third timeline item
+                'pending_timeline_index'      => 2,
+            ]
+        ];
+
+        // Case 7: ticket with 2 timeline items
+        // The first set the pending data and the second send the same data
+        // This simulate what will be sent if the user does not edit the displayed values
+        yield [
+            'timeline' => [
+                [
+                    'type'                        => ITILFollowup::class,
+                    'pending'                     => 1,
+                    'pendingreasons_id'           => $pending_reason1->getID(),
+                    'followup_frequency'          => 3 * DAY_TIMESTAMP,
+                    'followups_before_resolution' => 2,
+                ],
+                [
+                    'type'                        => ITILFollowup::class,
+                    'pending'                     => 1,
+                    'pendingreasons_id'           => $pending_reason1->getID(),
+                    'followup_frequency'          => 3 * DAY_TIMESTAMP,
+                    'followups_before_resolution' => 2,
+                ],
+            ],
+            'expected' => [
+                'status'                      => CommonITILObject::WAITING,
+                'pendingreasons_id'           => $pending_reason1->getID(),
+                'followup_frequency'          => 3 * DAY_TIMESTAMP,
+                'followups_before_resolution' => 2,
+                // Pending reason is attached to the first timeline item
+                'pending_timeline_index'      => 0,
+            ]
+        ];
+    }
+
+    /**
+     * Test that updates on pending reason data done through new timeline items
+     * are handled as expected
+     *
+     * This validate the "testHandlePendingReasonUpdateFromNewTimelineItem" method
+     * and its references in ITILFollowup's and CommonITILTask's post_addItem() method
+     *
+     * @dataProvider testUpdatesFromNewTimelineItemProvider
+     *
+     * @param array $timeline A simple description of the timeline items to create
+     *                        and their impact on pending reason data
+     * @param array $expected The expected state after all timeline items have been
+     *                        created
+     * @return void
+     */
+    public function testHandlePendingReasonUpdateFromNewTimelineItem(
+        array $timeline,
+        array $expected
+    ): void {
+        // Create test ticket
+        $ticket = $this->createItem(Ticket::class, [
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+            'name'        => 'test',
+            'content'     => 'test',
+        ]);
+
+        // Insert timeline
+        $items = [];
+        foreach ($timeline as $timeline_item) {
+            // Insert fake content
+            $timeline_item['content'] = 'test';
+
+            // Read and prepare itemtype (task or followup)
+            $itemtype = $timeline_item['type'];
+            unset($timeline_item['type']);
+
+            if ($itemtype == ITILFollowup::class) {
+                $timeline_item['itemtype'] = Ticket::class;
+                $timeline_item['items_id'] = $ticket->getID();
+            } else {
+                $timeline_item['tickets_id'] = $ticket->getID();
+            }
+            $items[] = $this->createItem($itemtype, $timeline_item, [
+                'pending',
+                'pendingreasons_id',
+                'followup_frequency',
+                'followups_before_resolution'
+            ]);
+        }
+
+        // Reload ticket
+        $ticket->getFromDB($ticket->getID());
+
+        // Compare final ticket state with expected state
+        $this->integer($ticket->fields['status'])->isEqualTo($expected['status']);
+        if ($ticket->fields['status'] == CommonITILObject::WAITING) {
+            // Compute ticket pending data
+            $last_timeline_item_pending_data = PendingReason_Item::getLastPendingTimelineItemDataForItem($ticket);
+            $ticket_pending_data = PendingReason_Item::getForItem($ticket);
+
+            // Validate pending data
+            $keys = ['pendingreasons_id', 'followup_frequency', 'followups_before_resolution'];
+            foreach ($keys as $key) {
+                $this
+                    ->integer($last_timeline_item_pending_data->fields[$key])
+                    ->isEqualTo($expected[$key])
+                ;
+                $this
+                    ->integer($ticket_pending_data->fields[$key])
+                    ->isEqualTo($expected[$key])
+                ;
+            }
+
+            // Check that pending data is attached to the correct followup
+            $correct_timeline_item = $items[$expected['pending_timeline_index']];
+            $this
+                ->string($last_timeline_item_pending_data->fields['itemtype'])
+                ->isEqualTo($correct_timeline_item::getType())
+            ;
+            $this
+                ->integer($last_timeline_item_pending_data->fields['items_id'])
+                ->isEqualTo($correct_timeline_item->getID())
+            ;
+        }
+    }
 }


### PR DESCRIPTION
Similarly to #15696, this was a feature from the 9.5 backport that was not integrated properly into GLPI 10.
I think @cedric-anne also suggested that we fix that a while ago but it didn't go anywhere at the time.

When adding a new followup to a ticket, it is possible to remove the `pending` status but we can't interact with the pending reasons: 

![image](https://github.com/glpi-project/glpi/assets/42734840/07c7287f-6685-4504-b5ff-6f0d8e3fcbfa)

After changes:
![image](https://github.com/glpi-project/glpi/assets/42734840/9af46bbe-6cf8-4a04-a4b4-ffa22dae3e07)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29772
