### PR TITLE
Monaco editors for webhook url and headers

### DIFF
--- a/js/modules/Monaco/MonacoEditor.js
+++ b/js/modules/Monaco/MonacoEditor.js
@@ -45,13 +45,36 @@ export default class MonacoEditor {
      * @param {string} language The code language
      * @param {string} value The default value for the editor
      * @param {CompletionItemDefinition[]} completions List of completion items
+     * @param {object} options Other options for the editor
      */
-    constructor(element_id, language, value = '', completions = []) {
+    constructor(element_id, language, value = '', completions = [], options = {}) {
         const el = document.getElementById(element_id);
         const trigger_characters = {
             twig: ['{', ' '],
         };
-        window.monaco.languages.registerCompletionItemProvider(language, {
+
+        // Stupid workaround to allow multiple Monaco editors to be created for the same language but with different completions
+        // since it registers completions by langauge in a global variable rather than allowing it to be instance-specific
+        const existing_lang = window.monaco.languages.getLanguages().find((lang) => lang.id === language);
+        const new_lang_id = 'glpi_' + language + '_' + Math.random().toString(36).substring(2, 15);
+
+        // register new language based on existing one's tokenizer
+        window.monaco.languages.register({
+            id: new_lang_id,
+            extensions: existing_lang.extensions,
+            aliases: existing_lang.aliases,
+            mimetypes: existing_lang.mimetypes
+        });
+
+        // Can't just specify the loader when registering the language apparently...
+        async function registerNewLangLoaderData() {
+            const loader = await existing_lang.loader();
+            window.monaco.languages.setMonarchTokensProvider(new_lang_id, loader.language);
+            window.monaco.languages.setLanguageConfiguration(new_lang_id, loader.conf);
+        }
+        registerNewLangLoaderData();
+
+        window.monaco.languages.registerCompletionItemProvider(new_lang_id, {
             triggerCharacters: trigger_characters[language] ?? [],
             provideCompletionItems: function (model, position) {
                 const word = model.getWordUntilPosition(position);
@@ -115,10 +138,77 @@ export default class MonacoEditor {
                 };
             }
         });
-        this.editor = window.monaco.editor.create(el, {
+        this.editor = window.monaco.editor.create(el, Object.assign({
             value: value,
-            language: language,
-        });
+            language: new_lang_id,
+        }, options));
+
+        if (options._single_line_editor) {
+            // force cursor to stay on the first line
+            this.editor.onDidChangeCursorPosition((e) => {
+                if (e.position.lineNumber !== 1) {
+                    this.editor.setValue(this.editor.getValue().trim());
+                    this.editor.setPosition({lineNumber: 1, column: Infinity});
+                }
+            });
+            this.editor.addAction({
+                id: 'blockNewline',
+                label: 'Block newline',
+                keybindings: [window.monaco.KeyCode.Enter],
+                run: () => {
+                    this.editor.setValue(this.editor.getValue().trim());
+                    this.editor.setPosition({lineNumber: 1, column: Infinity});
+                }
+            });
+        }
+    }
+
+    /**
+     * Get a set of options for Monaco editor that are suitable for a single line editor (similar to a text input but with syntax highlighting and suggestions)
+     */
+    static get singleLineEditorOptions() {
+        const font_size = $(document.body).css('font-size').replace('px', '');
+        return {
+            _single_line_editor: true, // Used by us only. The constructor will see this and do extra stuff.
+            acceptSuggestionOnEnter: "on",
+            contextmenu: false,
+            cursorStyle: "line-thin",
+            find: {
+                addExtraSpaceOnTop: false,
+                autoFindInSelection: "never",
+                seedSearchStringFromSelection: "never"
+            },
+            fixedOverflowWidgets: true,
+            folding: false,
+            fontSize: font_size,
+            fontWeight: "normal",
+            glyphMargin: false,
+            hideCursorInOverviewRuler: true,
+            hover: {
+                delay: 100
+            },
+            lineDecorationsWidth: 0,
+            lineNumbers: "off",
+            lineNumbersMinChars: 0,
+            links: false,
+            minimap: {
+                enabled: false
+            },
+            occurrencesHighlight: false,
+            overviewRulerBorder: false,
+            overviewRulerLanes: 0,
+            quickSuggestions: false,
+            renderLineHighlight: "none",
+            roundedSelection: false,
+            scrollBeyondLastColumn: 0,
+            scrollbar: {
+                horizontal: "hidden",
+                vertical: "hidden",
+                alwaysConsumeMouseWheel: false
+            },
+            wordBasedSuggestions: false,
+            wordWrap: "off",
+        };
     }
 }
 

--- a/js/modules/Monaco/MonacoEditor.js
+++ b/js/modules/Monaco/MonacoEditor.js
@@ -138,12 +138,16 @@ export default class MonacoEditor {
                 };
             }
         });
+        const dark_theme = $('html').attr('data-glpi-theme-dark') === '1';
         this.editor = window.monaco.editor.create(el, Object.assign({
             value: value,
             language: new_lang_id,
+            theme: dark_theme ? 'vs-dark' : 'vs'
         }, options));
 
         if (options._single_line_editor) {
+            $(el).find('.monaco-editor').get(0).style.setProperty('--vscode-editor-background', 'transparent');
+            $(el).find('.monaco-editor').get(0).style.setProperty('font', 'inherit');
             // force cursor to stay on the first line
             this.editor.onDidChangeCursorPosition((e) => {
                 if (e.position.lineNumber !== 1) {

--- a/js/modules/Monaco/MonacoEditor.js
+++ b/js/modules/Monaco/MonacoEditor.js
@@ -155,13 +155,10 @@ export default class MonacoEditor {
                     this.editor.setPosition({lineNumber: 1, column: Infinity});
                 }
             });
-            this.editor.addAction({
-                id: 'blockNewline',
-                label: 'Block newline',
-                keybindings: [window.monaco.KeyCode.Enter],
-                run: () => {
-                    this.editor.setValue(this.editor.getValue().trim());
-                    this.editor.setPosition({lineNumber: 1, column: Infinity});
+            this.editor.onDidChangeModelContent(() => {
+                // Remove all newlines but only if there are newlines (to avoid infinite loop)
+                if (this.editor.getValue().match(/\n/g)) {
+                    this.editor.setValue(this.editor.getValue().replace(/\n/g, ''));
                 }
             });
         }

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -724,7 +724,8 @@ class Webhook extends CommonDBTM implements FilterableInterface
         $this->initForm($id, $options);
 
         TemplateRenderer::getInstance()->display('pages/setup/webhook/webhook.html.twig', [
-            'item' => $this
+            'item' => $this,
+            'response_schema' => $this->getMonacoSuggestions(),
         ]);
 
         return true;
@@ -804,6 +805,7 @@ class Webhook extends CommonDBTM implements FilterableInterface
         TemplateRenderer::getInstance()->display('pages/setup/webhook/webhook_headers.html.twig', [
             'item' => $this,
             'item_fields' => $item_fields,
+            'response_schema' => $this->getMonacoSuggestions(),
             'params' => [
                 'candel' => false,
                 'formfooter' => false,
@@ -896,7 +898,7 @@ class Webhook extends CommonDBTM implements FilterableInterface
         return $controller_class::getKnownSchemas()[$schema_name] ?? null;
     }
 
-    private function showPayloadEditor(): void
+    private function getMonacoSuggestions(): array
     {
         $schema = self::getAPISchemaBySupportedItemtype($this->fields['itemtype']);
         $props = Schema::flattenProperties($schema['properties'], 'item.');
@@ -933,12 +935,19 @@ class Webhook extends CommonDBTM implements FilterableInterface
             if ($applicable_types !== array_keys($subtype_labels) && count($applicable_types)) {
                 //Note: In cases of child properties, there may not be any applicable types listed. They are handled at the top level only.
                 $suggestion['detail'] = '[' . implode(', ', array_map(static function ($type) use ($subtype_labels) {
-                    return $subtype_labels[$type];
-                }, $applicable_types)) . ']';
+                        return $subtype_labels[$type];
+                    }, $applicable_types)) . ']';
             }
 
             $response_schema[] = $suggestion;
         }
+        return $response_schema;
+    }
+
+    private function showPayloadEditor(): void
+    {
+        $schema = self::getAPISchemaBySupportedItemtype($this->fields['itemtype']);
+        $response_schema = $this->getMonacoSuggestions();
 
         TemplateRenderer::getInstance()->display('pages/setup/webhook/payload_editor.html.twig', [
             'item' => $this,

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -935,8 +935,8 @@ class Webhook extends CommonDBTM implements FilterableInterface
             if ($applicable_types !== array_keys($subtype_labels) && count($applicable_types)) {
                 //Note: In cases of child properties, there may not be any applicable types listed. They are handled at the top level only.
                 $suggestion['detail'] = '[' . implode(', ', array_map(static function ($type) use ($subtype_labels) {
-                        return $subtype_labels[$type];
-                    }, $applicable_types)) . ']';
+                    return $subtype_labels[$type];
+                }, $applicable_types)) . ']';
             }
 
             $response_schema[] = $suggestion;

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -678,7 +678,7 @@
    {% endif %}
 
    {% set value %}
-      <span class="{{ wrapper_class }}">{{ value|raw }}</span>
+      <span class="{{ options.wrapper_class }}">{{ value|raw }}</span>
    {% endset %}
    {{ _self.field(name, value, label, options) }}
 {% endmacro %}

--- a/templates/pages/setup/webhook/webhook.html.twig
+++ b/templates/pages/setup/webhook/webhook.html.twig
@@ -84,14 +84,27 @@
 
     {{ fields.largeTitle(_n('Target', 'Targets', 1), 'ti ti-viewfinder') }}
 
-    {{ fields.textField(
-        'url',
-        item.fields['url'],
-        __('URL'),
-        field_options|merge({
-            helper: __('It is strongly advised to use the HTTPS protocol.') ~ ' ' ~ __('You may use the same placeholder tags as in the payload content and header values.')
-        })
-    ) }}
+    {% set url_editor_container_id = 'url_' ~ random() %}
+    {% set url_editor_container %}
+        <div id="{{ url_editor_container_id }}" class="webhook_url form-control overflow-hidden" style="height: 36px"></div>
+    {% endset %}
+    {{ fields.htmlField('url', url_editor_container, __('URL'), field_options|merge({
+        wrapper_class: 'd-flex flex-grow-1',
+        helper: __('It is strongly advised to use the HTTPS protocol.') ~ ' ' ~ __('You may use the same placeholder tags as in the payload content and header values.')
+    })) }}
+    <script>
+        const editor_options = window.GLPI.MonacoEditor.singleLineEditorOptions;
+        new window.GLPI.MonacoEditor('{{ url_editor_container_id }}', 'twig', '{{ item.fields['url']|raw }}', {{ response_schema|json_encode|raw }}, editor_options);
+        $('#{{ url_editor_container_id }}').closest('form').on('formdata', (e) => {
+            const editors = window.monaco.editor.getEditors().filter((editor) => {
+                return editor._domElement.classList.contains('webhook_url');
+            });
+            if (editors.length) {
+                e.originalEvent.formData.delete('url');
+                e.originalEvent.formData.append('url', editors[0].getValue());
+            }
+        });
+    </script>
 
     {{ fields.dropdownArrayField(
         'http_method',

--- a/templates/pages/setup/webhook/webhook_headers.html.twig
+++ b/templates/pages/setup/webhook/webhook_headers.html.twig
@@ -77,7 +77,6 @@
               const custom_header_fields_container = $('div.custom-header-fields');
               const template = $($('#custom-header-fields-template').html());
               const header_name_field = template.find('input[name="header_name[]"]');
-              //const header_value_field = template.find('input[name="header_value[]"]');
               const header_value_id = `header_value${Math.round(Math.random() * 1000000)}`;
               $(``).insertAfter(template.find('input[name="header_value[]"]'));
               template.find('div.header_value').prop('id', header_value_id);
@@ -85,7 +84,6 @@
               const editor_options = window.GLPI.MonacoEditor.singleLineEditorOptions;
               if (readonly) {
                   header_name_field.prop('readonly', true);
-                  //header_value_field.prop('readonly', true);
                   // Delete the remove button
                   template.find('button[name="remove_header"]').remove();
                   editor_options.readOnly = true;

--- a/templates/pages/setup/webhook/webhook_headers.html.twig
+++ b/templates/pages/setup/webhook/webhook_headers.html.twig
@@ -50,23 +50,23 @@
                </button>
             {% endset %}
             {% set header_value_autocomplete %}
-               <input type="hidden" name="header_value[]" value="">
-               <div class="header_value_autocomplete"></div>
+                <div class="header_value form-control overflow-hidden" style="height: 36px"></div>
             {% endset %}
             {{ fields.htmlField('header_value[]', header_value_autocomplete, '', {
                no_label: true,
-               field_class: 'ms-2 h-100 d-flex col-4 justify-content-center',
+               field_class: 'ms-2 h-100 d-flex col-5 justify-content-center',
+               wrapper_class: 'd-flex flex-grow-1',
                add_field_html: remove_btn,
             }) }}
          {% endset %}
          {{ fields.field('custom_header[]', header_field_pair, '', {
             no_label: true,
-            field_class: 'col-12 d-flex custom-header-field-pair align-items-center',
+            field_class: 'col-12 d-flex custom-header-field-pair',
          }) }}
       </template>
 
       <div class="custom-header-fields">
-         <button class="btn btn-secondard" name="add_header" type="button">
+         <button class="btn btn-secondary" name="add_header" type="button">
             <i class="ti ti-plus"></i>
             {{ __('Add a custom header') }}
          </button>
@@ -77,63 +77,22 @@
               const custom_header_fields_container = $('div.custom-header-fields');
               const template = $($('#custom-header-fields-template').html());
               const header_name_field = template.find('input[name="header_name[]"]');
-              const header_value_field = template.find('input[name="header_value[]"]');
+              //const header_value_field = template.find('input[name="header_value[]"]');
+              const header_value_id = `header_value${Math.round(Math.random() * 1000000)}`;
+              $(``).insertAfter(template.find('input[name="header_value[]"]'));
+              template.find('div.header_value').prop('id', header_value_id);
               header_name_field.val(name);
-              header_value_field.val(value);
+              const editor_options = window.GLPI.MonacoEditor.singleLineEditorOptions;
               if (readonly) {
                   header_name_field.prop('readonly', true);
-                  header_value_field.prop('readonly', true);
+                  //header_value_field.prop('readonly', true);
                   // Delete the remove button
                   template.find('button[name="remove_header"]').remove();
+                  editor_options.readOnly = true;
               }
               // insert the template before the add button
-              let container = $(template).insertBefore(custom_header_fields_container.find('button[name="add_header"]'));
-              // init autocomplete
-              container = container.find('.header_value_autocomplete');
-              container.attr('id', `header_value_autocomplete${Math.round(Math.random() * 1000000)}`);
-              const item_fields = {{ item_fields|keys|json_encode|raw }};
-              const opts = [];
-              $.each(item_fields, (i, v) => {
-                  {% verbatim %}
-                  opts.push({ label: `{{ ${v} }}`, value: `{{ ${v} }}` });
-                  {% endverbatim %}
-              });
-              container.data('autocomplete', window.autocomplete({
-                  'container': `#${container.attr('id')}`,
-                  'detachedMediaQuery': 'none',
-                  'openOnFocus': !readonly,
-                  onStateChange({ state }) {
-                      container.parent().find('input[name="header_value[]"]').val(state.query);
-                  },
-                  getSources({ query }) {
-                      if (readonly) {
-                          return [];
-                      }
-                      return [
-                          {
-                              sourceId: 'fields',
-                              getItems() {
-                                  return opts.filter(({ label }) => label.toLowerCase().includes(query.toLowerCase()));
-                              },
-                              templates: {
-                                  noResults() {
-                                      return 'No results';
-                                  },
-                                  item({ item, html }) {
-                                      return html`<div class="item_field_option py-1 my-n1">${item.label}</div>`;
-                                  },
-                              }
-                          },
-                      ];
-                  },
-              }));
-              container.data('autocomplete').setQuery(value);
-              if (readonly) {
-                  container.find('.aa-Input').prop('readonly', true);
-                  container.find('.aa-Input').css('width', 'calc(100% - 3rem)');
-              } else {
-                  container.find('.aa-Input').css('width', 'calc(100% - 1rem)');
-              }
+              $(template).insertBefore(custom_header_fields_container.find('button[name="add_header"]'));
+              new window.GLPI.MonacoEditor(header_value_id, 'twig', value, {{ response_schema|json_encode|raw }}, editor_options);
           };
           $(() => {
               const known_custom = {{ item.fields['custom_headers']|default([])|json_encode(constant('JSON_FORCE_OBJECT'))|raw }};
@@ -151,27 +110,21 @@
                   $(e.target).closest('.custom-header-field-pair').remove();
               });
 
-              $('body').on('click', '.aa-List .item_field_option', (e) => {
-                  const selected = $(e.target);
-                  const list_id = selected.closest('.aa-List').attr('id');
-                  // the autocomplete id is the first two parts of the list id (ex: autocomplete-1-0-List -> autocomplete-1)
-                  const autocomplete_id = list_id.split('-').slice(0, 2).join('-') + '-input';
-                  $(`#${autocomplete_id}`).closest('.header_value_autocomplete').data('autocomplete').setQuery(selected.text());
-              });
-              $('body').on('click', (e) => {
-                  // Close panels when clicking outside of them unless we click on another input,
-                  // in which case we close all panels except the panel for the one we clicked on
-                  if ($(e.target).closest('.aa-Panels, .aa-Input').length === 0) {
-                      $.each($('.header_value_autocomplete'), (i, v) => {
-                          $(v).data('autocomplete').setIsOpen(false);
-                      });
-                  } else if ($(e.target).closest('.aa-Input').length > 0) {
-                      $.each($('.header_value_autocomplete'), (i, v) => {
-                          if (!$(v).find('.aa-Input').is($(e.target))) {
-                              $(v).data('autocomplete').setIsOpen(false);
-                          }
-                      });
-                  }
+              // Add formdata handler to inject the custom header values from the monaco editors
+              $('div.custom-header-fields').closest('form').on('formdata', (e) => {
+                  const editors = window.monaco.editor.getEditors().filter((editor) => {
+                      return editor._domElement.classList.contains('header_value');
+                  });
+                  // remove all header_name[] and header_value[] from the formdata
+                  e.originalEvent.formData.delete('header_name[]');
+                  e.originalEvent.formData.delete('header_value[]');
+
+                  $(editors).each((i, editor) => {
+                      const header_name = $(editor._domElement).closest('.custom-header-field-pair').find('input[name="header_name[]"]').val();
+                      const header_value = editor.getValue();
+                      e.originalEvent.formData.append('header_name[]', header_name);
+                      e.originalEvent.formData.append('header_value[]', header_value);
+                  });
               });
           });
       </script>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Currently, the URL, custom headers, and payload are all processed as twig templates. However, only the payload editor was actually using Monaco. The custom header value inputs were using a basic autocomplete which didn't make sense if you wanted more than just a single item property on its own. The URL field didn't have any autocomplete, so it wasn't obvious that it could accept twig tags.

This PR adds:
1. A helper function that returns a set of editor options that lets you configure an editor to mimic a `text` input with a single line.
2. A workaround for the global registration of completion items per language which makes having multiple editors a pain. This workaround involves registering a copy of the requested language per-editor which allows each editor to then have its own set of completions.
3. URL and custom header value inputs replaced with single-line Monaco editors. A `formdata` event listener is used in the forms to inject the Monaco editor values into the form data during submission.

This PR also includes a fix for the `wrapper_class` option in the `htmlField` macro.