### PR TITLE
Fix associate items to ticket permission mistake

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4417,7 +4417,7 @@ JAVASCRIPT;
         $ola = new OLA();
         $item_ticket = null;
 
-        $options['_canupdate'] = Session::haveRight('ticket', CREATE);
+        $options['_canupdate'] = Session::haveRight('ticket', UPDATE);
         if ($options['_canupdate']) {
             $item_ticket = new Item_Ticket();
         }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4417,7 +4417,12 @@ JAVASCRIPT;
         $ola = new OLA();
         $item_ticket = null;
 
-        $options['_canupdate'] = Session::haveRight('ticket', UPDATE);
+        if ($this->isNewItem()) {
+            $options['_canupdate'] = Session::haveRight('ticket', CREATE);
+        } else {
+            $options['_canupdate'] = Session::haveRight('ticket', UPDATE);
+        }
+
         if ($options['_canupdate']) {
             $item_ticket = new Item_Ticket();
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30441

This pull request allow the association of an item with a ticket when a profile doesn't have the ticket creation right. before this PR, a user without ticket creation rights has to navigate to the left tab to add an item, which is inconvenient. Now, the "Elements" section is present in the right-hand panel.
