### PR TITLE
Update rule matched log agent form in twig

### DIFF
--- a/src/RuleMatchedLog.php
+++ b/src/RuleMatchedLog.php
@@ -34,6 +34,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\View\TemplateRenderer;
 use Glpi\Inventory\Request;
 
 /**
@@ -300,64 +301,24 @@ class RuleMatchedLog extends CommonDBTM
 
         $rule = new RuleImportAsset();
 
-        echo "<table class='tab_cadre_fixe' cellpadding='1'>";
-
-        echo "<tr>";
-        echo "<th colspan='5'>";
-        echo __('Rule import logs');
-
-        echo "</th>";
-        echo "</tr>";
-
-        echo "<tr>";
-        echo "<th>";
-        echo _n('Date', 'Dates', 1);
-
-        echo "</th>";
-        echo "<th>";
-        echo __('Rule name');
-
-        echo "</th>";
-        echo "<th>";
-        echo __('Item type');
-
-        echo "</th>";
-        echo "<th>";
-        echo _n('Item', 'Items', 1);
-
-        echo "</th>";
-        echo "<th>";
-        echo __('Module');
-
-        echo "</th>";
-        echo "</tr>";
-
         $allData = $this->find(['agents_id' => $agents_id], ['date DESC']);
+        $rows = [];
         foreach ($allData as $data) {
-            echo "<tr class='tab_bg_1'>";
-            echo "<td align='center'>";
-            echo Html::convDateTime($data['date']);
-            echo "</td>";
-            echo "<td align='center'>";
+            $row['date'] = Html::convDateTime($data['date']);
             if ($rule->getFromDB($data['rules_id'])) {
-                echo $rule->getLink(1);
+                $row['rulelink'] = $rule->getLink(1) ?? '';
             }
-            echo "</td>";
-            echo "<td align='center'>";
             $itemtype = $data['itemtype'];
             $item = new $itemtype();
-            echo $item->getTypeName();
-            echo "</td>";
-            echo "<td align='center'>";
+            $row['itemtype'] = $item->getTypeName();
             if ($item->getFromDB($data['items_id'])) {
-                echo $item->getLink(1);
+                $row['itemlink'] = $item->getLink(1);
             }
-            echo "</td>";
-            echo "<td>";
-            echo Request::getModuleName($data['method']);
-            echo "</td>";
-            echo "</tr>";
+            $row['modulename'] = Request::getModuleName($data['method']);
+            $rows[] = $row;
         }
-        echo "</table>";
+        TemplateRenderer::getInstance()->display('components/form/rulematchedlogagent.html.twig', [
+            'allData' => $rows,
+        ]);
     }
 }

--- a/templates/components/form/rulematchedlogagent.html.twig
+++ b/templates/components/form/rulematchedlogagent.html.twig
@@ -49,7 +49,7 @@
             <td>{{ data.rulelink|raw }}</td>
             <td>{{ data.itemtype }}</td>
             <td>{{ data.itemlink|raw }}</td>
-            <td>{{ data.modulename}}</td>
+            <td>{{ data.modulename }}</td>
         </tr>
     {% endfor %}
     </table>

--- a/templates/components/form/rulematchedlogagent.html.twig
+++ b/templates/components/form/rulematchedlogagent.html.twig
@@ -1,0 +1,56 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2023 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% block more_fields %}
+    <table class="tab_cadre_fixe" cellpadding="1">
+        <tr>
+            <th colspan="5">{{ __('Rule import logs') }}</th>
+        </tr>
+        <tr>
+            <th>{{ _n('Date', 'Dates', 1) }}</th>
+            <th>{{ __('Rule name') }}</th>
+            <th>{{ __('Item type') }}</th>
+            <th>{{ _n('Item', 'Items', 1) }}</th>
+            <th>{{ __('Module') }}</th>
+        </tr>
+        {% for data in allData %}
+        <tr class="tab_bg_1">
+            <td>{{ data.date }}</td>
+            <td>{{ data.rulelink|raw }}</td>
+            <td>{{ data.itemtype }}</td>
+            <td>{{ data.itemlink|raw }}</td>
+            <td>{{ data.modulename}}</td>
+        </tr>
+    {% endfor %}
+    </table>
+{% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 943952b</samp>

The pull request updates the `RuleMatchedLog` class to use Twig templates for rendering HTML. It adds a new template `rulematchedlogagent.html.twig` to display the rule import logs for an agent. The template uses Twig features and translation functions to handle the data and links.