### PR TITLE
fix(ticket): watcher ignored on self-service form

### DIFF
--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -269,27 +269,29 @@
           $('.popover').popover('hide');
       });
 
-       actor_select.parent().popover({
-           selector: '[data-glpi-popover-source]',
-           container: actor_select.parent(),
-           html: true,
-           sanitize: false,
-           trigger: 'hover',
-           delay: {
+      setTimeout((function() {
+         actor_select.parent().popover({
+            selector: '[data-glpi-popover-source]',
+            container: actor_select.parent(),
+            html: true,
+            sanitize: false,
+            trigger: 'hover',
+            delay: {
                hide: 300
-           },
-           template: '<' + 'div class="popover shadow" role="tooltip"><' + 'div class="popover-arrow"><' + '/div><' + 'h3 class="popover-header"><' + '/h3><' + 'div class="popover-body"><' + '/div><' + '/div>',
-           content: function() {
+            },
+            template: '<' + 'div class="popover shadow" role="tooltip"><' + 'div class="popover-arrow"><' + '/div><' + 'h3 class="popover-header"><' + '/h3><' + 'div class="popover-body"><' + '/div><' + '/div>',
+            content: function() {
                // Close other popovers
                $('.popover').popover('hide');
                return $('#' + $(this).attr('data-glpi-popover-source')).html();
-           }
-       }).on('hide.bs.popover', function () {
+            }
+         }).on('hide.bs.popover', function () {
             // prevent closing popover when user card is hover
             if ($('.user-info-card:hover').length > 0) {
-                return false;
+               return false;
             }
-        });
+         });
+      }), 500);
 
         // when the mouse leave the user card in the popover, close it
         $(document).on('mouseleave', '.user-info-card', function() {

--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -269,7 +269,7 @@
           $('.popover').popover('hide');
       });
 
-      setTimeout((function() {
+      $(function () {
          actor_select.parent().popover({
             selector: '[data-glpi-popover-source]',
             container: actor_select.parent(),
@@ -291,7 +291,7 @@
                return false;
             }
          });
-      }), 500);
+      });
 
         // when the mouse leave the user card in the popover, close it
         $(document).on('mouseleave', '.user-info-card', function() {


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30913


On the native ticket creation form, in the simplified interface, the watcher was not taken into account.
So even if you filled it in, the created ticket didn't have it.

In the browser console, there was this error:
![image](https://github.com/glpi-project/glpi/assets/8530352/42759bb8-6ebc-4e8f-8f52-fbee8425adc4)

