### PR TITLE
Do not add duplicate hidden field input in rule test mode

### DIFF
--- a/src/Rule.php
+++ b/src/Rule.php
@@ -2636,10 +2636,8 @@ class Rule extends CommonDBTM
             RuleImportAsset::PATTERN_NETWORK_PORT_RESTRICT,
             RuleImportAsset::PATTERN_ONLY_CRITERIA_RULE,
         ];
-        if (in_array($condition, $hiddens)) {
-            if (!$test) {
-                echo Html::hidden($name, ['value' => 1]);
-            }
+        if (!$display && in_array($condition, $hiddens)) {
+            echo Html::hidden($name, ['value' => 1]);
             $display = true;
         }
 

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -2637,7 +2637,9 @@ class Rule extends CommonDBTM
             RuleImportAsset::PATTERN_ONLY_CRITERIA_RULE,
         ];
         if (in_array($condition, $hiddens)) {
-            echo Html::hidden($name, ['value' => 1]);
+            if (!$test) {
+                echo Html::hidden($name, ['value' => 1]);
+            }
             $display = true;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Related to #14543

When a criteria has only a single value possible like "Exists" or "Not exists", a hidden input is added with a value of 1 rather than showing a dropdown. In test mode however, it shows a dropdown of options as well as adding the hidden input. Both values are sent to the server, and since the hidden field is after the displayed one, its value overrides the selection. In this case, the hidden field is not needed.