### PR TITLE
Search engine: use "UNION ALL" for union_search_type

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -1024,7 +1024,7 @@ class Search
                     if ($first) {
                         $first = false;
                     } else {
-                        $QUERY .= " UNION ";
+                        $QUERY .= " UNION ALL ";
                     }
                     $tmpquery = "";
                    // AllAssets case


### PR DESCRIPTION
Improve search engine optimisation by using `UNION ALL`  instead of `UNION` on queries targeting `union_search_type` pages (e.g. `AllAssets`).

`UNION` is slower because it perform a `DISTINCT` operation on results, which should not be needed here since each query target a different itemtype (duplicated rows should thus be impossible).

Simple benchmark for the `AllAssets` page on a 300k assets database hosted on a questionable mariadb 11.1 docker container:
* `UNION`: ~20 seconds
* `UNION ALL`  ~ 14 seconds

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29967
