### PR TITLE
Improved handling of broken saved searches

### DIFF
--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -861,34 +861,36 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
 
         $iterator = $DB->request($criteria);
         foreach ($iterator as $data) {
+            $error = false;
+
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $this->fields = $data;
                 $count = null;
+                $search_data = null;
                 try {
                     $search_data = $this->execute(false, $enable_partial_warnings);
-                } catch (\RuntimeException $e) {
-                    ErrorHandler::getInstance()->handleException($e);
-                    $search_data = false;
                 } catch (\Throwable $e) {
                     ErrorHandler::getInstance()->handleException($e);
+                    $error = true;
+                }
+
+                if ($error) {
                     $info_message = __s('A fatal error occurred while executing this saved search. It is not able to be used.');
                     $count = "<span class='ti ti-alert-triangle-filled' title='$info_message'></span>";
-                    $data['_error'] = true;
-                }
-                if (isset($search_data['data']['totalcount'])) {
+                } elseif (isset($search_data['data']['totalcount'])) {
                     $count = $search_data['data']['totalcount'];
                 } else {
                     $info_message = ($this->fields['do_count'] == self::COUNT_NO)
                                 ? __s('Count for this saved search has been disabled.')
                                 : __s('Counting this saved search would take too long, it has been skipped.');
-                    if ($count === null) {
-                       //no count, just inform the user
-                        $count = "<span class='ti ti-info-circle' title='$info_message'></span>";
-                    }
+                    // no count, just inform the user
+                    $count = "<span class='ti ti-info-circle' title='$info_message'></span>";
                 }
 
                 $data['count'] = $count;
             }
+
+            $data['_error'] = $error;
 
             $searches[$data['id']] = $data;
         }

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -869,6 +869,11 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
                 } catch (\RuntimeException $e) {
                     ErrorHandler::getInstance()->handleException($e);
                     $search_data = false;
+                } catch (\Throwable $e) {
+                    ErrorHandler::getInstance()->handleException($e);
+                    $info_message = __s('A fatal error occurred while executing this saved search. It is not able to be used.');
+                    $count = "<span class='ti ti-alert-triangle-filled' title='$info_message'></span>";
+                    $data['_error'] = true;
                 }
                 if (isset($search_data['data']['totalcount'])) {
                     $count = $search_data['data']['totalcount'];

--- a/templates/layout/parts/saved_searches_list.html.twig
+++ b/templates/layout/parts/saved_searches_list.html.twig
@@ -41,7 +41,7 @@
 {% for search in saved_searches %}
    <div class="savedsearches-item grip-savedsearch list-group-item search-line d-flex align-items-center pe-1 {{ active == search['id'] ? 'active' : '' }}"
          data-id="{{ search['id'] }}">
-      {% if search['_error'] is not defined or search['_error'] == false %}
+      {% if not search['_error'] %}
           <a href="{{ 'SavedSearch'|itemtype_search_path }}?action=load&amp;id={{ search['id'] }}"
              class="d-block saved-searches-link text-truncate">
              {{ search['name']|verbatim_value }}
@@ -52,7 +52,7 @@
           </span>
       {% endif %}
       <div class="{{ search['is_default'] > 0 ? '' : 'list-group-item-actions' }} ms-auto default-ctrl">
-          {% if search['_error'] is not defined or search['_error'] == false %}
+          {% if not search['_error'] %}
              <i class="{{ search['is_default'] > 0 ? 'fas' : 'far' }} fa-star fa-xs mark-default me-1"
                 title="{{ search['is_default'] > 0 ? __('Default search') : __('mark as default') }}"
                 data-bs-toggle="tooltip" data-bs-placement="right"

--- a/templates/layout/parts/saved_searches_list.html.twig
+++ b/templates/layout/parts/saved_searches_list.html.twig
@@ -41,15 +41,23 @@
 {% for search in saved_searches %}
    <div class="savedsearches-item grip-savedsearch list-group-item search-line d-flex align-items-center pe-1 {{ active == search['id'] ? 'active' : '' }}"
          data-id="{{ search['id'] }}">
-      <a href="{{ 'SavedSearch'|itemtype_search_path }}?action=load&amp;id={{ search['id'] }}"
-         class="d-block saved-searches-link text-truncate">
-         {{ search['name']|verbatim_value }}
-      </a>
+      {% if search['_error'] is not defined or search['_error'] == false %}
+          <a href="{{ 'SavedSearch'|itemtype_search_path }}?action=load&amp;id={{ search['id'] }}"
+             class="d-block saved-searches-link text-truncate">
+             {{ search['name']|verbatim_value }}
+          </a>
+      {% else %}
+          <span class="d-block text-truncate">
+              {{ search['name']|verbatim_value }}
+          </span>
+      {% endif %}
       <div class="{{ search['is_default'] > 0 ? '' : 'list-group-item-actions' }} ms-auto default-ctrl">
-         <i class="{{ search['is_default'] > 0 ? 'fas' : 'far' }} fa-star fa-xs mark-default me-1"
-            title="{{ search['is_default'] > 0 ? __('Default search') : __('mark as default') }}"
-            data-bs-toggle="tooltip" data-bs-placement="right"
-            role="button"></i>
+          {% if search['_error'] is not defined or search['_error'] == false %}
+             <i class="{{ search['is_default'] > 0 ? 'fas' : 'far' }} fa-star fa-xs mark-default me-1"
+                title="{{ search['is_default'] > 0 ? __('Default search') : __('mark as default') }}"
+                data-bs-toggle="tooltip" data-bs-placement="right"
+                role="button"></i>
+          {% endif %}
       </div>
       <div class="d-flex flex-nowrap align-items-center">
          {% if search['is_private'] == 1 %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Try to avoid a situation where a single bad saved search could prevent the list of searches from being shown.
~~Also adds the ability to remove saved searches directly from the list.~~