### PR TITLE
fix(Inventory): add missing 'oscomment' value for RuleLocation

### DIFF
--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -492,6 +492,10 @@ abstract class MainAsset extends InventoryAsset
 
         $input['itemtype'] = $this->item->getType();
 
+        if (property_exists($val, 'comment')) {
+            $input['oscomment'] = $val->comment;
+        }
+
         // * entity rules
         $input['entities_id'] = $this->entities_id;
 

--- a/tests/functional/Glpi/Inventory/Assets/Computer.php
+++ b/tests/functional/Glpi/Inventory/Assets/Computer.php
@@ -1689,4 +1689,80 @@ class Computer extends AbstractInventoryAsset
         //check hw description has been stored
         $this->string($computer->fields['comment'])->isIdenticalTo("describ'ed from registry");
     }
+
+    public function testOsCommentRuleLocation()
+    {
+        global $DB;
+        $computer = new \Computer();
+        $location = new \Location();
+        $locations_id = $location->add([
+            'name' => 'Caen',
+        ]);
+        $this->integer($locations_id)->isGreaterThan(0);
+
+        $rule = new \Rule();
+        $input = [
+            'is_active' => 1,
+            'name'      => 'Location os comment -> caen',
+            'match'     => 'AND',
+            'sub_type'  => 'RuleLocation',
+            'ranking'   => 1
+        ];
+        $rules_id = $rule->add($input);
+        $this->integer($rules_id)->isGreaterThan(0);
+
+        $rulecriteria = new \RuleCriteria();
+        $input = [
+            'rules_id'  => $rules_id,
+            'criteria'  => "oscomment",
+            'pattern'   => "Caen",
+            'condition' => \Rule::PATTERN_CONTAIN
+        ];
+        $this->integer($rulecriteria->add($input))->isGreaterThan(0);
+
+        $ruleaction = new \RuleAction();
+        $input = [
+            'rules_id'    => $rules_id,
+            'action_type' => 'assign',
+            'field'       => 'locations_id',
+            'value'       => $locations_id
+        ];
+        $this->integer($ruleaction->add($input))->isGreaterThan(0);
+
+        $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+        <REQUEST>
+        <CONTENT>
+          <HARDWARE>
+            <NAME>glpixps</NAME>
+            <DESCRIPTION>TECLIB-CAEN</DESCRIPTION>
+            <UUID>25C1BB60-5BCB-11D9-B18F-5404A6A534C4</UUID>
+          </HARDWARE>
+          <BIOS>
+            <MSN>640HP72316892</MSN>
+          </BIOS>
+          <VERSIONCLIENT>FusionInventory-Inventory_v2.4.1-2.fc28</VERSIONCLIENT>
+        </CONTENT>
+        <DEVICEID>glpixps.teclib.infra-2018-10-03-08-42-36</DEVICEID>
+        <QUERY>INVENTORY</QUERY>
+        </REQUEST>";
+
+        $inventory = $this->doInventory($xml_source, true);
+
+        //check created agent itemtype / deviceid / entities_id
+        $agents = $DB->request(['FROM' => \Agent::getTable()]);
+        $this->integer(count($agents))->isIdenticalTo(1);
+        $agent = $agents->current();
+        $this->array($agent)
+            ->string['deviceid']->isIdenticalTo('glpixps.teclib.infra-2018-10-03-08-42-36')
+            ->string['itemtype']->isIdenticalTo('Computer')
+            ->integer['entities_id']->isIdenticalTo(0); //root entity
+
+
+        $computers_id = $inventory->getItem()->fields['id'];
+        $this->integer($computers_id)->isGreaterThan(0);
+        //load / test computer entities_id root
+        $this->boolean($computer->getFromDB($computers_id))->isTrue();
+        $this->integer($computer->fields['locations_id'])->isEqualTo($locations_id);
+    }
+
 }

--- a/tests/functional/Glpi/Inventory/Assets/Computer.php
+++ b/tests/functional/Glpi/Inventory/Assets/Computer.php
@@ -1764,5 +1764,4 @@ class Computer extends AbstractInventoryAsset
         $this->boolean($computer->getFromDB($computers_id))->isTrue();
         $this->integer($computer->fields['locations_id'])->isEqualTo($locations_id);
     }
-
 }


### PR DESCRIPTION
Originally on ```usionInventory``` plugin, the ```oscomment``` field sent in the ```RuleLocation```was retrieved from the hardware ```descritpion -> description```  node

```php
if (isset($array['HARDWARE']['DESCRIPTION'])) {
     $a_inventory['fusioninventorycomputer']['oscomment'] = $array['HARDWARE']['DESCRIPTION'];
}
```


This PR retrive and add missing input before call ```RuleLocation```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30563
