### PR TITLE
scroll to anchor after tab loading

### DIFF
--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -372,7 +372,14 @@ JAVASCRIPT;
                      tab_key: href_url_params.get('_glpi_tab'),
                      withtemplate: " . (int)($_GET['withtemplate'] ?? 0) . "
                   }
-               );
+               ).done(function() {
+                    // try to restore the scroll on a specific anchor
+                    if (window.location.hash.length > 0) {
+                        // as we load content by ajax, when full page was ready, the anchor was not present
+                        // se we recall it to force the scroll.
+                        window.location.hash = window.location.hash;
+                    }
+               });
             }
             if ($(target).html() && !force_reload) {
                 updateCurrentTab();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Anchors are present from a long time in the timeline and worked if you call the same url when the page is open.
But as timeline (like the rest of the ticket) is loaded by ajax, on opening a new url, anchor scrolling didn't worked.

I set the behavior in the global code because it also fix the KB (also have anchors)
Atm, I don't see where it can cause issue (non wanted scroll)