### PR TITLE
Fix notification entity restriction

### DIFF
--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -586,6 +586,17 @@ class NotificationTarget extends CommonDBChild
                 $this->getEntity(),
                 true
             );
+
+            // If one of the item is recursive, then we should also check the child entities
+            if ($this->mustCheckChildrenEntities()) {
+                $filt = [
+                    'OR' => [
+                        $filt,
+                        ['entities_id' => getSonsOf(Entity::getTable(), $this->getEntity())]
+                    ]
+                ];
+            }
+
             $prof = Profile_User::getUserProfiles($data['users_id'], $filt);
             if (!count($prof)) {
                 // No right on the entity of the object
@@ -857,10 +868,10 @@ class NotificationTarget extends CommonDBChild
                     ]
                 ]
             ],
-            $criteria['INNER JOIN']
+            $criteria['INNER JOIN'] ?? []
         );
         $criteria['WHERE'] = array_merge(
-            $criteria['WHERE'],
+            $criteria['WHERE'] ?? [],
             [
                 Group_User::getTable() . '.groups_id'  => $group_id,
                 Group::getTable() . '.is_notify'       => 1,
@@ -1340,7 +1351,7 @@ class NotificationTarget extends CommonDBChild
      */
     public function getProfileJoinCriteria()
     {
-        return [
+        $criteria = [
             'INNER JOIN'   => [
                 Profile_User::getTable() => [
                     'ON' => [
@@ -1349,13 +1360,26 @@ class NotificationTarget extends CommonDBChild
                     ]
                 ]
             ],
-            'WHERE'        => getEntitiesRestrictCriteria(
+            'WHERE' => getEntitiesRestrictCriteria(
                 Profile_User::getTable(),
                 'entities_id',
                 $this->getEntity(),
                 true
             )
         ];
+
+        if ($this->mustCheckChildrenEntities()) {
+            $criteria['WHERE'] = [
+                'OR' => [
+                    $criteria['WHERE'],
+                    [
+                        Profile_User::getTableField('entities_id') => getSonsOf(Entity::getTable(), $this->getEntity())
+                    ]
+                ]
+            ];
+        }
+
+        return $criteria;
     }
 
 
@@ -1709,5 +1733,23 @@ class NotificationTarget extends CommonDBChild
         $this->allow_response = $allow_response;
 
         return $this;
+    }
+
+    /**
+     * Check if at least one target item is recursive
+     *
+     * @return bool
+     */
+    protected function mustCheckChildrenEntities(): bool
+    {
+        $is_recursive = false;
+        foreach ($this->target_object as $obj) {
+            if ($obj->isRecursive()) {
+                $is_recursive = true;
+                break;
+            }
+        }
+
+        return $is_recursive;
     }
 }

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -1750,7 +1750,7 @@ class NotificationTarget extends CommonDBChild
         }
 
         // Not all items support recursion
-        if (!isset($this->obj->fields['is_recursive'])) {
+        if (!$this->obj->maybeRecursive()) {
             return false;
         }
 

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -588,7 +588,7 @@ class NotificationTarget extends CommonDBChild
             );
 
             // If one of the item is recursive, then we should also check the child entities
-            if ($this->mustCheckChildrenEntities()) {
+            if ($this->isTargetItemRecursive()) {
                 $filt = [
                     'OR' => [
                         $filt,
@@ -1368,7 +1368,7 @@ class NotificationTarget extends CommonDBChild
             )
         ];
 
-        if ($this->mustCheckChildrenEntities()) {
+        if ($this->isTargetItemRecursive()) {
             $criteria['WHERE'] = [
                 'OR' => [
                     $criteria['WHERE'],
@@ -1740,16 +1740,20 @@ class NotificationTarget extends CommonDBChild
      *
      * @return bool
      */
-    protected function mustCheckChildrenEntities(): bool
+    protected function isTargetItemRecursive(): bool
     {
-        $is_recursive = false;
-        foreach ($this->target_object as $obj) {
-            if ($obj->isRecursive()) {
-                $is_recursive = true;
-                break;
-            }
+        // If the notification target more than one item, we can't handle the
+        // entity restriction correctly and must discard any potential child
+        // entities check
+        if (count($this->target_object) > 1) {
+            return false;
         }
 
-        return $is_recursive;
+        // Not all items support recursion
+        if (!isset($this->obj->fields['is_recursive'])) {
+            return false;
+        }
+
+        return $this->obj->isRecursive();
     }
 }

--- a/tests/functional/Notification.php
+++ b/tests/functional/Notification.php
@@ -35,7 +35,15 @@
 
 namespace tests\units;
 
+use Config;
+use Contract;
 use DbTestCase;
+use Group;
+use Group_User;
+use NotificationEvent;
+use NotificationTarget;
+use QueuedNotification;
+use User;
 
 /* Test for inc/notification.class.php */
 
@@ -94,5 +102,136 @@ class Notification extends DbTestCase
         $this->string(\Notification::getMailingSignature($parent))->isEqualTo("signature_parent");
         $this->string(\Notification::getMailingSignature($child_1))->isEqualTo("signature_child_1");
         $this->string(\Notification::getMailingSignature($child_2))->isEqualTo("signature_child_2");
+    }
+
+    /**
+     * Data provider for the testEntityRestriction case
+     *
+     * @return iterable
+     */
+    protected function testEntityRestrictionProvider(): iterable
+    {
+        global $DB, $CFG_GLPI;
+
+        $this->login();
+
+        // Test users
+        list($user_root, $user_sub) = $this->createItems(User::class, [
+            [
+                'name'         => "User_root_entity",
+                '_useremails'  => [-1 => "user_root@teclib.com"],
+                '_entities_id' => $this->getTestRootEntity(true),
+                '_profiles_id' => 4,                                // Super admin
+            ],
+            [
+                'name'         => "User_sub_entity",
+                '_useremails'  => [-1 => "user_sub@teclib.com"],
+                '_entities_id' => getItemByTypeName('Entity', '_test_child_1', true),
+                '_profiles_id' => 4, // Super admin
+            ],
+        ]);
+
+        // Put all our tests user into a single group so its easy to add them as
+        // recipient of the test notification
+        $group = $this->createItem(Group::class, [
+            'name'        => "testEntityRestriction_group",
+            'entities_id' => $this->getTestRootEntity(true),
+            'is_recursive' => true,
+        ]);
+        $this->createItems(Group_User::class, [
+            [
+                'users_id'  => $user_root->getID(),
+                'groups_id' => $group->getID(),
+            ],
+            [
+                'users_id'  => $user_sub->getID(),
+                'groups_id' => $group->getID(),
+            ]
+        ]);
+
+        // Set up notifications
+        $DB->update(\Notification::getTable(), ['is_active' => 0], [1]);
+        $active_notification = countElementsInTable(\Notification::getTable(), ['is_active' => 1]);
+        $this->integer($active_notification)->isEqualTo(0);
+
+        // Enable notification
+        $CFG_GLPI['notifications_mailing'] = true;
+        $CFG_GLPI['use_notifications'] = true;
+
+        // Find the "Contract end" notification and enable it
+        $notification = getItemByTypeName(\Notification::class, "Contract End");
+        $this->updateItem(\Notification::class, $notification->getID(), ['is_active' => 1]);
+
+        // Clear any exisiting target then set our group target
+        $DB->delete(NotificationTarget::getTable(), ['notifications_id' => $notification->getID()]);
+        $this->createItem(NotificationTarget::class, [
+            'notifications_id' => $notification->getID(),
+            'items_id'         => $group->getID(),
+            'type'             => \Notification::GROUP_TYPE,
+        ]);
+
+        // First test case: contract in the root entity with no recursion
+        // It should only be visible for the first user
+        $contract_root = $this->createItem('Contract', [
+            'name'         => 'Contact',
+            'entities_id'  => $this->getTestRootEntity(true),
+            'is_recursive' => false,
+        ]);
+        yield [$contract_root, ["user_root@teclib.com"]];
+
+        // Second test case: contract in the root entity with recursion
+        // It should be visible for our two users
+        $contract_root_and_children = $this->createItem('Contract', [
+            'name'         => 'Contact',
+            'entities_id'  => $this->getTestRootEntity(true),
+            'is_recursive' => true,
+        ]);
+        yield [$contract_root_and_children, ["user_root@teclib.com", "user_sub@teclib.com"]];
+    }
+
+    /**
+     * Test that entity restriction are applied correctly for notifications (a
+     * user should only receive notification on items he is allowed to see)
+     *
+     * @dataProvider testEntityRestrictionProvider
+     *
+     * @param Contract $contract       Test subject on which the notification will be fired
+     * @param string[] $expected_queue Array of expected emails
+     *
+     * @return void
+     */
+    public function testEntityRestriction(Contract $contract, array $expected_queue): void
+    {
+        global $DB;
+
+        // Clear notification queue
+        $DB->delete(QueuedNotification::getTable(), [1]);
+        $queue_size = countElementsInTable(QueuedNotification::getTable());
+        $this->integer($queue_size)->isEqualTo(0);
+
+        // Raise fake notification
+        NotificationEvent::raiseEvent('end', $contract, [
+            'entities_id' => $this->getTestRootEntity(true),
+            'items'       => [
+                [
+                    'id'                => $contract->getID(),
+                    'name'              => $contract->fields['name'],
+                    'num'               => $contract->fields['num'],
+                    'comment'           => $contract->fields['comment'],
+                    'accounting_number' => $contract->fields['accounting_number'],
+                    'contracttypes_id'  => $contract->fields['contracttypes_id'],
+                    'states_id'         => $contract->fields['states_id'],
+                    'begin_date'        => $contract->fields['begin_date'],
+                    'duration'          => $contract->fields['duration'],
+                ]
+            ],
+        ]);
+
+        // Validate notification queue size
+        $queue = (new QueuedNotification())->find();
+        $emails = array_column($queue, 'recipient');
+        sort($emails);
+        sort($expected_queue);
+        $this->array($emails)->isEqualTo($expected_queue);
     }
 }


### PR DESCRIPTION
The notification system does not behave correctly with recursive items.

Lets assume we have a contract on the root entity with children entities enabled.
A user with an authorization on a sub entity can see the contract but won't receive any notifications.

You can see this example in details in the added test case, which is failing without the other changes.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !29820
