### PR TITLE
fix(Rule): do not import as refused equipement if rule denied with  no log

### DIFF
--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -583,7 +583,7 @@ abstract class MainAsset extends InventoryAsset
                     //Only main item is stored as refused, not all APs
                     unset($this->data[$key]);
                 } else {
-                    if (!$datarules['action'] == RuleImportAsset::LINK_RESULT_DENIED) {
+                    if ($datarules['action'] != RuleImportAsset::LINK_RESULT_DENIED) {
                         $input['rules_id'] = $datarules['rules_id'];
                         $this->addRefused($input);
                     }

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -54,7 +54,6 @@ use RuleImportEntityCollection;
 use RuleLocationCollection;
 use RuleMatchedLog;
 use stdClass;
-use Toolbox;
 use Transfer;
 
 abstract class MainAsset extends InventoryAsset

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -48,11 +48,13 @@ use Glpi\Toolbox\Sanitizer;
 use NetworkEquipment;
 use Printer;
 use RefusedEquipment;
+use RuleImportAsset;
 use RuleImportAssetCollection;
 use RuleImportEntityCollection;
 use RuleLocationCollection;
 use RuleMatchedLog;
 use stdClass;
+use Toolbox;
 use Transfer;
 
 abstract class MainAsset extends InventoryAsset
@@ -581,8 +583,10 @@ abstract class MainAsset extends InventoryAsset
                     //Only main item is stored as refused, not all APs
                     unset($this->data[$key]);
                 } else {
-                    $input['rules_id'] = $datarules['rules_id'];
-                    $this->addRefused($input);
+                    if (!$datarules['action'] == RuleImportAsset::LINK_RESULT_DENIED) {
+                        $input['rules_id'] = $datarules['rules_id'];
+                        $this->addRefused($input);
+                    }
                 }
             }
         }

--- a/src/RuleImportAsset.php
+++ b/src/RuleImportAsset.php
@@ -922,8 +922,13 @@ class RuleImportAsset extends Rule
 
         if (count($this->actions)) {
             foreach ($this->actions as $action) {
-                if ($action->fields['field'] == '_ignore_import' || $action->fields["value"] == self::RULE_ACTION_DENIED) {
+                if ($action->fields["value"] == self::RULE_ACTION_DENIED) {
                     $output['action'] = self::LINK_RESULT_DENIED;
+                    return $output;
+                }
+
+                if ($action->fields['field'] == '_ignore_import') {
+                    $output['action'] = self::LINK_RESULT_CREATE;
                     return $output;
                 }
 

--- a/templates/pages/admin/inventory/upload_result.html.twig
+++ b/templates/pages/admin/inventory/upload_result.html.twig
@@ -67,14 +67,19 @@
                                     </span>
                                 </td>
                                 <td>
-                                    {% for item in result['items'] %}
-                                        <div>
-                                            <span>
-                                            <i class="{{ item.getIcon() }}"></i>
-                                            {{ get_item_link(item) }}
-                                            </span>
-                                        </div>
-                                    {% endfor %}
+                                    {% if result['items'] is empty %}
+                                        {{ __('Import denied (no log)') }}
+                                    {% else %}
+                                        {% for item in result['items'] %}
+                                            <div>
+                                                <span>
+                                                <i class="{{ item.getIcon() }}"></i>
+                                                {{ get_item_link(item) }}
+                                                </span>
+                                            </div>
+                                        {% endfor %}
+                                    {% endif %}
+
                                 </td>
                             </tr>
                             {% endfor %}

--- a/tests/functional/Glpi/Inventory/Inventory.php
+++ b/tests/functional/Glpi/Inventory/Inventory.php
@@ -4319,7 +4319,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         $this->integer(
             $rulecriteria->add([
                 'rules_id'  => $rules_id,
-                'criteria'  => "name",
+                'criteria'  => "deviceid",
                 'pattern'   => "/^glpixps.*/",
                 'condition' => \RuleImportEntity::REGEX_MATCH
             ])


### PR DESCRIPTION
```RuleAction``` ```import denied (no log)``` should not add the asset to ```RefusedEquipment```
 
![image](https://github.com/glpi-project/glpi/assets/7335054/06830c6a-f915-42b7-9366-0f4050187135)


```RuleAction``` ```Refused import -> assign -> yes``` should add the asset to ```RefusedEquipment``` (currently the case)

![image](https://github.com/glpi-project/glpi/assets/7335054/9894c143-d123-4951-8014-f7e2c200b2c9)


This PR fix ```import denied (no log)``` action

Fix form for importing inventory files (massively)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29952
