### PR TITLE
Fix associated items label in template dropdown

### DIFF
--- a/src/ITILTemplate.php
+++ b/src/ITILTemplate.php
@@ -370,7 +370,7 @@ abstract class ITILTemplate extends CommonDropdown
                 'glpi_itilcategories'
             ),
             $ticket->getSearchOptionIDByField('field', 'type', 'glpi_tickets'),
-            $ticket->getSearchOptionIDByField('field', 'items_id', 'glpi_tickets'),
+            $ticket->getSearchOptionIDByField('field', 'items_id', 'glpi_items_tickets'),
             $ticket->getSearchOptionIDByField('field', 'name', 'glpi_documents'),
             66 // users_id_observer
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The field dropdowns within ticket templates say that the associate items field is only available in the standard interface. This is not correct. The code that lists the fields available in the simplified interface looks like it wasn't updated since the change to how associated items were stored in the DB and still refers to the "items_id" field in the ticket table. Since 0.90, more than one item could be associated with a ticket and this field was moved to a new table to allow linking multiple items to the same ticket.