### PR TITLE
fix: Adds a "disabled" option to the dashboard preferences for tickets

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -1499,7 +1499,7 @@ class Config extends CommonDBTM
                 'value' => $data['default_dashboard_mini_ticket'],
                 'display_emptychoice' => true,
                 'context'   => 'mini_core',
-            ]);
+            ], true);
             echo "</td></tr>";
         }
 

--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -1493,7 +1493,7 @@ HTML;
     }
 
 
-    public static function dropdownDashboard(string $name = "", array $params = [], bool $disabledOption = false): string
+    public static function dropdownDashboard(string $name = "", array $params = [], bool $disabled_option = false): string
     {
         $to_show = Dashboard::getAll(false, true, $params['context'] ?? 'core');
         $can_view_all = $params['can_view_all'] ?? false;
@@ -1505,7 +1505,7 @@ HTML;
             }
         }
 
-        if ($disabledOption) {
+        if ($disabled_option) {
             $options_dashboards = ['disabled' => __('Disabled')] + $options_dashboards;
         }
 

--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -1458,6 +1458,11 @@ HTML;
         $config_key = 'default_dashboard_' . $menu;
         $default    = $_SESSION["glpi$config_key"] ?? "";
         if (strlen($default)) {
+            // If default is "disabled", return empty string and skip default value from config
+            if ($default == 'disabled') {
+                return "";
+            }
+
             $dasboard = new Dashboard($default);
 
             if ($dasboard->load() && $dasboard->canViewCurrent()) {
@@ -1488,7 +1493,7 @@ HTML;
     }
 
 
-    public static function dropdownDashboard(string $name = "", array $params = []): string
+    public static function dropdownDashboard(string $name = "", array $params = [], bool $disabledOption = false): string
     {
         $to_show = Dashboard::getAll(false, true, $params['context'] ?? 'core');
         $can_view_all = $params['can_view_all'] ?? false;
@@ -1498,6 +1503,10 @@ HTML;
             if (self::canViewSpecificicDashboard($key, $can_view_all)) {
                 $options_dashboards[$key] = $dashboard['name'] ?? $key;
             }
+        }
+
+        if ($disabledOption) {
+            $options_dashboards = ['disabled' => __('Disabled')] + $options_dashboards;
         }
 
         return Dropdown::showFromArray($name, $options_dashboards, $params);


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

Restores the ability for users to disable the mini dashboard at the top of the ticket page. Previously, users could leave the value empty to hide the mini dashboard. However, PR #15382 changed this mechanism, using the empty value to default to the general configuration. This PR introduces a new 'Disabled' option for the 'Default for tickets (mini dashboard)' setting in user preferences, reinstating the ability for users to hide the mini dashboard if desired.

![image](https://github.com/glpi-project/glpi/assets/42278610/95420613-8335-4871-9243-2aab3ae85b88)
