### PR TITLE
fix(pending-reasons): prevent false form modification alert

### DIFF
--- a/templates/components/itilobject/timeline/pending_reasons.html.twig
+++ b/templates/components/itilobject/timeline/pending_reasons.html.twig
@@ -98,6 +98,10 @@
             });
 
             $('#dropdown_pendingreasons_id{{ rand }}').trigger('change');
+
+            // A change on the dropdown is triggered on load to initialize the component.
+            // It needs to be reset to avoid marking the form as modified.
+            window.glpiUnsavedFormChanges = false;
          </script>
       </div>
 


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

## Description

This PR addresses an issue in the `pending_reasons.html.twig` file where a change on the dropdown is triggered on load to initialize the component. This was marking the form as modified, causing a confirmation prompt to appear when attempting to leave or reload the page, disrupting the user experience.

## Changes

- Added a line of JavaScript to reset the `glpiUnsavedFormChanges` variable to `false` after the dropdown change is triggered. This prevents the form from being incorrectly marked as modified when the page loads.