### PR TITLE
fix(Inventory): use the right field for 'interface'

### DIFF
--- a/src/Inventory/Asset/Drive.php
+++ b/src/Inventory/Asset/Drive.php
@@ -38,7 +38,6 @@ namespace Glpi\Inventory\Asset;
 
 use CommonDBTM;
 use Glpi\Inventory\Conf;
-use Toolbox;
 
 class Drive extends Device
 {
@@ -47,7 +46,6 @@ class Drive extends Device
 
     public function prepare(): array
     {
-
         $mapping = [
             'name'         => 'designation',
             'interface'    => 'interfacetypes_id',

--- a/src/Inventory/Asset/Drive.php
+++ b/src/Inventory/Asset/Drive.php
@@ -38,6 +38,7 @@ namespace Glpi\Inventory\Asset;
 
 use CommonDBTM;
 use Glpi\Inventory\Conf;
+use Toolbox;
 
 class Drive extends Device
 {
@@ -46,9 +47,10 @@ class Drive extends Device
 
     public function prepare(): array
     {
+
         $mapping = [
             'name'         => 'designation',
-            'type'         => 'interfacetypes_id',
+            'interface'    => 'interfacetypes_id',
             'manufacturer' => 'manufacturers_id',
         ];
 

--- a/tests/functional/Glpi/Inventory/Assets/Drive.php
+++ b/tests/functional/Glpi/Inventory/Assets/Drive.php
@@ -78,13 +78,14 @@ class Drive extends AbstractInventoryAsset
       <SCSI_UNID>0</SCSI_UNID>
       <SERIALNUMBER />
       <TYPE>UNKNOWN</TYPE>
+      <INTERFACE>SSD</INTERFACE>
     </STORAGES>
     <VERSIONCLIENT>FusionInventory-Inventory_v2.4.1-2.fc28</VERSIONCLIENT>
   </CONTENT>
   <DEVICEID>glpixps.teclib.infra-2018-10-03-08-42-36</DEVICEID>
   <QUERY>INVENTORY</QUERY>
   </REQUEST>",
-                'expected'  => '{"description": "Lecteur de CD-ROM", "manufacturer": "(Lecteurs de CD-ROM standard)", "model": "VBOX CD-ROM ATA Device", "name": "VBOX CD-ROM ATA Device", "scsi_coid": "1", "scsi_lun": "0", "scsi_unid": "0", "type": "UNKNOWN", "designation": "Lecteur de CD-ROM", "interfacetypes_id": "UNKNOWN", "manufacturers_id": "(Lecteurs de CD-ROM standard)", "is_dynamic": 1}'
+                'expected'  => '{"description": "Lecteur de CD-ROM", "manufacturer": "(Lecteurs de CD-ROM standard)", "model": "VBOX CD-ROM ATA Device", "name": "VBOX CD-ROM ATA Device", "scsi_coid": "1", "scsi_lun": "0", "scsi_unid": "0", "type": "UNKNOWN", "designation": "Lecteur de CD-ROM", "interface": "SSD","interfacetypes_id": "SSD", "manufacturers_id": "(Lecteurs de CD-ROM standard)", "is_dynamic": 1}'
             ]
         ];
     }

--- a/tests/functional/Glpi/Inventory/Assets/Drive.php
+++ b/tests/functional/Glpi/Inventory/Assets/Drive.php
@@ -516,4 +516,91 @@ class Drive extends AbstractInventoryAsset
         $harddrives = $item_hdd->find(['itemtype' => 'Computer', 'items_id' => $computers_id, 'is_dynamic' => 0]);
         $this->integer(count($harddrives))->isIdenticalTo(1);
     }
+
+
+
+
+    public function testInventoryHardDrive()
+    {
+        global $DB;
+        $computer = new \Computer();
+        $device_hdd = new \DeviceHardDrive();
+        $item_hdd = new \Item_DeviceHardDrive();
+        $interface = new \InterfaceType();
+
+
+        $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<REQUEST>
+  <CONTENT>
+    <STORAGES>
+      <DESCRIPTION>PCI Slot 8 : Bus 85 : Device 0 : Function 0 : Adapter 1</DESCRIPTION>
+      <FIRMWARE>HPS1NFAV</FIRMWARE>
+      <INTERFACE>NVME</INTERFACE>
+      <MODEL>SAMSUNG MZVLQ512HBLU-00BH1</MODEL>
+      <NAME>PhysicalDisk0</NAME>
+      <SERIAL>9856_84F3_5641_9874</SERIAL>
+      <TYPE>SSD</TYPE>
+    </STORAGES>
+    <HARDWARE>
+      <NAME>pc002</NAME>
+    </HARDWARE>
+    <BIOS>
+      <SSN>ggheb7ne7</SSN>
+    </BIOS>
+    <VERSIONCLIENT>FusionInventory-Agent_v2.3.19</VERSIONCLIENT>
+  </CONTENT>
+  <DEVICEID>test-pc002</DEVICEID>
+  <QUERY>INVENTORY</QUERY>
+</REQUEST>";
+
+        $this->doInventory($xml_source, true);
+        //check created agent
+        $agents = $DB->request(['FROM' => \Agent::getTable(), "WHERE" => ['deviceid' => 'test-pc002']]);
+        $this->integer(count($agents))->isIdenticalTo(1);
+        $agent = $agents->current();
+
+        //check created computer
+        $computer = new \Computer();
+        $this->boolean($computer->getFromDB($agent['items_id']))->isTrue();
+
+        //we now have 1 harddrives linked to computer only
+        $harddrives = $item_hdd->find(['itemtype' => 'Computer', 'items_id' => $agent['items_id']]);
+        $this->integer(count($harddrives))->isIdenticalTo(1);
+        $this->boolean($device_hdd->getFromDB(current($harddrives)['deviceharddrives_id']))->isTrue();
+        $this->boolean($interface->getFromDB($device_hdd->fields['interfacetypes_id']))->isTrue();
+        $this->string($interface->fields['name'])->isEqualto('NVME');
+
+        //redo inventory by updating interface
+        $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+        <REQUEST>
+          <CONTENT>
+            <STORAGES>
+              <DESCRIPTION>PCI Slot 8 : Bus 85 : Device 0 : Function 0 : Adapter 1</DESCRIPTION>
+              <FIRMWARE>HPS1NFAV</FIRMWARE>
+              <INTERFACE>IDE</INTERFACE>
+              <MODEL>SAMSUNG MZVLQ512HBLU-00BH1</MODEL>
+              <NAME>PhysicalDisk0</NAME>
+              <SERIAL>9856_84F3_5641_9874</SERIAL>
+              <TYPE>SSD</TYPE>
+            </STORAGES>
+            <HARDWARE>
+              <NAME>pc002</NAME>
+            </HARDWARE>
+            <BIOS>
+              <SSN>ggheb7ne7</SSN>
+            </BIOS>
+            <VERSIONCLIENT>FusionInventory-Agent_v2.3.19</VERSIONCLIENT>
+          </CONTENT>
+          <DEVICEID>test-pc002</DEVICEID>
+          <QUERY>INVENTORY</QUERY>
+        </REQUEST>";
+
+        $this->doInventory($xml_source, true);
+        //alwys1 harddrives linked to computer only
+        $harddrives = $item_hdd->find(['itemtype' => 'Computer', 'items_id' => $agent['items_id']]);
+        $this->integer(count($harddrives))->isIdenticalTo(1);
+        $this->boolean($device_hdd->getFromDB(current($harddrives)['deviceharddrives_id']))->isTrue();
+        $this->boolean($interface->getFromDB($device_hdd->fields['interfacetypes_id']))->isTrue();
+        $this->string($interface->fields['name'])->isEqualto('IDE');
+    }
 }

--- a/tests/functional/Glpi/Inventory/Assets/Drive.php
+++ b/tests/functional/Glpi/Inventory/Assets/Drive.php
@@ -596,11 +596,12 @@ class Drive extends AbstractInventoryAsset
         </REQUEST>";
 
         $this->doInventory($xml_source, true);
-        //alwys1 harddrives linked to computer only
+        //always harddrives linked to computer only
         $harddrives = $item_hdd->find(['itemtype' => 'Computer', 'items_id' => $agent['items_id']]);
         $this->integer(count($harddrives))->isIdenticalTo(1);
         $this->boolean($device_hdd->getFromDB(current($harddrives)['deviceharddrives_id']))->isTrue();
         $this->boolean($interface->getFromDB($device_hdd->fields['interfacetypes_id']))->isTrue();
+        //check interface has been updated
         $this->string($interface->fields['name'])->isEqualto('IDE');
     }
 }


### PR DESCRIPTION
```interface``` value from inventory file 

```json
"storages": [
    {
        "description": "PCI Slot 8 : Bus 85 : Device 0 : Function 0 : Adapter 1",
        "disksize": 488386,
        "firmware": "HPS1NFAV",
        "interface": "NVME",   <--- HERE
        "model": "SAMSUNG MZVLQ512HBLU-00BH1",
        "name": "PhysicalDisk0",
        "serial": "9856_84F3_5641_9874.",
        "type": "SSD"
    }
],
```

is not used from native inventory (actuelly ```type``` is used)

```php
        $mapping = [
            'name'         => 'designation',
            'type'    => 'interfacetypes_id',
            'manufacturer' => 'manufacturers_id',
        ];
```

This PR fix this

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29959
