### PR TITLE
Split historical and log rights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The present file will list all changes made to the project; according to the
 ### Added
 
 ### Changed
+- Permissions for historical data and system logs (Administration > Logs) are now managed by "Historical (READ)" and "System Logs (READ)" respectively.
 
 ### Deprecated
 

--- a/install/migrations/update_10.0.11_to_10.0.12/log_rights.php
+++ b/install/migrations/update_10.0.11_to_10.0.12/log_rights.php
@@ -33,14 +33,10 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\Event;
+/**
+ * @var \DBmysql $DB
+ * @var \Migration $migration
+ */
 
-include('../inc/includes.php');
-
-Session::checkRight(Event::$rightname, READ);
-
-Html::header(Event::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "admin", "Glpi\\Event");
-
-Event::showList($_SERVER['PHP_SELF'], $_GET['order'] ?? 'DESC', $_GET['sort']  ?? 'date', $_GET['start'] ?? 0);
-
-Html::footer();
+// Grant READ right to system_logs to everyone who has READ and UPDATE 'config' rights already
+$migration->addRight('system_logs', READ);

--- a/src/Central.php
+++ b/src/Central.php
@@ -152,7 +152,7 @@ class Central extends CommonGLPI
         if (Contract::canView()) {
             $grid_items[] = Contract::showCentral(false);
         }
-        if (Session::haveRight("logs", READ)) {
+        if (Session::haveRight(Log::$rightname, READ)) {
            //Show last add events
             $grid_items[] = Event::showForUser($_SESSION["glpiname"], false);
         }

--- a/src/Event.php
+++ b/src/Event.php
@@ -51,15 +51,12 @@ use Toolbox;
  **/
 class Event extends CommonDBTM
 {
-    public static $rightname = 'logs';
-
-
+    public static $rightname = 'system_logs';
 
     public static function getTypeName($nb = 0)
     {
         return _n('Log', 'Logs', $nb);
     }
-
 
     public function prepareInputForAdd($input)
     {
@@ -90,7 +87,6 @@ class Event extends CommonDBTM
         }
     }
 
-
     /**
      * Log an event.
      *
@@ -119,7 +115,6 @@ class Event extends CommonDBTM
         return $tmp->add($input);
     }
 
-
     /**
      * Clean old event - Call by cron
      *
@@ -142,7 +137,6 @@ class Event extends CommonDBTM
         );
         return $DB->affectedRows();
     }
-
 
     /**
      * Return arrays for function showEvent et lastEvent
@@ -183,7 +177,6 @@ class Event extends CommonDBTM
 
         return [$logItemtype, $logService];
     }
-
 
     /**
      * @param $type
@@ -238,7 +231,6 @@ class Event extends CommonDBTM
             }
         }
     }
-
 
     /**
      * Print a nice tab for last event from inventory section
@@ -364,7 +356,6 @@ class Event extends CommonDBTM
         }
     }
 
-
     /**
      * Print a nice tab for last event
      *
@@ -443,9 +434,13 @@ class Event extends CommonDBTM
         ]);
     }
 
-
     public static function getIcon()
     {
         return "ti ti-news";
+    }
+
+    public function getRights($interface = 'central'): array
+    {
+        return [ READ => __('Read')];
     }
 }

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -3022,11 +3022,26 @@ class Profile extends CommonDBTM
             'name'               => _n('Log', 'Logs', Session::getPluralNumber()),
             'datatype'           => 'right',
             'rightclass'         => 'Log',
-            'rightname'          => 'logs',
+            'rightname'          => Log::$rightname,
             'nowrite'            => true,
             'joinparams'         => [
                 'jointype'           => 'child',
-                'condition'          => ['NEWTABLE.name' => 'logs']
+                'condition'          => ['NEWTABLE.name' => Log::$rightname]
+            ]
+        ];
+
+        $tab[] = [
+            'id'                 => '62',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => __('System logs'),
+            'datatype'           => 'right',
+            'rightclass'         => 'Log',
+            'rightname'          => Event::$rightname,
+            'nowrite'            => true,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => Event::$rightname]
             ]
         ];
 

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Event;
+
 /**
  * Profile class
  **/
@@ -945,6 +947,10 @@ class Profile extends CommonDBTM
                             $fn_get_rights(__CLASS__, 'central', ['scope' => 'global']),
                             $fn_get_rights(QueuedNotification::class, 'central', ['scope' => 'global']),
                             $fn_get_rights(Log::class, 'central', ['scope' => 'global']),
+                            $fn_get_rights(Event::class, 'central', [
+                                'scope' => 'global',
+                                'label' => __('System logs')
+                            ]),
                         ],
                         'inventory' => [
                             $fn_get_rights(\Glpi\Inventory\Conf::class, 'central', [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | -
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #16285

~Need to check/update tests and check plugins.~
This change should probably be highlighted in the release notes in case administrators don't check profiles after the update tells them permissions have changed.
With this PR, `logs` will refer to Historical data (`glpi_logs`) only while `system_logs` will refer to the system events/logs (`glpi_events`).