### PR TITLE
Take db groups into account for rights rules on LDAP users

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -2032,6 +2032,15 @@ class User extends CommonDBTM
                     $groups = [];
                 }
 
+                // Take database groups into acount
+                $searched_user = new User();
+                if (
+                    $login !== null
+                    && $searched_user->getFromDBbySyncField(Sanitizer::sanitize($login))
+                ) {
+                    $groups = array_merge($groups, Group_User::getUserGroups($searched_user->getID()));
+                }
+
                 $this->fields = $rule->processAllRules($groups, Toolbox::stripslashes_deep($this->fields), [
                     'type'        => Auth::LDAP,
                     'ldap_server' => $ldap_method["id"],

--- a/tests/DbTestCase.php
+++ b/tests/DbTestCase.php
@@ -272,9 +272,10 @@ class DbTestCase extends \GLPITestCase
      */
     protected function createRule(RuleBuilder $builder): Rule
     {
-        $rule = $this->createItem(RuleTicket::class, [
+        // Add rule ticket
+        $rule = $this->createItem($builder->getRuleType(), [
             'is_active'    => 1,
-            'sub_type'     => 'RuleTicket',
+            'sub_type'     => $builder->getRuleType(),
             'name'         => $builder->getName(),
             'match'        => $builder->getOperator(),
             'condition'    => $builder->getCondition(),

--- a/tests/RuleBuilder.php
+++ b/tests/RuleBuilder.php
@@ -44,6 +44,11 @@ class RuleBuilder
     protected string $name;
 
     /**
+     * @property string $name Rule name
+     */
+    protected string $rule_type;
+
+    /**
      * @property string $operator 'AND' or 'OR'
      */
     protected string $operator;
@@ -76,17 +81,23 @@ class RuleBuilder
     /**
      * @param string $name Rule name
      */
-    public function __construct(string $name)
+    public function __construct(string $name, ?string $rule_type = null)
     {
         $this->name = $name;
 
         // Default values
         $this->operator     = "AND";
-        $this->condition    = RuleTicket::ONADD | RuleTicket::ONUPDATE;
+        $this->rule_type    = $rule_type ?? RuleTicket::class;
         $this->is_recursive = true;
         $this->entities_id  = getItemByTypeName(Entity::class, '_test_root_entity', true);
         $this->criteria     = [];
         $this->actions      = [];
+
+        if ($this->rule_type === RuleTicket::class) {
+            $this->condition = RuleTicket::ONADD | RuleTicket::ONUPDATE;
+        } else {
+            $this->condition = 0;
+        }
     }
 
     /**
@@ -185,7 +196,6 @@ class RuleBuilder
         return $this;
     }
 
-
     /**
      * Get rule name
      *
@@ -194,6 +204,16 @@ class RuleBuilder
     public function getName(): string
     {
         return $this->name;
+    }
+
+    /**
+     * Get rule type
+     *
+     * @return string Rule type
+     */
+    public function getRuleType(): string
+    {
+        return $this->rule_type;
     }
 
     /**


### PR DESCRIPTION
The "groups" criteria for authorizations rules is not processed correctly for LDAP users.

I've tried to add a test case but sadly it isn't working correctly.
It feels like there is a cache somewhere that prevent the test case from being useful but doesn't prevent the fix from being effective on the "real" GLPI's UI.

I've still included the broken test, maybe someone can fix it in the future (I've not been able to myself after spending a lot of time on it and would like to cut my losses here...).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30694
