### PR TITLE
fix: checkbox visibility in general settings

### DIFF
--- a/templates/pages/setup/general/general_setup.html.twig
+++ b/templates/pages/setup/general/general_setup.html.twig
@@ -256,7 +256,7 @@
         'lock_use_lock_item',
         config['lock_use_lock_item'],
         __('Use locks'),
-        inline_field_options|merge({
+        field_options|merge({
             'id': id_lock_use_lock_item,
         })
     ) }}
@@ -332,14 +332,14 @@
         'login_remember_default',
         config['login_remember_default'],
         __("Default state of checkbox"),
-        inline_field_options
+        field_options
     ) }}
 
     {{ fields.checkboxField(
         'display_login_source',
         config['display_login_source'],
         __('Display source dropdown on login page'),
-        inline_field_options
+        field_options
     ) }}
 </div>
 


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

## Description
This pull request addresses an issue where some checkboxes in the general configuration were not visible due to a width of 0px. This was caused by the `inline_field_options` applying the CSS property `w-auto`, which is inconsistent as most other checkboxes use `field_options`.

![image](https://github.com/glpi-project/glpi/assets/42278610/d5a2507c-6608-4dd1-9a37-82b061a32593)

## Changes
- Changed the options used for the 'Use locks', 'Default state of checkbox', and 'Display source dropdown on login page' checkboxes from `inline_field_options` to `field_options` to ensure consistent visibility across all checkboxes in the general configuration.