### PR TITLE
Add helper function to read glpi_currenttime

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -2025,4 +2025,14 @@ class Session
     {
         return $_SESSION['glpilanguage'] ?? null;
     }
+
+    /**
+     * Helper function to get the date stored in $_SESSION['glpi_currenttime']
+     *
+     * @return null|string
+     */
+    public static function getCurrentTime(): ?string
+    {
+        return $_SESSION['glpi_currenttime'] ?? null;
+    }
 }

--- a/src/Session.php
+++ b/src/Session.php
@@ -2033,6 +2033,7 @@ class Session
      */
     public static function getCurrentTime(): ?string
     {
+        // TODO (10.1 refactoring): replace references to $_SESSION['glpi_currenttime'] by a call to this function
         return $_SESSION['glpi_currenttime'] ?? null;
     }
 }


### PR DESCRIPTION
Allow us to benefit from IDE auto completion when trying to get this value rather than trying to guess the correct key name from memory.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
