### PR TITLE
Fix duplicate alias in planning query

### DIFF
--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -1558,7 +1558,6 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
                 date: $ttask::getTable() . '.date_creation',
                 interval: new QueryExpression($DB::quoteName($ttask::getTable() . '.planned_duration')),
                 interval_unit: 'SECOND',
-                alias: 'notp_edate'
             );
             $SELECT[] = new QueryExpression($bdate, 'notp_date');
             $SELECT[] = new QueryExpression($edate, 'notp_edate');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Only affects `main`.
Planned task end date had an alias specified in the `QueryFunction` helper as well as the `QueryExpression` wrapper being added to the `SELECT` resulting in two aliases being added. The query function is used within the `WHERE` criteria, so the alias should only be specified in the `QueryExpression` on the `SELECT`.