### PR TITLE
[HLAPI] Improved response information in Swagger

### DIFF
--- a/src/Api/HL/OpenAPIGenerator.php
+++ b/src/Api/HL/OpenAPIGenerator.php
@@ -588,18 +588,55 @@ EOT;
                 'tags' => $route_path->getRouteTags(),
                 'responses' => $response_schema,
             ];
-            if (!isset($path_schema['responses']['200'])) {
-                $path_schema['responses']['200'] = [
-                    'description' => 'Success'
-                ];
-            } else {
-                $path_schema['responses']['200']['produces'] = array_keys($response_schema[200]['content']);
+
+            $default_responses = [
+                '200' => [
+                    'description' => 'Success',
+                    'methods' => ['GET', 'PATCH'] // Usually only GET and PATCH methods return 200
+                ],
+                '201' => [
+                    'description' => 'Success (created)',
+                    'methods' => ['POST']
+                ],
+                '204' => [
+                    'description' => 'Success (no content)',
+                    'methods' => ['DELETE']
+                ],
+                '400' => [
+                    'description' => 'Bad request',
+                    'methods' => [] // Empty array means all methods
+                ],
+                '401' => [
+                    'description' => 'Unauthorized',
+                    'methods' => []
+                ],
+                '403' => [
+                    'description' => 'Forbidden',
+                    'methods' => []
+                ],
+                '404' => [
+                    'description' => 'Not found',
+                    'methods' => []
+                ],
+                '500' => [
+                    'description' => 'Internal server error',
+                    'methods' => []
+                ],
+            ];
+
+            foreach ($default_responses as $code => $info) {
+                if (!empty($info['methods']) && !in_array(strtoupper($method), $info['methods'], true)) {
+                    continue;
+                }
+                if (!isset($path_schema['responses'][$code])) {
+                    $path_schema['responses'][$code] = [
+                        'description' => $info['description']
+                    ];
+                } else {
+                    $path_schema['responses'][$code]['produces'] = array_keys($response_schema[(int) $code]['content']);
+                }
             }
-            if (!isset($path_schema['responses']['500'])) {
-                $path_schema['responses']['500'] = [
-                    'description' => 'Internal server error'
-                ];
-            }
+
             $request_body = $this->getRequestBodySchema($route_path, $route_method);
 
             if ($route_doc !== null) {

--- a/src/Api/HL/OpenAPIGenerator.php
+++ b/src/Api/HL/OpenAPIGenerator.php
@@ -596,7 +596,31 @@ EOT;
                 ],
                 '201' => [
                     'description' => 'Success (created)',
-                    'methods' => ['POST']
+                    'methods' => ['POST'],
+                    'headers' => [
+                        'Location' => [
+                            'description' => 'The URL of the newly created resource',
+                            'schema' => [
+                                'type' => 'string'
+                            ]
+                        ]
+                    ],
+                    'content' => [
+                        'application/json' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'properties' => [
+                                    'id' => [
+                                        'type' => 'integer',
+                                        'format' => 'int64'
+                                    ],
+                                    'href' => [
+                                        'type' => 'string'
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
                 ],
                 '204' => [
                     'description' => 'Success (no content)',
@@ -604,34 +628,35 @@ EOT;
                 ],
                 '400' => [
                     'description' => 'Bad request',
-                    'methods' => [] // Empty array means all methods
                 ],
                 '401' => [
                     'description' => 'Unauthorized',
-                    'methods' => []
                 ],
                 '403' => [
                     'description' => 'Forbidden',
-                    'methods' => []
                 ],
                 '404' => [
                     'description' => 'Not found',
-                    'methods' => []
                 ],
                 '500' => [
                     'description' => 'Internal server error',
-                    'methods' => []
                 ],
             ];
 
             foreach ($default_responses as $code => $info) {
-                if (!empty($info['methods']) && !in_array(strtoupper($method), $info['methods'], true)) {
+                if (isset($info['methods']) && !in_array(strtoupper($method), $info['methods'], true)) {
                     continue;
                 }
                 if (!isset($path_schema['responses'][$code])) {
                     $path_schema['responses'][$code] = [
-                        'description' => $info['description']
+                        'description' => $info['description'],
                     ];
+                    if (isset($info['headers'])) {
+                        $path_schema['responses'][$code]['headers'] = $info['headers'];
+                    }
+                    if (isset($info['content'])) {
+                        $path_schema['responses'][$code]['content'] = $info['content'];
+                    }
                 } else {
                     $path_schema['responses'][$code]['produces'] = array_keys($response_schema[(int) $code]['content']);
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Currently, the OpenAPI documentation generator automatically adds a 200 and 500 code response if they aren't defined already in the route documentation attributes. However, the 200 response isn't valid/expected on all endpoints. For example, a POST endpoint creating an item should return 201 if it worked and a DELETE endpoint should only return 204 when successful.

This PR adds some logic to determine the applicable responses based on the route method, additional possible codes, and an in-depth explanation of the default 201 response including the response body and the presence of the `Location` response header.