### PR TITLE
Fix stat export

### DIFF
--- a/front/stat.tracking.php
+++ b/front/stat.tracking.php
@@ -125,7 +125,7 @@ Html::printPager(
     $params['start'],
     count($val),
     $CFG_GLPI['root_doc'] . '/front/stat.tracking.php',
-    http_build_query($params),
+    http_build_query($params, '', '&amp;'),
     'Stat',
     $params
 );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Data passed to `ajax/report.dynamic.php` was all combined as the value for `itemtype` instead of separated due to `Html::printPager` expecting each parameter to be separated by `&amp;` not `&`.