### PR TITLE
Set the color of a rack's weight and consumption

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -932,13 +932,13 @@ class Html
         $out = '';
         if ($params['create']) {
             $out = <<<HTML
-            <div class="progress" style="height: 16px" id="{$id}">
-               <div class="progress-bar progress-bar-striped bg-info" role="progressbar"
-                     style="width: 0%; overflow: visible"
-                     aria-valuenow="0"
-                     aria-valuemin="0" aria-valuemax="100"
-                     id="{$id}_text">
-               </div>
+            <div class="progress bg-primary-emphasis bg-light" style="height: 16px" id="{$id}">
+                <div class="progress-bar progress-bar-striped bg-info text-dark" role="progressbar"
+                    style="width: 0%; overflow: visible;"
+                    aria-valuenow="0"
+                    aria-valuemin="0" aria-valuemax="100"
+                    id="{$id}_text">
+                </div>
             </div>
 HTML;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30976

For the progress bar in a Rack's statistics box, the basic text color was white, except that if the bar is empty and the person is on a white background, the text is not visible. So I set a light color for the background of the empty bar and a dark color for the text.

Darker
![image](https://github.com/glpi-project/glpi/assets/107540223/e1004ced-b5f0-4ff6-aa34-88591254b4df)
PremiumRed
![image](https://github.com/glpi-project/glpi/assets/107540223/cd303fe9-bd7d-4af2-bba1-86db03342a81)
Teclib
![image](https://github.com/glpi-project/glpi/assets/107540223/5fb5fab4-5b8c-4f7d-8c8f-e5cf804dbb97)

