### PR TITLE
Add parent meta options for timeline types

### DIFF
--- a/src/Search/SearchEngine.php
+++ b/src/Search/SearchEngine.php
@@ -128,6 +128,15 @@ final class SearchEngine
                 continue;
             }
 
+            if ($key === 'itil_types') {
+                $timeline_types = [\ITILFollowup::class, \CommonITILTask::class, \ITILSolution::class, \CommonITILValidation::class];
+                foreach ($timeline_types as $timeline_type) {
+                    if (is_a($item, $timeline_type) || is_subclass_of($item, $timeline_type)) {
+                        $linked = [...$linked, ...$values];
+                    }
+                }
+            }
+
             foreach (self::getMetaParentItemtypesForTypesConfig($key) as $config_itemtype) {
                 if ($ref_itemtype === $config_itemtype::getType()) {
                     // List is related to source itemtype, all types of list are so linked

--- a/src/Search/SearchEngine.php
+++ b/src/Search/SearchEngine.php
@@ -131,7 +131,9 @@ final class SearchEngine
             if ($key === 'itil_types') {
                 $timeline_types = [\ITILFollowup::class, \CommonITILTask::class, \ITILSolution::class, \CommonITILValidation::class];
                 foreach ($timeline_types as $timeline_type) {
-                    if (is_a($item, $timeline_type)) {
+                    if (is_a($item, \CommonITILTask::class) || is_a($item, \CommonITILValidation::class)) {
+                        $linked[] = $item->getItilObjectItemType();
+                    } else if (is_a($item, $timeline_type)) {
                         $linked = [...$linked, ...$values];
                     }
                 }

--- a/src/Search/SearchEngine.php
+++ b/src/Search/SearchEngine.php
@@ -131,7 +131,7 @@ final class SearchEngine
             if ($key === 'itil_types') {
                 $timeline_types = [\ITILFollowup::class, \CommonITILTask::class, \ITILSolution::class, \CommonITILValidation::class];
                 foreach ($timeline_types as $timeline_type) {
-                    if (is_a($item, $timeline_type) || is_subclass_of($item, $timeline_type)) {
+                    if (is_a($item, $timeline_type)) {
                         $linked = [...$linked, ...$values];
                     }
                 }

--- a/src/Search/SearchEngine.php
+++ b/src/Search/SearchEngine.php
@@ -129,12 +129,14 @@ final class SearchEngine
             }
 
             if ($key === 'itil_types') {
-                $timeline_types = [\ITILFollowup::class, \CommonITILTask::class, \ITILSolution::class, \CommonITILValidation::class];
-                foreach ($timeline_types as $timeline_type) {
-                    if (is_a($item, \CommonITILTask::class) || is_a($item, \CommonITILValidation::class)) {
-                        $linked[] = $item->getItilObjectItemType();
-                    } else if (is_a($item, $timeline_type)) {
-                        $linked = [...$linked, ...$values];
+                if (is_a($item, \CommonITILTask::class) || is_a($item, \CommonITILValidation::class)) {
+                    $linked[] = $item->getItilObjectItemType();
+                } else {
+                    $timeline_types = [\ITILFollowup::class, \ITILSolution::class];
+                    foreach ($timeline_types as $timeline_type) {
+                        if (is_a($item, $timeline_type)) {
+                            $linked = [...$linked, ...$values];
+                        }
                     }
                 }
             }

--- a/tests/functional/TicketTask.php
+++ b/tests/functional/TicketTask.php
@@ -36,6 +36,7 @@
 namespace tests\units;
 
 use DbTestCase;
+use Glpi\Search\SearchEngine;
 
 /* Test for inc/tickettask.class.php */
 
@@ -534,5 +535,34 @@ class TicketTask extends DbTestCase
         $this->integer($task->fields['actiontime'])->isEqualTo(7200);
         $this->string($task->fields['begin'])->isEqualTo($date_begin_string);
         $this->string($task->fields['end'])->isEqualTo($date_begin->add(new \DateInterval('PT2H'))->format('Y-m-d H:i:s'));
+    }
+
+    public function testParentMetaSearchOptions()
+    {
+        $this->login();
+        $ticket = $this->getNewTicket(true);
+        $followup = new \ITILFollowup();
+        $this->integer($followup->add([
+            'itemtype' => 'Ticket',
+            'items_id' => $ticket->fields['id'],
+            'content'  => 'Test followup',
+        ]))->isGreaterThan(0);
+
+        $criteria = [
+            [
+                'link' => 'AND',
+                'itemtype' => 'Ticket',
+                'meta' => true,
+                'field' => 1, //Title
+                'searchtype' => 'contains',
+                'value' => 'ticket title',
+            ]
+        ];
+        $data = SearchEngine::getData('ITILFollowup', [
+            'criteria' => $criteria,
+        ]);
+        $this->integer($data['data']['totalcount'])->isEqualTo(1);
+        $this->string($data['data']['rows'][0]['Ticket_1'][0]['name'])->isEqualTo('ticket title');
+
     }
 }

--- a/tests/functional/TicketTask.php
+++ b/tests/functional/TicketTask.php
@@ -563,6 +563,5 @@ class TicketTask extends DbTestCase
         ]);
         $this->integer($data['data']['totalcount'])->isEqualTo(1);
         $this->string($data['data']['rows'][0]['Ticket_1'][0]['name'])->isEqualTo('ticket title');
-
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29810

Add meta options for timeline types like followups to be able to search fields of the parent type (tickets, changes, problems). Timeline types are usually not searchable, so this can really only be used in the API or the criteria filter feature in webhooks.