### PR TITLE
feat: Add user_dn_hash field to improve User::getFromDBbyDn performance

### DIFF
--- a/install/migrations/update_10.0.11_to_10.0.12/user.php
+++ b/install/migrations/update_10.0.11_to_10.0.12/user.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var \DBmysql $DB
+ * @var \Migration $migration
+ */
+
+ // Add user_dn_hash field
+$migration->addField('glpi_users', 'user_dn_hash', 'varchar(32)', [
+    'after'  => 'user_dn',
+]);
+
+$migration->addPostQuery($DB->buildUpdate(
+    'glpi_users',
+    [
+        'user_dn_hash' => new \QueryExpression('MD5(`user_dn`)'),
+    ],
+    [
+        'NOT' => [
+            'user_dn' => null
+        ]
+    ]
+));
+
+// Add user_dn_hash index
+$migration->addKey('glpi_users', 'user_dn_hash');

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -7610,6 +7610,7 @@ CREATE TABLE `glpi_users` (
   `password_forget_token` char(40) DEFAULT NULL,
   `password_forget_token_date` timestamp NULL DEFAULT NULL,
   `user_dn` text,
+  `user_dn_hash` varchar(32),
   `registration_number` varchar(255) DEFAULT NULL,
   `show_count_on_tabs` tinyint DEFAULT NULL,
   `refresh_views` int DEFAULT NULL,
@@ -7686,7 +7687,8 @@ CREATE TABLE `glpi_users` (
   KEY `groups_id` (`groups_id`),
   KEY `users_id_supervisor` (`users_id_supervisor`),
   KEY `auths_id` (`auths_id`),
-  KEY `default_requesttypes_id` (`default_requesttypes_id`)
+  KEY `default_requesttypes_id` (`default_requesttypes_id`),
+  KEY `user_dn_hash` (`user_dn_hash`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 

--- a/src/User.php
+++ b/src/User.php
@@ -838,6 +838,14 @@ class User extends CommonDBTM
         );
     }
 
+    public function pre_addInDB()
+    {
+        // Hash user_dn if set
+        if (isset($this->input['user_dn']) && is_string($this->input['user_dn']) && strlen($this->input['user_dn']) > 0) {
+            $this->input['user_dn_hash'] = md5($this->input['user_dn']);
+        }
+    }
+
     public function post_addItem()
     {
 
@@ -894,14 +902,6 @@ class User extends CommonDBTM
                 $right                       = new Profile_User();
                 $right->add($affectation);
             }
-        }
-
-        // Hash user_dn if set
-        if (isset($this->input['user_dn']) && is_string($this->input['user_dn']) && strlen($this->input['user_dn']) > 0) {
-            $this->update([
-                'id' => $this->fields['id'],
-                'user_dn_hash' => md5($this->input['user_dn'])
-            ]);
         }
     }
 
@@ -1198,17 +1198,7 @@ class User extends CommonDBTM
                 true
             );
         }
-
-        // Hash user_dn if is updated
-        if (in_array('user_dn', $this->updates)) {
-            $this->update([
-                'id' => $this->fields['id'],
-                'user_dn_hash' => is_string($this->fields['user_dn']) && strlen($this->fields['user_dn']) > 0 ? md5($this->fields['user_dn']) : null,
-            ]);
-        }
     }
-
-
 
     /**
      * Apply rules to determine dynamic rights of the user.
@@ -3503,6 +3493,12 @@ HTML;
                 unset($this->updates[$key]);
                 unset($this->oldvalues['comment']);
             }
+        }
+
+        // Hash user_dn if is updated
+        if (in_array('user_dn', $this->updates)) {
+            $this->updates[] = 'user_dn_hash';
+            $this->fields['user_dn_hash'] = is_string($this->input['user_dn']) && strlen($this->input['user_dn']) > 0 ? md5($this->input['user_dn']) : null;
         }
     }
 

--- a/src/User.php
+++ b/src/User.php
@@ -897,7 +897,7 @@ class User extends CommonDBTM
         }
 
         // Hash user_dn if set
-        if (isset($this->input['user_dn'])) {
+        if (isset($this->input['user_dn']) && is_string($this->input['user_dn']) && strlen($this->input['user_dn']) > 0) {
             $this->update([
                 'id' => $this->fields['id'],
                 'user_dn_hash' => md5($this->input['user_dn'])
@@ -1203,7 +1203,7 @@ class User extends CommonDBTM
         if (in_array('user_dn', $this->updates)) {
             $this->update([
                 'id' => $this->fields['id'],
-                'user_dn_hash' => md5($this->fields['user_dn'])
+                'user_dn_hash' => is_string($this->fields['user_dn']) && strlen($this->fields['user_dn']) > 0 ? md5($this->fields['user_dn']) : null,
             ]);
         }
     }

--- a/tests/LDAP/AuthLdap.php
+++ b/tests/LDAP/AuthLdap.php
@@ -1336,6 +1336,7 @@ class AuthLDAP extends DbTestCase
         unset($dup['id']);
         unset($dup['date_creation']);
         unset($dup['date_mod']);
+        unset($dup['user_dn_hash']);
         $aid = $dup['auths_id'];
         $dup['auths_id'] = $aid + 1;
 

--- a/tests/functional/User.php
+++ b/tests/functional/User.php
@@ -1293,4 +1293,75 @@ class User extends \DbTestCase
         $this->variable($user->fields['show_count_on_tabs'])->isNull();
         $this->variable($user->fields['itil_layout'])->isEqualTo($itil_layout_2);
     }
+
+    /**
+     * Test that user_dn_hash is correctly set on user creation and update
+     *
+     * @return void
+     */
+    public function testUserDnIsHashedOnAddAndUpdate(): void
+    {
+        // Create user whithout dn and check that user_dn_hash is not set
+        $user = $this->createItem('User', [
+            'name'      => __FUNCTION__,
+        ]);
+        $this->variable($user->fields['user_dn'])->isNull();
+        $this->variable($user->fields['user_dn_hash'])->isNull();
+
+        // Create user with dn and check that user_dn_hash is set
+        $dn = 'user=' . __FUNCTION__ . '_created,dc=test,dc=glpi-project,dc=org';
+        $user = $this->createItem('User', [
+            'name'      => __FUNCTION__ . '_created',
+            'user_dn'   => $dn
+        ]);
+        $this->string($user->fields['user_dn_hash'])->isEqualTo(md5($dn));
+
+        // Update user dn and check that user_dn_hash is updated
+        $dn = 'user=' . __FUNCTION__ . '_updated,dc=test,dc=glpi-project,dc=org';
+        $this->updateItem('User', $user->getID(), [
+            'user_dn'   => $dn
+        ]);
+        $user->getFromDB($user->getID());
+        $this->string($user->fields['user_dn_hash'])->isEqualTo(md5($dn));
+    }
+
+    /**
+     * Test that user_dn_hash is correctly used in getFromDBbyDn method
+     *
+     * @return void
+     */
+    public function testUserDnHashIsUsedInGetFromDBbyDn(): void
+    {
+        global $DB;
+
+        $retrievedUser = new \User();
+
+        // Get a user with a bad dn
+        $this->boolean($retrievedUser->getFromDBbyDn(__FUNCTION__))
+            ->isFalse();
+        $this->boolean($retrievedUser->isNewItem())->isTrue();
+
+        // Create a user with a dn
+        $dn = 'user=' . __FUNCTION__ . ',dc=test,dc=glpi-project,dc=org';
+        $user = $this->createItem('User', [
+            'name'      => __FUNCTION__,
+            'user_dn'   => $dn
+        ]);
+
+        // Retrieve the user using getFromDBbyDn method
+        $this->boolean($retrievedUser->getFromDBbyDn($dn))->isTrue();
+        $this->boolean($retrievedUser->isNewItem())->isFalse();
+
+        // Unset user_dn to check that user_dn_hash is used
+        $DB->update(
+            \User::getTable(),
+            ['user_dn' => ''],
+            ['id' => $user->getID()]
+        );
+
+        // Retrieve the user using getFromDBbyDn and check if user_dn_hash is used
+        $this->boolean($retrievedUser->getFromDBbyDn($dn))->isTrue();
+        $this->boolean($retrievedUser->isNewItem())->isFalse();
+        $this->string($retrievedUser->fields['user_dn'])->isEmpty();
+    }
 }

--- a/tests/functional/User.php
+++ b/tests/functional/User.php
@@ -1323,6 +1323,20 @@ class User extends \DbTestCase
         ]);
         $user->getFromDB($user->getID());
         $this->string($user->fields['user_dn_hash'])->isEqualTo(md5($dn));
+
+        // Set user_dn to empty and check that user_dn_hash is set to null
+        $this->updateItem('User', $user->getID(), [
+            'user_dn'   => ''
+        ]);
+        $user->getFromDB($user->getID());
+        $this->variable($user->fields['user_dn_hash'])->isNull();
+
+        // Set user_dn to null and check that user_dn_hash is set to null
+        $this->updateItem('User', $user->getID(), [
+            'user_dn'   => null
+        ]);
+        $user->getFromDB($user->getID());
+        $this->variable($user->fields['user_dn_hash'])->isNull();
     }
 
     /**


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30554

**Description:**

This PR introduces a new field `user_dn_hash` in the `glpi_users` table. This field is a virtual field that is generated by hashing the `user_dn` field. This change is aimed at improving the performance of queries that involve the `user_dn` field by using the hashed value instead.

**Changes:**

1. Added `ext-hash` to the required PHP extensions in `composer.json` and `composer.lock` to avoid soft dependency issues.
2. Created a new migration file `user.php` in `install/migrations/update_10.0.10_to_10.0.11/` to add the `user_dn_hash` field and its index to the `glpi_users` table.
3. Updated `glpi-empty.sql` to include the `user_dn_hash` field and its index in the `glpi_users` table creation statement.
4. Updated the `getFromDBbyDn` method in `User.php` to use the `user_dn_hash` field for the database query.
5. Updated the test file `AuthLdap.php` to unset the `user_dn_hash` field in the `dup` array.