### PR TITLE
fix incorrect decimal sql warning on new ticket form

### DIFF
--- a/src/CommonITILActor.php
+++ b/src/CommonITILActor.php
@@ -126,7 +126,7 @@ abstract class CommonITILActor extends CommonDBRelation
         global $DB;
 
         $iterator = $DB->request([
-            'FROM'   => $this->getTable(),
+            'FROM'   => static::getTable(),
             'WHERE'  => [
                 static::getItilObjectForeignKey()   => $items_id,
                 'alternative_email'                 => $email

--- a/src/CommonITILActor.php
+++ b/src/CommonITILActor.php
@@ -99,6 +99,10 @@ abstract class CommonITILActor extends CommonDBRelation
         /** @var \DBmysql $DB */
         global $DB;
 
+        if (empty($items_id)) {
+            return [];
+        }
+
         $users = [];
         $iterator = $DB->request([
             'FROM'   => $this->getTable(),

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -118,7 +118,7 @@ abstract class CommonITILObject extends CommonDBTM
      */
     public function loadUsers(): void
     {
-        if (!empty($this->userlinkclass) && isset($this->fields['id'])) {
+        if (!empty($this->userlinkclass) && !$this->isNewItem()) {
             $class = new $this->userlinkclass();
             $this->lazy_loaded_users = $class->getActors($this->fields['id']);
         } else {
@@ -133,7 +133,7 @@ abstract class CommonITILObject extends CommonDBTM
      */
     protected function loadGroups(): void
     {
-        if (!empty($this->grouplinkclass) && isset($this->fields['id'])) {
+        if (!empty($this->grouplinkclass) && !$this->isNewItem()) {
             $class = new $this->grouplinkclass();
             $this->lazy_loaded_groups = $class->getActors($this->fields['id']);
         } else {
@@ -148,7 +148,7 @@ abstract class CommonITILObject extends CommonDBTM
      */
     public function loadSuppliers(): void
     {
-        if (!empty($this->supplierlinkclass) && isset($this->fields['id'])) {
+        if (!empty($this->supplierlinkclass) && !$this->isNewItem()) {
             $class = new $this->supplierlinkclass();
             $this->lazy_loaded_suppliers = $class->getActors($this->fields['id']);
         } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

A new install of GLPI 10.0.10 generates a "Truncated incorrect DECIMAL value: ''" SQL warning when viewing the new ticket form as it tries calling `CommonITILActor::getActors` with an empty string as the ID.