### PR TITLE
feat(search-option): add ticket age search option

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2702,6 +2702,17 @@ JAVASCRIPT;
         $tab = array_merge($tab, $this->getSearchOptionsMain());
 
         $tab[] = [
+            'id'                 => '70',
+            'table'              => $this->getTable(),
+            'field'              => '_virtual_age',
+            'datatype'           => 'specific',
+            'name'               => __('Age'),
+            'massiveaction'      => false,
+            'nosearch'           => true,
+            'additionalfields'   => ['id']
+        ];
+
+        $tab[] = [
             'id'                 => '155',
             'table'              => $this->getTable(),
             'field'              => 'time_to_own',
@@ -3264,6 +3275,7 @@ JAVASCRIPT;
                 }
             }
         }
+
         return $tab;
     }
 
@@ -3277,6 +3289,22 @@ JAVASCRIPT;
         switch ($field) {
             case 'type':
                 return self::getTicketTypeName($values[$field]);
+            case '_virtual_age':
+                $ticket = new Ticket();
+                $ticket->getFromDB($values['id']);
+                $calendars_id = Entity::getUsedConfig('id', $ticket->fields['entities_id'], 'calendars_id', 0);
+
+                if ($calendars_id) {
+                    $calendar = new Calendar();
+                    $calendar->getFromDB($calendars_id);
+                    $time = $calendar->getActiveTimeBetween($ticket->fields['date'], $_SESSION["glpi_currenttime"]);
+                } else {
+                    $ticket_date = new DateTime($ticket->fields['date']);
+                    $now = new DateTime($_SESSION["glpi_currenttime"]);
+                    $time = $now->getTimestamp() - $ticket_date->getTimestamp();
+                }
+
+                return sprintf(__('%s days %s hours %s minutes'), floor($time / 86400), floor(($time % 86400) / 3600), floor(($time % 3600) / 60));
         }
         return parent::getSpecificValueToDisplay($field, $values, $options);
     }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2706,7 +2706,7 @@ JAVASCRIPT;
             'table'              => $this->getTable(),
             'field'              => '_virtual_age',
             'datatype'           => 'specific',
-            'name'               => __('Age'),
+            'name'               => __('Time since opening'),
             'massiveaction'      => false,
             'nosearch'           => true,
             'additionalfields'   => ['id']

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -3303,7 +3303,7 @@ JAVASCRIPT;
                     $time = $now->getTimestamp() - $ticket_date->getTimestamp();
                 }
 
-                return sprintf(__('%s hours %s minutes ago'), floor($time / 3600), floor(($time % 3600) / 60));
+                return sprintf(__('%s hours %s minutes'), floor($time / 3600), floor(($time % 3600) / 60));
         }
         return parent::getSpecificValueToDisplay($field, $values, $options);
     }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2709,7 +2709,8 @@ JAVASCRIPT;
             'name'               => __('Time since opening'),
             'massiveaction'      => false,
             'nosearch'           => true,
-            'additionalfields'   => ['id']
+            'nosort'             => true,
+            'additionalfields'   => ['entities_id', 'date']
         ];
 
         $tab[] = [
@@ -3290,21 +3291,19 @@ JAVASCRIPT;
             case 'type':
                 return self::getTicketTypeName($values[$field]);
             case '_virtual_age':
-                $ticket = new Ticket();
-                $ticket->getFromDB($values['id']);
-                $calendars_id = Entity::getUsedConfig('id', $ticket->fields['entities_id'], 'calendars_id', 0);
+                $calendars_id = Entity::getUsedConfig('id', $values['entities_id'], 'calendars_id', 0);
 
                 if ($calendars_id) {
                     $calendar = new Calendar();
                     $calendar->getFromDB($calendars_id);
-                    $time = $calendar->getActiveTimeBetween($ticket->fields['date'], $_SESSION["glpi_currenttime"]);
+                    $time = $calendar->getActiveTimeBetween($values['date'], $_SESSION["glpi_currenttime"]);
                 } else {
-                    $ticket_date = new DateTime($ticket->fields['date']);
+                    $ticket_date = new DateTime($values['date']);
                     $now = new DateTime($_SESSION["glpi_currenttime"]);
                     $time = $now->getTimestamp() - $ticket_date->getTimestamp();
                 }
 
-                return sprintf(__('%s days %s hours %s minutes'), floor($time / 86400), floor(($time % 86400) / 3600), floor(($time % 3600) / 60));
+                return sprintf(__('%s hours %s minutes ago'), floor($time / 3600), floor(($time % 3600) / 60));
         }
         return parent::getSpecificValueToDisplay($field, $values, $options);
     }

--- a/tests/functional/Ticket.php
+++ b/tests/functional/Ticket.php
@@ -7022,7 +7022,7 @@ HTML
             $entity->getID(),
             0,
             '2023-11-26 10:00:00',
-            '1 days 0 hours 0 minutes'
+            '24 hours 0 minutes ago'
         ];
 
         // Calendar with 24/24 working hours
@@ -7030,7 +7030,7 @@ HTML
             $entity->getID(),
             $calendar2->getID(),
             '2023-11-11 10:00:00',
-            '6 days 0 hours 0 minutes'
+            '144 hours 0 minutes ago'
         ];
 
         // Calendar with 0 working hours
@@ -7038,7 +7038,7 @@ HTML
             $entity->getID(),
             $calendar3->getID(),
             '2023-11-11 10:00:00',
-            '0 days 0 hours 0 minutes'
+            '0 hours 0 minutes ago'
         ];
 
         // Calendar with working hours
@@ -7046,7 +7046,7 @@ HTML
             $entity->getID(),
             $calendar4->getID(),
             '2023-11-10 10:47:21',
-            '3 days 8 hours 12 minutes'
+            '80 hours 12 minutes ago'
         ];
 
         // Calendar with working hours with ticket creation date outside working hours
@@ -7054,7 +7054,7 @@ HTML
             $entity->getID(),
             $calendar4->getID(),
             '2023-11-11 10:00:00',
-            '3 days 2 hours 0 minutes'
+            '74 hours 0 minutes ago'
         ];
 
         return $data;
@@ -7095,7 +7095,8 @@ HTML
         $this->string($ticket->getSpecificValueToDisplay(
             '_virtual_age',
             [
-                'id' => $ticket->getID(),
+                'entities_id' => $entity_id,
+                'date' => $date
             ]
         ))->isEqualTo($expected);
     }

--- a/tests/functional/Ticket.php
+++ b/tests/functional/Ticket.php
@@ -7022,7 +7022,7 @@ HTML
             $entity->getID(),
             0,
             '2023-11-26 10:00:00',
-            '24 hours 0 minutes ago'
+            '24 hours 0 minutes'
         ];
 
         // Calendar with 24/24 working hours
@@ -7030,7 +7030,7 @@ HTML
             $entity->getID(),
             $calendar2->getID(),
             '2023-11-11 10:00:00',
-            '144 hours 0 minutes ago'
+            '144 hours 0 minutes'
         ];
 
         // Calendar with 0 working hours
@@ -7038,7 +7038,7 @@ HTML
             $entity->getID(),
             $calendar3->getID(),
             '2023-11-11 10:00:00',
-            '0 hours 0 minutes ago'
+            '0 hours 0 minutes'
         ];
 
         // Calendar with working hours
@@ -7046,7 +7046,7 @@ HTML
             $entity->getID(),
             $calendar4->getID(),
             '2023-11-10 10:47:21',
-            '80 hours 12 minutes ago'
+            '80 hours 12 minutes'
         ];
 
         // Calendar with working hours with ticket creation date outside working hours
@@ -7054,7 +7054,7 @@ HTML
             $entity->getID(),
             $calendar4->getID(),
             '2023-11-11 10:00:00',
-            '74 hours 0 minutes ago'
+            '74 hours 0 minutes'
         ];
 
         return $data;

--- a/tests/functional/Ticket.php
+++ b/tests/functional/Ticket.php
@@ -6947,4 +6947,156 @@ HTML
         $this->boolean(property_exists($ticket, 'plugin_xxx_data'))->isTrue();
         $this->string($ticket->plugin_xxx_data)->isEqualTo('test');
     }
+
+    protected function ageSearchOptionDataProvider()
+    {
+        $this->login();
+        $_SESSION['glpi_currenttime'] = '2023-11-27 10:00:00';
+
+        $entity = $this->createItem(
+            \Entity::class,
+            [
+                'name' => __FUNCTION__
+            ]
+        );
+
+        $calendar = $this->createItem(
+            \Calendar::class,
+            [
+                'name' => __FUNCTION__
+            ]
+        );
+
+        $segments = $this->createItems(\CalendarSegment::class, [
+            ['calendars_id' => $calendar->getID(), 'day' => 0, 'begin' => '00:00:00', 'end' => '24:00:00'],
+            ['calendars_id' => $calendar->getID(), 'day' => 1, 'begin' => '00:00:00', 'end' => '24:00:00'],
+            ['calendars_id' => $calendar->getID(), 'day' => 2, 'begin' => '00:00:00', 'end' => '24:00:00'],
+            ['calendars_id' => $calendar->getID(), 'day' => 3, 'begin' => '00:00:00', 'end' => '24:00:00'],
+            ['calendars_id' => $calendar->getID(), 'day' => 4, 'begin' => '00:00:00', 'end' => '24:00:00'],
+            ['calendars_id' => $calendar->getID(), 'day' => 5, 'begin' => '00:00:00', 'end' => '24:00:00'],
+            ['calendars_id' => $calendar->getID(), 'day' => 6, 'begin' => '00:00:00', 'end' => '24:00:00'],
+        ]);
+
+        $calendar2 = $this->createItem(
+            \Calendar::class,
+            [
+                'name' => __FUNCTION__
+            ]
+        );
+
+        $segments2 = $this->createItems(\CalendarSegment::class, [
+            ['calendars_id' => $calendar2->getID(), 'day' => 0, 'begin' => '08:00:00', 'end' => '17:00:00'],
+            ['calendars_id' => $calendar2->getID(), 'day' => 1, 'begin' => '08:00:00', 'end' => '17:00:00'],
+            ['calendars_id' => $calendar2->getID(), 'day' => 2, 'begin' => '08:00:00', 'end' => '17:00:00'],
+            ['calendars_id' => $calendar2->getID(), 'day' => 3, 'begin' => '08:00:00', 'end' => '17:00:00'],
+            ['calendars_id' => $calendar2->getID(), 'day' => 4, 'begin' => '08:00:00', 'end' => '17:00:00'],
+            ['calendars_id' => $calendar2->getID(), 'day' => 5, 'begin' => '08:00:00', 'end' => '17:00:00'],
+            ['calendars_id' => $calendar2->getID(), 'day' => 6, 'begin' => '08:00:00', 'end' => '17:00:00'],
+        ]);
+
+        $calendar3 = $this->createItem(
+            \Calendar::class,
+            [
+                'name' => __FUNCTION__
+            ]
+        );
+
+        $calendar4 = $this->createItem(
+            \Calendar::class,
+            [
+                'name' => __FUNCTION__
+            ]
+        );
+
+        $segmetns4 = $this->createItems(\CalendarSegment::class, [
+            ['calendars_id' => $calendar4->getID(), 'day' => 1, 'begin' => '08:00:00', 'end' => '17:00:00'],
+            ['calendars_id' => $calendar4->getID(), 'day' => 2, 'begin' => '08:00:00', 'end' => '17:00:00'],
+            ['calendars_id' => $calendar4->getID(), 'day' => 4, 'begin' => '08:00:00', 'end' => '17:00:00'],
+            ['calendars_id' => $calendar4->getID(), 'day' => 5, 'begin' => '08:00:00', 'end' => '17:00:00'],
+        ]);
+
+        $data = array();
+
+        // No calendar defined, 24/24
+        $data[] = [
+            $entity->getID(),
+            0,
+            '2023-11-26 10:00:00',
+            '1 days 0 hours 0 minutes'
+        ];
+
+        // Calendar with 24/24 working hours
+        $data[] = [
+            $entity->getID(),
+            $calendar2->getID(),
+            '2023-11-11 10:00:00',
+            '6 days 0 hours 0 minutes'
+        ];
+
+        // Calendar with 0 working hours
+        $data[] = [
+            $entity->getID(),
+            $calendar3->getID(),
+            '2023-11-11 10:00:00',
+            '0 days 0 hours 0 minutes'
+        ];
+
+        // Calendar with working hours
+        $data[] = [
+            $entity->getID(),
+            $calendar4->getID(),
+            '2023-11-10 10:47:21',
+            '3 days 8 hours 12 minutes'
+        ];
+
+        // Calendar with working hours with ticket creation date outside working hours
+        $data[] = [
+            $entity->getID(),
+            $calendar4->getID(),
+            '2023-11-11 10:00:00',
+            '3 days 2 hours 0 minutes'
+        ];
+
+        return $data;
+    }
+
+    /**
+     * @dataProvider ageSearchOptionDataProvider
+     */
+    public function testAgeSearchOption(
+        int $entity_id,
+        int $calendar_id,
+        string $date,
+        string $expected
+    ) {
+        $this->login();
+        $_SESSION['glpi_currenttime'] = '2023-11-27 10:00:00';
+
+        if ($calendar_id) {
+            $this->updateItem(
+                \Entity::class,
+                $entity_id,
+                [
+                    'calendars_id' => $calendar_id,
+                ]
+            );
+        }
+
+        $ticket = $this->createItem(
+            \Ticket::class,
+            [
+                'name'        => __FUNCTION__,
+                'content'     => __FUNCTION__,
+                'entities_id' => $entity_id,
+                'date'        => $date
+            ]
+        );
+
+        $this->string($ticket->getSpecificValueToDisplay(
+            '_virtual_age',
+            [
+                'id' => $ticket->getID(),
+            ]
+        ))->isEqualTo($expected);
+    }
 }


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

## Description

This PR introduces a new 'Age' search option for tickets. This option is not usable for searching but only displayable in the results. The 'Age' is calculated as the time difference between the ticket's date and the current time. If a calendar is associated with the ticket, it calculates the active time between the ticket's date and the current time.

## Changes

- Added 'Age' search option to tickets.
- Updated `getSpecificValueToDisplay` method to handle the new 'Age' field.
- Added `ageSearchOptionDataProvider` method to provide data for testing the 'Age' option.
- Added `testAgeSearchOption` method to test the 'Age' option.