### PR TITLE
Improve reminder duration dropdown performance

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -1883,6 +1883,8 @@ JAVASCRIPT;
      *    - inhours         : only show timestamp in hours not in days
      *    - display         : boolean / display or return string
      *    - width           : string / display width of the item
+     *    - allow_max_change: boolean / allow to change max value according to max($params['value'], $params['max']) (default true).
+     *                        If false and the value is greater than the max, the value will be adjusted based on the step and then added to the dropdown as an extra option.
      **/
     public static function showTimeStamp($myname, $options = [])
     {
@@ -1902,6 +1904,7 @@ JAVASCRIPT;
         $params['display_emptychoice'] = true;
         $params['width']               = '';
         $params['class']               = 'form-select';
+        $params['allow_max_change']    = true;
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {
@@ -1916,7 +1919,9 @@ JAVASCRIPT;
             $params['min'] = $params['step'];
         }
 
-        $params['max'] = max($params['value'], $params['max']);
+        if ($params['allow_max_change']) {
+            $params['max'] = max($params['value'], $params['max']);
+        }
 
        // Floor with MINUTE_TIMESTAMP for rounded purpose
         if (empty($params['value'])) {
@@ -1930,6 +1935,10 @@ JAVASCRIPT;
         } else if (!in_array($params['value'], $params['toadd'])) {
            // Round to a valid step except if value is already valid (defined in values to add)
             $params['value'] = floor(($params['value']) / $params['step']) * $params['step'];
+        }
+
+        if (!$params['allow_max_change'] && $params['value'] > $params['max']) {
+            $params['toadd'][] = $params['value'];
         }
 
         // Generate array keys

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -805,7 +805,8 @@ JAVASCRIPT;
             'min'        => 0,
             'max'        => 24 * HOUR_TIMESTAMP,
             'value'      => $default_delay,
-            'emptylabel' => __('Specify an end date')
+            'emptylabel' => __('Specify an end date'),
+            'allow_max_change' => false
         ]);
         echo "<br><div id='date_end$rand'></div>";
         $params = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #16074

By default, a timestamp dropdown will automatically increase the `max` parameter to match the current `value` if it is higher than the specified `max` and fill in the values between the `min` and `max` based on the `step`. This causes a lot of client-side and network performance issues when the step is too small or the value is too big. For example, a reservation set for 60 days would cause over 17,000 options to be added to the dropdown assuming a `time_step` of 5 minutes.

I don't know if there is a legitimate case for expanding the generated options range like this, but to avoid breaking something I added a new option `allow_max_change` which is set to true by default. When set to false, the `max` isn't changed and instead the current value is added on its own as an extra option.