### PR TITLE
Enhance password expiration message

### DIFF
--- a/front/helpdesk.public.php
+++ b/front/helpdesk.public.php
@@ -105,12 +105,6 @@ if (isset($_GET['create_ticket'])) {
     $password_alert = "";
     $user = new User();
     $user->getFromDB(Session::getLoginUserID());
-    if ($user->fields['authtype'] == Auth::DB_GLPI && $user->shouldChangePassword()) {
-        $password_alert = sprintf(
-            __('Your password will expire on %s.'),
-            Html::convDateTime(date('Y-m-d H:i:s', $user->getPasswordExpirationTime()))
-        );
-    }
 
     $ticket_summary = "";
     $survey_list    = "";
@@ -140,7 +134,7 @@ if (isset($_GET['create_ticket'])) {
 
     Html::requireJs('masonry');
     TemplateRenderer::getInstance()->display('pages/self-service/home.html.twig', [
-        'password_alert' => $password_alert,
+        'password_alert' => $user->getPasswordExpirationMessage(),
         'ticket_summary' => $ticket_summary,
         'survey_list'    => $survey_list,
         'reminder_list'  => $reminder_list,

--- a/src/Central.php
+++ b/src/Central.php
@@ -457,11 +457,8 @@ class Central extends CommonGLPI
 
         $user = new User();
         $user->getFromDB(Session::getLoginUserID());
-        if ($user->fields['authtype'] == Auth::DB_GLPI && $user->shouldChangePassword()) {
-            $expiration_msg = sprintf(
-                __('Your password will expire on %s.'),
-                Html::convDateTime(date('Y-m-d H:i:s', $user->getPasswordExpirationTime()))
-            );
+        $expiration_msg = $user->getPasswordExpirationMessage();
+        if ($expiration_msg !== null) {
             $messages['warnings'][] = $expiration_msg
              . ' '
              . '<a href="' . $CFG_GLPI['root_doc'] . '/front/updatepassword.php">'

--- a/src/User.php
+++ b/src/User.php
@@ -6365,6 +6365,13 @@ HTML;
             return null;
         }
 
+        if (null === $this->fields['password_last_update']) {
+            // password never updated
+            return strtotime(
+                '+ ' . $expiration_delay . ' days',
+                strtotime($this->fields['date_creation'])
+            );
+        }
         return strtotime(
             '+ ' . $expiration_delay . ' days',
             strtotime($this->fields['password_last_update'])
@@ -6414,6 +6421,26 @@ HTML;
         }
 
         return $expiration_time < time();
+    }
+
+    public function getPasswordExpirationMessage(): ?string
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+        $expiration_msg = null;
+        if ($this->fields['authtype'] == Auth::DB_GLPI && $this->shouldChangePassword()) {
+            $expire_time = $this->getPasswordExpirationTime();
+            $expire_has_passed = $expire_time < time();
+            if ($expire_has_passed) {
+                $expiration_msg = __('Your password has expired.');
+            } else {
+                $expiration_msg = sprintf(
+                    __('Your password will expire on %s.'),
+                    Html::convDateTime(date('Y-m-d H:i:s', $expire_time))
+                );
+            }
+        }
+        return $expiration_msg;
     }
 
     public static function getFriendlyNameSearchCriteria(string $filter): array

--- a/tests/functional/User.php
+++ b/tests/functional/User.php
@@ -952,6 +952,7 @@ class User extends \DbTestCase
 
         return [
             [
+                'creation_date'                   => $_SESSION['glpi_currenttime'],
                 'last_update'                     => date('Y-m-d H:i:s', strtotime('-10 years', $time)),
                 'expiration_delay'                => -1,
                 'expiration_notice'               => -1,
@@ -960,6 +961,7 @@ class User extends \DbTestCase
                 'expected_has_password_expire'    => false,
             ],
             [
+                'creation_date'                   => $_SESSION['glpi_currenttime'],
                 'last_update'                     => date('Y-m-d H:i:s', strtotime('-10 days', $time)),
                 'expiration_delay'                => 15,
                 'expiration_notice'               => -1,
@@ -968,6 +970,7 @@ class User extends \DbTestCase
                 'expected_has_password_expire'    => false,
             ],
             [
+                'creation_date'                   => $_SESSION['glpi_currenttime'],
                 'last_update'                     => date('Y-m-d H:i:s', strtotime('-10 days', $time)),
                 'expiration_delay'                => 15,
                 'expiration_notice'               => 10,
@@ -976,10 +979,29 @@ class User extends \DbTestCase
                 'expected_has_password_expire'    => false,
             ],
             [
+                'creation_date'                   => $_SESSION['glpi_currenttime'],
                 'last_update'                     => date('Y-m-d H:i:s', strtotime('-20 days', $time)),
                 'expiration_delay'                => 15,
                 'expiration_notice'               => -1,
                 'expected_expiration_time'        => strtotime('-5 days', $time),
+                'expected_should_change_password' => true,
+                'expected_has_password_expire'    => true,
+            ],
+            [
+                'creation_date'                   => $_SESSION['glpi_currenttime'],
+                'last_update'                     => null,
+                'expiration_delay'                => 15,
+                'expiration_notice'               => -1,
+                'expected_expiration_time'        => strtotime('+15 days', strtotime($_SESSION['glpi_currenttime'])),
+                'expected_should_change_password' => false,
+                'expected_has_password_expire'    => false,
+            ],
+            [
+                'creation_date'                   => '2021-12-03 17:54:32',
+                'last_update'                     => null,
+                'expiration_delay'                => 15,
+                'expiration_notice'               => -1,
+                'expected_expiration_time'        => strtotime('2021-12-18 17:54:32'),
                 'expected_should_change_password' => true,
                 'expected_has_password_expire'    => true,
             ],
@@ -990,7 +1012,8 @@ class User extends \DbTestCase
      * @dataProvider passwordExpirationMethodsProvider
      */
     public function testPasswordExpirationMethods(
-        string $last_update,
+        string $creation_date,
+        ?string $last_update,
         int $expiration_delay,
         int $expiration_notice,
         $expected_expiration_time,
@@ -1003,9 +1026,10 @@ class User extends \DbTestCase
         $username = 'prepare_for_update_' . mt_rand();
         $user_id = $user->add(
             [
-                'name'      => $username,
-                'password'  => 'pass',
-                'password2' => 'pass'
+                'date_creation' => $creation_date,
+                'name'          => $username,
+                'password'      => 'pass',
+                'password2'     => 'pass'
             ]
         );
         $this->integer($user_id)->isGreaterThan(0);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When impersonating a user who has never had their password changed, and when the password expiration policy is set, the warning on the user's homepage says the password will expire in 1970. It also shows a debug error because 'password_last_update' is null and passing null to strtotime is deprecated. This PR prevents passing null to strtotime and also changes the message to "Your password has expired." when the expiration date has passed.