### PR TITLE
Add the possibility to see the result of satisfaction survey once expired

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -10424,7 +10424,6 @@ abstract class CommonITILObject extends CommonDBTM
             in_array($item->fields['status'], static::getClosedStatusArray())
             && $satisfaction->getFromDB($item->getID())
         ) {
-            // Get suffix for entity config fields. For backwards compatibility, ticket values have no suffix.
             $satisfaction->showSatisactionForm($item);
         } else {
             echo "<p class='center b'>" . __('No generated survey') . "</p>";

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -10425,18 +10425,7 @@ abstract class CommonITILObject extends CommonDBTM
             && $satisfaction->getFromDB($item->getID())
         ) {
             // Get suffix for entity config fields. For backwards compatibility, ticket values have no suffix.
-            $config_suffix = static::getType() === 'Ticket' ? '' : ('_' . strtolower(static::getType()));
-
-            $duration = (int) Entity::getUsedConfig('inquest_duration' . $config_suffix, $item->fields['entities_id']);
-            $date2    = strtotime($satisfaction->fields['date_begin']);
-            if (
-                ($duration === 0)
-                || (time() - $date2) <= $duration * DAY_TIMESTAMP
-            ) {
-                $satisfaction->showSatisactionForm($item);
-            } else {
-                echo "<p class='center b'>" . __('Satisfaction survey expired') . "</p>";
-            }
+            $satisfaction->showSatisactionForm($item);
         } else {
             echo "<p class='center b'>" . __('No generated survey') . "</p>";
         }

--- a/src/CommonITILSatisfaction.php
+++ b/src/CommonITILSatisfaction.php
@@ -157,12 +157,12 @@ abstract class CommonITILSatisfaction extends CommonDBTM
             $max_rate = Entity::getUsedConfig('inquest_config' . $config_suffix, $item->fields['entities_id'], 'inquest_max_rate' . $config_suffix);
             $duration = (int) Entity::getUsedConfig('inquest_duration', $item->fields['entities_id']);
             $date2 = strtotime($this->fields['date_begin']);
-            $expired = 1;
+            $expired = true;
             if (
                 ($duration === 0)
                 || (time() - $date2) <= $duration * DAY_TIMESTAMP
             ) {
-                $expired = 0;
+                $expired = false;
             }
             TemplateRenderer::getInstance()->display('/components/itilobject/itilsatisfaction.html.twig', [
                 'item'   => $this,

--- a/src/CommonITILSatisfaction.php
+++ b/src/CommonITILSatisfaction.php
@@ -155,15 +155,8 @@ abstract class CommonITILSatisfaction extends CommonDBTM
                 $this->fields["satisfaction"] = $default_rate;
             }
             $max_rate = Entity::getUsedConfig('inquest_config' . $config_suffix, $item->fields['entities_id'], 'inquest_max_rate' . $config_suffix);
-            $duration = (int) Entity::getUsedConfig('inquest_duration', $item->fields['entities_id']);
-            $date2 = strtotime($this->fields['date_begin']);
-            $expired = true;
-            if (
-                ($duration === 0)
-                || (time() - $date2) <= $duration * DAY_TIMESTAMP
-            ) {
-                $expired = false;
-            }
+            $duration = (int) Entity::getUsedConfig('inquest_duration' . $config_suffix, $item->fields['entities_id']);
+            $expired = $duration !== 0 && (time() - strtotime($this->fields['date_begin'])) > $duration * DAY_TIMESTAMP;
             TemplateRenderer::getInstance()->display('/components/itilobject/itilsatisfaction.html.twig', [
                 'item'   => $this,
                 'parent_item' => $item,

--- a/src/CommonITILSatisfaction.php
+++ b/src/CommonITILSatisfaction.php
@@ -155,11 +155,21 @@ abstract class CommonITILSatisfaction extends CommonDBTM
                 $this->fields["satisfaction"] = $default_rate;
             }
             $max_rate = Entity::getUsedConfig('inquest_config' . $config_suffix, $item->fields['entities_id'], 'inquest_max_rate' . $config_suffix);
+            $duration = (int) Entity::getUsedConfig('inquest_duration', $item->fields['entities_id']);
+            $date2 = strtotime($this->fields['date_begin']);
+            $expired = 1;
+            if (
+                ($duration === 0)
+                || (time() - $date2) <= $duration * DAY_TIMESTAMP
+            ) {
+                $expired = 0;
+            }
             TemplateRenderer::getInstance()->display('/components/itilobject/itilsatisfaction.html.twig', [
                 'item'   => $this,
                 'parent_item' => $item,
                 'max_rate' => $max_rate,
                 'params' => $options,
+                'expired' => $expired,
             ]);
         }
     }

--- a/templates/components/itilobject/itilsatisfaction.html.twig
+++ b/templates/components/itilobject/itilsatisfaction.html.twig
@@ -107,6 +107,7 @@
                 _n('Comment', 'Comments', get_plural_number()),
                 {
                     'full_width': true,
+                    'readonly': expired,
                 }
             ) }}
 

--- a/templates/components/itilobject/itilsatisfaction.html.twig
+++ b/templates/components/itilobject/itilsatisfaction.html.twig
@@ -64,7 +64,7 @@
             {{ fields.htmlField(
                 '',
                 '',
-                __('No result gived'),
+                __('No response given'),
                 {
                     'input_class' : 'col-xxl-9',
                     'label_class' : 'col-xxl-3'

--- a/templates/components/itilobject/itilsatisfaction.html.twig
+++ b/templates/components/itilobject/itilsatisfaction.html.twig
@@ -47,7 +47,7 @@
 
     {% else %}
         {% if expired == 1 %}
-            {% set message = __('Satisfaction survey expired, here are the results recorded.') %}
+            {% set message = __('Satisfaction survey expired.') %}
         {% else %}
             {% set message = __('After 12 hours, you can no longer modify your response.') %}
         {% endif %}

--- a/templates/components/itilobject/itilsatisfaction.html.twig
+++ b/templates/components/itilobject/itilsatisfaction.html.twig
@@ -46,7 +46,7 @@
         ) }}
 
     {% else %}
-        {% if expired == 1 %}
+        {% if expired == true %}
             {% set message = __('Satisfaction survey expired.') %}
         {% else %}
             {% set message = __('After 12 hours, you can no longer modify your response.') %}
@@ -60,7 +60,7 @@
             </div>
         </div>
         {% set result = item.fields['date_answered'] is empty ? 0 : 1 %}
-        {% if result == 0 and expired == 1 %}
+        {% if result == 0 and expired == true %}
             {{ fields.htmlField(
                 '',
                 '',
@@ -139,7 +139,7 @@
                 });
             </script>
 
-            {% if expired == 0 %}
+            {% if expired == false %}
                 {{ include('components/form/buttons.html.twig') }}
             {% endif %}
         {% endif %}

--- a/templates/components/itilobject/itilsatisfaction.html.twig
+++ b/templates/components/itilobject/itilsatisfaction.html.twig
@@ -49,7 +49,7 @@
         {% if expired == 1 %}
             {% set message = __('Satisfaction survey expired, here are the results recorded.') %}
         {% else %}
-            {% set message = __('After 12 hours, you can no longer modify your notice.') %}
+            {% set message = __('After 12 hours, you can no longer modify your response.') %}
         {% endif %}
         <div class="alert alert-info d-flex align-items-center" role="alert">
             <div class="text-dark">

--- a/templates/components/itilobject/itilsatisfaction.html.twig
+++ b/templates/components/itilobject/itilsatisfaction.html.twig
@@ -46,83 +46,102 @@
         ) }}
 
     {% else %}
+        {% if expired == 1 %}
+            {% set message = __('Satisfaction survey expired, here are the results recorded.') %}
+        {% else %}
+            {% set message = __('After 12 hours, you can no longer modify your notice.') %}
+        {% endif %}
         <div class="alert alert-info d-flex align-items-center" role="alert">
             <div class="text-dark">
                 <span class="ms-2">
                     <i class="fas fa-xl fa-info-circle"></i>
-                    {{ __('After 12 hours, you can no longer modify your notice.') }}
+                    {{ message }}
                 </span>
             </div>
         </div>
-
-        {{ fields.hiddenField(
-            parent_item.getForeignKeyField(),
-            parent_item.fields['id'],
-            '',
-            {
-                'full_width': true,
-            }
-        ) }}
-
-        {% set select_dom %}
-            <select id="satisfaction_data" name="satisfaction">
-                {% for i in range(0, max_rate) %}
-                    <option value="{{ i }}" {% if i == item.fields['satisfaction'] %} selected {% endif %}>{{ i }}</option>
-                {% endfor %}
-            </select>
-            <div class="rateit" id="stars"></div>
-        {% endset %}
-
-        {{ fields.htmlField(
-            'satisfaction',
-            select_dom,
-            __('Satisfaction with the resolution of the %s')|format(parent_item.getTypeName(1)),
-            {
-                'full_width': true,
-                'full_width_adapt_column': false,
-                'label_class': 'col-xxl-4',
-                'input_class': 'col-xxl-8 text-start',
-            }
-        ) }}
-
-        {{ fields.textareaField(
-            'comment',
-            item.fields['comment'],
-            _n('Comment', 'Comments', get_plural_number()),
-            {
-                'full_width': true,
-            }
-        ) }}
-
-        {% if item.fields['date_answered'] > 0 %}
-
-            {{ fields.datetimeField(
-                'date_answered',
-                item.fields['date_answered'],
-                __('Response date to the satisfaction survey.'),
+        {% set result = item.fields['date_answered'] is empty ? 0 : 1 %}
+        {% if result == 0 and expired == 1 %}
+            {{ fields.htmlField(
+                '',
+                '',
+                __('No result gived'),
+                {
+                    'input_class' : 'col-xxl-9',
+                    'label_class' : 'col-xxl-3'
+                }
+            ) }}
+        {% else %}
+            {{ fields.hiddenField(
+                parent_item.getForeignKeyField(),
+                parent_item.fields['id'],
+                '',
                 {
                     'full_width': true,
-                    'readonly' : true
                 }
             ) }}
 
-        {% endif %}
+            {% set select_dom %}
+                <select id="satisfaction_data" name="satisfaction">
+                    {% for i in range(0, max_rate) %}
+                        <option value="{{ i }}" {% if i == item.fields['satisfaction'] %} selected {% endif %}>{{ i }}</option>
+                    {% endfor %}
+                </select>
+                <div class="rateit" id="stars"></div>
+            {% endset %}
 
-        <script>
-            $(function() {
-                $('#stars').rateit({
-                    value: {{ item.fields['satisfaction'] }},
-                    min: 0,
-                    max: {{ max_rate }},
-                    step: 1,
-                    backingfld: '#satisfaction_data',
-                    ispreset: true,
-                    resetable: false
+            {{ fields.htmlField(
+                'satisfaction',
+                select_dom,
+                __('Satisfaction with the resolution of the %s')|format(parent_item.getTypeName(1)),
+                {
+                    'full_width': true,
+                    'full_width_adapt_column': false,
+                    'label_class': 'col-xxl-4',
+                    'input_class': 'col-xxl-8 text-start',
+                }
+            ) }}
+
+            {{ fields.textareaField(
+                'comment',
+                item.fields['comment'],
+                _n('Comment', 'Comments', get_plural_number()),
+                {
+                    'full_width': true,
+                }
+            ) }}
+
+            {% if item.fields['date_answered'] > 0 %}
+
+                {{ fields.datetimeField(
+                    'date_answered',
+                    item.fields['date_answered'],
+                    __('Response date to the satisfaction survey.'),
+                    {
+                        'full_width': true,
+                        'readonly' : true
+                    }
+                ) }}
+
+            {% endif %}
+
+            <script>
+                $(function() {
+                    $('#stars').rateit({
+                        value: {{ item.fields['satisfaction'] }},
+                        min: 0,
+                        max: {{ max_rate }},
+                        step: 1,
+                        backingfld: '#satisfaction_data',
+                        ispreset: true,
+                        resetable: false
+                    });
                 });
-            });
-        </script>
+            </script>
 
-        {{ include('components/form/buttons.html.twig') }}
+            {% if expired == 0 %}
+                {{ include('components/form/buttons.html.twig') }}
+            {% endif %}
+        {% endif %}
     {% endif %}
 
 {% endblock %}

--- a/templates/components/itilobject/itilsatisfaction.html.twig
+++ b/templates/components/itilobject/itilsatisfaction.html.twig
@@ -46,7 +46,7 @@
         ) }}
 
     {% else %}
-        {% if expired == true %}
+        {% if expired %}
             {% set message = __('Satisfaction survey expired.') %}
         {% else %}
             {% set message = __('After 12 hours, you can no longer modify your response.') %}
@@ -59,8 +59,7 @@
                 </span>
             </div>
         </div>
-        {% set result = item.fields['date_answered'] is empty ? 0 : 1 %}
-        {% if result == 0 and expired == true %}
+        {% if item.fields['date_answered'] is empty and expired %}
             {{ fields.htmlField(
                 '',
                 '',
@@ -139,7 +138,7 @@
                 });
             </script>
 
-            {% if expired == false %}
+            {% if not expired %}
                 {{ include('components/form/buttons.html.twig') }}
             {% endif %}
         {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #16009

When the response time has expired, the message Satisfaction survey expired is displayed. If the user has added a note before the time limit expires, the note is visible, otherwise the message No response has been given is displayed.

**Response gived**
![image](https://github.com/glpi-project/glpi/assets/107540223/81a5a8e8-2ed2-4e7f-ada9-65c993357baa)
**No response gived**
![image](https://github.com/glpi-project/glpi/assets/107540223/8b583fd9-9057-4e44-ac08-3a4389042592)

Verification used to be done in CommonItilObject, which called CommonItilSatisfaction or displayed the error message. Now, whether or not the message is displayed is managed on the twig page of satisfactions.