### PR TITLE
fix(network port): warning message in log

### DIFF
--- a/src/NetworkPort_NetworkPort.php
+++ b/src/NetworkPort_NetworkPort.php
@@ -183,11 +183,12 @@ class NetworkPort_NetworkPort extends CommonDBRelation
      */
     public function disconnectFrom($ports_id)
     {
-        $opposite_id = $this->getOppositeContact($ports_id);
-        if ($opposite_id && $this->getFromDBForNetworkPort($opposite_id) || $this->getFromDBForNetworkPort($ports_id)) {
-            return $this->delete($this->fields);
-        }
-        return true; // Nothing to disconnect
+        return $this->deleteByCriteria([
+            'OR'  => [
+                'networkports_id_1'  => $ports_id,
+                'networkports_id_2'  => $ports_id,
+            ]
+        ]);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30599


Prevent this warning message:

```
glpiphplog.WARNING:   *** PHP User Warning (512): getFromDBByCrit expects to get one result, 23 found in query "SELECT `id` FROM `glpi_networkports_networkports` WHERE (`glpi_networkports_networkports`.`networkports_id_1` = '9967539' OR `glpi_networkports_networkports`.`networkports_id_2` = '9967539')". in www\glpi\src\CommonDBTM.php at line 391
  Backtrace :
  src\CommonDBTM.php:391                             trigger_error()
  src\NetworkPort_NetworkPort.php:62                 CommonDBTM->getFromDBByCrit()
  src\NetworkPort_NetworkPort.php:186                NetworkPort_NetworkPort->getFromDBForNetworkPort()
  src\NetworkPort_NetworkPort.php:138                NetworkPort_NetworkPort->disconnectFrom()
  src\Inventory\Asset\NetworkPort.php:880            NetworkPort_NetworkPort->connectToHub()
  src\Inventory\Asset\NetworkPort.php:368            Glpi\Inventory\Asset\NetworkPort->handleHub()
  src\Inventory\Asset\NetworkPort.php:609            Glpi\Inventory\Asset\NetworkPort->handleMacConnection()
  src\Inventory\Asset\NetworkPort.php:631            Glpi\Inventory\Asset\NetworkPort->handleConnections()
  src\Inventory\Asset\NetworkPort.php:621            Glpi\Inventory\Asset\NetworkPort->portChanged()
  src\Inventory\Asset\InventoryNetworkPort.php:515   Glpi\Inventory\Asset\NetworkPort->portUpdated()
  src\Inventory\Asset\InventoryNetworkPort.php:121   Glpi\Inventory\Asset\NetworkPort->handleUpdates()
  src\Inventory\Asset\NetworkPort.php:823            Glpi\Inventory\Asset\NetworkPort->handlePortsTrait()
  src\Inventory\Asset\NetworkPort.php:616            Glpi\Inventory\Asset\NetworkPort->handlePorts()
  src\Inventory\Asset\MainAsset.php:937              Glpi\Inventory\Asset\NetworkPort->handle()
  src\Inventory\Asset\MainAsset.php:852              Glpi\Inventory\Asset\MainAsset->handleAssets()
  src\Inventory\Asset\NetworkEquipment.php:228       Glpi\Inventory\Asset\MainAsset->rulepassed()
  src\RuleImportAsset.php:969                        Glpi\Inventory\Asset\NetworkEquipment->rulepassed()
  src\Rule.php:1533                                  RuleImportAsset->executeActions()
  src\RuleCollection.php:1640                        Rule->process()
  src\Inventory\Asset\MainAsset.php:574              RuleCollection->processAllRules()
  src\Inventory\Inventory.php:722                    Glpi\Inventory\Asset\MainAsset->handle()
  src\Inventory\Inventory.php:353                    Glpi\Inventory\Inventory->handleItem()
  ...inc\communicationnetworkinventory.class.php:169 Glpi\Inventory\Inventory->doInventory()
  marketplace\glpiinventory\hook.php:1085            PluginGlpiinventoryCommunicationNetworkInventory->import()
  src\Plugin.php:1714                                plugin_glpiinventory_network_inventory()
  src\Inventory\Request.php:276                      Plugin::doHookFunction()
  src\Inventory\Request.php:250                      Glpi\Inventory\Request->network()
  src\Inventory\Request.php:98                       Glpi\Inventory\Request->networkInventory()
  src\Agent\Communication\AbstractRequest.php:332    Glpi\Inventory\Request->handleAction()
  src\Agent\Communication\AbstractRequest.php:269    Glpi\Agent\Communication\AbstractRequest->handleXMLRequest()
  front\inventory.php:94                             Glpi\Agent\Communication\AbstractRequest->handleRequest()
  ...tplace\glpiinventory\front\communication.php:72 include_once()
  marketplace\glpiinventory\index.php:45             include_once()
  public\index.php:82                                require()
```
