### PR TITLE
don't break header layout when global search is disabled

### DIFF
--- a/templates/layout/parts/global_search_form.html.twig
+++ b/templates/layout/parts/global_search_form.html.twig
@@ -31,7 +31,7 @@
  # ---------------------------------------------------------------------
  #}
 
-{% if get_current_interface() == 'central' %}
+{% if get_current_interface() == 'central' and config('allow_search_global') %}
 <form action="{{ path('front/search.php') }}" role="search" method="get" data-submit-once>
    <div class="input-group input-group-flat">
       <input type="text" class="form-control" name="globalsearch" placeholder="{{ __('Search…') }}" />

--- a/templates/layout/parts/page_header.html.twig
+++ b/templates/layout/parts/page_header.html.twig
@@ -95,11 +95,9 @@
             {% if user_pref('page_layout') == 'vertical' %}
                {{ include('layout/parts/breadcrumbs.html.twig') }}
 
-               {% if config('allow_search_global') %}
-                  <div class="ms-lg-auto d-none d-lg-block flex-grow-1 flex-lg-grow-0">
+                <div class="ms-lg-auto d-none d-lg-block flex-grow-1 flex-lg-grow-0">
                      {{ include('layout/parts/global_search_form.html.twig') }}
-                  </div>
-               {% endif %}
+                </div>
 
             {% elseif user_pref('page_layout') == 'horizontal' %}
                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-menu">
@@ -133,11 +131,9 @@
       <div class="navbar navbar-expand-md navbar-light secondary-bar sticky-md-top shadow-sm">
          <div class="container-fluid justify-content-start">
             {{ include('layout/parts/breadcrumbs.html.twig') }}
-            {% if config('allow_search_global') %}
-               <div class="ms-md-auto d-none d-md-block flex-grow-1 flex-md-grow-0">
-                  {{ include('layout/parts/global_search_form.html.twig') }}
-               </div>
-            {% endif %}
+            <div class="ms-md-auto d-none d-md-block flex-grow-1 flex-md-grow-0">
+                {{ include('layout/parts/global_search_form.html.twig') }}
+            </div>
          </div>
       </div>
       {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

When global search bar is disable (in setup > general), the header and breadcrumbs move.
I keep the div empty to get flex working correctly.

Before:
![image](https://github.com/glpi-project/glpi/assets/418844/89b106ce-d1ea-4475-abcb-ce3d826e7724)

After: 
![image](https://github.com/glpi-project/glpi/assets/418844/214b8c75-bc81-4fc4-aa0b-b1d4c78efa82)


