### PR TITLE
Fix helpdesk ticket creation

### DIFF
--- a/front/tracking.injector.php
+++ b/front/tracking.injector.php
@@ -75,7 +75,6 @@ if (isset($_POST['add'])) {
     }
     $_POST['check_delegatee'] = true;
     if (isset($_POST['_actors'])) {
-        $_POST['_actors'] = json_decode($_POST['_actors'], true);
        // with self-service, we only have observers
         unset($_POST['_actors']['requester'], $_POST['_actors']['assign']);
     }


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

Correction of a bug that prevented the creation of ticket in helpdesk interface.

When a user tried to create a ticket from the helpdesk interface, the creation failed and ended up with a white screen.
In the logs, we could see the following error:
```
[2023-11-02 09:59:16] glpiphplog.CRITICAL:   *** Uncaught Exception TypeError: json_decode(): Argument #1 ($json) must be of type string, array given in /home/glpi/main/front/tracking.injector.php at line 78
  Backtrace :
  front/tracking.injector.php:78                     json_decode()
  public/index.php:82                                require()
```

A redundancy in the class `tracking.injector.php` seems to be present for a long time.
Indeed, the json contained in the variable `$_POST['_actors']` is deserialized twice.
Nevertheless, before 440adc38fe555fc9d58ba67be700fb0357256f96, the variable `$_POST['_actors']` was not overwrite by the result of the first deserialization because of the global sanitization which took its content from the variable `$_UPOST['_actors']`, sanitization which was removed by 440adc38fe555fc9d58ba67be700fb0357256f96.
