### PR TITLE
Do not call front/cron.php if no web tasks are enabled

### DIFF
--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -2132,8 +2132,8 @@ class CronTask extends CommonDBTM
     protected static function mustRunWebTasks(): bool
     {
         $web_tasks_count = countElementsInTable(self::getTable(), [
-            'mode'  => 1, // "GLPI" mode
-            'state' => ['<>', 0], // State is not "disabled"
+            'mode'  => self::MODE_INTERNAL, // "GLPI" mode
+            'state' => self::STATE_WAITING,
         ]);
 
         return $web_tasks_count > 0;

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -2115,9 +2115,11 @@ class CronTask extends CommonDBTM
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $path = $CFG_GLPI['root_doc'] . "/front/cron.php";
+        if (self::mustRunWebTasks()) {
+            $path = $CFG_GLPI['root_doc'] . "/front/cron.php";
+            echo "<div style=\"background-image: url('$path');\"></div>";
+        }
 
-        echo "<div style=\"background-image: url('$path');\"></div>";
         return true;
     }
 
@@ -2145,16 +2147,12 @@ class CronTask extends CommonDBTM
      **/
     public static function callCron()
     {
+
         if (isset($_SESSION["glpicrontimer"])) {
            // call static function callcron() every 5min
             if ((time() - $_SESSION["glpicrontimer"]) > 300) {
-                if (self::mustRunWebTasks()) {
-                    if (self::callCronForce()) {
-                        // Restart timer
-                        $_SESSION["glpicrontimer"] = time();
-                    }
-                } else {
-                    // Restart timer
+                if (self::callCronForce()) {
+                   // Restart timer
                     $_SESSION["glpicrontimer"] = time();
                 }
             }


### PR DESCRIPTION
Prevent useless HTTP request if there are no web cron tasks enabled (which should always be the case in production).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
