### PR TITLE
Fix handling of null values during updates

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -670,8 +670,8 @@ class CommonDBTM extends CommonGLPI
 
         $tobeupdated = [];
         foreach ($updates as $field) {
-            if (isset($this->fields[$field])) {
-                if (isset($oldvalues[$field]) && $this->fields[$field] == $oldvalues[$field]) {
+            if (array_key_exists($field, $this->fields)) {
+                if (array_key_exists($field, $oldvalues) && $this->fields[$field] == $oldvalues[$field]) {
                     unset($oldvalues[$field]);
                 }
                 $tobeupdated[$field] = $this->fields[$field];

--- a/src/Log.php
+++ b/src/Log.php
@@ -154,7 +154,7 @@ class Log extends CommonDBTM
                         && ($val2['rightname'] == $item->fields['name'])
                     ) {
                         $id_search_option = $key2;
-                        $changes          =  [$id_search_option, addslashes($oldval ?? ''), $values[$key]];
+                        $changes          =  [$id_search_option, addslashes($oldval ?? ''), $values[$key] ?? ''];
                     }
                 } else if (
                     ($val2['linkfield'] == $key && $real_type === $item->getType())
@@ -169,7 +169,7 @@ class Log extends CommonDBTM
                             $oldval = CommonTreeDropdown::sanitizeSeparatorInCompletename($oldval);
                             $values[$key] = CommonTreeDropdown::sanitizeSeparatorInCompletename($values[$key]);
                         }
-                        $changes = [$id_search_option, addslashes($oldval ?? ''), $values[$key]];
+                        $changes = [$id_search_option, addslashes($oldval ?? ''), $values[$key] ?? ''];
                     } else {
                        // other cases; link field -> get data from dropdown
                         if ($val2["table"] != 'glpi_auth_tables') {

--- a/tests/functional/CommonDBTM.php
+++ b/tests/functional/CommonDBTM.php
@@ -924,6 +924,20 @@ class CommonDBTM extends DbTestCase
         $this->string($computer->fields['name'])->isIdenticalTo('Computer01 \'');
         $this->boolean($computer->getFromDB($computerID))->isTrue();
         $this->string($computer->fields['name'])->isIdenticalTo('Computer01 \'');
+
+        $this->boolean(
+            $computer->update(['id' => $computerID, 'name' => null])
+        )->isTrue();
+        $this->variable($computer->fields['name'])->isIdenticalTo(null);
+        $this->boolean($computer->getFromDB($computerID))->isTrue();
+        $this->variable($computer->fields['name'])->isIdenticalTo(null);
+
+        $this->boolean(
+            $computer->update(['id' => $computerID, 'name' => 'renamed'])
+        )->isTrue();
+        $this->string($computer->fields['name'])->isIdenticalTo('renamed');
+        $this->boolean($computer->getFromDB($computerID))->isTrue();
+        $this->string($computer->fields['name'])->isIdenticalTo('renamed');
     }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | see #15543 

When a value was update to `null`, it was actually not update because the `isset($this->fields[$field])` was returning false. Using `array_key_exists($field, $this->fields)` fixes this issue.

Issue was introduced in 5bab9bda02a60f3cd49dde9053c19b7ab501177d (10.0.6).