### PR TITLE
Discourage usage of PHP 8.0

### DIFF
--- a/src/System/Requirement/PhpSupportedVersion.php
+++ b/src/System/Requirement/PhpSupportedVersion.php
@@ -41,12 +41,12 @@ namespace Glpi\System\Requirement;
 class PhpSupportedVersion extends AbstractRequirement
 {
     /**
-     * Minimal supported version of PHP version.
+     * Minimal version of PHP version that still get security fixes.
      *
      * @var string
      * @see https://www.php.net/supported-versions
      */
-    private const MIN_SUPPORTED_VERSION = '8.0';
+    private const MIN_SECURITY_SUPPORTED_VERSION = '8.1';
 
     public function __construct()
     {
@@ -59,7 +59,7 @@ class PhpSupportedVersion extends AbstractRequirement
     {
         $php_version =  preg_replace('/^(\d+\.\d+)\..*$/', '$1', phpversion());
 
-        if (version_compare($php_version, self::MIN_SUPPORTED_VERSION, '>=')) {
+        if (version_compare($php_version, self::MIN_SECURITY_SUPPORTED_VERSION, '>=')) {
             $this->validated = true;
             // No validation message as we cannot be sure that PHP is up-to-date.
         } else {

--- a/tests/units/Glpi/System/Requirement/PhpSupportedVersion.php
+++ b/tests/units/Glpi/System/Requirement/PhpSupportedVersion.php
@@ -59,18 +59,48 @@ class PhpSupportedVersion extends \GLPITestCase
 
         yield [
             'phpversion' => '8.0.0-rc1',
+            'validated'  => false,
+            'messages'   => ['PHP 8.0 official support has ended. An upgrade to a more recent PHP version is recommended.'],
+        ];
+
+        yield [
+            'phpversion' => '8.0.15',
+            'validated'  => false,
+            'messages'   => ['PHP 8.0 official support has ended. An upgrade to a more recent PHP version is recommended.'],
+        ];
+
+        yield [
+            'phpversion' => '8.1.0-rc1',
             'validated'  => true,
             'messages'   => [],
         ];
 
         yield [
-            'phpversion' => '8.0.15',
+            'phpversion' => '8.1.7',
+            'validated'  => true,
+            'messages'   => [],
+        ];
+
+        yield [
+            'phpversion' => '8.2.0-alpha3',
             'validated'  => true,
             'messages'   => [],
         ];
 
         yield [
             'phpversion' => '8.2.34',
+            'validated'  => true,
+            'messages'   => [],
+        ];
+
+        yield [
+            'phpversion' => '8.3.0-dev',
+            'validated'  => true,
+            'messages'   => [],
+        ];
+
+        yield [
+            'phpversion' => '8.3.1',
             'validated'  => true,
             'messages'   => [],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I guess we will release GLPI 10.0.11 after the PHP 8.0 security support end date.