### PR TITLE
Prevent composer 2.7 audit to fail due to abandoned packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,6 +112,9 @@
         "sort-packages": true,
         "allow-plugins": {
             "phpstan/extension-installer": true
+        },
+        "audit": {
+            "abandoned": "report"
         }
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The weekly audit workflow would fail in composer 2.7 without this change. See following image
![image](https://github.com/glpi-project/glpi/assets/33253653/42fe234d-a4ee-4ef1-bf7f-1dc8ac2994b5)

With this change, abandoned packages are still reported, but exit code of the command is 0 (success).
![image](https://github.com/glpi-project/glpi/assets/33253653/1fb1bc91-e23c-438e-a76a-a1dc56ad1422)
