### PR TITLE
Fix default rights on Problem for tech user

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -7121,7 +7121,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'problem',
-                'rights' => Problem::READMY | Problem::READALL | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | Problem::READMY | Problem::READALL | READNOTE | UPDATENOTE,
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'knowbasecategory',

--- a/tests/functional/RuleCommonITILObject.php
+++ b/tests/functional/RuleCommonITILObject.php
@@ -2770,16 +2770,6 @@ abstract class RuleCommonITILObject extends DbTestCase
             $itil_fk => $itil_object->getID(),
         ]))->isTrue();
 
-
-        if ($this->getTestedClass() === 'RuleProblem') {
-            // tech can't update problem by default
-            // only the following rights are permitted from fresh install
-            // Problem::READMY | Problem::READALL | READNOTE | UPDATENOTE
-            \ProfileRight::updateProfileRights(getItemByTypeName('Profile', "Technician", true), [
-                'problem' => (ALLSTANDARDRIGHT + \Problem::READALL + READNOTE + UPDATENOTE)
-            ]);
-        }
-
         //reload ITIL object
         $this->boolean($itil_object->getFromDB($itil_object->getID()))->isTrue();
 

--- a/tests/functional/RuleCommonITILObject.php
+++ b/tests/functional/RuleCommonITILObject.php
@@ -2770,8 +2770,14 @@ abstract class RuleCommonITILObject extends DbTestCase
             $itil_fk => $itil_object->getID(),
         ]))->isTrue();
 
+
         if ($this->getTestedClass() === 'RuleProblem') {
-            return; // FIXME, it does not work for problems
+            // tech can't update problem by default
+            // only the following rights are permitted from fresh install
+            // Problem::READMY | Problem::READALL | READNOTE | UPDATENOTE
+            \ProfileRight::updateProfileRights(getItemByTypeName('Profile', "Technician", true), [
+                'problem' => (ALLSTANDARDRIGHT + \Problem::READALL + READNOTE + UPDATENOTE)
+            ]);
         }
 
         //reload ITIL object


### PR DESCRIPTION
From fresh install, user ```tech``` only have this rights for ```problem``` scope

```Problem::READMY | Problem::READALL | READNOTE | UPDATENOTE```

So a unit test that update problem with user 'tech' failed

https://github.com/glpi-project/glpi/blob/6e3f5405cca9ca1eea0ec3c5c00417b2c7d79e63/tests/functional/RuleCommonITILObject.php#L2773-L2775


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
