### PR TITLE
Fix 0 being read as missing rsql value

### DIFF
--- a/src/Api/HL/RSQL/Lexer.php
+++ b/src/Api/HL/RSQL/Lexer.php
@@ -183,7 +183,7 @@ final class Lexer
                         $buffer .= $char;
                     }
                 }
-                if (!empty($buffer)) {
+                if ($buffer !== '') {
                     $tokens[] = [self::T_VALUE, $buffer];
                     $buffer = '';
                 } else if ($tokens[count($tokens) - 1][0] === self::T_OPERATOR) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Bad use of `empty()` was seeing an RSQL filter value of '0' as if it were a missing value.