### PR TITLE
Do not format dates in getHistoricalData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ The present file will list all changes made to the project; according to the
 - `title` property of Kanban items must be text only. HTML no longer supported.
 - `kanban:filter` JS event now includes the columns in the event data. Filtering must set the `_filtered_out` property of cards to hide them instead of changing the elements in the DOM.
 - `CommonITILActor::getActors()` signature changed. The `$items_id` parameter must strictly be an integer.
+- The `date_mod` property for historical entries returned by `Log::getHistoryData` is no longer formatted based on the user's preferences.
 
 #### Deprecated
 - Usage of `GLPI_USE_CSRF_CHECK` constant.

--- a/src/Csv/LogCsvExport.php
+++ b/src/Csv/LogCsvExport.php
@@ -36,6 +36,7 @@
 namespace Glpi\Csv;
 
 use CommonDBTM;
+use Html;
 use Log;
 use Toolbox;
 use User;
@@ -88,6 +89,7 @@ class LogCsvExport implements ExportToCsvInterface
         $logs = array_map(function ($log) {
             unset($log['display_history']);
             unset($log['datatype']);
+            $log['date_mod'] = Html::convDateTime($log["date_mod"]);
             return $log;
         }, $logs);
 

--- a/src/Log.php
+++ b/src/Log.php
@@ -391,7 +391,7 @@ class Log extends CommonDBTM
 
             $tmp['display_history'] = true;
             $tmp['id']              = $data["id"];
-            $tmp['date_mod']        = Html::convDateTime($data["date_mod"]);
+            $tmp['date_mod']        = $data["date_mod"];
             $tmp['user_name']       = $data["user_name"];
             $tmp['field']           = "";
             $tmp['change']          = "";

--- a/src/NotificationTargetCommonITILObject.php
+++ b/src/NotificationTargetCommonITILObject.php
@@ -1529,10 +1529,11 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
             $data["##$objettype.numberoffollowups##"] = count($data['followups']);
 
             $data['log'] = [];
-           // Use list_limit_max or load the full history ?
-            foreach (Log::getHistoryData($item, 0, $CFG_GLPI['list_limit_max']) as $log) {
+            // Use list_limit_max or load the full history ?
+            $log_data = Log::getHistoryData($item, 0, $CFG_GLPI['list_limit_max']);
+            foreach ($log_data as $log) {
                 $tmp                               = [];
-                $tmp["##$objettype.log.date##"]    = $log['date_mod'];
+                $tmp["##$objettype.log.date##"]    = Html::convDateTime($log['date_mod']);
                 $tmp["##$objettype.log.user##"]    = $log['user_name'];
                 $tmp["##$objettype.log.field##"]   = $log['field'];
                 $tmp["##$objettype.log.content##"] = $log['change'];

--- a/src/NotificationTargetProject.php
+++ b/src/NotificationTargetProject.php
@@ -468,12 +468,13 @@ class NotificationTargetProject extends NotificationTarget
         }
         $this->data["##project.numberofcosts##"] = count($this->data['costs']);
 
-       // History infos
+        // History infos
         $this->data['log'] = [];
-       // Use list_limit_max or load the full history ?
-        foreach (Log::getHistoryData($item, 0, $CFG_GLPI['list_limit_max']) as $data) {
+        // Use list_limit_max or load the full history ?
+        $log_data = Log::getHistoryData($item, 0, $CFG_GLPI['list_limit_max']);
+        foreach ($log_data as $data) {
             $tmp                            = [];
-            $tmp["##project.log.date##"]    = $data['date_mod'];
+            $tmp["##project.log.date##"]    = Html::convDateTime($data['date_mod']);
             $tmp["##project.log.user##"]    = $data['user_name'];
             $tmp["##project.log.field##"]   = $data['field'];
             $tmp["##project.log.content##"] = $data['change'];

--- a/src/NotificationTargetProjectTask.php
+++ b/src/NotificationTargetProjectTask.php
@@ -415,10 +415,11 @@ class NotificationTargetProjectTask extends NotificationTarget
        // History infos
 
         $this->data['log'] = [];
-       // Use list_limit_max or load the full history ?
-        foreach (Log::getHistoryData($item, 0, $CFG_GLPI['list_limit_max']) as $data) {
+        // Use list_limit_max or load the full history ?
+        $log_data = Log::getHistoryData($item, 0, $CFG_GLPI['list_limit_max']);
+        foreach ($log_data as $data) {
             $tmp                                = [];
-            $tmp["##projecttask.log.date##"]    = $data['date_mod'];
+            $tmp["##projecttask.log.date##"]    = Html::convDateTime($data['date_mod']);
             $tmp["##projecttask.log.user##"]    = $data['user_name'];
             $tmp["##projecttask.log.field##"]   = $data['field'];
             $tmp["##projecttask.log.content##"] = $data['change'];

--- a/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
@@ -32,34 +32,21 @@
  #}
 
 {% set timeline_display_date = session('glpitimeline_date_format') %}
-{% set date_creation_formatted = date_creation %}
-{% set date_mod_formatted = date_mod %}
-{% set date_creation_relative = date_creation %}
-{% set date_mod_relative = date_mod %}
-
-{% if not (anchor starts with 'Log_') %}
-    {# Workaround issue where log data already has a formatted datetime -- see https://github.com/glpi-project/glpi/pull/15901 #}
-    {# TODO in GLPI 10.1: Remove this workaround #}
-    {% set date_creation_formatted = date_creation|formatted_datetime %}
-    {% set date_mod_formatted = date_mod|formatted_datetime %}
-    {% set date_creation_relative = date_creation|relative_datetime %}
-    {% set date_mod_relative = date_mod|relative_datetime %}
-{% endif %}
 
 <span class="badge user-select-auto text-wrap d-none d-md-block">
    {% set date_span %}
       <span
          {% if timeline_display_date == constant('Config::TIMELINE_RELATIVE_DATE') %}
-            title="{{ date_creation_formatted }}"
+            title="{{ date_creation|formatted_datetime }}"
             data-bs-toggle="tooltip" data-bs-placement="bottom"
          {% endif %}
       >
          <i class="far fa-clock me-1"></i>
          <a href="#{{ anchor }}">
             {% if timeline_display_date == constant('Config::TIMELINE_RELATIVE_DATE') %}
-               {{ date_creation_relative }}
+               {{ date_creation|relative_datetime }}
             {% else %}
-               {{ date_creation_formatted }}
+               {{ date_creation|formatted_datetime }}
             {% endif %}
          </a>
       </span>
@@ -107,15 +94,15 @@
       {% set date_span %}
          <span
             {% if timeline_display_date == constant('Config::TIMELINE_RELATIVE_DATE') %}
-               title="{{ date_mod_formatted }}"
+               title="{{ date_mod|formatted_datetime }}"
                data-bs-toggle="tooltip" data-bs-placement="bottom"
             {% endif %}
          >
             <i class="far fa-clock me-1"></i>
             {% if timeline_display_date == constant('Config::TIMELINE_RELATIVE_DATE') %}
-               {{ date_mod_relative }}
+               {{ date_mod|relative_datetime }}
             {% else %}
-               {{ date_mod_formatted }}
+               {{ date_mod|formatted_datetime }}
             {% endif %}
          </span>
       {% endset %}

--- a/templates/components/logs.html.twig
+++ b/templates/components/logs.html.twig
@@ -119,7 +119,7 @@
          {% for entry in logs %}
             <tr>
                <td>{{ entry['id'] }}</td>
-               <td>{{ entry['date_mod'] }}</td>
+               <td>{{ entry['date_mod']|formatted_datetime }}</td>
                <td>{{ entry['user_name'] }}</td>
                <td>{{ entry['field'] }}</td>
                <td colspan="2" style="width: 60%">{{ entry['change']|raw }}</td>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

More correct fix of #15901. This removes the automatic formatting of dates in the `Log::getHistoryData` and moves the formatting to the point where the dates are actually shown.