### PR TITLE
fix(pending-reasons): additional fix to prevent false form modification on alert

### DIFF
--- a/templates/components/itilobject/timeline/pending_reasons.html.twig
+++ b/templates/components/itilobject/timeline/pending_reasons.html.twig
@@ -74,24 +74,34 @@
             }
          ) }}
          <script>
+            // Initialize a flag to check if the pending reasons dropdown has been initialized
+            let pendingReasonsInitalized{{ rand }} = false;
+
             $('#dropdown_pendingreasons_id{{ rand }}').change(function() {
-               var pending_val = $(this).val();
+               let pending_val = $(this).val();
                if (pending_val > 0) {
                   $('#pending-reasons-more_options_{{ rand }}').addClass('show');
-                  $.ajax({
+                  let data = await $.ajax({
                      url: '{{ path("ajax/pendingreason.php") }}',
                      type: 'POST',
                      data: {
                         pendingreasons_id: pending_val
                      }
-                  }).done(function(data) {
-                     $('#dropdown_followup_frequency{{ rand }}')
-                        .val(data.followup_frequency)
-                        .trigger('change');
-                     $('#dropdown_followups_before_resolution{{ rand }}')
-                        .val(data.followups_before_resolution)
-                        .trigger('change');
                   });
+
+                  $('#dropdown_followup_frequency{{ rand }}')
+                     .val(data.followup_frequency)
+                     .trigger('change');
+                  $('#dropdown_followups_before_resolution{{ rand }}')
+                     .val(data.followups_before_resolution)
+                     .trigger('change');
+
+                  // If this is the first time the dropdown is being initialized
+                  // Mark the dropdown as initialized and reset the form modification flag to avoid triggering the unsaved changes warning
+                  if (!pendingReasonsInitalized{{ rand }}) {
+                     pendingReasonsInitalized{{ rand }} = true;
+                     window.glpiUnsavedFormChanges = false;
+                  }
                } else {
                   $('#pending-reasons-more_options_{{ rand }}').removeClass('show');
                }
@@ -99,9 +109,12 @@
 
             $('#dropdown_pendingreasons_id{{ rand }}').trigger('change');
 
-            // A change on the dropdown is triggered on load to initialize the component.
-            // It needs to be reset to avoid marking the form as modified.
-            window.glpiUnsavedFormChanges = false;
+            // If this is the first time the dropdown is being initialized
+            // Mark the dropdown as initialized and reset the form modification flag to avoid triggering the unsaved changes warning
+            if (!pendingReasonsInitalized{{ rand }}) {
+               pendingReasonsInitalized{{ rand }} = true;
+               window.glpiUnsavedFormChanges = false;
+            }
          </script>
       </div>
 


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

**Description**

This PR provides an additional fix to the issue in the `pending_reasons.html.twig` file where a change on the dropdown is triggered on load to initialize the component. The previous PR (#16072) partially addressed this issue. However, the form was still being marked as modified, causing a confirmation prompt to appear when attempting to leave or reload the page, disrupting the user experience.