### PR TITLE
fix(printer-log): use fixed date for tests to prevent occasional failures

### DIFF
--- a/src/PrinterLog.php
+++ b/src/PrinterLog.php
@@ -129,7 +129,7 @@ class PrinterLog extends CommonDBChild
         }
 
         if (!$start_date) {
-            $start_date = new DateTime();
+            $start_date = new DateTime(Session::getCurrentTime());
             $start_date->sub(new DateInterval($interval));
         }
 

--- a/tests/functional/PrinterLog.php
+++ b/tests/functional/PrinterLog.php
@@ -50,11 +50,12 @@ class PrinterLog extends DbTestCase
         ]);
         $this->integer($printers_id)->isGreaterThan(0);
 
-        $now = new \DateTime();
+        $_SESSION['glpi_currenttime'] = '2023-10-10 10:10:10';
+        $now = new \DateTime(\Session::getCurrentTime());
 
         $log = new \PrinterLog();
 
-        $cdate1 = new \DateTime('-14 months');
+        $cdate1 = (new \DateTime(\Session::getCurrentTime()))->modify('-14 months');
         $input = [
             'printers_id' => $printers_id,
             'total_pages' => 5132,
@@ -66,7 +67,7 @@ class PrinterLog extends DbTestCase
         ];
         $this->integer($log->add($input))->isGreaterThan(0);
 
-        $cdate2 = new \DateTime('-6 months');
+        $cdate2 = (new \DateTime(\Session::getCurrentTime()))->modify('-6 months');
         $input = [
             'printers_id' => $printers_id,
             'total_pages' => 6521,
@@ -78,7 +79,7 @@ class PrinterLog extends DbTestCase
         ];
         $this->integer($log->add($input))->isGreaterThan(0);
 
-        $cdate3 = new \DateTime('first day of previous month');
+        $cdate3 = (new \DateTime(\Session::getCurrentTime()))->modify('first day of previous month');
         $input = [
             'printers_id' => $printers_id,
             'total_pages' => 3464,
@@ -116,7 +117,7 @@ class PrinterLog extends DbTestCase
         $this->array($log->getMetrics($printer, end_date: $now)[$printer->getID()])->hasSize(3);
         $this->array($log->getMetrics($printer, start_date: $cdate1, end_date: $now->sub(new \DateInterval('P1D')))[$printer->getID()])->hasSize(3);
 
-        $datex = new \DateTime();
+        $datex = new \DateTime(\Session::getCurrentTime());
         for ($i = 0; $i < 21; $i++) {
             $datex->sub(new \DateInterval('P1D'));
             $input = [


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |

This PR addresses an issue where tests would occasionally fail, particularly at the start of the year, due to the predefined printer logs used for testing. 

Upon analysis of the method, it doesn't appear that there's an issue within it. It would be rather complex to define logs at dates that never cause problems. The simplest solution is to use a fixed date.

The changes include replacing the dynamic date generation with a fixed date in the session for the PrinterLog tests. This ensures that the tests are consistent and do not depend on the actual date when the tests are run.