### PR TITLE
feat(Ruleticket): add '$this->fields[$key]' value if key is used by rule criteria and not update

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1248,6 +1248,13 @@ class Ticket extends CommonITILObject
                 ) {
                     $changes[] = $key;
                 }
+            } elseif (
+                array_key_exists($key, $this->fields) //existing in original field
+                && !array_key_exists($key, $post_added) //not already added by rules
+                && !array_key_exists($key, $input) //not in input, so not changed
+            ) {
+                $input[$key] = $this->fields[$key]; //add it to input to be able to use it in rules
+                $changes[] = $key; //add it to changes to be able to use it in rules
             }
         }
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1249,6 +1249,7 @@ class Ticket extends CommonITILObject
                     $changes[] = $key;
                 }
             } elseif (
+                //get related value from original object (from DB)
                 array_key_exists($key, $this->fields) //existing in original field
                 && !array_key_exists($key, $post_added) //not already added by rules
                 && !array_key_exists($key, $input) //not in input, so not changed


### PR DESCRIPTION
The idea of this PR is to inject into the ```$input```  (used by the rules) the values that would not be modified during an update.

Currently, only the ```keys``` updated **and** used by the rules are sent.

With this PR, we can now send ```keys``` that have been : 
- updated (with ```$obj->update(['key' => $val]);``` and used by the rules and not already added by rules (see ```$post_added```)
- not updated but used by the rules and not already added by rules (see ```$post_added```)

**Case study** 

A rule checks the status of a ticket when a validation request is approved.

The status is never sent as it is not updated in the process (```CommonITILValidation```)


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
