### PR TITLE
Fix broken install script

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -353,7 +353,7 @@ function step4($databasename, $newdatabasename)
                 $prev_form($host, $user, $password);
             }
         } else { // try to create the DB
-            if ($link->doQuery("CREATE DATABASE IF NOT EXISTS `" . $newdatabasename . "`")) {
+            if ($link->query("CREATE DATABASE IF NOT EXISTS `" . $newdatabasename . "`")) {
                 echo "<p>" . __('Database created') . "</p>";
 
                 $select_db = $link->select_db($newdatabasename);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fix bad replacement in install script. This `$link` variable is a `mysqli` object, not `DBmysql`. There was one other instance of a bad replacement that was previously fixed in this file.