### PR TITLE
Open one PR from dependabot instead of several

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,22 +13,26 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    allow:
-      - dependency-type: "development"
-    open-pull-requests-limit: 100
-    target-branch: "10.0/bugfixes"
-    versioning-strategy: "increase"
-    rebase-strategy: "disabled"
+    groups:
+      javascripts:
+        allow:
+          - dependency-type: "development"
+        open-pull-requests-limit: 100
+        target-branch: "10.0/bugfixes"
+        versioning-strategy: "increase"
+        rebase-strategy: "disabled"
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
       interval: "monthly"
-    allow:
-      - dependency-type: "development"
-    open-pull-requests-limit: 100
-    target-branch: "10.0/bugfixes"
-    versioning-strategy: "increase"
-    rebase-strategy: "disabled"
+    groups:
+      phplibs:
+        allow:
+          - dependency-type: "development"
+        open-pull-requests-limit: 100
+        target-branch: "10.0/bugfixes"
+        versioning-strategy: "increase"
+        rebase-strategy: "disabled"
 
 
   # Update production dependencies on future release branch (main).
@@ -36,19 +40,23 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    allow:
-      - dependency-type: "production"
-    open-pull-requests-limit: 100
-    target-branch: "main"
-    versioning-strategy: "increase"
-    rebase-strategy: "disabled"
+    groups:
+      javascripts:
+        allow:
+          - dependency-type: "production"
+        open-pull-requests-limit: 100
+        target-branch: "main"
+        versioning-strategy: "increase"
+        rebase-strategy: "disabled"
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
       interval: "monthly"
-    allow:
-      - dependency-type: "production"
-    open-pull-requests-limit: 100
-    target-branch: "main"
-    versioning-strategy: "increase"
-    rebase-strategy: "disabled"
+    groups:
+      phplibs:
+        allow:
+          - dependency-type: "production"
+        open-pull-requests-limit: 100
+        target-branch: "main"
+        versioning-strategy: "increase"
+        rebase-strategy: "disabled"


### PR DESCRIPTION
See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/customizing-dependency-updates#grouping-dependabot-version-updates-into-one-pull-request

I almost understand anything; and I have no idea how to check if that configuration is valid :/
