### PR TITLE
fix: hide priority field for profiles without priority change rights

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -802,15 +802,17 @@ abstract class CommonITILObject extends CommonDBTM
 
         // Recompute priority if not predefined and impact/urgency was changed
         if (
-            !isset($predefined_fields['priority'])
+            !isset($predefined_fields['priority'], $options['priority'])
             && (
                 isset($predefined_fields['urgency'])
                 || isset($predefined_fields['impact'])
+                || isset($options['impact'])
+                || isset($options['urgency'])
             )
         ) {
             $this->fields['priority'] = self::computePriority(
-                $this->fields['urgency'] ?? 3,
-                $this->fields['impact'] ?? 3
+                $this->fields['urgency'] ?: $predefined_fields['urgency'] ?? 3 /* Medium */,
+                $this->fields['impact'] ?: $predefined_fields['impact']  ?? 3 /* Medium */
             );
         }
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4412,8 +4412,8 @@ JAVASCRIPT;
         // compute priority if is new ticket and user have no right to change priority
         if ($this->isNewItem() && !$canpriority) {
             $this->fields['priority'] = $this->computePriority(
-                $this->fields['urgency'] ?? 3,
-                $this->fields['impact'] ?? 3
+                $this->fields['urgency'] ?: $predefined_fields['urgency'] ?? 3 /* Medium */,
+                $this->fields['impact'] ?: $predefined_fields['impact']  ?? 3 /* Medium */
             );
         }
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4409,14 +4409,6 @@ JAVASCRIPT;
             $options['_noupdate'] = true;
         }
 
-        // compute priority if is new ticket and user have no right to change priority
-        if ($this->isNewItem() && !$canpriority) {
-            $this->fields['priority'] = $this->computePriority(
-                $this->fields['urgency'] ?: $predefined_fields['urgency'] ?? 3 /* Medium */,
-                $this->fields['impact'] ?: $predefined_fields['impact']  ?? 3 /* Medium */
-            );
-        }
-
         $sla = new SLA();
         $ola = new OLA();
         $item_ticket = null;

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4409,6 +4409,14 @@ JAVASCRIPT;
             $options['_noupdate'] = true;
         }
 
+        // compute priority if is new ticket and user have no right to change priority
+        if ($this->isNewItem() && !$canpriority) {
+            $this->fields['priority'] = $this->computePriority(
+                $this->fields['urgency'] ?? 3,
+                $this->fields['impact'] ?? 3
+            );
+        }
+
         $sla = new SLA();
         $ola = new OLA();
         $item_ticket = null;


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13603 

The priority field in the ticket form was visible to all users. It was disabled, for those who did not have the right to modify the priority. Except that the priority was "reset" when changing category, for example. For more information, please refer to issue #13603. The changes made in this RP ensure that the priority field is hidden for these users, but remains visible to users with the appropriate rights.
