### PR TITLE
Fix typo in dictionary

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -115,7 +115,7 @@ class CommonDBTM extends CommonGLPI
     protected static $notable = false;
 
     /**
-     * List of fields that must not be taken into account for dictionnary processing.
+     * List of fields that must not be taken into account for dictionary processing.
      *
      * @var string[]
      */

--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -768,7 +768,7 @@ abstract class CommonDropdown extends CommonDBTM
     /**
      * Import a value in a dropdown table.
      *
-     * This import a new dropdown if it doesn't exist - Play dictionnary if needed
+     * This import a new dropdown if it doesn't exist - Play dictionary if needed
      *
      * @param string  $value           Value of the new dropdown (need to be addslashes)
      * @param integer $entities_id     Entity in case of specific dropdown (default -1)

--- a/src/Console/Rules/ReplayDictionnaryRulesCommand.php
+++ b/src/Console/Rules/ReplayDictionnaryRulesCommand.php
@@ -48,14 +48,14 @@ class ReplayDictionnaryRulesCommand extends AbstractCommand
         parent::configure();
 
         $this->setName('rules:replay_dictionnary_rules');
-        $this->setDescription(__('Replay dictionnary rules on existing items'));
+        $this->setDescription(__('Replay dictionary rules on existing items'));
 
         $this->addOption(
             'dictionnary',
             'd',
             InputOption::VALUE_REQUIRED,
             sprintf(
-                __('Dictionnary to use. Possible values are: %s'),
+                __('Dictionary to use. Possible values are: %s'),
                 implode(', ', $this->getDictionnaryTypes())
             )
         );
@@ -65,7 +65,7 @@ class ReplayDictionnaryRulesCommand extends AbstractCommand
             'm',
             InputOption::VALUE_REQUIRED,
             __('If option is set, only items having given manufacturer ID will be processed.')
-            . "\n" . __('Currently only available for Software dictionnary.')
+            . "\n" . __('Currently only available for Software dictionary.')
         );
     }
 
@@ -73,11 +73,11 @@ class ReplayDictionnaryRulesCommand extends AbstractCommand
     {
 
         if (empty($input->getOption('dictionnary'))) {
-           // Ask for dictionnary argument is empty
+           // Ask for dictionary argument is empty
             /** @var \Symfony\Component\Console\Helper\QuestionHelper $question_helper */
             $question_helper = $this->getHelper('question');
             $question = new ChoiceQuestion(
-                __('Which dictionnary do you want to replay?'),
+                __('Which dictionary do you want to replay?'),
                 $this->getDictionnaryTypes()
             );
             $answer = $question_helper->ask(
@@ -100,7 +100,7 @@ class ReplayDictionnaryRulesCommand extends AbstractCommand
             || !($rulecollection instanceof \RuleCollection)
         ) {
             throw new \Symfony\Component\Console\Exception\InvalidArgumentException(
-                sprintf(__('Invalid "dictionnary" value.'))
+                sprintf(__('Invalid "dictionary" value.'))
             );
         }
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -2452,7 +2452,7 @@ JAVASCRIPT;
     /**
      * Import a value in a dropdown table.
      *
-     * This import a new dropdown if it doesn't exist - Play dictionnary if needed
+     * This import a new dropdown if it doesn't exist - Play dictionary if needed
      *
      * @param string  $itemtype         name of the class
      * @param string  $value            Value of the new dropdown.

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -1037,7 +1037,7 @@ class Profile extends CommonDBTM
                                 'scope'     => 'global'
                             ]),
                             $fn_get_rights(RuleDictionnaryPrinter::class, 'central', [
-                                'label'     => __('Printers dictionnary'),
+                                'label'     => __('Printers dictionary'),
                                 'scope'     => 'global'
                             ]),
                         ]

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -48,7 +48,7 @@ class RuleCollection extends CommonDBTM
     public $orderby                               = "ranking";
    /// Processing several rules : use result of the previous one to computer the current one
     public $use_output_rule_process_as_next_input = false;
-   /// Rule collection can be replay (for dictionnary)
+   /// Rule collection can be replay (for dictionary)
     public $can_replay_rules                      = false;
    /// List of rules of the rule collection
     public $RuleList                              = null;
@@ -2052,7 +2052,7 @@ JAVASCRIPT;
      * Get rulecollection classname by giving his itemtype
      *
      * @param $itemtype                 itemtype
-     * @param $check_dictionnary_type   check if the itemtype is a dictionnary or not
+     * @param $check_dictionnary_type   check if the itemtype is a dictionary or not
      *                                  (false by default)
      *
      * @return RuleCollection|null

--- a/src/RuleDictionnaryComputerModelCollection.php
+++ b/src/RuleDictionnaryComputerModelCollection.php
@@ -35,9 +35,6 @@
 
 class RuleDictionnaryComputerModelCollection extends RuleDictionnaryDropdownCollection
 {
-   // From RuleCollection
-   //public $rule_class_name = 'RuleDictionnaryComputerModel';
-
     public $item_table  = "glpi_computermodels";
     public $menu_option = "model.computer";
 
@@ -46,6 +43,6 @@ class RuleDictionnaryComputerModelCollection extends RuleDictionnaryDropdownColl
      **/
     public function getTitle()
     {
-        return __('Dictionnary of computer models');
+        return __('Dictionary of computer models');
     }
 }

--- a/src/RuleDictionnaryComputerTypeCollection.php
+++ b/src/RuleDictionnaryComputerTypeCollection.php
@@ -35,9 +35,6 @@
 
 class RuleDictionnaryComputerTypeCollection extends RuleDictionnaryDropdownCollection
 {
-   // From RuleCollection
-   //public $rule_class_name = 'RuleDictionnaryComputerType';
-
     public $item_table  = "glpi_computertypes";
     public $menu_option = "type.computer";
 
@@ -46,6 +43,6 @@ class RuleDictionnaryComputerTypeCollection extends RuleDictionnaryDropdownColle
      **/
     public function getTitle()
     {
-        return __('Dictionnary of computer types');
+        return __('Dictionary of computer types');
     }
 }

--- a/src/RuleDictionnaryMonitorModelCollection.php
+++ b/src/RuleDictionnaryMonitorModelCollection.php
@@ -43,6 +43,6 @@ class RuleDictionnaryMonitorModelCollection extends RuleDictionnaryDropdownColle
      **/
     public function getTitle()
     {
-        return __('Dictionnary of computer models');
+        return __('Dictionary of computer models');
     }
 }

--- a/src/RuleDictionnaryMonitorTypeCollection.php
+++ b/src/RuleDictionnaryMonitorTypeCollection.php
@@ -35,9 +35,6 @@
 
 class RuleDictionnaryMonitorTypeCollection extends RuleDictionnaryDropdownCollection
 {
-   // From RuleCollection
-   //public $rule_class_name = 'RuleDictionnaryMonitorType';
-
     public $item_table  = "glpi_monitortypes";
     public $menu_option = "type.monitor";
 
@@ -46,6 +43,6 @@ class RuleDictionnaryMonitorTypeCollection extends RuleDictionnaryDropdownCollec
      **/
     public function getTitle()
     {
-        return __('Dictionnary of monitor types');
+        return __('Dictionary of monitor types');
     }
 }

--- a/src/RuleDictionnaryNetworkEquipmentModelCollection.php
+++ b/src/RuleDictionnaryNetworkEquipmentModelCollection.php
@@ -43,6 +43,6 @@ class RuleDictionnaryNetworkEquipmentModelCollection extends RuleDictionnaryDrop
      **/
     public function getTitle()
     {
-        return __('Dictionnary of networking equipment models');
+        return __('Dictionary of networking equipment models');
     }
 }

--- a/src/RuleDictionnaryNetworkEquipmentTypeCollection.php
+++ b/src/RuleDictionnaryNetworkEquipmentTypeCollection.php
@@ -43,6 +43,6 @@ class RuleDictionnaryNetworkEquipmentTypeCollection extends RuleDictionnaryDropd
      **/
     public function getTitle()
     {
-        return __('Dictionnary of network equipment types');
+        return __('Dictionary of network equipment types');
     }
 }

--- a/src/RuleDictionnaryOperatingSystemArchitectureCollection.php
+++ b/src/RuleDictionnaryOperatingSystemArchitectureCollection.php
@@ -43,6 +43,6 @@ class RuleDictionnaryOperatingSystemArchitectureCollection extends RuleDictionna
      **/
     public function getTitle()
     {
-        return __('Dictionnary of operating system architectures');
+        return __('Dictionary of operating system architectures');
     }
 }

--- a/src/RuleDictionnaryOperatingSystemCollection.php
+++ b/src/RuleDictionnaryOperatingSystemCollection.php
@@ -43,6 +43,6 @@ class RuleDictionnaryOperatingSystemCollection extends RuleDictionnaryDropdownCo
      **/
     public function getTitle()
     {
-        return __('Dictionnary of operating systems');
+        return __('Dictionary of operating systems');
     }
 }

--- a/src/RuleDictionnaryOperatingSystemEditionCollection.php
+++ b/src/RuleDictionnaryOperatingSystemEditionCollection.php
@@ -43,6 +43,6 @@ class RuleDictionnaryOperatingSystemEditionCollection extends RuleDictionnaryDro
      **/
     public function getTitle()
     {
-        return __('Dictionnary of operating system editions');
+        return __('Dictionary of operating system editions');
     }
 }

--- a/src/RuleDictionnaryOperatingSystemServicePackCollection.php
+++ b/src/RuleDictionnaryOperatingSystemServicePackCollection.php
@@ -43,6 +43,6 @@ class RuleDictionnaryOperatingSystemServicePackCollection extends RuleDictionnar
      **/
     public function getTitle()
     {
-        return __('Dictionnary of service packs');
+        return __('Dictionary of service packs');
     }
 }

--- a/src/RuleDictionnaryOperatingSystemVersionCollection.php
+++ b/src/RuleDictionnaryOperatingSystemVersionCollection.php
@@ -43,6 +43,6 @@ class RuleDictionnaryOperatingSystemVersionCollection extends RuleDictionnaryDro
      **/
     public function getTitle()
     {
-        return __('Dictionnary of operating system versions');
+        return __('Dictionary of operating system versions');
     }
 }

--- a/src/RuleDictionnaryPeripheralModelCollection.php
+++ b/src/RuleDictionnaryPeripheralModelCollection.php
@@ -43,6 +43,6 @@ class RuleDictionnaryPeripheralModelCollection extends RuleDictionnaryDropdownCo
      **/
     public function getTitle()
     {
-        return __('Dictionnary of device models');
+        return __('Dictionary of device models');
     }
 }

--- a/src/RuleDictionnaryPeripheralTypeCollection.php
+++ b/src/RuleDictionnaryPeripheralTypeCollection.php
@@ -43,6 +43,6 @@ class RuleDictionnaryPeripheralTypeCollection extends RuleDictionnaryDropdownCol
      **/
     public function getTitle()
     {
-        return __('Dictionnary of device types');
+        return __('Dictionary of device types');
     }
 }

--- a/src/RuleDictionnaryPhoneModelCollection.php
+++ b/src/RuleDictionnaryPhoneModelCollection.php
@@ -43,6 +43,6 @@ class RuleDictionnaryPhoneModelCollection extends RuleDictionnaryDropdownCollect
      **/
     public function getTitle()
     {
-        return __('Dictionnary of phone models');
+        return __('Dictionary of phone models');
     }
 }

--- a/src/RuleDictionnaryPhoneTypeCollection.php
+++ b/src/RuleDictionnaryPhoneTypeCollection.php
@@ -43,6 +43,6 @@ class RuleDictionnaryPhoneTypeCollection extends RuleDictionnaryDropdownCollecti
      **/
     public function getTitle()
     {
-        return __('Dictionnary of phone types');
+        return __('Dictionary of phone types');
     }
 }

--- a/src/RuleDictionnaryPrinter.php
+++ b/src/RuleDictionnaryPrinter.php
@@ -49,7 +49,7 @@ class RuleDictionnaryPrinter extends Rule
 
     public function getTitle()
     {
-        return __('Dictionnary of printers');
+        return __('Dictionary of printers');
     }
 
 

--- a/src/RuleDictionnaryPrinterCollection.php
+++ b/src/RuleDictionnaryPrinterCollection.php
@@ -49,7 +49,7 @@ class RuleDictionnaryPrinterCollection extends RuleCollection
      **/
     public function getTitle()
     {
-        return __('Dictionnary of printers');
+        return __('Dictionary of printers');
     }
 
 
@@ -130,7 +130,7 @@ class RuleDictionnaryPrinterCollection extends RuleCollection
                 }
             }
 
-           //Replay printer dictionnary rules
+           //Replay printer dictionary rules
             $res_rule = $this->processAllRules($input, [], []);
 
             foreach (['manufacturer', 'is_global', 'name'] as $attr) {
@@ -157,7 +157,7 @@ class RuleDictionnaryPrinterCollection extends RuleCollection
                     foreach ($print_iterator as $result) {
                         $IDs[] = $result["id"];
                     }
-                     //Replay dictionnary on all the printers
+                     //Replay dictionary on all the printers
                      $this->replayDictionnaryOnPrintersByID($IDs, $res_rule);
                 }
             }
@@ -204,7 +204,7 @@ class RuleDictionnaryPrinterCollection extends RuleCollection
 
 
     /**
-     * Replay dictionnary on several printers
+     * Replay dictionary on several printers
      *
      * @param $IDs       array of printers IDs to replay
      * @param $res_rule  array of rule results
@@ -266,7 +266,7 @@ class RuleDictionnaryPrinterCollection extends RuleCollection
 
 
     /**
-     * Replay dictionnary on one printer
+     * Replay dictionary on one printer
      *
      * @param &$new_printers   array containing new printers already computed
      * @param $res_rule        array of rule results

--- a/src/RuleDictionnaryPrinterModelCollection.php
+++ b/src/RuleDictionnaryPrinterModelCollection.php
@@ -43,6 +43,6 @@ class RuleDictionnaryPrinterModelCollection extends RuleDictionnaryDropdownColle
      **/
     public function getTitle()
     {
-        return __('Dictionnary of printer models');
+        return __('Dictionary of printer models');
     }
 }

--- a/src/RuleDictionnaryPrinterTypeCollection.php
+++ b/src/RuleDictionnaryPrinterTypeCollection.php
@@ -43,6 +43,6 @@ class RuleDictionnaryPrinterTypeCollection extends RuleDictionnaryDropdownCollec
      **/
     public function getTitle()
     {
-        return __('Dictionnary of printer types');
+        return __('Dictionary of printer types');
     }
 }

--- a/src/RuleDictionnarySoftware.php
+++ b/src/RuleDictionnarySoftware.php
@@ -54,7 +54,7 @@ class RuleDictionnarySoftware extends Rule
     public function getTitle()
     {
        //TRANS: plural for software
-        return __('Dictionnary of software');
+        return __('Dictionary of software');
     }
 
 

--- a/src/RuleDictionnarySoftwareCollection.php
+++ b/src/RuleDictionnarySoftwareCollection.php
@@ -50,7 +50,7 @@ class RuleDictionnarySoftwareCollection extends RuleCollection
     public function getTitle()
     {
        //TRANS: software in plural
-        return __('Dictionnary of software');
+        return __('Dictionary of software');
     }
 
 
@@ -173,12 +173,12 @@ class RuleDictionnarySoftwareCollection extends RuleCollection
                     }
                 }
 
-               //If manufacturer is set, then first run the manufacturer's dictionnary
+               //If manufacturer is set, then first run the manufacturer's dictionary
                 if (isset($input["manufacturer"])) {
                     $input["manufacturer"] = Manufacturer::processName($input["manufacturer"]);
                 }
 
-               //Replay software dictionnary rules
+               //Replay software dictionary rules
                 $res_rule = $this->processAllRules($input, [], []);
 
                 if (
@@ -209,7 +209,7 @@ class RuleDictionnarySoftwareCollection extends RuleCollection
                         foreach ($same_iterator as $result) {
                             $IDs[] = $result["id"];
                         }
-                        //Replay dictionnary on all the software
+                        //Replay dictionary on all the software
                         $this->replayDictionnaryOnSoftwaresByID($IDs, $res_rule);
                     }
                 }
@@ -302,7 +302,7 @@ class RuleDictionnarySoftwareCollection extends RuleCollection
 
 
     /**
-     * Replay dictionnary on one software
+     * Replay dictionary on one software
      *
      * @param &$new_softs      array containing new software already computed
      * @param $res_rule        array of rule results

--- a/src/Software.php
+++ b/src/Software.php
@@ -871,7 +871,7 @@ class Software extends CommonDBTM
 
 
     /**
-     * Put software in trashbin because it's been removed by GLPI software dictionnary
+     * Put software in trashbin because it's been removed by GLPI software dictionary
      *
      * @param $ID        the ID of the software to put in trashbin
      * @param $comment   the comment to add to the already existing software's comment (default '')
@@ -895,7 +895,7 @@ class Software extends CommonDBTM
             $input["softwarecategories_id"] = $CFG_GLPI["softwarecategories_id_ondelete"];
         }
 
-       //Add dictionnary comment to the current comment
+       //Add dictionary comment to the current comment
         $input["comment"] = (($this->fields["comment"] != '') ? "\n" : '') . $comment;
 
         return $this->update($input);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

See #15795

I've just fixed in comments and translations. Files, classes and methods names remains unchanged (this would be a very huge job to change properly all of that).
