### PR TITLE
id attributes cannot contains square brackets

### DIFF
--- a/templates/components/search/query_builder/criteria_group.html.twig
+++ b/templates/components/search/query_builder/criteria_group.html.twig
@@ -54,7 +54,7 @@
          {% set parents_num = (parents_num|default([]))|merge([num]) %}
          {{ call("Glpi\\Search\\Input\\QueryBuilder::showGenericSearch", [itemtype, {
             mainform: false,
-            prefix_crit: prefix ~ '[' ~ num ~ '][criteria]',
+            prefix_crit: prefix  ~ num ~ '_criteria_',
             parents_num: parents_num,
             criteria: criteria['criteria'],
          }]) }}

--- a/templates/components/search/query_builder/criteria_group.html.twig
+++ b/templates/components/search/query_builder/criteria_group.html.twig
@@ -54,7 +54,7 @@
          {% set parents_num = (parents_num|default([]))|merge([num]) %}
          {{ call("Glpi\\Search\\Input\\QueryBuilder::showGenericSearch", [itemtype, {
             mainform: false,
-            prefix_crit: prefix  ~ num ~ '_criteria_',
+            prefix_crit: prefix ~ num ~ '_criteria_',
             parents_num: parents_num,
             criteria: criteria['criteria'],
          }]) }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Since #15861, but after check it was present before merge (probably due to a previous redesign of search), when adding a metaciteria within a group, it's sub part doesn't show:


![image](https://github.com/glpi-project/glpi/assets/418844/021719d8-4435-43ed-b88c-42d954521976)

This was due to usage of square brackets in the id, that is forbidden (browser mays autofix them, but jquery no)
