### PR TITLE
Fix Task Duration Update Behavior in CommonITILTask

### DIFF
--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -266,6 +266,29 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         }
     }
 
+    /**
+     * Handle the task duration and planned duration logic.
+     *
+     * This function ensures a bi-directional link between the task duration and the planned duration.
+     * These two fields can be a bit redundant when task planning is enabled.
+     *
+     * @param array $input The input array, passed by reference.
+     * @param int $timestart The start time of the task.
+     * @param int $timeend The end time of the task.
+     * @return void
+     */
+    public function handleTaskDuration(&$input, $timestart, $timeend)
+    {
+        // If 'actiontime' is set and different from the current 'actiontime'
+        if (isset($input['actiontime']) && $this->fields['actiontime'] != $input['actiontime']) {
+            // Compute the end date based on 'actiontime'
+            $input["end"] = date("Y-m-d H:i:s", $timestart + $input['actiontime']);
+        } else {
+            // If 'actiontime' is not set, compute it based on the start and end times
+            $input["actiontime"] = $timeend - $timestart;
+        }
+    }
+
 
     public function prepareInputForUpdate($input)
     {
@@ -310,15 +333,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             $timestart              = strtotime($input["begin"]);
             $timeend                = strtotime($input["end"]);
 
-            // This piece of code was added to ensure a bi-directional link between the task duration and the planned duration.
-            // It is true that these two fields are a bit redundant when task planning is enabled.
-            if (isset($input['actiontime']) && $this->fields['actiontime'] != $input['actiontime']) {
-                // If actiontime is set, compute end date
-                $input["end"] = date("Y-m-d H:i:s", $timestart + $input['actiontime']);
-            } else {
-                // If actiontime is not set, compute it
-                $input["actiontime"] = $timeend - $timestart;
-            }
+            $this->handleTaskDuration($input, $timestart, $timeend);
 
             unset($input["plan"]);
 
@@ -533,15 +548,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             $timestart              = strtotime($input["begin"]);
             $timeend                = strtotime($input["end"]);
 
-            // This piece of code was added to ensure a bi-directional link between the task duration and the planned duration.
-            // It is true that these two fields are a bit redundant when task planning is enabled.
-            if (isset($input['actiontime']) && $this->fields['actiontime'] != $input['actiontime']) {
-                // If actiontime is set, compute end date
-                $input["end"] = date("Y-m-d H:i:s", $timestart + $input['actiontime']);
-            } else {
-                // If actiontime is not set, compute it
-                $input["actiontime"] = $timeend - $timestart;
-            }
+            $this->handleTaskDuration($input, $timestart, $timeend);
 
             unset($input["plan"]);
             if (!$this->test_valid_date($input)) {

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -309,7 +309,16 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
 
             $timestart              = strtotime($input["begin"]);
             $timeend                = strtotime($input["end"]);
-            $input["actiontime"]    = $timeend - $timestart;
+
+            // This piece of code was added to ensure a bi-directional link between the task duration and the planned duration.
+            // It is true that these two fields are a bit redundant when task planning is enabled.
+            if (isset($input['actiontime']) && $this->fields['actiontime'] != $input['actiontime']) {
+                // If actiontime is set, compute end date
+                $input["end"] = date("Y-m-d H:i:s", $timestart + $input['actiontime']);
+            } else {
+                // If actiontime is not set, compute it
+                $input["actiontime"] = $timeend - $timestart;
+            }
 
             unset($input["plan"]);
 
@@ -523,7 +532,16 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
 
             $timestart              = strtotime($input["begin"]);
             $timeend                = strtotime($input["end"]);
-            $input["actiontime"]    = $timeend - $timestart;
+
+            // This piece of code was added to ensure a bi-directional link between the task duration and the planned duration.
+            // It is true that these two fields are a bit redundant when task planning is enabled.
+            if (isset($input['actiontime']) && $this->fields['actiontime'] != $input['actiontime']) {
+                // If actiontime is set, compute end date
+                $input["end"] = date("Y-m-d H:i:s", $timestart + $input['actiontime']);
+            } else {
+                // If actiontime is not set, compute it
+                $input["actiontime"] = $timeend - $timestart;
+            }
 
             unset($input["plan"]);
             if (!$this->test_valid_date($input)) {

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -277,7 +277,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
      * @param int $timeend The end time of the task.
      * @return void
      */
-    public function handleTaskDuration(&$input, $timestart, $timeend)
+    private function handleTaskDuration(array &$input, int $timestart, int $timeend): void
     {
         // If 'actiontime' is set and different from the current 'actiontime'
         if (isset($input['actiontime']) && $this->fields['actiontime'] != $input['actiontime']) {


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15650

This Pull Request addresses an issue in the `CommonITILTask` class where the manually edited task duration was not replacing the planned duration. 

The changes in this PR ensure that the task duration and the planned duration are bi-directionally linked. This means that if the `actiontime` (task duration) is manually set, it will compute and update the end date accordingly. Conversely, if the `actiontime` is not set, it will compute it based on the difference between the start and end times.

This fix is crucial as it allows the actual time spent on a task to be accurately reflected, even if it differs from the initially planned duration. This behavior aligns with previous versions of the application, where the manually entered task duration would replace the planned duration.