### PR TITLE
Fix `plugin_xxx_deactivate` hook execution

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1116,6 +1116,9 @@ class Plugin extends CommonDBTM
     {
 
         if ($this->getFromDB($ID)) {
+            // Load plugin hooks
+            self::load($this->fields['directory'], true);
+
             $deactivate_function = 'plugin_' . $this->fields['directory'] . '_deactivate';
             if (function_exists($deactivate_function)) {
                 $deactivate_function();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #16075

The  `plugin_xxx_deactivate` hook was almost never executed as corresponding plugin `hook.php` file was not loaded.