### PR TITLE
Forms: draft status

### DIFF
--- a/front/form/form.form.php
+++ b/front/form/form.form.php
@@ -46,7 +46,8 @@ $id = $_REQUEST['id'] ?? null;
 if (($_GET['id'] ?? 0) == 0) {
     // Clear stale drafts
     // TODO: move to a dedicated cron task
-    $DB->delete(Form::getTable(), [
+    $form = new Form();
+    $form->deleteByCriteria([
         'is_draft'      => true,
         'date_creation' => ['<=', date('Y-m-d', strtotime('-7 days'))]
     ]);

--- a/front/form/form.form.php
+++ b/front/form/form.form.php
@@ -43,17 +43,25 @@ Session::checkRight("config", UPDATE);
 // Read parameters
 $id = $_REQUEST['id'] ?? null;
 
-if (isset($_POST["add"])) {
-    // Create form
-    $form = new Form();
-    $form->check($id, CREATE);
+if (($_GET['id'] ?? 0) == 0) {
+    // Clear stale drafts
+    // TODO: move to a dedicated cron task
+    $DB->delete(Form::getTable(), [
+        'is_draft'      => true,
+        'date_creation' => ['<=', date('Y-m-d', strtotime('-7 days'))]
+    ]);
 
-    if ($form->add($_POST)) {
-        if ($_SESSION['glpibackcreated']) {
-            Html::redirect($form->getLinkURL());
-        }
-    }
-    Html::back();
+    // Add as draft and redirect to the creation page
+    // This allow to seamlessly skip the creation step and get straight to the
+    // edit page which will contains more fields
+    $form = new Form();
+    $id = $form->add([
+        'name'     => __("Untitled form"),
+        "header"   => __("Form description..."),
+        'is_draft' => true,
+    ]);
+    Html::redirect($form->getLinkURL());
+    // Code stop here due to exit() in the Html::redirect() method
 } else {
     // Show requested form
     Form::displayFullPageForItem($id, ['admin', Form::getType()], []);

--- a/install/migrations/update_10.0.x_to_10.1.0/form.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/form.php
@@ -52,6 +52,7 @@ if (!$DB->tableExists('glpi_forms_forms')) {
             `is_recursive` tinyint NOT NULL DEFAULT '0',
             `is_active` tinyint NOT NULL DEFAULT '0',
             `is_deleted` tinyint NOT NULL DEFAULT '0',
+            `is_draft` tinyint NOT NULL DEFAULT '0',
             `name` varchar(255) NOT NULL DEFAULT '',
             `header` text,
             `date_mod` timestamp NULL DEFAULT NULL,
@@ -62,6 +63,7 @@ if (!$DB->tableExists('glpi_forms_forms')) {
             KEY `is_recursive` (`is_recursive`),
             KEY `is_active` (`is_active`),
             KEY `is_deleted` (`is_deleted`),
+            KEY `is_draft` (`is_draft`),
             KEY `date_mod` (`date_mod`),
             KEY `date_creation` (`date_creation`)
         ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;"
@@ -123,3 +125,10 @@ if (!$DB->tableExists('glpi_forms_answerssets')) {
 
 // Name (forced), Entities (forced), Child entities, Active, Last update
 $ADDTODISPLAYPREF['Glpi\Form\Form'] = [1, 80, 86, 3, 4];
+
+// Temporary migration code to cover dev migrations
+// TODO: Should be removed from the final release
+if (GLPI_VERSION == "10.1.0-dev") {
+    $migration->addField("glpi_forms_forms", "is_draft", "bool");
+    $migration->addKey("glpi_forms_forms", "is_draft");
+}

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9475,6 +9475,7 @@ CREATE TABLE `glpi_forms_forms` (
     `is_recursive` tinyint NOT NULL DEFAULT '0',
     `is_active` tinyint NOT NULL DEFAULT '0',
     `is_deleted` tinyint NOT NULL DEFAULT '0',
+    `is_draft` tinyint NOT NULL DEFAULT '0',
     `name` varchar(255) NOT NULL DEFAULT '',
     `header` text,
     `date_mod` timestamp NULL DEFAULT NULL,
@@ -9485,6 +9486,7 @@ CREATE TABLE `glpi_forms_forms` (
     KEY `is_recursive` (`is_recursive`),
     KEY `is_active` (`is_active`),
     KEY `is_deleted` (`is_deleted`),
+    KEY `is_draft` (`is_draft`),
     KEY `date_mod` (`date_mod`),
     KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;

--- a/js/common_ajax_controller.js
+++ b/js/common_ajax_controller.js
@@ -76,6 +76,10 @@ class GlpiCommonAjaxController
             this.#handleFriendlyNameUpdate(response);
             this.#handleTrashbinStatus(response, form);
             this.#handleRedirect(response);
+
+            // Trigger a custom event to allow the client to execute an handler
+            // after the form has been successfully submitted
+            form.trigger("glpi-ajax-controller-submit-success", response);
         } catch (error) {
             // Handle known backend errors
             if (

--- a/src/Search/Provider/SQLProvider.php
+++ b/src/Search/Provider/SQLProvider.php
@@ -41,6 +41,7 @@ use CommonITILObject;
 use DBmysqlIterator;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Debug\Profiler;
+use Glpi\Form\Form;
 use Glpi\RichText\RichText;
 use Glpi\Search\Input\QueryBuilder;
 use Glpi\Search\SearchEngine;
@@ -979,6 +980,11 @@ final class SQLProvider implements SearchProviderInterface
 
             case 'KnowbaseItem':
                 $criteria = \KnowbaseItem::getVisibilityCriteria(false)['WHERE'];
+                break;
+
+            case Form::class:
+                // Do not show unsaved drafts in the form list
+                $criteria = ['is_draft' => 0];
                 break;
 
             default:

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -53,13 +53,10 @@
     "
     method="POST"
     action="{{ item.getFormURL() }}"
-    {% if not item.isNewItem() %}
-        data-ajax-submit {# Form will be submitted using AJAX #}
-        data-ajax-submit-itemtype="Glpi\Form\Form" {# Target itemtype #}
-    {% endif %}
+    data-ajax-submit {# Form will be submitted using AJAX #}
+    data-ajax-submit-itemtype="Glpi\Form\Form" {# Target itemtype #}
 >
     {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::PRE_ITEM_FORM'), {'item': item, 'options': params}) }}
-
 
     {# Form editor page #}
     {# UX and items placement are a work in progress #}
@@ -153,9 +150,16 @@
         </button>
 
         {# Move to trashbin form action #}
-        {% if not item.isNewItem() and item.canDelete() %}
+        {% if item.canDelete() %}
+            {# Hidden if the item is still in draft mode #}
             <button
-                class="btn btn-ghost-warning me-2 {{ item.fields.is_deleted ? "d-none" : "" }}"
+                class="
+                    btn
+                    btn-ghost-warning
+                    me-2
+                    {{ item.fields.is_deleted ? "d-none" : "" }}
+                    {{ item.fields.is_draft ? "d-none" : "" }}
+                "
                 type="submit"
                 name="delete"
                 form="form-form"
@@ -181,7 +185,12 @@
         {# Restore action #}
         {% if item.canDelete() %}
             <button
-                class="btn btn-ghost-secondary me-2 {{ not item.fields.is_deleted ? "d-none" : "" }}"
+                class="
+                    btn
+                    btn-ghost-secondary
+                    me-2
+                    {{ not item.fields.is_deleted ? "d-none" : "" }}
+                "
                 type="submit"
                 name="restore"
                 form="form-form"
@@ -191,12 +200,12 @@
             </button>
         {% endif %}
 
-        {% if item.isNewItem() and item.canCreate() %}
-            {# Add action #}
+        {% if item.fields.is_draft %}
+            {# Add action (which is an update form as we just change the is_draft field's value #}
             <button
                 class="btn btn-primary"
                 type="submit"
-                name="add"
+                name="update"
                 form="form-form"
                 title="{{ __("Add") }}"
             >
@@ -222,10 +231,12 @@
     {# Form id #}
     <input type="hidden" name="id" value="{{ item.fields.id }}">
 
-    {% if item.isNewItem() %}
-        {# CSRF #}
-        <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
+    {# Set as non draft once saved #}
+    {% if item.fields.is_draft %}
+        <input type="hidden" name="is_draft" value="0">
     {% endif %}
+
+    {# TODO: add bootstrap tooltips on each buttons #}
 
     {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::POST_ITEM_FORM'), {'item': item, 'options': params}) }}
 </form>
@@ -243,5 +254,8 @@
 </div>
 
 <script>
-    new GlpiFormEditorController("[data-glpi-form-editor-container]");
+    new GlpiFormEditorController(
+        "[data-glpi-form-editor-container]",
+        {{ item.fields.is_draft ? "true" : "false"}}
+    );
 </script>

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -256,6 +256,6 @@
 <script>
     new GlpiFormEditorController(
         "[data-glpi-form-editor-container]",
-        {{ item.fields.is_draft ? "true" : "false"}}
+        {{ item.fields.is_draft ? "true" : "false" }}
     );
 </script>


### PR DESCRIPTION
## Changes

The creation step is a bit redundant for complex objets like forms as we can't handle child items (sections and questions) that make up the most part of our form.

To avoid that, we use the `is_draft` flag:
* When going to the form creation page, a form is created with `is_draft = true` and the user is redirected to the form update page.
* The page still appears like the classic creation form with the "Add" action at the end of the toolbar.
* On the first update, we set `is_draft = false` and replace the "Add" button by the "Update" button.
* Items with `is_draft = true` are not shown in the form list and will be deleted after 7 days.

This may seems like a trivial change but it really streamline the UX of the form creation process and allow to fully use the AJAX controller even for a new item.

## Technical

A new `data-ajax-submit-callback` property can be set for `data-ajax-submit` forms, allowing a custom js callback to be executed after any update.
We use it here to swap the Add/Update button when the form is no longer a draft.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
