### PR TITLE
fix(search): limit dropdown

### DIFF
--- a/templates/components/dropdown/limit.html.twig
+++ b/templates/components/dropdown/limit.html.twig
@@ -70,6 +70,9 @@
 {% if max > 10 %}
    {% set options = options|merge([max - 10]) %}
 {% endif %}
+{% if user_pref('list_limit') not in options %}
+   {% set options = options|merge([user_pref('list_limit')]) %}
+{% endif %}
 <select class="form-select form-select-sm mx-1 d-inline-block w-auto {{ select_class|default('') }}"
         {% if not no_onchange %}onChange="{{ href }}"{% endif %}>
    {% for value in options|sort %}


### PR DESCRIPTION
When you customize the number of "Results to display by page" with "70" for example, which is not one of the original values proposed, the limit applied is indeed 70, but the dropdown displays 5.

Settings:
![image](https://github.com/glpi-project/glpi/assets/8530352/fb5d5706-1abe-41de-91b1-8645d9baa641)

![image](https://github.com/glpi-project/glpi/assets/8530352/951ef64e-cd09-4b7e-a5fe-234b456c77de)

Before:
![image](https://github.com/glpi-project/glpi/assets/8530352/5b6142a1-ea92-42da-aeae-0ee0945d00f9)

After:
![image](https://github.com/glpi-project/glpi/assets/8530352/46019a47-8738-437f-b9d6-fe8dd81ad007)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
