### PR TITLE
fix(core) fix rediction with inventory import

### DIFF
--- a/templates/pages/admin/inventory/upload_result.html.twig
+++ b/templates/pages/admin/inventory/upload_result.html.twig
@@ -43,7 +43,7 @@
                         </span>
                     </div>
                     <div class='btn-group flex-wrap mb-3 ms-2'>
-                        <a href="{{ url("front/inventory.conf.php") }}" class="btn btn-primary">
+                        <a href="../front/inventory.conf.php" class="btn btn-primary">
                         <i class='fas fa-backward fa-lg me-2'></i>
                             {{ __('Back') }}
                         </a>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

If the directory in which the glpi is located is not called "glpi", but something else like here: "10.0bugfixes". When pressing the "Back" button on the page following the data import via inventory, the redirection fails.
![image](https://github.com/glpi-project/glpi/assets/107540223/b1f8f73a-fa8f-440f-a3cc-316dc7e32a40)
![image](https://github.com/glpi-project/glpi/assets/107540223/ae6f6056-04b6-4877-b653-a3661fb3da16)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2f262e0</samp>

Fix back button bug in inventory upload result page. Use relative paths instead of `url` function in `templates/pages/admin/inventory/upload_result.html.twig`.