### PR TITLE
fix(inventory): prevent warning message

### DIFF
--- a/src/HTMLTableEntity.php
+++ b/src/HTMLTableEntity.php
@@ -183,7 +183,7 @@ abstract class HTMLTableEntity
             }
         } else {
             // Manage __RAND__ to be computed on display
-            $content = $this->content;
+            $content = $this->content ?? '';
             $content = str_replace('__RAND__', mt_rand(), $content);
             echo $content;
         }


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Prevent warning message:

```
PHP Deprecated function (8192): str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in .../src/HTMLTableEntity.php at line 187
```

![image](https://github.com/glpi-project/glpi/assets/8530352/ec836e26-8907-4807-a34e-d89da31437f1)

