### PR TITLE
Fix/defer entitytree loading

### DIFF
--- a/templates/layout/parts/profile_selector.html.twig
+++ b/templates/layout/parts/profile_selector.html.twig
@@ -34,223 +34,222 @@
 {% set rand = random() %}
 
 <div class="dropdown dropstart">
-   <button class="dropdown-item dropdown-toggle" type="button" data-bs-toggle="dropdown"
-           aria-haspopup="true" aria-expanded="false">
-      <i class="ti ti-user-check"></i>
-      {{ (session('glpiactiveprofile')['name'] ?? '')|verbatim_value }}
-   </button>
-   <div class="dropdown-menu" data-bs-popper="none">
-      <span class="dropdown-header">{{ __('Profiles') }}</span>
-      {% for profile_id, profile in session('glpiprofiles') %}
-      <a class="dropdown-item {{ profile_id == (session('glpiactiveprofile')['id'] ?? 0) ? 'active' : '' }}"
-         href="{{ index_path() }}?newprofile={{ profile_id }}">
-         <i class="ti ti-user-check"></i>{{ profile['name']|verbatim_value }}
-      </a>
-      {% endfor %}
-   </div>
+    <button class="dropdown-item dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <i class="ti ti-user-check"></i>
+        {{ (session('glpiactiveprofile')['name'] ?? '')|verbatim_value }}
+    </button>
+    <div class="dropdown-menu" data-bs-popper="none">
+        <span class="dropdown-header">{{ __('Profiles') }}</span>
+        {% for profile_id, profile in session('glpiprofiles') %}
+            <a class="dropdown-item {{ profile_id == (session('glpiactiveprofile')['id'] ?? 0) ? 'active' : '' }}" href="{{ index_path() }}?newprofile={{ profile_id }}">
+                <i class="ti ti-user-check"></i>
+                {{ profile['name']|verbatim_value }}
+            </a>
+        {% endfor %}
+    </div>
 </div>
 
 {% set target = path("front/central.php") %}
 {% if get_current_interface() == "helpdesk" %}
-   {% set target = path("front/helpdesk.public.php") %}
+    {% set target = path("front/helpdesk.public.php") %}
 {% endif %}
 
 {% set current_entity = session('glpiactive_entity_name')|verbatim_value %}
 {% set current_entity_short = session('glpiactive_entity_shortname')|verbatim_value %}
 {% if current_entity != current_entity_short %}
-   {% set current_entity_short = '... > ' ~ current_entity_short %}
+    {% set current_entity_short = '... > ' ~ current_entity_short %}
 {% endif %}
 {% if not is_multi_entities_mode() %}
-   <span class="dropdown-item dropdown-item-text" title="{{ current_entity }}">
-      <i class="fa-fw ti ti-stack"></i>
-      {{ current_entity_short|u.truncate(35, '...') }}
-   </span>
+    <span class="dropdown-item dropdown-item-text" title="{{ current_entity }}">
+        <i class="fa-fw ti ti-stack"></i>
+        {{ current_entity_short|u.truncate(35, '...') }}
+    </span>
 {% else %}
-   <div class="dropdown dropstart" id="entity-tree-dropdown-{{ rand }}">
-      <a href="#" class="dropdown-item dropdown-toggle entity-dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" title="{{ current_entity }}">
-         <i class="fa-fw ti ti-stack"></i>
-         {{ current_entity_short|u.truncate(35, '...') }}
-      </a>
-      <div class="dropdown-menu p-3">
-         <h3>{{ __('Select the desired entity') }}</h3>
+    <div class="dropdown dropstart" id="entity-tree-dropdown-{{ rand }}">
+        <a href="#" class="dropdown-item dropdown-toggle entity-dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" title="{{ current_entity }}">
+            <i class="fa-fw ti ti-stack"></i>
+            {{ current_entity_short|u.truncate(35, '...') }}
+        </a>
+        <div class="dropdown-menu p-3">
+            <h3>{{ __('Select the desired entity') }}</h3>
 
-         <div class="alert alert-info" role="alert">
-            {% set shortcut = __('Ctrl + Alt + E') %}
-            {% if platform == constant("donatj\\UserAgent\\Platforms::MACINTOSH") %}
-                {% set shortcut = __('⌥ (option) + ⌘ (command) + E') %}
-            {% endif %}
-            {{ __("Tip: You can call this modal with %s keys combination")|format('<kbd>' ~ shortcut ~ '</kbd>')|raw }}
-         </div>
-         <div class="alert alert-info" role="alert">
-            <i class="fas fa-info-circle"></i>
-            <span class="ms-2">
-               {% set recursive_icon %}
-                  <i class="fas fa-angle-double-down" title="{{ __('+ sub-entities') }}"></i>
-               {% endset %}
-               {{ __('Click on the %s icon to load the elements of the selected entity, as well as its sub-entities.')|format(recursive_icon)|raw }}
-            </span>
-         </div>
-
-         <form id="entsearchform{{ rand }}">
-            <div class="input-group">
-               <input type="text" class="form-control" name="entsearchtext" id="entsearchtext{{ rand }}"
-                     placeholder="{{ __('Search entity') }}" autocomplete="off">
-               <button type="submit" class="btn btn-icon btn-primary" title="{{ __('Search') }}"
-                     data-bs-toggle="tooltip" data-bs-placement="top">
-                  <i class="ti ti-search"></i>
-               </button>
-               <a class="btn btn-icon btn-outline-secondary" href="#" id="entsearchtext{{ rand }}_clear"
-                  title="{{ __("Clear search") }}" data-bs-toggle="tooltip" data-bs-placement="top">
-                     <i class="ti ti-x"></i>
-               </a>
-               <a href="{{ target }}?active_entity=all" class="btn btn-secondary"
-                  title="{{ __('Select all') }}" data-bs-toggle="tooltip" data-bs-placement="top">
-                  <i class="ti ti-eye"></i>
-               </a>
+            <div class="alert alert-info" role="alert">
+                {% set shortcut = __('Ctrl + Alt + E') %}
+                {% if platform == constant("donatj\\UserAgent\\Platforms::MACINTOSH") %}
+                    {% set shortcut = __('⌥ (option) + ⌘ (command) + E') %}
+                {% endif %}
+                {{ __("Tip: You can call this modal with %s keys combination")|format('<kbd>' ~ shortcut ~ '</kbd>')|raw }}
             </div>
-         </form>
+            <div class="alert alert-info" role="alert">
+                <i class="fas fa-info-circle"></i>
+                <span class="ms-2">
+                {% set recursive_icon %}
+                    <i class="fas fa-angle-double-down" title="{{ __('+ sub-entities') }}"></i>
+                {% endset %}
+                {{ __('Click on the %s icon to load the elements of the selected entity, as well as its sub-entities.')|format(recursive_icon)|raw }}
+                </span>
+            </div>
 
-         <div class="fancytree-grid-container flexbox-item-grow entity_tree">
-            <table id="tree_entity{{ rand }}">
-               <colgroup>
-                  <col></col>
-               </colgroup>
-               <thead>
-                  <tr>
-                     <th class="parent-path"></th>
-                  </tr>
-               </thead>
-               <tbody>
-               </tbody>
-            </table>
-            <div id="verticalScrollbar-{{ rand }}" style="height:100%;"></div>
-         </div>
-      </div>
-   </div>
+            <form id="entsearchform{{ rand }}">
+                <div class="input-group">
+                <input type="text" class="form-control" name="entsearchtext" id="entsearchtext{{ rand }}"
+                        placeholder="{{ __('Search entity') }}" autocomplete="off">
+                <button type="submit" class="btn btn-icon btn-primary" title="{{ __('Search') }}"
+                        data-bs-toggle="tooltip" data-bs-placement="top">
+                    <i class="ti ti-search"></i>
+                </button>
+                <a class="btn btn-icon btn-outline-secondary" href="#" id="entsearchtext{{ rand }}_clear"
+                    title="{{ __("Clear search") }}" data-bs-toggle="tooltip" data-bs-placement="top">
+                        <i class="ti ti-x"></i>
+                </a>
+                <a href="{{ target }}?active_entity=all" class="btn btn-secondary"
+                    title="{{ __('Select all') }}" data-bs-toggle="tooltip" data-bs-placement="top">
+                    <i class="ti ti-eye"></i>
+                </a>
+                </div>
+            </form>
 
-   <script type="text/javascript">
-   $(function() {
-      var initTree{{ rand }} = function() {
-        $('#tree_entity{{ rand }}').fancytree({
-            // load plugins
-            extensions: ['filter', 'glyph', 'grid'],
+            <div class="fancytree-grid-container flexbox-item-grow entity_tree">
+                <table id="tree_entity{{ rand }}">
+                <colgroup>
+                    <col></col>
+                </colgroup>
+                <thead>
+                    <tr>
+                        <th class="parent-path"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                </tbody>
+                </table>
+                <div id="verticalScrollbar-{{ rand }}" style="height:100%;"></div>
+            </div>
+        </div>
+    </div>
 
-            // Scroll node into visible area, when focused by keyboard
-            autoScroll: true,
+    <script type="text/javascript">
+    $(function() {
+        var initTree{{ rand }} = function() {
+            $('#tree_entity{{ rand }}').fancytree({
+                // load plugins
+                extensions: ['filter', 'glyph', 'grid'],
 
-            // enable font-awesome icons
-            glyph: {
-                preset: "awesome5",
-                map: {}
-            },
+                // Scroll node into visible area, when focused by keyboard
+                autoScroll: true,
 
-            // enable virtual dom, it requires the grid (table extension) plugin
-            table: {
-                indentation: 20,       // indent 20px per node level
-                nodeColumnIdx: 0,      // render the node title into the 1st column
-                mergeStatusColumns: false,
-            },
-            grid: {
-                mergeStatusColumns: false,
-            },
-            viewport: {
-                enabled: true,
-                count: 15, // number of items to display at once
-            },
+                // enable font-awesome icons
+                glyph: {
+                    preset: "awesome5",
+                    map: {}
+                },
 
-            // load data by ajax
-            source: {
-                url:  '{{ path("/ajax/entitytreesons.php") }}',
-                cache: false
-            },
+                // enable virtual dom, it requires the grid (table extension) plugin
+                table: {
+                    indentation: 20,       // indent 20px per node level
+                    nodeColumnIdx: 0,      // render the node title into the 1st column
+                    mergeStatusColumns: false,
+                },
+                grid: {
+                    mergeStatusColumns: false,
+                },
+                viewport: {
+                    enabled: true,
+                    count: 15, // number of items to display at once
+                },
 
-            // filter plugin options
-            filter: {
-                mode: "hide", // remove unmatched nodes
-                autoExpand: true, // if results found in children, auto-expand parent
-                nodata: '{{ __("No entity found") }}', // message when no data found
-                highlight: false, // do not highlight matches by wrapping inside tags (when true, this strip the a tag)
-                counter: false, // do not show counters when filtering entity tree
-            },
+                // load data by ajax
+                source: {
+                    url:  '{{ path("/ajax/entitytreesons.php") }}',
+                    cache: false
+                },
 
-            // load 3rd party scrollbar extension for viewport mode
-            preInit: function(event, data) {
-                var tree = data.tree;
+                // filter plugin options
+                filter: {
+                    mode: "hide", // remove unmatched nodes
+                    autoExpand: true, // if results found in children, auto-expand parent
+                    nodata: '{{ __("No entity found") }}', // message when no data found
+                    highlight: false, // do not highlight matches by wrapping inside tags (when true, this strip the a tag)
+                    counter: false, // do not show counters when filtering entity tree
+                },
 
-                tree.verticalScrollbar = new PlainScrollbar({
-                alwaysVisible: true,
-                arrows: true,
-                orientation: "vertical",
-                onSet: function(numberOfItems) {
-                    tree.setViewport({
-                        start: Math.round(numberOfItems.start),
+                // load 3rd party scrollbar extension for viewport mode
+                preInit: function(event, data) {
+                    var tree = data.tree;
+
+                    tree.verticalScrollbar = new PlainScrollbar({
+                    alwaysVisible: true,
+                    arrows: true,
+                    orientation: "vertical",
+                    onSet: function(numberOfItems) {
+                        tree.setViewport({
+                            start: Math.round(numberOfItems.start),
+                        });
+                    },
+                    scrollbarElement: document.getElementById("verticalScrollbar-{{ rand }}"),
                     });
                 },
-                scrollbarElement: document.getElementById("verticalScrollbar-{{ rand }}"),
-                });
-            },
 
-            // update scrollbar when viewport is updated
-            updateViewport: function(event, data) {
-                var tree = data.tree;
+                // update scrollbar when viewport is updated
+                updateViewport: function(event, data) {
+                    var tree = data.tree;
 
-                tree.verticalScrollbar.set({
-                start: tree.viewport.start,
-                total: tree.visibleNodeList.length,
-                visible: tree.viewport.count,
-                }, true);  // do not trigger `onSet`
+                    tree.verticalScrollbar.set({
+                    start: tree.viewport.start,
+                    total: tree.visibleNodeList.length,
+                    visible: tree.viewport.count,
+                    }, true);  // do not trigger `onSet`
 
-                initTooltips();
-            },
+                    initTooltips();
+                },
 
-            // update toolips on node expand
-            expand: function(event, data) {
-                initTooltips();
-            },
-        });
-      };
+                // update toolips on node expand
+                expand: function(event, data) {
+                    initTooltips();
+                },
+            });
+        };
 
       // init Entities tree only when user ask for it (when dropdown is opened)
-      document.getElementById('entity-tree-dropdown-{{ rand }}')
-        .addEventListener('show.bs.dropdown', function (event) {
-            initTree{{ rand }}();
+        document.getElementById('entity-tree-dropdown-{{ rand }}')
+            .addEventListener('show.bs.dropdown', function (event) {
+                initTree{{ rand }}();
+            });
+
+        var searchTree = function() {
+            var search_text = $("#entsearchtext{{ rand }}").val();
+            $.ui.fancytree.getTree("#tree_entity{{ rand }}").filterBranches(search_text);
+        }
+
+        $('#entsearchform{{ rand }}').submit(function(event) {
+            // cancel submit of entity search form
+            event.preventDefault();
+
+            searchTree();
         });
 
-      var searchTree = function() {
-         var search_text = $("#entsearchtext{{ rand }}").val();
-         $.ui.fancytree.getTree("#tree_entity{{ rand }}").filterBranches(search_text);
-      }
+        $('#entsearchtext{{ rand }}').keyup(function () {
+            var inputsearch = $(this);
+            typewatch(function () {
+                if (inputsearch.val().length >= 3) {
+                searchTree();
+                }
+            }, 500);
+        }).focus();
 
-      $('#entsearchform{{ rand }}').submit(function(event) {
-         // cancel submit of entity search form
-         event.preventDefault();
+        $('#entsearchtext{{ rand }}_clear').click(function () {
+            $('#entsearchtext{{ rand }}').val('');
+            searchTree();
+        });
 
-         searchTree();
-      });
-
-      $('#entsearchtext{{ rand }}').keyup(function () {
-         var inputsearch = $(this);
-         typewatch(function () {
-            if (inputsearch.val().length >= 3) {
-               searchTree();
-            }
-         }, 500);
-      }).focus();
-
-      $('#entsearchtext{{ rand }}_clear').click(function () {
-         $('#entsearchtext{{ rand }}').val('');
-         searchTree();
-      });
-
-      // when the shortcut for entity form is called
-      hotkeys('ctrl+alt+e, option+command+e', async function(e) {
-         e.stopPropagation();
-         e.preventDefault();
-         $('.user-menu-dropdown-toggle').dropdown('show');
-         await new Promise(r => setTimeout(r, 100));
-         $('.entity-dropdown-toggle').dropdown('show');
-         $('input[name=entsearchtext]').filter(":visible")[0].focus();
-      });
-   });
-   </script>
+        // when the shortcut for entity form is called
+        hotkeys('ctrl+alt+e, option+command+e', async function(e) {
+            e.stopPropagation();
+            e.preventDefault();
+            $('.user-menu-dropdown-toggle').dropdown('show');
+            await new Promise(r => setTimeout(r, 100));
+            $('.entity-dropdown-toggle').dropdown('show');
+            $('input[name=entsearchtext]').filter(":visible")[0].focus();
+        });
+    });
+    </script>
 {% endif %}

--- a/templates/layout/parts/profile_selector.html.twig
+++ b/templates/layout/parts/profile_selector.html.twig
@@ -161,6 +161,14 @@
                     count: 15, // number of items to display at once
                 },
 
+                // translate strings
+                strings: {
+                    loading: __("Loading..."),
+                    loadError: __("Load error!"),
+                    moreData: __("More..."),
+                    noData: __("No data found")
+                },
+
                 // load data by ajax
                 source: {
                     url:  '{{ path("/ajax/entitytreesons.php") }}',

--- a/templates/layout/parts/profile_selector.html.twig
+++ b/templates/layout/parts/profile_selector.html.twig
@@ -164,7 +164,7 @@
                 // translate strings
                 strings: {
                     loading: __("Loading..."),
-                    loadError: __("Load error!"),
+                    loadError: __("Unexpected error."),
                     moreData: __("More..."),
                     noData: __("No data found")
                 },

--- a/templates/layout/parts/profile_selector.html.twig
+++ b/templates/layout/parts/profile_selector.html.twig
@@ -130,6 +130,10 @@
     <script type="text/javascript">
     $(function() {
         var initTree{{ rand }} = function() {
+            if ($.ui.fancytree.getTree("#tree_entity{{ rand }}") !== null) {
+                return;
+            }
+
             $('#tree_entity{{ rand }}').fancytree({
                 // load plugins
                 extensions: ['filter', 'glyph', 'grid'],

--- a/templates/layout/parts/profile_selector.html.twig
+++ b/templates/layout/parts/profile_selector.html.twig
@@ -66,7 +66,7 @@
       {{ current_entity_short|u.truncate(35, '...') }}
    </span>
 {% else %}
-   <div class="dropdown dropstart">
+   <div class="dropdown dropstart" id="entity-tree-dropdown-{{ rand }}">
       <a href="#" class="dropdown-item dropdown-toggle entity-dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" title="{{ current_entity }}">
          <i class="fa-fw ti ti-stack"></i>
          {{ current_entity_short|u.truncate(35, '...') }}
@@ -130,83 +130,91 @@
 
    <script type="text/javascript">
    $(function() {
-      $('#tree_entity{{ rand }}').fancytree({
-         // load plugins
-         extensions: ['filter', 'glyph', 'grid'],
+      var initTree{{ rand }} = function() {
+        $('#tree_entity{{ rand }}').fancytree({
+            // load plugins
+            extensions: ['filter', 'glyph', 'grid'],
 
-         // Scroll node into visible area, when focused by keyboard
-         autoScroll: true,
+            // Scroll node into visible area, when focused by keyboard
+            autoScroll: true,
 
-         // enable font-awesome icons
-         glyph: {
-            preset: "awesome5",
-            map: {}
-         },
+            // enable font-awesome icons
+            glyph: {
+                preset: "awesome5",
+                map: {}
+            },
 
-         // enable virtual dom, it requires the grid (table extension) plugin
-         table: {
-            indentation: 20,       // indent 20px per node level
-            nodeColumnIdx: 0,      // render the node title into the 1st column
-            mergeStatusColumns: false,
-         },
-         grid: {
-            mergeStatusColumns: false,
-         },
-         viewport: {
-            enabled: true,
-            count: 15, // number of items to display at once
-         },
+            // enable virtual dom, it requires the grid (table extension) plugin
+            table: {
+                indentation: 20,       // indent 20px per node level
+                nodeColumnIdx: 0,      // render the node title into the 1st column
+                mergeStatusColumns: false,
+            },
+            grid: {
+                mergeStatusColumns: false,
+            },
+            viewport: {
+                enabled: true,
+                count: 15, // number of items to display at once
+            },
 
-         // load data by ajax
-         source: {
-            url:  '{{ path("/ajax/entitytreesons.php") }}',
-            cache: false
-         },
+            // load data by ajax
+            source: {
+                url:  '{{ path("/ajax/entitytreesons.php") }}',
+                cache: false
+            },
 
-         // filter plugin options
-         filter: {
-            mode: "hide", // remove unmatched nodes
-            autoExpand: true, // if results found in children, auto-expand parent
-            nodata: '{{ __("No entity found") }}', // message when no data found
-            highlight: false, // do not highlight matches by wrapping inside tags (when true, this strip the a tag)
-            counter: false, // do not show counters when filtering entity tree
-         },
+            // filter plugin options
+            filter: {
+                mode: "hide", // remove unmatched nodes
+                autoExpand: true, // if results found in children, auto-expand parent
+                nodata: '{{ __("No entity found") }}', // message when no data found
+                highlight: false, // do not highlight matches by wrapping inside tags (when true, this strip the a tag)
+                counter: false, // do not show counters when filtering entity tree
+            },
 
-         // load 3rd party scrollbar extension for viewport mode
-         preInit: function(event, data) {
-            var tree = data.tree;
+            // load 3rd party scrollbar extension for viewport mode
+            preInit: function(event, data) {
+                var tree = data.tree;
 
-            tree.verticalScrollbar = new PlainScrollbar({
-               alwaysVisible: true,
-               arrows: true,
-               orientation: "vertical",
-               onSet: function(numberOfItems) {
-                  tree.setViewport({
-                     start: Math.round(numberOfItems.start),
-                  });
-               },
-               scrollbarElement: document.getElementById("verticalScrollbar-{{ rand }}"),
-            });
-         },
+                tree.verticalScrollbar = new PlainScrollbar({
+                alwaysVisible: true,
+                arrows: true,
+                orientation: "vertical",
+                onSet: function(numberOfItems) {
+                    tree.setViewport({
+                        start: Math.round(numberOfItems.start),
+                    });
+                },
+                scrollbarElement: document.getElementById("verticalScrollbar-{{ rand }}"),
+                });
+            },
 
-         // update scrollbar when viewport is updated
-         updateViewport: function(event, data) {
-            var tree = data.tree;
+            // update scrollbar when viewport is updated
+            updateViewport: function(event, data) {
+                var tree = data.tree;
 
-            tree.verticalScrollbar.set({
-               start: tree.viewport.start,
-               total: tree.visibleNodeList.length,
-               visible: tree.viewport.count,
-            }, true);  // do not trigger `onSet`
+                tree.verticalScrollbar.set({
+                start: tree.viewport.start,
+                total: tree.visibleNodeList.length,
+                visible: tree.viewport.count,
+                }, true);  // do not trigger `onSet`
 
-            initTooltips();
-         },
+                initTooltips();
+            },
 
-        // update toolips on node expand
-        expand: function(event, data) {
-            initTooltips();
-        },
-      });
+            // update toolips on node expand
+            expand: function(event, data) {
+                initTooltips();
+            },
+        });
+      };
+
+      // init Entities tree only when user ask for it (when dropdown is opened)
+      document.getElementById('entity-tree-dropdown-{{ rand }}')
+        .addEventListener('show.bs.dropdown', function (event) {
+            initTree{{ rand }}();
+        });
 
       var searchTree = function() {
          var search_text = $("#entsearchtext{{ rand }}").val();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Avoid systematic load of entity tree by ajax (on large instance this can consumes 500ms and delay other ajax requests)
More, the tree is initalized twice, as we need to have the user menu at different places for responsive design.

a0791ffbb5041ece1fbe3b3ec2a7f2d4d2a986f3 is just re-indenting correctly the file as I already rewrite of good bunch of code. I can drop it if it's too much
