### PR TITLE
Fix MFA performances

### DIFF
--- a/src/Security/PermissionManager.php
+++ b/src/Security/PermissionManager.php
@@ -69,13 +69,12 @@ final class PermissionManager
                 $profile_table => [
                     'ON'    => [
                         $profile_table => 'id',
-                        Profile_User::getTable() => 'profiles_id', [
-                            'AND' => [
-                                Profile_User::getTableField('users_id') => $users_id,
-                            ]
-                        ]
+                        Profile_User::getTable() => 'profiles_id',
                     ]
                 ]
+            ],
+            'WHERE' => [
+                Profile_User::getTableField('users_id') => $users_id,
             ]
         ]);
         $entities = [];

--- a/src/Security/PermissionManager.php
+++ b/src/Security/PermissionManager.php
@@ -79,12 +79,14 @@ final class PermissionManager
         ]);
         $entities = [];
         foreach ($iterator as $row) {
-            $entities[] = $row['entities_id'];
+            $entities[] = [$row['entities_id']];
             if ($row['is_recursive']) {
-                /** @noinspection SlowArrayOperationsInLoopInspection */
-                $entities = array_merge($entities, getSonsOf('glpi_entities', $row['entities_id']));
+                $entities[] = getSonsOf('glpi_entities', $row['entities_id']);
             }
         }
+
+        // Avoid running array_merge in a loop by storing multiple arrays into $entities
+        $entities = array_merge(...$entities);
 
         return array_unique($entities);
     }

--- a/src/Security/PermissionManager.php
+++ b/src/Security/PermissionManager.php
@@ -37,8 +37,6 @@ namespace Glpi\Security;
 
 use Profile;
 use Profile_User;
-use ProfileRight;
-use Glpi\DBAL\QueryExpression;
 
 /**
  * Check permission information for a user, including users other than the currently logged in one.


### PR DESCRIPTION
MFA has a huge performance impact even when not enabled.

---

The main issue is fixed by my first commit ec903d06e5eede8aa2fbf0a1e69bd94035f630ee.
The SQL request was faulty and returned a lot more results than expected, which is very bad as we are performing costly operation on these results later in the function.

Before changes, the request would return duplicated results:

![image](https://github.com/glpi-project/glpi/assets/42734840/d5654de3-0bfe-4bbb-8af5-7669be9aded4)

After fixing the query, we get the expected results:

![image](https://github.com/glpi-project/glpi/assets/42734840/d7579dcd-e171-4c94-bb7b-f7041c0c57a8)

This small change fix the main issue and reduce the `getAllEntities()` function execution time from 10s to 0.002s on a GLPI with around 8000 entries in `glpi_profiles_users`.

---

The second commit 766c6f23914a25c221303e05414fe895db351cb4 follow the recommandation found [here](https://github.com/kalessil/phpinspectionsea/blob/master/docs/performance.md#slow-array-function-used-in-loop) to avoid the function being tagged as `SlowArrayOperationsInLoopInspection`.

Performances gain for this commit should be pretty low as our loop do not run many times (once per authorization)  but it doesn't hurt to fix it as well :)

---

Third and final commit remove unused imports.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29995
