### PR TITLE
Fix error on 10.0.2 -> 10.0.3 migration

### DIFF
--- a/install/migrations/update_10.0.2_to_10.0.3/notifications.php
+++ b/install/migrations/update_10.0.2_to_10.0.3/notifications.php
@@ -97,6 +97,10 @@ $template_iterator = $DB->request([
     'FROM'   => 'glpi_notificationtemplatetranslations',
 ]);
 foreach ($template_iterator as $template_data) {
+    if ($template_data['content_html'] === null) {
+        continue;
+    }
+
     $content_html = Sanitizer::decodeHtmlSpecialChars($template_data['content_html']);
 
     if (str_contains($content_html, '&lt;p&gt;') && str_contains($content_html, '&lt;/p&gt;')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://forum.glpi-project.org/viewtopic.php?pid=505474

Fixes following error:
```
glpiphplog.CRITICAL:   *** Uncaught Exception TypeError: Argument 1 passed to Glpi\Toolbox\Sanitizer::decodeHtmlSpecialChars() must be of the type string, null given, called>
  Backtrace :
  ...s/update_10.0.2_to_10.0.3/notifications.php:100 Glpi\Toolbox\Sanitizer::decodeHtmlSpecialChars()
  install/migrations/update_10.0.2_to_10.0.3.php:59  require()
  src/Update.php:260                                 update1002to1003()
  src/Console/Database/UpdateCommand.php:212         Update->doUpdates()
  vendor/symfony/console/Command/Command.php:298     Glpi\Console\Database\UpdateCommand->execute()
  vendor/symfony/console/Application.php:1040        Symfony\Component\Console\Command\Command->run()
  src/Console/Application.php:272                    Symfony\Component\Console\Application->doRunCommand()
  vendor/symfony/console/Application.php:301         Glpi\Console\Application->doRunCommand()
  vendor/symfony/console/Application.php:171         Symfony\Component\Console\Application->doRun()
  bin/console:122                                    Symfony\Component\Console\Application->run()
```