### PR TITLE
fix: disable submit via enter key

### DIFF
--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -128,36 +128,7 @@
             </button>
          {% else %}
 
-            <div class="btn-group" role="group" id="right-actions">
-               {% if item.canDeleteItem() %}
-                  {% if item.isDeleted() %}
-                     <button class="btn btn-outline-secondary" type="submit" name="restore" form="itil-form"
-                           title="{{ _x('button', 'Restore') }}">
-                        <i class="fas fa-trash-restore-alt"></i>
-                        <span class="d-none d-lg-block">{{ _x('button', 'Restore') }}</span>
-                     </button>
-
-                     <button class="btn btn-outline-danger" type="submit" name="purge" form="itil-form"
-                           title="{{ _x('button', 'Delete permanently') }}"
-                           onclick="return confirm('{{ __('Confirm the final deletion?') }}');">
-                        <i class="ti ti-trash"></i>
-                        <span class="d-none d-lg-block">{{ _x('button', 'Delete permanently') }}</span>
-                     </button>
-                  {% else %}
-                     <button class="btn btn-outline-danger" type="submit" name="delete" form="itil-form"
-                           title="{{ _x('button', 'Put in trashbin') }}"
-                           data-bs-toggle="tooltip" data-bs-placement="top">
-                        <i class="ti ti-trash"></i>
-                     </button>
-                  {% endif %}
-               {% endif %}
-
-               {% if canupdate %}
-                  {{ include('components/form/single-action.html.twig', {
-                     'onlyicon': true
-                  }) }}
-               {% endif %}
-
+            <div class="btn-group flex-row-reverse" role="group" id="right-actions">
                {% set is_locked = params['locked'] is defined and params['locked'] %}
                {% set display_save_btn = not is_locked and (canupdate or can_requester or canpriority or canassign or canassigntome) %}
                {% if display_save_btn %}
@@ -166,6 +137,35 @@
                      <i class="far fa-save"></i>
                      <span class="d-none d-xl-block">{{ _x('button', 'Save') }}</span>
                   </button>
+               {% endif %}
+
+               {% if canupdate %}
+                  {{ include('components/form/single-action.html.twig', {
+                     'onlyicon': true
+                  }) }}
+               {% endif %}
+
+               {% if item.canDeleteItem() %}
+                  {% if item.isDeleted() %}
+                     <button class="btn btn-outline-danger" type="submit" name="purge" form="itil-form"
+                           title="{{ _x('button', 'Delete permanently') }}"
+                           onclick="return confirm('{{ __('Confirm the final deletion?') }}');">
+                        <i class="ti ti-trash"></i>
+                        <span class="d-none d-lg-block">{{ _x('button', 'Delete permanently') }}</span>
+                     </button>
+
+                     <button class="btn btn-outline-secondary" type="submit" name="restore" form="itil-form"
+                           title="{{ _x('button', 'Restore') }}">
+                        <i class="fas fa-trash-restore-alt"></i>
+                        <span class="d-none d-lg-block">{{ _x('button', 'Restore') }}</span>
+                     </button>
+                  {% else %}
+                     <button class="btn btn-outline-danger" type="submit" name="delete" form="itil-form"
+                           title="{{ _x('button', 'Put in trashbin') }}"
+                           data-bs-toggle="tooltip" data-bs-placement="top">
+                        <i class="ti ti-trash"></i>
+                     </button>
+                  {% endif %}
                {% endif %}
             </div>
 
@@ -205,10 +205,6 @@
       $("#itil-footer .main-actions").hide();
       // hide also itil object action to prevent confusion
       $("#right-actions").hide();
-   });
-
-   $(document).on("keydown", ":input:not(textarea):not(:submit)", function(event) {
-      return event.key != "Enter";
    });
 
    $(function() {

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -128,36 +128,26 @@
             </button>
          {% else %}
 
-            <div class="btn-group flex-row-reverse" role="group" id="right-actions">
-               {% set is_locked = params['locked'] is defined and params['locked'] %}
-               {% set display_save_btn = not is_locked and (canupdate or can_requester or canpriority or canassign or canassigntome) %}
-               {% if display_save_btn %}
-                  <button class="btn btn-primary" type="submit" name="update" form="itil-form"
-                        title="{{ _x('button', 'Save') }}">
-                     <i class="far fa-save"></i>
-                     <span class="d-none d-xl-block">{{ _x('button', 'Save') }}</span>
-                  </button>
-               {% endif %}
+            {% set is_locked = params['locked'] is defined and params['locked'] %}
+            {% set display_save_btn = not is_locked and (canupdate or can_requester or canpriority or canassign or canassigntome) %}
+            {% if display_save_btn %}
+               <button class="btn btn-primary d-none" type="submit" name="update" form="itil-form"></button>
+            {% endif %}
 
-               {% if canupdate %}
-                  {{ include('components/form/single-action.html.twig', {
-                     'onlyicon': true
-                  }) }}
-               {% endif %}
-
+            <div class="btn-group" role="group" id="right-actions">
                {% if item.canDeleteItem() %}
                   {% if item.isDeleted() %}
+                     <button class="btn btn-outline-secondary" type="submit" name="restore" form="itil-form"
+                           title="{{ _x('button', 'Restore') }}">
+                        <i class="fas fa-trash-restore-alt"></i>
+                        <span class="d-none d-lg-block">{{ _x('button', 'Restore') }}</span>
+                     </button>
+
                      <button class="btn btn-outline-danger" type="submit" name="purge" form="itil-form"
                            title="{{ _x('button', 'Delete permanently') }}"
                            onclick="return confirm('{{ __('Confirm the final deletion?') }}');">
                         <i class="ti ti-trash"></i>
                         <span class="d-none d-lg-block">{{ _x('button', 'Delete permanently') }}</span>
-                     </button>
-
-                     <button class="btn btn-outline-secondary" type="submit" name="restore" form="itil-form"
-                           title="{{ _x('button', 'Restore') }}">
-                        <i class="fas fa-trash-restore-alt"></i>
-                        <span class="d-none d-lg-block">{{ _x('button', 'Restore') }}</span>
                      </button>
                   {% else %}
                      <button class="btn btn-outline-danger" type="submit" name="delete" form="itil-form"
@@ -166,6 +156,20 @@
                         <i class="ti ti-trash"></i>
                      </button>
                   {% endif %}
+               {% endif %}
+
+               {% if canupdate %}
+                  {{ include('components/form/single-action.html.twig', {
+                     'onlyicon': true
+                  }) }}
+               {% endif %}
+
+               {% if display_save_btn %}
+                  <button class="btn btn-primary" type="submit" name="update" form="itil-form"
+                        title="{{ _x('button', 'Save') }}">
+                     <i class="far fa-save"></i>
+                     <span class="d-none d-xl-block">{{ _x('button', 'Save') }}</span>
+                  </button>
                {% endif %}
             </div>
 

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -131,7 +131,7 @@
             {% set is_locked = params['locked'] is defined and params['locked'] %}
             {% set display_save_btn = not is_locked and (canupdate or can_requester or canpriority or canassign or canassigntome) %}
             {% if display_save_btn %}
-               <button class="btn btn-primary d-none" type="submit" name="update" form="itil-form"></button>
+               <button class="d-none" type="submit" name="update" form="itil-form"></button>
             {% endif %}
 
             <div class="btn-group" role="group" id="right-actions">

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -207,6 +207,10 @@
       $("#right-actions").hide();
    });
 
+   $(document).on("keydown", ":input:not(textarea):not(:submit)", function(event) {
+      return event.key != "Enter";
+   });
+
    $(function() {
       // when close button of new answer block is clicked, show again the new answer button (and the itil object actions)
       $(document).on("click", "#new-itilobject-form .close-itil-answer", function() {

--- a/tests/functional/Ticket.php
+++ b/tests/functional/Ticket.php
@@ -1252,7 +1252,7 @@ class Ticket extends DbTestCase
 
        //Save button
         $matches = iterator_to_array($crawler->filter("#itil-footer button[type=submit][name=update]:not([disabled])"));
-        $this->array($matches)->hasSize(($save === true ? 1 : 0), ($save === true ? 'Save button missing' : 'Save button present') . ' ' . $caller);
+        $this->array($matches)->hasSize(($save === true ? 2 : 0), ($save === true ? 'Save button missing' : 'Save button present') . ' ' . $caller);
 
        //Assign to
        /*preg_match(


### PR DESCRIPTION
For example: On a ticket, if you add a text input via the Fields plugin. When you modify this field and press enter, the ticket is deleted, because the 1st submit button on the form is delete.

_I don't think this case is specific to the plugin._

This PR disables submit via enter key from an input field (itilobject only).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
