### PR TITLE
Trigger a warning when an updatable field does not exist

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -665,9 +665,16 @@ class CommonDBTM extends CommonGLPI
                 }
                 $tobeupdated[$field] = $this->fields[$field];
             } else {
+                trigger_error(
+                    sprintf('The `%s` field cannot be updated as its value is not defined.', $field),
+                    E_USER_WARNING
+                );
                 // Clean oldvalues
                 unset($oldvalues[$field]);
             }
+        }
+        if (count($tobeupdated) === 0) {
+            return false;
         }
         $result = $DB->update(
             $this->getTable(),

--- a/tests/functional/CommonDBTM.php
+++ b/tests/functional/CommonDBTM.php
@@ -954,7 +954,6 @@ class CommonDBTM extends DbTestCase
             ->withType(E_USER_WARNING)
             ->withMessage('The `_not_a_real_field` field cannot be updated as its value is not defined.')
             ->exists();
-
     }
 
     public function testTimezones()

--- a/tests/functional/CommonDBTM.php
+++ b/tests/functional/CommonDBTM.php
@@ -940,6 +940,22 @@ class CommonDBTM extends DbTestCase
         $this->string($computer->fields['name'])->isIdenticalTo('renamed');
     }
 
+    public function testEmptyUpdateInDB()
+    {
+        // Simulate a call to `updateInDB()` that pass an invalid list of fields.
+        // This is only possible if `pre_updateInDB()` modifies the entries of either `$this->updates` and `$this->fields`
+        // and results in having an entry in `$this->updates` that does not corresponds to a valid key of `$this->fields`.
+        $computer = getItemByTypeName(\Computer::class, '_test_pc01');
+        $this->when(
+            function () use ($computer) {
+                $this->boolean($computer->updateInDB(['_not_a_real_field']))->isFalse();
+            }
+        )->error()
+            ->withType(E_USER_WARNING)
+            ->withMessage('The `_not_a_real_field` field cannot be updated as its value is not defined.')
+            ->exists();
+
+    }
 
     public function testTimezones()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Alternative to #15709.

When trying to see how to add a test case for #15709, I figured out that a call to `CommonDBTM::updateInDB()` passing a field key that does not actually exists is not supposed to happen. Indeed, `$this->updates` should contains only keys that are existing in `$this->fields` due to the following code: https://github.com/glpi-project/glpi/blob/b46d23510c9a5edb3d85e689d9e8508e2a91ed2f/src/CommonDBTM.php#L1651-L1652

So, if `$this->updates` contains an entry that does not correspond to a valid key in `$this->fields`, it means that `pre_updateInDB()` method of the corresponding item probably does something wrong.