### PR TITLE
Fix readonly dropdown with defined width

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -185,7 +185,7 @@ class Dropdown
 
         if ($params['readonly']) {
             return '<span class="form-control" readonly'
-                . ($params['width'] ? 'style="width: ' . $params["width"] . '"' : '') . '>'
+                . ($params['width'] ? ' style="width: ' . $params["width"] . '"' : '') . '>'
                 . ($params['multiple'] ? implode(', ', $names) : $name)
                 . '</span>';
         }


### PR DESCRIPTION
Readonly Dropdown with width set in parameters were not applied because html attributes were concatenated

`<span class="form-control" readonlystyle="width: 100%">XXXXXXXXXXXXXX</span>`

becomes :

`<span class="form-control" readonly style="width: 100%">XXXXXXXXXXXXXX</span>`