### PR TITLE
Unmanaged is present in CFG_GLPI['state_types'] but missing in database

### DIFF
--- a/install/migrations/update_10.0.10_to_10.0.11/states.php
+++ b/install/migrations/update_10.0.10_to_10.0.11/states.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var \DBmysql $DB
+ * @var \Migration $migration
+ * @var array $ADDTODISPLAYPREF
+ */
+
+if (!$DB->fieldExists('glpi_states', 'is_visible_unmanaged')) {
+    $migration->addField('glpi_states', 'is_visible_unmanaged', 'bool', [
+        'value' => 1,
+        'after' => 'is_visible_cable'
+    ]);
+}
+$migration->addKey('glpi_states', 'is_visible_unmanaged');

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -6880,6 +6880,7 @@ CREATE TABLE `glpi_states` (
   `is_visible_appliance` tinyint NOT NULL DEFAULT '1',
   `is_visible_databaseinstance` tinyint NOT NULL DEFAULT '1',
   `is_visible_cable` tinyint NOT NULL DEFAULT '1',
+  `is_visible_unmanaged` tinyint NOT NULL DEFAULT '1',
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
@@ -6906,6 +6907,7 @@ CREATE TABLE `glpi_states` (
   KEY `is_visible_appliance` (`is_visible_appliance`),
   KEY `is_visible_databaseinstance` (`is_visible_databaseinstance`),
   KEY `is_visible_cable` (`is_visible_cable`),
+  KEY `is_visible_unmanaged` (`is_visible_unmanaged`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `level` (`level`)

--- a/src/Unmanaged.php
+++ b/src/Unmanaged.php
@@ -184,6 +184,15 @@ class Unmanaged extends CommonDBTM
             'name'         => __('IP'),
         ];
 
+        $tab[] = [
+            'id'                 => '31',
+            'table'              => 'glpi_states',
+            'field'              => 'completename',
+            'name'               => __('Status'),
+            'datatype'           => 'dropdown',
+            'condition'          => ['is_visible_unmanaged' => 1]
+        ];
+
         return $tab;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Alternatively, `Unmanaged` entry may be removed from `$CFG_GLPI['state_types']`; dunno what the best solution is.