### PR TITLE
Do not cache ancestors for multiple IDs together

### DIFF
--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -1213,7 +1213,7 @@ final class DbUtils
         } else {
             // Save the results to the cache for each requested item ID
             $to_cache = [];
-            foreach ($items_id as $id) {
+            foreach ($ids_needed_to_fetch as $id) {
                 if (!isset($ancestors_by_id[$id])) {
                     $ancestors_by_id[$id] = [];
                 }

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -1051,7 +1051,7 @@ final class DbUtils
      * @phpstan-param non-empty-array<int>|int|numeric-string $items_id
      *
      * @return array Array of IDs of the ancestors. The keys and values should be identical. The result *may* include the IDs passed in the $items_id parameter.
-     * @todo Should this function really return the requested ID in the result? Especially if only a single ID is requested?
+     * @todo Should this function really allow returning the requested ID in the result? Especially if only a single ID is requested?
      */
     public function getAncestorsOf($table, $items_id)
     {
@@ -1210,6 +1210,9 @@ final class DbUtils
         } else {
             // Save the results to the cache for each requested item ID
             foreach ($items_id as $id) {
+                if (!isset($ancestors_by_id[$id])) {
+                    $ancestors_by_id[$id] = [];
+                }
                 $GLPI_CACHE->set("ancestors_cache_{$table}_{$id}", $ancestors_by_id[$id]);
             }
         }

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -1047,9 +1047,11 @@ final class DbUtils
      * Get the ancestors of an item in a tree dropdown
      *
      * @param string       $table    Table name
-     * @param array|string $items_id The IDs of the items
+     * @param array|string|int $items_id The IDs of the items. If an array is passed, the result will be the union of the ancestors of each item.
+     * @phpstan-param non-empty-array<int>|int|numeric-string $items_id
      *
-     * @return array of IDs of the ancestors
+     * @return array Array of IDs of the ancestors. The keys and values should be identical. The result *may* include the IDs passed in the $items_id parameter.
+     * @todo Should this function really return the requested ID in the result? Especially if only a single ID is requested?
      */
     public function getAncestorsOf($table, $items_id)
     {
@@ -1062,33 +1064,73 @@ final class DbUtils
         if ($items_id === null) {
             return [];
         }
-        $ckey = 'ancestors_cache_';
+
+        // We don't want to cache results for multiple items together. Default the cache key to null.
+        $ckey = null;
         if (is_array($items_id)) {
-            $ckey .= $table . '_' . md5(implode('|', $items_id));
-        } else {
-            $ckey .= $table . '_' . $items_id;
+            if (count($items_id) === 0) {
+                return [];
+            }
+            if (count($items_id) === 1) {
+                // An array with a single item can be destructured and is acceptable to use the cache directly
+                $items_id = (int) reset($items_id);
+            }
         }
 
-        $ancestors = $GLPI_CACHE->get($ckey);
-        if ($ancestors !== null) {
-            return $ancestors;
+        $lowest_valid_id = $table === 'glpi_entities' ? 0 : 1;
+        if (!is_array($items_id)) {
+            if ($items_id <= $lowest_valid_id) {
+                // Impossible for there to be any valid ancestors, so we already know the result
+                return [$items_id => $items_id];
+            }
+            // A single item can use the cache directly
+            $ckey = "ancestors_cache_{$table}_{$items_id}";
         }
 
-        $ancestors = [];
-
-       // IDs to be present in the final array
-        $parentIDfield = $this->getForeignKeyFieldForTable($table);
-        $use_cache     = $DB->fieldExists($table, "ancestors_cache");
+        /**
+         * @var array<int, int> $ancestors_by_id Temporary array to store ancestors by the IDs passed in the $items_id parameter.
+         */
+        $ancestors_by_id = [];
 
         if (!is_array($items_id)) {
-            $items_id = (array)$items_id;
+            $items_id = (array) $items_id;
         }
+        $ids_needed_to_fetch = array_map(static function ($id) {
+            return (int) $id;
+        }, $items_id);
+
+        if ($ckey !== null && ($ancestors = $GLPI_CACHE->get($ckey)) !== null) {
+            // If we only need to get ancestors for a single item, we can use the cached values if they exist
+            return $ancestors;
+        } else if ($ckey === null) {
+            // For multiple IDs, we need to check the cache for each ID
+            foreach ($ids_needed_to_fetch as $id) {
+                if (($ancestors = $GLPI_CACHE->get("ancestors_cache_{$table}_{$id}")) !== null) {
+                    $ancestors_by_id[$id] = $ancestors;
+                    unset($ids_needed_to_fetch[$id]);
+                }
+            }
+            // If we got everything from the cache, we can return the results now
+            if (count($ids_needed_to_fetch) === 0) {
+                $ancestors = [];
+                foreach ($ancestors_by_id as $ancestors_for_id) {
+                    foreach ($ancestors_for_id as $ai => $ancestor_id) {
+                        $ancestors[$ai] = $ancestor_id;
+                    }
+                }
+                return $ancestors;
+            }
+        }
+
+        // IDs to be present in the final array
+        $parentIDfield = $this->getForeignKeyFieldForTable($table);
+        $use_cache     = $DB->fieldExists($table, "ancestors_cache");
 
         if ($use_cache) {
             $iterator = $DB->request([
                 'SELECT' => ['id', 'ancestors_cache', $parentIDfield],
                 'FROM'   => $table,
-                'WHERE'  => ['id' => $items_id]
+                'WHERE'  => ['id' => $ids_needed_to_fetch]
             ]);
 
             foreach ($iterator as $row) {
@@ -1096,25 +1138,22 @@ final class DbUtils
                     $rancestors = $row['ancestors_cache'];
                     $parent     = $row[$parentIDfield];
 
-                  // Return datas from cache in DB
+                    // Return datas from cache in DB
                     if (!empty($rancestors)) {
-                        $ancestors = array_replace($ancestors, $this->importArrayFromDB($rancestors));
+                        $ancestors_by_id[(int) $row['id']] = $this->importArrayFromDB($rancestors);
                     } else {
                         $loc_id_found = [];
-                     // Recursive solution for table with-cache
+                        // Recursive solution for table with-cache
                         if ($parent > 0) {
-                              $loc_id_found = $this->getAncestorsOf($table, $parent);
+                            $loc_id_found = $this->getAncestorsOf($table, $parent);
                         }
 
-                     // ID=0 only exists for Entities
-                        if (
-                            ($parent > 0)
-                            || ($table == 'glpi_entities')
-                        ) {
+                        // ID=0 only exists for Entities
+                        if ($parent >= $lowest_valid_id) {
                             $loc_id_found[$parent] = $parent;
                         }
 
-                     // Store cache datas in DB
+                        // Store cache datas in DB
                         $DB->update(
                             $table,
                             [
@@ -1125,14 +1164,14 @@ final class DbUtils
                             ]
                         );
 
-                        $ancestors = array_replace($ancestors, $loc_id_found);
+                        $ancestors_by_id[(int) $row['id']] = $loc_id_found;
                     }
                 }
             }
         } else {
-           // Get the ancestors
-           // iterative solution for table without cache
-            foreach ($items_id as $id) {
+            // Get the ancestors
+            // iterative solution for table without cache
+            foreach ($ids_needed_to_fetch as $id) {
                 $IDf = $id;
                 while ($IDf > 0) {
                     // Get next elements
@@ -1144,16 +1183,16 @@ final class DbUtils
 
                     if (count($iterator) > 0) {
                         $result = $iterator->current();
-                        $IDf = $result[$parentIDfield];
+                        $IDf = (int) $result[$parentIDfield];
                     } else {
                         $IDf = 0;
                     }
 
-                    if (
-                        !isset($ancestors[$IDf])
-                         && (($IDf > 0) || ($table == 'glpi_entities'))
-                    ) {
-                        $ancestors[$IDf] = $IDf;
+                    if (!isset($ancestors_by_id[$id][$IDf]) && $IDf >= $lowest_valid_id) {
+                        if (!isset($ancestors_by_id[$id])) {
+                            $ancestors_by_id[$id] = [];
+                        }
+                        $ancestors_by_id[$id][$IDf] = $IDf;
                     } else {
                         $IDf = 0;
                     }
@@ -1161,7 +1200,27 @@ final class DbUtils
             }
         }
 
-        $GLPI_CACHE->set($ckey, $ancestors);
+        if ($ckey !== null) {
+            // Save the results to the cache for the single requested item ID
+            $to_get = array_values($items_id)[0];
+            if (!isset($ancestors_by_id[$to_get])) {
+                $ancestors_by_id[$to_get] = [];
+            }
+            $GLPI_CACHE->set($ckey, $ancestors_by_id[$to_get]);
+        } else {
+            // Save the results to the cache for each requested item ID
+            foreach ($items_id as $id) {
+                $GLPI_CACHE->set("ancestors_cache_{$table}_{$id}", $ancestors_by_id[$id]);
+            }
+        }
+
+        // Combine the results for all requested item IDs
+        $ancestors = [];
+        foreach ($ancestors_by_id as $id => $ancestors_for_id) {
+            foreach ($ancestors_for_id as $ai => $ancestor_id) {
+                $ancestors[$ai] = $ancestor_id;
+            }
+        }
 
         return $ancestors;
     }

--- a/tests/functional/DbUtils.php
+++ b/tests/functional/DbUtils.php
@@ -852,21 +852,14 @@ class DbUtils extends DbTestCase
             $this->array($GLPI_CACHE->get($ckey_new_id2))->isIdenticalTo($expected);
         }
 
-       //test on multiple entities
+        // test on multiple entities
+        // getAncestorsOf was already called on $new_id and $new_id2 separately, so cache is already populated since we don't cache ancestors of multiple entities together anymore.
+        // Ex: getAncestorsOf('glpi_entities', [$new_id, $new_id2]) will populate ancestors_cache_glpi_entities_$new_id and ancestors_cache_glpi_entities_$new_id2
+        // but not ancestors_cache_glpi_entities_ . md5(implode('|', [$new_id, $new_id2]))
+        // We will ignore the $cache and $hit parameters here and just ensure the combined result is correct.
         $expected = [0 => 0, $ent0 => $ent0, $ent1 => $ent1, $ent2 => $ent2];
-        $ckey_new_all = 'ancestors_cache_glpi_entities_' . md5($new_id . '|' . $new_id2);
-        if ($cache === true && $hit === false) {
-            $this->boolean($GLPI_CACHE->has($ckey_new_all))->isFalse();
-        } else if ($cache === true && $hit === true) {
-            $this->array($GLPI_CACHE->get($ckey_new_all))->isIdenticalTo($expected);
-        }
-
         $ancestors = getAncestorsOf('glpi_entities', [$new_id, $new_id2]);
         $this->array($ancestors)->isIdenticalTo($expected);
-
-        if ($cache === true && $hit === false) {
-            $this->array($GLPI_CACHE->get($ckey_new_all))->isIdenticalTo($expected);
-        }
     }
 
     public function testGetAncestorsOf()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15752

Issue:
When entities are restructured, the ancestor values in the GLPI_CACHE are only regenerated for the specific entity IDs, but there can remain old cached data for multiple IDs. When `getAncestorsOf` is called with an array as `$items_id`, the cache key was calculated as `ancestors_cache_$table . '_' . md5(implode('|', $items_id))`. These keys wouldn't be regenerated at all unless they were missing completely from the cache.
So, if EntityA and EntityB are created and something calls `getAncestorsOf` with the ID of both entities in an array, a combined cache entry is created. If you change the parent entity of EntityB to EntityA, GLPI will regenerate the ancestors of EntityB (ancestors_cache_glpi_entities_X) and sons of EntityA. The combined result's cache entry is not modified/cleared and there is no good way to know which entries relate to the modified entities since we cannot get all cache keys.

Solution:
Don't cache any combined results. Instead, if we need ancestors of multiple items:
1. Check the GLPI_CACHE for each individual item
2. For any items that had no results in the GLPI_CACHE, fall back to checking the DB cache or manually traversing the parents in the DB
3. Update the GLPI_CACHE for each individual item
4. Combine the ancestors of the individual items and return the combined result

Improvement(s) to try and help with performance:
1. If ancestors are requested for an ID that is less than or equal to the lowest possible ID value, we return that ID as the only result without having to check any cache/DB. If an array with a single ID is passed, this improvement will also apply. Not sure if it is best to return nothing or the requested ID. This function seems to return the requested ID as an ancestor in at least some cases.