### PR TITLE
Add helper method to access the tests root entity

### DIFF
--- a/tests/GLPITestCase.php
+++ b/tests/GLPITestCase.php
@@ -320,9 +320,11 @@ class GLPITestCase extends atoum
     /**
      * Get the "_test_root_entity" entity created by the tests's bootstrap file
      *
+     * @param bool $only_id
+     *
      * @return Entity|int
      */
-    protected function getTestRootEntity(int $only_id = false)
+    protected function getTestRootEntity(bool $only_id = false)
     {
         return getItemByTypeName('Entity', '_test_root_entity', $only_id);
     }

--- a/tests/GLPITestCase.php
+++ b/tests/GLPITestCase.php
@@ -322,7 +322,7 @@ class GLPITestCase extends atoum
      *
      * @return Entity|int
      */
-    public function getTestRootEntity(int $only_id = false)
+    protected function getTestRootEntity(int $only_id = false)
     {
         return getItemByTypeName('Entity', '_test_root_entity', $only_id);
     }

--- a/tests/GLPITestCase.php
+++ b/tests/GLPITestCase.php
@@ -316,4 +316,14 @@ class GLPITestCase extends atoum
         }
         return $this->int++;
     }
+
+    /**
+     * Get the "_test_root_entity" entity created by the tests's bootstrap file
+     *
+     * @return Entity|int
+     */
+    public function getTestRootEntity(int $only_id = false)
+    {
+        return getItemByTypeName('Entity', '_test_root_entity', $only_id);
+    }
 }


### PR DESCRIPTION
Getting the root entity while writing tests is frustrating because you have to remember its exact name (`_test_root_entity`).
Maybe my memory isn't so good because I'm never sure of the exact name and up searching for it in other files most of the time.

Adding a simple helper method to `GLPITestCase.php` allow memory-impaired developers to rely on code completion for futures tests ;)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
