### PR TITLE
Review CI PHP/SQL versions matrix

### DIFF
--- a/.github/actions/init_build.sh
+++ b/.github/actions/init_build.sh
@@ -4,18 +4,21 @@ set -e -u -x -o pipefail
 # Stable versions contains only 3 groups of digits separated by a dot,
 # i.e. no "dev", "alpha", "beta, "rc", ... keyword.
 STABLE_REGEX="^[0-9]+\.[0-9]+\.[0-9]+$"
-
-PHP_MAJOR_VERSION="$(echo $PHP_VERSION | cut -d '.' -f 1,2)"
+PHP_MAJOR_VERSION="$(echo $PHP_VERSION | cut -d '.' -f 1,2 | sed 's/\.//')"
+CHECK_PLATFORM_REQS="false"
+if [[ "$PHP_VERSION" =~ $STABLE_REGEX && "$PHP_MAJOR_VERSION" -lt "82" ]]; then
+    CHECK_PLATFORM_REQS="true"
+fi
 
 # Validate composer config
 composer validate --strict
-if [[ "$PHP_VERSION" =~ $STABLE_REGEX && "$PHP_MAJOR_VERSION" -ne "8.2" ]]; then
+if [[ "$CHECK_PLATFORM_REQS" == "true" ]]; then
   composer check-platform-reqs;
 fi
 
 # Install dependencies
 COMPOSER_ADD_OPTS=""
-if ! [[ "$PHP_VERSION" =~ $STABLE_REGEX && "$PHP_MAJOR_VERSION" -ne "8.2" ]]; then
+if [[ "$CHECK_PLATFORM_REQS" == "false" ]]; then
   COMPOSER_ADD_OPTS="--ignore-platform-reqs";
 fi
 bin/console dependencies install --composer-options="$COMPOSER_ADD_OPTS --prefer-dist --no-progress"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       matrix:
         include:
           - {php-version: "7.4"} # Lint on lower PHP version to detected too early usage of new syntaxes
-          - {php-version: "8.2"} # Lint on higher PHP version to detected deprecated elements usage
-          - {php-version: "8.3"}
+          - {php-version: "8.3"} # Lint on higher PHP version to detected deprecated elements usage
     env:
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml"
       APPLICATION_ROOT: "${{ github.workspace }}"
@@ -104,20 +103,18 @@ jobs:
       matrix:
         include:
           # test higher PHP version with higher MariaDB and MySQL versions
-          - {php-version: "8.2", db-image: "mariadb:11.0", always: true}
-          - {php-version: "8.2", db-image: "mysql:8.1", always: true}
-          - {php-version: "8.3", db-image: "mariadb:11.0", always: true}
+          - {php-version: "8.3", db-image: "mariadb:10.11", always: true}
+          - {php-version: "8.3", db-image: "mysql:8.0", always: true}
           # test other PHP versions
-          - {php-version: "8.1", db-image: "mariadb:11.0", always: false}
-          - {php-version: "8.0", db-image: "mariadb:11.0", always: false}
-          - {php-version: "7.4", db-image: "mariadb:11.0", always: false}
-          # test other DB servers/versions
-          - {php-version: "8.2", db-image: "mariadb:10.2", always: false}
           - {php-version: "8.2", db-image: "mariadb:10.11", always: false}
-          - {php-version: "8.2", db-image: "mysql:5.7", always: false}
-          - {php-version: "8.2", db-image: "mysql:8.0", always: false}
-          - {php-version: "8.2", db-image: "percona:5.7", always: false}
-          - {php-version: "8.2", db-image: "percona:8.0", always: false}
+          - {php-version: "8.1", db-image: "mariadb:10.11", always: false}
+          - {php-version: "8.0", db-image: "mariadb:10.11", always: false}
+          - {php-version: "7.4", db-image: "mariadb:10.11", always: false}
+          # test other DB servers/versions
+          - {php-version: "8.3", db-image: "mariadb:10.2", always: false}
+          - {php-version: "8.3", db-image: "mysql:5.7", always: false}
+          - {php-version: "8.3", db-image: "percona:5.7", always: false}
+          - {php-version: "8.3", db-image: "percona:8.0", always: false}
     env:
       # Skip jobs that should not be always run on pull requests or on push on tier repository (to limit workers usage).
       # No jobs will be skipped on nightly build, manual dispatch or push on main branches (main and */bugfixes) or tags.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Do not check platform requirements on PHP 8.3. Checks were already ignored on PHP 8.2, because some of our dependencies are not marked as compatible with PHP > 8.1, even if they are probably compatible. We cannot update them because new versions are not compatible with PHP 7.4. E.g. `friendsoftwig/twigcs` v6.3 has support of PHP 8.3 but no support of PHP 7.4.

2. Use PHP 8.3 instead of PHP 8.2 for checks done on PRs.

3. Remove MySQL and MariaDB recent releases that are not marked as LTS. They are producing a new release every 3 months and it will take too much time to update our ci matrix so often. Moreover, these non LTS versions have a really short support cycle (MySQL 8.1 support has already ending, 4 months after its initial release).