### PR TITLE
Fix pourcentage problems on TTRs

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -7121,8 +7121,9 @@ JAVASCRIPT;
                                                  - strtotime($item->fields['date']);
                             }
                         }
+                        $pending_duration = $item->getPendingDuration();
                         if ($totaltime != 0) {
-                            $percentage  = round((100 * $currenttime) / $totaltime);
+                            $percentage  = round((100 * ($currenttime - $pending_duration)) / ($totaltime - $pending_duration));
                         } else {
                            // Total time is null : no active time
                             $percentage = 100;

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2463,13 +2463,12 @@ class Ticket extends CommonITILObject
 
         $iterator = $DBread->request($query);
         $startPause = null;
-        foreach($iterator as $data)
-        {
-            if($data['new_value'] == self::WAITING) {
+        foreach ($iterator as $data) {
+            if ($data['new_value'] == self::WAITING) {
                 $startPause = $data['date_mod'];
             }
 
-            if($data['old_value'] == self::WAITING && $startPause !== null) {
+            if ($data['old_value'] == self::WAITING && $startPause !== null) {
                 $endPause = $data['date_mod'];
                 $duration += strtotime($endPause) - strtotime($startPause);
                 $startPause = null;

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2428,6 +2428,7 @@ class Ticket extends CommonITILObject
      */
     public function getPendingDuration($startPeriod = null, $endPeriod = null)
     {
+        /** @var \DBmysql $DB */
         global $DB;
 
         $startPeriod = $startPeriod ?? $this->fields['date'];


### PR DESCRIPTION
### **Ticket #30259 Pourcentage problem**

### PROCEDURE FOR REPRODUCING TICKET BUG #30259

_1. Create a ticket and assign it an SLA (Type: TTR; Duration: 12h). The resolution time (TTR) is set for the following day at 6:00 for a progression of 2%.
2. Change ticket status to "Pending".
3. Change apache server timezone (php.ini): From: date.timezone = Europe/Paris UTC+0h To: date.timezone = Asia/Yekaterinburg UTC+4h
4. Change ticket status to "In progress". The resolution time (TTR) is set for the next day at 10:00 for a progress of 28%.
5. 

Conclusion: The ticket pause time has been taken into account by :
    :heavy_check_mark: -The TTR, as it has increased from 6:00 to 10:00 (4h waiting time).
    :x: -The progress bar, as its value should have remained unchanged following the
        of the ticket._

To overcome this problem, a `getPendingDuration()` function has been created in Ticket.php. It calculates the time a ticket has been on hold.

This result is then used to calculate the TTR percentage.
Unit tests have not yet been performed.