### PR TITLE
Feature : choose to display satisfaction survey elements vertically or horizontally

### DIFF
--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -10,7 +10,7 @@ jobs:
       issues: write  # for actions/stale to close stale issues
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@v9
         with:
           stale-issue-message: >-
             There has been no activity on this issue for some time and therefore it is considered stale

--- a/ajax/ticketsatisfaction.php
+++ b/ajax/ticketsatisfaction.php
@@ -49,11 +49,13 @@ if (isset($_POST['inquest_config']) && isset($_POST['entities_id'])) {
         $inquest_rate      = $entity->getfield('inquest_rate');
         $inquest_duration  = $entity->getfield('inquest_duration');
         $max_closedate     = $entity->getfield('max_closedate');
+        $inquest_display   = $entity->getfield('inquest_display');
     } else {
         $inquest_delay     = -1;
         $inquest_rate      = -1;
         $inquest_duration  = -1;
         $max_closedate     = '';
+        $inquest_display   = 0;
     }
 
     if ($_POST['inquest_config'] > 0) {
@@ -102,6 +104,18 @@ if (isset($_POST['inquest_config']) && isset($_POST['entities_id'])) {
         Html::showDateTimeField("max_closedate", ['value'      => $max_closedate,
             'timestep'   => 1
         ]);
+        echo "</td></tr>";
+
+
+        echo "<tr class='tab_bg_1'>" .
+           "<td>" . __('Arrange the elements') . "</td>";
+        echo "<td>";
+        Dropdown::showFromArray(
+            'inquest_display',
+            ['0' => __('Vertically'),
+             '1' => __('Horizontally')],
+            ['value' => $inquest_display,]
+        );
         echo "</td></tr>";
 
         if ($_POST['inquest_config'] == 2) {

--- a/install/migrations/update_10.0.10_to_10.0.11/states.php
+++ b/install/migrations/update_10.0.10_to_10.0.11/states.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var \DBmysql $DB
+ * @var \Migration $migration
+ * @var array $ADDTODISPLAYPREF
+ */
+
+if (!$DB->fieldExists('glpi_states', 'is_visible_unmanaged')) {
+    $migration->addField('glpi_states', 'is_visible_unmanaged', 'bool', [
+        'value' => 1,
+        'after' => 'is_visible_cable'
+    ]);
+}
+$migration->addKey('glpi_states', 'is_visible_unmanaged');

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -6880,6 +6880,7 @@ CREATE TABLE `glpi_states` (
   `is_visible_appliance` tinyint NOT NULL DEFAULT '1',
   `is_visible_databaseinstance` tinyint NOT NULL DEFAULT '1',
   `is_visible_cable` tinyint NOT NULL DEFAULT '1',
+  `is_visible_unmanaged` tinyint NOT NULL DEFAULT '1',
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
@@ -6906,6 +6907,7 @@ CREATE TABLE `glpi_states` (
   KEY `is_visible_appliance` (`is_visible_appliance`),
   KEY `is_visible_databaseinstance` (`is_visible_databaseinstance`),
   KEY `is_visible_cable` (`is_visible_cable`),
+  KEY `is_visible_unmanaged` (`is_visible_unmanaged`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `level` (`level`)

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -2759,6 +2759,7 @@ CREATE TABLE `glpi_entities` (
   `inquest_rate` int NOT NULL DEFAULT '0',
   `inquest_delay` int NOT NULL DEFAULT '-10',
   `inquest_URL` varchar(255) DEFAULT NULL,
+  `inquest_display` int NOT NULL DEFAULT '0',
   `autofill_warranty_date` varchar(255) NOT NULL DEFAULT '-2',
   `autofill_use_date` varchar(255) NOT NULL DEFAULT '-2',
   `autofill_buy_date` varchar(255) NOT NULL DEFAULT '-2',

--- a/js/modules/Kanban/Kanban.js
+++ b/js/modules/Kanban/Kanban.js
@@ -1096,7 +1096,7 @@ class GLPIKanbanRights {
                     let list_item = "<li data-list-id='"+column.id+"'>";
                     // The `columns_used` array seems to store the ids as strings
                     // We'll check if the values exist as they are or as strings to cover both formats
-                    if (columns_used.includes(column.id) || columns_used.includes(column.id.toString())) {
+                    if (column.id && (columns_used.includes(column.id) || columns_used.includes(column.id.toString()))) {
                         list_item += "<input type='checkbox' checked='true' class='form-check-input' />";
                     } else {
                         list_item += "<input type='checkbox' class='form-check-input' />";

--- a/lib/bundles/base.js
+++ b/lib/bundles/base.js
@@ -94,11 +94,16 @@ window._ = require('lodash');
 // add translation function into global scope
 // signature is almost the same as for PHP functions, but accept extra arguments for string variables
 window.i18n = require('gettext.js/lib/gettext').default({domain: 'glpi'});
+
+const escape_msgid = function (msgid) {
+    return msgid.replace(/%(\d+)\$/g, '%%$1\$');
+};
+
 window.__ = function (msgid, domain /* , extra */) {
     domain = typeof(domain) !== 'undefined' ? domain : 'glpi';
     var text = i18n.dcnpgettext.apply(
         i18n,
-        [domain, undefined, msgid, undefined, undefined].concat(Array.prototype.slice.call(arguments, 2))
+        [domain, undefined, escape_msgid(msgid), undefined, undefined].concat(Array.prototype.slice.call(arguments, 2))
     );
     return _.escape(text);
 };
@@ -107,7 +112,7 @@ window._n = function (msgid, msgid_plural, n, domain /* , extra */) {
     domain = typeof(domain) !== 'undefined' ? domain : 'glpi';
     var text = i18n.dcnpgettext.apply(
         i18n,
-        [domain, undefined, msgid, msgid_plural, n].concat(Array.prototype.slice.call(arguments, 4))
+        [domain, undefined, escape_msgid(msgid), escape_msgid(msgid_plural), n].concat(Array.prototype.slice.call(arguments, 4))
     );
     return _.escape(text);
 };
@@ -115,7 +120,7 @@ window._x = function (msgctxt, msgid, domain /* , extra */) {
     domain = typeof(domain) !== 'undefined' ? domain : 'glpi';
     var text = i18n.dcnpgettext.apply(
         i18n,
-        [domain, msgctxt, msgid, undefined, undefined].concat(Array.prototype.slice.call(arguments, 3))
+        [domain, msgctxt, escape_msgid(msgid), undefined, undefined].concat(Array.prototype.slice.call(arguments, 3))
     );
     return _.escape(text);
 };
@@ -123,7 +128,7 @@ window._nx = function (msgctxt, msgid, msgid_plural, n, domain /* , extra */) {
     domain = typeof(domain) !== 'undefined' ? domain : 'glpi';
     var text = i18n.dcnpgettext.apply(
         i18n,
-        [domain, msgctxt, msgid, msgid_plural, n].concat(Array.prototype.slice.call(arguments, 5))
+        [domain, msgctxt, escape_msgid(msgid), escape_msgid(msgid_plural), n].concat(Array.prototype.slice.call(arguments, 5))
     );
     return _.escape(text);
 };

--- a/src/Config.php
+++ b/src/Config.php
@@ -1932,7 +1932,7 @@ class Config extends CommonDBTM
 
         foreach (
             ['max_execution_time', 'memory_limit', 'post_max_size', 'safe_mode',
-                'session.save_handler', 'upload_max_filesize'
+                'session.save_handler', 'upload_max_filesize', 'disable_functions'
             ] as $key
         ) {
             $msg .= $key . '="' . ini_get($key) . '" ';

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -650,7 +650,6 @@ class Document_Item extends CommonDBRelation
                     $entities = $entity;
                 }
             }
-            $limit = getEntitiesRestrictRequest(" AND ", "glpi_documents", '', $entities, true);
 
             $count = $DB->request([
                 'COUNT'     => 'cpt',

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -126,7 +126,7 @@ class Entity extends CommonTreeDropdown
         'entity_helpdesk' => [
             'calendars_strategy', 'calendars_id', 'tickettype', 'auto_assign_mode',
             'autoclose_delay', 'inquest_config',
-            'inquest_rate', 'inquest_delay',
+            'inquest_rate', 'inquest_delay', 'inquest_display',
             'inquest_duration','inquest_URL',
             'max_closedate', 'tickettemplates_strategy', 'tickettemplates_id',
             'changetemplates_strategy', 'changetemplates_id', 'problemtemplates_strategy', 'problemtemplates_id',

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -747,7 +747,7 @@ class Ticket extends CommonITILObject
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-
+        /** @var CommonDBTM $item */
         if (static::canView()) {
             $nb    = 0;
             $title = self::getTypeName(Session::getPluralNumber());
@@ -871,25 +871,21 @@ class Ticket extends CommonITILObject
         }
 
        // Not check self::READALL for Ticket itself
-        switch ($item->getType()) {
-            case __CLASS__:
-                $ong    = [];
+        if ($item instanceof self) {
+            $ong    = [];
 
-               // enquete si statut clos
-                $satisfaction = new TicketSatisfaction();
-                if (
-                    $satisfaction->getFromDB($item->getID())
-                    && $item->fields['status'] == self::CLOSED
-                ) {
-                    $ong[3] = __('Satisfaction');
-                }
-                if ($item->canView()) {
-                    $ong[4] = __('Statistics');
-                }
-                return $ong;
-
-           //   default :
-           //      return _n('Ticket','Tickets', Session::getPluralNumber());
+            // enquete si statut clos
+            $satisfaction = new TicketSatisfaction();
+            if (
+                $satisfaction->getFromDB($item->getID())
+                && $item->fields['status'] == self::CLOSED
+            ) {
+                $ong[3] = __('Satisfaction');
+            }
+            if ($item->canView()) {
+                $ong[4] = __('Statistics');
+            }
+            return $ong;
         }
 
         return '';
@@ -899,8 +895,8 @@ class Ticket extends CommonITILObject
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
     {
 
-        switch ($item->getType()) {
-            case __CLASS__:
+        switch (get_class($item)) {
+            case self::class:
                 switch ($tabnum) {
                     case 3:
                         $satisfaction = new TicketSatisfaction();
@@ -929,9 +925,9 @@ class Ticket extends CommonITILObject
                 }
                 break;
 
-            case 'Group':
-            case 'SLA':
-            case 'OLA':
+            case Group::class:
+            case SLA::class:
+            case OLA::class:
             default:
                 self::showListForItem($item, $withtemplate);
         }
@@ -2698,7 +2694,7 @@ class Ticket extends CommonITILObject
                 $rand = mt_rand();
                 $mergeparam = [
                     'name'         => "_mergeticket",
-                    'used'         => $ma->items['Ticket'],
+                    'used'         => $ma->getItems()['Ticket'],
                     'displaywith'  => ['id'],
                     'rand'         => $rand
                 ];
@@ -5395,8 +5391,8 @@ JAVASCRIPT;
             'reset'    => 'reset',
         ];
 
-        switch ($item->getType()) {
-            case 'User':
+        switch (get_class($item)) {
+            case User::class:
                 $restrict['glpi_tickets_users.users_id'] = $item->getID();
                 $restrict['glpi_tickets_users.type'] = CommonITILActor::REQUESTER;
 
@@ -5406,7 +5402,7 @@ JAVASCRIPT;
                 $options['criteria'][0]['link']       = 'AND';
                 break;
 
-            case 'SLA':
+            case SLA::class:
                 $restrict[] = [
                     'OR' => [
                         'slas_id_tto'  => $item->getID(),
@@ -5421,7 +5417,7 @@ JAVASCRIPT;
                 $options['criteria'][0]['link']       = 'AND';
                 break;
 
-            case 'OLA':
+            case OLA::class:
                 $restrict[] = [
                     'OR' => [
                         'olas_id_tto'  => $item->getID(),
@@ -5436,7 +5432,7 @@ JAVASCRIPT;
                 $options['criteria'][0]['link']       = 'AND';
                 break;
 
-            case 'Supplier':
+            case Supplier::class:
                 $restrict['glpi_suppliers_tickets.suppliers_id'] = $item->getID();
                 $restrict['glpi_suppliers_tickets.type'] = CommonITILActor::ASSIGN;
 
@@ -5446,7 +5442,7 @@ JAVASCRIPT;
                 $options['criteria'][0]['link']       = 'AND';
                 break;
 
-            case 'Group':
+            case Group::class:
                // Mini search engine
                 if ($item->haveChildren()) {
                     $tree = Session::getSavedOption(__CLASS__, 'tree', 0);

--- a/src/Unmanaged.php
+++ b/src/Unmanaged.php
@@ -184,6 +184,15 @@ class Unmanaged extends CommonDBTM
             'name'         => __('IP'),
         ];
 
+        $tab[] = [
+            'id'                 => '31',
+            'table'              => 'glpi_states',
+            'field'              => 'completename',
+            'name'               => __('Status'),
+            'datatype'           => 'dropdown',
+            'condition'          => ['is_visible_unmanaged' => 1]
+        ];
+
         return $tab;
     }
 

--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -120,7 +120,7 @@
                   ) }}
                </div>
                {% if get_current_interface() == 'central' %}
-                  <div class="col-12 col-xl-5 col-xxl-4 order-first order-md-last pe-o pe-xxl-auto">
+                  <div class="col-12 col-xl-5 col-xxl-4 order-first order-md-last pe-0 pe-xxl-auto">
                      <div class="row">
 
                         {% set fup_template_lbl %}

--- a/templates/components/itilobject/timeline/form_solution.html.twig
+++ b/templates/components/itilobject/timeline/form_solution.html.twig
@@ -121,7 +121,7 @@
                      }
                   ) }}
                </div>
-               <div class="col-12 col-xl-5 col-xxl-4 order-first order-md-last pe-o pe-xxl-auto">
+               <div class="col-12 col-xl-5 col-xxl-4 order-first order-md-last pe-0 pe-xxl-auto">
                   <div class="row">
                      {% if candedit %}
                         {% if can_read_kb %}

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -177,7 +177,7 @@
                      }
                   ) }}
                </div>
-               <div class="col-12 col-xl-5 col-xxl-4 order-first order-md-last pe-o pe-xxl-auto">
+               <div class="col-12 col-xl-5 col-xxl-4 order-first order-md-last pe-0 pe-xxl-auto">
                   <div class="row">
 
                      {% set task_template_lbl %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | no

We would like to add a new feature about the satisfaction survey.
We want to be able to choose whether we want to display the elements horizontally (which is the current display) or vertically.
This is what it would look like : 

![image](https://github.com/glpi-project/glpi/assets/99427405/439b5668-d6fa-4158-bc5e-ff25a87a3a74)

![image](https://github.com/glpi-project/glpi/assets/99427405/1519c67c-bc2a-4a25-9920-019c731cb8b8)

so we should probably apply a new CSS like : 
![image](https://github.com/glpi-project/glpi/assets/99427405/d0fe13b5-7686-4f13-a6cf-2da3a89c0cac)

I don't know if it is possible to do such a thing and if it is okay to do it in glpi core or if we should do it in a plugin.

Sincerely,

Anthony from IT Gouvernance.
