### PR TITLE
Deprecate (non strict) usage of raw SQL in iterator

### DIFF
--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -1139,9 +1139,9 @@ class DBmysql
     {
        // No translation, used in sysinfo
         $ret = [];
-        $req = $this->request("SELECT @@sql_mode as mode, @@version AS vers, @@version_comment AS stype");
+        $req = $this->doQuery("SELECT @@sql_mode as mode, @@version AS vers, @@version_comment AS stype");
 
-        if (($data = $req->current())) {
+        if (($data = $req->fetch_array())) {
             if ($data['stype']) {
                 $ret['Server Software'] = $data['stype'];
             }
@@ -1798,7 +1798,8 @@ class DBmysql
      */
     public function getVersion()
     {
-        $req = $this->request('SELECT version()')->current();
+        $res = $this->doQuery('SELECT version()');
+        $req = $res->fetch_array();
         $raw = $req['version()'];
         return $raw;
     }

--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -140,7 +140,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
 
         if ($is_legacy) {
             Toolbox::deprecated(
-                'Direct query usage calling DBmysqlIterator is strongly discouraged! Use DB::request() instead.',
+                'Direct query usage calling DBmysqlIterator is strongly discouraged! Use DBmysql::doQuery() instead.',
                 false
             );
             $this->sql = $table;

--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -140,7 +140,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
 
         if ($is_legacy) {
             Toolbox::deprecated(
-                'Direct query usage calling DBmysqlIterator is strongly discouraged! Use DB::request() instead.',
+                'Direct query usage is strongly discouraged!.',
                 false
             );
             $this->sql = $table;

--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -140,7 +140,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
 
         if ($is_legacy) {
             Toolbox::deprecated(
-                'Direct query usage calling DBmysqlIterator is strongly discouraged! Use DBmysql::doQuery() instead.',
+                'Direct query usage calling DBmysqlIterator is strongly discouraged! Use DB::request() instead.',
                 false
             );
             $this->sql = $table;

--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -139,9 +139,10 @@ class DBmysqlIterator implements SeekableIterator, Countable
         }
 
         if ($is_legacy) {
-           //if ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE) {
-           //   trigger_error("Deprecated usage of SQL in DB/request (full query)", E_USER_DEPRECATED);
-           //}
+            Toolbox::deprecated(
+                'Direct query usage calling DBmysqlIterator is strongly discouraged! Use DB::request() instead.',
+                false
+            );
             $this->sql = $table;
         } else {
            // Modern way

--- a/tests/units/DBmysqlIterator.php
+++ b/tests/units/DBmysqlIterator.php
@@ -57,7 +57,7 @@ class DBmysqlIterator extends DbTestCase
         $this->when($this->it->execute($req))
             ->error()
             ->withType(E_USER_DEPRECATED)
-            ->withMessage('Direct query usage calling DBmysqlIterator is strongly discouraged! Use DB::request() instead.')
+            ->withMessage('Direct query usage is strongly discouraged!.')
             ->exists();
         $this->string($this->it->getSql())->isIdenticalTo($req);
 
@@ -65,7 +65,7 @@ class DBmysqlIterator extends DbTestCase
         $this->when($this->it->execute($req))
             ->error()
             ->withType(E_USER_DEPRECATED)
-            ->withMessage('Direct query usage calling DBmysqlIterator is strongly discouraged! Use DB::request() instead.')
+            ->withMessage('Direct query usage is strongly discouraged!.')
             ->exists();
         $this->string($this->it->getSql())->isIdenticalTo($req);
     }

--- a/tests/units/DBmysqlIterator.php
+++ b/tests/units/DBmysqlIterator.php
@@ -54,12 +54,20 @@ class DBmysqlIterator extends DbTestCase
     public function testQuery()
     {
         $req = 'SELECT Something FROM Somewhere';
-        $it = $this->it->execute($req);
-        $this->string($it->getSql())->isIdenticalTo($req);
+        $this->when($this->it->execute($req))
+            ->error()
+            ->withType(E_USER_DEPRECATED)
+            ->withMessage('Direct query usage calling DBmysqlIterator is strongly discouraged! Use DB::request() instead.')
+            ->exists();
+        $this->string($this->it->getSql())->isIdenticalTo($req);
 
         $req = 'SELECT @@sql_mode as mode';
-        $it = $this->it->execute($req);
-        $this->string($it->getSql())->isIdenticalTo($req);
+        $this->when($this->it->execute($req))
+            ->error()
+            ->withType(E_USER_DEPRECATED)
+            ->withMessage('Direct query usage calling DBmysqlIterator is strongly discouraged! Use DB::request() instead.')
+            ->exists();
+        $this->string($this->it->getSql())->isIdenticalTo($req);
     }
 
 

--- a/tests/units/DBmysqlIterator.php
+++ b/tests/units/DBmysqlIterator.php
@@ -57,7 +57,7 @@ class DBmysqlIterator extends DbTestCase
         $this->when($this->it->execute($req))
             ->error()
             ->withType(E_USER_DEPRECATED)
-            ->withMessage('Direct query usage calling DBmysqlIterator is strongly discouraged! Use DBmysql::doQuery() instead.')
+            ->withMessage('Direct query usage calling DBmysqlIterator is strongly discouraged! Use DB::request() instead.')
             ->exists();
         $this->string($this->it->getSql())->isIdenticalTo($req);
 
@@ -65,7 +65,7 @@ class DBmysqlIterator extends DbTestCase
         $this->when($this->it->execute($req))
             ->error()
             ->withType(E_USER_DEPRECATED)
-            ->withMessage('Direct query usage calling DBmysqlIterator is strongly discouraged! Use DBmysql::doQuery() instead.')
+            ->withMessage('Direct query usage calling DBmysqlIterator is strongly discouraged! Use DB::request() instead.')
             ->exists();
         $this->string($this->it->getSql())->isIdenticalTo($req);
     }

--- a/tests/units/DBmysqlIterator.php
+++ b/tests/units/DBmysqlIterator.php
@@ -57,7 +57,7 @@ class DBmysqlIterator extends DbTestCase
         $this->when($this->it->execute($req))
             ->error()
             ->withType(E_USER_DEPRECATED)
-            ->withMessage('Direct query usage calling DBmysqlIterator is strongly discouraged! Use DB::request() instead.')
+            ->withMessage('Direct query usage calling DBmysqlIterator is strongly discouraged! Use DBmysql::doQuery() instead.')
             ->exists();
         $this->string($this->it->getSql())->isIdenticalTo($req);
 
@@ -65,7 +65,7 @@ class DBmysqlIterator extends DbTestCase
         $this->when($this->it->execute($req))
             ->error()
             ->withType(E_USER_DEPRECATED)
-            ->withMessage('Direct query usage calling DBmysqlIterator is strongly discouraged! Use DB::request() instead.')
+            ->withMessage('Direct query usage calling DBmysqlIterator is strongly discouraged! Use DBmysql::doQuery() instead.')
             ->exists();
         $this->string($this->it->getSql())->isIdenticalTo($req);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | kind of
| Deprecations? | no
| Tests pass?   | yes

I'm almost sure this has not been handled in main.

I've always considered that was an mistake; fortunately this is not widely used in core code. Depreciation is not strict, unless constant is set (like in test suite).
