### PR TITLE
fix(assets): input label

### DIFF
--- a/src/Cable.php
+++ b/src/Cable.php
@@ -272,7 +272,7 @@ class Cable extends CommonDBTM
             'table'              => 'glpi_users',
             'field'              => 'name',
             'linkfield'          => 'users_id_tech',
-            'name'               => __('Technician in charge of the hardware'),
+            'name'               => __('Technician in charge'),
             'datatype'           => 'dropdown'
         ];
 

--- a/src/CartridgeItem.php
+++ b/src/CartridgeItem.php
@@ -303,7 +303,7 @@ class CartridgeItem extends CommonDBTM
             'table'              => 'glpi_users',
             'field'              => 'name',
             'linkfield'          => 'users_id_tech',
-            'name'               => __('Technician in charge of the hardware'),
+            'name'               => __('Technician in charge'),
             'datatype'           => 'dropdown',
             'right'              => 'own_ticket'
         ];
@@ -313,7 +313,7 @@ class CartridgeItem extends CommonDBTM
             'table'              => 'glpi_groups',
             'field'              => 'completename',
             'linkfield'          => 'groups_id_tech',
-            'name'               => __('Group in charge of the hardware'),
+            'name'               => __('Group in charge'),
             'condition'          => ['is_assign' => 1],
             'datatype'           => 'dropdown'
         ];

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -247,7 +247,7 @@ class Certificate extends CommonDBTM
             'table'              => 'glpi_users',
             'field'              => 'name',
             'linkfield'          => 'users_id_tech',
-            'name'               => __('Technician in charge of the hardware'),
+            'name'               => __('Technician in charge'),
             'datatype'           => 'dropdown',
             'right'              => 'own_ticket'
         ];
@@ -266,7 +266,7 @@ class Certificate extends CommonDBTM
             'table'              => 'glpi_groups',
             'field'              => 'completename',
             'linkfield'          => 'groups_id_tech',
-            'name'               => __('Group in charge of the hardware'),
+            'name'               => __('Group in charge'),
             'condition'          => ['is_assign' => 1],
             'datatype'           => 'dropdown'
         ];

--- a/src/Cluster.php
+++ b/src/Cluster.php
@@ -127,7 +127,7 @@ class Cluster extends CommonDBTM
             'table'              => 'glpi_users',
             'field'              => 'name',
             'linkfield'          => 'users_id_tech',
-            'name'               => __('Technician in charge of the hardware'),
+            'name'               => __('Technician in charge'),
             'datatype'           => 'dropdown',
             'right'              => 'own_ticket'
         ];
@@ -137,7 +137,7 @@ class Cluster extends CommonDBTM
             'table'              => 'glpi_groups',
             'field'              => 'completename',
             'linkfield'          => 'groups_id_tech',
-            'name'               => __('Group in charge of the hardware'),
+            'name'               => __('Group in charge'),
             'condition'          => ['is_assign' => 1],
             'datatype'           => 'dropdown'
         ];

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -3530,7 +3530,7 @@ class CommonDBTM extends CommonGLPI
         if ($this->isField('users_id_tech')) {
             $tmp = getUserName($this->getField('users_id_tech'));
             if ((strlen($tmp) != 0) && ($tmp != '&nbsp;')) {
-                $toadd[] = ['name'  => __('Technician in charge of the hardware'),
+                $toadd[] = ['name'  => __('Technician in charge'),
                     'value' => $tmp
                 ];
             }

--- a/src/Computer.php
+++ b/src/Computer.php
@@ -545,7 +545,7 @@ class Computer extends CommonDBTM
             'table'              => 'glpi_users',
             'field'              => 'name',
             'linkfield'          => 'users_id_tech',
-            'name'               => __('Technician in charge of the hardware'),
+            'name'               => __('Technician in charge'),
             'datatype'           => 'dropdown',
             'right'              => 'own_ticket'
         ];
@@ -555,7 +555,7 @@ class Computer extends CommonDBTM
             'table'              => 'glpi_groups',
             'field'              => 'completename',
             'linkfield'          => 'groups_id_tech',
-            'name'               => __('Group in charge of the hardware'),
+            'name'               => __('Group in charge'),
             'condition'          => ['is_assign' => 1],
             'datatype'           => 'dropdown'
         ];

--- a/src/ConsumableItem.php
+++ b/src/ConsumableItem.php
@@ -237,7 +237,7 @@ class ConsumableItem extends CommonDBTM
             'table'              => 'glpi_users',
             'field'              => 'name',
             'linkfield'          => 'users_id_tech',
-            'name'               => __('Technician in charge of the hardware'),
+            'name'               => __('Technician in charge'),
             'datatype'           => 'dropdown',
             'right'              => 'own_ticket'
         ];
@@ -247,7 +247,7 @@ class ConsumableItem extends CommonDBTM
             'table'              => 'glpi_groups',
             'field'              => 'completename',
             'linkfield'          => 'groups_id_tech',
-            'name'               => __('Group in charge of the hardware'),
+            'name'               => __('Group in charge'),
             'condition'          => ['is_assign' => 1],
             'datatype'           => 'dropdown'
         ];

--- a/src/DatabaseInstance.php
+++ b/src/DatabaseInstance.php
@@ -237,7 +237,7 @@ class DatabaseInstance extends CommonDBTM
         echo "</td></tr>\n";
 
         echo "<tr class='tab_bg_1'>";
-        echo "<td><label for='dropdown_groups_id_tech$rand'>" . __('Group in charge of the hardware') . "</label></td>";
+        echo "<td><label for='dropdown_groups_id_tech$rand'>" . __('Group in charge') . "</label></td>";
         echo "<td>";
         Group::dropdown([
             'name'      => 'groups_id_tech',
@@ -259,7 +259,7 @@ class DatabaseInstance extends CommonDBTM
         echo "</textarea></td></tr>";
 
         echo "<tr class='tab_bg_1'>";
-        echo "<td><label for='dropdown_users_id_tech$rand'>" . __('Technician in charge of the hardware') . "</label></td>";
+        echo "<td><label for='dropdown_users_id_tech$rand'>" . __('Technician in charge') . "</label></td>";
         echo "<td>";
         User::dropdown(['name'   => 'users_id_tech',
             'value'  => $this->fields["users_id_tech"],

--- a/src/Enclosure.php
+++ b/src/Enclosure.php
@@ -188,7 +188,7 @@ class Enclosure extends CommonDBTM
             'table'              => 'glpi_users',
             'field'              => 'name',
             'linkfield'          => 'users_id_tech',
-            'name'               => __('Technician in charge of the hardware'),
+            'name'               => __('Technician in charge'),
             'datatype'           => 'dropdown',
             'right'              => 'own_ticket'
         ];
@@ -198,7 +198,7 @@ class Enclosure extends CommonDBTM
             'table'              => 'glpi_groups',
             'field'              => 'completename',
             'linkfield'          => 'groups_id_tech',
-            'name'               => __('Group in charge of the hardware'),
+            'name'               => __('Group in charge'),
             'condition'          => ['is_assign' => 1],
             'datatype'           => 'dropdown'
         ];

--- a/src/ITILCategory.php
+++ b/src/ITILCategory.php
@@ -55,14 +55,14 @@ class ITILCategory extends CommonTreeDropdown
             ],
             [
                 'name'      => 'users_id',
-                'label'     => __('Technician in charge of the hardware'),
+                'label'     => __('Technician in charge'),
                 'type'      => 'UserDropdown',
                 'right'     => 'own_ticket',
                 'list'      => true,
             ],
             [
                 'name'      => 'groups_id',
-                'label'     => __('Group in charge of the hardware'),
+                'label'     => __('Group in charge'),
                 'type'      => 'dropdownValue',
                 'condition' => ['is_assign' => 1],
                 'list'      => true,
@@ -157,7 +157,7 @@ class ITILCategory extends CommonTreeDropdown
             'id'                 => '70',
             'table'              => 'glpi_users',
             'field'              => 'name',
-            'name'               => __('Technician in charge of the hardware'),
+            'name'               => __('Technician in charge'),
             'datatype'           => 'dropdown',
             'right'              => 'own_ticket'
         ];

--- a/src/Monitor.php
+++ b/src/Monitor.php
@@ -409,7 +409,7 @@ class Monitor extends CommonDBTM
             'table'              => 'glpi_users',
             'field'              => 'name',
             'linkfield'          => 'users_id_tech',
-            'name'               => __('Technician in charge of the hardware'),
+            'name'               => __('Technician in charge'),
             'datatype'           => 'dropdown',
             'right'              => 'own_ticket'
         ];
@@ -419,7 +419,7 @@ class Monitor extends CommonDBTM
             'table'              => 'glpi_groups',
             'field'              => 'completename',
             'linkfield'          => 'groups_id_tech',
-            'name'               => __('Group in charge of the hardware'),
+            'name'               => __('Group in charge'),
             'condition'          => ['is_assign' => 1],
             'datatype'           => 'dropdown'
         ];

--- a/src/NetworkEquipment.php
+++ b/src/NetworkEquipment.php
@@ -446,7 +446,7 @@ class NetworkEquipment extends CommonDBTM
             'table'              => 'glpi_users',
             'field'              => 'name',
             'linkfield'          => 'users_id_tech',
-            'name'               => __('Technician in charge of the hardware'),
+            'name'               => __('Technician in charge'),
             'datatype'           => 'dropdown',
             'right'              => 'own_ticket'
         ];
@@ -456,7 +456,7 @@ class NetworkEquipment extends CommonDBTM
             'table'              => 'glpi_groups',
             'field'              => 'completename',
             'linkfield'          => 'groups_id_tech',
-            'name'               => __('Group in charge of the hardware'),
+            'name'               => __('Group in charge'),
             'condition'          => ['is_assign' => 1],
             'datatype'           => 'dropdown'
         ];

--- a/src/NotificationTargetReservation.php
+++ b/src/NotificationTargetReservation.php
@@ -53,11 +53,11 @@ class NotificationTargetReservation extends NotificationTarget
         if ($event != 'alert') {
             $this->addTarget(
                 Notification::ITEM_TECH_IN_CHARGE,
-                __('Technician in charge of the hardware')
+                __('Technician in charge')
             );
             $this->addTarget(
                 Notification::ITEM_TECH_GROUP_IN_CHARGE,
-                __('Group in charge of the hardware')
+                __('Group in charge')
             );
             $this->addTarget(Notification::ITEM_USER, __('Hardware user'));
             $this->addTarget(Notification::AUTHOR, _n('Requester', 'Requesters', 1));
@@ -181,7 +181,7 @@ class NotificationTargetReservation extends NotificationTarget
             'reservation.note'        => __('Notes'),
             'reservation.item.entity' => Entity::getTypeName(1),
             'reservation.item.name'   => _n('Associated item', 'Associated items', 1),
-            'reservation.item.tech'   => __('Technician in charge of the hardware')
+            'reservation.item.tech'   => __('Technician in charge')
         ];
 
         foreach ($tags_except_alert as $tag => $label) {

--- a/src/PDU.php
+++ b/src/PDU.php
@@ -157,7 +157,7 @@ class PDU extends CommonDBTM
             'table'              => 'glpi_users',
             'field'              => 'name',
             'linkfield'          => 'users_id_tech',
-            'name'               => __('Technician in charge of the hardware'),
+            'name'               => __('Technician in charge'),
             'datatype'           => 'dropdown',
             'right'              => 'own_ticket'
         ];
@@ -175,7 +175,7 @@ class PDU extends CommonDBTM
             'table'              => 'glpi_groups',
             'field'              => 'completename',
             'linkfield'          => 'groups_id_tech',
-            'name'               => __('Group in charge of the hardware'),
+            'name'               => __('Group in charge'),
             'condition'          => ['is_assign' => 1],
             'datatype'           => 'dropdown'
         ];

--- a/src/PassiveDCEquipment.php
+++ b/src/PassiveDCEquipment.php
@@ -154,7 +154,7 @@ class PassiveDCEquipment extends CommonDBTM
             'table'              => 'glpi_users',
             'field'              => 'name',
             'linkfield'          => 'users_id_tech',
-            'name'               => __('Technician in charge of the hardware'),
+            'name'               => __('Technician in charge'),
             'datatype'           => 'dropdown',
             'right'              => 'own_ticket'
         ];
@@ -172,7 +172,7 @@ class PassiveDCEquipment extends CommonDBTM
             'table'              => 'glpi_groups',
             'field'              => 'completename',
             'linkfield'          => 'groups_id_tech',
-            'name'               => __('Group in charge of the hardware'),
+            'name'               => __('Group in charge'),
             'condition'          => ['is_assign' => 1],
             'datatype'           => 'dropdown'
         ];

--- a/src/Peripheral.php
+++ b/src/Peripheral.php
@@ -321,7 +321,7 @@ class Peripheral extends CommonDBTM
             'table'              => 'glpi_users',
             'field'              => 'name',
             'linkfield'          => 'users_id_tech',
-            'name'               => __('Technician in charge of the hardware'),
+            'name'               => __('Technician in charge'),
             'datatype'           => 'dropdown',
             'right'              => 'own_ticket'
         ];
@@ -331,7 +331,7 @@ class Peripheral extends CommonDBTM
             'table'              => 'glpi_groups',
             'field'              => 'completename',
             'linkfield'          => 'groups_id_tech',
-            'name'               => __('Group in charge of the hardware'),
+            'name'               => __('Group in charge'),
             'condition'          => ['is_assign' => 1],
             'datatype'           => 'dropdown'
         ];

--- a/src/Phone.php
+++ b/src/Phone.php
@@ -386,7 +386,7 @@ class Phone extends CommonDBTM
             'table'              => 'glpi_users',
             'field'              => 'name',
             'linkfield'          => 'users_id_tech',
-            'name'               => __('Technician in charge of the hardware'),
+            'name'               => __('Technician in charge'),
             'datatype'           => 'dropdown',
             'right'              => 'own_ticket'
         ];
@@ -396,7 +396,7 @@ class Phone extends CommonDBTM
             'table'              => 'glpi_groups',
             'field'              => 'completename',
             'linkfield'          => 'groups_id_tech',
-            'name'               => __('Group in charge of the hardware'),
+            'name'               => __('Group in charge'),
             'condition'          => ['is_assign' => 1],
             'datatype'           => 'dropdown'
         ];

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -602,7 +602,7 @@ class Printer extends CommonDBTM
             'table'              => 'glpi_users',
             'field'              => 'name',
             'linkfield'          => 'users_id_tech',
-            'name'               => __('Technician in charge of the hardware'),
+            'name'               => __('Technician in charge'),
             'datatype'           => 'dropdown',
             'right'              => 'own_ticket'
         ];
@@ -612,7 +612,7 @@ class Printer extends CommonDBTM
             'table'              => 'glpi_groups',
             'field'              => 'completename',
             'linkfield'          => 'groups_id_tech',
-            'name'               => __('Group in charge of the hardware'),
+            'name'               => __('Group in charge'),
             'condition'          => ['is_assign' => 1],
             'datatype'           => 'dropdown'
         ];

--- a/src/Rack.php
+++ b/src/Rack.php
@@ -254,7 +254,7 @@ class Rack extends CommonDBTM
             'table'              => 'glpi_users',
             'field'              => 'name',
             'linkfield'          => 'users_id_tech',
-            'name'               => __('Technician in charge of the hardware'),
+            'name'               => __('Technician in charge'),
             'datatype'           => 'dropdown',
             'right'              => 'own_ticket'
         ];
@@ -264,7 +264,7 @@ class Rack extends CommonDBTM
             'table'              => 'glpi_groups',
             'field'              => 'completename',
             'linkfield'          => 'groups_id_tech',
-            'name'               => __('Group in charge of the hardware'),
+            'name'               => __('Group in charge'),
             'condition'          => ['is_assign' => 1],
             'datatype'           => 'dropdown'
         ];

--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -275,7 +275,7 @@ class ReservationItem extends CommonDBChild
             'table'              => 'glpi_users',
             'field'              => 'name',
             'linkfield'          => 'users_id_tech',
-            'name'               => __('Technician in charge of the hardware'),
+            'name'               => __('Technician in charge'),
             'datatype'           => 'dropdown',
             'right'              => 'interface',
             'massiveaction'      => false

--- a/src/RuleAsset.php
+++ b/src/RuleAsset.php
@@ -185,9 +185,9 @@ class RuleAsset extends Rule
 
         $actions['users_id_tech']['table']      = 'glpi_users';
         $actions['users_id_tech']['type']       = 'dropdown_users';
-        $actions['users_id_tech']['name']       = __('Technician in charge of the hardware');
+        $actions['users_id_tech']['name']       = __('Technician in charge');
 
-        $actions['groups_id_tech']['name']      = __('Group in charge of the hardware');
+        $actions['groups_id_tech']['name']      = __('Group in charge');
         $actions['groups_id_tech']['type']      = 'dropdown';
         $actions['groups_id_tech']['table']     = 'glpi_groups';
         $actions['groups_id_tech']['condition'] = ['is_assign' => 1];

--- a/src/RuleImportEntity.php
+++ b/src/RuleImportEntity.php
@@ -266,12 +266,12 @@ class RuleImportEntity extends Rule
                 'type' => 'yesno'
             ],
             'groups_id_tech' => [
-                'name' => __('Group in charge of the hardware'),
+                'name' => __('Group in charge'),
                 'type' => 'dropdown',
                 'table' => Group::getTable()
             ],
             'users_id_tech' => [
-                'name' => __('Technician in charge of the hardware'),
+                'name' => __('Technician in charge'),
                 'type' => 'dropdown_users'
             ]
         ];

--- a/src/Search.php
+++ b/src/Search.php
@@ -8199,13 +8199,13 @@ HTML;
                     self::$search[$itemtype][24]['table']         = 'glpi_users';
                     self::$search[$itemtype][24]['field']         = 'name';
                     self::$search[$itemtype][24]['linkfield']     = 'users_id_tech';
-                    self::$search[$itemtype][24]['name']          = __('Technician in charge of the hardware');
+                    self::$search[$itemtype][24]['name']          = __('Technician in charge');
                     self::$search[$itemtype][24]['condition']     = ['is_assign' => 1];
 
                     self::$search[$itemtype][49]['table']          = 'glpi_groups';
                     self::$search[$itemtype][49]['field']          = 'completename';
                     self::$search[$itemtype][49]['linkfield']      = 'groups_id_tech';
-                    self::$search[$itemtype][49]['name']           = __('Group in charge of the hardware');
+                    self::$search[$itemtype][49]['name']           = __('Group in charge');
                     self::$search[$itemtype][49]['condition']      = ['is_assign' => 1];
                     self::$search[$itemtype][49]['datatype']       = 'dropdown';
 

--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -374,7 +374,7 @@
                            'User',
                            'users_id_tech',
                            item.fields['users_id_tech'],
-                           __('Technician in charge of the hardware'),
+                           __('Technician in charge of the asset'),
                            field_options|merge({
                               'entity': item.fields['entities_id'],
                               'right': 'own_ticket',
@@ -397,7 +397,7 @@
                            'Group',
                            'groups_id_tech',
                            item.fields['groups_id_tech'],
-                           __('Group in charge of the hardware'),
+                           __('Group in charge of the asset'),
                            field_options|merge({
                               'entity': item.fields['entities_id'],
                               'condition': {'is_assign': 1},

--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -374,7 +374,7 @@
                            'User',
                            'users_id_tech',
                            item.fields['users_id_tech'],
-                           __('Technician in charge of the asset'),
+                           __('Technician in charge'),
                            field_options|merge({
                               'entity': item.fields['entities_id'],
                               'right': 'own_ticket',
@@ -397,7 +397,7 @@
                            'Group',
                            'groups_id_tech',
                            item.fields['groups_id_tech'],
-                           __('Group in charge of the asset'),
+                           __('Group in charge'),
                            field_options|merge({
                               'entity': item.fields['entities_id'],
                               'condition': {'is_assign': 1},


### PR DESCRIPTION
The label "Technician in charge of the hardware" is a generic text, but it's not suitable for software. Same thing for the group.

Perhaps replace with "Technician in charge of the asset" or just "Technician in charge"?

Before:

![image](https://github.com/glpi-project/glpi/assets/8530352/5fd9d1ad-cb29-4ded-84cd-b07c08b83450)

After:

![image](https://github.com/glpi-project/glpi/assets/8530352/e7f38dc3-c578-4e7b-bb81-3a7d3e4c74f9)


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30281
