### PR TITLE
Fix satisfaction survey link criteria

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4971,21 +4971,28 @@ JAVASCRIPT;
                         $options['criteria'][2]['value']      = 'NULL';
                         $options['criteria'][2]['link']       = 'AND';
 
-                        $options['criteria'][3]['link'] = 'AND';
-                        $options['criteria'][3]['criteria'] = [
-                            [
-                                'link'        => 'AND',
-                                'field'       => 22, // author
-                                'searchtype'  => 'equals',
-                                'value'       => Session::getLoginUserID(),
-                            ],
-                            [
-                                'link'        => 'OR',
-                                'field'       => 4, // requester
-                                'searchtype'  => 'equals',
-                                'value'       => Session::getLoginUserID(),
-                            ]
-                        ];
+                        if (Session::haveRight('ticket', Ticket::SURVEY)) {
+                            $options['criteria'][3]['link'] = 'AND';
+                            $options['criteria'][3]['criteria'] = [
+                                [
+                                    'link'        => 'AND',
+                                    'field'       => 22, // author
+                                    'searchtype'  => 'equals',
+                                    'value'       => Session::getLoginUserID(),
+                                ],
+                                [
+                                    'link'        => 'OR',
+                                    'field'       => 4, // requester
+                                    'searchtype'  => 'equals',
+                                    'value'       => Session::getLoginUserID(),
+                                ]
+                            ];
+                        } else {
+                            $options['criteria'][3]['field'] = 4; // requester
+                            $options['criteria'][3]['searchtype'] = 'equals';
+                            $options['criteria'][3]['value'] = Session::getLoginUserID();
+                            $options['criteria'][3]['link'] = 'AND';
+                        }
                         $forcetab                 = 'Ticket$3';
 
                         $main_header = "<a href=\"" . Ticket::getSearchURL() . "?" .

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4972,7 +4972,7 @@ JAVASCRIPT;
                         $options['criteria'][2]['link']       = 'AND';
 
                         if (Session::haveRight('ticket', Ticket::SURVEY)) {
-                            $options['criteria'][3]['link'] = 'AND';
+                            $options['criteria'][3]['link']     = 'AND';
                             $options['criteria'][3]['criteria'] = [
                                 [
                                     'link'        => 'AND',
@@ -4988,10 +4988,10 @@ JAVASCRIPT;
                                 ]
                             ];
                         } else {
-                            $options['criteria'][3]['field'] = 4; // requester
-                            $options['criteria'][3]['searchtype'] = 'equals';
-                            $options['criteria'][3]['value'] = Session::getLoginUserID();
-                            $options['criteria'][3]['link'] = 'AND';
+                            $options['criteria'][3]['field']        = 4; // requester
+                            $options['criteria'][3]['searchtype']   = 'equals';
+                            $options['criteria'][3]['value']        = Session::getLoginUserID();
+                            $options['criteria'][3]['link']         = 'AND';
                         }
                         $forcetab                 = 'Ticket$3';
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4971,17 +4971,21 @@ JAVASCRIPT;
                         $options['criteria'][2]['value']      = 'NULL';
                         $options['criteria'][2]['link']       = 'AND';
 
-                        if (Session::haveRight('ticket', Ticket::SURVEY)) {
-                            $options['criteria'][3]['field']      = 22; // author
-                            $options['criteria'][3]['searchtype'] = 'equals';
-                            $options['criteria'][3]['value']      = Session::getLoginUserID();
-                            $options['criteria'][3]['link']       = 'AND';
-                        } else {
-                            $options['criteria'][3]['field']      = 4; // requester
-                            $options['criteria'][3]['searchtype'] = 'equals';
-                            $options['criteria'][3]['value']      = Session::getLoginUserID();
-                            $options['criteria'][3]['link']       = 'AND';
-                        }
+                        $options['criteria'][3]['link'] = 'AND';
+                        $options['criteria'][3]['criteria'] = [
+                            [
+                                'link'        => 'AND',
+                                'field'       => 22, // author
+                                'searchtype'  => 'equals',
+                                'value'       => Session::getLoginUserID(),
+                            ],
+                            [
+                                'link'        => 'OR',
+                                'field'       => 4, // requester
+                                'searchtype'  => 'equals',
+                                'value'       => Session::getLoginUserID(),
+                            ]
+                        ];
                         $forcetab                 = 'Ticket$3';
 
                         $main_header = "<a href=\"" . Ticket::getSearchURL() . "?" .


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30498

Different results between the satisfaction survey table in the personal view and the filter assigned to it in the view of tickets awaiting satisfaction survey.

The problem is a mistake between the two queries which are supposed to return the same result.