### PR TITLE
fix(planning): All users of a group restriction

### DIFF
--- a/src/Planning.php
+++ b/src/Planning.php
@@ -1313,7 +1313,7 @@ JAVASCRIPT;
     {
         echo Group::getTypeName(1) . " : <br>";
 
-        $condition = ['is_task' => 1];
+        $condition = [];
        // filter groups
         if (!Session::haveRight('planning', self::READALL)) {
             $condition['id'] = $_SESSION['glpigroups'];


### PR DESCRIPTION
On the planning screen, when you wanted to add all the users in a group, the group dropdown filtered to display only those groups that could have tasks, whereas it wasn't the group you were adding, but just its members.

![image](https://github.com/glpi-project/glpi/assets/8530352/a44df1b2-f28c-4bae-8fb7-7cc762256b6d)

![image_paste9554390](https://github.com/glpi-project/glpi/assets/8530352/6eb5ef20-0eff-4c0a-8c70-03e36d7d223d)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29922
