### PR TITLE
fix(RuleImportAsset): use ignore_import instead of import denied no log from dataset

### DIFF
--- a/resources/Rules/RuleImportAsset.xml
+++ b/resources/Rules/RuleImportAsset.xml
@@ -25,8 +25,8 @@
         </rulecriteria>
         <ruleaction>
             <action_type>assign</action_type>
-            <field>_inventory</field>
-            <value>2</value>
+            <field>_ignore_import</field>
+            <value>1</value>
         </ruleaction>
     </rule>
     <rule>
@@ -381,8 +381,8 @@
         </rulecriteria>
         <ruleaction>
             <action_type>assign</action_type>
-            <field>_inventory</field>
-            <value>2</value>
+            <field>_ignore_import</field>
+            <value>1</value>
         </ruleaction>
     </rule>
     <rule>
@@ -774,8 +774,8 @@
         </rulecriteria>
         <ruleaction>
             <action_type>assign</action_type>
-            <field>_inventory</field>
-            <value>2</value>
+            <field>_ignore_import</field>
+            <value>1</value>
         </ruleaction>
     </rule>
     <rule>
@@ -803,8 +803,8 @@
         </rulecriteria>
         <ruleaction>
             <action_type>assign</action_type>
-            <field>_inventory</field>
-            <value>2</value>
+            <field>_ignore_import</field>
+            <value>1</value>
         </ruleaction>
     </rule>
     <rule>
@@ -953,8 +953,8 @@
         </rulecriteria>
         <ruleaction>
             <action_type>assign</action_type>
-            <field>_inventory</field>
-            <value>2</value>
+            <field>_ignore_import</field>
+            <value>1</value>
         </ruleaction>
     </rule>
     <rule>
@@ -982,8 +982,8 @@
         </rulecriteria>
         <ruleaction>
             <action_type>assign</action_type>
-            <field>_inventory</field>
-            <value>2</value>
+            <field>_ignore_import</field>
+            <value>1</value>
         </ruleaction>
     </rule>
     <rule>
@@ -1132,8 +1132,8 @@
         </rulecriteria>
         <ruleaction>
             <action_type>assign</action_type>
-            <field>_inventory</field>
-            <value>2</value>
+            <field>_ignore_import</field>
+            <value>1</value>
         </ruleaction>
     </rule>
     <rule>
@@ -1219,8 +1219,8 @@
         </rulecriteria>
         <ruleaction>
             <action_type>assign</action_type>
-            <field>_inventory</field>
-            <value>2</value>
+            <field>_ignore_import</field>
+            <value>1</value>
         </ruleaction>
     </rule>
     <rule>
@@ -1306,8 +1306,8 @@
         </rulecriteria>
         <ruleaction>
             <action_type>assign</action_type>
-            <field>_inventory</field>
-            <value>2</value>
+            <field>_ignore_import</field>
+            <value>1</value>
         </ruleaction>
     </rule>
     <rule>
@@ -1335,8 +1335,8 @@
         </rulecriteria>
         <ruleaction>
             <action_type>assign</action_type>
-            <field>_inventory</field>
-            <value>2</value>
+            <field>_ignore_import</field>
+            <value>1</value>
         </ruleaction>
     </rule>
     <rule>
@@ -1422,8 +1422,8 @@
         </rulecriteria>
         <ruleaction>
             <action_type>assign</action_type>
-            <field>_inventory</field>
-            <value>2</value>
+            <field>_ignore_import</field>
+            <value>1</value>
         </ruleaction>
     </rule>
     <rule>
@@ -1509,8 +1509,8 @@
         </rulecriteria>
         <ruleaction>
             <action_type>assign</action_type>
-            <field>_inventory</field>
-            <value>2</value>
+            <field>_ignore_import</field>
+            <value>1</value>
         </ruleaction>
     </rule>
     <rule>
@@ -1596,8 +1596,8 @@
         </rulecriteria>
         <ruleaction>
             <action_type>assign</action_type>
-            <field>_inventory</field>
-            <value>2</value>
+            <field>_ignore_import</field>
+            <value>1</value>
         </ruleaction>
     </rule>
     <rule>
@@ -1620,8 +1620,8 @@
         </rulecriteria>
         <ruleaction>
             <action_type>assign</action_type>
-            <field>_inventory</field>
-            <value>2</value>
+            <field>_ignore_import</field>
+            <value>1</value>
         </ruleaction>
     </rule>
     <rule>
@@ -1750,8 +1750,8 @@
         </rulecriteria>
         <ruleaction>
             <action_type>assign</action_type>
-            <field>_inventory</field>
-            <value>2</value>
+            <field>_ignore_import</field>
+            <value>1</value>
         </ruleaction>
     </rule>
     <rule>
@@ -1842,8 +1842,8 @@
         </rulecriteria>
         <ruleaction>
             <action_type>assign</action_type>
-            <field>_inventory</field>
-            <value>2</value>
+            <field>_ignore_import</field>
+            <value>1</value>
         </ruleaction>
     </rule>
     <rule>
@@ -1929,8 +1929,8 @@
         </rulecriteria>
         <ruleaction>
             <action_type>assign</action_type>
-            <field>_inventory</field>
-            <value>2</value>
+            <field>_ignore_import</field>
+            <value>1</value>
         </ruleaction>
     </rule>
 </rules>

--- a/tests/functional/Glpi/Inventory/Inventory.php
+++ b/tests/functional/Glpi/Inventory/Inventory.php
@@ -4050,7 +4050,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
             $rule->getFromDBByCrit(['name' => 'Computer import denied'])
         )->isTrue();
         $rules_id_refuse = $rule->fields['id'];
-        //udate action to refused import with no log
+        // update action to refused import with no log
         $action = new \RuleAction();
         $action->getFromDBByCrit([
             "rules_id" => $rules_id_refuse,

--- a/tests/functional/Glpi/Inventory/Inventory.php
+++ b/tests/functional/Glpi/Inventory/Inventory.php
@@ -4050,6 +4050,15 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
             $rule->getFromDBByCrit(['name' => 'Computer import denied'])
         )->isTrue();
         $rules_id_refuse = $rule->fields['id'];
+        //udate action to refused import with no log
+        $action = new \RuleAction();
+        $action->getFromDBByCrit([
+            "rules_id" => $rules_id_refuse,
+        ]);
+        $action->fields['field'] = '_inventory';
+        $action->fields['value'] = 2;
+        $action->update($action->fields);
+
 
         $this->boolean(
             $rule->getFromDBByCrit(['name' => 'Computer import (by name)'])


### PR DESCRIPTION
Since https://github.com/glpi-project/glpi/pull/15748

```import denied (no log) ``` no longer adds ```RefusedEquipement``` -> perfect

on the other hand, we should keep the default import denied with log.

The user can then decide to completely refuse the import without logging.

_it's frustrating to start the inventory and not have any information _

ATM I just modified the XMls dataset 

from : 
```xml
<ruleaction>
    <action_type>assign</action_type>  // assign
    <field>_inventory</field>          // inventory link
    <value>2</value>                   // import denied (no log)
</ruleaction>
```

to :

```xml
<ruleaction>
    <action_type>assign</action_type>  // assign
    <field>_ignore_import</field>      // refuse import action
    <value>1</value>                   // yes
</ruleaction>
```

I'm still hesitating to create a migration method

for people who don't have the reflex to "reset" the rules 

what do you think?


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
