### PR TITLE
Enhancing Custom Theme Handling in front/css.php

### DIFF
--- a/front/css.php
+++ b/front/css.php
@@ -62,7 +62,7 @@ ErrorHandler::getInstance()->disableOutput();
 
 // If a custom theme is requested, we need to get the real path of the theme
 if (isset($_GET['file']) && isset($_GET['is_custom_theme']) && $_GET['is_custom_theme']) {
-    $theme = ThemeManager::getInstance()->getTheme(preg_replace('/\.scss$/', '', $_GET['file']));
+    $theme = ThemeManager::getInstance()->getTheme($_GET['file']);
 
     if (!$theme) {
         $theme = ThemeManager::DEFAULT_THEME;

--- a/front/css.php
+++ b/front/css.php
@@ -65,7 +65,7 @@ if (isset($_GET['file']) && isset($_GET['is_custom_theme']) && $_GET['is_custom_
     $theme = ThemeManager::getInstance()->getTheme($_GET['file']);
 
     if (!$theme) {
-        $theme = ThemeManager::DEFAULT_THEME;
+        $theme = ThemeManager::getInstance()->getTheme(ThemeManager::DEFAULT_THEME);
     }
 
     $_GET['file'] = $theme->getPath();

--- a/front/css.php
+++ b/front/css.php
@@ -65,6 +65,7 @@ if (isset($_GET['file']) && isset($_GET['is_custom_theme']) && $_GET['is_custom_
     $theme = ThemeManager::getInstance()->getTheme($_GET['file']);
 
     if (!$theme) {
+        trigger_error(sprintf('Unable to find theme `%s`.', $_GET['file']), E_USER_WARNING);
         $theme = ThemeManager::getInstance()->getTheme(ThemeManager::DEFAULT_THEME);
     }
 

--- a/front/css.php
+++ b/front/css.php
@@ -40,6 +40,7 @@ if (!defined('GLPI_ROOT')) {
 }
 
 use Glpi\Application\ErrorHandler;
+use Glpi\UI\ThemeManager;
 
 $_GET["donotcheckversion"]   = true;
 $dont_check_maintenance_mode = true;
@@ -58,6 +59,17 @@ if (Toolbox::getMemoryLimit() < ($max_memory * 1024 * 1024)) {
 
 // Ensure warnings will not break CSS output.
 ErrorHandler::getInstance()->disableOutput();
+
+// If a custom theme is requested, we need to get the real path of the theme
+if (isset($_GET['file']) && isset($_GET['is_custom_theme']) && $_GET['is_custom_theme']) {
+    $theme = ThemeManager::getInstance()->getTheme(preg_replace('/\.scss$/', '', $_GET['file']));
+
+    if (!$theme) {
+        $theme = ThemeManager::DEFAULT_THEME;
+    }
+
+    $_GET['file'] = $theme->getPath();
+}
 
 $css = Html::compileScss($_GET);
 

--- a/src/Application/View/Extension/FrontEndAssetsExtension.php
+++ b/src/Application/View/Extension/FrontEndAssetsExtension.php
@@ -38,6 +38,7 @@ namespace Glpi\Application\View\Extension;
 use DBmysql;
 use Entity;
 use Glpi\Toolbox\FrontEnd;
+use Glpi\UI\ThemeManager;
 use Html;
 use Plugin;
 use Session;
@@ -99,7 +100,11 @@ class FrontEndAssetsExtension extends AbstractExtension
 
         $extra_params = parse_url($path, PHP_URL_QUERY) ?: '';
 
-        if (preg_match('/\.scss$/', $file_path)) {
+        if (
+            preg_match('/\.scss$/', $file_path)
+            || (strpos($extra_params, 'is_custom_theme=1') !== false
+                && ThemeManager::getInstance()->getTheme($file_path))
+        ) {
             $compiled_file = Html::getScssCompilePath($file_path, $this->root_dir);
 
             if (!$is_debug && file_exists($compiled_file)) {

--- a/src/Html.php
+++ b/src/Html.php
@@ -1255,7 +1255,7 @@ HTML;
         }
 
         if ($theme->isCustomTheme()) {
-            $theme_path = $theme->getKey() . '.scss?is_custom_theme=1';
+            $theme_path = $theme->getKey() . '?is_custom_theme=1';
 
             // Custom theme files might be modified by external source
             $theme_path .= "&lastupdate=" . filemtime($theme->getPath(false));

--- a/src/Html.php
+++ b/src/Html.php
@@ -1254,10 +1254,13 @@ HTML;
             }
         }
 
-        $theme_path = $theme->getPath();
         if ($theme->isCustomTheme()) {
+            $theme_path = $theme->getKey() . '.scss?is_custom_theme=1';
+
             // Custom theme files might be modified by external source
-            $theme_path .= "?lastupdate=" . filemtime($theme->getPath(false));
+            $theme_path .= "&lastupdate=" . filemtime($theme->getPath(false));
+        } else {
+            $theme_path = $theme->getPath();
         }
         $tpl_vars['css_files'][] = ['path' => $theme_path];
 


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

This Pull Request aims to improve the way custom themes are handled in the front/css.php file. Currently, when loading the relative path of the user's theme via front/css.php, it inadvertently exposes sensitive server structure information, which is undesirable.

To address this issue, this modification proposes the addition of a specific parameter is_custom_theme in front/css.php requests. When is_custom_theme is set to 1, GLPI will recognize that the request pertains to a custom theme and will load the theme directly from the correct directory, without exposing internal server paths. This enhancement enhances security by avoiding the disclosure of sensitive information.

Furthermore, this modification opens the door to a second improvement. In the event of an error while loading the custom theme (e.g., due to missing files or invalid SCSS), GLPI will automatically load the default theme. This ensures that users do not end up with a CSS-less GLPI in case of issues, and errors will be logged for later investigation.