### PR TITLE
fix(email notification): html entity decode

### DIFF
--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -2072,12 +2072,12 @@ class MailCollector extends CommonDBTM
 
         $mmail = new GLPIMailer();
         $mmail->AddCustomHeader("Auto-Submitted: auto-replied");
-        $mmail->SetFrom($CFG_GLPI["admin_email"], html_entity_decode($CFG_GLPI["admin_email_name"]));
+        $mmail->SetFrom($CFG_GLPI["admin_email"], Sanitizer::decodeHtmlSpecialChars($CFG_GLPI["admin_email_name"]));
         $mmail->AddAddress($to);
        // Normalized header, no translation
         $mmail->Subject  = 'Re: ' . $subject;
         $mmail->Body     = __("Your email could not be processed.\nIf the problem persists, contact the administrator") .
-                         "\n-- \n" . html_entity_decode($CFG_GLPI["mailing_signature"]);
+                         "\n-- \n" . Sanitizer::decodeHtmlSpecialChars($CFG_GLPI["mailing_signature"]);
         $mmail->Send();
     }
 

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -2072,12 +2072,12 @@ class MailCollector extends CommonDBTM
 
         $mmail = new GLPIMailer();
         $mmail->AddCustomHeader("Auto-Submitted: auto-replied");
-        $mmail->SetFrom($CFG_GLPI["admin_email"], $CFG_GLPI["admin_email_name"]);
+        $mmail->SetFrom($CFG_GLPI["admin_email"], html_entity_decode($CFG_GLPI["admin_email_name"]));
         $mmail->AddAddress($to);
        // Normalized header, no translation
         $mmail->Subject  = 'Re: ' . $subject;
         $mmail->Body     = __("Your email could not be processed.\nIf the problem persists, contact the administrator") .
-                         "\n-- \n" . $CFG_GLPI["mailing_signature"];
+                         "\n-- \n" . html_entity_decode($CFG_GLPI["mailing_signature"]);
         $mmail->Send();
     }
 

--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -33,6 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Toolbox\Sanitizer;
 use PHPMailer\PHPMailer\PHPMailer;
 
 class NotificationEventMailing extends NotificationEventAbstract

--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -172,10 +172,10 @@ class NotificationEventMailing extends NotificationEventAbstract
                     }
                 }
 
-                $mmail->SetFrom($current->fields['sender'], html_entity_decode($current->fields['sendername']));
+                $mmail->SetFrom($current->fields['sender'], Sanitizer::decodeHtmlSpecialChars($current->fields['sendername']));
 
                 if ($current->fields['replyto']) {
-                    $mmail->AddReplyTo($current->fields['replyto'], html_entity_decode($current->fields['replytoname']));
+                    $mmail->AddReplyTo($current->fields['replyto'], Sanitizer::decodeHtmlSpecialChars($current->fields['replytoname']));
                 }
                 $mmail->Subject = $current->fields['name'];
 
@@ -385,7 +385,7 @@ class NotificationEventMailing extends NotificationEventAbstract
                     $mmail->AltBody .= $text;
                 }
 
-                $mmail->AddAddress($recipient, html_entity_decode($current->fields['recipientname']));
+                $mmail->AddAddress($recipient, Sanitizer::decodeHtmlSpecialChars($current->fields['recipientname']));
 
                 if (!empty($current->fields['messageid'])) {
                     $mmail->MessageID = "<" . $current->fields['messageid'] . ">";

--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -172,10 +172,10 @@ class NotificationEventMailing extends NotificationEventAbstract
                     }
                 }
 
-                $mmail->SetFrom($current->fields['sender'], $current->fields['sendername']);
+                $mmail->SetFrom($current->fields['sender'], html_entity_decode($current->fields['sendername']));
 
                 if ($current->fields['replyto']) {
-                    $mmail->AddReplyTo($current->fields['replyto'], $current->fields['replytoname']);
+                    $mmail->AddReplyTo($current->fields['replyto'], html_entity_decode($current->fields['replytoname']));
                 }
                 $mmail->Subject = $current->fields['name'];
 
@@ -385,7 +385,7 @@ class NotificationEventMailing extends NotificationEventAbstract
                     $mmail->AltBody .= $text;
                 }
 
-                $mmail->AddAddress($recipient, $current->fields['recipientname']);
+                $mmail->AddAddress($recipient, html_entity_decode($current->fields['recipientname']));
 
                 if (!empty($current->fields['messageid'])) {
                     $mmail->MessageID = "<" . $current->fields['messageid'] . ">";

--- a/src/NotificationMailing.php
+++ b/src/NotificationMailing.php
@@ -103,9 +103,9 @@ class NotificationMailing implements NotificationInterface
         $mmail->AddCustomHeader("Auto-Submitted: auto-generated");
        // For exchange
         $mmail->AddCustomHeader("X-Auto-Response-Suppress: OOF, DR, NDR, RN, NRN");
-        $mmail->SetFrom($sender['email'], $sender['name'] ?? '', false);
+        $mmail->SetFrom($sender['email'], html_entity_decode($sender['name'] ?? ''), false);
 
-        $text = __('This is a test email.') . "\n-- \n" . $CFG_GLPI["mailing_signature"];
+        $text = __('This is a test email.') . "\n-- \n" . html_entity_decode($CFG_GLPI["mailing_signature"]);
         $recipient = $CFG_GLPI['admin_email'];
         if (defined('GLPI_FORCE_MAIL')) {
            //force recipient to configured email address
@@ -114,7 +114,7 @@ class NotificationMailing implements NotificationInterface
             $text .= "\n" . sprintf(__('Original email address was %1$s'), $CFG_GLPI['admin_email']);
         }
 
-        $mmail->AddAddress($recipient, $CFG_GLPI["admin_email_name"]);
+        $mmail->AddAddress($recipient, html_entity_decode($CFG_GLPI["admin_email_name"]));
         $mmail->Subject = "[GLPI] " . __('Mail test');
         $mmail->Body    = $text;
 

--- a/src/NotificationMailing.php
+++ b/src/NotificationMailing.php
@@ -103,9 +103,9 @@ class NotificationMailing implements NotificationInterface
         $mmail->AddCustomHeader("Auto-Submitted: auto-generated");
        // For exchange
         $mmail->AddCustomHeader("X-Auto-Response-Suppress: OOF, DR, NDR, RN, NRN");
-        $mmail->SetFrom($sender['email'], html_entity_decode($sender['name'] ?? ''), false);
+        $mmail->SetFrom($sender['email'], Sanitizer::decodeHtmlSpecialChars($sender['name'] ?? ''), false);
 
-        $text = __('This is a test email.') . "\n-- \n" . html_entity_decode($CFG_GLPI["mailing_signature"]);
+        $text = __('This is a test email.') . "\n-- \n" . Sanitizer::decodeHtmlSpecialChars($CFG_GLPI["mailing_signature"]);
         $recipient = $CFG_GLPI['admin_email'];
         if (defined('GLPI_FORCE_MAIL')) {
            //force recipient to configured email address
@@ -114,7 +114,7 @@ class NotificationMailing implements NotificationInterface
             $text .= "\n" . sprintf(__('Original email address was %1$s'), $CFG_GLPI['admin_email']);
         }
 
-        $mmail->AddAddress($recipient, html_entity_decode($CFG_GLPI["admin_email_name"]));
+        $mmail->AddAddress($recipient, Sanitizer::decodeHtmlSpecialChars($CFG_GLPI["admin_email_name"]));
         $mmail->Subject = "[GLPI] " . __('Mail test');
         $mmail->Body    = $text;
 


### PR DESCRIPTION
The `&` in the notification settings was displayed as `&#38;` in received mails.

![image](https://github.com/glpi-project/glpi/assets/8530352/62666069-00e7-4b72-8c93-f135686ef7f1)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30570
