### PR TITLE
fix(pending-reasons): displaying frequency and duration before resolution dropdown

### DIFF
--- a/templates/components/itilobject/timeline/pending_reasons.html.twig
+++ b/templates/components/itilobject/timeline/pending_reasons.html.twig
@@ -73,12 +73,13 @@
                'add_field_html': pending_reasons_id_script
             }
          ) }}
-         <script>
+         <script type="module">
             // Initialize a flag to check if the pending reasons dropdown has been initialized
             let pendingReasonsInitalized{{ rand }} = false;
 
-            $('#dropdown_pendingreasons_id{{ rand }}').change(function() {
-               let pending_val = $(this).val();
+            let handlePendingReasonsChange{{ rand }} = async () => {
+               let pending_val = $('#dropdown_pendingreasons_id{{ rand }}').val();
+
                if (pending_val > 0) {
                   $('#pending-reasons-more_options_{{ rand }}').addClass('show');
                   let data = await $.ajax({
@@ -95,19 +96,12 @@
                   $('#dropdown_followups_before_resolution{{ rand }}')
                      .val(data.followups_before_resolution)
                      .trigger('change');
-
-                  // If this is the first time the dropdown is being initialized
-                  // Mark the dropdown as initialized and reset the form modification flag to avoid triggering the unsaved changes warning
-                  if (!pendingReasonsInitalized{{ rand }}) {
-                     pendingReasonsInitalized{{ rand }} = true;
-                     window.glpiUnsavedFormChanges = false;
-                  }
                } else {
                   $('#pending-reasons-more_options_{{ rand }}').removeClass('show');
                }
-            });
+            }
 
-            $('#dropdown_pendingreasons_id{{ rand }}').trigger('change');
+            await handlePendingReasonsChange{{ rand }}();
 
             // If this is the first time the dropdown is being initialized
             // Mark the dropdown as initialized and reset the form modification flag to avoid triggering the unsaved changes warning
@@ -115,6 +109,8 @@
                pendingReasonsInitalized{{ rand }} = true;
                window.glpiUnsavedFormChanges = false;
             }
+
+            $('#dropdown_pendingreasons_id{{ rand }}').change(handlePendingReasonsChange{{ rand }});
          </script>
       </div>
 


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

## Description

The previous fix (#16086) didn't completely solve the initial problem and brought several issues preventing the display of frequency and duration dropdowns before resolution, making it more or less impossible to use pending reasons. This PR modifies the way the javascript script works, so that the pending reasons form is not considered modified on initialization, with better asynchronous management.