### PR TITLE
Fix users not able to update own protected fields

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -1029,7 +1029,7 @@ class User extends CommonDBTM
         if (
             count(array_intersect($protected_input_keys, array_keys($input))) > 0
             && !Session::isCron() // cron context is considered safe
-            && $input['id'] !== Session::getLoginUserID()
+            && (int) $input['id'] !== Session::getLoginUserID()
             && !$this->currentUserHaveMoreRightThan($input['id'])
         ) {
             foreach ($protected_input_keys as $input_key) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Due to the user's ID being a string in the input array and being used in a strict comparison with the logged in user's ID which should always be an integer in the session data, users were not able to update their own "protected" fields such as API token, emails, etc unless the `currentUserHaveMoreRightThan` check also passes. My database must have some bad/orphaned data related to rights as a user with a self-service and technician profile was unable to change these fields, but was able to with an admin profile. Regardless, a user should be able to change their own fields.