### PR TITLE
fix(UserMention): fix fatal error on null

### DIFF
--- a/src/RichText/UserMention.php
+++ b/src/RichText/UserMention.php
@@ -204,7 +204,7 @@ final class UserMention
             return [];
         }
 
-        if (!$content_as_xml || is_null($content_as_xml)) {
+        if ($content_as_xml === null) {
             return [];
         }
 

--- a/src/RichText/UserMention.php
+++ b/src/RichText/UserMention.php
@@ -198,7 +198,7 @@ final class UserMention
             libxml_use_internal_errors(true);
             $dom->loadHTML($content);
             // TODO In GLPI 10.1, find a way to remove usage of this `@` operator
-            // xhich added to prevent Error E_WARNING simplexml_import_dom(): Invalid Nodetype to import
+            // that was added to prevent Error E_WARNING simplexml_import_dom(): Invalid Nodetype to import
             // with bad HTML content.
             $content_as_xml = @simplexml_import_dom($dom);
         } catch (\Throwable $e) {

--- a/src/RichText/UserMention.php
+++ b/src/RichText/UserMention.php
@@ -194,6 +194,8 @@ final class UserMention
 
         try {
             $content = Sanitizer::getVerbatimValue($content);
+            //clean HTML to prevent Error E_WARNING simplexml_import_dom(): Invalid Nodetype to import
+            $content = RichText::getSafeHtml($content);
             $dom = new DOMDocument();
             libxml_use_internal_errors(true);
             $dom->loadHTML($content);

--- a/src/RichText/UserMention.php
+++ b/src/RichText/UserMention.php
@@ -204,6 +204,10 @@ final class UserMention
             return [];
         }
 
+        if (!$content_as_xml || is_null($content_as_xml)) {
+            return [];
+        }
+
         $mention_elements = $content_as_xml->xpath('//*[@data-user-mention="true"]');
         foreach ($mention_elements as $mention_element) {
             $ids[] = (int)$mention_element->attributes()->{'data-user-id'};

--- a/src/RichText/UserMention.php
+++ b/src/RichText/UserMention.php
@@ -194,12 +194,13 @@ final class UserMention
 
         try {
             $content = Sanitizer::getVerbatimValue($content);
-            //clean HTML to prevent Error E_WARNING simplexml_import_dom(): Invalid Nodetype to import
-            $content = RichText::getSafeHtml($content);
             $dom = new DOMDocument();
             libxml_use_internal_errors(true);
             $dom->loadHTML($content);
-            $content_as_xml = simplexml_import_dom($dom);
+            // TODO In GLPI 10.1, find a way to remove usage of this `@` operator
+            // xhich added to prevent Error E_WARNING simplexml_import_dom(): Invalid Nodetype to import
+            // with bad HTML content.
+            $content_as_xml = @simplexml_import_dom($dom);
         } catch (\Throwable $e) {
            // Sanitize process does not handle correctly `<` and `>` chars that are not surrounding html tags.
            // This generates invalid HTML that cannot be loaded by `SimpleXMLElement`.

--- a/tests/functional/Glpi/RichText/UserMention.php
+++ b/tests/functional/Glpi/RichText/UserMention.php
@@ -188,7 +188,7 @@ HTML
                     'itemtype'      => $itemtype,
                     'main_itemtype' => $main_type,
 
-               // bad HTML no users are not notified
+               // bad HTML no users are notified
                     'add_content'            => <<<HTML
                   </span></p></div></body></html>
 HTML
@@ -196,7 +196,7 @@ HTML
                     'add_expected_observers' => [],
                     'add_expected_notified'  => [],
 
-               // update bad HTML => no users are not notified
+               // update bad HTML => no users are notified
                     'update_content'            => <<<HTML
                   </span></p></div></body></html>
 HTML

--- a/tests/functional/Glpi/RichText/UserMention.php
+++ b/tests/functional/Glpi/RichText/UserMention.php
@@ -132,7 +132,6 @@ HTML
                     'update_expected_observers' => [],
                     'update_expected_notified'  => [],
                 ];
-
                 yield [
                     'itemtype'      => $itemtype,
                     'main_itemtype' => $main_type,
@@ -185,6 +184,26 @@ HTML
                         'is_private'                => true,
                     ];
                 }
+                yield [
+                    'itemtype'      => $itemtype,
+                    'main_itemtype' => $main_type,
+
+               // bad HTML no users are not notified
+                    'add_content'            => <<<HTML
+                  </span></p></div></body></html>
+HTML
+               ,
+                    'add_expected_observers' => [],
+                    'add_expected_notified'  => [],
+
+               // update bad HTML => no users are not notified
+                    'update_content'            => <<<HTML
+                  </span></p></div></body></html>
+HTML
+               ,
+                    'update_expected_observers' => [],
+                    'update_expected_notified'  => [],
+                ];
             }
         }
     }


### PR DESCRIPTION
Prevent  error when ```UserMention``` can't convert ```HTML``` to ```XML``` without thrown error from ```try / catch``` (but just by returning ```null``` or ```false```)

_@return SimpleXMLElement|null — a SimpleXMLElement or FALSE on failure._

```shell
[2023-10-26 06:01:31] glpiphplog.CRITICAL:   *** Uncaught Exception Error: Call to a member function xpath() on null in /mnt/data/glpi/src/RichText/UserMention.php at line 207
  Backtrace :
  src/RichText/UserMention.php:91                    Glpi\RichText\UserMention::getUserIdsFromUserMentions()
  src/CommonDBTM.php:1538                            Glpi\RichText\UserMention::handleUserMentions()
  src/CommonDBTM.php:1324                            CommonDBTM->post_addItem()
  src/CronTask.php:375                               CommonDBTM->add()
  src/MailCollector.php:1916                         CronTask->log()
  src/CronTask.php:1018                              MailCollector::cronMailgate()
  front/cron.php:84                                  CronTask::launch()
  ```




| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30182
