### PR TITLE
fix(IPNetwork): Don't display unicity check result from native inventory process

### DIFF
--- a/src/IPNetwork.php
+++ b/src/IPNetwork.php
@@ -380,11 +380,9 @@ class IPNetwork extends CommonImplicitTreeDropdown
             $sameNetworks = self::searchNetworks("equals", $params, $entities_id, false);
            // Check unicity !
             if ($sameNetworks && (count($sameNetworks) > 0)) {
-                $return = ['input' => false];
-                if (!isset($input['_no_message'])) {
-                    $return['error'] = __('Network already defined in visible entities');
-                }
-                return $return;
+                return ['error' => __('Network already defined in visible entities'),
+                    'input' => false
+                ];
             }
 
            // Then, update $input to reflect the network and the netmask
@@ -463,7 +461,7 @@ class IPNetwork extends CommonImplicitTreeDropdown
 
         $preparedInput = $this->prepareInput($input);
 
-        if (isset($preparedInput['error'])) {
+        if (isset($preparedInput['error']) && !isset($input['_no_message'])) {
             Session::addMessageAfterRedirect($preparedInput['error'], false, ERROR);
         }
 

--- a/src/IPNetwork.php
+++ b/src/IPNetwork.php
@@ -380,9 +380,11 @@ class IPNetwork extends CommonImplicitTreeDropdown
             $sameNetworks = self::searchNetworks("equals", $params, $entities_id, false);
            // Check unicity !
             if ($sameNetworks && (count($sameNetworks) > 0)) {
-                return ['error' => __('Network already defined in visible entities'),
-                    'input' => false
-                ];
+                $return = ['input' => false];
+                if (!isset($input['from_native_inventory'])) {
+                    $return['error'] = __('Network already defined in visible entities');
+                }
+                return $return;
             }
 
            // Then, update $input to reflect the network and the netmask

--- a/src/IPNetwork.php
+++ b/src/IPNetwork.php
@@ -479,7 +479,7 @@ class IPNetwork extends CommonImplicitTreeDropdown
 
         $preparedInput = $this->prepareInput($input);
 
-        if (isset($preparedInput['error'])) {
+        if (isset($preparedInput['error']) && !isset($input['_no_message'])) {
             Session::addMessageAfterRedirect($preparedInput['error'], false, ERROR);
         }
 

--- a/src/IPNetwork.php
+++ b/src/IPNetwork.php
@@ -381,7 +381,7 @@ class IPNetwork extends CommonImplicitTreeDropdown
            // Check unicity !
             if ($sameNetworks && (count($sameNetworks) > 0)) {
                 $return = ['input' => false];
-                if (!isset($input['from_native_inventory'])) {
+                if (!isset($input['_no_message'])) {
                     $return['error'] = __('Network already defined in visible entities');
                 }
                 return $return;

--- a/src/Inventory/Asset/InventoryNetworkPort.php
+++ b/src/Inventory/Asset/InventoryNetworkPort.php
@@ -237,10 +237,11 @@ trait InventoryNetworkPort
 
             if ($count == 0) {
                  $input = [
-                     'name'         => sprintf('%s/%s - %s', $port->subnet, $port->netmask, $port->gateway),
-                     'network'      => sprintf('%s/%s', $port->subnet, $port->netmask),
-                     'gateway'      => $port->gateway,
-                     'entities_id'  => $this->entities_id
+                     'name'                     => sprintf('%s/%s - %s', $port->subnet, $port->netmask, $port->gateway),
+                     'network'                  => sprintf('%s/%s', $port->subnet, $port->netmask),
+                     'gateway'                  => $port->gateway,
+                     'entities_id'              => $this->entities_id,
+                     'from_native_inventory'    => true //to prevent 'Network already defined in visible entities' message on add
                  ];
                  $ipnetwork->add(Sanitizer::sanitize($input));
             }

--- a/src/Inventory/Asset/InventoryNetworkPort.php
+++ b/src/Inventory/Asset/InventoryNetworkPort.php
@@ -237,11 +237,11 @@ trait InventoryNetworkPort
 
             if ($count == 0) {
                  $input = [
-                     'name'                     => sprintf('%s/%s - %s', $port->subnet, $port->netmask, $port->gateway),
-                     'network'                  => sprintf('%s/%s', $port->subnet, $port->netmask),
-                     'gateway'                  => $port->gateway,
-                     'entities_id'              => $this->entities_id,
-                     'from_native_inventory'    => true //to prevent 'Network already defined in visible entities' message on add
+                     'name'         => sprintf('%s/%s - %s', $port->subnet, $port->netmask, $port->gateway),
+                     'network'      => sprintf('%s/%s', $port->subnet, $port->netmask),
+                     'gateway'      => $port->gateway,
+                     'entities_id'  => $this->entities_id,
+                     '_no_message'  => true //to prevent 'Network already defined in visible entities' message on add
                  ];
                  $ipnetwork->add(Sanitizer::sanitize($input));
             }


### PR DESCRIPTION
When an ```IPNetwork``` already exist in GLPI (for the destination entity)

a message is displayed

![image](https://github.com/glpi-project/glpi/assets/7335054/c550c68e-bf16-4369-bd7c-f9807de90803)

From the GLPI interface the message is useful but during the native inventory process, it's rather disturbing to get this error message (especially in red)



| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30610
