### PR TITLE
Fix mail import with missing Content Type header

### DIFF
--- a/tests/emails-tests/42-missing-content-type.eml
+++ b/tests/emails-tests/42-missing-content-type.eml
@@ -1,0 +1,43 @@
+Return-Path: <normal@glpi-project.org>
+Delivered-To: <unittests@glpi-project.org>
+Received: from mxs.XXXX
+	by mxs.XXXX with LMTP id 6OnXN+L3ZWVRYwAA1CwxZw
+	for <support@XXXX>; Tue, 28 Nov 2023 15:23:30 +0100
+Received: from rtr.XXXX (gateway [10.254.0.1])
+	by mxs.XXXX (Postfix) with ESMTP id D6C65116E44C9
+	for <support@XXXX>; Tue, 28 Nov 2023 15:23:30 +0100 (CET)
+DKIM-Filter: OpenDKIM Filter v2.11.0 mxs.XXXX D6C65116E44C9
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=XXXX;
+	s=default; t=1701181410;
+	bh=jc3bzYXYh1Yhyino9PySDFP+COLU8x6+JVm73VOhvlw=;
+	h=From:To:Subject:Date:From;
+	b=qWnQGMou/CsqevHT3nfMuWcoVYaVx86YRJFeUOxIIfSXVa94rQyelwBIpzJa4ofbE
+	 iiehOUIMo9KXRDt6xFo2o8tdGlLNSkDEA9+Ng89RdiecJhldoSKrC8MKb0FbdtI6dW
+	 ksy5vboNJNlUlLdEJdwDL0y+AfSqn9MA8NOvg96z23zHJHR2GdgFanDVN1HhNfiLxf
+	 YxCg1S6bzPqLHVKjJFnZIjMx1jkxIlAMFp4wkpWRdJ7K5WCpVTna+fJJQg/dRL5TgX
+	 DKfwlqZMC18JF2KyqcEb/KFP61iOMX3v2r0zXIu3Y6NEEMymWwaNdyI0sow3+OC02H
+	 t21xTSoQv6j4g==
+From: <normal@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>
+Subject: 42 - Missing Content Type
+Date: Tue, 28 Nov 2023 15:23:30 +0100
+X-Rspamd-Queue-Id: D6C65116E44C9
+X-Rspamd-Server: mxs.XXXX
+X-Spamd-Result: default: False [0.00 / 15.00];
+	IP_WHITELIST(0.00)[10.254.0.1]
+X-Rspamd-Pre-Result: action=no action;
+	module=multimap;
+	Matched map: IP_WHITELIST
+
+Notifications in this message: 3
+================================
+
+15:23:03 UPS Notification from rtr.XXXX - Tue, 28 Nov 2023 15:23:03 +0100
+
+Communications with UPS SC1500I lost
+15:23:08 UPS Notification from rtr.XXXX - Tue, 28 Nov 2023 15:23:08 +0100
+
+UPS SC1500I is unavailable
+15:23:13 UPS Notification from rtr.XXXX - Tue, 28 Nov 2023 15:23:13 +0100
+
+Communications with UPS SC1500I established

--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -792,6 +792,7 @@ class MailCollector extends DbTestCase
                     '40.2 - Empty content (html)',
                     '40.3 - Empty content (plain text)',
                     '41 - Image src without quotes',
+                    '42 - Missing Content Type'
                 ]
             ],
          // Mails having "normal" user as observer (add_cc_to_observer = true)
@@ -889,6 +890,20 @@ PLAINTEXT,
             '40.1 - Empty content (multipart)' => '',
             '40.2 - Empty content (html)' => '',
             '40.3 - Empty content (plain text)' => '',
+            '42 - Missing Content Type' => <<<PLAINTEXT
+Notifications in this message: 3
+================================
+
+15:23:03 UPS Notification from rtr.XXXX - Tue, 28 Nov 2023 15:23:03 +0100
+
+Communications with UPS SC1500I lost
+15:23:08 UPS Notification from rtr.XXXX - Tue, 28 Nov 2023 15:23:08 +0100
+
+UPS SC1500I is unavailable
+15:23:13 UPS Notification from rtr.XXXX - Tue, 28 Nov 2023 15:23:13 +0100
+
+Communications with UPS SC1500I established
+PLAINTEXT,
         ];
 
         foreach ($actors_specs as $actor_specs) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In some cases, an email may be sent to the GLPI mail receiver with no Content-Type header. Currently, we skip message parts that have no Content-Type, so an email with this header missing completely will result in a ticket being created with no content. I found no RFC that says this is a required header. Instead, I found multiple RFC including RFC 2045 that say the default Content-Type of `text/plain` is assumed when the header is missing.