### PR TITLE
Enhance CI results when updated DB is not consistent

### DIFF
--- a/.github/actions/test_update-from-9.5.sh
+++ b/.github/actions/test_update-from-9.5.sh
@@ -11,12 +11,12 @@ bin/console database:configure \
 
 # Execute update
 ## First run should do the migration (with no warnings/errors).
-bin/console database:update --config-dir=./tests/config --ansi --no-interaction --allow-unstable | tee $LOG_FILE
+bin/console database:update --config-dir=./tests/config --skip-db-checks --ansi --no-interaction --allow-unstable | tee $LOG_FILE
 if [[ -n $(grep "Error\|Warning\|No migration needed." $LOG_FILE) ]];
   then echo "bin/console database:update command FAILED" && exit 1;
 fi
 ## Second run should do nothing.
-bin/console database:update --config-dir=./tests/config --ansi --no-interaction --allow-unstable | tee $LOG_FILE
+bin/console database:update --config-dir=./tests/config --skip-db-checks --ansi --no-interaction --allow-unstable | tee $LOG_FILE
 if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
   then echo "bin/console database:update command FAILED" && exit 1;
 fi

--- a/.github/actions/test_update-from-older-version.sh
+++ b/.github/actions/test_update-from-older-version.sh
@@ -11,12 +11,12 @@ bin/console database:configure \
 
 # Execute update
 ## First run should do the migration (with no warnings/errors).
-bin/console database:update --config-dir=./tests/config --ansi --no-interaction --allow-unstable | tee $LOG_FILE
+bin/console database:update --config-dir=./tests/config --skip-db-checks --ansi --no-interaction --allow-unstable | tee $LOG_FILE
 if [[ -n $(grep "Error\|Warning\|No migration needed." $LOG_FILE) ]];
   then echo "bin/console database:update command FAILED" && exit 1;
 fi
 ## Second run should do nothing.
-bin/console database:update --config-dir=./tests/config --ansi --no-interaction --allow-unstable | tee $LOG_FILE
+bin/console database:update --config-dir=./tests/config --skip-db-checks --ansi --no-interaction --allow-unstable | tee $LOG_FILE
 if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
   then echo "bin/console database:update command FAILED" && exit 1;
 fi

--- a/src/Console/Database/UpdateCommand.php
+++ b/src/Console/Database/UpdateCommand.php
@@ -105,7 +105,7 @@ class UpdateCommand extends AbstractCommand implements ConfigurationCommandInter
             '--skip-db-checks',
             's',
             InputOption::VALUE_NONE,
-            __('Do not check database schema integrity before performing the update')
+            __('Do not check database schema integrity before and after performing the update')
         );
 
         $this->addOption(
@@ -221,7 +221,18 @@ class UpdateCommand extends AbstractCommand implements ConfigurationCommandInter
 
         $this->handTelemetryActivation($input, $output);
 
-        if (!$update->isUpdatedSchemaConsistent()) {
+        if ($this->input->getOption('skip-db-checks')) {
+            $this->output->writeln(
+                [
+                    '<comment>' . __('The database schema integrity check has been skipped.') . '</comment>',
+                    '<comment>' . sprintf(
+                        __('It is recommended to run the "%s" command to validate that the database schema is consistent with the current GLPI version.'),
+                        'php bin/console database:check_schema_integrity'
+                    ) . '</comment>'
+                ],
+                OutputInterface::VERBOSITY_QUIET
+            );
+        } elseif (!$update->isUpdatedSchemaConsistent()) {
             // Exit with an error if database schema is not consistent.
             // Keep this code at end of command to ensure that the whole migration is still executed.
             // Many old GLPI instances will likely have differences, and people will have to fix them manually.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When DB update produces an unexpected result, CI does not provide any usefull information, see https://github.com/glpi-project/glpi/actions/runs/6812882059/job/18526239897?pr=15931

The `--skip-db-checks` option only skips checks done before performing the update. I consider we could use it also to disable checks that are done after the update. I added a comment message to invite people to run the `db:check` command.

Before:
![image](https://github.com/glpi-project/glpi/assets/33253653/90c70176-9580-4893-8a0d-e621291b94f8)

After:
![image](https://github.com/glpi-project/glpi/assets/33253653/abd99da5-48d9-49a4-86da-5eba2ac95652)
