### PR TITLE
fix software installation dropdown

### DIFF
--- a/src/Software.php
+++ b/src/Software.php
@@ -668,7 +668,7 @@ class Software extends CommonDBTM
             $entity_restrict,
             true
         );
-        $rand = Dropdown::show('Software', ['condition' => $where]);
+        $rand = Dropdown::show('Software', ['condition' => ['WHERE' => $where]]);
 
         $paramsselsoft = ['softwares_id' => '__VALUE__',
             'myname'       => $myname


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Previously, it wasn't required that the condition be inside an array with a `WHERE` key, but a change on the main branch now tries prepending the table name to all keys in the condition array if they don't have a ".". Since a condition can have joins and where criteria, it is more correct to have the conditions inside a `WHERE` value here than to have an `is_array` check on the condition values in `Dropdown::getDropdownValue`. 