### PR TITLE
fix(RuleTicket): fix default profiles criterion

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1280,8 +1280,10 @@ class Ticket extends CommonITILObject
             if ($user_id !== null && $user->getFromDB($user_id)) {
                 $input['_locations_id_of_requester']   = $user->fields['locations_id'];
                 $input['users_default_groups']         = $user->fields['groups_id'];
+                $input['profiles_id']         = $user->fields['profiles_id'];
                 $changes[]                             = '_locations_id_of_requester';
                 $changes[]                             = '_groups_id_of_requester';
+                $changes[]                             = 'profiles_id';
             }
 
             $input = $rules->processAllRules(

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1941,11 +1941,13 @@ class Ticket extends CommonITILObject
                 ) {
                     $input['_locations_id_of_requester'] = $user->fields['locations_id'];
                     $input['users_default_groups'] = $user->fields['groups_id'];
+                    $input['profiles_id'] = $user->fields['profiles_id']; //default profile
                     $tmprequester = $input["_users_id_requester"];
                 } else if (is_array($input["_users_id_requester"]) && ($user_id = reset($input["_users_id_requester"])) !== false) {
                     if ($user->getFromDB($user_id)) {
                         $input['_locations_id_of_requester'] = $user->fields['locations_id'];
                         $input['users_default_groups'] = $user->fields['groups_id'];
+                        $input['profiles_id'] = $user->fields['profiles_id']; //default profile
                     }
                 }
             }

--- a/tests/functional/RuleTicket.php
+++ b/tests/functional/RuleTicket.php
@@ -3442,4 +3442,44 @@ class RuleTicket extends DbTestCase
         // Check if the location "Test location" is assigned
         $this->integer($ticket->fields['locations_id'])->isEqualTo($location->getID());
     }
+
+    /**
+     * Test that the "Default profile" criterion works correctly
+     * @return void
+     */
+    public function testDefaultProfileCriterion(): void
+    {
+
+        // Get the root entity
+        $entity = getItemByTypeName(Entity::class, '_test_root_entity', true);
+
+        // Create a location
+        $location = $this->createItem(Location::class, [
+            'name' => 'Test location',
+            'entities_id' => $entity,
+        ]);
+
+        // Create two rules
+        $builder = new RuleBuilder('Test default profile criterion rule');
+        $builder
+            ->addCriteria('profiles_id', Rule::PATTERN_IS, 4)
+            ->addAction('assign', 'locations_id', $location->getID());
+        $this->createRule($builder);
+
+        //Load user tech
+        $user = new \User();
+        $user->getFromDB(getItemByTypeName('User', 'jsmith123', true));
+
+        // Create a ticket with "Very high" urgency
+        $ticket = $this->createItem(\Ticket::class, [
+            'name' => 'Test ticket',
+            'content' => 'Test ticket content',
+            'entities_id' => $entity,
+            '_users_id_requester' => $user->fields['id']
+        ]);
+
+
+        // Check if the location "Test location" is assigned
+        $this->integer($ticket->fields['locations_id'])->isEqualTo($location->getID());
+    }
 }


### PR DESCRIPTION
Add missing data for ```Default profile``` criterion from rules ticket (on add and on update)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30117
