### PR TITLE
feat(Approval): use anchor to point directly to the form in the timeline

### DIFF
--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -673,8 +673,9 @@ class NotificationTarget extends CommonDBChild
      *
      * @param $usertype
      * @param $redirect
+     * @param $anchor
      **/
-    public function formatURL($usertype, $redirect)
+    public function formatURL($usertype, $redirect, ?string $anchor = null)
     {
         if (urldecode($redirect) === $redirect) {
             // `redirect` parameter value have to be url-encoded.
@@ -684,18 +685,23 @@ class NotificationTarget extends CommonDBChild
             $redirect = rawurlencode($redirect);
         }
 
+        if (!empty($anchor)) {
+            // anchor have to be url-encoded to correctly pass '#' character as '%23'
+            $anchor = rawurlencode('#' . $anchor);
+        }
+
         $base_url = $this->getUrlBase();
 
         switch ($usertype) {
             case self::EXTERNAL_USER:
-                return "$base_url/index.php?redirect=$redirect";
+                return "$base_url/index.php?redirect={$redirect}{$anchor}";
 
             case self::ANONYMOUS_USER:
                // No URL
                 return '';
 
             case self::GLPI_USER:
-                return "$base_url/index.php?redirect=$redirect&noAUTO=1";
+                return "$base_url/index.php?redirect={$redirect}&noAUTO=1{$anchor}";
         }
     }
 

--- a/src/NotificationTargetChange.php
+++ b/src/NotificationTargetChange.php
@@ -79,11 +79,17 @@ class NotificationTargetChange extends NotificationTargetCommonITILObject
        // Common ITIL data
         $data = parent::getDataForObject($item, $options, $simple);
 
-       // Specific data
+        // Specific data
+        $anchor = null;
+        if (isset($options['validation_id']) && $options['validation_id']) {
+            $anchor = "ChangeValidation_" . $options['validation_id'];
+        }
+
         $data['##change.urlvalidation##']
                      = $this->formatURL(
                          $options['additionnaloption']['usertype'],
-                         "change_" . $item->getField("id") . '_Change$main'
+                         "change_" . $item->getField("id") . '_Change$main',
+                         $anchor
                      );
         $data['##change.globalvalidation##']
                      = ChangeValidation::getStatus($item->getField('global_validation'));

--- a/src/NotificationTargetTicket.php
+++ b/src/NotificationTargetTicket.php
@@ -162,11 +162,18 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
         $data = parent::getDataForObject($item, $options, $simple);
 
         $data['##ticket.content##'] = $data['##ticket.description##'];
-       // Specific data
+
+        // Specific data
+        $anchor = null;
+        if (isset($options['validation_id']) && $options['validation_id']) {
+            $anchor = "TicketValidation_" . $options['validation_id'];
+        }
+
         $data['##ticket.urlvalidation##']
                         = $this->formatURL(
                             $options['additionnaloption']['usertype'],
-                            "ticket_" . $item->getField("id") . '_Ticket$main'
+                            "ticket_" . $item->getField("id") . '_Ticket$main',
+                            $anchor
                         );
         $data['##ticket.globalvalidation##']
                         = TicketValidation::getStatus($item->getField('global_validation'));

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -1489,7 +1489,9 @@ class Toolbox
                     Html::redirect($redirect_to);
                 }
 
-                $data = explode("_", $where);
+                // explode with limit 3 to preserve the last part of the url
+                // /index.php?redirect=ticket_2_Ticket$main#TicketValidation_1 (preserve anchor)
+                $data = explode("_", $where, 3);
                 $forcetab = '';
                 // forcetab for simple items
                 if (isset($data[2])) {


### PR DESCRIPTION
To resume the following PR https://github.com/glpi-project/glpi/pull/14428
which continued the work of  https://github.com/glpi-project/glpi/pull/14256
and since https://github.com/glpi-project/glpi/pull/15831

The idea would be (via HTML anchors) to position the user directly on the validation form (which concerns him) in the time line.

you can use this URL (must be adapted to your GLPI url) to test

jsut  replace ```#ID_TICKET#``` and ```#ID_VALIDATION#```

```
/index.php?redirect=ticket_#ID_TICKET#_Ticket%24main%23TicketValidation_#ID_VALIDATION#
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
