### PR TITLE
Prevent namespaced itemtype to be falsely considered as changed

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1636,33 +1636,36 @@ class CommonDBTM extends CommonGLPI
                       // Compare item
                         $ischanged = true;
                         $searchopt = $this->getSearchOptionByField('field', $key, $this->getTable());
+
+                        $current_value = $this->fields[$key];
+                        $new_value     = is_string($this->input[$key]) ? Sanitizer::dbUnescape($this->input[$key]) : $this->input[$key];
                         if (isset($searchopt['datatype'])) {
                             switch ($searchopt['datatype']) {
                                 case 'string':
                                 case 'text':
                                     $ischanged = (strcmp(
-                                        (string)$DB->escape($this->fields[$key]),
-                                        (string)$this->input[$key]
+                                        (string)$current_value,
+                                        (string)$new_value
                                     ) != 0);
                                     break;
 
                                 case 'itemlink':
                                     if ($key == 'name') {
                                         $ischanged = (strcmp(
-                                            (string)$DB->escape($this->fields[$key]),
-                                            (string)$this->input[$key]
+                                            (string)$current_value,
+                                            (string)$new_value
                                         ) != 0);
                                         break;
                                     }
                                // else default
 
                                 default:
-                                    $ischanged = ($DB->escape($this->fields[$key]) != $this->input[$key]);
+                                    $ischanged = $current_value != $new_value;
                                     break;
                             }
                         } else {
                          // No searchoption case
-                            $ischanged = ($DB->escape($this->fields[$key]) != $this->input[$key]);
+                            $ischanged = $current_value != $new_value;
                         }
                         if ($ischanged) {
                             if ($key != "id") {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30569

In a plugin that stores namespaced itemtypes in an `itemtype` field, this field is considered changed everytime the corresponding form is submitted.

This is due to a combination of concurrent logics:
 - comparison is done using the $input value (expected to be sanitized) VS the escaped $fields value, see https://github.com/glpi-project/glpi/blob/d4a8ae89aef14572f8922af70d23fcdd5b82ebfa/src/CommonDBTM.php#L1660
 - itemtypes are not sanitized, see https://github.com/glpi-project/glpi/blob/d4a8ae89aef14572f8922af70d23fcdd5b82ebfa/src/Toolbox/Sanitizer.php#L76-L80

With this logic, `$this->input[$key]` value is `GlpiPlugin\MyPlugin\Itemtype` and `$DB->escape($this->fields[$key])` value is `GlpiPlugin\\MyPlugin\\Itemtype`, so they are considered different.

Instead of escapting the `$fields` value, I propose to unescape the `$input` value.