### PR TITLE
 Fix category filter in tickets Kanban

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8927,7 +8927,9 @@ abstract class CommonITILObject extends CommonDBTM
 
     public static function getDataToDisplayOnKanban($ID, $criteria = [])
     {
-        /** @var \DBmysql $DB */
+        /**
+         * @var \DBmysql $DB
+        */
         global $DB;
 
         // List of items to return
@@ -9170,11 +9172,23 @@ abstract class CommonITILObject extends CommonDBTM
             }
         }
 
+        $category_names = [];
         foreach ($common_itil_iterator as $data) {
+            if (!array_key_exists($data['itilcategories_id'], $category_names)) {
+                $category_name = DropdownTranslation::getTranslatedValue(
+                    $data['itilcategories_id'],
+                    ITILCategory::class
+                );
+                if ($category_name === '') {
+                    $category_name = ITILCategory::getFriendlyNameById($data['itilcategories_id']);
+                }
+
+                $category_names[$data['itilcategories_id']] = $category_name;
+            }
             $data = [
                 'id'        => $data['id'],
                 'name'      => $data['name'],
-                'category'  => $data['itilcategories_id'],
+                'category'  => $category_names[$data['itilcategories_id']] ?? '',
                 'content'   => $data['content'],
                 'status'    => $data['status'],
                 '_itemtype' => $itemtype,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30496

Filtering tickets by category in the global kanban was not working. 

### Reason
Searching by category was done via a text comparison, but a ticket's category was defined by its ID.

### Development
Changed the definition of the categorory field so that it now corresponds to the category name.

![image](https://github.com/glpi-project/glpi/assets/107540223/0f340cc5-6166-4eb1-ae33-88bcb53592ea)
![image](https://github.com/glpi-project/glpi/assets/107540223/e2331587-281e-4f7c-94d0-13f4eda6908d)