### PR TITLE
Prevent exception when checked schema is empty

### DIFF
--- a/src/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
+++ b/src/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
@@ -286,13 +286,14 @@ class DatabaseSchemaIntegrityChecker
         }
 
         if ($include_unknown_tables) {
-            $unknown_tables_criteria = [
-                [
+            $unknown_tables_criteria = [];
+            if (count($schema) > 0) {
+                $unknown_tables_criteria[] = [
                     'NOT' => [
                         'table_name' => array_keys($schema)
                     ]
-                ],
-            ];
+                ];
+            }
             $is_context_valid = true;
             if ($context === 'core') {
                 $unknown_tables_criteria[] = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15767

There may be edge cases where GLPI fails to extract tables from a `glpi-XXX-empty.sql` schema file. For instance, if the file is corrupted.
In this case, to avoid having an exception (see #15767), the code have to be adapted.