### PR TITLE
`getTableForItemType()` must support `CommonDBTM::getTable()` overrides

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -211,7 +211,7 @@ class CommonDBTM extends CommonGLPI
         }
 
         if (!isset(self::$tables_of[$classname]) || empty(self::$tables_of[$classname])) {
-            self::$tables_of[$classname] = getTableForItemType($classname);
+            self::$tables_of[$classname] = (new DbUtils())->getExpectedTableNameForClass($classname);
         }
 
         return self::$tables_of[$classname];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Currently, when a class overrides `CommonDBTM::getTable()` to force usage of a specific table, this override is not reflected in `getTableForItemType()` results. It does not seems to produce issues for now because overrides are not used for assets yet, but there are lots of usages of `getTableForItemType()` that would fail if someones push into `$CFG_GLPI['xxx_types']` a class that overrides the `CommonDBTM::getTable()` method. For instance, in #15729 , I figured out that many pieces of code were failing.

Replacing all usages of `getTableForItemType()` by `$itemtype::getTable()` is not really an option, at least in a short term. First, it would be a pain, there are hundreds of usages of it, and we may miss some occurences. Second, it would require a deprecation phase, so we would still have to fix the `getTableForItemType()` results.

Before:
```php
getTableForItemType('RuleTicket'); // glpi_ruletickets
RuleTicket::getTable(); // glpi_rules
```

After:
```php
getTableForItemType('RuleTicket'); // glpi_rules
RuleTicket::getTable(); // glpi_rules
```