### PR TITLE
better style for invalid states

### DIFF
--- a/css/includes/components/_search_input.scss
+++ b/css/includes/components/_search_input.scss
@@ -98,16 +98,14 @@ div.search-input {
     }
 }
 
-input:invalid {
-    background-color: var(--tblr-warning) !important;
-}
+.was-validated .form-control:valid,
+.form-control.is-valid {
+    border-color: var(--tblr-border-color);
+    background-image: none;
+    padding-right: initial;
 
-input + span.info {
-    display: none;
-}
-
-input:invalid + span.info {
-    display: inline;
-    color: var(--tblr-warning);
-    font-size: 0.8rem;
+    &:focus {
+        border-color: var(--tblr-border-color);
+        box-shadow: initial;
+    }
 }

--- a/js/common.js
+++ b/js/common.js
@@ -1462,7 +1462,7 @@ function validateFormWithBootstrap(event) {
     }
 
     return valid;
-};
+}
 
 $(() => {
     $(document.body).on('submit', 'form[data-submit-once]', (e) => {

--- a/js/common.js
+++ b/js/common.js
@@ -1462,11 +1462,11 @@ window.validateFormWithBootstrap = function (event) {
     }
 
     return valid;
-}
+};
 
 $(() => {
     $(document.body).on('submit', 'form[data-submit-once]', (e) => {
-        if (!validateFormWithBootstrap(e)) {
+        if (!window.validateFormWithBootstrap(e)) {
             return false;
         }
 

--- a/js/common.js
+++ b/js/common.js
@@ -1448,7 +1448,7 @@ function blockFormSubmit(form, e) {
     form.attr('data-submitted', 'true');
 }
 
-function validateFormWithBootstrap(event) {
+window.validateFormWithBootstrap = function (event) {
     const form = $(event.target).closest('form');
     const valid = form[0].checkValidity();
 

--- a/js/common.js
+++ b/js/common.js
@@ -1448,8 +1448,28 @@ function blockFormSubmit(form, e) {
     form.attr('data-submitted', 'true');
 }
 
+function validateFormWithBootstrap(event) {
+    const form = $(event.target).closest('form');
+    const valid = form[0].checkValidity();
+
+    if (form.hasClass('needs-validation')) {
+        if (!valid) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+
+        form.addClass('was-validated');
+    }
+
+    return valid;
+};
+
 $(() => {
     $(document.body).on('submit', 'form[data-submit-once]', (e) => {
+        if (!validateFormWithBootstrap(e)) {
+            return false;
+        }
+
         const form = $(e.target).closest('form');
         if (form.attr('data-submitted') === 'true') {
             e.preventDefault();

--- a/js/modules/Search/Table.js
+++ b/js/modules/Search/Table.js
@@ -31,7 +31,7 @@
  * ---------------------------------------------------------------------
  */
 
-/* global bootstrap */
+/* global bootstrap, validateFormWithBootstrap */
 
 import GenericView from './GenericView.js';
 

--- a/js/modules/Search/Table.js
+++ b/js/modules/Search/Table.js
@@ -269,7 +269,9 @@ window.GLPI.Search.Table = class Table extends GenericView {
 
         $(search_container).on('click', '.search-form-container button[name="search"]', (e) => {
             e.preventDefault();
-            this.onSearch();
+            if (validateFormWithBootstrap(e)) {
+                this.onSearch();
+            }
         });
 
         $(ajax_container).on('click', '.trigger-sort', (e) => {

--- a/js/modules/Search/Table.js
+++ b/js/modules/Search/Table.js
@@ -269,7 +269,7 @@ window.GLPI.Search.Table = class Table extends GenericView {
 
         $(search_container).on('click', '.search-form-container button[name="search"]', (e) => {
             e.preventDefault();
-            if (validateFormWithBootstrap(e)) {
+            if (window.validateFormWithBootstrap(e)) {
                 this.onSearch();
             }
         });

--- a/src/Search/Input/QueryBuilder.php
+++ b/src/Search/Input/QueryBuilder.php
@@ -360,7 +360,7 @@ final class QueryBuilder implements SearchInputInterface
 
             echo "<input type='text' class='form-control' size='13' name='$inputname' value=\"" .
                 htmlspecialchars($request['value']) . "\" pattern=\"" . htmlspecialchars($pattern) . "\">" .
-                "<span class='info'>" . htmlspecialchars($message) . "</span>";
+                "<span class='invalid-tooltip'>" . htmlspecialchars($message) . "</span>";
         }
     }
 
@@ -958,13 +958,13 @@ final class QueryBuilder implements SearchInputInterface
                 break;
 
             case 'datetime':
-                $pattern = $relative_operators_pattern . '([\d:\- ]+|\-?\s*\d+(\.\d+)?)';
+                $pattern = $relative_operators_pattern . '([\d:\- ]+|-?\s*\d+(\.\d+)?)';
                 $message = __('must be a date time (YYYY-MM-DD HH:mm:SS) or be a relative number of months (e.g. > -6 for dates higher than 6 months ago)');
                 break;
 
             case 'date':
             case 'date_delay':
-                $pattern = $relative_operators_pattern . '([\d\-]+|\-?\s*\d+(\.\d+)?)';
+                $pattern = $relative_operators_pattern . '([\d\-]+|-?\s*\d+(\.\d+)?)';
                 $message = __('must be a date (YYYY-MM-DD) or be a relative number of months (e.g. > -6 for dates higher than 6 months ago)');
                 break;
 

--- a/templates/components/itilobject/mainform_open.html.twig
+++ b/templates/components/itilobject/mainform_open.html.twig
@@ -49,7 +49,7 @@
 {% endif %}
 
 <form method="POST" action="{{ form_path }}" enctype="{{ enctype }}"
-      data-track-changes="{{ track_changes }}" id="itil-form" class="{{ new_cls }}" data-submit-once>
+      data-track-changes="{{ track_changes }}" id="itil-form" class="{{ new_cls }} needs-validation" data-submit-once novalidate>
    {% if not item.isNewItem() %}
        <input type="hidden" name="id" value="{{ item.fields['id'] }}" />
    {% endif %}

--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -43,7 +43,7 @@
         {% set mainform = mainform ?? true %}
         {% set showaction = showaction ?? true %}
         {% if mainform and showaction %}
-        <form name="searchform{{ normalized_itemtype }}" class="search-form-container" method="get" action="{{ p['target'] }}">
+        <form name="searchform{{ normalized_itemtype }}" class="search-form-container needs-validation" novalidate method="get" action="{{ p['target'] }}">
         {% endif %}
         <div class="primary-controls">
             <div class="btn-group me-1 me-xl-2">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

![image](https://github.com/glpi-project/glpi/assets/418844/473f2c6c-cba3-4561-a685-b9213e1cf995)

Issue come from multiple pr (last was #14875)
but invalid states from inputs (required, check pattern, etc) were ugly or absent.

I leverage bootstrap [validation component](https://getbootstrap.com/docs/5.1/forms/validation/) to get proper style.
In most case, I didn't find a case where the `:valid` css rule was pertinent to keep. And so I tried to remove it properly (we lost focus style after validation).

One last point, on firefox, escaped char in regex pattern, when it should not be escaped, triggers an error (and failed completely the check), example : `\-` -> `-`.  