### PR TITLE
Ensure `config` dir is included in release archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,5 @@
-/config/cache.php
-/config/config_db*
-/config/glpi.key
-/config/glpicrypt.key
-/config/local_define.php
-/config/oauth.pem
-/config/oauth.pub
-/tests/config_db*
-/tests/cache.php
+/config/*
+!/config/.gitkeep
 /marketplace/*
 !/marketplace/.gitkeep
 /plugins/*
@@ -29,10 +22,6 @@ phpunit.xml
 /tests/coverage-*/
 /tests/files/
 /tests/.env
-/tests/glpicrypt.key
-/config/based_config.php
-/config/config.php
-/config/define.php
 /nbproject
 .composer.hash
 /**/*.min.css


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In main branch, as it will be mandatory to use `/public` as  GLPI root directory, we removed `.htaccess` files. A side effect of this was that the `config` dir was not containing any versionned file and therefore was no more part of the repository. Adding a `.gitkeep` file will fix that.

I also simplified the `.gitignore` file that was containing way too much instructions related to config files.