### PR TITLE
fix(ldap): do not check TLS files if empty

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -4770,6 +4770,7 @@ class AuthLDAP extends CommonDBTM
     {
         if (
             isset($input['tls_certfile'])
+            && strlen($input['tls_certfile']) > 0
             && (!Filesystem::isFilepathSafe($input['tls_certfile']) || !file_exists($input['tls_certfile']))
         ) {
             Session::addMessageAfterRedirect(
@@ -4782,6 +4783,7 @@ class AuthLDAP extends CommonDBTM
 
         if (
             isset($input['tls_keyfile'])
+            && strlen($input['tls_certfile']) > 0
             && (!Filesystem::isFilepathSafe($input['tls_keyfile']) || !file_exists($input['tls_keyfile']))
         ) {
             Session::addMessageAfterRedirect(

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -4783,7 +4783,7 @@ class AuthLDAP extends CommonDBTM
 
         if (
             isset($input['tls_keyfile'])
-            && strlen($input['tls_certfile']) > 0
+            && strlen($input['tls_keyfile']) > 0
             && (!Filesystem::isFilepathSafe($input['tls_keyfile']) || !file_exists($input['tls_keyfile']))
         ) {
             Session::addMessageAfterRedirect(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A

On 10.0.11 it's impossible to update "Advanced information" for an LDAP server if "TLS" files options are empty.
