### PR TITLE
Fix: carriage return in log files

### DIFF
--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -1082,7 +1082,7 @@ class MailCollector extends CommonDBTM
                 $tkt['_tag']      = $this->tags;
             } else {
                //TRANS: %s is a directory
-                Toolbox::logInFile('mailgate', sprintf(__('%s is not writable'), GLPI_TMP_DIR . "/"));
+                Toolbox::logInFile('mailgate', sprintf(__('%s is not writable'), GLPI_TMP_DIR . "/") . '\n');
             }
         }
 

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -198,7 +198,7 @@ class Migration
        // Do not log if more than 3 log error
         if (
             $this->log_errors < 3
-            && !Toolbox::logInFile($log_file_name, $message . ' @ ', true)
+            && !Toolbox::logInFile($log_file_name, $message . ' @\n', true)
         ) {
             $this->log_errors++;
         }

--- a/src/Session.php
+++ b/src/Session.php
@@ -1620,7 +1620,7 @@ class Session
         ) {
             $requested_url = (isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : 'Unknown');
             $user_id = self::getLoginUserID() ?? 'Anonymous';
-            Toolbox::logInFile('access-errors', "CSRF check failed for User ID: $user_id at $requested_url");
+            Toolbox::logInFile('access-errors', "CSRF check failed for User ID: $user_id at $requested_url\n");
             // Output JSON if requested by client
             if (strpos($_SERVER['HTTP_ACCEPT'] ?? '', 'application/json') !== false) {
                 http_response_code(403);


### PR DESCRIPTION
In some log files the line break was missing

Example here before the date:
![image](https://github.com/glpi-project/glpi/assets/8530352/485bfd0f-95df-4b32-863b-9fd743fa4a90)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
