### PR TITLE
fix(SearchOption): change type for IP and MAC

### DIFF
--- a/src/RefusedEquipment.php
+++ b/src/RefusedEquipment.php
@@ -115,7 +115,7 @@ class RefusedEquipment extends CommonDBTM
             'table'         => $this->getTable(),
             'field'         => 'ip',
             'name'          => __('IP'),
-            'datatype'      => 'string',
+            'datatype'      => 'text',
             'massiveaction' => false,
         ];
 
@@ -124,7 +124,7 @@ class RefusedEquipment extends CommonDBTM
             'table'         => $this->getTable(),
             'field'         => 'mac',
             'name'          => __('MAC'),
-            'datatype'      => 'string',
+            'datatype'      => 'text',
             'massiveaction' => false,
         ];
 


### PR DESCRIPTION
In addition of https://github.com/glpi-project/glpi/pull/15604

Even if the column is updated in the database, GLPI continues to display a warning because 

GLPI compares the data length with the type of the corresponding ```search option``` with ```CommonDBTM->FilterValues```

Is it possible to add it to the 10.0.11 release?

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
