### PR TITLE
fix(Inventory): add missing RuleMatchedLog from Discovery (on update)

### DIFF
--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -857,6 +857,18 @@ abstract class MainAsset extends InventoryAsset
                     'snmpcredentials_id'    => $input['snmpcredentials_id'],
                     'is_dynamic'            => true
                 ]));
+                //add rule matched log
+                $rulesmatched = new RuleMatchedLog();
+                $inputrulelog = [
+                    'date'      => date('Y-m-d H:i:s'),
+                    'rules_id'  => $rules_id,
+                    'items_id'  => $items_id,
+                    'itemtype'  => $itemtype,
+                    'agents_id' => $this->agent->fields['id'],
+                    'method'    => Request::NETDISCOVERY_TASK
+                ];
+                $rulesmatched->add($inputrulelog, [], false);
+                $rulesmatched->cleanOlddata($items_id, $itemtype);
                 return;
             }
         }


### PR DESCRIPTION
When a ```discovery``` is performed on ```update``` (when asset is already inventoried with SNMP for example)

There is no ```RuleMatchedLog``` attached to it

This PR fix this

![image](https://github.com/glpi-project/glpi/assets/7335054/683d0d76-937b-4146-ac4e-3b9b959144ed)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
