### PR TITLE
Fix Notification ObjectLock

### DIFF
--- a/ajax/unlockobject.php
+++ b/ajax/unlockobject.php
@@ -76,7 +76,7 @@ if (isset($_POST['unlock']) && isset($_POST["id"])) {
     if ($ol->getFromDB($_POST["id"])) {
         $itemtype = $ol->fields['itemtype'];
         $object = new $itemtype();
-        if ($object->getFromDB($ol->fields["items_id"])){
+        if ($object->getFromDB($ol->fields["items_id"])) {
             NotificationEvent::raiseEvent('unlock', $object);
             $ret = 1;
         }

--- a/ajax/unlockobject.php
+++ b/ajax/unlockobject.php
@@ -74,8 +74,12 @@ if (isset($_POST['unlock']) && isset($_POST["id"])) {
    // the we must ask for unlock
     $ol = new ObjectLock();
     if ($ol->getFromDB($_POST["id"])) {
-        NotificationEvent::raiseEvent('unlock', $ol);
-        $ret = 1;
+        $itemtype = $ol->fields['itemtype'];
+        $object = new $itemtype();
+        if ($object->getFromDB($ol->fields["items_id"])){
+            NotificationEvent::raiseEvent('unlock', $object);
+            $ret = 1;
+        }
     }
 } else if (
     isset($_GET['lockstatus'])

--- a/src/ObjectLock.php
+++ b/src/ObjectLock.php
@@ -247,7 +247,7 @@ class ObjectLock extends CommonDBTM
                      cache: false,
                      data: {
                         requestunlock: 1,
-                        id: {$this->fields['id']}
+                        id: {$this->itemid}
                      },
                      dataType: 'json',
                      success: function( data, textStatus, jqXHR ) {

--- a/src/ObjectLock.php
+++ b/src/ObjectLock.php
@@ -247,7 +247,7 @@ class ObjectLock extends CommonDBTM
                      cache: false,
                      data: {
                         requestunlock: 1,
-                        id: {$this->itemid}
+                        id: {$this->fields['id']}
                      },
                      dataType: 'json',
                      success: function( data, textStatus, jqXHR ) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ###

When you define a notification for  ObjectLock, the notficiation is not sended because it's not the good id of the ticket which beeing sended
