### PR TITLE
Prevent useless updatecurrenttab request

### DIFF
--- a/ajax/updatecurrenttab.php
+++ b/ajax/updatecurrenttab.php
@@ -36,6 +36,8 @@
 /** @var array $_UGET */
 global $_UGET;
 
+// TODO: in GLPI 10.1 if we drop the old tab parameter then we can use
+// PLUGINS_INCLUDED=false here to speed up the framework initiation time
 include('../inc/includes.php');
 
 if (!basename($_SERVER['SCRIPT_NAME']) == "helpdesk.faq.php") {

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -359,7 +359,7 @@ JAVASCRIPT;
             echo "</div>"; // .container-fluid
             $js = "
          var url_hash = window.location.hash;
-         var loadTabContents = function (tablink, force_reload = false) {
+         var loadTabContents = function (tablink, force_reload = false, update_session_tab = true) {
             const href_url_params = new URLSearchParams($(tablink).prop('href'));
             var url = tablink.attr('href');
             var target = tablink.attr('data-bs-target');
@@ -399,7 +399,9 @@ JAVASCRIPT;
 
                $(target).closest('main').trigger('glpi.tab.loaded');
 
-               updateCurrentTab();
+               if (update_session_tab) {
+                   updateCurrentTab();
+               }
             });
          };
 
@@ -416,13 +418,20 @@ JAVASCRIPT;
          };
 
          $(function() {
+            // Keep track of the first load which will be the tab stored in the
+            // session.
+            // In this case, it is useless to sebd a request to the
+            // updatecurrenttab endpoint as we already are on this tab
+            let first_load = true;
+
             $('a[data-bs-toggle=\"tab\"]').on('shown.bs.tab', function(e) {
                e.preventDefault();
-               loadTabContents($(this));
+               loadTabContents($(this), false, !first_load);
             });
 
             // load initial tab
             $('a[data-bs-target=\"#{$active_id}\"]').tab('show');
+            first_load = false;
 
             // select events in responsive mode
             $('#$tabdiv_id-select').on('change', function (e) {


### PR DESCRIPTION
When opening an item, we are displaying the current tab (found in the session data).
There is no need in the case to call the `updatecurrenttab.php` endpoint to rewrite the value as it is already correct.

On our support, this would prevent a 500ms request that is executed on almost every page.
On another GLPI installation with more plugins and a bigger database, the request is taking almost 1 second so it could have a decent impact on server load.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
