### PR TITLE
Fix migration on MySQL 5.7

### DIFF
--- a/install/migrations/update_10.0.9_to_10.0.10/ldap_fields.php
+++ b/install/migrations/update_10.0.9_to_10.0.10/ldap_fields.php
@@ -75,8 +75,9 @@ $users = $DB->request([
         'authtype' => 3,
         [
             'OR' => [
-                'user_dn' => ['REGEXP', '(<|>|(&(?!#?[a-z0-9]+;)))'],
-                'sync_field' => ['REGEXP', '(<|>|(&(?!#?[a-z0-9]+;)))'],
+                // only a pre-filter, MySQL 5.7 does not support the complex regex used in PHP
+                'user_dn' => ['REGEXP', '(<|>|&)'],
+                'sync_field' => ['REGEXP', '(<|>|&)'],
             ]
         ]
     ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Follows #15733.
Fixes `` SQL Error "1139": Got error 'repetition-operator operand invalid' from regexp in query "SELECT `glpi_users`.`id`, `glpi_users`.`user_dn`, `glpi_users`.`sync_field` FROM `glpi_users` WHERE `authtype` = '3' AND ((`user_dn` REGEXP '(<|>|(&(?!#?[a-z0-9]+;)))' OR `sync_field` REGEXP '(<|>|(&(?!#?[a-z0-9]+;)))'))" ``.