### PR TITLE
Prevent bad behavior with global  entities_id lock

### DIFF
--- a/install/migrations/update_10.0.10_to_10.0.11/lockedfield.php
+++ b/install/migrations/update_10.0.10_to_10.0.11/lockedfield.php
@@ -50,3 +50,14 @@ $migration->addPostQuery(
         ]
     )
 );
+
+//global lock on entities_id should not / no longer exist
+$migration->addPostQuery(
+    $DB->buildDelete(
+        'glpi_lockedfields',
+        [
+            'is_global' => 1,
+            'field' => 'entities_id'
+        ]
+    )
+);

--- a/src/Lockedfield.php
+++ b/src/Lockedfield.php
@@ -375,8 +375,7 @@ class Lockedfield extends CommonDBTM
             'locations_id',
             'networks_id',
             'manufacturers_id',
-            'uuid',
-            'entities_id'
+            'uuid'
         ];
         $itemtypes = $CFG_GLPI['inventory_types'] + $CFG_GLPI['inventory_lockable_objects'];
 


### PR DESCRIPTION
A global lock on the entites_id field is/will be problematic in several contexts:

- Deleting an entity
- Automatic transfer of assets (via rules) 
- etc ...

Lock management must not interfere with internal GLPI processes

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30301
