### PR TITLE
fix(config): historical tab empty

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -4020,12 +4020,11 @@ HTML;
         /** @var \DBmysql $DB */
         global $DB;
         $iterator = $DB->request([
-            'SELECT' => 'id',
+            'SELECT' => ['MIN' => 'id AS id'],
             'FROM'   => self::getTable(),
             'WHERE'  => [
                 'context' => $context,
             ],
-            'LIMIT'  => 1,
         ]);
         if (count($iterator)) {
             return $iterator->current()['id'];

--- a/tests/functional/Config.php
+++ b/tests/functional/Config.php
@@ -923,4 +923,13 @@ class Config extends DbTestCase
             }
         }
     }
+
+    public function testConfigLogNotEmpty()
+    {
+        $itemtype = 'Config';
+        $config_id = \Config::getConfigIDForContext('core');
+        $this->integer($config_id)->isGreaterThan(0);
+        $total_number = countElementsInTable("glpi_logs", ['items_id' => $config_id, 'itemtype' => $itemtype]);
+        $this->integer($total_number)->isGreaterThan(0);
+    }
 }


### PR DESCRIPTION
Historical tab was empty

![image](https://github.com/glpi-project/glpi/assets/8530352/32e8fbb3-6521-4721-8d73-0b6f00566183)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30358
