### PR TITLE
Upgrade node/npm requirement to latest LTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "description": "GLPI dependencies",
     "license": "GPL-3.0-or-later",
     "engines": {
-        "node": ">= 16.11",
-        "npm": ">= 8.0"
+        "node": ">= 20.9",
+        "npm": ">= 10.1"
     },
     "dependencies": {
         "@algolia/autocomplete-js": "^1.12.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Latest tabler version requires, at least, node 18.x. I propose to upgrade minimal requirement to 20.x (the latest LTS). It will affect only developpers or people that want to build GLPI dependencies.