### PR TITLE
fix(ticket): percentage of resolution time

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -7097,6 +7097,7 @@ JAVASCRIPT;
                                 $item->fields['date'],
                                 $data[$ID][0]['name']
                             );
+                            $waitingtime = $slaField === 'slas_id_ttr' ? $item->fields['sla_waiting_duration'] : 0;
                         } else {
                             $calendars_id = Entity::getUsedConfig(
                                 'calendars_strategy',
@@ -7120,9 +7121,9 @@ JAVASCRIPT;
                                 $totaltime   = strtotime($data[$ID][0]['name'])
                                                  - strtotime($item->fields['date']);
                             }
+                            $waitingtime = 0;
                         }
                         if ($totaltime != 0) {
-                            $waitingtime = $item->fields['sla_waiting_duration'];
                             $percentage  = round((100 * ($currenttime - $waitingtime)) / ($totaltime - $waitingtime));
                         } else {
                            // Total time is null : no active time

--- a/src/Search.php
+++ b/src/Search.php
@@ -7122,7 +7122,8 @@ JAVASCRIPT;
                             }
                         }
                         if ($totaltime != 0) {
-                            $percentage  = round((100 * $currenttime) / $totaltime);
+                            $waitingtime = $item->fields['sla_waiting_duration'];
+                            $percentage  = round((100 * ($currenttime - $waitingtime)) / ($totaltime - $waitingtime));
                         } else {
                            // Total time is null : no active time
                             $percentage = 100;


### PR DESCRIPTION
Percentage of resolution time does not exclude waiting time. I think that the pending should freeze this evolution, so its value should be similar just before the pending and just after the exit of pending.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30259
