### PR TITLE
Add Log Right To getTabNameForItem

### DIFF
--- a/src/Log.php
+++ b/src/Log.php
@@ -87,6 +87,9 @@ class Log extends CommonDBTM
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
+        if (!self::canView()) {
+            return '';
+        }
 
         $nb = 0;
         if ($_SESSION['glpishow_count_on_tabs']) {
@@ -298,6 +301,10 @@ class Log extends CommonDBTM
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
+
+        if (!self::canView()) {
+            return;
+        }
 
         $itemtype = $item->getType();
         $items_id = $item->getField('id');

--- a/tests/LDAP/AuthLdap.php
+++ b/tests/LDAP/AuthLdap.php
@@ -256,8 +256,8 @@ class AuthLDAP extends DbTestCase
     {
         $ldap     = new \AuthLDAP();
         $tabs     = $ldap->defineTabs();
-        $expected = ['AuthLDAP$main' => 'LDAP directory',
-            'Log$1'         => 'Historical'
+        $expected = [
+            'AuthLDAP$main' => 'LDAP directory',
         ];
         $this->array($tabs)->isIdenticalTo($expected);
     }

--- a/tests/functional/Agent.php
+++ b/tests/functional/Agent.php
@@ -46,7 +46,6 @@ class Agent extends DbTestCase
         $expected = [
             'Agent$main'        => 'Agent',
             'RuleMatchedLog$0'  => 'Import information',
-            'Log$1'             => 'Historical'
         ];
         $this
          ->given($this->newTestedInstance)

--- a/tests/functional/Appliance.php
+++ b/tests/functional/Appliance.php
@@ -45,7 +45,6 @@ class Appliance extends DbTestCase
             'Appliance$main'     => 'Appliance',
             'Impact$1'           => 'Impact analysis',
             'ManualLink$1'       => 'Links',
-            'Log$1'              => 'Historical',
         ];
         $this
          ->given($this->newTestedInstance)

--- a/tests/functional/Config.php
+++ b/tests/functional/Config.php
@@ -95,7 +95,6 @@ class Config extends DbTestCase
             'Config$4'      => 'Assistance',
             'Config$12'     => 'Management',
             'GLPINetwork$1' => 'GLPI Network',
-            'Log$1'         => 'Historical',
         ];
         $this
          ->given($this->newTestedInstance)

--- a/tests/functional/Document.php
+++ b/tests/functional/Document.php
@@ -96,8 +96,6 @@ class Document extends DbTestCase
             'Document$main'   => 'Document',
             'Document_Item$1' => 'Associated items',
             'Document_Item$2' => 'Documents',
-            'Log$1'           => 'Historical'
-
         ];
         $this
          ->given($this->newTestedInstance)

--- a/tests/functional/OperatingSystem.php
+++ b/tests/functional/OperatingSystem.php
@@ -60,7 +60,6 @@ class OperatingSystem extends CommonDropdown
     {
         return [
             'OperatingSystem$main'  => 'Operating system',
-            'Log$1'                 => 'Historical'
         ];
     }
 

--- a/tests/functional/OperatingSystemArchitecture.php
+++ b/tests/functional/OperatingSystemArchitecture.php
@@ -60,7 +60,6 @@ class OperatingSystemArchitecture extends CommonDropdown
     {
         return [
             'OperatingSystemArchitecture$main'  => 'Operating system architecture',
-            'Log$1'                             => 'Historical'
         ];
     }
 

--- a/tests/functional/OperatingSystemEdition.php
+++ b/tests/functional/OperatingSystemEdition.php
@@ -68,7 +68,6 @@ class OperatingSystemEdition extends CommonDropdown
     {
         return [
             'OperatingSystemEdition$main' => 'Edition',
-            'Log$1'                       => 'Historical'
         ];
     }
 

--- a/tests/functional/OperatingSystemKernel.php
+++ b/tests/functional/OperatingSystemKernel.php
@@ -60,7 +60,6 @@ class OperatingSystemKernel extends CommonDropdown
     {
         return [
             'OperatingSystemKernel$main'  => 'Kernel',
-            'Log$1'                       => 'Historical'
         ];
     }
 

--- a/tests/functional/OperatingSystemKernelVersion.php
+++ b/tests/functional/OperatingSystemKernelVersion.php
@@ -75,7 +75,6 @@ class OperatingSystemKernelVersion extends CommonDropdown
     {
         return [
             'OperatingSystemKernelVersion$main' => 'Kernel version',
-            'Log$1'                             => 'Historical'
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

There is now a new right : 

![image](https://github.com/glpi-project/glpi/assets/13178158/c4b2c2ec-e338-460a-a0c5-2813233c800f)

But this right is not used for display tab
