### PR TITLE
Apply profile restrictions to linked tickets display

### DIFF
--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -724,6 +724,8 @@ class DBmysqlIterator implements SeekableIterator, Countable
                 $fkey = $this->analyseFkey($values);
                 return $fkey . ' ' . key($condition) . ' ' . $this->analyseCrit(current($condition));
             }
+        } else if ($values instanceof QueryExpression) {
+            return $values->getValue();
         }
         throw new \LogicException('BAD FOREIGN KEY, should be [ table1 => key1, table2 => key2 ] or [ table1 => key1, table2 => key2, [criteria]].');
     }

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -3297,7 +3297,7 @@ JAVASCRIPT;
                         if (!empty($joins_str)) {
                             $criteria['LEFT JOIN'] = [new QueryExpression($joins_str)];
                         }
-                        $where[] = Search::addDefaultWhere(Ticket::class);
+                        $where[] = new QueryExpression(Search::addDefaultWhere(Ticket::class));
                     }
                     break;
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -3283,6 +3283,24 @@ JAVASCRIPT;
                     }
                     break;
 
+                case Ticket::class:
+                    $criteria = [
+                        'SELECT' => array_merge(["$table.*"], $addselect),
+                        'FROM'   => $table,
+                    ];
+                    if (count($ljoin)) {
+                        $criteria['LEFT JOIN'] = $ljoin;
+                    }
+                    if (!Session::haveRight(Ticket::$rightname, Ticket::READALL)) {
+                        $unused_ref = [];
+                        $joins_str = Search::addDefaultJoin(Ticket::class, Ticket::getTable(), $unused_ref);
+                        if (!empty($joins_str)) {
+                            $criteria['LEFT JOIN'] = [new QueryExpression($joins_str)];
+                        }
+                        $where[] = Search::addDefaultWhere(Ticket::class);
+                    }
+                    break;
+
                 case Project::getType():
                     $visibility = Project::getVisibilityCriteria();
                     if (count($visibility['LEFT JOIN'])) {

--- a/src/Ticket_Ticket.php
+++ b/src/Ticket_Ticket.php
@@ -128,11 +128,12 @@ class Ticket_Ticket extends CommonDBRelation
     /**
      * Get linked tickets to a ticket
      *
-     * @param $ID ID of the ticket id
+     * @param integer $ID ID of the ticket id
+     * @param boolean $check_view_rights check view rights
      *
      * @return array of linked tickets  array(id=>linktype)
      **/
-    public static function getLinkedTicketsTo($ID)
+    public static function getLinkedTicketsTo($ID, bool $check_view_rights = false)
     {
         /** @var \DBmysql $DB */
         global $DB;
@@ -142,15 +143,33 @@ class Ticket_Ticket extends CommonDBRelation
             return [];
         }
 
-        $iterator = $DB->request([
-            'FROM'   => self::getTable(),
+        $table = self::getTable();
+        $criteria = [
+            'SELECT' => ["{$table}.*"],
+            'FROM'   => $table,
             'WHERE'  => [
                 'OR'  => [
                     'tickets_id_1' => $ID,
                     'tickets_id_2' => $ID
                 ]
             ]
-        ]);
+        ];
+        if ($check_view_rights && !Session::haveRight(Ticket::$rightname, Ticket::READALL)) {
+            $ticket_table = Ticket::getTable();
+            $criteria['LEFT JOIN'] = [
+                $ticket_table => [
+                    'ON' => new QueryExpression("{$ticket_table}.id=(CASE WHEN {$table}.tickets_id_1={$ID} THEN {$table}.tickets_id_2 ELSE {$table}.tickets_id_1 END)")
+                ],
+            ];
+            $unused_ref = [];
+            $joins_str = Search::addDefaultJoin(Ticket::class, Ticket::getTable(), $unused_ref);
+            if (!empty($joins_str)) {
+                $db_it = new DBmysqlIterator($DB);
+                $criteria['LEFT JOIN'] = [new QueryExpression($db_it->analyseJoins(['LEFT JOIN' => $criteria['LEFT JOIN']]) . ' ' . $joins_str)];
+            }
+            $criteria['WHERE'][] = new QueryExpression(Search::addDefaultWhere(Ticket::class));
+        }
+        $iterator = $DB->request($criteria);
         $tickets = [];
 
         foreach ($iterator as $data) {

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -421,7 +421,7 @@
          <h2 class="accordion-header" id="linked_tickets-heading" title="{{ 'Ticket_Ticket'|itemtype_name(nb_linked_tickets) }}" data-bs-toggle="tooltip">
             <button class="accordion-button {{ linked_tickets_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#linked_tickets" aria-expanded="true" aria-controls="linked_tickets">
                <i class="ti ti-link me-1"></i>
-               {% set linked_tickets = ticket_ticket.getLinkedTicketsTo(item.fields['id']) %}
+               {% set linked_tickets = ticket_ticket.getLinkedTicketsTo(item.fields['id'], true) %}
                {% set nb_linked_tickets = linked_tickets|length %}
                {% if item.isNewItem() and params['_link']['tickets_id_2'] > 0 %}
                   {% set nb_linked_tickets = 1 %}

--- a/templates/components/itilobject/linked_tickets.html.twig
+++ b/templates/components/itilobject/linked_tickets.html.twig
@@ -33,7 +33,7 @@
 
 <input type="hidden" name="_link[tickets_id_1]" value="{{ item.fields['id'] }}" />
 
-{% set linked_tickets = ticket_ticket.getLinkedTicketsTo(item.fields['id'], true) %}
+{% set linked_tickets = linked_tickets|default(ticket_ticket.getLinkedTicketsTo(item.fields['id'], true)) %}
 {% if linked_tickets|length %}
 <div class="card">
    <div class="list-group list-group-flush list-group-hoverable">

--- a/templates/components/itilobject/linked_tickets.html.twig
+++ b/templates/components/itilobject/linked_tickets.html.twig
@@ -33,7 +33,7 @@
 
 <input type="hidden" name="_link[tickets_id_1]" value="{{ item.fields['id'] }}" />
 
-{% set linked_tickets = ticket_ticket.getLinkedTicketsTo(item.fields['id']) %}
+{% set linked_tickets = ticket_ticket.getLinkedTicketsTo(item.fields['id'], true) %}
 {% if linked_tickets|length %}
 <div class="card">
    <div class="list-group list-group-flush list-group-hoverable">

--- a/tests/functional/Ticket.php
+++ b/tests/functional/Ticket.php
@@ -6464,6 +6464,18 @@ HTML
         $idor = \Session::getNewIDORToken(\Ticket::class, $dropdown_params);
         $values = \Dropdown::getDropdownValue($dropdown_params + ['_idor_token' => $idor], false);
         $this->array($values['results'])->size->isGreaterThan(1);
+        $this->boolean($fn_dropdown_has_id($values['results'], $not_my_tickets_id))->isFalse();
+
+        // Add user as requester
+        $ticket_user = new \Ticket_User();
+        $ticket_user->add([
+            'tickets_id' => $not_my_tickets_id,
+            'users_id' => $_SESSION['glpiID'],
+            'type' => CommonITILActor::REQUESTER,
+        ]);
+        $idor = \Session::getNewIDORToken(\Ticket::class, $dropdown_params);
+        $values = \Dropdown::getDropdownValue($dropdown_params + ['_idor_token' => $idor], false);
+        $this->array($values['results'])->size->isGreaterThan(1);
         $this->boolean($fn_dropdown_has_id($values['results'], $not_my_tickets_id))->isTrue();
     }
 }

--- a/tests/functional/Ticket.php
+++ b/tests/functional/Ticket.php
@@ -6422,4 +6422,48 @@ HTML
         $this->boolean(property_exists($ticket, 'plugin_xxx_data'))->isTrue();
         $this->string($ticket->plugin_xxx_data)->isEqualTo('test');
     }
+
+    public function testRestrictedDropdownValues()
+    {
+        $this->login();
+
+        $fn_dropdown_has_id = static function ($dropdown_values, $id) use (&$fn_dropdown_has_id) {
+            foreach ($dropdown_values as $dropdown_value) {
+                if (isset($dropdown_value['children'])) {
+                    if ($fn_dropdown_has_id($dropdown_value['children'], $id)) {
+                        return true;
+                    }
+                } elseif ((int) $dropdown_value['id'] === (int) $id) {
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        $ticket = new \Ticket();
+        $this->integer($not_my_tickets_id = $ticket->add([
+            'name'      => __FUNCTION__,
+            'content'   => __FUNCTION__,
+            'users_id'  => $_SESSION['glpiID'] + 1, // Not current user
+            '_skip_auto_assign' => true,
+            'entities_id' => $this->getTestRootEntity(true),
+        ]))->isGreaterThan(0);
+
+        $dropdown_params = [
+            'itemtype' => \Ticket::class,
+            'entity_restrict' => -1,
+            'page_limit' => 1000
+        ];
+        $idor = \Session::getNewIDORToken(\Ticket::class, $dropdown_params);
+        $values = \Dropdown::getDropdownValue($dropdown_params + ['_idor_token' => $idor], false);
+        $this->array($values['results'])->size->isGreaterThan(1);
+        $this->boolean($fn_dropdown_has_id($values['results'], $not_my_tickets_id))->isTrue();
+
+        // Remove permission to see all tickets
+        $_SESSION['glpiactiveprofile']['ticket'] = READ;
+        $idor = \Session::getNewIDORToken(\Ticket::class, $dropdown_params);
+        $values = \Dropdown::getDropdownValue($dropdown_params + ['_idor_token' => $idor], false);
+        $this->array($values['results'])->size->isGreaterThan(1);
+        $this->boolean($fn_dropdown_has_id($values['results'], $not_my_tickets_id))->isTrue();
+    }
 }

--- a/tests/functional/Ticket_Ticket.php
+++ b/tests/functional/Ticket_Ticket.php
@@ -202,9 +202,9 @@ class Ticket_Ticket extends DbTestCase
 
         $ticket_ticket = new \Ticket_Ticket();
         $this->integer($ticket_ticket->add([
-                'tickets_id_1' => $this->tone->getID(),
-                'tickets_id_2' => $this->ttwo->getID(),
-                'link'         => \Ticket_Ticket::LINK_TO
+            'tickets_id_1' => $this->tone->getID(),
+            'tickets_id_2' => $this->ttwo->getID(),
+            'link'         => \Ticket_Ticket::LINK_TO
         ]))->isGreaterThan(0);
 
         $ticket = new \Ticket();

--- a/tests/functional/Ticket_Ticket.php
+++ b/tests/functional/Ticket_Ticket.php
@@ -194,4 +194,46 @@ class Ticket_Ticket extends DbTestCase
         )->isTrue();
         $this->integer(\Ticket_Ticket::countOpenChildren($ttwo->getID()))->isIdenticalTo(0);
     }
+
+    public function testRestrictedGetLinkedTicketsTo()
+    {
+        $this->login();
+        $this->createTickets();
+
+        $ticket_ticket = new \Ticket_Ticket();
+        $this->integer($ticket_ticket->add([
+                'tickets_id_1' => $this->tone->getID(),
+                'tickets_id_2' => $this->ttwo->getID(),
+                'link'         => \Ticket_Ticket::LINK_TO
+        ]))->isGreaterThan(0);
+
+        $ticket = new \Ticket();
+        $this->integer($other_tickets_id = $ticket->add([
+            'name'      => 'Linked ticket 03',
+            'content'   => 'Linked ticket 03',
+            'users_id'  => $_SESSION['glpiID'] + 1, // Not current user
+            '_skip_auto_assign' => true,
+            'entities_id' => $this->getTestRootEntity(true),
+        ]))->isGreaterThan(0);
+
+        $this->integer($ticket_ticket->add([
+            'tickets_id_1' => $this->tone->getID(),
+            'tickets_id_2' => $other_tickets_id,
+            'link'         => \Ticket_Ticket::LINK_TO
+        ]))->isGreaterThan(0);
+
+        $linked = \Ticket_Ticket::getLinkedTicketsTo($this->tone->getID());
+        $this->integer(count($linked))->isEqualTo(2);
+        $this->array(array_column($linked, 'tickets_id'))->containsValues([$this->ttwo->getID(), $other_tickets_id]);
+
+        // Remove READALL ticket permission
+        $_SESSION['glpiactiveprofile']['ticket'] = READ;
+        $linked = \Ticket_Ticket::getLinkedTicketsTo($this->tone->getID());
+        $this->integer(count($linked))->isEqualTo(2);
+        $this->array(array_column($linked, 'tickets_id'))->containsValues([$this->ttwo->getID(), $other_tickets_id]);
+        // Get linked tickets using view restrictions
+        $linked = \Ticket_Ticket::getLinkedTicketsTo($this->tone->getID(), true);
+        $this->integer(count($linked))->isEqualTo(1);
+        $this->array(array_column($linked, 'tickets_id'))->containsValues([$this->ttwo->getID()]);
+    }
 }

--- a/tests/units/DBmysqlIterator.php
+++ b/tests/units/DBmysqlIterator.php
@@ -43,6 +43,7 @@ use QueryExpression;
 
 class DBmysqlIterator extends DbTestCase
 {
+    /** @var \DBmysqlIterator */
     private $it;
 
     public function beforeTestMethod($method)
@@ -1441,5 +1442,14 @@ SQL
         ];
 
         return new \QueryExpression('(' . implode(' UNION ALL ', $users_table) . ') AS users');
+    }
+
+    public function testRawFKeyCondition()
+    {
+        $this->string(
+            $this->it->analyseCrit([
+                'ON' => new QueryExpression("glpi_tickets.id=(CASE WHEN glpi_tickets_tickets.tickets_id_1=103 THEN glpi_tickets_tickets.tickets_id_2 ELSE glpi_tickets_tickets.tickets_id_1 END)")
+            ])
+        )->isEqualTo("glpi_tickets.id=(CASE WHEN glpi_tickets_tickets.tickets_id_1=103 THEN glpi_tickets_tickets.tickets_id_2 ELSE glpi_tickets_tickets.tickets_id_1 END)");
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14110

Ticket dropdowns now apply the same SQL conditions as the search engine to restrict results to the user's current permissions (unless they have permission to see all tickets). The linked ticket list also now only shows the tickets the user has access to view.

Finally, the linked ticket list template was adjusted to avoid having to call `Ticket_Ticket::getLinkedTicketsTo` once for the counter and then again for the actual list.

Also added the ability to use a QueryExpression as the value for a join's `ON`/`FKEY`. This was needed to conditionally join the ticket table on tickets_id_1 or tickets_id_2 (whichever field didn't match the current ticket ID) to apply the permission conditions.