### PR TITLE
Fix "Operating system name" search option

### DIFF
--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -392,6 +392,7 @@ class Item_OperatingSystem extends CommonDBRelation
             'field'              => 'name',
             'name'               => _n('Version', 'Versions', 1),
             'datatype'           => 'dropdown',
+            'forcegroupby'       => true,
             'massiveaction'      => false,
             'joinparams'         => [
                 'beforejoin'         => [
@@ -410,6 +411,7 @@ class Item_OperatingSystem extends CommonDBRelation
             'field'              => 'name',
             'name'               => OperatingSystemServicePack::getTypeName(1),
             'datatype'           => 'dropdown',
+            'forcegroupby'       => true,
             'massiveaction'      => false,
             'joinparams'         => [
                 'beforejoin'         => [
@@ -428,6 +430,7 @@ class Item_OperatingSystem extends CommonDBRelation
             'field'              => 'license_number',
             'name'               => __('Serial number'),
             'datatype'           => 'string',
+            'forcegroupby'       => true,
             'massiveaction'      => false,
             'joinparams'         => [
                 'jointype'           => 'itemtype_item',
@@ -441,6 +444,7 @@ class Item_OperatingSystem extends CommonDBRelation
             'field'              => 'licenseid',
             'name'               => __('Product ID'),
             'datatype'           => 'string',
+            'forcegroupby'       => true,
             'massiveaction'      => false,
             'joinparams'         => [
                 'jointype'           => 'itemtype_item',
@@ -454,6 +458,7 @@ class Item_OperatingSystem extends CommonDBRelation
             'field'              => 'install_date',
             'name'               => __('Installation date'),
             'datatype'           => 'datetime',
+            'forcegroupby'       => true,
             'massiveaction'      => false,
             'joinparams'         => [
                 'jointype'           => 'itemtype_item',
@@ -467,6 +472,7 @@ class Item_OperatingSystem extends CommonDBRelation
             'field'              => 'name',
             'name'               => _n('Architecture', 'Architectures', 1),
             'datatype'           => 'dropdown',
+            'forcegroupby'       => true,
             'massiveaction'      => false,
             'joinparams'         => [
                 'beforejoin'         => [
@@ -485,6 +491,7 @@ class Item_OperatingSystem extends CommonDBRelation
             'field'              => 'name',
             'name'               => _n('Kernel', 'Kernels', 1),
             'datatype'           => 'dropdown',
+            'forcegroupby'       => true,
             'massiveaction'      => false,
             'joinparams'         => [
                 'beforejoin'         => [
@@ -508,6 +515,7 @@ class Item_OperatingSystem extends CommonDBRelation
             'field'              => 'name',
             'name'               => _n('Kernel version', 'Kernel versions', 1),
             'datatype'           => 'dropdown',
+            'forcegroupby'       => true,
             'massiveaction'      => false,
             'joinparams'         => [
                 'beforejoin'         => [
@@ -526,6 +534,7 @@ class Item_OperatingSystem extends CommonDBRelation
             'field'              => 'name',
             'name'               => _n('Edition', 'Editions', 1),
             'datatype'           => 'dropdown',
+            'forcegroupby'       => true,
             'massiveaction'      => false,
             'joinparams'         => [
                 'beforejoin'         => [

--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -373,6 +373,7 @@ class Item_OperatingSystem extends CommonDBRelation
             'field'              => 'name',
             'name'               => __('Name'),
             'datatype'           => 'dropdown',
+            'forcegroupby'       => true,
             'massiveaction'      => false,
             'joinparams'         => [
                 'beforejoin'         => [


### PR DESCRIPTION
This search option may return multiple results and should thus use `GROUP CONCAT` to prevent duplicated results.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
