### PR TITLE
Do not use jquery.ready when rendering actors

### DIFF
--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -74,7 +74,10 @@
    {% endif %}
 
    <script type="text/javascript">
-   $(function() {
+
+   // Do not use jquery ready wrapper here as it behave unexpectedly with ajax
+   // requests, adding an unnecessary delay
+   (function() {
       var actorytype = '{{ actortype }}';
 
       // function to display an option in the list or the selected input
@@ -360,6 +363,6 @@
       {% if itiltemplate.isHiddenField('_groups_id_' ~ actortype) %}
          $(".actor_entry[data-itemtype=\"Group\"][data-actortype=\"{{ actortype }}\"]").parent().css("display", "none");
       {% endif %}
-   });
+   })();
    </script>
 {% endif %}


### PR DESCRIPTION
Jquery's ready wrapper do not work as expected in our AJAX fetched content.

The documentation state the following:
> The .ready() method offers a way to run JavaScript code as soon as the page's Document Object Model (DOM) becomes safe to manipulate. This will often be a good time to perform tasks that are needed before the user views or interacts with the page, for example to add event handlers and initialize plugins. When multiple functions are added via successive calls to this method, they run when the DOM is ready in the order in which they are added. As of jQuery 3.0, jQuery ensures that an exception occuring in one handler does not prevent subsequently added handlers from executing.
>
>Most browsers [provide similar functionality](https://caniuse.com/#search=DOMContentLoaded) in the form of a DOMContentLoaded event. However, jQuery's .ready() method differs in an important and useful way: If the DOM becomes ready and the browser fires DOMContentLoaded before the code calls .ready( handler ), the function handler will still be executed. In contrast, a DOMContentLoaded event listener added after the event fires is never executed.

Reading this documentation would suggest that code inside the ready wrapper would be executed when the `DOMContentLoaded` event is fired or immediately if that event was already fired before our call.

If that was the case, the actor rendering javascript should be immediately executed as the document is already ready.
We are sure of this because the content came from the AJAX loading of the main tab, which itself is done when the document is ready.

This can be confirmed by adding some debug code displaying the state of `document.readyState`, which will be `complete`.

This is however not what's happening here as we end up with at least a one second delay before the rendering code is executed.

This delay is explained when looking into Jquery's code:

![image](https://github.com/glpi-project/glpi/assets/42734840/5598c558-d63a-44ad-8751-978c6eb64ccf)

This code seems to indicate that Jquery will wait for all ongoing AJAX request to be over before running the ready function.
Which mean that any request done after the document is ready would block the ready function execution until its completed, leading to potential huge delay if we have a lot of chained requests.

The fix here is simple : don't use jquery's ready wrapper for this case (but we do keep a self invoking function to maintain variable isolation).

As we discussed it together (@cedric-anne, @orthagh) there is probably other client code that could be improved with similar changes (and we should be very vigilent when using the ready wrapper in the future).

Keep in mind that while this specific change seems to be bring great performances gain without any stability risk, this may not be the case on others possible changes (tab load, dashboard load, ...) which is why they are not included in this PR and may not be worth doing in the near future.

Side note: we may also want to use our own ready state function to bypass this weird jquery behavior.
Bootstrap does something like this for example:

![image](https://github.com/glpi-project/glpi/assets/42734840/f94a4b62-b7a0-4700-a391-1b783af5c278)

The proposed code changes are safe because we are 100% sure it will be executed when the document is already loaded but such a function would keep things extra safe in case the code is moved somewhere else in the future.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29995
