### PR TITLE
fix(Inventory): purge useless Domain instead of delete it

### DIFF
--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -753,7 +753,7 @@ abstract class MainAsset extends InventoryAsset
                     'is_dynamic' => 1,
                     ['NOT' => ['domains_id' => $domain->getID()]]
                 ],
-                0,
+                1,
                 0
             );
         }

--- a/tests/functional/Glpi/Inventory/Assets/Computer.php
+++ b/tests/functional/Glpi/Inventory/Assets/Computer.php
@@ -1540,8 +1540,7 @@ class Computer extends AbstractInventoryAsset
         //check relation has been created - and there is only one remaining
         $domain_item = new \Domain_Item();
         $this->boolean($domain_item->getFromDBByCrit(['domains_id' => $domain->fields['id']]))->isTrue();
-        $this->boolean($domain_item->getFromDBByCrit(['domains_id' => $first_id]))->isTrue();
-        $this->boolean($domain_item->getFromDBByCrit(['domains_id' => $first_id, 'is_deleted' => 1]))->isTrue();
+        $this->boolean($domain_item->getFromDBByCrit(['domains_id' => $first_id]))->isFalse();
 
         //check if one has been added non dynamic
         $ndyn_domain = new \Domain();


### PR DESCRIPTION
Currently, when a domain disappears from the inventory file
it is only deleted (and visible in the "Lock" tab)

It should be purged immediately

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29950
