### PR TITLE
Add warnings on cache issues

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -77,6 +77,8 @@ if (!file_exists(GLPI_CONFIG_DIR . '/config_db.php')) {
 
 \Glpi\Tests\BootstrapUtils::initVarDirectories();
 
+include_once __DIR__ . '/../inc/includes.php';
+
 //init cache
 if (file_exists(GLPI_CONFIG_DIR . DIRECTORY_SEPARATOR . CacheManager::CONFIG_FILENAME)) {
    // Use configured cache for cache tests
@@ -86,8 +88,6 @@ if (file_exists(GLPI_CONFIG_DIR . DIRECTORY_SEPARATOR . CacheManager::CONFIG_FIL
    // Use "in-memory" cache for other tests
     $GLPI_CACHE = new SimpleCache(new ArrayAdapter());
 }
-
-include_once __DIR__ . '/../inc/includes.php';
 
 // Errors/exceptions that are not explicitely validated by `$this->error()` or `$this->exception` asserter will already make test fails.
 // There is no need to pollute the output with error messages.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | see !30032

I spend a few hours trying to understand why the filesystem of a customer was saturated by temporary file cache entries. The root cause was that a sub directory of the translations cache directory was owned by the `root` user, but file entry writing failure was not triggering any error/warning.

To get warnings, the logger must be defined on the cache adapter.

Warnings will look like this:
```
glpiphplog.WARNING: Failed to save key "{key}" of type array: fopen(/var/www/glpi/files/_cache/core/739e585a1908): Failed to open stream: Permission denied {"key":"0d74920f7b4ea661e0670b6c28ffda3a7c2eb869","exception":"[object] (ErrorException(code: 0): fopen(/var/www/glpi/files/_cache/core/739e585a1908): Failed to open stream: Permission denied at /var/www/glpi/vendor/symfony/cache/Traits/FilesystemCommonTrait.php:99)","cache-adapter":"Symfony\\Component\\Cache\\Adapter\\FilesystemAdapter"}
```