### PR TITLE
fix(central): warning displayed on all profiles

### DIFF
--- a/src/Central.php
+++ b/src/Central.php
@@ -519,11 +519,11 @@ class Central extends CommonGLPI
                 . ' '
                 . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:unsigned_keys');
             }
-        }
 
-        $safe_doc_root_requirement = new SafeDocumentRoot();
-        if (!$safe_doc_root_requirement->isValidated()) {
-            $messages['warnings'] = array_merge(($messages['warnings'] ?? []), $safe_doc_root_requirement->getValidationMessages());
+            $safe_doc_root_requirement = new SafeDocumentRoot();
+            if (!$safe_doc_root_requirement->isValidated()) {
+                $messages['warnings'] = array_merge(($messages['warnings'] ?? []), $safe_doc_root_requirement->getValidationMessages());
+            }
         }
 
         if ($DB->isSlave() && !$DB->first_connection) {

--- a/src/System/Requirement/SafeDocumentRoot.php
+++ b/src/System/Requirement/SafeDocumentRoot.php
@@ -83,7 +83,9 @@ final class SafeDocumentRoot extends AbstractRequirement
             $this->validation_messages[] = __('Web server root directory configuration seems safe.');
         } else {
             $this->validated = false;
-            $this->validation_messages[] = __('Web server root directory configuration is not safe as it permits access to non-public files. See installation documentation for more details.');
+            if (\Session::haveRight("config", UPDATE)) {
+                $this->validation_messages[] = __('Web server root directory configuration is not safe as it permits access to non-public files. See installation documentation for more details.');
+            }
         }
     }
 }

--- a/src/System/Requirement/SafeDocumentRoot.php
+++ b/src/System/Requirement/SafeDocumentRoot.php
@@ -83,9 +83,7 @@ final class SafeDocumentRoot extends AbstractRequirement
             $this->validation_messages[] = __('Web server root directory configuration seems safe.');
         } else {
             $this->validated = false;
-            if (\Session::haveRight("config", UPDATE)) {
-                $this->validation_messages[] = __('Web server root directory configuration is not safe as it permits access to non-public files. See installation documentation for more details.');
-            }
+            $this->validation_messages[] = __('Web server root directory configuration is not safe as it permits access to non-public files. See installation documentation for more details.');
         }
     }
 }


### PR DESCRIPTION
The warning message about root directory configuration was displayed on all profiles, whereas other such messages are filtered so that they are only visible to admins.

![image](https://github.com/glpi-project/glpi/assets/8530352/310cc8d4-9f72-467d-b957-86f8e078b3c3)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30455
