### PR TITLE
fix(NetworkName): fix form with insufficient rights

### DIFF
--- a/src/NetworkName.php
+++ b/src/NetworkName.php
@@ -475,25 +475,39 @@ class NetworkName extends FQDNLabel
         );
         echo "</td>\n";
 
-        echo "</tr><tr class='tab_bg_1'>\n";
+        echo "</tr>";
 
-        echo "<td>" . IPAddress::getTypeName(Session::getPluralNumber());
-        IPAddress::showAddChildButtonForItemForm($name, 'NetworkName__ipaddresses');
-        echo "</td>";
-        echo "<td>";
-        IPAddress::showChildsForItemForm($name, 'NetworkName__ipaddresses');
-        echo "</td>";
+        if ($name->isNewItem()) {
+            if (!$name->canCreate()) {
+                $canedit = false;
+            }
+            $canedit = $name->canUpdate();
+        } else {
+            if (!$name->can($name->getID(), READ)) {
+                $canedit = false;
+            }
+            $canedit = $name->can($name->getID(), UPDATE);
+        }
 
-       // MoYo : really need to display it here ?
-       // make confure because not updatable
-       // echo "<td>".IPNetwork::getTypeName(Session::getPluralNumber())."&nbsp;";
-       // Html::showToolTip(__('IP network is not included in the database. However, you can see current available networks.'));
-       // echo "</td><td>";
-       // IPNetwork::showIPNetworkProperties($name->getEntityID());
-       // echo "</td>\n";
-        echo "<td colspan='2'>&nbsp;</td>";
+        if ($canedit) {
+            echo "<tr class='tab_bg_1'>\n";
+            echo "<td>" . IPAddress::getTypeName(Session::getPluralNumber());
+            IPAddress::showAddChildButtonForItemForm($name, 'NetworkName__ipaddresses', $canedit);
+            echo "</td>";
+            echo "<td>";
+            IPAddress::showChildsForItemForm($name, 'NetworkName__ipaddresses', $canedit);
+            echo "</td>";
 
-        echo "</tr>\n";
+           // MoYo : really need to display it here ?
+           // make confure because not updatable
+           // echo "<td>".IPNetwork::getTypeName(Session::getPluralNumber())."&nbsp;";
+           // Html::showToolTip(__('IP network is not included in the database. However, you can see current available networks.'));
+           // echo "</td><td>";
+           // IPNetwork::showIPNetworkProperties($name->getEntityID());
+           // echo "</td>\n";
+            echo "<td colspan='2'>&nbsp;</td>";
+            echo "</tr>\n";
+        }
     }
 
 

--- a/src/NetworkName.php
+++ b/src/NetworkName.php
@@ -478,14 +478,8 @@ class NetworkName extends FQDNLabel
         echo "</tr>";
 
         if ($name->isNewItem()) {
-            if (!$name->canCreate()) {
-                $canedit = false;
-            }
-            $canedit = $name->canUpdate();
+            $canedit = $name->canCreate();
         } else {
-            if (!$name->can($name->getID(), READ)) {
-                $canedit = false;
-            }
             $canedit = $name->can($name->getID(), UPDATE);
         }
 

--- a/src/NetworkName.php
+++ b/src/NetworkName.php
@@ -497,14 +497,6 @@ class NetworkName extends FQDNLabel
             echo "<td>";
             IPAddress::showChildsForItemForm($name, 'NetworkName__ipaddresses', $canedit);
             echo "</td>";
-
-           // MoYo : really need to display it here ?
-           // make confure because not updatable
-           // echo "<td>".IPNetwork::getTypeName(Session::getPluralNumber())."&nbsp;";
-           // Html::showToolTip(__('IP network is not included in the database. However, you can see current available networks.'));
-           // echo "</td><td>";
-           // IPNetwork::showIPNetworkProperties($name->getEntityID());
-           // echo "</td>\n";
             echo "<td colspan='2'>&nbsp;</td>";
             echo "</tr>\n";
         }


### PR DESCRIPTION
If current user have no right on ```internet``` 

![image](https://github.com/glpi-project/glpi/assets/7335054/f945b94b-6930-4ef7-8f09-85ea537d9b22)

it cannot add / update IP addresses, 
but from ```NetworkName``` form ```IP Addresses``` label is displayed


![image](https://github.com/glpi-project/glpi/assets/7335054/07db3f3d-2cfe-4d8f-ad50-e78cf8d617e6)

which leads to confusion, see #15990




| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15990
