### PR TITLE
Prevent TinyMCE to remove styles when content is pasted from a template

### DIFF
--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -349,7 +349,8 @@ const setRichTextEditorContent = function(editor_id, content) {
         editor.setContent('');
         // use paste command to force images registering
         editor.execCommand('mceInsertClipboardContent', false, {
-            html: content
+            html: content,
+            internal: true, // disable some filterings operations that would remove styles (maybe a bug)
         });
         // force trigger of event handlers that will save editor contents
         // and remove "required" state


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15636

After some reverse engeneering, I figured out that there was an undocumented `internal` option that could be passed to `mceInsertClipboardContent` command. Passing this option with the `true` values disable some filtering operations that seems to be the cause of the issue here.

I was not able to identify exactly what is the issue here, and if it is a bug from TinyMCE or an expected behaviour. I will probably open an issue on their repository later.

To reproduce :
- create a solution template that contains a table with a background color;
- create a ticket and add a solution based on this template;
- check whether the background color is preserved when solution content is copied from the template.