### PR TITLE
reorder save button

### DIFF
--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -139,12 +139,6 @@
                   </button>
                {% endif %}
 
-               {% if canupdate %}
-                  {{ include('components/form/single-action.html.twig', {
-                     'onlyicon': true
-                  }) }}
-               {% endif %}
-
                {% if item.canDeleteItem() %}
                   {% if item.isDeleted() %}
                      <button class="btn btn-outline-secondary" type="submit" name="restore" form="itil-form"
@@ -166,6 +160,12 @@
                         <i class="ti ti-trash"></i>
                      </button>
                   {% endif %}
+               {% endif %}
+
+               {% if canupdate %}
+                  {{ include('components/form/single-action.html.twig', {
+                     'onlyicon': true
+                  }) }}
                {% endif %}
             </div>
 

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -129,6 +129,22 @@
          {% else %}
 
             <div class="btn-group" role="group" id="right-actions">
+               {% set is_locked = params['locked'] is defined and params['locked'] %}
+               {% set display_save_btn = not is_locked and (canupdate or can_requester or canpriority or canassign or canassigntome) %}
+               {% if display_save_btn %}
+                  <button class="btn btn-primary" type="submit" name="update" form="itil-form"
+                        title="{{ _x('button', 'Save') }}">
+                     <i class="far fa-save"></i>
+                     <span class="d-none d-xl-block">{{ _x('button', 'Save') }}</span>
+                  </button>
+               {% endif %}
+
+               {% if canupdate %}
+                  {{ include('components/form/single-action.html.twig', {
+                     'onlyicon': true
+                  }) }}
+               {% endif %}
+
                {% if item.canDeleteItem() %}
                   {% if item.isDeleted() %}
                      <button class="btn btn-outline-secondary" type="submit" name="restore" form="itil-form"
@@ -150,22 +166,6 @@
                         <i class="ti ti-trash"></i>
                      </button>
                   {% endif %}
-               {% endif %}
-
-               {% if canupdate %}
-                  {{ include('components/form/single-action.html.twig', {
-                     'onlyicon': true
-                  }) }}
-               {% endif %}
-
-               {% set is_locked = params['locked'] is defined and params['locked'] %}
-               {% set display_save_btn = not is_locked and (canupdate or can_requester or canpriority or canassign or canassigntome) %}
-               {% if display_save_btn %}
-                  <button class="btn btn-primary" type="submit" name="update" form="itil-form"
-                        title="{{ _x('button', 'Save') }}">
-                     <i class="far fa-save"></i>
-                     <span class="d-none d-xl-block">{{ _x('button', 'Save') }}</span>
-                  </button>
                {% endif %}
             </div>
 


### PR DESCRIPTION
See https://github.com/glpi-project/glpi/pull/15725

Moves the save button to 1st, to allow saving via the enter key.
Previously, when a text input was validated via the enter key, the ticket was deleted, as it was the 1st submit of the form.

Before:
![image](https://github.com/glpi-project/glpi/assets/8530352/11ee14a3-5f94-4dad-9610-5e975677c1b8)

After:
![image](https://github.com/glpi-project/glpi/assets/8530352/e32103a2-1c32-407a-8fac-9e3acd12c6e9)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
