### PR TITLE
Fix handling of `%x$y` in JS translations

### DIFF
--- a/lib/bundles/base.js
+++ b/lib/bundles/base.js
@@ -94,11 +94,16 @@ window._ = require('lodash');
 // add translation function into global scope
 // signature is almost the same as for PHP functions, but accept extra arguments for string variables
 window.i18n = require('gettext.js/lib/gettext').default({domain: 'glpi'});
+
+const escape_msgid = function (msgid) {
+    return msgid.replace(/%(\d+)\$/g, '%%$1\$');
+};
+
 window.__ = function (msgid, domain /* , extra */) {
     domain = typeof(domain) !== 'undefined' ? domain : 'glpi';
     var text = i18n.dcnpgettext.apply(
         i18n,
-        [domain, undefined, msgid, undefined, undefined].concat(Array.prototype.slice.call(arguments, 2))
+        [domain, undefined, escape_msgid(msgid), undefined, undefined].concat(Array.prototype.slice.call(arguments, 2))
     );
     return _.escape(text);
 };
@@ -107,7 +112,7 @@ window._n = function (msgid, msgid_plural, n, domain /* , extra */) {
     domain = typeof(domain) !== 'undefined' ? domain : 'glpi';
     var text = i18n.dcnpgettext.apply(
         i18n,
-        [domain, undefined, msgid, msgid_plural, n].concat(Array.prototype.slice.call(arguments, 4))
+        [domain, undefined, escape_msgid(msgid), escape_msgid(msgid_plural), n].concat(Array.prototype.slice.call(arguments, 4))
     );
     return _.escape(text);
 };
@@ -115,7 +120,7 @@ window._x = function (msgctxt, msgid, domain /* , extra */) {
     domain = typeof(domain) !== 'undefined' ? domain : 'glpi';
     var text = i18n.dcnpgettext.apply(
         i18n,
-        [domain, msgctxt, msgid, undefined, undefined].concat(Array.prototype.slice.call(arguments, 3))
+        [domain, msgctxt, escape_msgid(msgid), undefined, undefined].concat(Array.prototype.slice.call(arguments, 3))
     );
     return _.escape(text);
 };
@@ -123,7 +128,7 @@ window._nx = function (msgctxt, msgid, msgid_plural, n, domain /* , extra */) {
     domain = typeof(domain) !== 'undefined' ? domain : 'glpi';
     var text = i18n.dcnpgettext.apply(
         i18n,
-        [domain, msgctxt, msgid, msgid_plural, n].concat(Array.prototype.slice.call(arguments, 5))
+        [domain, msgctxt, escape_msgid(msgid), escape_msgid(msgid_plural), n].concat(Array.prototype.slice.call(arguments, 5))
     );
     return _.escape(text);
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`gettext.js` tries to replace `%x` by extra args.

- `__('Created by %1$s on %2$s')` will return `Created by undefined$s on undefined$s`
- `__('Created by %1$s on %2$s', 'glpi', 'me', '2023/12/07')` will return `Created by me$s on 2023/12/07$s`

With proposed patch, `%x$y` will be protected by an extra `%` (e.g. `%%x$y`), so the translation component could be used as expected: `__('Created by %1$s on %2$s').replace('%1$s', 'me').replace('%1$s', '2023/12/07')`.