### PR TITLE
Fix Pending Reason display condition for non-last timeline items

### DIFF
--- a/src/PendingReason_Item.php
+++ b/src/PendingReason_Item.php
@@ -353,10 +353,6 @@ class PendingReason_Item extends CommonDBRelation
             return true;
         }
 
-        if (PendingReason_Item::getForItem($item, true)) {
-            return true;
-        }
-
         if (PendingReason_Item::isLastTimelineItem($item)) {
             return true;
         }

--- a/src/PendingReason_Item.php
+++ b/src/PendingReason_Item.php
@@ -342,6 +342,29 @@ class PendingReason_Item extends CommonDBRelation
     }
 
     /**
+     * Determines if a pending reason can be displayed for a given item.
+     *
+     * @param CommonDBTM $item
+     * @return boolean
+     */
+    public static function canDisplayPendingReasonForItem(CommonDBTM $item): bool
+    {
+        if ($item->isNewItem()) {
+            return true;
+        }
+
+        if (PendingReason_Item::getForItem($item, true)) {
+            return true;
+        }
+
+        if (PendingReason_Item::isLastTimelineItem($item)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * User might be trying to update the active pending reason by modifying the
      * pending reason data in a new timeline item form
      *
@@ -456,7 +479,11 @@ class PendingReason_Item extends CommonDBRelation
             }
         } else {
            // Not pending yet; did it change ?
-            if ($timeline_item->input['pending'] ?? 0) {
+            if (
+                $timeline_item->input['pending'] ?? 0
+                && isset($timeline_item->input['pendingreasons_id'])
+                && $timeline_item->input['pendingreasons_id'] > 0
+            ) {
                // Set parent status
                 $timeline_item->input['_status'] = CommonITILObject::WAITING;
 

--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -217,7 +217,7 @@
             <div class="d-flex card-footer mx-n3 mb-n3 flex-wrap" style="row-gap: 10px; min-height: 79px">
                {% set pending_reasons %}
                   {% set show_pending_reasons_actions = item.fields['status'] == constant('CommonITILObject::WAITING') and not add_reopen %}
-                  {% if get_current_interface() == 'central' and item.isAllowedStatus(item.fields['status'], constant('CommonITILObject::WAITING')) %}
+                  {% if get_current_interface() == 'central' and item.isAllowedStatus(item.fields['status'], constant('CommonITILObject::WAITING')) and call('PendingReason_Item::canDisplayPendingReasonForItem', [subitem]) %}
                      <span
                         class="input-group-text bg-yellow-lt py-0 pe-0 {{ show_pending_reasons_actions ? 'flex-fill' : '' }}"
                         id="pending-reasons-control-{{ rand }}"

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -396,33 +396,35 @@
 
             {% set pending_reasons %}
                {% set show_pending_reasons_actions = item.fields['status'] == constant('CommonITILObject::WAITING') and not has_pending_reason %}
-               <span
-                  class="input-group-text bg-yellow-lt py-0 pe-0 {{ show_pending_reasons_actions ? 'flex-fill' : '' }}"
-                  id="pending-reasons-control-{{ rand }}"
-               >
-                  <span class="d-inline-flex align-items-center" title="{{ __("Set the status to pending") }}"
-                        data-bs-toggle="tooltip" data-bs-placement="top" role="button">
-                     <i class="fas fa-pause me-2"></i>
-                     <label class="form-check form-switch mt-2">
-                        <input type="hidden"   name="pending" value="0" />
-                        <input type="checkbox" name="pending" value="1" class="form-check-input"
-                              id="enable-pending-reasons-{{ rand }}"
-                              role="button"
-                              {{ item.fields['status'] == constant('CommonITILObject::WAITING') ? 'checked' : '' }}
-                              data-bs-toggle="collapse" data-bs-target="#pending-reasons-setup-{{ rand }}" />
-                     </label>
-                  </span>
+               {% if call('PendingReason_Item::canDisplayPendingReasonForItem', [subitem]) %}
+                  <span
+                     class="input-group-text bg-yellow-lt py-0 pe-0 {{ show_pending_reasons_actions ? 'flex-fill' : '' }}"
+                     id="pending-reasons-control-{{ rand }}"
+                  >
+                     <span class="d-inline-flex align-items-center" title="{{ __("Set the status to pending") }}"
+                           data-bs-toggle="tooltip" data-bs-placement="top" role="button">
+                        <i class="fas fa-pause me-2"></i>
+                        <label class="form-check form-switch mt-2">
+                           <input type="hidden"   name="pending" value="0" />
+                           <input type="checkbox" name="pending" value="1" class="form-check-input"
+                                 id="enable-pending-reasons-{{ rand }}"
+                                 role="button"
+                                 {{ item.fields['status'] == constant('CommonITILObject::WAITING') ? 'checked' : '' }}
+                                 data-bs-toggle="collapse" data-bs-target="#pending-reasons-setup-{{ rand }}" />
+                        </label>
+                     </span>
 
-                  {% if not has_pending_reason %}
-                     <div
-                        class="collapse ps-2 py-1 flex-fill {{ show_pending_reasons_actions ? 'show' : '' }}"
-                        aria-expanded="{{ show_pending_reasons_actions ? 'true' : 'false' }}"
-                        id="pending-reasons-setup-{{ rand }}"
-                     >
-                        {{ include('components/itilobject/timeline/pending_reasons.html.twig') }}
-                     </div>
-                  {% endif %}
-               </span>
+                     {% if not has_pending_reason %}
+                        <div
+                           class="collapse ps-2 py-1 flex-fill {{ show_pending_reasons_actions ? 'show' : '' }}"
+                           aria-expanded="{{ show_pending_reasons_actions ? 'true' : 'false' }}"
+                           id="pending-reasons-setup-{{ rand }}"
+                        >
+                           {{ include('components/itilobject/timeline/pending_reasons.html.twig') }}
+                        </div>
+                     {% endif %}
+                  </span>
+               {% endif %}
             {% endset %}
 
             {{ call_plugin_hook('post_item_form', {"item": subitem, 'options': params}) }}

--- a/templates/components/itilobject/timeline/pending_reasons.html.twig
+++ b/templates/components/itilobject/timeline/pending_reasons.html.twig
@@ -33,10 +33,11 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
-{% set pending_item = call('PendingReason_Item::getForItem', [subitem, true]) %}
-{% set pending_item_parent = call('PendingReason_Item::getForItem', [item, true]) %}
-{% set pendingreasons_id = pending_item.fields['pendingreasons_id'] ?? pending_item_parent.fields['pendingreasons_id'] ?? 0 %}
-{% if subitem.isNewItem() or pending_item or call('PendingReason_Item::isLastTimelineItem', [subitem])  %}
+{% if call('PendingReason_Item::canDisplayPendingReasonForItem', [subitem]) %}
+   {% set pending_item = call('PendingReason_Item::getForItem', [subitem, true]) %}
+   {% set pending_item_parent = call('PendingReason_Item::getForItem', [item, true]) %}
+   {% set pendingreasons_id = pending_item.fields['pendingreasons_id'] ?? pending_item_parent.fields['pendingreasons_id'] ?? 0 %}
+
    <div class="row">
       <div class="col-12 col-sm-4" title="{{ "PendingReason"|itemtype_name }}"
            data-bs-toggle="tooltip" data-bs-placement="top">


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15951

## Description
This pull request addresses a bug and an inconsistency in the display of the 'pending reason' for tasks or follow-ups that are not the last item in the timeline. Previously, the system allowed graphically setting a 'pending reason' for any task or follow-up, regardless of its position in the timeline. This led to a SQL error when the system tried to insert a NULL 'pendingreasons_id' into the 'glpi_pendingreasons_items' table.

## Changes
The changes introduced in this pull request add a new method `canDisplayPendingReasonForItem` in the `PendingReason_Item` class. This method checks if a 'pending reason' can be displayed for a given item based on the following conditions:
- The item is new.
- The item already has a 'pending reason'.
- The item is the last one in the timeline.

The method is then used in the Twig templates to conditionally display the 'pending reason' controls only when it's appropriate. This prevents the SQL error from occurring and makes the display of 'pending reasons' more consistent with their actual functionality.

Additionally, the conditions for adding pending reasons are strengthened. Now, a timeline item is only considered pending if its 'pendingreasons_id' is set and greater than 0, preventing potential SQL errors.