### PR TITLE
Remove `GLPI_CONFIG_DIR` write access from mandatory requirements

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -65,12 +65,21 @@ $GLPI_CACHE = $cache_manager->getCoreCacheInstance();
 
 Config::detectRootDoc();
 
-if (!isset($skip_db_check) && !file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
+if ($skip_db_check ?? false) {
+    $missing_db_config = false;
+} elseif (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
+    $missing_db_config = true;
+} else {
+    include_once(GLPI_CONFIG_DIR . "/config_db.php");
+    $missing_db_config = !class_exists('DB', false);
+}
+
+if ($missing_db_config) {
     Session::loadLanguage('', false);
 
     // no translation
     $title_text        = 'GLPI seems to not be configured properly.';
-    $missing_conf_text = sprintf('Database configuration file "%s" is missing.', GLPI_CONFIG_DIR . '/config_db.php');
+    $missing_conf_text = sprintf('Database configuration file "%s" is missing or is corrupted.', GLPI_CONFIG_DIR . '/config_db.php');
     $hint_text         = 'You have to either restart the install process, either restore this file.';
 
     if (!isCommandLine()) {

--- a/install/install.php
+++ b/install/install.php
@@ -133,17 +133,20 @@ function step0()
 //Step 1 checking some compatibility issue and some write tests.
 function step1($update)
 {
-    $config_write_failed  = !Filesystem::canWriteFile(GLPI_CONFIG_DIR . '/config_db.php');
-    $glpikey_write_failed = $update === 'yes' && (new GLPIKey())->keyExists()
-        ? false // no need to have write access on update if key already exists
-        : !Filesystem::canWriteFile(GLPI_CONFIG_DIR . '/glpicrypt.key');
+    $config_files_to_update = [
+        GLPI_CONFIG_DIR . DIRECTORY_SEPARATOR . 'config_db.php',
+    ];
+    if ($update !== 'yes' || !(new GLPIKey())->keyExists()) {
+        $config_files_to_update[] = GLPI_CONFIG_DIR . DIRECTORY_SEPARATOR . 'glpicrypt.key';
+    }
+    $config_write_denied = !Filesystem::canWriteFiles($config_files_to_update);
     $requiremements      = (new RequirementsManager())->getCoreRequirementList();
 
     TemplateRenderer::getInstance()->display('install/step1.html.twig', [
-        'update'                => $update,
-        'config_write_failed'   => $config_write_failed,
-        'glpikey_write_failed'  => $glpikey_write_failed,
-        'requirements'          => $requiremements,
+        'update'                 => $update,
+        'config_write_denied'    => $config_write_denied,
+        'config_files_to_update' => $config_files_to_update,
+        'requirements'           => $requiremements,
     ]);
 }
 

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -41,9 +41,11 @@ use DBmysql;
 use GLPI;
 use Glpi\Application\ErrorHandler;
 use Glpi\Cache\CacheManager;
+use Glpi\Console\Command\ConfigurationCommandInterface;
 use Glpi\Console\Command\ForceNoPluginsOptionCommandInterface;
 use Glpi\Console\Command\GlpiCommandInterface;
 use Glpi\System\RequirementsManager;
+use Glpi\Toolbox\Filesystem;
 use Plugin;
 use Session;
 use Symfony\Component\Console\Application as BaseApplication;
@@ -67,6 +69,13 @@ class Application extends BaseApplication
      * @var integer
      */
     const ERROR_MISSING_REQUIREMENTS = 128; // start application codes at 128 be sure to be different from commands codes
+
+    /**
+     * Error code returned if write access to configuration files is denied.
+     *
+     * @var integer
+     */
+    const ERROR_CONFIG_WRITE_ACCESS_DENIED = 129;
 
     /**
      * Error code returned when DB is not up-to-date.
@@ -266,6 +275,10 @@ class Application extends BaseApplication
             && !$this->checkCoreMandatoryRequirements()
         ) {
             return self::ERROR_MISSING_REQUIREMENTS;
+        }
+
+        if (!$this->checkConfigWriteAccess($command, $input)) {
+            return self::ERROR_CONFIG_WRITE_ACCESS_DENIED;
         }
 
         try {
@@ -511,6 +524,40 @@ class Application extends BaseApplication
                 . sprintf(__('Run the "%1$s" command for more details.'), 'php bin/console system:check_requirements');
             $this->output->writeln(
                 '<error>' . $message . '</error>',
+                OutputInterface::VERBOSITY_QUIET
+            );
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check potentially required write access to configuration files.
+     *
+     * @param Command $command
+     * @param InputInterface $input
+     *
+     * @return bool
+     */
+    private function checkConfigWriteAccess(Command $command, InputInterface $input): bool
+    {
+        if (!($command instanceof ConfigurationCommandInterface)) {
+            return true;
+        }
+
+        $config_files_to_update = array_map(
+            function ($path) {
+                return GLPI_CONFIG_DIR . DIRECTORY_SEPARATOR . $path;
+            },
+            $command->getConfigurationFilesToUpdate($input)
+        );
+        if (!Filesystem::canWriteFiles($config_files_to_update)) {
+            $this->output->writeln(
+                [
+                    '<error>' . sprintf(__('A temporary write access to the following files is required: %s.'), '`' . implode('`, `', $config_files_to_update) . '`') . '</error>',
+                    '<error>' . __('Write access to these files can be removed once the operation is finished.') . '</error>',
+                ],
                 OutputInterface::VERBOSITY_QUIET
             );
             return false;

--- a/src/Console/Cache/ConfigureCommand.php
+++ b/src/Console/Cache/ConfigureCommand.php
@@ -37,6 +37,7 @@ namespace Glpi\Console\Cache;
 
 use Glpi\Cache\CacheManager;
 use Glpi\Console\AbstractCommand;
+use Glpi\Console\Command\ConfigurationCommandInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -44,7 +45,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @since 10.0.0
  */
-class ConfigureCommand extends AbstractCommand
+class ConfigureCommand extends AbstractCommand implements ConfigurationCommandInterface
 {
     /**
      * Error code returned if cache configuration file cannot be write.
@@ -202,5 +203,10 @@ class ConfigureCommand extends AbstractCommand
         );
 
         return 0; // Success
+    }
+
+    public function getConfigurationFilesToUpdate(InputInterface $input): array
+    {
+        return [$this->cache_manager::CONFIG_FILENAME];
     }
 }

--- a/src/Console/Cache/SetNamespacePrefixCommand.php
+++ b/src/Console/Cache/SetNamespacePrefixCommand.php
@@ -37,6 +37,7 @@ namespace Glpi\Console\Cache;
 
 use Glpi\Cache\CacheManager;
 use Glpi\Console\AbstractCommand;
+use Glpi\Console\Command\ConfigurationCommandInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -44,7 +45,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @since 10.0.0
  */
-class SetNamespacePrefixCommand extends AbstractCommand
+class SetNamespacePrefixCommand extends AbstractCommand implements ConfigurationCommandInterface
 {
     /**
      * Error code returned if cache configuration file cannot be write.
@@ -98,5 +99,10 @@ class SetNamespacePrefixCommand extends AbstractCommand
         );
 
         return 0; // Success
+    }
+
+    public function getConfigurationFilesToUpdate(InputInterface $input): array
+    {
+        return [$this->cache_manager::CONFIG_FILENAME];
     }
 }

--- a/src/Console/Command/ConfigurationCommandInterface.php
+++ b/src/Console/Command/ConfigurationCommandInterface.php
@@ -33,33 +33,19 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Console\Database;
+namespace Glpi\Console\Command;
 
-use Glpi\Console\Command\ConfigurationCommandInterface;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 
-class ConfigureCommand extends AbstractConfigureCommand implements ConfigurationCommandInterface
+interface ConfigurationCommandInterface
 {
-    protected function configure()
-    {
-
-        parent::configure();
-
-        $this->setName('database:configure');
-        $this->setAliases(['db:configure']);
-        $this->setDescription('Define database configuration');
-    }
-
-    protected function execute(InputInterface $input, OutputInterface $output)
-    {
-        $this->configureDatabase($input, $output);
-
-        return 0; // Success if configuration throw no EarlyExitException
-    }
-
-    public function getConfigurationFilesToUpdate(InputInterface $input): array
-    {
-        return ['config_db.php'];
-    }
+    /**
+     * Defines the list of configuration files that would be updated by the command.
+     * Files path must be relative to `GLPI_CONFIG_DIR`.
+     *
+     * @param InputInterface $input
+     *
+     * @return array
+     */
+    public function getConfigurationFilesToUpdate(InputInterface $input): array;
 }

--- a/src/Console/Database/EnableTimezonesCommand.php
+++ b/src/Console/Database/EnableTimezonesCommand.php
@@ -37,11 +37,12 @@ namespace Glpi\Console\Database;
 
 use DBConnection;
 use Glpi\Console\AbstractCommand;
+use Glpi\Console\Command\ConfigurationCommandInterface;
 use Glpi\System\Requirement\DbTimezones;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class EnableTimezonesCommand extends AbstractCommand
+class EnableTimezonesCommand extends AbstractCommand implements ConfigurationCommandInterface
 {
     /**
      * Error code returned if DB configuration file cannot be updated.
@@ -108,5 +109,14 @@ class EnableTimezonesCommand extends AbstractCommand
         $output->writeln('<info>' . __('Timezone usage has been enabled.') . '</info>');
 
         return 0; // Success
+    }
+
+    public function getConfigurationFilesToUpdate(InputInterface $input): array
+    {
+        $config_files_to_update = ['config_db.php'];
+        if (file_exists(GLPI_CONFIG_DIR . '/config_db_slave.php')) {
+            $config_files_to_update[] = 'config_db_slave.php';
+        }
+        return $config_files_to_update;
     }
 }

--- a/src/Console/Database/InstallCommand.php
+++ b/src/Console/Database/InstallCommand.php
@@ -38,6 +38,7 @@ namespace Glpi\Console\Database;
 use DBConnection;
 use DBmysql;
 use Glpi\Cache\CacheManager;
+use Glpi\Console\Command\ConfigurationCommandInterface;
 use Glpi\Console\Traits\TelemetryActivationTrait;
 use Glpi\System\Requirement\DbConfiguration;
 use GLPIKey;
@@ -47,7 +48,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Toolbox;
 
-class InstallCommand extends AbstractConfigureCommand
+class InstallCommand extends AbstractConfigureCommand implements ConfigurationCommandInterface
 {
     use TelemetryActivationTrait;
 
@@ -319,6 +320,17 @@ class InstallCommand extends AbstractConfigureCommand
         $this->handTelemetryActivation($input, $output);
 
         return 0; // Success
+    }
+
+    public function getConfigurationFilesToUpdate(InputInterface $input): array
+    {
+        $config_files_to_update = [
+            'glpicrypt.key', // key is regenerated everytime
+        ];
+        if (!$this->isDbAlreadyConfigured() || $input->hasParameterOption('--reconfigure', true)) {
+            $config_files_to_update[] = 'config_db.php';
+        }
+        return $config_files_to_update;
     }
 
     /**

--- a/src/Console/Database/UpdateCommand.php
+++ b/src/Console/Database/UpdateCommand.php
@@ -37,11 +37,13 @@ namespace Glpi\Console\Database;
 
 use Glpi\Cache\CacheManager;
 use Glpi\Console\AbstractCommand;
+use Glpi\Console\Command\ConfigurationCommandInterface;
 use Glpi\Console\Command\ForceNoPluginsOptionCommandInterface;
 use Glpi\Console\Traits\TelemetryActivationTrait;
 use Glpi\System\Diagnostic\DatabaseSchemaIntegrityChecker;
 use Glpi\Toolbox\DatabaseSchema;
 use Glpi\Toolbox\VersionParser;
+use GLPIKey;
 use Migration;
 use Session;
 use Symfony\Component\Console\Helper\Table;
@@ -50,7 +52,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Update;
 
-class UpdateCommand extends AbstractCommand implements ForceNoPluginsOptionCommandInterface
+class UpdateCommand extends AbstractCommand implements ConfigurationCommandInterface, ForceNoPluginsOptionCommandInterface
 {
     use TelemetryActivationTrait;
 
@@ -336,5 +338,14 @@ class UpdateCommand extends AbstractCommand implements ForceNoPluginsOptionComma
         }
 
         return $version_cleaned;
+    }
+
+    public function getConfigurationFilesToUpdate(InputInterface $input): array
+    {
+        if (!(new GLPIKey())->keyExists()) {
+            return ['glpicrypt.key'];
+        }
+
+        return [];
     }
 }

--- a/src/Console/Migration/MigrateAllCommand.php
+++ b/src/Console/Migration/MigrateAllCommand.php
@@ -36,11 +36,12 @@
 namespace Glpi\Console\Migration;
 
 use Glpi\Console\AbstractCommand;
+use Glpi\Console\Command\ConfigurationCommandInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\ArrayInput;
 
-class MigrateAllCommand extends AbstractCommand
+class MigrateAllCommand extends AbstractCommand implements ConfigurationCommandInterface
 {
     protected function configure()
     {
@@ -85,5 +86,14 @@ class MigrateAllCommand extends AbstractCommand
         }
 
         return self::SUCCESS;
+    }
+
+    public function getConfigurationFilesToUpdate(InputInterface $input): array
+    {
+        $config_files_to_update = ['config_db.php'];
+        if (file_exists(GLPI_CONFIG_DIR . '/config_db_slave.php')) {
+            $config_files_to_update[] = 'config_db_slave.php';
+        }
+        return $config_files_to_update;
     }
 }

--- a/src/Console/Migration/MyIsamToInnoDbCommand.php
+++ b/src/Console/Migration/MyIsamToInnoDbCommand.php
@@ -37,10 +37,11 @@ namespace Glpi\Console\Migration;
 
 use DBConnection;
 use Glpi\Console\AbstractCommand;
+use Glpi\Console\Command\ConfigurationCommandInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class MyIsamToInnoDbCommand extends AbstractCommand
+class MyIsamToInnoDbCommand extends AbstractCommand implements ConfigurationCommandInterface
 {
     /**
      * Error code returned when failed to migrate one table.
@@ -132,5 +133,14 @@ class MyIsamToInnoDbCommand extends AbstractCommand
         }
 
         return 0; // Success
+    }
+
+    public function getConfigurationFilesToUpdate(InputInterface $input): array
+    {
+        $config_files_to_update = ['config_db.php'];
+        if (file_exists(GLPI_CONFIG_DIR . '/config_db_slave.php')) {
+            $config_files_to_update[] = 'config_db_slave.php';
+        }
+        return $config_files_to_update;
     }
 }

--- a/src/Console/Migration/TimestampsCommand.php
+++ b/src/Console/Migration/TimestampsCommand.php
@@ -37,11 +37,12 @@ namespace Glpi\Console\Migration;
 
 use DBConnection;
 use Glpi\Console\AbstractCommand;
+use Glpi\Console\Command\ConfigurationCommandInterface;
 use Glpi\System\Requirement\DbTimezones;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class TimestampsCommand extends AbstractCommand
+class TimestampsCommand extends AbstractCommand implements ConfigurationCommandInterface
 {
     /**
      * Error code returned when failed to migrate one table.
@@ -237,5 +238,14 @@ class TimestampsCommand extends AbstractCommand
         }
 
         return 0; // Success
+    }
+
+    public function getConfigurationFilesToUpdate(InputInterface $input): array
+    {
+        $config_files_to_update = ['config_db.php'];
+        if (file_exists(GLPI_CONFIG_DIR . '/config_db_slave.php')) {
+            $config_files_to_update[] = 'config_db_slave.php';
+        }
+        return $config_files_to_update;
     }
 }

--- a/src/Console/Migration/UnsignedKeysCommand.php
+++ b/src/Console/Migration/UnsignedKeysCommand.php
@@ -37,11 +37,12 @@ namespace Glpi\Console\Migration;
 
 use DBConnection;
 use Glpi\Console\AbstractCommand;
+use Glpi\Console\Command\ConfigurationCommandInterface;
 use Plugin;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class UnsignedKeysCommand extends AbstractCommand
+class UnsignedKeysCommand extends AbstractCommand implements ConfigurationCommandInterface
 {
     /**
      * Error code returned when failed to migrate one column.
@@ -269,5 +270,14 @@ class UnsignedKeysCommand extends AbstractCommand
         }
 
         return 0; // Success
+    }
+
+    public function getConfigurationFilesToUpdate(InputInterface $input): array
+    {
+        $config_files_to_update = ['config_db.php'];
+        if (file_exists(GLPI_CONFIG_DIR . '/config_db_slave.php')) {
+            $config_files_to_update[] = 'config_db_slave.php';
+        }
+        return $config_files_to_update;
     }
 }

--- a/src/Console/Migration/Utf8mb4Command.php
+++ b/src/Console/Migration/Utf8mb4Command.php
@@ -37,11 +37,12 @@ namespace Glpi\Console\Migration;
 
 use DBConnection;
 use Glpi\Console\AbstractCommand;
+use Glpi\Console\Command\ConfigurationCommandInterface;
 use Glpi\System\Requirement\DbConfiguration;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class Utf8mb4Command extends AbstractCommand
+class Utf8mb4Command extends AbstractCommand implements ConfigurationCommandInterface
 {
     /**
      * Error code returned if migration failed on, at least, one table.
@@ -200,5 +201,14 @@ class Utf8mb4Command extends AbstractCommand
         if (count($tables) > 0) {
             $this->output->writeln('<info>' . __('Migration done.') . '</info>');
         }
+    }
+
+    public function getConfigurationFilesToUpdate(InputInterface $input): array
+    {
+        $config_files_to_update = ['config_db.php'];
+        if (file_exists(GLPI_CONFIG_DIR . '/config_db_slave.php')) {
+            $config_files_to_update[] = 'config_db_slave.php';
+        }
+        return $config_files_to_update;
     }
 }

--- a/src/Console/Security/ChangekeyCommand.php
+++ b/src/Console/Security/ChangekeyCommand.php
@@ -36,11 +36,12 @@
 namespace Glpi\Console\Security;
 
 use Glpi\Console\AbstractCommand;
+use Glpi\Console\Command\ConfigurationCommandInterface;
 use GLPIKey;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ChangekeyCommand extends AbstractCommand
+class ChangekeyCommand extends AbstractCommand implements ConfigurationCommandInterface
 {
     /**
      * Error code returned when unable to renew key.
@@ -92,5 +93,10 @@ class ChangekeyCommand extends AbstractCommand
         $output->writeln('<info>' . __('New security key generated; database updated.') . '</info>');
 
         return 0; // Success
+    }
+
+    public function getConfigurationFilesToUpdate(InputInterface $input): array
+    {
+        return ['glpicrypt.key'];
     }
 }

--- a/src/System/Variables.php
+++ b/src/System/Variables.php
@@ -49,7 +49,6 @@ class Variables
     {
         return [
             'GLPI_CACHE_DIR',
-            'GLPI_CONFIG_DIR',
             'GLPI_CRON_DIR',
             'GLPI_DOC_DIR',
             'GLPI_DUMP_DIR',

--- a/src/Toolbox/Filesystem.php
+++ b/src/Toolbox/Filesystem.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Toolbox;
+
+class Filesystem
+{
+    /**
+     * Checks if the file with given path can be written.
+     *
+     * @param string $path
+     *
+     * @return bool
+     */
+    public static function canWriteFile(string $path): bool
+    {
+        if (file_exists($path)) {
+            return is_writable($path);
+        }
+
+        // If the file does not exists, try to create it.
+        $file = @fopen($path, 'c');
+        if ($file === false) {
+            return false;
+        }
+        @fclose($file);
+
+        // Remove the file, as presence of an empty file may not be handled properly.
+        @unlink($path);
+
+        return true;
+    }
+}

--- a/src/Toolbox/Filesystem.php
+++ b/src/Toolbox/Filesystem.php
@@ -62,4 +62,22 @@ class Filesystem
 
         return true;
     }
+
+    /**
+     * Checks if the files with given paths can be written.
+     *
+     * @param string[] $path
+     *
+     * @return bool
+     */
+    public static function canWriteFiles(array $paths): bool
+    {
+        foreach ($paths as $path) {
+            if (!self::canWriteFile($path)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/templates/install/step1.html.twig
+++ b/templates/install/step1.html.twig
@@ -31,7 +31,7 @@
  # ---------------------------------------------------------------------
  #}
 
-{% if config_write_failed or glpikey_write_failed %}
+{% if config_write_denied %}
     <h3>{{ __("Checking write access to configuration files") }}</h3>
     <div class="alert alert-danger" role="alert">
         <div class="d-flex">
@@ -39,18 +39,11 @@
                 <i class="ti ti-alert-circle me-2"></i>
             </div>
             <div>
-                <h4 class="alert-title">{{ __('Unable to save configuration files') }}</h4>
+                <h4 class="alert-title">{{ __('Write access denied for configuration files') }}</h4>
                 <div class="text-secondary">
-                    {{ __('GLPI must be able to store data into configuration files.') }}<br />
-                    {% if config_write_failed %}
-                        {{ __('The `%s` file will be used to store the database configuration.')|format(constant('GLPI_CONFIG_DIR') ~ constant('DIRECTORY_SEPARATOR') ~ 'config_db.php') }}
-                        <br />
-                    {% endif %}
-                    {% if glpikey_write_failed %}
-                        {{ __('The `%s` file will be used to store the key used to encrypt sensitive data.')|format(constant('GLPI_CONFIG_DIR') ~ constant('DIRECTORY_SEPARATOR') ~ 'glpicrypt.key') }}
-                        <br />
-                    {% endif %}
-                    {{ __('Write access to these files can be removed once the GLPI installation is done.') }}
+                    {{ __('A temporary write access to the following files is required: %s.')|format('`' ~ config_files_to_update|join('`, `') ~ '`') }}
+                    <br />
+                    {{ __('Write access to these files can be removed once the operation is finished.') }}
                 </div>
             </div>
         </div>
@@ -90,7 +83,7 @@
    </form>
 {% endset %}
 
-{% if config_write_failed or glpikey_write_failed or requirements.hasMissingMandatoryRequirements() %}
+{% if config_write_denied or requirements.hasMissingMandatoryRequirements() %}
    <h3>{{ __('Do you want to continue?') }}</h3>
    <div class="text-center">
       {{ retry_form }}

--- a/templates/install/step1.html.twig
+++ b/templates/install/step1.html.twig
@@ -31,9 +31,34 @@
  # ---------------------------------------------------------------------
  #}
 
-<h3>{{ __("Checking of the compatibility of your environment with the execution of GLPI") }}</h3>
-
-{{ include('install/blocks/requirements_table.html.twig', {requirements: requirements}, with_context = false) }}
+{% if config_write_failed or glpikey_write_failed %}
+    <h3>{{ __("Checking write access to configuration files") }}</h3>
+    <div class="alert alert-danger" role="alert">
+        <div class="d-flex">
+            <div>
+                <i class="ti ti-alert-circle me-2"></i>
+            </div>
+            <div>
+                <h4 class="alert-title">{{ __('Unable to save configuration files') }}</h4>
+                <div class="text-secondary">
+                    {{ __('GLPI must be able to store data into configuration files.') }}<br />
+                    {% if config_write_failed %}
+                        {{ __('The `%s` file will be used to store the database configuration.')|format(constant('GLPI_CONFIG_DIR') ~ constant('DIRECTORY_SEPARATOR') ~ 'config_db.php') }}
+                        <br />
+                    {% endif %}
+                    {% if glpikey_write_failed %}
+                        {{ __('The `%s` file will be used to store the key used to encrypt sensitive data.')|format(constant('GLPI_CONFIG_DIR') ~ constant('DIRECTORY_SEPARATOR') ~ 'glpicrypt.key') }}
+                        <br />
+                    {% endif %}
+                    {{ __('Write access to these files can be removed once the GLPI installation is done.') }}
+                </div>
+            </div>
+        </div>
+    </div>
+{% else %}
+    <h3>{{ __("Checking of the compatibility of your environment with the execution of GLPI") }}</h3>
+    {{ include('install/blocks/requirements_table.html.twig', {requirements: requirements}, with_context = false) }}
+{% endif %}
 
 {% set common_hiddens %}
    <input type="hidden" name="language" value="{{ session('glpilanguage') }}">
@@ -65,7 +90,7 @@
    </form>
 {% endset %}
 
-{% if requirements.hasMissingMandatoryRequirements() %}
+{% if config_write_failed or glpikey_write_failed or requirements.hasMissingMandatoryRequirements() %}
    <h3>{{ __('Do you want to continue?') }}</h3>
    <div class="text-center">
       {{ retry_form }}

--- a/tests/units/Glpi/Toolbox/Filesystem.php
+++ b/tests/units/Glpi/Toolbox/Filesystem.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Toolbox;
+
+use org\bovigo\vfs\vfsStream;
+
+class Filesystem extends \GLPITestCase
+{
+    public function testCanWriteFile()
+    {
+        $config_dir = vfsStream::setup('config');
+
+        $this->newTestedInstance();
+
+        // Files can be written when they not exists and directory is writable
+        $config_dir->chmod(0700);
+        $this->boolean($this->testedInstance->canWriteFile(vfsStream::url('config/config_db.php')))->isEqualTo(true);
+        $this->boolean($this->testedInstance->canWriteFile(vfsStream::url('config/whatever.yml')))->isEqualTo(true);
+        $this->boolean($this->testedInstance->canWriteFiles([vfsStream::url('config/config_db.php'), vfsStream::url('config/whatever.yml')]))->isEqualTo(true);
+
+        // Files cannot be written when they not exists and directory is not writable
+        $config_dir->chmod(0500);
+        $this->boolean($this->testedInstance->canWriteFile(vfsStream::url('config/config_db.php')))->isEqualTo(false);
+        $this->boolean($this->testedInstance->canWriteFile(vfsStream::url('config/whatever.yml')))->isEqualTo(false);
+        $this->boolean($this->testedInstance->canWriteFiles([vfsStream::url('config/config_db.php'), vfsStream::url('config/whatever.yml')]))->isEqualTo(false);
+
+        // Files cannot be written when they exists but are not writable (even if directory is writable)
+        $config_dir->chmod(0700);
+        $file1 = vfsStream::newFile('config_db.php', 0400)->at($config_dir)->setContent('<?php //my config file');
+        $this->boolean($this->testedInstance->canWriteFile(vfsStream::url('config/config_db.php')))->isEqualTo(false);
+        $this->boolean($this->testedInstance->canWriteFile(vfsStream::url('config/whatever.yml')))->isEqualTo(true);
+        $this->boolean($this->testedInstance->canWriteFiles([vfsStream::url('config/config_db.php'), vfsStream::url('config/whatever.yml')]))->isEqualTo(false);
+
+        // Files can be written when they exists and are writable (even if directory is not writable)
+        $file1->chmod(0600);
+        $this->boolean($this->testedInstance->canWriteFile(vfsStream::url('config/config_db.php')))->isEqualTo(true);
+        $this->boolean($this->testedInstance->canWriteFile(vfsStream::url('config/whatever.yml')))->isEqualTo(true);
+        $this->boolean($this->testedInstance->canWriteFiles([vfsStream::url('config/config_db.php'), vfsStream::url('config/whatever.yml')]))->isEqualTo(true);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14030 !29985

For the moment, `GLPI_CONFIG_DIR` write access is considered as a mandatory requirement, but, for security reasons, one should be able to remove the write access to configuration files once GLPI has been installed/configured.

1. Remove `GLPI_CONFIG_DIR` write access from mandatory requirements

2. Checks that `config_db.php` and `glpicrypt.key` files can be written during installation process. On UI, it is done during the requirements checks.
![image](https://github.com/glpi-project/glpi/assets/33253653/91952ae0-1ee1-4f93-9dee-4eaa1c9dff25)

3. Check config files can be written on CLI commands that requires it.
![image](https://github.com/glpi-project/glpi/assets/33253653/c2316300-1d6e-4406-96a3-1a9da8f97f09)

