### PR TITLE
fix(migration 10.0.9 to 10.0.10): PHP Error Allowed memory size

### DIFF
--- a/install/migrations/update_10.0.9_to_10.0.10/ldap_fields.php
+++ b/install/migrations/update_10.0.9_to_10.0.10/ldap_fields.php
@@ -64,7 +64,17 @@ foreach ($groups as $group) {
 /** /Fix non encoded LDAP fields in groups */
 
 /** Fix non encoded LDAP fields in users */
-$users = getAllDataFromTable('glpi_users', ['authtype' => 3]);
+$users = $DB->request([
+    'SELECT' => [
+        'glpi_users.id',
+        'glpi_users.user_dn',
+        'glpi_users.sync_field',
+    ],
+    'FROM'   => 'glpi_users',
+    'WHERE'  => [
+        'authtype' => 3,
+    ],
+]);
 foreach ($users as $user) {
     $updated = [];
     foreach (['user_dn', 'sync_field'] as $ldap_field) {

--- a/install/migrations/update_10.0.9_to_10.0.10/ldap_fields.php
+++ b/install/migrations/update_10.0.9_to_10.0.10/ldap_fields.php
@@ -75,8 +75,8 @@ $users = $DB->request([
         'authtype' => 3,
         [
             'OR' => [
-                'user_dn' => ['REGEXP' => '(<|>|(&(?!#?[a-z0-9]+;)))'],
-                'sync_field' => ['REGEXP' => '(<|>|(&(?!#?[a-z0-9]+;)))'],
+                'user_dn' => ['REGEXP', '(<|>|(&(?!#?[a-z0-9]+;)))'],
+                'sync_field' => ['REGEXP', '(<|>|(&(?!#?[a-z0-9]+;)))'],
             ]
         ]
     ],

--- a/install/migrations/update_10.0.9_to_10.0.10/ldap_fields.php
+++ b/install/migrations/update_10.0.9_to_10.0.10/ldap_fields.php
@@ -73,6 +73,12 @@ $users = $DB->request([
     'FROM'   => 'glpi_users',
     'WHERE'  => [
         'authtype' => 3,
+        [
+            'OR' => [
+                'user_dn' => ['REGEXP' => '(<|>|(&(?!#?[a-z0-9]+;)))'],
+                'sync_field' => ['REGEXP' => '(<|>|(&(?!#?[a-z0-9]+;)))'],
+            ]
+        ]
     ],
 ]);
 foreach ($users as $user) {


### PR DESCRIPTION
```
PHP Error (1): Allowed memory size of 1073741824 bytes exhausted (tried to allocate 8192 bytes) in
.../src/DBmysql.php at line 570
```

![2023-10-05 13_26_11-Setup GLPI](https://github.com/glpi-project/glpi/assets/8530352/217ecd17-ccb1-41f4-a89a-5cf73b0f03e7)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29888
