### PR TITLE
Fix getReplyTo when not allow response

### DIFF
--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -1211,6 +1211,9 @@ class NotificationTarget extends CommonDBChild
      **/
     public function getReplyTo(): array
     {
+        if (!$this->allowResponse()) {
+            return Config::getNoReplyEmailSender($this->getEntity());
+        }
         return Config::getReplyToEmailSender($this->getEntity());
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

When you not allow response on glpi notifications, the sender is replaced by getNoReplyEmailSender() but not the address used for response
