### PR TITLE
Explicitely define valid elements for tinymce

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -3926,6 +3926,7 @@ JS;
 
                // Content settings
                entity_encoding: 'raw',
+               valid_elements: '*',
                invalid_elements: '{$invalid_elements}',
                readonly: {$readonlyjs},
                relative_urls: false,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15636 

According to documentation:
«Use * to include all elements and all attributes. This can be very useful when used with the invalid_elements option.»

Maybe that fix related issue.
