### PR TITLE
fix(Contract_Item): harmonize behavior from Contract or Item form

### DIFF
--- a/src/Contract_Item.php
+++ b/src/Contract_Item.php
@@ -303,8 +303,7 @@ class Contract_Item extends CommonDBRelation
 
             echo "<tr class='tab_bg_1'><td>";
             Contract::dropdown(['entity'  => $item->getEntityID(),
-                'used'    => $used,
-                'expired' => false
+                'used'    => $used
             ]);
 
             echo "</td><td class='center'>";


### PR DESCRIPTION
From an ```item``` with ```Contract``` tab it is not possible to add an "expired" contract 

But from an "expired" contract, any item can be added.

This PR  harmonize behavior from Contract or Item form

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30934
