### PR TITLE
Fix possibility to delete assets in Closed tickets

### DIFF
--- a/src/Item_Ticket.php
+++ b/src/Item_Ticket.php
@@ -383,13 +383,13 @@ class Item_Ticket extends CommonItilObject_Item
 
         $types_iterator = self::getDistinctTypes($instID);
         $number = count($types_iterator);
-
+        $ticket_closed = in_array($ticket->fields['status'], array_merge(
+            $ticket->getClosedStatusArray(),
+            $ticket->getSolvedStatusArray()
+        ));
         if (
             $canedit
-            && !in_array($ticket->fields['status'], array_merge(
-                $ticket->getClosedStatusArray(),
-                $ticket->getSolvedStatusArray()
-            ))
+            && !$ticket_closed
         ) {
             echo "<div class='firstbloc'>";
             echo "<form name='ticketitem_form$rand' id='ticketitem_form$rand' method='post'
@@ -427,9 +427,8 @@ class Item_Ticket extends CommonItilObject_Item
             Html::closeForm();
             echo "</div>";
         }
-
         echo "<div class='spaced'>";
-        if ($canedit && $number) {
+        if ($canedit && $number && !$ticket_closed) {
             Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
             $massiveactionparams = ['container' => 'mass' . __CLASS__ . $rand];
             Html::showMassiveActions($massiveactionparams);
@@ -439,7 +438,7 @@ class Item_Ticket extends CommonItilObject_Item
         $header_top    = '';
         $header_bottom = '';
         $header_end    = '';
-        if ($canedit && $number) {
+        if ($canedit && $number && !$ticket_closed) {
             $header_top    .= "<th width='10'>" . Html::getCheckAllAsCheckbox('mass' . __CLASS__ . $rand);
             $header_top    .= "</th>";
             $header_bottom .= "<th width='10'>" . Html::getCheckAllAsCheckbox('mass' . __CLASS__ . $rand);
@@ -484,7 +483,7 @@ class Item_Ticket extends CommonItilObject_Item
                     }
 
                     echo "<tr class='tab_bg_1'>";
-                    if ($canedit) {
+                    if ($canedit && !$ticket_closed) {
                         echo "<td width='10'>";
                         Html::showMassiveActionCheckBox(__CLASS__, $data["linkid"]);
                         echo "</td>";
@@ -521,7 +520,7 @@ class Item_Ticket extends CommonItilObject_Item
         }
 
         echo "</table>";
-        if ($canedit && $number) {
+        if ($canedit && $number && !$ticket_closed) {
             $massiveactionparams['ontop'] = false;
             Html::showMassiveActions($massiveactionparams);
             Html::closeForm();

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4403,28 +4403,27 @@ JAVASCRIPT;
                         || (Session::getCurrentInterface() == "central"
                             && $this->canUpdateItem());
         $can_requester = $this->canRequesterUpdateItem();
-        $canpriority   = (bool) Session::haveRight(self::$rightname, self::CHANGEPRIORITY);
         $canassign     = $this->canAssign();
         $canassigntome = $this->canAssignToMe();
 
+        $item_ticket = null;
         if ($ID && in_array($this->fields['status'], $this->getClosedStatusArray())) {
             $canupdate = false;
             // No update for actors
             $options['_noupdate'] = true;
+            $canpriority = false;
+        } else {
+            $item_ticket = new Item_Ticket();
+            $canpriority   = (bool) Session::haveRight(self::$rightname, self::CHANGEPRIORITY);
         }
 
         $sla = new SLA();
         $ola = new OLA();
-        $item_ticket = null;
 
         if ($this->isNewItem()) {
             $options['_canupdate'] = Session::haveRight('ticket', CREATE);
         } else {
             $options['_canupdate'] = Session::haveRight('ticket', UPDATE);
-        }
-
-        if ($options['_canupdate']) {
-            $item_ticket = new Item_Ticket();
         }
 
         TemplateRenderer::getInstance()->display('components/itilobject/layout.html.twig', [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15960

When a ticket is closed, massive actions and checkboxes are no longer displayed. In addition, the ability to "change" the priority of a closed ticket and to add an item to it has been removed.
**Before**
![image](https://github.com/glpi-project/glpi/assets/107540223/af7f93dc-839c-472f-8bbe-d37c92d01b03)
![image](https://github.com/glpi-project/glpi/assets/107540223/2fbe69a7-337f-4311-8740-cf9455563232)

**After**
![image](https://github.com/glpi-project/glpi/assets/107540223/4d442ef5-9399-4b70-bf89-f572d5a159fb)
![image](https://github.com/glpi-project/glpi/assets/107540223/a258f3b5-1f6e-44d4-83f2-f06fd1669c73)
