### PR TITLE
use internal auth for webhook api access

### DIFF
--- a/src/Api/HL/Middleware/InternalAuthMiddleware.php
+++ b/src/Api/HL/Middleware/InternalAuthMiddleware.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Api\HL\Middleware;
+
+/**
+ * This middleware is not loaded by default when using the API.
+ * It may be manually added on the Router instance in cases where GLPI itself needs to access the API.
+ * If a user is already logged in, this middleware will allow the request to continue.
+ */
+class InternalAuthMiddleware extends AbstractMiddleware implements AuthMiddlewareInterface
+{
+    public function process(MiddlewareInput $input, callable $next): void
+    {
+        if (\Session::getLoginUserID()) {
+            $input->response = null;
+        } else {
+            $next($input);
+        }
+    }
+}

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -455,9 +455,9 @@ class Webhook extends CommonDBTM implements FilterableInterface
     private function getAPIResponse(string $path): ?array
     {
         $router = Router::getInstance();
+        $router->registerAuthMiddleware(new \Glpi\Api\HL\Middleware\InternalAuthMiddleware());
         $path = rtrim($path, '/');
         $request = new Request('GET', $path);
-        $request = $request->withHeader('Glpi-Session-Token', $_SESSION['valid_id']);
         $response = $router->handleRequest($request);
         if ($response->getStatusCode() === 200) {
             $body = (string)$response->getBody();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Session-based authentication is no longer supported with the new API, but the webhook feature was still trying to use it to authenticate when directly interfacing with the API.
To handle such cases of GLPI accessing its own API internally, I've added a new Auth middleware that isn't loaded by default which "authenticates" the API request as long as a user is logged into the session. This bypasses the default OAuth authentication feature in the API.