### PR TITLE
Allow LDAP sync command to sync emails

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -1012,22 +1012,22 @@ class User extends CommonDBTM
         }
 
         // prevent changing tokens and emails from users with lower rights
-        $protected_input_keys = array_intersect(
-            [
-                'api_token',
-                '_reset_api_token',
-                'cookie_token',
-                'password_forget_token',
-                'personal_token',
-                '_reset_personal_token',
+        $protected_input_keys = [
+            'api_token',
+            '_reset_api_token',
+            'cookie_token',
+            'password_forget_token',
+            'personal_token',
+            '_reset_personal_token',
 
-                '_emails',
-                '_useremails',
-            ],
-            array_keys($input)
-        );
+            '_useremails',
+        ];
+        if (!isCommandLine()) {
+            // Disallow `_emails` input unless on CLI context (e.g. LDAP sync command).
+            $protected_input_keys[] = '_emails';
+        }
         if (
-            $protected_input_keys > 0
+            count(array_intersect($protected_input_keys, array_keys($input))) > 0
             && !Session::isCron() // cron context is considered safe
             && $input['id'] !== Session::getLoginUserID()
             && !$this->currentUserHaveMoreRightThan($input['id'])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30769

Alternative to #16172.

1. On CLI context, the `_email` input key should be allowed to permit emails to be synchronized with LDAP during execution of `ldap:sync` command.
2. Previous logic was checking `$protected_input_keys > 0`, but as `$protected_input_keys` was an array, condition was probaly always `true`. I fixed that.