### PR TITLE
Fix hidden predefined dates for changes and problems

### DIFF
--- a/src/Change.php
+++ b/src/Change.php
@@ -932,6 +932,7 @@ class Change extends CommonITILObject
             'name'                       => '',
             'itilcategories_id'          => 0,
             'actiontime'                 => 0,
+            'date'                      => 'NULL',
             '_add_validation'            => 0,
             'users_id_validate'          => [],
             '_tasktemplates_id'          => [],

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -1551,6 +1551,7 @@ class Problem extends CommonITILObject
             'entities_id'                => $_SESSION['glpiactive_entity'],
             'itilcategories_id'          => 0,
             'actiontime'                 => 0,
+            'date'                      => 'NULL',
             '_add_validation'            => 0,
             'users_id_validate'          => [],
             '_tasktemplates_id'          => [],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13908

Opening date was not in the defaults array for Change or Problem, so when the predefined value was loaded, it was made a hidden value instead of changing the value in the displayed field.