### PR TITLE
feat(Timeline): add new action for anchor

### DIFF
--- a/templates/components/itilobject/timeline/main_description.html.twig
+++ b/templates/components/itilobject/timeline/main_description.html.twig
@@ -35,6 +35,7 @@
 {% set entry_rand = random() %}
 
 <div class="timeline-item mb-3 ITILContent"
+     id="{{ item.getType() }}_{{ item.fields['id'] }}"
      data-itemtype="{{ item.getType() }}" data-items-id="{{ item.fields['id'] }}">
    <div class="row">
       <div class="col-auto d-flex flex-column ">
@@ -56,6 +57,10 @@
 
                   {% if canupdate %}
                     <div class="dropdown ms-auto timeline-item-buttons">
+                        <a class="anchor-link btn btn-sm btn-ghost-secondary timeline-more-actions" href="#{{ item.getType() ~ '_' ~ item.fields['id'] }}" aria-label="{{ __('Link to this %s')|format(item.getType()) }}">
+                           <i class="ti ti-link"></i>
+                        </a>
+
                         <button class="btn btn-sm btn-ghost-secondary timeline-more-actions" type="button" id="more-actions-{{ entry_rand }}" data-bs-toggle="dropdown" aria-expanded="false">
                             <i class="fas ti ti-dots-vertical"></i>
                         </button>

--- a/templates/components/itilobject/timeline/timeline_item_header.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header.html.twig
@@ -98,6 +98,9 @@
 
       {% if actions|length %}
          <div class="dropdown ms-2">
+            <a class="anchor-link btn btn-sm btn-ghost-secondary timeline-more-actions" href="#{{ entry['type'] ~ '_' ~ entry_i['id'] }}" aria-label="{{ __('Link to this %s')|format(entry['type']|itemtype_name) }}">
+               <i class="ti ti-link"></i>
+            </a>
             <button class="btn btn-sm btn-ghost-secondary timeline-more-actions" type="button" id="more-actions-{{ entry_rand }}" data-bs-toggle="dropdown" aria-expanded="false">
                <i class="ti ti-dots-vertical"></i>
             </button>


### PR DESCRIPTION
Following on from :
https://github.com/glpi-project/glpi/pull/15831
https://github.com/glpi-project/glpi/pull/15853
https://github.com/glpi-project/glpi/pull/15836

Add new action to use anchor from timeline item (and description).

![image](https://github.com/glpi-project/glpi/assets/7335054/4d9e12ff-5c9f-4693-8dfa-3f4d344df5ed)

Same behavior as bootstrap documetnation

![image](https://github.com/glpi-project/glpi/assets/7335054/ddb174dc-a579-4f18-b24c-ff4f7dda87b7)

Need : https://github.com/glpi-project/glpi/pull/15853

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
