### PR TITLE
Fix incorrect display in reminder list label

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -1152,11 +1152,18 @@ function onTinyMCEChange(e) {
 }
 
 function relativeDate(str) {
+    var today = new Date(),
+        strdate = new Date(str);
+    today.setHours(0, 0, 0, 0);
+    strdate.setHours(0, 0, 0, 0);
+
     var s = ( +new Date() - Date.parse(str) ) / 1e3,
         m = s / 60,
         h = m / 60,
-        d = h / 24,
-        y = d / 365.242199,
+        d = ( today - strdate ) / 864e5,
+        w = d / 7,
+        mo = d / 30.44,
+        y = mo / 12,
         tmp;
 
     return (tmp = Math.round(s)) === 1 ? __('just now')
@@ -1166,9 +1173,13 @@ function relativeDate(str) {
                     : (tmp = Math.round(h)) === 1 ? __('an hour ago')
                         : d < 1.01 ? '%s hours ago'.replace('%s', tmp)
                             : (tmp = Math.round(d)) === 1 ? __('yesterday')
-                                : y < 1.01 ? '%s days ago'.replace('%s', tmp)
-                                    : (tmp = Math.round(y)) === 1 ? __('a year ago')
-                                        : '%s years ago'.replace('%s', tmp);
+                                : w < 1.01 ? '%s days ago'.replace('%s', tmp)
+                                    : (tmp = Math.floor(w)) === 1 ? __('a week ago')
+                                        : mo < 1.01 ? '%s weeks ago'.replace('%s', tmp)
+                                            : (tmp = Math.floor(mo)) === 1 ? __('a month ago')
+                                                : y < 1.01 ? '%s month ago'.replace('%s', tmp)
+                                                    : (tmp = Math.floor(y)) === 1 ? __('a year ago')
+                                                        : '%s years ago'.replace('%s', tmp);
 }
 
 /**

--- a/js/common.js
+++ b/js/common.js
@@ -1163,7 +1163,7 @@ function relativeDate(str) {
         d = ( today - strdate ) / 864e5,
         w = d / 7,
         mo = d / 30.44,
-        y = mo / 12,
+        y = d / 365.24,
         tmp;
 
     return (tmp = Math.round(s)) === 1 ? __('just now')
@@ -1177,7 +1177,7 @@ function relativeDate(str) {
                                     : (tmp = Math.floor(w)) === 1 ? __('a week ago')
                                         : mo < 1.01 ? '%s weeks ago'.replace('%s', tmp)
                                             : (tmp = Math.floor(mo)) === 1 ? __('a month ago')
-                                                : y < 1.01 ? '%s month ago'.replace('%s', tmp)
+                                                : y < 1 ? '%s month ago'.replace('%s', tmp)
                                                     : (tmp = Math.floor(y)) === 1 ? __('a year ago')
                                                         : '%s years ago'.replace('%s', tmp);
 }

--- a/js/common.js
+++ b/js/common.js
@@ -1167,19 +1167,19 @@ function relativeDate(str) {
         tmp;
 
     return (tmp = Math.round(s)) === 1 ? __('just now')
-        : m < 1.01 ? '%s seconds ago'.replace('%s', tmp)
+        : m < 1.01 ? __('%s seconds ago').replace('%s', tmp)
             : (tmp = Math.round(m)) === 1 ? __('a minute ago')
-                : h < 1.01 ? '%s minutes ago'.replace('%s', tmp)
+                : h < 1.01 ? __('%s minutes ago').replace('%s', tmp)
                     : (tmp = Math.round(h)) === 1 ? __('an hour ago')
                         : d < 1.01 ? __('%s hours ago').replace('%s', tmp)
                             : (tmp = Math.round(d)) === 1 ? __('yesterday')
-                                : w < 1.01 ? '%s days ago'.replace('%s', tmp)
+                                : w < 1.01 ? __('%s days ago').replace('%s', tmp)
                                     : (tmp = Math.floor(w)) === 1 ? __('a week ago')
-                                        : mo < 1.01 ? '%s weeks ago'.replace('%s', tmp)
+                                        : mo < 1.01 ? __('%s weeks ago').replace('%s', tmp)
                                             : (tmp = Math.floor(mo)) === 1 ? __('a month ago')
-                                                : y < 1 ? '%s months ago'.replace('%s', tmp)
+                                                : y < 1 ? __('%s months ago').replace('%s', tmp)
                                                     : (tmp = Math.floor(y)) === 1 ? __('a year ago')
-                                                        : '%s years ago'.replace('%s', tmp);
+                                                        : __('%s years ago').replace('%s', tmp);
 }
 
 /**

--- a/js/common.js
+++ b/js/common.js
@@ -1177,7 +1177,7 @@ function relativeDate(str) {
                                     : (tmp = Math.floor(w)) === 1 ? __('a week ago')
                                         : mo < 1.01 ? '%s weeks ago'.replace('%s', tmp)
                                             : (tmp = Math.floor(mo)) === 1 ? __('a month ago')
-                                                : y < 1 ? '%s month ago'.replace('%s', tmp)
+                                                : y < 1 ? '%s months ago'.replace('%s', tmp)
                                                     : (tmp = Math.floor(y)) === 1 ? __('a year ago')
                                                         : '%s years ago'.replace('%s', tmp);
 }

--- a/js/common.js
+++ b/js/common.js
@@ -1171,7 +1171,7 @@ function relativeDate(str) {
             : (tmp = Math.round(m)) === 1 ? __('a minute ago')
                 : h < 1.01 ? '%s minutes ago'.replace('%s', tmp)
                     : (tmp = Math.round(h)) === 1 ? __('an hour ago')
-                        : d < 1.01 ? '%s hours ago'.replace('%s', tmp)
+                        : d < 1.01 ? __('%s hours ago').replace('%s', tmp)
                             : (tmp = Math.round(d)) === 1 ? __('yesterday')
                                 : w < 1.01 ? '%s days ago'.replace('%s', tmp)
                                     : (tmp = Math.floor(w)) === 1 ? __('a week ago')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12152

Corrected display of dates in reminder lists. 
![image](https://github.com/glpi-project/glpi/assets/107540223/9c32132d-27cc-4439-82ba-0d6e7d36af34)![image](https://github.com/glpi-project/glpi/assets/107540223/bdb0e984-c207-454d-92d3-befa7e936137)
For example, previously, if the item creation date was 2023-10-28 23:59:59.000 and the current date was 2023-10-30 07:00:00.000, the label displayed was not 2 days ago but yesterday.

This pull request changes the way days are counted, retaining only the date without the time. It also adds week and month management.
![image](https://github.com/glpi-project/glpi/assets/107540223/135d91d5-0c51-40b5-a3c5-794d7737f143)![image](https://github.com/glpi-project/glpi/assets/107540223/84799d0e-51cb-48cf-b2fb-a6e58535ad08)
