### PR TITLE
fix(search): deprecated htmlspecialchars

### DIFF
--- a/src/Planning.php
+++ b/src/Planning.php
@@ -262,9 +262,12 @@ class Planning extends CommonGLPI
      */
     public static function getStatusIcon($status): string
     {
+        $label = htmlspecialchars(Planning::getState($status), ENT_QUOTES);
+        if (empty($label)) {
+            return '';
+        }
         $class = Planning::getStatusClass($status);
         $color = Planning::getStatusColor($status);
-        $label = htmlspecialchars(Planning::getState($status), ENT_QUOTES);
         return "<i class='itilstatus $class $color me-1' title='$label' data-bs-toggle='tooltip'></i><span>" . $label . "</span>";
     }
 

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -246,6 +246,9 @@ class Planning extends CommonGLPI
 
             case static::DONE:
                 return __('Done');
+
+            default:
+                return '';
         }
     }
 


### PR DESCRIPTION
Fix warning message on ticket search

`Deprecated: htmlspecialchars(): Passing null to parameter (Sstring) of type string is deprecated in /mnt/data/glpi/src/Planning.php on line 263`

![6538b5b65d4dd8 53298316image_paste](https://github.com/glpi-project/glpi/assets/8530352/51fd4150-1672-4534-a445-c322d74b2971)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30152
