### PR TITLE
fix:(export): &nbsp; in CSV

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -8757,7 +8757,7 @@ HTML;
                     $value = preg_replace('/' . self::LBBR . '/', '<br>', $value);
                     $value = preg_replace('/' . self::LBHR . '/', '<hr>', $value);
                     $value = '<div class="fup-popup">' . $value . '</div>';
-                    $valTip = '' . Html::showToolTip(
+                    $valTip = ' ' . Html::showToolTip(
                         $value,
                         [
                             'awesome-class'   => 'fa-comments',

--- a/src/Search.php
+++ b/src/Search.php
@@ -6887,7 +6887,7 @@ JAVASCRIPT;
                         return "<img class='middle' alt='' src='" . $CFG_GLPI["typedoc_icon_dir"] . "/" .
                            $data[$ID][0]['name'] . "'>";
                     }
-                    return "&nbsp;";
+                    return '';
 
                 case "glpi_documents.filename":
                     $doc = new Document();
@@ -7268,7 +7268,7 @@ JAVASCRIPT;
                             return implode("<br>", $items);
                         }
                     }
-                    return '&nbsp;';
+                    return '';
 
                 case 'glpi_items_tickets.itemtype':
                 case 'glpi_items_problems.itemtype':
@@ -7291,7 +7291,7 @@ JAVASCRIPT;
                         }
                     }
 
-                    return '&nbsp;';
+                    return '';
 
                 case 'glpi_tickets.name':
                 case 'glpi_problems.name':
@@ -7432,7 +7432,7 @@ JAVASCRIPT;
                                           $data["refID"] . "' title=\"" . __s('See planning') . "\">" .
                                           "<i class='far fa-calendar-alt'></i><span class='sr-only'>" . __('See planning') . "</span></a>";
                     } else {
-                        return "&nbsp;";
+                        return '';
                     }
 
                 case "glpi_tickets.priority":
@@ -7643,7 +7643,7 @@ JAVASCRIPT;
                             $out .= "</a>";
                         }
                     }
-                    return (empty($out) ? "&nbsp;" : $out);
+                    return (empty($out) ? '' : $out);
 
                 case "weblink":
                     $orig_link = trim((string)$data[$ID][0]['name']);
@@ -7656,7 +7656,7 @@ JAVASCRIPT;
                         }
                         return "<a href=\"" . Toolbox::formatOutputWebLink($orig_link) . "\" target='_blank'>$link</a>";
                     }
-                    return "&nbsp;";
+                    return '';
 
                 case "count":
                 case "number":
@@ -8757,7 +8757,7 @@ HTML;
                     $value = preg_replace('/' . self::LBBR . '/', '<br>', $value);
                     $value = preg_replace('/' . self::LBHR . '/', '<hr>', $value);
                     $value = '<div class="fup-popup">' . $value . '</div>';
-                    $valTip = "&nbsp;" . Html::showToolTip(
+                    $valTip = '' . Html::showToolTip(
                         $value,
                         [
                             'awesome-class'   => 'fa-comments',

--- a/src/Toolbox/DataExport.php
+++ b/src/Toolbox/DataExport.php
@@ -84,10 +84,6 @@ class DataExport
             $value = trim($value, " \n\r\t" . $nbsp);
         }
 
-        if ($value == '&nbsp;') {
-            $value = '';
-        }
-
         return $value;
     }
 }

--- a/src/Toolbox/DataExport.php
+++ b/src/Toolbox/DataExport.php
@@ -84,6 +84,10 @@ class DataExport
             $value = trim($value, " \n\r\t" . $nbsp);
         }
 
+        if ($value == '&nbsp;') {
+            $value = '';
+        }
+
         return $value;
     }
 }


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30871

When exporting to CSV, some empty data appeared with &nbsp;

Example with the User > Computer Emails column:
![image](https://github.com/glpi-project/glpi/assets/8530352/c4f6cb90-9f39-42ac-a748-bc1d2c3bb1c2)

![image](https://github.com/glpi-project/glpi/assets/8530352/dfad1fee-b792-45d3-b275-b13f111c8c10)
