### PR TITLE
Fix to use getPendings on QueueNotification 

### DIFF
--- a/src/QueuedNotification.php
+++ b/src/QueuedNotification.php
@@ -533,7 +533,7 @@ class QueuedNotification extends CommonDBTM
             'WHERE'  => [
                 'is_deleted'   => 0,
                 'mode'         => 'TOFILL',
-                'send_time'    => ['<', $send_time],
+                'send_time'    => ['<=', $send_time],
             ] +  $extra_where,
             'ORDER'  => 'send_time ASC',
             'START'  => 0,


### PR DESCRIPTION
Fix to use **getPendings** on QueueNotification in the same time of create a message to notify

Example: There are a plugin from TICGAL(Golden Partner) called MFA that send an email with OTP (one time password) by GLPI notifications and the function **forceSendFor** to process the queue, but the queue is not processed because getPendings filter are '<' and in the moment of **forceSendFor** is called the time is '=' of time registered, so the filter must be '<='

<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

