### PR TITLE
Revert "fix(Inventory): use the right field for 'interface' (#15989)"

### DIFF
--- a/src/Inventory/Asset/Drive.php
+++ b/src/Inventory/Asset/Drive.php
@@ -48,7 +48,7 @@ class Drive extends Device
     {
         $mapping = [
             'name'         => 'designation',
-            'interface'    => 'interfacetypes_id',
+            'type'         => 'interfacetypes_id',
             'manufacturer' => 'manufacturers_id',
         ];
 


### PR DESCRIPTION
This reverts commit 02e72ce8007a8b46d31b41e5be6d154bdb02e5f6.

Because ```Drive``` use ```type``` for ```interfacetypes_id```

```php
    public function prepare(): array
    {
        $mapping = [
            'name'         => 'designation',
            'type'         => 'interfacetypes_id',  <---- HERE
            'manufacturer' => 'manufacturers_id',
        ];

        $hdd = [];
        foreach ($this->data as $k => &$val) {
            if ($this->isDrive($val)) { // it's cd-rom / dvd
                foreach ($mapping as $origin => $dest) {
                    if (property_exists($val, $origin)) {
                        $val->$dest = $val->$origin;
                    }
                }

                if (property_exists($val, 'description')) {
                    $val->designation = $val->description;
                }

                $val->is_dynamic = 1;
            } else { // it's harddisk
                $hdd[] = $val;
                unset($this->data[$k]);
            }
        }
        if (count($hdd)) {
            $this->harddrives = new HardDrive($this->item, $hdd);
            $prep_hdds = $this->harddrives->prepare();
            if (defined('TU_USER')) {
                $this->prepared_harddrives = $prep_hdds;
            }
        }

        return $this->data;
    }
```

but ``` $this->harddrives->prepare();``` use ```interface``` field from inventory file

```php
public function prepare(): array
    {
        $mapping = [
            'disksize'      => 'capacity',
            'interface'     => 'interfacetypes_id',  <-- HERE
            'manufacturer'  => 'manufacturers_id',
            'model'         => 'designation'
        ];

        foreach ($this->data as &$val) {
            foreach ($mapping as $origin => $dest) {
                if (property_exists($val, $origin)) {
                    $val->$dest = $val->$origin;
                }
            }

            if ((!property_exists($val, 'model') || $val->model == '') && property_exists($val, 'name')) {
                $val->designation = $val->name;
            }

            if (!isset($val->capacity) || $val->capacity == '') {
                $val->capacity = 0;
            }

            $val->is_dynamic = 1;
        }

        return $this->data;
    }
``` 

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
