### PR TITLE
Improve behavior of antivirus search options

### DIFF
--- a/src/ComputerAntivirus.php
+++ b/src/ComputerAntivirus.php
@@ -152,6 +152,7 @@ class ComputerAntivirus extends CommonDBChild
             'field'              => 'name',
             'name'               => __('Name'),
             'forcegroupby'       => true,
+            'usehaving'          => true,
             'massiveaction'      => false,
             'datatype'           => 'dropdown',
             'joinparams'         => [
@@ -166,6 +167,7 @@ class ComputerAntivirus extends CommonDBChild
             'field'              => 'antivirus_version',
             'name'               => _n('Version', 'Versions', 1),
             'forcegroupby'       => true,
+            'usehaving'          => true,
             'massiveaction'      => false,
             'datatype'           => 'text',
             'joinparams'         => [
@@ -185,6 +187,7 @@ class ComputerAntivirus extends CommonDBChild
             ],
             'massiveaction'      => false,
             'forcegroupby'       => true,
+            'usehaving'          => true,
             'searchtype'         => ['equals']
         ];
 
@@ -200,6 +203,7 @@ class ComputerAntivirus extends CommonDBChild
             ],
             'massiveaction'      => false,
             'forcegroupby'       => true,
+            'usehaving'          => true,
             'searchtype'         => ['equals']
         ];
 
@@ -209,6 +213,7 @@ class ComputerAntivirus extends CommonDBChild
             'field'              => 'signature_version',
             'name'               => __('Signature database version'),
             'forcegroupby'       => true,
+            'usehaving'          => true,
             'massiveaction'      => false,
             'datatype'           => 'text',
             'joinparams'         => [
@@ -222,6 +227,7 @@ class ComputerAntivirus extends CommonDBChild
             'field'              => 'date_expiration',
             'name'               => __('Expiration date'),
             'forcegroupby'       => true,
+            'usehaving'          => true,
             'massiveaction'      => false,
             'datatype'           => 'date',
             'joinparams'         => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #16246

Change antivirus search options to use HAVING statements to try matching the expected behavior.