### PR TITLE
Fix(Contract): use standard Location search options

### DIFF
--- a/install/migrations/update_10.0.11_to_10.0.12/contract.php
+++ b/install/migrations/update_10.0.11_to_10.0.12/contract.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var \DBmysql $DB
+ * @var \Migration $migration
+ */
+$migration->changeSearchOption(Contract::class, 3, 9); //Number search option move to index 9
+$migration->changeSearchOption(Contract::class, 8, 3); //Location completename move to index 3

--- a/install/migrations/update_10.0.11_to_10.0.12/contract.php
+++ b/install/migrations/update_10.0.11_to_10.0.12/contract.php
@@ -43,4 +43,5 @@ $displaypref = new DisplayPreference();
 if ($displaypref->getFromDBByCrit(['itemtype' => 'Contract', 'users_id' => 0, 'num' => 3])) {
     $migration->changeSearchOption(Contract::class, 3, 9); //Number search option move to index 9
 }
+//migration is needed because searchoption with index 8 is set from default view
 $migration->changeSearchOption(Contract::class, 8, 3); //Location completename move to index 3

--- a/install/migrations/update_10.0.11_to_10.0.12/contract.php
+++ b/install/migrations/update_10.0.11_to_10.0.12/contract.php
@@ -37,5 +37,10 @@
  * @var \DBmysql $DB
  * @var \Migration $migration
  */
-$migration->changeSearchOption(Contract::class, 3, 9); //Number search option move to index 9
+
+$displaypref = new DisplayPreference();
+//if the displaypref is found, a migration is needed
+if ($displaypref->getFromDBByCrit(['itemtype' => 'Contract', 'users_id' => 0, 'num' => 3])) {
+    $migration->changeSearchOption(Contract::class, 3, 9); //Number search option move to index 9
+}
 $migration->changeSearchOption(Contract::class, 8, 3); //Location completename move to index 3

--- a/src/Contract.php
+++ b/src/Contract.php
@@ -500,7 +500,7 @@ class Contract extends CommonDBTM
         ];
 
         $tab[] = [
-            'id'                 => '3',
+            'id'                 => '9',
             'table'              => $this->getTable(),
             'field'              => 'num',
             'name'               => _x('phone', 'Number'),
@@ -585,14 +585,6 @@ class Contract extends CommonDBTM
             'datatype'           => 'number',
             'max'                => 120,
             'unit'               => 'month'
-        ];
-
-        $tab[] = [
-            'id'                 => '8',
-            'table'              => 'glpi_locations',
-            'field'              => 'completename',
-            'name'               => Location::getTypeName(1),
-            'datatype'           => 'dropdown'
         ];
 
         $tab[] = [
@@ -862,6 +854,8 @@ class Contract extends CommonDBTM
                 ]
             ]
         ];
+
+        $tab = array_merge($tab, Location::rawSearchOptionsToAdd());
 
         return $tab;
     }


### PR DESCRIPTION
Add missing standard Location search options to ```Contract```

Move ```Number``` ```searchoption``` with index ```3``` to ```9``` (because index ```3``` is used by ```Location / completename```

Move old  ```Location / completename``` with index ```8``` to ```3```


Fix #16231 


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #16231
