### PR TITLE
Skip unneeded LDAP auth checks

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -825,7 +825,7 @@ class Auth extends CommonGLPI
                 $ldapservers = [];
                 $ldapservers_status = false;
                //if LDAP enabled too, get user's infos from LDAP
-                if (Toolbox::canUseLdap()) {
+                if ($this->user->fields['authtype'] === self::LDAP && Toolbox::canUseLdap()) {
                    //User has already authenticated, at least once: it's ldap server if filled
                     if (
                         isset($this->user->fields["auths_id"])

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -825,7 +825,7 @@ class Auth extends CommonGLPI
                 $ldapservers = [];
                 $ldapservers_status = false;
                //if LDAP enabled too, get user's infos from LDAP
-                if ($this->user->fields['authtype'] === self::LDAP && Toolbox::canUseLdap()) {
+                if ((!isset($this->user->fields['authtype']) || $this->user->fields['authtype'] === self::LDAP) && Toolbox::canUseLdap()) {
                    //User has already authenticated, at least once: it's ldap server if filled
                     if (
                         isset($this->user->fields["auths_id"])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15262

When logging in through the API with a user_token instead of a username/password, the authentication code was trying to connect to every active LDAP server even if the user was not from an LDAP. When the user is from an LDAP and has an `auths_id` set, then only that one server is checked. When `auths_id` is 0 or missing, it checks every server. This code should first check the `authtype` before anything else related to LDAP.