### PR TITLE
Interactive local test env

### DIFF
--- a/.github/actions/init_initialize-ldap-fixtures.sh
+++ b/.github/actions/init_initialize-ldap-fixtures.sh
@@ -6,7 +6,11 @@ ROOT_DIR=$(readlink -f "$(dirname $0)/../..")
 for f in `ls $ROOT_DIR/tests/LDAP/ldif/*.ldif`; do
   # Delete all LDAP entries (in reverse ordre compared to creation)
   # but ignore errors as these entries may not exists.
-  (tac $f | grep -E '^dn:' | sed -E "s/^dn: (.*)$/\\1/" | docker-compose exec -T openldap ldapdelete -x -H ldap://127.0.0.1:3890/ -D "cn=Manager,dc=glpi,dc=org" -w insecure -c) \
+  #(tac $f | grep -E '^dn:' | sed -E "s/^dn: (.*)$/\\1/" | docker-compose exec -T openldap ldapdelete -x -H ldap://127.0.0.1:3890/ -D "cn=Manager,dc=glpi,dc=org" -w insecure -c) \
+  #|| true
+
+  # Recursively delete all LDAP entries
+  (cat $f | grep -E '^dn:' | sed -E "s/^dn: (.*)$/\\1/" | docker-compose exec -T openldap ldapdelete -x -r -H ldap://127.0.0.1:3890/ -D "cn=Manager,dc=glpi,dc=org" -w insecure -c) \
   || true
 done
 for f in `ls $ROOT_DIR/tests/LDAP/ldif/*.ldif`; do

--- a/.github/actions/init_initialize-ldap-fixtures.sh
+++ b/.github/actions/init_initialize-ldap-fixtures.sh
@@ -3,16 +3,9 @@ set -e -u -x -o pipefail
 
 ROOT_DIR=$(readlink -f "$(dirname $0)/../..")
 
-for f in `ls $ROOT_DIR/tests/LDAP/ldif/*.ldif`; do
-  # Delete all LDAP entries (in reverse ordre compared to creation)
-  # but ignore errors as these entries may not exists.
-  #(tac $f | grep -E '^dn:' | sed -E "s/^dn: (.*)$/\\1/" | docker-compose exec -T openldap ldapdelete -x -H ldap://127.0.0.1:3890/ -D "cn=Manager,dc=glpi,dc=org" -w insecure -c) \
-  #|| true
+# Recursively delete all LDAP entries
+docker-compose exec -T openldap ldapdelete -x -r -H ldap://127.0.0.1:3890/ -D "cn=Manager,dc=glpi,dc=org" -w insecure -c "dc=glpi,dc=org" || true
 
-  # Recursively delete all LDAP entries
-  (cat $f | grep -E '^dn:' | sed -E "s/^dn: (.*)$/\\1/" | docker-compose exec -T openldap ldapdelete -x -r -H ldap://127.0.0.1:3890/ -D "cn=Manager,dc=glpi,dc=org" -w insecure -c) \
-  || true
-done
 for f in `ls $ROOT_DIR/tests/LDAP/ldif/*.ldif`; do
   cat $f | docker-compose exec -T openldap ldapadd -x -H ldap://127.0.0.1:3890/ -D "cn=Manager,dc=glpi,dc=org" -w insecure
 done

--- a/.github/actions/test_tests-functional.sh
+++ b/.github/actions/test_tests-functional.sh
@@ -28,14 +28,17 @@ fi
 # Determine if scope is a file or a directory and set a scope type variable to 'd' or 'f' accordingly
 # scopes ending with a slash are considered as directories
 # Without a slash, if the file exists, it is considered as a file, otherwise as a directory
+# If the scope contains ::, it is a specific test method ('m' type)
 if [[ "$SCOPE" == *"/" ]]; then
   SCOPE_TYPE="d"
+elif [[ -f "$SCOPE" ]]; then
+  SCOPE_TYPE="f"
+elif [[ "$SCOPE" == *"::"* ]]; then
+  SCOPE_TYPE="m"
+  # Escape \ with \\
+  SCOPE=${SCOPE//\\/\\\\}
 else
-  if [[ -f "$SCOPE" ]]; then
-    SCOPE_TYPE="f"
-  else
-    SCOPE_TYPE="d"
-  fi
+  SCOPE_TYPE="d"
 fi
 
 vendor/bin/atoum \

--- a/.github/actions/test_tests-functional.sh
+++ b/.github/actions/test_tests-functional.sh
@@ -8,6 +8,36 @@ else
   ATOUM_ADDITIONNAL_OPTIONS="--no-code-coverage";
 fi
 
+# Get scope from -s option or default to 'tests/functional'
+SCOPE="tests/functional"
+while getopts ":s:" opt; do
+  case $opt in
+    s)
+      SCOPE=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
+if [[ "$SCOPE" == "" || "$SCOPE" == "default" ]]; then
+  SCOPE="tests/functional"
+fi
+
+# Determine if scope is a file or a directory and set a scope type variable to 'd' or 'f' accordingly
+# scopes ending with a slash are considered as directories
+# Without a slash, if the file exists, it is considered as a file, otherwise as a directory
+if [[ "$SCOPE" == *"/" ]]; then
+  SCOPE_TYPE="d"
+else
+  if [[ -f "$SCOPE" ]]; then
+    SCOPE_TYPE="f"
+  else
+    SCOPE_TYPE="d"
+  fi
+fi
+
 vendor/bin/atoum \
   -p 'php -d memory_limit=512M' \
   --debug \
@@ -18,6 +48,6 @@ vendor/bin/atoum \
   --fail-if-skipped-methods \
   $ATOUM_ADDITIONNAL_OPTIONS \
   --max-children-number 1 \
-  -d tests/functional
+  -$SCOPE_TYPE $SCOPE \
 
 unset COVERAGE_DIR

--- a/.github/actions/test_tests-functional.sh
+++ b/.github/actions/test_tests-functional.sh
@@ -8,12 +8,16 @@ else
   ATOUM_ADDITIONNAL_OPTIONS="--no-code-coverage";
 fi
 
-# Get scope from -s option or default to 'tests/functional'
-SCOPE="tests/functional"
-while getopts ":s:" opt; do
-  case $opt in
-    s)
-      SCOPE=$OPTARG
+# Get additional test arguments from -f, -d and -m options.
+SCOPE="-d tests/functional"
+METHODS=""
+while getopts ":d:f:m:" OPTNAME; do
+  case $OPTNAME in
+    d|f)
+      SCOPE="-${OPTNAME} ${OPTARG}"
+      ;;
+    m)
+      METHODS="-m ${OPTARG}"
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
@@ -21,25 +25,6 @@ while getopts ":s:" opt; do
       ;;
   esac
 done
-if [[ "$SCOPE" == "" || "$SCOPE" == "default" ]]; then
-  SCOPE="tests/functional"
-fi
-
-# Determine if scope is a file or a directory and set a scope type variable to 'd' or 'f' accordingly
-# scopes ending with a slash are considered as directories
-# Without a slash, if the file exists, it is considered as a file, otherwise as a directory
-# If the scope contains ::, it is a specific test method ('m' type)
-if [[ "$SCOPE" == *"/" ]]; then
-  SCOPE_TYPE="d"
-elif [[ -f "$SCOPE" ]]; then
-  SCOPE_TYPE="f"
-elif [[ "$SCOPE" == *"::"* ]]; then
-  SCOPE_TYPE="m"
-  # Escape \ with \\
-  SCOPE=${SCOPE//\\/\\\\}
-else
-  SCOPE_TYPE="d"
-fi
 
 vendor/bin/atoum \
   -p 'php -d memory_limit=512M' \
@@ -51,6 +36,7 @@ vendor/bin/atoum \
   --fail-if-skipped-methods \
   $ATOUM_ADDITIONNAL_OPTIONS \
   --max-children-number 1 \
-  -$SCOPE_TYPE $SCOPE \
+  $SCOPE \
+  $METHODS
 
 unset COVERAGE_DIR

--- a/.github/actions/test_tests-units.sh
+++ b/.github/actions/test_tests-units.sh
@@ -8,12 +8,16 @@ else
   ATOUM_ADDITIONNAL_OPTIONS="--no-code-coverage";
 fi
 
-# Get scope from -s option or default to 'tests/functional'
-SCOPE="tests/units"
-while getopts ":s:" opt; do
-  case $opt in
-    s)
-      SCOPE=$OPTARG
+# Get additional test arguments from -f, -d and -m options.
+SCOPE="-d tests/units"
+METHODS=""
+while getopts ":d:f:m:" OPTNAME; do
+  case $OPTNAME in
+    d|f)
+      SCOPE="-${OPTNAME} ${OPTARG}"
+      ;;
+    m)
+      METHODS="-m ${OPTARG}"
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
@@ -21,25 +25,6 @@ while getopts ":s:" opt; do
       ;;
   esac
 done
-if [[ "$SCOPE" == "" || "$SCOPE" == "default" ]]; then
-  SCOPE="tests/units"
-fi
-
-# Determine if scope is a file or a directory and set a scope type variable to 'd' or 'f' accordingly
-# scopes ending with a slash are considered as directories
-# Without a slash, if the file exists, it is considered as a file, otherwise as a directory
-# If the scope contains ::, it is a specific test method ('m' type)
-if [[ "$SCOPE" == *"/" ]]; then
-  SCOPE_TYPE="d"
-elif [[ -f "$SCOPE" ]]; then
-  SCOPE_TYPE="f"
-elif [[ "$SCOPE" == *"::"* ]]; then
-  SCOPE_TYPE="m"
-  # Escape \ with \\
-  SCOPE=${SCOPE//\\/\\\\}
-else
-  SCOPE_TYPE="d"
-fi
 
 vendor/bin/atoum \
   -p 'php -d memory_limit=512M' \
@@ -51,6 +36,7 @@ vendor/bin/atoum \
   --fail-if-skipped-methods \
   $ATOUM_ADDITIONNAL_OPTIONS \
   --max-children-number 10 \
-  -$SCOPE_TYPE $SCOPE
+  $SCOPE \
+  $METHODS
 
 unset COVERAGE_DIR

--- a/.github/actions/test_tests-units.sh
+++ b/.github/actions/test_tests-units.sh
@@ -8,6 +8,36 @@ else
   ATOUM_ADDITIONNAL_OPTIONS="--no-code-coverage";
 fi
 
+# Get scope from -s option or default to 'tests/functional'
+SCOPE="tests/units"
+while getopts ":s:" opt; do
+  case $opt in
+    s)
+      SCOPE=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
+if [[ "$SCOPE" == "" || "$SCOPE" == "default" ]]; then
+  SCOPE="tests/units"
+fi
+
+# Determine if scope is a file or a directory and set a scope type variable to 'd' or 'f' accordingly
+# scopes ending with a slash are considered as directories
+# Without a slash, if the file exists, it is considered as a file, otherwise as a directory
+if [[ "$SCOPE" == *"/" ]]; then
+  SCOPE_TYPE="d"
+else
+  if [[ -f "$SCOPE" ]]; then
+    SCOPE_TYPE="f"
+  else
+    SCOPE_TYPE="d"
+  fi
+fi
+
 vendor/bin/atoum \
   -p 'php -d memory_limit=512M' \
   --debug \
@@ -18,6 +48,6 @@ vendor/bin/atoum \
   --fail-if-skipped-methods \
   $ATOUM_ADDITIONNAL_OPTIONS \
   --max-children-number 10 \
-  -d tests/units
+  -$SCOPE_TYPE $SCOPE
 
 unset COVERAGE_DIR

--- a/.github/actions/test_tests-units.sh
+++ b/.github/actions/test_tests-units.sh
@@ -28,14 +28,17 @@ fi
 # Determine if scope is a file or a directory and set a scope type variable to 'd' or 'f' accordingly
 # scopes ending with a slash are considered as directories
 # Without a slash, if the file exists, it is considered as a file, otherwise as a directory
+# If the scope contains ::, it is a specific test method ('m' type)
 if [[ "$SCOPE" == *"/" ]]; then
   SCOPE_TYPE="d"
+elif [[ -f "$SCOPE" ]]; then
+  SCOPE_TYPE="f"
+elif [[ "$SCOPE" == *"::"* ]]; then
+  SCOPE_TYPE="m"
+  # Escape \ with \\
+  SCOPE=${SCOPE//\\/\\\\}
 else
-  if [[ -f "$SCOPE" ]]; then
-    SCOPE_TYPE="f"
-  else
-    SCOPE_TYPE="d"
-  fi
+  SCOPE_TYPE="d"
 fi
 
 vendor/bin/atoum \

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -350,7 +350,7 @@ EOF
       TESTS_TO_RUN=(${CHOICE#settest })
     elif [[ "$CHOICE" = setscope* ]]; then
       SCOPE=${CHOICE#setscope }
-      if [[ ! "$SCOPE" =~ ^tests/ ]]; then
+      if [[ ! "$SCOPE" =~ ^tests/ && "$SCOPE" != "default" && "$SCOPE" != "" ]]; then
         SCOPE="tests/$SCOPE"
       fi
     elif [[ "$CHOICE" = "info" ]]; then

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -342,10 +342,10 @@ fi
 
 if [[ "$INTERACTIVE" = true ]]; then
   CHOICE=""
-  TESTS_TO_RUN=("${SELECTED_TESTS_TO_RUN[@]}")
-  SCOPE=$SELECTED_SCOPE
-  show_info
   while [[ "$CHOICE" != "exit" ]]; do
+    TESTS_TO_RUN=("${SELECTED_TESTS_TO_RUN[@]}")
+    SCOPE=$SELECTED_SCOPE
+    show_info
     read -e -p "GLPI Tests > " CHOICE
     if [[ "$CHOICE" = run* ]]; then
       # If actions were specified after the run choice, use them instead of the ones selected

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -364,57 +364,55 @@ if [[ "$INTERACTIVE" = true ]]; then
     SCOPE=$SELECTED_SCOPE
     METHODS=$SELECTED_METHODS
     show_info
-    while read -r -e -d $'\n' -p 'GLPI Tests > ' CHOICE; do
-      history -s "$CHOICE"
-      if [[ "$CHOICE" = run* ]]; then
-        # If actions were specified after the run choice, use them instead of the ones selected
-        if [[ "$CHOICE" != "run" ]]; then
-          RUN_OPTS=(${CHOICE#run })
-          # TESTS_TO_RUN is the first argument. It should be a single word without spaces.
-          # The second argument, if it exists, is the scope. If it doesn't exist, the scope is the selected one.
-          TESTS_TO_RUN=(${RUN_OPTS[0]})
-          if [[ ${#RUN_OPTS[@]} -gt 1 ]]; then
-            SCOPE=${RUN_OPTS[1]}
-          else
-            SCOPE="default"
-          fi
-          # The third argument, if it exists, is the methods pattern. If it doesn't exist, the methods pattern is the selected one.
-          if [[ ${#RUN_OPTS[@]} -gt 2 ]]; then
-            METHODS=${RUN_OPTS[2]}
-          else
-            METHODS="all"
-          fi
+    read -e -r -p "GLPI Tests > " CHOICE
+    if [[ "$CHOICE" = run* ]]; then
+      # If actions were specified after the run choice, use them instead of the ones selected
+      if [[ "$CHOICE" != "run" ]]; then
+        RUN_OPTS=(${CHOICE#run })
+        # TESTS_TO_RUN is the first argument. It should be a single word without spaces.
+        # The second argument, if it exists, is the scope. If it doesn't exist, the scope is the selected one.
+        TESTS_TO_RUN=(${RUN_OPTS[0]})
+        if [[ ${#RUN_OPTS[@]} -gt 1 ]]; then
+          SCOPE=${RUN_OPTS[1]}
+        else
+          SCOPE="default"
         fi
-        run_tests
-      elif [[ "$CHOICE" = "help" ]]; then
-        cat << EOF
-  Available commands:
-    - run [action] [scope]: Run the currently selected actions or run the single specified action with the specified scope (defaults to the selected scope).
-    - set action [actions]: Change the currently selected actions.
-    - set scope [scope]: Change the currently selected scope. The scope affects which file or directory the tests are run on (if supported by the test).
-    - set methods [methods]: Change the currently selected methods pattern. This affects which tests methods are run (if supported by the test).
-    - info: Display information about the currently selected actions, scope and methods pattern.
-    - exit: Stop the containers and exit.
-    - help: See this list of commands.
-EOF
-      elif [[ "$CHOICE" = set[[:space:]]action* ]]; then
-        SELECTED_TESTS_TO_RUN=(${CHOICE#set[[:space:]]action })
-      elif [[ "$CHOICE" = set[[:space:]]scope* ]]; then
-        SELECTED_SCOPE=${CHOICE#set[[:space:]]scope }
-        if [[ ! "$SELECTED_SCOPE" =~ ^tests/ && "$SELECTED_SCOPE" != "default" && "$SELECTED_SCOPE" != "" ]]; then
-          SELECTED_SCOPE="tests/$SELECTED_SCOPE"
+        # The third argument, if it exists, is the methods pattern. If it doesn't exist, the methods pattern is the selected one.
+        if [[ ${#RUN_OPTS[@]} -gt 2 ]]; then
+          METHODS=${RUN_OPTS[2]}
+        else
+          METHODS="all"
         fi
-      elif [[ "$CHOICE" = set[[:space:]]methods* ]]; then
-        SELECTED_METHODS=${CHOICE#set[[:space:]]methods }
-      elif [[ "$CHOICE" = "info" ]]; then
-        show_info
-      elif [[ "$CHOICE" = "exit" ]]; then
-        cleanup_and_exit
-      else
-        echo -e "\e[1;39;41m Invalid command \e[0m"
       fi
-      CHOICE=""
-    done
+      run_tests
+    elif [[ "$CHOICE" = "help" ]]; then
+      cat << EOF
+Available commands:
+  - run [action] [scope]: Run the currently selected actions or run the single specified action with the specified scope (defaults to the selected scope).
+  - set action [actions]: Change the currently selected actions.
+  - set scope [scope]: Change the currently selected scope. The scope affects which file or directory the tests are run on (if supported by the test).
+  - set methods [methods]: Change the currently selected methods pattern. This affects which tests methods are run (if supported by the test).
+  - info: Display information about the currently selected actions, scope and methods pattern.
+  - exit: Stop the containers and exit.
+  - help: See this list of commands.
+EOF
+    elif [[ "$CHOICE" = set[[:space:]]action* ]]; then
+      SELECTED_TESTS_TO_RUN=(${CHOICE#set[[:space:]]action })
+    elif [[ "$CHOICE" = set[[:space:]]scope* ]]; then
+      SELECTED_SCOPE=${CHOICE#set[[:space:]]scope }
+      if [[ ! "$SELECTED_SCOPE" =~ ^tests/ && "$SELECTED_SCOPE" != "default" && "$SELECTED_SCOPE" != "" ]]; then
+        SELECTED_SCOPE="tests/$SELECTED_SCOPE"
+      fi
+    elif [[ "$CHOICE" = set[[:space:]]methods* ]]; then
+      SELECTED_METHODS=${CHOICE#set[[:space:]]methods }
+    elif [[ "$CHOICE" = "info" ]]; then
+      show_info
+    elif [[ "$CHOICE" = "exit" ]]; then
+      cleanup_and_exit
+    else
+      echo -e "\e[1;39;41m Invalid command \e[0m"
+    fi
+    CHOICE=""
   done
 fi
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -364,55 +364,57 @@ if [[ "$INTERACTIVE" = true ]]; then
     SCOPE=$SELECTED_SCOPE
     METHODS=$SELECTED_METHODS
     show_info
-    read -e -r -p "GLPI Tests > " CHOICE
-    if [[ "$CHOICE" = run* ]]; then
-      # If actions were specified after the run choice, use them instead of the ones selected
-      if [[ "$CHOICE" != "run" ]]; then
-        RUN_OPTS=(${CHOICE#run })
-        # TESTS_TO_RUN is the first argument. It should be a single word without spaces.
-        # The second argument, if it exists, is the scope. If it doesn't exist, the scope is the selected one.
-        TESTS_TO_RUN=(${RUN_OPTS[0]})
-        if [[ ${#RUN_OPTS[@]} -gt 1 ]]; then
-          SCOPE=${RUN_OPTS[1]}
-        else
-          SCOPE="default"
+    while read -r -e -d $'\n' -p 'GLPI Tests > ' CHOICE; do
+      history -s "$CHOICE"
+      if [[ "$CHOICE" = run* ]]; then
+        # If actions were specified after the run choice, use them instead of the ones selected
+        if [[ "$CHOICE" != "run" ]]; then
+          RUN_OPTS=(${CHOICE#run })
+          # TESTS_TO_RUN is the first argument. It should be a single word without spaces.
+          # The second argument, if it exists, is the scope. If it doesn't exist, the scope is the selected one.
+          TESTS_TO_RUN=(${RUN_OPTS[0]})
+          if [[ ${#RUN_OPTS[@]} -gt 1 ]]; then
+            SCOPE=${RUN_OPTS[1]}
+          else
+            SCOPE="default"
+          fi
+          # The third argument, if it exists, is the methods pattern. If it doesn't exist, the methods pattern is the selected one.
+          if [[ ${#RUN_OPTS[@]} -gt 2 ]]; then
+            METHODS=${RUN_OPTS[2]}
+          else
+            METHODS="all"
+          fi
         fi
-        # The third argument, if it exists, is the methods pattern. If it doesn't exist, the methods pattern is the selected one.
-        if [[ ${#RUN_OPTS[@]} -gt 2 ]]; then
-          METHODS=${RUN_OPTS[2]}
-        else
-          METHODS="all"
-        fi
-      fi
-      run_tests
-    elif [[ "$CHOICE" = "help" ]]; then
-      cat << EOF
-Available commands:
-  - run [action] [scope]: Run the currently selected actions or run the single specified action with the specified scope (defaults to the selected scope).
-  - set action [actions]: Change the currently selected actions.
-  - set scope [scope]: Change the currently selected scope. The scope affects which file or directory the tests are run on (if supported by the test).
-  - set methods [methods]: Change the currently selected methods pattern. This affects which tests methods are run (if supported by the test).
-  - info: Display information about the currently selected actions, scope and methods pattern.
-  - exit: Stop the containers and exit.
-  - help: See this list of commands.
+        run_tests
+      elif [[ "$CHOICE" = "help" ]]; then
+        cat << EOF
+  Available commands:
+    - run [action] [scope]: Run the currently selected actions or run the single specified action with the specified scope (defaults to the selected scope).
+    - set action [actions]: Change the currently selected actions.
+    - set scope [scope]: Change the currently selected scope. The scope affects which file or directory the tests are run on (if supported by the test).
+    - set methods [methods]: Change the currently selected methods pattern. This affects which tests methods are run (if supported by the test).
+    - info: Display information about the currently selected actions, scope and methods pattern.
+    - exit: Stop the containers and exit.
+    - help: See this list of commands.
 EOF
-    elif [[ "$CHOICE" = set[[:space:]]action* ]]; then
-      SELECTED_TESTS_TO_RUN=(${CHOICE#set[[:space:]]action })
-    elif [[ "$CHOICE" = set[[:space:]]scope* ]]; then
-      SELECTED_SCOPE=${CHOICE#set[[:space:]]scope }
-      if [[ ! "$SELECTED_SCOPE" =~ ^tests/ && "$SELECTED_SCOPE" != "default" && "$SELECTED_SCOPE" != "" ]]; then
-        SELECTED_SCOPE="tests/$SELECTED_SCOPE"
+      elif [[ "$CHOICE" = set[[:space:]]action* ]]; then
+        SELECTED_TESTS_TO_RUN=(${CHOICE#set[[:space:]]action })
+      elif [[ "$CHOICE" = set[[:space:]]scope* ]]; then
+        SELECTED_SCOPE=${CHOICE#set[[:space:]]scope }
+        if [[ ! "$SELECTED_SCOPE" =~ ^tests/ && "$SELECTED_SCOPE" != "default" && "$SELECTED_SCOPE" != "" ]]; then
+          SELECTED_SCOPE="tests/$SELECTED_SCOPE"
+        fi
+      elif [[ "$CHOICE" = set[[:space:]]methods* ]]; then
+        SELECTED_METHODS=${CHOICE#set[[:space:]]methods }
+      elif [[ "$CHOICE" = "info" ]]; then
+        show_info
+      elif [[ "$CHOICE" = "exit" ]]; then
+        cleanup_and_exit
+      else
+        echo -e "\e[1;39;41m Invalid command \e[0m"
       fi
-    elif [[ "$CHOICE" = set[[:space:]]methods* ]]; then
-      SELECTED_METHODS=${CHOICE#set[[:space:]]methods }
-    elif [[ "$CHOICE" = "info" ]]; then
-      show_info
-    elif [[ "$CHOICE" = "exit" ]]; then
-      cleanup_and_exit
-    else
-      echo -e "\e[1;39;41m Invalid command \e[0m"
-    fi
-    CHOICE=""
+      CHOICE=""
+    done
   done
 fi
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -350,7 +350,7 @@ EOF
       TESTS_TO_RUN=(${CHOICE#settest })
     elif [[ "$CHOICE" = setscope* ]]; then
       SCOPE=${CHOICE#setscope }
-      if [[ ! "$SCOPE" =~ ^tests/ && "$SCOPE" != "default" && "$SCOPE" != "" ]]; then
+      if [[ ! "$SCOPE" =~ ^tests/ && "$SCOPE" != "default" && "$SCOPE" != "" && "$SCOPE" != *"::"* ]]; then
         SCOPE="tests/$SCOPE"
       fi
     elif [[ "$CHOICE" = "info" ]]; then


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

GLPI tests (specifically PHP code tests) can take a very long time to run. My previous answer for that was to manually edit the `test_tests-functional.sh` file locally to restrict tests to a specific directory or file. While that worked, it could be quicker if the docker containers didn't have to get recreated every time `tests/run_tests.sh` is run.

This PR adds a new "interactive" mode to the `run_tests.sh` script which can be activated with the `--interactive` flag. In interactive mode, all containers are started immediately and then it asks the user to enter one of several commands:
- test: Run the currently selected tests. By default, it gets this from the `run_tests.sh` arguments like it did before.
- settest: Change the currently selected test(s)
- setscope: Change the currently selected scope. This is the file or directory to run tests against if the test supports it. Currently, this only affects unit and functional tests. By default, this is "default" which means the default scope for the test (units/functional test folder)
- info: Displays the currently selected tests and scope
- help: Displays the command list
- exit: Stops the containers and exits

After tests are run in interactive mode, regardless of their success, the user is prompted for another command rather than exiting.
If you run tests again and the install was already run, it will not repeat the install tests unless they were explicitly requested.

Also, I tried to fix the LDAP fixture cleanup. When I tried running LDAP tests multiple times, it would fail to add `dc=glpi,dc=org` again and I think it is because the script was only running `ldapdelete` on leaf nodes. I changed it to do recursive deletes instead, but I am not 100% confident it was the best solution.

Examples:
- `tests/run_tests.sh functional`: Run functional tests in non-interactive mode. Same as before.
- `tests/run_tests.sh --interactive functional`: Run in interactive mode and select "functional" tests.
- `settest lint ldap` (inside interactive mode test runner): Select lint and ldap test(s)