### PR TITLE
Fix dashboard fullscreen toggle

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -876,7 +876,9 @@ class GLPIDashboard {
         this.grid.setStatic(!activate);
 
         // set filters as sortable (draggable) or not
-        sortable(this.filters_selector, activate ? 'enable' : 'disable');
+        if ($(this.filters_selector).children().length > 0) {
+            sortable(this.filters_selector, activate ? 'enable' : 'disable');
+        }
 
         if (!this.edit_mode) {
             // save markdown textareas set as dirty


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Toggling fullscreen mode on a dashboard would not work on accounts when there were no filters shown/the user didn't have access to filters. When it would try to enable fullscreen, it tried to force edit mode to be disabled. When it did that, `sortable` was called for the filter container element and was failing since there were no elements under that container.