### PR TITLE
Fix recurrent ticket computation when start_date is outside of calendar

### DIFF
--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -568,7 +568,7 @@ class Calendar extends CommonDropdown
                         $timeoftheday = $cache_duration[$dayofweek];
                     }
 
-                    if ($delay === 0 && $timeoftheday === 0) {
+                    if ($delay === 0 && $timeoftheday === 0 && $this->isAWorkingHour($timestart)) {
                         // Special case:
                         // - current day is a working day;
                         // - there is no delay to add;

--- a/src/CommonITILRecurrent.php
+++ b/src/CommonITILRecurrent.php
@@ -383,7 +383,7 @@ abstract class CommonITILRecurrent extends CommonDropdown
         ?int $create_before,
         ?int $calendars_id
     ): string {
-        $now = time();
+        $now = strtotime(Session::getCurrentTime());
         $periodicity_pattern = '/([0-9]+)(MONTH|YEAR)/';
 
         if ($begin_date === null || DateTime::createFromFormat('Y-m-d H:i:s', $begin_date) === false) {
@@ -462,10 +462,28 @@ abstract class CommonITILRecurrent extends CommonDropdown
                 }
                // Jump to next working hour if occurence is outside working hours.
                 if (!$calendar->isAWorkingHour($occurence_time)) {
-                    $occurence_date = $calendar->computeEndDate(
-                        date('Y-m-d', $occurence_time),
-                        0 // 0 second delay to get the first working "second"
-                    );
+                    $tmp_search_time = null;
+
+                    // Find the first calendar segment that is after the current date
+                    do {
+                        if ($tmp_search_time === null) {
+                            // On the first iteration, we work with the start of the day
+                            $tmp_search_time = date('Y-m-d', $occurence_time);
+                        } else {
+                            // If we iterate a second time, this mean the date returned was too early
+                            // We will add the periodicity once again to try to get a valid date
+                            $tmp_search_time = date(
+                                'Y-m-d H:i:s',
+                                strtotime("+ $periodicity_as_interval", strtotime($occurence_date))
+                            );
+                        }
+
+                        $occurence_date = $calendar->computeEndDate(
+                            $tmp_search_time,
+                            0 // 0 second delay to get the first working "second"
+                        );
+                    } while ($occurence_date < date('Y-m-d H:i:s', $now));
+
                     $occurence_time = strtotime($occurence_date);
                 }
                 $creation_time  = $occurence_time - $create_before;


### PR DESCRIPTION
If a recurrent ticket's start date was outside its defined calendar some calculation were not done properly.

The fix is not easy to explain, IMO you should mainly look at the new test cases and make sure you agree with their expected results.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30651
