### PR TITLE
fix: imap folders globalname

### DIFF
--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -360,14 +360,7 @@ class MailCollector extends CommonDBTM
                var input_id = li.data('input-id');
                var folder   = li.children('.folder-name').html();
 
-               var _label = '';
-               var _parents = li.parents('li').children('.folder-name');
-               for (i = _parents.length -1 ; i >= 0; i--) {
-                  _label += $(_parents[i]).html() + '/';
-               }
-               _label += folder;
-
-               $('#'+input_id).val(_label);
+               $('#'+input_id).val(folder);
 
                var modalEl = $('#'+input_id+'_modal')[0];
                var modal = bootstrap.Modal.getInstance(modalEl);
@@ -427,7 +420,7 @@ class MailCollector extends CommonDBTM
      */
     private function displayFolder($folder, $input_id)
     {
-        $fname = mb_convert_encoding($folder->getLocalName(), "UTF-8", "UTF7-IMAP");
+        $fname = mb_convert_encoding($folder->getGlobalName(), "UTF-8", "UTF7-IMAP");
         echo "<li class='pointer' data-input-id='$input_id'>
                <i class='fa fa-folder'></i>&nbsp;
                <span class='folder-name'>" . $fname . "</span>";

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -420,8 +420,8 @@ class MailCollector extends CommonDBTM
      */
     private function displayFolder($folder, $input_id)
     {
-        $fglobalname = mb_convert_encoding($folder->getGlobalName(), "UTF-8", "UTF7-IMAP");
-        $flocalname  = mb_convert_encoding($folder->getLocalName(), "UTF-8", "UTF7-IMAP");
+        $fglobalname = htmlspecialchars(mb_convert_encoding($folder->getGlobalName(), "UTF-8", "UTF7-IMAP"), ENT_QUOTES);
+        $flocalname  = htmlspecialchars(mb_convert_encoding($folder->getLocalName(), "UTF-8", "UTF7-IMAP"), ENT_QUOTES);
         echo "<li class='pointer' data-input-id='$input_id'>
                <i class='fa fa-folder'></i>&nbsp;
                <span class='folder-name' data-globalname='" . $fglobalname . "'>" . $flocalname . "</span>";

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -358,7 +358,7 @@ class MailCollector extends CommonDBTM
 
                var li       = $(this);
                var input_id = li.data('input-id');
-               var folder   = li.children('.folder-name').html();
+               var folder   = li.find('.folder-name').data('globalname');
 
                $('#'+input_id).val(folder);
 
@@ -420,10 +420,11 @@ class MailCollector extends CommonDBTM
      */
     private function displayFolder($folder, $input_id)
     {
-        $fname = mb_convert_encoding($folder->getGlobalName(), "UTF-8", "UTF7-IMAP");
+        $fglobalname = mb_convert_encoding($folder->getGlobalName(), "UTF-8", "UTF7-IMAP");
+        $flocalname  = mb_convert_encoding($folder->getLocalName(), "UTF-8", "UTF7-IMAP");
         echo "<li class='pointer' data-input-id='$input_id'>
                <i class='fa fa-folder'></i>&nbsp;
-               <span class='folder-name'>" . $fname . "</span>";
+               <span class='folder-name' data-globalname='" . $fglobalname . "'>" . $flocalname . "</span>";
         echo "<ul>";
 
         foreach ($folder as $sfolder) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | I hope
| Fixed tickets | N/A

Mailbox hierarchy delimiter can be "/" or "." (it depend on server NAMESPACE configuration).

So I propose to use "globalName" (which already contains the full path of folder constructed by Laminas lib with the correct server delimiter), instead of using "localName" and construct the path on GLPI side.

![image](https://github.com/glpi-project/glpi/assets/470612/978d02c7-85bc-40ac-9e9d-fcf892042d6a)

This only affect "preselection" feature in collector UI configuration form.

