### PR TITLE
fix(object lock): duplicate keys in search options

### DIFF
--- a/install/migrations/update_10.0.11_to_10.0.12.php
+++ b/install/migrations/update_10.0.11_to_10.0.12.php
@@ -43,8 +43,9 @@ function update10011to10012()
     /**
      * @var \DBmysql $DB
      * @var \Migration $migration
+     * @var array $CFG_GLPI
      */
-    global $DB, $migration;
+    global $DB, $migration, $CFG_GLPI;
 
     $updateresult       = true;
     $ADDTODISPLAYPREF   = [];

--- a/install/migrations/update_10.0.11_to_10.0.12.php
+++ b/install/migrations/update_10.0.11_to_10.0.12.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * Update from 10.0.11 to 10.0.12
+ *
+ * @return bool for success (will die for most error)
+ **/
+function update10011to10012()
+{
+    /**
+     * @var \DBmysql $DB
+     * @var \Migration $migration
+     */
+    global $DB, $migration;
+
+    $updateresult       = true;
+    $ADDTODISPLAYPREF   = [];
+    $DELFROMDISPLAYPREF = [];
+    $update_dir = __DIR__ . '/update_10.0.11_to_10.0.12/';
+
+    //TRANS: %s is the number of new version
+    $migration->displayTitle(sprintf(__('Update to %s'), '10.0.12'));
+    $migration->setVersion('10.0.12');
+
+    $update_scripts = scandir($update_dir);
+    foreach ($update_scripts as $update_script) {
+        if (preg_match('/\.php$/', $update_script) !== 1) {
+            continue;
+        }
+        require $update_dir . $update_script;
+    }
+
+    // ************ Keep it at the end **************
+    $migration->updateDisplayPrefs($ADDTODISPLAYPREF, $DELFROMDISPLAYPREF);
+
+    $migration->executeMigration();
+
+    return $updateresult;
+}

--- a/install/migrations/update_10.0.11_to_10.0.12.php
+++ b/install/migrations/update_10.0.11_to_10.0.12.php
@@ -43,9 +43,8 @@ function update10011to10012()
     /**
      * @var \DBmysql $DB
      * @var \Migration $migration
-     * @var array $CFG_GLPI
      */
-    global $DB, $migration, $CFG_GLPI;
+    global $DB, $migration;
 
     $updateresult       = true;
     $ADDTODISPLAYPREF   = [];

--- a/install/migrations/update_10.0.11_to_10.0.12/duplicate_searchopt_fixes.php
+++ b/install/migrations/update_10.0.11_to_10.0.12/duplicate_searchopt_fixes.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var array $CFG_GLPI
+ * @var \Migration $migration
+ */
+
+if ($CFG_GLPI["lock_use_lock_item"]) {
+    foreach ($CFG_GLPI['lock_item_list'] as $itemtype) {
+        $migration->changeSearchOption($itemtype, 205, 207);
+        $migration->changeSearchOption($itemtype, 206, 208);
+    }
+}

--- a/install/migrations/update_10.0.11_to_10.0.12/duplicate_searchopt_fixes.php
+++ b/install/migrations/update_10.0.11_to_10.0.12/duplicate_searchopt_fixes.php
@@ -45,7 +45,7 @@ if ($lock_use_lock_item) {
     $iterator = $DB->request('glpi_configs', ['name' => 'lock_item_list']);
     $lock_item_list = $iterator->current()['value'] ?? '';
     $lock_item_list = explode(',', $lock_item_list);
-    
+
     foreach ($lock_item_list as $itemtype) {
         $migration->changeSearchOption($itemtype, 205, 207);
         $migration->changeSearchOption($itemtype, 206, 208);

--- a/install/migrations/update_10.0.11_to_10.0.12/duplicate_searchopt_fixes.php
+++ b/install/migrations/update_10.0.11_to_10.0.12/duplicate_searchopt_fixes.php
@@ -38,7 +38,7 @@
  * @var \Migration $migration
  */
 
-if ($CFG_GLPI["lock_use_lock_item"]) {
+if ($CFG_GLPI["lock_use_lock_item"] ?? false) {
     foreach ($CFG_GLPI['lock_item_list'] as $itemtype) {
         $migration->changeSearchOption($itemtype, 205, 207);
         $migration->changeSearchOption($itemtype, 206, 208);

--- a/install/migrations/update_10.0.11_to_10.0.12/duplicate_searchopt_fixes.php
+++ b/install/migrations/update_10.0.11_to_10.0.12/duplicate_searchopt_fixes.php
@@ -34,12 +34,19 @@
  */
 
 /**
- * @var array $CFG_GLPI
+ * @var \DBmysql $DB
  * @var \Migration $migration
  */
 
-if ($CFG_GLPI["lock_use_lock_item"] ?? false) {
-    foreach ($CFG_GLPI['lock_item_list'] as $itemtype) {
+$iterator = $DB->request('glpi_configs', ['name' => 'lock_use_lock_item']);
+$lock_use_lock_item = $iterator->current()['value'] ?? false;
+
+if ($lock_use_lock_item) {
+    $iterator = $DB->request('glpi_configs', ['name' => 'lock_item_list']);
+    $lock_item_list = $iterator->current()['value'] ?? '';
+    $lock_item_list = explode(',', $lock_item_list);
+    
+    foreach ($lock_item_list as $itemtype) {
         $migration->changeSearchOption($itemtype, 205, 207);
         $migration->changeSearchOption($itemtype, 206, 208);
     }

--- a/install/migrations/update_10.0.11_to_10.0.12/duplicate_searchopt_fixes.php
+++ b/install/migrations/update_10.0.11_to_10.0.12/duplicate_searchopt_fixes.php
@@ -38,8 +38,6 @@
  * @var \Migration $migration
  */
 
-global $CFG_GLPI;
-
 if ($CFG_GLPI["lock_use_lock_item"]) {
     foreach ($CFG_GLPI['lock_item_list'] as $itemtype) {
         $migration->changeSearchOption($itemtype, 205, 207);

--- a/install/migrations/update_10.0.11_to_10.0.12/duplicate_searchopt_fixes.php
+++ b/install/migrations/update_10.0.11_to_10.0.12/duplicate_searchopt_fixes.php
@@ -38,6 +38,8 @@
  * @var \Migration $migration
  */
 
+global $CFG_GLPI;
+
 if ($CFG_GLPI["lock_use_lock_item"]) {
     foreach ($CFG_GLPI['lock_item_list'] as $itemtype) {
         $migration->changeSearchOption($itemtype, 205, 207);

--- a/install/migrations/update_10.0.11_to_10.0.12/duplicate_searchopt_fixes.php
+++ b/install/migrations/update_10.0.11_to_10.0.12/duplicate_searchopt_fixes.php
@@ -44,7 +44,7 @@ $lock_use_lock_item = $iterator->current()['value'] ?? false;
 if ($lock_use_lock_item) {
     $iterator = $DB->request('glpi_configs', ['name' => 'lock_item_list']);
     $lock_item_list = $iterator->current()['value'] ?? '';
-    $lock_item_list = explode(',', $lock_item_list);
+    $lock_item_list = json_decode($lock_item_list);
 
     foreach ($lock_item_list as $itemtype) {
         $migration->changeSearchOption($itemtype, 205, 207);

--- a/install/migrations/update_10.0.11_to_10.0.12/duplicate_searchopt_fixes.php
+++ b/install/migrations/update_10.0.11_to_10.0.12/duplicate_searchopt_fixes.php
@@ -46,8 +46,10 @@ if ($lock_use_lock_item) {
     $lock_item_list = $iterator->current()['value'] ?? '';
     $lock_item_list = json_decode($lock_item_list);
 
-    foreach ($lock_item_list as $itemtype) {
-        $migration->changeSearchOption($itemtype, 205, 207);
-        $migration->changeSearchOption($itemtype, 206, 208);
+    if (is_array($lock_item_list)) {
+        foreach ($lock_item_list as $itemtype) {
+            $migration->changeSearchOption($itemtype, 205, 207);
+            $migration->changeSearchOption($itemtype, 206, 208);
+        }
     }
 }

--- a/src/ObjectLock.php
+++ b/src/ObjectLock.php
@@ -594,7 +594,7 @@ class ObjectLock extends CommonDBTM
             && in_array($itemtype, $CFG_GLPI['lock_item_list'])
         ) {
             $tab[] = [
-                'id' => '205',
+                'id'            => '207',
                 'table'         => 'glpi_users',
                 'field'         => 'name',
                 'datatype'      => 'dropdown',
@@ -612,7 +612,7 @@ class ObjectLock extends CommonDBTM
             ];
 
             $tab[] = [
-                'id'            => '206',
+                'id'            => '208',
                 'table'         => getTableForItemType('ObjectLock'),
                 'field'         => 'date',
                 'datatype'      => 'datetime',

--- a/tests/functional/Search.php
+++ b/tests/functional/Search.php
@@ -52,7 +52,7 @@ class Search extends DbTestCase
 {
     private function doSearch($itemtype, $params, array $forcedisplay = [])
     {
-        global $DEBUG_SQL;
+        global $DEBUG_SQL, $CFG_GLPI;
 
        // check param itemtype exists (to avoid search errors)
         if ($itemtype !== 'AllAssets') {
@@ -62,6 +62,12 @@ class Search extends DbTestCase
        // login to glpi if needed
         if (!isset($_SESSION['glpiname'])) {
             $this->login();
+        }
+
+        // force item lock
+        if (in_array($itemtype, $CFG_GLPI['lock_lockable_objects'])) {
+            $CFG_GLPI["lock_use_lock_item"] = 1;
+            $CFG_GLPI["lock_item_list"] = [$itemtype];
         }
 
        // force session in debug mode (to store & retrieve sql errors)


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Prevent warning message when locks are enabled in `Setup > General`:

```
PHP User Warning (512): Duplicate keys found in search options for item type Computer: 205, 206 in .../src/Search.php at line 8282
```

![image](https://github.com/glpi-project/glpi/assets/8530352/cc1ebf1f-7813-4c28-87c5-715edbcfe516)



