### PR TITLE
Drop support of MariaDB < 10.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
           # test other PHP versions
           - {php-version: "8.1", db-image: "mariadb:11.0", always: false}
           # test other DB servers/versions
-          - {php-version: "8.2", db-image: "mariadb:10.3", always: false}
+          - {php-version: "8.2", db-image: "mariadb:10.5", always: false}
           - {php-version: "8.2", db-image: "mariadb:10.11", always: false}
           - {php-version: "8.2", db-image: "mysql:8.0", always: false}
           - {php-version: "8.2", db-image: "percona:8.0", always: false}

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ It is distributed under the GNU GENERAL PUBLIC LICENSE Version 3 - please consul
 ## Prerequisites
 
 * A web server (Apache, Nginx, IIS, etc.)
-* MariaDB >= 10.3 or MySQL >= 8.0
+* MariaDB >= 10.5 or MySQL >= 8.0
 * PHP (See compatibility matrix below)
 
     | GLPI Version | Minimum PHP | Maximum PHP |

--- a/src/Config.php
+++ b/src/Config.php
@@ -1490,9 +1490,9 @@ class Config extends CommonDBTM
         $server  = preg_match('/-MariaDB/', $raw) ? 'MariaDB' : 'MySQL';
         $version = preg_replace('/^((\d+\.?)+).*$/', '$1', $raw);
 
-        // MySQL >= 8.0 || MariaDB >= 10.3
+        // MySQL >= 8.0 || MariaDB >= 10.5
         $is_supported = $server === 'MariaDB'
-            ? version_compare($version, '10.3', '>=')
+            ? version_compare($version, '10.5', '>=')
             : version_compare($version, '8.0', '>=');
 
         return [$version => $is_supported];

--- a/src/System/Requirement/DbEngine.php
+++ b/src/System/Requirement/DbEngine.php
@@ -62,7 +62,7 @@ class DbEngine extends AbstractRequirement
 
         switch ($server) {
             case 'MariaDB':
-                $min_version = '10.3';
+                $min_version = '10.5';
                 break;
             case 'MySQL':
             default:

--- a/tests/functional/Config.php
+++ b/tests/functional/Config.php
@@ -400,11 +400,11 @@ class Config extends DbTestCase
             ], [
                 'raw'       => '10.3.28-MariaDB',
                 'version'   => '10.3.28',
-                'compat'    => true
+                'compat'    => false
             ], [
                 'raw'       => '10.4.8-MariaDB-1:10.4.8+maria~bionic',
                 'version'   => '10.4.8',
-                'compat'    => true
+                'compat'    => false
             ], [
                 'raw'       => '10.5.9-MariaDB',
                 'version'   => '10.5.9',

--- a/tests/functional/Search.php
+++ b/tests/functional/Search.php
@@ -2444,13 +2444,7 @@ class Search extends DbTestCase
         // required, because there is no search option that corresponds to it yet.
 
         global $DB;
-        $version_string = $DB->getVersion();
-        $server  = preg_match('/-MariaDB/', $version_string) ? 'MariaDB' : 'MySQL';
-        $version = preg_replace('/^((\d+\.?)+).*$/', '$1', $version_string);
-        $is_mariadb      = $server === 'MariaDB';
-        $is_mariadb_10_2 = $is_mariadb && version_compare($version, '10.3', '<');
-        $is_mysql_5_7    = $server === 'MySQL' && version_compare($version, '8.0', '<');
-
+        $is_mariadb = preg_match('/-MariaDB/', $DB->getVersion()) === 1;
 
         // Check simple values search.
         // Usage is only relevant for textual fields, so it is not tested on other fields.
@@ -2732,11 +2726,6 @@ class Search extends DbTestCase
             'expected_and'      => "(1=0)",
             'expected_and_not'  => "(1=0)",
         ];
-        if ($is_mysql_5_7) {
-            // log for both AND and AND NOT cases
-            $this->hasSqlLogRecordThatContains("Truncated incorrect date value: '%test%'", LogLevel::WARNING);
-            $this->hasSqlLogRecordThatContains("Truncated incorrect date value: '%test%'", LogLevel::WARNING);
-        }
         yield [
             'itemtype'          => \Contract::class,
             'search_option'     => 20, // end_date
@@ -2744,11 +2733,6 @@ class Search extends DbTestCase
             'expected_and'      => "(DATE_ADD(`glpi_contracts`.`begin_date`, INTERVAL `glpi_contracts`.`duration` MONTH) LIKE '%2023-12%')",
             'expected_and_not'  => "(DATE_ADD(`glpi_contracts`.`begin_date`, INTERVAL `glpi_contracts`.`duration` MONTH) NOT LIKE '%2023-12%' OR DATE_ADD(`glpi_contracts`.`begin_date`, INTERVAL `glpi_contracts`.`duration` MONTH) IS NULL)",
         ];
-        if ($is_mysql_5_7) {
-            // log for both AND and AND NOT cases
-            $this->hasSqlLogRecordThatContains("Truncated incorrect date value: '%2023-12%'", LogLevel::WARNING);
-            $this->hasSqlLogRecordThatContains("Truncated incorrect date value: '%2023-12%'", LogLevel::WARNING);
-        }
 
         // datatype=email
         yield [
@@ -2881,10 +2865,7 @@ class Search extends DbTestCase
                 'expected_and_not'  => "(`glpi_authldaps`.`port` IS NOT NULL AND `glpi_authldaps`.`port` <> '')",
             ];
             // log for both AND and AND NOT cases
-            if ($is_mariadb_10_2) {
-                $this->hasSqlLogRecordThatContains("Truncated incorrect DOUBLE value: ''", LogLevel::WARNING);
-                $this->hasSqlLogRecordThatContains("Truncated incorrect DOUBLE value: ''", LogLevel::WARNING);
-            } elseif ($is_mariadb) {
+            if ($is_mariadb) {
                 $this->hasSqlLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
                 $this->hasSqlLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
             }
@@ -2898,10 +2879,7 @@ class Search extends DbTestCase
                 'expected_and_not'  => "(`glpi_authldaps`.`timeout` IS NOT NULL AND `glpi_authldaps`.`timeout` <> '')",
             ];
             // log for both AND and AND NOT cases
-            if ($is_mariadb_10_2) {
-                $this->hasSqlLogRecordThatContains("Truncated incorrect DOUBLE value: ''", LogLevel::WARNING);
-                $this->hasSqlLogRecordThatContains("Truncated incorrect DOUBLE value: ''", LogLevel::WARNING);
-            } elseif ($is_mariadb) {
+            if ($is_mariadb) {
                 $this->hasSqlLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
                 $this->hasSqlLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
             }
@@ -2945,10 +2923,7 @@ class Search extends DbTestCase
                 'expected_and_not'  => "(`ITEM_Ticket_27` IS NOT NULL AND `ITEM_Ticket_27` <> '')",
             ];
             // log for both AND and AND NOT cases
-            if ($is_mariadb_10_2) {
-                $this->hasSqlLogRecordThatContains("Truncated incorrect DOUBLE value: ''", LogLevel::WARNING);
-                $this->hasSqlLogRecordThatContains("Truncated incorrect DOUBLE value: ''", LogLevel::WARNING);
-            } elseif ($is_mariadb) {
+            if ($is_mariadb) {
                 $this->hasSqlLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
                 $this->hasSqlLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
             }
@@ -2980,10 +2955,7 @@ class Search extends DbTestCase
                 'expected_and_not'  => "(`glpi_crontasks`.`frequency` IS NOT NULL AND `glpi_crontasks`.`frequency` <> '')",
             ];
             // log for both AND and AND NOT cases
-            if ($is_mariadb_10_2) {
-                $this->hasSqlLogRecordThatContains("Truncated incorrect DOUBLE value: ''", LogLevel::WARNING);
-                $this->hasSqlLogRecordThatContains("Truncated incorrect DOUBLE value: ''", LogLevel::WARNING);
-            } elseif ($is_mariadb) {
+            if ($is_mariadb) {
                 $this->hasSqlLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
                 $this->hasSqlLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
             }

--- a/tests/units/Glpi/System/Requirement/DbConfiguration.php
+++ b/tests/units/Glpi/System/Requirement/DbConfiguration.php
@@ -74,50 +74,6 @@ class DbConfiguration extends \GLPITestCase
                 ]
             ],
             [
-            // Default variables on MariaDB 10.3
-                'version'   => '10.3.27-MariaDB',
-                'variables' => [
-                    'innodb_page_size'    => 16384,
-                ],
-                'validated' => true,
-                'messages'  => [
-                    'Database configuration is OK.',
-                ]
-            ],
-            [
-            // Incompatible variables on MariaDB 10.3
-                'version'   => '10.3.27-MariaDB',
-                'variables' => [
-                    'innodb_page_size'    => 4096,
-                ],
-                'validated' => false,
-                'messages'  => [
-                    '"innodb_page_size" must be >= 8KB.',
-                ]
-            ],
-            [
-            // Default variables on MariaDB 10.4
-                'version'   => '10.4.17-MariaDB',
-                'variables' => [
-                    'innodb_page_size'    => 16384,
-                ],
-                'validated' => true,
-                'messages'  => [
-                    'Database configuration is OK.',
-                ]
-            ],
-            [
-            // Incompatible variables on MariaDB 10.4
-                'version'   => '10.4.17-MariaDB',
-                'variables' => [
-                    'innodb_page_size'    => 4096,
-                ],
-                'validated' => false,
-                'messages'  => [
-                    '"innodb_page_size" must be >= 8KB.',
-                ]
-            ],
-            [
             // Default variables on MariaDB 10.5
                 'version'   => '10.5.8-MariaDB',
                 'variables' => [

--- a/tests/units/Glpi/System/Requirement/DbEngine.php
+++ b/tests/units/Glpi/System/Requirement/DbEngine.php
@@ -63,22 +63,22 @@ class DbEngine extends \GLPITestCase
             [
                 'version'   => '10.1.48-MariaDB',
                 'validated' => false,
-                'messages'  => ['Database engine version (10.1.48) is not supported. Minimum required version is MariaDB 10.3.'],
+                'messages'  => ['Database engine version (10.1.48) is not supported. Minimum required version is MariaDB 10.5.'],
             ],
             [
                 'version'   => '10.2.36-MariaDB',
                 'validated' => false,
-                'messages'  => ['Database engine version (10.2.36) is not supported. Minimum required version is MariaDB 10.3.'],
+                'messages'  => ['Database engine version (10.2.36) is not supported. Minimum required version is MariaDB 10.5.'],
             ],
             [
                 'version'   => '10.3.28-MariaDB',
-                'validated' => true,
-                'messages'  => ['Database engine version (10.3.28) is supported.'],
+                'validated' => false,
+                'messages'  => ['Database engine version (10.3.28) is not supported. Minimum required version is MariaDB 10.5.'],
             ],
             [
                 'version'   => '10.4.8-MariaDB-1:10.4.8+maria~bionic',
-                'validated' => true,
-                'messages'  => ['Database engine version (10.4.8) is supported.'],
+                'validated' => false,
+                'messages'  => ['Database engine version (10.4.8) is not supported. Minimum required version is MariaDB 10.5.'],
             ],
             [
                 'version'   => '10.5.9-MariaDB',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Tests are failing on the `main` branch due to usage of a JSON DB field (introduced in #15229). We could probably fix them, as it is probably just an issue only in the DB check logic, but I am not sure it is worth the effort.

The MariaDB 10.3 EOL is already passed (05/2023).
The MariaDB 10.4 EOL will arrive soon (06/2024).

The MariaDB default version on main Linux distributions is now 10.5 at least:

| OS | Release date | MySQL version | MariaDB version |
| -------- | -------- | -------- | -------- |
| RHEL 8.5     | 11/2021     | 8.0     | 10.5     |
| RHEL 8.6/9.0     | 05/2022     | 8.0     | 10.5     |
| RHEL 8.7/9.1     | 11/2022      | 8.0     | 10.5     |
| RHEL 8.8/9.2     | 05/2023      | 8.0     | 10.5     |
| Debian Bullseye     | 08/2021     | 8.0 (using MySQL PPA)     | 10.5     |
| Debian Bookworm     | 06/2023     | 8.0 (using MySQL PPA)     | 10.11 LTS     |
| Ubuntu 20.04 LTS     | 04/2020     | 8.0     | 10.3     |
| Ubuntu 22.04 LTS     | 04/2022     | 8.0     | 10.6 LTS    |