### PR TITLE
Prevent planning modal duplicates

### DIFF
--- a/js/glpi_dialog.js
+++ b/js/glpi_dialog.js
@@ -144,6 +144,10 @@ var glpi_html_dialog = function({
         // call close event
         close(event);
 
+        if ($('div.modal.show').length === 0) {
+            $('div.modal-backdrop').remove();
+        }
+
         // remove html on modal close
         $('#'+id).remove();
     });

--- a/js/planning.js
+++ b/js/planning.js
@@ -591,19 +591,25 @@ var GLPIPlanning  = {
                 var start = info.start;
                 var end = info.end;
 
-                glpi_ajax_dialog({
-                    url: CFG_GLPI.root_doc+"/ajax/planning.php",
-                    params: {
-                        action: 'add_event_fromselect',
-                        begin:  start.toISOString(),
-                        end:    end.toISOString(),
-                        res_itemtype: itemtype,
-                        res_items_id: items_id,
-                    },
-                    dialogclass: 'modal-lg',
-                    title: __('Add an event'),
-                    bs_focus: false
-                });
+                if ($('div.modal.planning-modal').length === 0) {
+                    glpi_ajax_dialog({
+                        url: CFG_GLPI.root_doc + "/ajax/planning.php",
+                        params: {
+                            action: 'add_event_fromselect',
+                            begin: start.toISOString(),
+                            end: end.toISOString(),
+                            res_itemtype: itemtype,
+                            res_items_id: items_id,
+                        },
+                        dialogclass: 'modal-lg planning-modal',
+                        title: __('Add an event'),
+                        bs_focus: false
+                    });
+                    GLPIPlanning.calendar.setOption('selectable', false);
+                    window.setTimeout(function() {
+                        GLPIPlanning.calendar.setOption('selectable', true);
+                    }, 500);
+                }
 
                 GLPIPlanning.calendar.unselect();
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13534

Two changes:
1. When the last visible modal is closed, all backdrops are forcibly removed.
2. When opening the planning modal, the calendar becomes unselectable for half of a second to prevent extra clicks from opening more modals.