### PR TITLE
Add rule criteria to the Rule match Log page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,8 @@ The present file will list all changes made to the project; according to the
 - `RuleCollection::showTestResults()`
 - `RuleImportComputer` class.
 - `RuleImportComputerCollection` class.
+- `RuleMatchedLog::showFormAgent()`.
+- `RuleMatchedLog::showItemForm()`.
 - `Search::computeTitle()`
 - `Search::csv_clean()`
 - `Search::findCriteriaInSession()`

--- a/install/migrations/update_10.0.x_to_10.1.0/rulesmatchedlogs.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/rulesmatchedlogs.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+ $migration->addField('glpi_rulematchedlogs', 'criteria', "text");

--- a/install/migrations/update_10.0.x_to_10.1.0/rulesmatchedlogs.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/rulesmatchedlogs.php
@@ -38,4 +38,4 @@
  * @var Migration $migration
  */
 
- $migration->addField('glpi_rulematchedlogs', 'criteria', "text");
+ $migration->addField('glpi_rulematchedlogs', 'input', 'text');

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9029,7 +9029,7 @@ CREATE TABLE `glpi_rulematchedlogs` (
   `rules_id` int unsigned DEFAULT NULL,
   `agents_id` int unsigned NOT NULL DEFAULT '0',
   `method` varchar(255) DEFAULT NULL,
-  `criteria` text,
+  `input` text,
   PRIMARY KEY (`id`),
   KEY `agents_id` (`agents_id`),
   KEY `item` (`itemtype`,`items_id`),

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9029,6 +9029,7 @@ CREATE TABLE `glpi_rulematchedlogs` (
   `rules_id` int unsigned DEFAULT NULL,
   `agents_id` int unsigned NOT NULL DEFAULT '0',
   `method` varchar(255) DEFAULT NULL,
+  `criteria` text,
   PRIMARY KEY (`id`),
   KEY `agents_id` (`agents_id`),
   KEY `item` (`itemtype`,`items_id`),

--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -68,7 +68,7 @@ abstract class InventoryAsset
     /** @var array */
     protected $rulelocation_data = [];
     /** @var array */
-    protected array $rulematchedlog_data = [];
+    protected array $rulematchedlog_input = [];
     /** @var boolean */
     protected $links_handled = false;
     /** @var boolean */

--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -67,6 +67,8 @@ abstract class InventoryAsset
     protected $ruleentity_data = [];
     /** @var array */
     protected $rulelocation_data = [];
+    /** @var array */
+    protected array $rulematchedlog_data = [];
     /** @var boolean */
     protected $links_handled = false;
     /** @var boolean */

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -573,6 +573,8 @@ abstract class MainAsset extends InventoryAsset
                     $this->rulelocation_data['locations_id'] = $dataLocation['locations_id'];
                 }
             }
+            // set rulematchedlog_data as $input
+            $this->rulematchedlog_data = $input;
 
             //call rules on current collected data to find item
             //a callback on rulepassed() will be done if one is found.
@@ -915,6 +917,10 @@ abstract class MainAsset extends InventoryAsset
             $this->handleAssets();
         }
 
+        // append data from RulematchedLogs
+        $criteria = $this->rulematchedlog_data;
+        $criteria = json_encode($criteria);
+
         $rulesmatched = new RuleMatchedLog();
         $inputrulelog = [
             'date'      => date('Y-m-d H:i:s'),
@@ -922,7 +928,8 @@ abstract class MainAsset extends InventoryAsset
             'items_id'  => $items_id,
             'itemtype'  => $itemtype,
             'agents_id' => $this->agent->fields['id'],
-            'method'    => $this->request_query ?? Request::INVENT_QUERY
+            'method'    => $this->request_query ?? Request::INVENT_QUERY,
+            'criteria'  => $criteria
         ];
         $rulesmatched->add($inputrulelog, [], false);
         $rulesmatched->cleanOlddata($items_id, $itemtype);

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -573,8 +573,9 @@ abstract class MainAsset extends InventoryAsset
                     $this->rulelocation_data['locations_id'] = $dataLocation['locations_id'];
                 }
             }
-            // set rulematchedlog_data as $input
-            $this->rulematchedlog_data = $input;
+
+            // store rule input
+            $this->rulematchedlog_input = $input;
 
             //call rules on current collected data to find item
             //a callback on rulepassed() will be done if one is found.
@@ -917,10 +918,6 @@ abstract class MainAsset extends InventoryAsset
             $this->handleAssets();
         }
 
-        // append data from RulematchedLogs
-        $criteria = $this->rulematchedlog_data;
-        $criteria = json_encode($criteria);
-
         $rulesmatched = new RuleMatchedLog();
         $inputrulelog = [
             'date'      => date('Y-m-d H:i:s'),
@@ -929,7 +926,7 @@ abstract class MainAsset extends InventoryAsset
             'itemtype'  => $itemtype,
             'agents_id' => $this->agent->fields['id'],
             'method'    => $this->request_query ?? Request::INVENT_QUERY,
-            'criteria'  => $criteria
+            'input'     => json_encode($this->rulematchedlog_input),
         ];
         $rulesmatched->add($inputrulelog, [], false);
         $rulesmatched->cleanOlddata($items_id, $itemtype);

--- a/src/RuleMatchedLog.php
+++ b/src/RuleMatchedLog.php
@@ -232,15 +232,13 @@ class RuleMatchedLog extends CommonDBTM
         $rows = [];
         foreach ($DB->request($params) as $data) {
             $row = [
-                'date'          => $data['date'],
-                'rules_id'      => $data['rules_id'],
-                'itemtype'      => Agent::class,
-                'items_id'      => $data['agents_id'],
-                'modulename'    => Request::getModuleName($data['method']),
+                'date'       => $data['date'],
+                'rules_id'   => $data['rules_id'],
+                'itemtype'   => Agent::class,
+                'items_id'   => $data['agents_id'],
+                'modulename' => Request::getModuleName($data['method']),
+                'input'      => json_decode($data['input'] ?? '[]', true),
             ];
-            if (isset($data['criteria'])) {
-                $row['criteria'] = json_decode($data['criteria'], true);
-            }
             $rows[] = $row;
         }
 
@@ -297,15 +295,13 @@ class RuleMatchedLog extends CommonDBTM
         $rows = [];
         foreach ($DB->request($params) as $data) {
             $row = [
-                'date'          => $data['date'],
-                'rules_id'      => $data['rules_id'],
-                'itemtype'      => $data['itemtype'],
-                'items_id'      => $data['items_id'],
-                'modulename'    => Request::getModuleName($data['method']),
+                'date'       => $data['date'],
+                'rules_id'   => $data['rules_id'],
+                'itemtype'   => $data['itemtype'],
+                'items_id'   => $data['items_id'],
+                'modulename' => Request::getModuleName($data['method']),
+                'input'      => json_decode($data['input'] ?? '[]', true),
             ];
-            if (isset($data['criteria'])) {
-                $row['criteria'] = json_decode($data['criteria'], true);
-            }
             $rows[] = $row;
         }
         TemplateRenderer::getInstance()->display('components/form/rulematchedlogs.html.twig', [

--- a/templates/components/form/rulematchedlogs.html.twig
+++ b/templates/components/form/rulematchedlogs.html.twig
@@ -1,0 +1,87 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% block more_fields %}
+    {{ printerAjaxPager|raw }}
+    <table class="tab_cadre_fixe">
+        <tr>
+            <th colspan="5"> {{ __('Rule import logs') }} </th>
+        </tr>
+        <tr>
+            <th> {{ _n('Date', 'Dates', 1) }}</th>
+            <th>{{ __('Rule name') }}</th>
+            <th>{{ typename }}</th>
+            <th>{{ __('Module') }}</th>
+            <th style="width: 30%">{{ __('Criteria') }}</th>
+        </tr>
+        {% for data in rows %}
+            <tr>
+                <td>{{ data['date']|formatted_datetime }}</td>
+                <td>{{ get_item_link('RuleImportAsset', data['rules_id']) }}</td>
+                <td>
+                    {{ get_item_link(data['itemtype'], data['items_id']) }}</td>
+                <td>{{ data['modulename'] }}</td>
+                <td>
+                    {% if data['criteria'] is not empty %}
+                        {% set rand = random() %}
+                        <div class="accordion" id="criteriaAccordion{{ rand }}">
+                            <div class="" id="item{{ rand }}">
+                                <a data-bs-toggle="collapse" href="#collapse{{ rand }}">{{ __("See Criteria") }}</a>
+                            </div>
+                            <div id="collapse{{ rand }}" class="accordion-collapse collapse" data-bs-parent="#criteriaAccordion{{ rand }}">
+                                <div class="nested list-group list-group-flush card">
+                                    <div class="list-group-item ">
+                                        {% for criterion, value in data['criteria'] %}
+                                            {% if value is iterable %}
+                                                <b>{{ criterion }}</b> :
+                                                {% for subvalue in value %}
+                                                    <br>&emsp;&bull;{{ subvalue }}
+                                                {% endfor %}
+                                                <br>
+                                            {% else %}
+                                                <b>{{ criterion }}</b> : {{ value }}<br>
+                                            {% endif %}
+                                        {% endfor %}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    {% else %}
+                        {{ __('No criteria') }}
+                    {% endif %}
+                </td>
+            </tr>
+        {% endfor %}
+    </table>
+    {{ printerAjaxPager|raw }}
+{% endblock %}

--- a/templates/components/form/rulematchedlogs.html.twig
+++ b/templates/components/form/rulematchedlogs.html.twig
@@ -32,7 +32,8 @@
  #}
 
 {% block more_fields %}
-    {{ printerAjaxPager|raw }}
+    {% do call('Html::printAjaxPager', ['RuleMatchedLog'|itemtype_name, start, count]) %}
+
     <table class="tab_cadre_fixe">
         <tr>
             <th colspan="5"> {{ __('Rule import logs') }} </th>
@@ -40,7 +41,13 @@
         <tr>
             <th> {{ _n('Date', 'Dates', 1) }}</th>
             <th>{{ __('Rule name') }}</th>
-            <th>{{ typename }}</th>
+            <th>
+                {% if item is instanceof('Agent') %}
+                    {{ _n('Item', 'Items', 1) }}
+                {% else %}
+                    {{ 'Agent'|itemtype_name }}
+                {% endif %}
+            </th>
             <th>{{ __('Module') }}</th>
             <th style="width: 30%">{{ __('Input') }}</th>
         </tr>
@@ -49,14 +56,19 @@
                 <td>{{ data['date']|formatted_datetime }}</td>
                 <td>{{ get_item_link('RuleImportAsset', data['rules_id']) }}</td>
                 <td>
-                    {{ get_item_link(data['itemtype'], data['items_id']) }}</td>
+                    {% if item is instanceof('Agent') %}
+                        {{ get_item_link(data['itemtype'], data['items_id']) }}
+                    {% else %}
+                        {{ get_item_link('Agent', data['agents_id']) }}
+                    {% endif %}
+                </td>
                 <td>{{ data['modulename'] }}</td>
                 <td>
                     {% if data['input'] is iterable and data['input'] is not empty %}
                         {% set rand = random() %}
                         <div class="accordion" id="inputAccordion{{ rand }}">
-                            <div class="" id="item{{ rand }}">
-                                <a data-bs-toggle="collapse" href="#collapse{{ rand }}">{{ __("See Criteria") }}</a>
+                            <div id="item{{ rand }}">
+                                <a data-bs-toggle="collapse" href="#collapse{{ rand }}">{{ __("See input") }}</a>
                             </div>
                             <div id="collapse{{ rand }}" class="accordion-collapse collapse" data-bs-parent="#inputAccordion{{ rand }}">
                                 <div class="nested list-group list-group-flush card">
@@ -83,5 +95,6 @@
             </tr>
         {% endfor %}
     </table>
-    {{ printerAjaxPager|raw }}
+
+    {% do call('Html::printAjaxPager', ['RuleMatchedLog'|itemtype_name, start, count]) %}
 {% endblock %}

--- a/templates/components/form/rulematchedlogs.html.twig
+++ b/templates/components/form/rulematchedlogs.html.twig
@@ -42,7 +42,7 @@
             <th>{{ __('Rule name') }}</th>
             <th>{{ typename }}</th>
             <th>{{ __('Module') }}</th>
-            <th style="width: 30%">{{ __('Criteria') }}</th>
+            <th style="width: 30%">{{ __('Input') }}</th>
         </tr>
         {% for data in rows %}
             <tr>
@@ -52,24 +52,24 @@
                     {{ get_item_link(data['itemtype'], data['items_id']) }}</td>
                 <td>{{ data['modulename'] }}</td>
                 <td>
-                    {% if data['criteria'] is not empty %}
+                    {% if data['input'] is iterable and data['input'] is not empty %}
                         {% set rand = random() %}
-                        <div class="accordion" id="criteriaAccordion{{ rand }}">
+                        <div class="accordion" id="inputAccordion{{ rand }}">
                             <div class="" id="item{{ rand }}">
                                 <a data-bs-toggle="collapse" href="#collapse{{ rand }}">{{ __("See Criteria") }}</a>
                             </div>
-                            <div id="collapse{{ rand }}" class="accordion-collapse collapse" data-bs-parent="#criteriaAccordion{{ rand }}">
+                            <div id="collapse{{ rand }}" class="accordion-collapse collapse" data-bs-parent="#inputAccordion{{ rand }}">
                                 <div class="nested list-group list-group-flush card">
                                     <div class="list-group-item ">
-                                        {% for criterion, value in data['criteria'] %}
+                                        {% for name, value in data['input'] %}
                                             {% if value is iterable %}
-                                                <b>{{ criterion }}</b> :
+                                                <b>{{ name }}</b> :
                                                 {% for subvalue in value %}
                                                     <br>&emsp;&bull;{{ subvalue }}
                                                 {% endfor %}
                                                 <br>
                                             {% else %}
-                                                <b>{{ criterion }}</b> : {{ value }}<br>
+                                                <b>{{ name }}</b> : {{ value }}<br>
                                             {% endif %}
                                         {% endfor %}
                                     </div>
@@ -77,7 +77,7 @@
                             </div>
                         </div>
                     {% else %}
-                        {{ __('No criteria') }}
+                        {{ __('No input') }}
                     {% endif %}
                 </td>
             </tr>

--- a/tests/functional/RuleMatchedLog.php
+++ b/tests/functional/RuleMatchedLog.php
@@ -118,9 +118,9 @@ class RuleMatchedLog extends DbTestCase
                 'itemtype' => Printer::class,
             ]
         ))->isTrue();
-        $criteria = $rulematchedlog->fields['criteria'];
-        $this->string($criteria)->isNotEmpty();
-        $this->string($criteria)->isEqualTo('{"_auto":1,"deviceid":"bar","autoupdatesystems_id":"GLPI Native Inventory","last_inventory_update":"' . $date_add . '","manufacturer":"HP","memory":64,"model":"LaserJet Pro MFP M428fdw","name":"Imprimante HP LaserJet Pro MFP M428fdw","serial":"ABC123456","type":"Printer","uptime":"7 days, 12:34:56.78","ip":["192.168.1.100"],"mac":"01:23:45:67:89:ab","description":"Imprimante HP LaserJet Pro MFP M428fdw","sysdescr":"Imprimante HP LaserJet Pro MFP M428fdw","printertypes_id":"Printer","manufacturers_id":"HP","have_ethernet":1,"memory_size":128,"itemtype":"Printer","entities_id":"0"}');
+        $input = $rulematchedlog->fields['input'];
+        $this->string($input)->isNotEmpty();
+        $this->string($input)->isEqualTo('{"_auto":1,"deviceid":"bar","autoupdatesystems_id":"GLPI Native Inventory","last_inventory_update":"' . $date_add . '","manufacturer":"HP","memory":64,"model":"LaserJet Pro MFP M428fdw","name":"Imprimante HP LaserJet Pro MFP M428fdw","serial":"ABC123456","type":"Printer","uptime":"7 days, 12:34:56.78","ip":["192.168.1.100"],"mac":"01:23:45:67:89:ab","description":"Imprimante HP LaserJet Pro MFP M428fdw","sysdescr":"Imprimante HP LaserJet Pro MFP M428fdw","printertypes_id":"Printer","manufacturers_id":"HP","have_ethernet":1,"memory_size":128,"itemtype":"Printer","entities_id":"0"}');
 
         // Update test
         $xmlupdate = '<?xml version="1.0" encoding="UTF-8" ?>
@@ -171,8 +171,8 @@ class RuleMatchedLog extends DbTestCase
             1
         );
         $update_result = reset($result);
-        $criteria = $update_result['criteria'];
-        $this->string($criteria)->isNotEmpty();
-        $this->string($criteria)->isEqualTo('{"_auto":1,"deviceid":"bar","autoupdatesystems_id":"GLPI Native Inventory","last_inventory_update":"' . $date_update . '","manufacturer":"HP","memory":64,"model":"LaserJet Pro MFP M428fdw V2","name":"Imprimante HP LaserJet Pro MFP M428fdw V2","serial":"ABC123456","type":"Printer","uptime":"7 days, 12:34:56.78","ip":["192.168.1.100"],"mac":"01:23:45:67:89:ab","description":"Imprimante HP LaserJet Pro MFP M428fdw V2","sysdescr":"Imprimante HP LaserJet Pro MFP M428fdw V2","printertypes_id":"Printer","manufacturers_id":"HP","have_ethernet":1,"memory_size":128,"itemtype":"Printer","entities_id":"0"}');
+        $input = $update_result['input'];
+        $this->string($input)->isNotEmpty();
+        $this->string($input)->isEqualTo('{"_auto":1,"deviceid":"bar","autoupdatesystems_id":"GLPI Native Inventory","last_inventory_update":"' . $date_update . '","manufacturer":"HP","memory":64,"model":"LaserJet Pro MFP M428fdw V2","name":"Imprimante HP LaserJet Pro MFP M428fdw V2","serial":"ABC123456","type":"Printer","uptime":"7 days, 12:34:56.78","ip":["192.168.1.100"],"mac":"01:23:45:67:89:ab","description":"Imprimante HP LaserJet Pro MFP M428fdw V2","sysdescr":"Imprimante HP LaserJet Pro MFP M428fdw V2","printertypes_id":"Printer","manufacturers_id":"HP","have_ethernet":1,"memory_size":128,"itemtype":"Printer","entities_id":"0"}');
     }
 }

--- a/tests/functional/RuleMatchedLog.php
+++ b/tests/functional/RuleMatchedLog.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use DbTestCase;
+use RuleMatchedLog as GlobalRuleMatchedLog;
+use Printer;
+
+/* Test for inc/rule.class.php */
+
+class RuleMatchedLog extends DbTestCase
+{
+    public function testCriteriaAddition()
+    {
+        $printer = new Printer();
+        $rulematchedlog = new GlobalRuleMatchedLog();
+        // Addition test
+        $xml = '<?xml version="1.0" encoding="UTF-8" ?>
+        <REQUEST>
+          <CONTENT>
+            <DEVICE>
+              <INFO>
+                <COMMENTS>Imprimante HP LaserJet Pro MFP M428fdw</COMMENTS>
+                <ID>123456</ID>
+                <MANUFACTURER>HP</MANUFACTURER>
+                <MEMORY>64</MEMORY>
+                <MODEL>LaserJet Pro MFP M428fdw</MODEL>
+                <NAME>Imprimante HP LaserJet Pro MFP M428fdw</NAME>
+                <RAM>128</RAM>
+                <SERIAL>ABC123456</SERIAL>
+                <TYPE>PRINTER</TYPE>
+                <UPTIME>7 days, 12:34:56.78</UPTIME>
+                <IPS><IP>192.168.1.100</IP></IPS>
+                <MAC>01:23:45:67:89:ab</MAC>
+              </INFO>
+              <PORTS>
+                <PORT>
+                  <IFDESCR>Ethernet/1</IFDESCR>
+                  <IFINERRORS>0</IFINERRORS>
+                  <IFINOCTETS>1234567890</IFINOCTETS>
+                  <IFINTERNALSTATUS>1</IFINTERNALSTATUS>
+                  <IFLASTCHANGE>12.34 seconds</IFLASTCHANGE>
+                  <IFMTU>1500</IFMTU>
+                  <IFNAME>Port 1</IFNAME>
+                  <IFNUMBER>1</IFNUMBER>
+                  <IFOUTERRORS>0</IFOUTERRORS>
+                  <IFOUTOCTETS>987654321</IFOUTOCTETS>
+                  <IFSPEED>1000000000</IFSPEED>
+                  <IFSTATUS>1</IFSTATUS>
+                  <IFTYPE>7</IFTYPE>
+                  <IP>192.168.1.100</IP>
+                  <IPS>
+                    <IP>192.168.1.100</IP>
+                  </IPS>
+                  <MAC>01:23:45:67:89:ab</MAC>
+                </PORT>
+              </PORTS>
+            </DEVICE>
+          </CONTENT>
+          <QUERY>SNMP</QUERY>
+          <DEVICEID>bar</DEVICEID>
+        </REQUEST>';
+
+        $converter = new \Glpi\Inventory\Converter();
+        $data = $converter->convert($xml);
+        $json = json_decode($data);
+
+        $inventory = new \Glpi\Inventory\Inventory($json);
+        $date_add = $_SESSION['glpi_currenttime'];
+
+        if ($inventory->inError()) {
+            $this->dump($inventory->getErrors());
+        }
+        $this->boolean($inventory->inError())->isFalse();
+        $this->array($inventory->getErrors())->isEmpty();
+
+        $printers_id = $inventory->getItem()->fields['id'];
+        $this->integer($printers_id)->isGreaterThan(0);
+
+        $this->boolean($printer->getFromDB($printers_id))->isTrue();
+
+        $this->boolean($rulematchedlog->getFromDBByCrit(
+            [
+                'items_id' => $printers_id,
+                'itemtype' => Printer::class,
+            ]
+        ))->isTrue();
+        $criteria = $rulematchedlog->fields['criteria'];
+        $this->string($criteria)->isNotEmpty();
+        $this->string($criteria)->isEqualTo('{"_auto":1,"deviceid":"bar","autoupdatesystems_id":"GLPI Native Inventory","last_inventory_update":"' . $date_add . '","manufacturer":"HP","memory":64,"model":"LaserJet Pro MFP M428fdw","name":"Imprimante HP LaserJet Pro MFP M428fdw","serial":"ABC123456","type":"Printer","uptime":"7 days, 12:34:56.78","ip":["192.168.1.100"],"mac":"01:23:45:67:89:ab","description":"Imprimante HP LaserJet Pro MFP M428fdw","sysdescr":"Imprimante HP LaserJet Pro MFP M428fdw","printertypes_id":"Printer","manufacturers_id":"HP","have_ethernet":1,"memory_size":128,"itemtype":"Printer","entities_id":"0"}');
+
+        // Update test
+        $xmlupdate = '<?xml version="1.0" encoding="UTF-8" ?>
+        <REQUEST>
+          <CONTENT>
+            <DEVICE>
+              <INFO>
+                <COMMENTS>Imprimante HP LaserJet Pro MFP M428fdw V2</COMMENTS>
+                <ID>123456</ID>
+                <MANUFACTURER>HP</MANUFACTURER>
+                <MEMORY>64</MEMORY>
+                <MODEL>LaserJet Pro MFP M428fdw V2</MODEL>
+                <NAME>Imprimante HP LaserJet Pro MFP M428fdw V2</NAME>
+                <RAM>128</RAM>
+                <SERIAL>ABC123456</SERIAL>
+                <TYPE>PRINTER</TYPE>
+                <UPTIME>7 days, 12:34:56.78</UPTIME>
+                <IPS><IP>192.168.1.100</IP></IPS>
+                <MAC>01:23:45:67:89:ab</MAC>
+              </INFO>
+            </DEVICE>
+          </CONTENT>
+          <QUERY>SNMP</QUERY>
+          <DEVICEID>bar</DEVICEID>
+        </REQUEST>';
+
+        $dataupdate = $converter->convert($xmlupdate);
+        $jsonupdate = json_decode($dataupdate);
+        $inventoryupdate = new \Glpi\Inventory\Inventory($jsonupdate);
+        $date_update = $_SESSION['glpi_currenttime'];
+        if ($inventoryupdate->inError()) {
+            $this->dump($inventoryupdate->getErrors());
+        }
+        $this->boolean($inventoryupdate->inError())->isFalse();
+        $this->array($inventoryupdate->getErrors())->isEmpty();
+
+        $results = $rulematchedlog->find([
+            'items_id' => $printers_id,
+            'itemtype' => Printer::class,
+        ]);
+        $this->integer(count($results))->isEqualTo(2);
+        $result = $rulematchedlog->find(
+            [
+                'items_id' => $printers_id,
+                'itemtype' => Printer::class,
+            ],
+            'id DESC',
+            1
+        );
+        $update_result = reset($result);
+        $criteria = $update_result['criteria'];
+        $this->string($criteria)->isNotEmpty();
+        $this->string($criteria)->isEqualTo('{"_auto":1,"deviceid":"bar","autoupdatesystems_id":"GLPI Native Inventory","last_inventory_update":"' . $date_update . '","manufacturer":"HP","memory":64,"model":"LaserJet Pro MFP M428fdw V2","name":"Imprimante HP LaserJet Pro MFP M428fdw V2","serial":"ABC123456","type":"Printer","uptime":"7 days, 12:34:56.78","ip":["192.168.1.100"],"mac":"01:23:45:67:89:ab","description":"Imprimante HP LaserJet Pro MFP M428fdw V2","sysdescr":"Imprimante HP LaserJet Pro MFP M428fdw V2","printertypes_id":"Printer","manufacturers_id":"HP","have_ethernet":1,"memory_size":128,"itemtype":"Printer","entities_id":"0"}');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c910c0a</samp>

This pull request adds a new feature to store and display the criteria data used by the rules engine to match the inventory assets. It modifies several classes in the `src/Inventory/Asset` directory to collect and encode the criteria data, and adds a new field `criteria` to the `glpi_rulematchedlogs` table. It also refactors the rule log form to use a Twig template in the `templates/components/form` directory.
