### PR TITLE
Fix(Profil): avoid duplicate column for right

### DIFF
--- a/src/Profile.php
+++ b/src/Profile.php
@@ -975,7 +975,10 @@ class Profile extends CommonDBTM
                                 'rights' => [
                                     READ  => __('Read'),
                                     UPDATE  => __('Update'),
-                                    DELETE => __('Delete'),
+                                    DELETE => [
+                                        'short' => __('Delete'),
+                                        'long'  => _x('button', 'Put in trashbin')
+                                    ],
                                     PURGE   => [
                                         'short' => __('Purge'),
                                         'long'  => _x('button', 'Delete permanently')


### PR DESCRIPTION
The ```delete``` right for ```Unmanaged``` does not have the same format 

```php
DELETE => __('Delete'),
```
as that used by the core

```php
DELETE => [
    'short' => __('Delete'),
    'long'  => _x('button', 'Put in trashbin')
],
```

This adds an extra "delete" column
![image](https://github.com/glpi-project/glpi/assets/7335054/5676852c-fa91-4410-a2cb-98c79f2a8269)



this PR corrects this behaviour
![image](https://github.com/glpi-project/glpi/assets/7335054/e57b972f-9679-4b05-af03-945bd92345b6)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
