### PR TITLE
Fix legacy query detection

### DIFF
--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -131,7 +131,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
 
         $is_legacy = false;
 
-        if (is_string($table) && strpos($table, " ")) {
+        if (is_string($table) && strpos($table, " ") !== false) {
             $names = preg_split('/\s+AS\s+/i', $table);
             if (isset($names[1]) && strpos($names[1], ' ') || !isset($names[1]) || strpos($names[0], ' ')) {
                 $is_legacy = true;
@@ -140,7 +140,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
 
         if ($is_legacy) {
             Toolbox::deprecated(
-                'Direct query usage is strongly discouraged!.',
+                'Direct query usage is strongly discouraged!',
                 false
             );
             $this->sql = $table;

--- a/tests/units/DBmysqlIterator.php
+++ b/tests/units/DBmysqlIterator.php
@@ -57,7 +57,7 @@ class DBmysqlIterator extends DbTestCase
         $this->when($this->it->execute($req))
             ->error()
             ->withType(E_USER_DEPRECATED)
-            ->withMessage('Direct query usage is strongly discouraged!.')
+            ->withMessage('Direct query usage is strongly discouraged!')
             ->exists();
         $this->string($this->it->getSql())->isIdenticalTo($req);
 
@@ -65,11 +65,40 @@ class DBmysqlIterator extends DbTestCase
         $this->when($this->it->execute($req))
             ->error()
             ->withType(E_USER_DEPRECATED)
-            ->withMessage('Direct query usage is strongly discouraged!.')
+            ->withMessage('Direct query usage is strongly discouraged!')
             ->exists();
         $this->string($this->it->getSql())->isIdenticalTo($req);
     }
 
+    protected function legacyQueryProvider(): iterable
+    {
+        yield [
+            'input'  => 'SELECT * FROM glpi_computers',
+            'output' => 'SELECT * FROM glpi_computers',
+        ];
+
+        yield [
+            'input'  => <<<SQL
+                SELECT * FROM glpi_computers
+SQL
+            ,
+            'output' => ' SELECT * FROM glpi_computers',
+        ];
+    }
+
+    /**
+     * @dataProvider legacyQueryProvider
+     */
+    public function testBuildQueryLegacy(string $input, string $output): void
+    {
+        $this->when($this->it->buildQuery($input))
+            ->error()
+            ->withType(E_USER_DEPRECATED)
+            ->withMessage('Direct query usage is strongly discouraged!')
+            ->exists();
+
+        $this->string($this->it->getSql())->isIdenticalTo($output);
+    }
 
     public function testSqlError()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

We recently had a bug in a plugin due to a code quality refactoring.

We changed a piece of code like this:
```php
    $sql = "SELECT * FROM mytable
            WHERE x < $val
            AND y = 0";
```
to:
```php
    $sql = <<<
        SELECT * FROM mytable
        WHERE x < $val
        AND y = 0
SQL;

The new form was not detected as legacy SQL beacause the space char was the first char (index = 0), and `strpos($table, " ")` was then falsy.