### PR TITLE
Drop useless `update_current_tab` param usage

### DIFF
--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -413,7 +413,7 @@ HTML;
                     }
                });
             }
-            if (update_current_tab && $(target).html() && !force_reload) {
+            if ($(target).html() && !force_reload) {
                 updateCurrentTab();
                 return;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Due to a mistake during merge of 10.0/bugfixes branch into main, the `update_current_tab` param of `loadTabContents` function dissapeared and it results in the following error:
```
Uncaught ReferenceError: update_current_tab is not defined
    at loadTabContents
```

It does not seems usefull to reintroduce it, as no call to this function is redefining it. It was introduced in e0c3219131dd748f1d2e45a08618cfb72a6c3adb but was not actually used.