### PR TITLE
Do not trust session cookie configuration on CLI context

### DIFF
--- a/src/System/Requirement/SessionsSecurityConfiguration.php
+++ b/src/System/Requirement/SessionsSecurityConfiguration.php
@@ -59,7 +59,7 @@ class SessionsSecurityConfiguration extends AbstractRequirement
 
         if ($is_cli) {
             $this->validation_messages[] = __('Checking the session cookie configuration of the web server cannot be done in the CLI context.');
-            $this->validation_messages[] = __('However, you should apply the following recommendations for configuring the web server.');
+            $this->validation_messages[] = __('You should apply the following recommendations for configuring the web server.');
             $this->out_of_context = true;
         }
         $cookie_secure_ko = $is_https_request && !$cookie_secure;

--- a/tests/units/Glpi/System/Requirement/SessionsSecurityConfiguration.php
+++ b/tests/units/Glpi/System/Requirement/SessionsSecurityConfiguration.php
@@ -165,7 +165,7 @@ class SessionsSecurityConfiguration extends \GLPITestCase
         $this->array($this->testedInstance->getValidationMessages())->isEqualTo(
             [
                 'Checking the session cookie configuration of the web server cannot be done in the CLI context.',
-                'However, you should apply the following recommendations for configuring the web server.',
+                'You should apply the following recommendations for configuring the web server.',
                 'PHP directive "session.cookie_secure" should be set to "on" when GLPI can be accessed on HTTPS protocol.',
                 'PHP directive "session.cookie_httponly" should be set to "on" to prevent client-side script to access cookie values.',
                 'PHP directive "session.cookie_samesite" should be set, at least, to "Lax", to prevent cookie to be sent on cross-origin POST requests.',

--- a/tests/units/Glpi/System/Requirement/SessionsSecurityConfiguration.php
+++ b/tests/units/Glpi/System/Requirement/SessionsSecurityConfiguration.php
@@ -39,11 +39,6 @@ class SessionsSecurityConfiguration extends \GLPITestCase
 {
     protected function configProvider(): iterable
     {
-        $invalid_secure_msg   = 'PHP directive "session.cookie_secure" should be set to "on" when GLPI can be accessed on HTTPS protocol.';
-        $invalid_httponly_msg = 'PHP directive "session.cookie_httponly" should be set to "on" to prevent client-side script to access cookie values.';
-        $invalid_samesite_msg = 'PHP directive "session.cookie_samesite" should be set, at least, to "Lax", to prevent cookie to be sent on cross-origin POST requests.';
-        $valid_msg            = 'Sessions configuration is secured.';
-
         // Totally unsecure config
         yield [
             'cookie_secure'   => '0',
@@ -52,7 +47,6 @@ class SessionsSecurityConfiguration extends \GLPITestCase
             'server_https'    => 'on',
             'server_port'     => '443',
             'is_valid'        => false,
-            'messages'        => [$invalid_secure_msg, $invalid_httponly_msg, $invalid_samesite_msg],
         ];
 
         // Strict config
@@ -63,7 +57,6 @@ class SessionsSecurityConfiguration extends \GLPITestCase
             'server_https'    => 'on',
             'server_port'     => '443',
             'is_valid'        => true,
-            'messages'        => [$valid_msg],
         ];
 
         // cookie_secure can be 0 if query is not on HTTPS
@@ -74,7 +67,6 @@ class SessionsSecurityConfiguration extends \GLPITestCase
             'server_https'    => 'off',
             'server_port'     => '80',
             'is_valid'        => true,
-            'messages'        => [$valid_msg],
         ];
 
         // cookie_secure should be 1 if query is on HTTPS (detected from $_SERVER['HTTPS'])
@@ -85,7 +77,6 @@ class SessionsSecurityConfiguration extends \GLPITestCase
             'server_https'    => 'on',
             'server_port'     => null,
             'is_valid'        => false,
-            'messages'        => [$invalid_secure_msg],
         ];
 
         // cookie_secure should be 1 if query is on HTTPS (detected from $_SERVER['SERVER_PORT'])
@@ -96,7 +87,6 @@ class SessionsSecurityConfiguration extends \GLPITestCase
             'server_https'    => null,
             'server_port'     => '443',
             'is_valid'        => false,
-            'messages'        => [$invalid_secure_msg],
         ];
 
         // cookie_httponly should be 1
@@ -107,7 +97,6 @@ class SessionsSecurityConfiguration extends \GLPITestCase
             'server_https'    => 'off',
             'server_port'     => '80',
             'is_valid'        => false,
-            'messages'        => [$invalid_httponly_msg],
         ];
 
         // cookie_samesite should be 'Lax', 'Strict', or ''
@@ -126,7 +115,6 @@ class SessionsSecurityConfiguration extends \GLPITestCase
                 'server_https'    => 'off',
                 'server_port'     => '80',
                 'is_valid'        => $is_valid,
-                'messages'        => $is_valid ? [$valid_msg] : [$invalid_samesite_msg],
             ];
             yield [
                 'cookie_secure'   => '0',
@@ -135,7 +123,6 @@ class SessionsSecurityConfiguration extends \GLPITestCase
                 'server_https'    => 'off',
                 'server_port'     => '80',
                 'is_valid'        => $is_valid,
-                'messages'        => $is_valid ? [$valid_msg] : [$invalid_samesite_msg],
             ];
         }
     }
@@ -149,8 +136,7 @@ class SessionsSecurityConfiguration extends \GLPITestCase
         string $cookie_samesite,
         ?string $server_https,
         ?string $server_port,
-        bool $is_valid,
-        array $messages
+        bool $is_valid
     ) {
         $this->function->ini_get = function ($name) use ($cookie_secure, $cookie_httponly, $cookie_samesite) {
             switch ($name) {
@@ -176,6 +162,14 @@ class SessionsSecurityConfiguration extends \GLPITestCase
 
         $this->newTestedInstance();
         $this->boolean($this->testedInstance->isValidated())->isEqualTo($is_valid);
-        $this->array($this->testedInstance->getValidationMessages())->isEqualTo($messages);
+        $this->array($this->testedInstance->getValidationMessages())->isEqualTo(
+            [
+                'Checking the session cookie configuration of the web server cannot be done in the CLI context.',
+                'However, you should apply the following recommendations for configuring the web server.',
+                'PHP directive "session.cookie_secure" should be set to "on" when GLPI can be accessed on HTTPS protocol.',
+                'PHP directive "session.cookie_httponly" should be set to "on" to prevent client-side script to access cookie values.',
+                'PHP directive "session.cookie_samesite" should be set, at least, to "Lax", to prevent cookie to be sent on cross-origin POST requests.',
+            ]
+        );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30084

When requirements are checked on CLI context, the used PHP configuration file may often be different than the one that will be used in web context. For most requirements, it is not an issue. Either they are not strictly related to PHP configuration, either fatal errors will be triggered if they are not met on web context (e.g. a missing extension will propably result in fatal errors).

For the session cookie configuration check, it may be an issue. Indeed, we should not explicitely say that `Sessions configuration is secured.` if we cannot be sure that it is really the case on web context. I propose to always show recommendations for this requirement when it is checked on CLI context:

![image](https://github.com/glpi-project/glpi/assets/33253653/67a7e5db-5293-4983-9b1d-7e44782fc97d)
