### PR TITLE
Fix(ui): add missing icon for agent stale action

### DIFF
--- a/src/Inventory/Conf.php
+++ b/src/Inventory/Conf.php
@@ -953,7 +953,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'><td colspan=2></td>";
             echo "<td>";
             echo "<span id='blocaction1' style='display:none'>";
-            echo __('Change the status');
+            echo \State::createTabEntry(__('Change the status'), 0, \State::getType());
             echo "</span>";
             echo "</td>";
             echo "<td width='20%'>";


### PR DESCRIPTION
 Add missing icon for agent stale action

![image](https://github.com/glpi-project/glpi/assets/7335054/c1ebf185-cdda-4144-ba94-5a85a553342f)

reuses icon from 'default status' option

![image](https://github.com/glpi-project/glpi/assets/7335054/14c43d88-4db4-4f7d-9527-7038c39e4b79)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
