### PR TITLE
Fix changing ticket status on document addition

### DIFF
--- a/front/document.form.php
+++ b/front/document.form.php
@@ -63,6 +63,18 @@ if (isset($_POST["add"])) {
                     "login",
                     sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $doc->fields["name"])
                 );
+                if (isset($_POST['itemtype']) && $_POST['itemtype'] == Ticket::getTypeName()) {
+                    $ticket = new Ticket();
+                    $ticket->getFromDB($_POST['items_id']);
+                    if ($_SESSION['glpiID'] ==  $ticket->fields['users_id_recipient']) {
+                        if ($ticket->fields['status'] == Ticket::WAITING) {
+                            $ticket->update([
+                                'id' => $_POST['items_id'],
+                                'status' => Ticket::ASSIGNED
+                            ]);
+                        }
+                    }
+                }
             }
         }
         if ($_SESSION['glpibackcreated'] && (!isset($_POST['itemtype']) || !isset($_POST['items_id']))) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30408

This pull request corrects the fact that the status of a ticket does not change from "Pending" to "Processing" when the ticket requester adds a new document without follow-up.