### PR TITLE
Fix PathInfo parsing in PHP router

### DIFF
--- a/src/Http/ProxyRouter.php
+++ b/src/Http/ProxyRouter.php
@@ -58,21 +58,40 @@ final class ProxyRouter
      */
     private ?string $pathinfo;
 
-    public function __construct(string $root_dir, string $path)
+    public function __construct(string $root_dir, string $uri)
     {
         $this->root_dir = $root_dir;
 
-        $path = preg_replace('/\/{2,}/', '/', $path); // remove duplicates `/`
+        $uri = preg_replace('/\/{2,}/', '/', $uri); // remove duplicates `/`
 
-        $path_matches = [];
-        if (
-            preg_match('/^(?<path>.+\.[^\/]+)(?<pathinfo>\/.*)$/', $path, $path_matches) === 1
-            && is_file($this->root_dir . $path_matches['path'])
-        ) {
-            // Separate path and pathinfo.
-            $path     = $path_matches['path'];
-            $pathinfo = $path_matches['pathinfo'];
-        } else {
+        $path     = null;
+        $pathinfo = null;
+
+        // Parse URI to find requested script and PathInfo
+        $slash_pos = 0;
+        while ($slash_pos !== false && ($dot_pos = strpos($uri, '.', $slash_pos)) !== false) {
+            $slash_pos = strpos($uri, '/', $dot_pos);
+            $filepath = substr($uri, 0, $slash_pos !== false ? $slash_pos : strlen($uri));
+            if (is_file($this->root_dir . $filepath)) {
+                $path = $filepath;
+
+                $pathinfo = substr($uri, strlen($filepath));
+                if ($pathinfo !== '') {
+                    // On any regular PHP script that is directly served by Apache, `$_SERVER['PATH_INFO']`
+                    // contains decoded URL.
+                    // We have to reproduce this decoding operation to prevent issues with endoded chars.
+                    $pathinfo = urldecode($pathinfo);
+                } else {
+                    $pathinfo = null;
+                }
+                break;
+            }
+        }
+
+        if ($path === null) {
+            // Fallback to requested URI
+            $path = $uri;
+
             // Clean trailing `/`.
             $path = rtrim($path, '/');
 
@@ -80,8 +99,6 @@ final class ProxyRouter
             if (is_dir($this->root_dir . $path) && is_file($this->root_dir . $path . '/index.php')) {
                 $path .= '/index.php';
             }
-
-            $pathinfo = null;
         }
 
         $this->path     = $path;

--- a/tests/units/Glpi/Http/ProxyRouter.php
+++ b/tests/units/Glpi/Http/ProxyRouter.php
@@ -55,6 +55,11 @@ class ProxyRouter extends \GLPITestCase
                     'common.js' => 'console.log("ok");',
                 ],
                 'marketplace' => [
+                    'myplugin' => [
+                        'some.dir' => [
+                            'file.test.php' => '<?php //a PHP script in a dir that contains a dot',
+                        ],
+                    ],
                     'mystaleplugin' => [
                         'front' => [
                             'page.php5' => '<?php //a PHP5 script',
@@ -67,6 +72,7 @@ class ProxyRouter extends \GLPITestCase
                     ],
                 ],
                 'apirest.php' => '<php echo(1);',
+                'caldav.php' => '<php echo(1);',
                 'index.php' => '<php echo(1);',
             ]
         );
@@ -114,6 +120,13 @@ class ProxyRouter extends \GLPITestCase
 
         // Path to an existing file, but containing an extra PathInfo
         yield [
+            'path'            => '/apirest.php/',
+            'target_path'     => '/apirest.php',
+            'target_pathinfo' => '/',
+            'target_file'     => vfsStream::url('glpi/apirest.php'),
+            'is_php_script'   => true,
+        ];
+        yield [
             'path'            => '/apirest.php/initSession/',
             'target_path'     => '/apirest.php',
             'target_pathinfo' => '/initSession/',
@@ -125,6 +138,20 @@ class ProxyRouter extends \GLPITestCase
             'target_path'     => '/apirest.php',
             'target_pathinfo' => '/initSession/',
             'target_file'     => vfsStream::url('glpi/apirest.php'),
+            'is_php_script'   => true,
+        ];
+        yield [
+            'path'            => '/apirest.php/GlpiPlugin%5CNamespace%5CUnexemple/',
+            'target_path'     => '/apirest.php',
+            'target_pathinfo' => '/GlpiPlugin\Namespace\Unexemple/',
+            'target_file'     => vfsStream::url('glpi/apirest.php'),
+            'is_php_script'   => true,
+        ];
+        yield [
+            'path'            => '/caldav.php/calendars/users/J.DUPONT/calendar/',
+            'target_path'     => '/caldav.php',
+            'target_pathinfo' => '/calendars/users/J.DUPONT/calendar/',
+            'target_file'     => vfsStream::url('glpi/caldav.php'),
             'is_php_script'   => true,
         ];
 
@@ -144,6 +171,22 @@ class ProxyRouter extends \GLPITestCase
             'target_pathinfo' => null,
             'target_file'     => vfsStream::url('glpi/js/common.js'),
             'is_php_script'   => false,
+        ];
+
+        // Path to a PHP script in a directory that has a dot in its name.
+        yield [
+            'path'            => '/marketplace/myplugin/some.dir/file.test.php',
+            'target_path'     => '/marketplace/myplugin/some.dir/file.test.php',
+            'target_pathinfo' => null,
+            'target_file'     => vfsStream::url('glpi/marketplace/myplugin/some.dir/file.test.php'),
+            'is_php_script'   => true,
+        ];
+        yield [
+            'path'            => '/marketplace/myplugin/some.dir/file.test.php/path/to/item',
+            'target_path'     => '/marketplace/myplugin/some.dir/file.test.php',
+            'target_pathinfo' => '/path/to/item',
+            'target_file'     => vfsStream::url('glpi/marketplace/myplugin/some.dir/file.test.php'),
+            'is_php_script'   => true,
         ];
 
         // Path to a `.php5` script.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #16035 !29545 !30449

1. When the URL contains encoded chars (e.g. `/apirest.php/GlpiPlugin%5CNamespace%5CUnexemple/`), the resulting `$_SERVER['PATH_INFO']` should correspond to the decoded char (i.e. `/GlpiPlugin\Namespace\Unexemple/`). This is how it works when file is directly served by a web server (validated on Apache), so we should reproduce the same behaviour in our PHP router.

2. When the URL contains multiple dots, it is not safe to rely on a regex to extract a possible filename (see screenshot below). I replace this by a `while` loop that will analyze all possible filenames until it found a valid one.
![image](https://github.com/glpi-project/glpi/assets/33253653/a09856fd-de52-4814-8169-2f82bfce6d3f)
