### PR TITLE
Create toggle switch button to change defaut plugin page

### DIFF
--- a/front/plugin.form.php
+++ b/front/plugin.form.php
@@ -41,7 +41,7 @@ include('../inc/includes.php');
 
 Session::checkRight("config", UPDATE);
 
-if (isset($_POST['formIdentifier']) && $_POST['formIdentifier'] === 'change_default_interfaceform'){
+if (isset($_POST['formIdentifier']) && $_POST['formIdentifier'] === 'change_default_interfaceform') {
     Config::setConfigurationValues('core', [
         'marketplace_replace_plugins' => $_POST['value']
     ]);

--- a/front/plugin.form.php
+++ b/front/plugin.form.php
@@ -41,6 +41,13 @@ include('../inc/includes.php');
 
 Session::checkRight("config", UPDATE);
 
+if (isset($_POST['formIdentifier']) && $_POST['formIdentifier'] === 'change_default_interfaceform'){
+    Config::setConfigurationValues('core', [
+        'marketplace_replace_plugins' => $_POST['value']
+    ]);
+    Html::back();
+}
+
 $plugin = new Plugin();
 
 $id     = isset($_POST['id']) && is_numeric($_POST['id']) ? (int)$_POST['id'] : null;

--- a/front/plugin.php
+++ b/front/plugin.php
@@ -48,17 +48,6 @@ Html::header(__('Setup'), $_SERVER['PHP_SELF'], "config", "plugin");
 
 \Glpi\Marketplace\View::showFeatureSwitchDialog();
 
-
-$url = "'" . Plugin::getFormURL() . "'";
-$fields = "{ 'formIdentifier' : 'change_default_interfaceform', '_glpi_csrf_token' : '" . Session::getNewCSRFToken() . "', 'value' : 3}";
-
-echo '
-   <div class="form-check form-switch">
-      <input class="form-check-input" type="checkbox" id="defaultplugininterface" onchange="submitGetLink(' . $url . ',' . $fields . ')">
-      <label class="form-check-label" for="defaultplugininterface">Plugins Default</label>
-   </div>
-';
-
 $catalog_btn = '<div class="center my-2">'
    . '<a href="http://plugins.glpi-project.org" class="btn btn-primary" target="_blank">'
    . "<i class='fas fa-eye'></i>"

--- a/front/plugin.php
+++ b/front/plugin.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\View\TemplateRenderer;
+
 include('../inc/includes.php');
 
 Session::checkRight("config", UPDATE);
@@ -45,6 +47,17 @@ $plugin->checkStates(true);
 Html::header(__('Setup'), $_SERVER['PHP_SELF'], "config", "plugin");
 
 \Glpi\Marketplace\View::showFeatureSwitchDialog();
+
+
+$url = "'" . Plugin::getFormURL() . "'";
+$fields = "{ 'formIdentifier' : 'change_default_interfaceform', '_glpi_csrf_token' : '" . Session::getNewCSRFToken() . "', 'value' : 3}";
+
+echo '
+   <div class="form-check form-switch">
+      <input class="form-check-input" type="checkbox" id="defaultplugininterface" onchange="submitGetLink(' . $url . ',' . $fields . ')">
+      <label class="form-check-label" for="defaultplugininterface">Plugins Default</label>
+   </div>
+';
 
 $catalog_btn = '<div class="center my-2">'
    . '<a href="http://plugins.glpi-project.org" class="btn btn-primary" target="_blank">'

--- a/src/Marketplace/View.php
+++ b/src/Marketplace/View.php
@@ -459,7 +459,7 @@ HTML;
             $url = "'" . Plugin::getFormURL() . "'";
             $fields = "{ 'formIdentifier' : 'change_default_interfaceform', '_glpi_csrf_token' : '" . Session::getNewCSRFToken() . "', 'value' : 2}";
             $default = $displaybutton = '';
- $marketplace_replace_plugins = Config::getConfigurationValue('core', 'marketplace_replace_plugins');
+            $marketplace_replace_plugins = Config::getConfigurationValue('core', 'marketplace_replace_plugins');
             if ($marketplace_replace_plugins == Controller::MP_REPLACE_YES) {
                 $default = 'checked disabled';
             } else if ($marketplace_replace_plugins == Controller::MP_REPLACE_ASK || is_null($marketplace_replace_plugins)) {

--- a/src/Marketplace/View.php
+++ b/src/Marketplace/View.php
@@ -459,9 +459,10 @@ HTML;
             $url = "'" . Plugin::getFormURL() . "'";
             $fields = "{ 'formIdentifier' : 'change_default_interfaceform', '_glpi_csrf_token' : '" . Session::getNewCSRFToken() . "', 'value' : 2}";
             $default = $displaybutton = '';
-            if (Config::getConfigurationValue('core', 'marketplace_replace_plugins') == 2) {
+ $marketplace_replace_plugins = Config::getConfigurationValue('core', 'marketplace_replace_plugins');
+            if ($marketplace_replace_plugins == Controller::MP_REPLACE_YES) {
                 $default = 'checked disabled';
-            } else if (Config::getConfigurationValue('core', 'marketplace_replace_plugins') == 1) {
+            } else if ($marketplace_replace_plugins == Controller::MP_REPLACE_ASK || is_null($marketplace_replace_plugins)) {
                 $displaybutton = 'd-none';
             }
             $label = __("Default View");

--- a/src/Marketplace/View.php
+++ b/src/Marketplace/View.php
@@ -458,11 +458,14 @@ HTML;
             $search_label = __("Filter plugin list");
             $url = "'" . Plugin::getFormURL() . "'";
             $fields = "{ 'formIdentifier' : 'change_default_interfaceform', '_glpi_csrf_token' : '" . Session::getNewCSRFToken() . "', 'value' : 2}";
-            $default = '';
+            $default = $displaybutton = '';
             if (Config::getConfigurationValue('core', 'marketplace_replace_plugins') == 2) {
                 $default = 'checked disabled';
-            };
+            } else if (Config::getConfigurationValue('core', 'marketplace_replace_plugins') == 1) {
+                $displaybutton = 'd-none';
+            }
             $label = __("Default Plugin Page");
+
 
             $marketplace  = <<<HTML
                 <div class='marketplace $tab' data-tab='{$tab}'>
@@ -474,7 +477,7 @@ HTML;
                                 $sort_controls
                                 <i class='ti ti-refresh refresh-plugin-list' title='{$refresh_lbl}'></i>
                             </div>
-                            <div class="form-check form-switch pe-2">
+                            <div class="form-check form-switch pe-2 {$displaybutton}">
                                 <label class="fw-bold text-secondary"> {$label} </label>
                                 <input class="form-check-input" type="checkbox" id="defaultplugininterface"
                                 onchange="submitGetLink({$url}, {$fields})" {$default}>

--- a/src/Marketplace/View.php
+++ b/src/Marketplace/View.php
@@ -458,6 +458,10 @@ HTML;
             $search_label = __("Filter plugin list");
             $url = "'" . Plugin::getFormURL() . "'";
             $fields = "{ 'formIdentifier' : 'change_default_interfaceform', '_glpi_csrf_token' : '" . Session::getNewCSRFToken() . "', 'value' : 2}";
+            $default = '';
+            if (Config::getConfigurationValue('core', 'marketplace_replace_plugins') == 2) {
+                $default = 'checked disabled';
+            };
 
             $marketplace  = <<<HTML
                 <div class='marketplace $tab' data-tab='{$tab}'>
@@ -470,7 +474,7 @@ HTML;
                                 <i class='ti ti-refresh refresh-plugin-list' title='{$refresh_lbl}'></i>
                             </div>
                             <div class="form-check form-switch">
-                                <input class="form-check-input" type="checkbox" id="defaultplugininterface" onchange="submitGetLink({$url}, {$fields})">
+                                <input class="form-check-input" type="checkbox" id="defaultplugininterface" onchange="submitGetLink({$url}, {$fields})" {$default}>
                             </div>
                         </div>
                         <ul class='plugins'>

--- a/src/Marketplace/View.php
+++ b/src/Marketplace/View.php
@@ -462,6 +462,7 @@ HTML;
             if (Config::getConfigurationValue('core', 'marketplace_replace_plugins') == 2) {
                 $default = 'checked disabled';
             };
+            $label = __("Default Plugin Page");
 
             $marketplace  = <<<HTML
                 <div class='marketplace $tab' data-tab='{$tab}'>
@@ -473,8 +474,10 @@ HTML;
                                 $sort_controls
                                 <i class='ti ti-refresh refresh-plugin-list' title='{$refresh_lbl}'></i>
                             </div>
-                            <div class="form-check form-switch">
-                                <input class="form-check-input" type="checkbox" id="defaultplugininterface" onchange="submitGetLink({$url}, {$fields})" {$default}>
+                            <div class="form-check form-switch pe-2">
+                                <label class="fw-bold text-secondary"> {$label} </label>
+                                <input class="form-check-input" type="checkbox" id="defaultplugininterface"
+                                onchange="submitGetLink({$url}, {$fields})" {$default}>
                             </div>
                         </div>
                         <ul class='plugins'>

--- a/src/Marketplace/View.php
+++ b/src/Marketplace/View.php
@@ -464,7 +464,7 @@ HTML;
             } else if (Config::getConfigurationValue('core', 'marketplace_replace_plugins') == 1) {
                 $displaybutton = 'd-none';
             }
-            $label = __("Default Plugin Page");
+            $label = __("Default View");
 
 
             $marketplace  = <<<HTML
@@ -478,7 +478,7 @@ HTML;
                                 <i class='ti ti-refresh refresh-plugin-list' title='{$refresh_lbl}'></i>
                             </div>
                             <div class="form-check form-switch pe-2 {$displaybutton}">
-                                <label class="fw-bold text-secondary"> {$label} </label>
+                                <label class="text-secondary"> {$label} </label>
                                 <input class="form-check-input" type="checkbox" id="defaultplugininterface"
                                 onchange="submitGetLink({$url}, {$fields})" {$default}>
                             </div>

--- a/src/Marketplace/View.php
+++ b/src/Marketplace/View.php
@@ -42,6 +42,7 @@ use Glpi\Marketplace\Api\Plugins as PluginsApi;
 use GLPINetwork;
 use Html;
 use Plugin;
+use Session;
 use Toolbox;
 
 class View extends CommonGLPI
@@ -455,6 +456,8 @@ HTML;
             $networkmail  = GLPI_NETWORK_MAIL;
             $refresh_lbl  = __("Refresh plugin list");
             $search_label = __("Filter plugin list");
+            $url = "'" . Plugin::getFormURL() . "'";
+            $fields = "{ 'formIdentifier' : 'change_default_interfaceform', '_glpi_csrf_token' : '" . Session::getNewCSRFToken() . "', 'value' : 2}";
 
             $marketplace  = <<<HTML
                 <div class='marketplace $tab' data-tab='{$tab}'>
@@ -465,6 +468,9 @@ HTML;
                             <div class='controls'>
                                 $sort_controls
                                 <i class='ti ti-refresh refresh-plugin-list' title='{$refresh_lbl}'></i>
+                            </div>
+                            <div class="form-check form-switch">
+                                <input class="form-check-input" type="checkbox" id="defaultplugininterface" onchange="submitGetLink({$url}, {$fields})">
                             </div>
                         </div>
                         <ul class='plugins'>

--- a/templates/components/search/display_data.html.twig
+++ b/templates/components/search/display_data.html.twig
@@ -62,7 +62,7 @@
                   {% set url = call('Plugin::getFormURL', []) %}
                   {% set config_value = call('Config::getConfigurationValue', ['core', 'marketplace_replace_plugins']) %}
                   {% if config_value is not null and config_value != constant('Glpi\\Marketplace\\Controller::MP_REPLACE_ASK')  %}
-                     {% if config_value is not null and  config_value == constant('Glpi\\Marketplace\\Controller::MP_REPLACE_NEVER')  %}
+                     {% if config_value is not null and config_value == constant('Glpi\\Marketplace\\Controller::MP_REPLACE_NEVER')  %}
                         {% set checked = 'checked disabled' %}
                      {% else %}
                         {% set checked = '' %}

--- a/templates/components/search/display_data.html.twig
+++ b/templates/components/search/display_data.html.twig
@@ -61,16 +61,18 @@
                {% if normalized_itemtype == 'Plugin' %}
                   {% set url = call('Plugin::getFormURL', []) %}
                   {% set config_value = call('Config::getConfigurationValues', ['core', ['marketplace_replace_plugins']]) %}
-                  {% if config_value['marketplace_replace_plugins'] == '3' %}
-                     {% set checked = 'checked disabled' %}
-                  {% else %}
-                     {% set checked = '' %}
+                  {% if config_value['marketplace_replace_plugins'] != '1' %}
+                     {% if config_value['marketplace_replace_plugins'] == '3' %}
+                        {% set checked = 'checked disabled' %}
+                     {% else %}
+                        {% set checked = '' %}
+                     {% endif %}
+                     <div class="form-check form-switch">
+                        <label class="fw-bold text-secondary"> {{ __("Default Plugin Page") }}</label>
+                        <input class="form-check-input" type="checkbox" id="defaultplugininterface"
+                        onchange="submitGetLink('{{ url }}',{ 'formIdentifier' : 'change_default_interfaceform', '_glpi_csrf_token' : '{{ csrf_token() }}', 'value' : 3})" {{ checked }}>
+                     </div>
                   {% endif %}
-                  <div class="form-check form-switch">
-                     <label class="fw-bold text-secondary"> {{ __("Default Plugin Page") }}</label>
-                     <input class="form-check-input" type="checkbox" id="defaultplugininterface"
-                     onchange="submitGetLink('{{ url }}',{ 'formIdentifier' : 'change_default_interfaceform', '_glpi_csrf_token' : '{{ csrf_token() }}', 'value' : 3})" {{ checked }}>
-                  </div>
                {% endif %}
             {% endif %}
          </div>

--- a/templates/components/search/display_data.html.twig
+++ b/templates/components/search/display_data.html.twig
@@ -68,7 +68,7 @@
                         {% set checked = '' %}
                      {% endif %}
                      <div class="form-check form-switch">
-                        <label class="fw-bold text-secondary"> {{ __("Default Plugin Page") }}</label>
+                        <label class="text-secondary search-results">{{ __("Default View") }}</label>
                         <input class="form-check-input" type="checkbox" id="defaultplugininterface"
                         onchange="submitGetLink('{{ url }}',{ 'formIdentifier' : 'change_default_interfaceform', '_glpi_csrf_token' : '{{ csrf_token() }}', 'value' : 3})" {{ checked }}>
                      </div>

--- a/templates/components/search/display_data.html.twig
+++ b/templates/components/search/display_data.html.twig
@@ -60,9 +60,9 @@
                {{ include('components/search/controls.html.twig') }}
                {% if normalized_itemtype == 'Plugin' %}
                   {% set url = call('Plugin::getFormURL', []) %}
-                  {% set config_value = call('Config::getConfigurationValues', ['core', ['marketplace_replace_plugins']]) %}
-                  {% if config_value['marketplace_replace_plugins'] != '1' %}
-                     {% if config_value['marketplace_replace_plugins'] == '3' %}
+                  {% set config_value = call('Config::getConfigurationValue', ['core', 'marketplace_replace_plugins']) %}
+                  {% if config_value is not null and config_value != constant('Glpi\\Marketplace\\Controller::MP_REPLACE_ASK')  %}
+                     {% if config_value is not null and  config_value == constant('Glpi\\Marketplace\\Controller::MP_REPLACE_NEVER')  %}
                         {% set checked = 'checked disabled' %}
                      {% else %}
                         {% set checked = '' %}

--- a/templates/components/search/display_data.html.twig
+++ b/templates/components/search/display_data.html.twig
@@ -46,7 +46,7 @@
       data-search-itemtype="{{ data['itemtype'] }}" data-start="{{ start }}" data-count="{{ count }}" data-limit="{{ limit }}" data-submit-once>
    <div class="card card-sm mt-0 search-card">
       {% if not hide_controls %}
-         <div class="card-header d-flex justify-content-between search-header pe-0">
+         <div class="card-header d-flex justify-content-between search-header">
             {% if data['display_type'] == constant('Search::GLOBAL_SEARCH') %}
                <h2>{{ itemtype|itemtype_name }}</h2>
 
@@ -58,6 +58,20 @@
                {% endif %}
             {% else %}
                {{ include('components/search/controls.html.twig') }}
+               {% if normalized_itemtype == 'Plugin' %}
+                  {% set url = call('Plugin::getFormURL', []) %}
+                  {% set config_value = call('Config::getConfigurationValues', ['core', ['marketplace_replace_plugins']]) %}
+                  {% if config_value['marketplace_replace_plugins'] == '3' %}
+                     {% set checked = 'checked disabled' %}
+                  {% else %}
+                     {% set checked = '' %}
+                  {% endif %}
+                  <div class="form-check form-switch">
+                     <label class="fw-bold text-secondary"> {{ __("Default Plugin Page") }}</label>
+                     <input class="form-check-input" type="checkbox" id="defaultplugininterface"
+                     onchange="submitGetLink('{{ url }}',{ 'formIdentifier' : 'change_default_interfaceform', '_glpi_csrf_token' : '{{ csrf_token() }}', 'value' : 3})" {{ checked }}>
+                  </div>
+               {% endif %}
             {% endif %}
          </div>
       {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #####

Creation of a switch to define the default plugin page (marketplace or original page).
![image](https://github.com/glpi-project/glpi/assets/107540223/67fe1835-16c1-46d6-95ba-a8f1ddc7b54b)
![image](https://github.com/glpi-project/glpi/assets/107540223/202f88e1-1d4f-4f2a-89f1-9b17f8046593)

This pull request adds functionality allowing users to choose the default plugin page in GLPI. It modifies the files src/Marketplace/View.php, templates/components/search/display_data.html.twig, front/plugin.form.php, and front/plugin.php to implement default page changes.