### PR TITLE
fix(entity): mishandling of the entity transfer option

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -1942,11 +1942,11 @@ class Entity extends CommonTreeDropdown
             'value'      => $entity->fields['transfers_id'],
             'display_emptychoice' => false
         ];
+        $params['toadd'] = [
+            self::CONFIG_NEVER => __('No automatic transfer')
+        ];
         if ($entity->fields['id'] > 0) {
-            $params['toadd'] = [
-                self::CONFIG_NEVER => __('No automatic transfer'),
-                self::CONFIG_PARENT => __('Inheritance of the parent entity')
-            ];
+            $params['toadd'][self::CONFIG_PARENT] = __('Inheritance of the parent entity');
         }
         Dropdown::show('Transfer', $params);
         if ($entity->fields['transfers_strategy'] == self::CONFIG_PARENT) {

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -3775,6 +3775,7 @@ class Entity extends CommonTreeDropdown
             case 'transfers_id':
                 $strategy = $values['transfers_strategy'] ?? $values[$field];
                 if ($strategy == self::CONFIG_NEVER) {
+                    return __('No automatic transfer');
                 }
                 if ($strategy == self::CONFIG_PARENT) {
                     return __('Inheritance of the parent entity');


### PR DESCRIPTION
On the root entity, when "Model for automatic entity transfer on inventories" was defined once, it was no longer possible to remove it, as the "No automatic transfer" option was only displayed on child entities. 

![image](https://github.com/glpi-project/glpi/assets/8530352/287ad4f6-1d2d-4b67-bcb7-6d67049b4b03)

Since https://github.com/glpi-project/glpi/pull/14247

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30475
