### PR TITLE
Fix associated items not found in DB instances

### DIFF
--- a/src/DatabaseInstance.php
+++ b/src/DatabaseInstance.php
@@ -482,8 +482,11 @@ class DatabaseInstance extends CommonDBTM
                 if ($itemtype !== null && class_exists($itemtype)) {
                     if ($values[$field] > 0) {
                         $item = new $itemtype();
-                        $item->getFromDB($values[$field]);
-                        return "<a href='" . $item->getLinkURL() . "'>" . $item->fields['name'] . "</a>";
+                        if ($item->getFromDB($values[$field])) {
+                            return "<a href='" . $item->getLinkURL() . "'>" . $item->fields['name'] . "</a>";
+                        } else {
+                            return ' ';
+                        }
                     }
                 } else {
                     return ' ';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In the database instance view, some items associated with database instances are listed as associated but cannot be found in the database. This problem generates an undefined "name" field error.

Here the error : `PHP Warning (2): Undefined array key "name" in /var/www/glpi/src/DatabaseInstance.php at line 486`