### PR TITLE
Do not log agent last contact change

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -69,6 +69,8 @@ class Agent extends CommonDBTM
 
     private static $found_address = false;
 
+    public $history_blacklist = ['last_contact'];
+
     public static function getTypeName($nb = 0)
     {
         return _n('Agent', 'Agents', $nb);


### PR DESCRIPTION
Agent last contact information create a log of logs that do not seems very interesting to me.

Would it be OK to blacklist this field for the history or do you think it is useful to keep track of past inventories date ?

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
