### PR TITLE
Highlight security requirements

### DIFF
--- a/css/install.scss
+++ b/css/install.scss
@@ -104,14 +104,6 @@ p {
     margin-right: 3px;
 }
 
-.tab_check td i.fa-check {
-    color: #008e2c;
-}
-
-.tab_check td i.fa-exclamation-triangle {
-    color: #ffa500;
-}
-
 .red {
     color: red;
 }

--- a/css/legacy/includes/_styles.scss
+++ b/css/legacy/includes/_styles.scss
@@ -1406,12 +1406,6 @@
       font-size: 12px;
       margin-right: 3px;
    }
-   .tab_check td i.fa-check {
-      color: #008e2c;
-   }
-   .tab_check td i.fa-exclamation-triangle {
-      color: #ffa500;
-   }
    /* /Styles for update page */
 
    .lockedfield i.ti-lock {

--- a/src/Central.php
+++ b/src/Central.php
@@ -36,7 +36,9 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Event;
 use Glpi\Plugin\Hooks;
+use Glpi\System\Requirement\PhpSupportedVersion;
 use Glpi\System\Requirement\SafeDocumentRoot;
+use Glpi\System\Requirement\SessionsSecurityConfiguration;
 
 /**
  * Central class
@@ -520,9 +522,15 @@ class Central extends CommonGLPI
                 . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:unsigned_keys');
             }
 
-            $safe_doc_root_requirement = new SafeDocumentRoot();
-            if (!$safe_doc_root_requirement->isValidated()) {
-                $messages['warnings'] = array_merge(($messages['warnings'] ?? []), $safe_doc_root_requirement->getValidationMessages());
+            $security_requirements = [
+                new PhpSupportedVersion(),
+                new SafeDocumentRoot(),
+                new SessionsSecurityConfiguration(),
+            ];
+            foreach ($security_requirements as $requirement) {
+                if (!$requirement->isValidated()) {
+                    $messages['warnings'] = array_merge(($messages['warnings'] ?? []), $requirement->getValidationMessages());
+                }
             }
         }
 

--- a/src/Console/System/CheckRequirementsCommand.php
+++ b/src/Console/System/CheckRequirementsCommand.php
@@ -76,15 +76,22 @@ class CheckRequirementsCommand extends AbstractCommand
                 $status = sprintf('<%s>[%s]</> ', 'fg=white;bg=yellow', __('SKIPPED'));
             } elseif ($requirement->isValidated()) {
                 $status = sprintf('<%s>[%s]</>', 'fg=black;bg=green', __('OK'));
+            } elseif (!$requirement->isOptional()) {
+                $status = sprintf('<%s>[%s]</> ', 'fg=white;bg=red', __('ERROR'));
+            } elseif ($requirement->isRecommendedForSecurity()) {
+                $status = sprintf('<%s>[%s]</> ', 'fg=white;bg=red', __('INFO'));
             } else {
-                $status = $requirement->isOptional()
-                    ? sprintf('<%s>[%s]</> ', 'fg=white;bg=yellow', __('INFO'))
-                    : sprintf('<%s>[%s]</> ', 'fg=white;bg=red', __('ERROR'));
+                $status = sprintf('<%s>[%s]</> ', 'fg=white;bg=yellow', __('INFO'));
             }
 
-            $badge = $requirement->isOptional()
-                ? sprintf('<%s>[%s]</> ', 'fg=black;bg=bright-blue', mb_strtoupper(__('Suggested')))
-                : sprintf('<%s>[%s]</> ', 'fg=black;bg=bright-yellow', mb_strtoupper(__('Required')));
+            $badge = '';
+            if (!$requirement->isOptional()) {
+                $badge = sprintf('<%s>[%s]</> ', 'fg=black;bg=bright-yellow', mb_strtoupper(__('Required')));
+            } elseif ($requirement->isRecommendedForSecurity()) {
+                $badge = sprintf('<%s>[%s]</> ', 'fg=black;bg=red', mb_strtoupper(__('Security')));
+            } else {
+                $badge = sprintf('<%s>[%s]</> ', 'fg=black;bg=bright-blue', mb_strtoupper(__('Suggested')));
+            }
             $title = $badge . '<options=bold>' . $requirement->getTitle() . '</>';
             if (!empty($description = $requirement->getDescription())) {
                 // wordwrap to keep table width acceptable

--- a/src/System/Requirement/AbstractRequirement.php
+++ b/src/System/Requirement/AbstractRequirement.php
@@ -55,6 +55,13 @@ abstract class AbstractRequirement implements RequirementInterface
     protected $optional = false;
 
     /**
+     * Flag that indicates if requirement is recommended for security reasons.
+     *
+     * @var bool
+     */
+    protected bool $recommended_for_security = false;
+
+    /**
      * Flag that indicates if requirement is considered as out of context.
      *
      * @var bool
@@ -145,6 +152,13 @@ abstract class AbstractRequirement implements RequirementInterface
         $this->doCheck();
 
         return $this->optional;
+    }
+
+    public function isRecommendedForSecurity(): bool
+    {
+        $this->doCheck();
+
+        return $this->recommended_for_security;
     }
 
     public function isOutOfContext(): bool

--- a/src/System/Requirement/DataDirectoriesProtectedPath.php
+++ b/src/System/Requirement/DataDirectoriesProtectedPath.php
@@ -74,6 +74,7 @@ final class DataDirectoriesProtectedPath extends AbstractRequirement
         $this->title = __('Safe path for data directories');
         $this->description = __('GLPI data directories should be placed outside web root directory. It can be achieved by redefining corresponding constants. See installation documentation for more details.');
         $this->optional = true;
+        $this->recommended_for_security = true;
 
         $this->directories_constants = $directories_constants;
         $this->var_root_constant     = $var_root_constant;

--- a/src/System/Requirement/PhpSupportedVersion.php
+++ b/src/System/Requirement/PhpSupportedVersion.php
@@ -53,6 +53,7 @@ class PhpSupportedVersion extends AbstractRequirement
         $this->title = __('PHP supported version');
         $this->description = __('An officially supported PHP version should be used to get the benefits of security and bug fixes.');
         $this->optional = true;
+        $this->recommended_for_security = true;
     }
 
     protected function check()

--- a/src/System/Requirement/RequirementInterface.php
+++ b/src/System/Requirement/RequirementInterface.php
@@ -76,6 +76,14 @@ interface RequirementInterface
     public function isOptional(): bool;
 
     /**
+     * Indicates if requirement is recommended for security reasons.
+     *
+     * @return bool
+     */
+    // TODO Uncomment this in GLPI 10.1
+    // public function isRecommendedForSecurity(): bool;
+
+    /**
      * Indicates if requirement is considered as out of context
      * (i.e. system is not compatible).
      *

--- a/src/System/Requirement/SafeDocumentRoot.php
+++ b/src/System/Requirement/SafeDocumentRoot.php
@@ -48,6 +48,7 @@ final class SafeDocumentRoot extends AbstractRequirement
             realpath(GLPI_ROOT) . DIRECTORY_SEPARATOR . 'public'
         );
         $this->optional = true;
+        $this->recommended_for_security = true;
     }
 
     protected function check()

--- a/src/System/Requirement/SessionsSecurityConfiguration.php
+++ b/src/System/Requirement/SessionsSecurityConfiguration.php
@@ -45,6 +45,7 @@ class SessionsSecurityConfiguration extends AbstractRequirement
         $this->title = __('Security configuration for sessions');
         $this->description = __('Ensure security is enforced on session cookies.');
         $this->optional = true;
+        $this->recommended_for_security = true;
     }
 
     protected function check()

--- a/templates/install/blocks/requirements_table.html.twig
+++ b/templates/install/blocks/requirements_table.html.twig
@@ -41,9 +41,12 @@
    <tbody>
       {% for requirement in requirements %}
          {% if not requirement.isOutOfContext() %}
+            {% set is_important = not requirement.isOptional() or requirement.isRecommendedForSecurity() %}
             <tr class="tab_bg_1">
                <td class="text-start">
-                  {% if requirement.isOptional() %}
+                  {% if requirement.isRecommendedForSecurity() %}
+                     <span class="badge bg-danger">{{ __('Security') }}</span>
+                  {% elseif requirement.isOptional() %}
                      <span class="badge bg-secondary">{{ __('Suggested') }}</span>
                   {% else %}
                      <span class="badge bg-warning">{{ __('Required') }}</span>
@@ -57,11 +60,15 @@
                   {% if not requirement.isValidated() %}
                       {% for message in requirement.getValidationMessages() %}
                           <br />
-                          <strong><em class="{{ not requirement.isOptional() ? 'red' : 'missing' }}">{{ message }}</em></strong>
+                          <strong>
+                             <em class="{{ is_important ? 'red' : 'missing' }}">
+                                {{ message }}
+                             </em>
+                          </strong>
                       {% endfor %}
                   {% endif %}
                </td>
-               <td class="{{ requirement.isMissing() and not requirement.isOptional() ? 'red' : '' }}">
+               <td class="{{ requirement.isMissing() ? (is_important ? 'red' : 'missing') : 'green' }}">
                   <span data-bs-toggle="popover"
                         data-bs-placement="right"
                         data-bs-html="true"

--- a/templates/install/blocks/requirements_table.html.twig
+++ b/templates/install/blocks/requirements_table.html.twig
@@ -44,12 +44,12 @@
             {% set is_important = not requirement.isOptional() or requirement.isRecommendedForSecurity() %}
             <tr class="tab_bg_1">
                <td class="text-start">
-                  {% if requirement.isRecommendedForSecurity() %}
-                     <span class="badge bg-danger">{{ __('Security') }}</span>
-                  {% elseif requirement.isOptional() %}
-                     <span class="badge bg-secondary">{{ __('Suggested') }}</span>
-                  {% else %}
+                  {% if not requirement.isOptional() %}
                      <span class="badge bg-warning">{{ __('Required') }}</span>
+                  {% elseif requirement.isRecommendedForSecurity() %}
+                     <span class="badge bg-danger">{{ __('Security') }}</span>
+                  {% else %}
+                     <span class="badge bg-secondary">{{ __('Suggested') }}</span>
                   {% endif %}
                   <strong>{{ requirement.getTitle() }}</strong>
                   {% set description = requirement.getDescription() %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

As we recently see by checking the telemetry data, there are still lots of people that are using PHP 7.4. Highlighting the security requirements and adding a message about it on central page may encourage people to fullfill them.

## On install/update page:
Before:
![image](https://github.com/glpi-project/glpi/assets/33253653/7c58ece9-e7be-47e7-acbf-02d07732fb4c)

After:
![image](https://github.com/glpi-project/glpi/assets/33253653/eb4525d8-3b5f-450a-ab77-2a165f0f1de2)

## On central page
![image](https://github.com/glpi-project/glpi/assets/33253653/f7207ffc-372b-4ad6-9090-e76593c364d8)
