### PR TITLE
Fix invalid date format error for ticket history in timeline

### DIFF
--- a/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
@@ -32,20 +32,33 @@
  #}
 
 {% set timeline_display_date = session('glpitimeline_date_format') %}
+{% set date_creation_formatted = date_creation %}
+{% set date_mod_formatted = date_mod %}
+{% set date_creation_relative = date_creation %}
+{% set date_mod_relative = date_mod %}
+
+{% if not (anchor starts with 'Log_') %}
+    {# Workaround issue where log data already has a formatted datetime #}
+    {% set date_creation_formatted = date_creation|formatted_datetime %}
+    {% set date_mod_formatted = date_mod|formatted_datetime %}
+    {% set date_creation_relative = date_creation|relative_datetime %}
+    {% set date_mod_relative = date_mod|relative_datetime %}
+{% endif %}
+
 <span class="badge user-select-auto text-wrap d-none d-md-block">
    {% set date_span %}
       <span
          {% if timeline_display_date == constant('Config::TIMELINE_RELATIVE_DATE') %}
-            title="{{ date_creation|formatted_datetime }}"
+            title="{{ date_creation_formatted }}"
             data-bs-toggle="tooltip" data-bs-placement="bottom"
          {% endif %}
       >
          <i class="far fa-clock me-1"></i>
          <a href="#{{ anchor }}">
             {% if timeline_display_date == constant('Config::TIMELINE_RELATIVE_DATE') %}
-               {{ date_creation|relative_datetime }}
+               {{ date_creation_relative }}
             {% else %}
-               {{ date_creation|formatted_datetime }}
+               {{ date_creation_formatted }}
             {% endif %}
          </a>
       </span>
@@ -71,15 +84,15 @@
       {% set date_span %}
          <span
             {% if timeline_display_date == constant('Config::TIMELINE_RELATIVE_DATE') %}
-               title="{{ date_mod|formatted_datetime }}"
+               title="{{ date_mod_formatted }}"
                data-bs-toggle="tooltip" data-bs-placement="bottom"
             {% endif %}
          >
             <i class="far fa-clock me-1"></i>
             {% if timeline_display_date == constant('Config::TIMELINE_RELATIVE_DATE') %}
-               {{ date_mod|relative_datetime }}
+               {{ date_mod_relative }}
             {% else %}
-               {{ date_mod|formatted_datetime }}
+               {{ date_mod_formatted }}
             {% endif %}
          </span>
       {% endset %}

--- a/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
@@ -38,7 +38,8 @@
 {% set date_mod_relative = date_mod %}
 
 {% if not (anchor starts with 'Log_') %}
-    {# Workaround issue where log data already has a formatted datetime #}
+    {# Workaround issue where log data already has a formatted datetime -- see https://github.com/glpi-project/glpi/pull/15901 #}
+    {# TODO in GLPI 10.1: Remove this workaround #}
     {% set date_creation_formatted = date_creation|formatted_datetime %}
     {% set date_mod_formatted = date_mod|formatted_datetime %}
     {% set date_creation_relative = date_creation|relative_datetime %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15892

When a user has their date format preference as MM-DD-YYYY, invalid date errors are shown when viewing a ticket's timeline. This is because Log items in the timeline are retrieved with `Log::getHistoryData` which already formats the date. In the template for the timeline item header badges, it tries converting it a second time which doesn't work. For now, the workaround is to show the date as-is for log entries.

I guess in GLPI 10.1 this workaround can be removed and the `Log::getHistoryData` method changed to return the raw date (and fix everything else that may use it).