### PR TITLE
Fix Duplicate Notification On Solve

### DIFF
--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -393,6 +393,7 @@ class ITILFollowup extends CommonDBChild
         }
        // if ($input["_isadmin"] && $input["_type"]!="update") {
         if (isset($input["add_close"])) {
+            $input['_disablenotif'] = true;
             $input['_close'] = 1;
             $input['_no_reopen'] = 1;
             if (empty($input['content'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

When the user approve (with adding comment or not), 2 notifications are sended : One for Solve ticket : OK but another for adding Followup.

I had _disablenotif on add_close case for fix it
