### PR TITLE
fix itil rule right checks

### DIFF
--- a/src/RuleCommonITILObjectCollection.php
+++ b/src/RuleCommonITILObjectCollection.php
@@ -62,7 +62,7 @@ abstract class RuleCommonITILObjectCollection extends RuleCollection
     public static function canView()
     {
         $rule_class = (new static())->getRuleClassName();
-        return Session::haveRightsOr(self::$rightname, [READ, $rule_class::PARENT]);
+        return Session::haveRightsOr(static::$rightname, [READ, $rule_class::PARENT]);
     }
 
     public function canList()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Use of `self` instead of `static` meant it was checking the default right for rule collections which is `config` rather than the specific rights for ITIL rules like `rule_ticket`.