### PR TITLE
Fix change status after refused solution

### DIFF
--- a/src/Change.php
+++ b/src/Change.php
@@ -126,22 +126,6 @@ class Change extends CommonITILObject
     }
 
     /**
-     * Is the current user have right to approve solution of the current change ?
-     *
-     * @return boolean
-     **/
-    public function canApprove()
-    {
-
-        return ((($this->fields["users_id_recipient"] === Session::getLoginUserID())
-               &&  Session::haveRight('change', Change::WAITING))
-              || $this->isUser(CommonITILActor::REQUESTER, Session::getLoginUserID())
-              || (isset($_SESSION["glpigroups"])
-                  && $this->haveAGroup(CommonITILActor::REQUESTER, $_SESSION["glpigroups"])));
-    }
-
-
-    /**
      * Is the current user have right to create the current change ?
      *
      * @return boolean

--- a/src/Change.php
+++ b/src/Change.php
@@ -672,7 +672,7 @@ class Change extends CommonITILObject
 
     public static function getReopenableStatusArray()
     {
-        return [self::SOLVED] + self::getClosedStatusArray();
+        return array_merge(self::getClosedStatusArray(), [self::SOLVED]);
     }
 
     public function getRights($interface = 'central')

--- a/src/Change.php
+++ b/src/Change.php
@@ -125,6 +125,21 @@ class Change extends CommonITILObject
                               ))))));
     }
 
+    /**
+     * Is the current user have right to approve solution of the current change ?
+     *
+     * @return boolean
+     **/
+    public function canApprove()
+    {
+
+        return ((($this->fields["users_id_recipient"] === Session::getLoginUserID())
+               &&  Session::haveRight('change', Change::WAITING))
+              || $this->isUser(CommonITILActor::REQUESTER, Session::getLoginUserID())
+              || (isset($_SESSION["glpigroups"])
+                  && $this->haveAGroup(CommonITILActor::REQUESTER, $_SESSION["glpigroups"])));
+    }
+
 
     /**
      * Is the current user have right to create the current change ?
@@ -673,7 +688,7 @@ class Change extends CommonITILObject
 
     public static function getReopenableStatusArray()
     {
-        return self::getClosedStatusArray();
+        return [self::SOLVED] + self::getClosedStatusArray();
     }
 
     public function getRights($interface = 'central')

--- a/src/Features/ParentStatus.php
+++ b/src/Features/ParentStatus.php
@@ -175,7 +175,7 @@ trait ParentStatus
             $input['_status'] = CommonITILObject::PLANNED;
         }
 
-       //change ITILObject status only if imput change
+       //change ITILObject status only if input change
         if (
             !$reopened
             && $input['_status'] != $parentitem->fields['status']

--- a/tests/functional/Change.php
+++ b/tests/functional/Change.php
@@ -289,4 +289,34 @@ class Change extends DbTestCase
         // Even when automatically assigning a user, the initial status should be set to New
         $this->integer($change->fields['status'])->isIdenticalTo(\CommonITILObject::INCOMING);
     }
+
+    public function testValidationStatus()
+    {
+        $this->login();
+        $change = new \Change();
+        $changes_id = $change->add([
+            'name' => "test initial status",
+            'content' => "test initial status",
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+            '_users_id_assign' => getItemByTypeName('User', TU_USER, true),
+            'status'    => \CommonITILObject::SOLVED,
+        ]);
+        $this->integer($changes_id)->isGreaterThan(0);
+
+        $followup = new \ITILFollowup();
+        $followup_id = $followup->add([
+            'itemtype' => 'Change',
+            'items_id' => $changes_id,
+            'users_id' => getItemByTypeName('User', TU_USER, true),
+            'users_id_editor' => getItemByTypeName('User', TU_USER, true),
+            'content' => 'Test followup content',
+            'requesttypes_id' => 1,
+            'timeline_position' => \CommonITILObject::TIMELINE_LEFT,
+            'add_reopen' => ''
+        ]);
+        $this->integer($followup_id)->isGreaterThan(0);
+
+        $item = $change->getById($changes_id);
+        $this->integer($item->fields['status'])->isIdenticalTo(\CommonITILObject::INCOMING);
+    }
 }

--- a/tests/functional/Change.php
+++ b/tests/functional/Change.php
@@ -290,7 +290,7 @@ class Change extends DbTestCase
         $this->integer($change->fields['status'])->isIdenticalTo(\CommonITILObject::INCOMING);
     }
 
-    public function testValidationStatus()
+    public function testStatusWhenSolutionIsRefused()
     {
         $this->login();
         $change = new \Change();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15700

The status Applied for objects of type Change was not defined in the list of statuses allowing the reopening of a CommonITILObject, which prevented GLPI from updating its status, which therefore remained Applied (SOLVED).