### PR TITLE
Replace Codemirror with Monaco in debug bar

### DIFF
--- a/js/modules/Monaco/MonacoEditor.js
+++ b/js/modules/Monaco/MonacoEditor.js
@@ -211,6 +211,28 @@ export default class MonacoEditor {
             wordWrap: "off",
         };
     }
+
+    /**
+     * Apply syntax hightlighting styles to the given text
+     * @param {string} text The text to colorize
+     * @param {string} language The language to use for colorizing
+     * @return {Promise<string>}
+     */
+    static colorizeText(text, language) {
+        return window.monaco.editor.colorize(text, language);
+    }
+
+    /**
+     * Apply syntax hightlighting styles to the given element
+     * @param {HTMLElement} element The element to colorize
+     * @param {string} language The language to use for colorizing
+     * @return {Promise<void>}
+     */
+    static colorizeElement(element, language) {
+        return window.monaco.editor.colorizeElement(element, {
+            language: language
+        });
+    }
 }
 
 window.GLPI.MonacoEditor = MonacoEditor;

--- a/js/src/vue/Debug/Widget/Globals.vue
+++ b/js/src/vue/Debug/Widget/Globals.vue
@@ -1,5 +1,6 @@
 <script setup>
     import {onMounted} from "vue";
+    import MonacoEditor from "../../../../modules/Monaco/MonacoEditor.js";
 
     const props = defineProps({
         current_profile: {
@@ -7,6 +8,8 @@
             required: false
         },
     });
+
+    const monaco_editors = [];
 
     const appendGlobals = (data, container) => {
         if (data === undefined || data === null) {
@@ -24,16 +27,27 @@
             }
         }
 
-        const editor = new window.CodeMirror.EditorView({
-            extensions: [
-                window.CodeMirror.setup,
-                window.CodeMirror.languages.json(),
-                window.CodeMirror.EditorView.lineWrapping,
-                window.CodeMirror.EditorView.contentAttributes.of({contenteditable: false}),
-            ],
-            doc: data_string
+        const editor_element_id = `monacoeditor${Math.floor(Math.random() * 1000000)}`;
+        const editor_element = document.createElement('div');
+        editor_element.setAttribute('id', editor_element_id);
+        editor_element.classList.add('monaco-editor-container');
+        container.append(editor_element);
+        const editor = new MonacoEditor(editor_element_id, 'javascript', data_string, [], {
+            readOnly: true,
         });
-        container.append(editor.dom);
+        // Fold everything recursively by default except the first level
+        editor.editor.trigger('fold', 'editor.foldAll');
+        editor.editor.trigger('unfold', 'editor.unfold', {
+            levels: 1
+        });
+        editor.editor.layout();
+        monaco_editors.push(editor);
+    };
+
+    const updateEditorLayouts = () => {
+        monaco_editors.forEach((editor) => {
+            editor.editor.layout();
+        });
     };
 
     const rand = Math.floor(Math.random() * 1000000);
@@ -51,10 +65,10 @@
     <div>
         <div :id="`debugpanel${rand}`" class="container-fluid card p-0 border-top-0">
             <ul class="nav nav-pills" data-bs-toggle="tabs">
-                <li class="nav-item"><a class="nav-link active" data-bs-toggle="tab" :href="`#debugpost${rand}`">POST</a></li>
-                <li class="nav-item"><a class="nav-link" data-bs-toggle="tab" :href="`#debugget${rand}`">GET</a></li>
-                <li class="nav-item"><a class="nav-link" data-bs-toggle="tab" :href="`#debugsession${rand}`">SESSION</a></li>
-                <li class="nav-item"><a class="nav-link" data-bs-toggle="tab" :href="`#debugserver${rand}`">SERVER</a></li>
+                <li class="nav-item" @click="updateEditorLayouts"><a class="nav-link active" data-bs-toggle="tab" :href="`#debugpost${rand}`">POST</a></li>
+                <li class="nav-item" @click="updateEditorLayouts"><a class="nav-link" data-bs-toggle="tab" :href="`#debugget${rand}`">GET</a></li>
+                <li class="nav-item" @click="updateEditorLayouts"><a class="nav-link" data-bs-toggle="tab" :href="`#debugsession${rand}`">SESSION</a></li>
+                <li class="nav-item" @click="updateEditorLayouts"><a class="nav-link" data-bs-toggle="tab" :href="`#debugserver${rand}`">SERVER</a></li>
             </ul>
 
             <div class="card-body overflow-auto p-1">
@@ -73,5 +87,13 @@
     .container-fluid {
         min-width: 400px;
         max-width: 90vw;
+
+        .tab-content {
+            min-height: 30vh;
+        }
+
+        &::v-deep(.monaco-editor-container .monaco-editor) {
+            min-height: 30vh !important;
+        }
     }
 </style>

--- a/js/src/vue/Debug/Widget/HTTPRequests.vue
+++ b/js/src/vue/Debug/Widget/HTTPRequests.vue
@@ -41,6 +41,10 @@
     $('#debug-toolbar').on('keyup', (e) => {
         e.preventDefault();
         e.stopPropagation();
+        // ignore input inside monaco editors
+        if ($(e.target).closest('.monaco-editor').length > 0) {
+            return;
+        }
         if (e.keyCode === 84) { // 't'
             show_timeline.value = !show_timeline.value;
         }

--- a/js/src/vue/Debug/Widget/SQLRequests.vue
+++ b/js/src/vue/Debug/Widget/SQLRequests.vue
@@ -171,4 +171,7 @@
     #debug-sql-request-table tbody tr td:nth-of-type(4) {
         white-space: nowrap;
     }
+    #debug-sql-request-table::v-deep(span.mtk1) {
+        color: var(--tblr-body-color);
+    }
 </style>

--- a/lib/bundles/codemirror.js
+++ b/lib/bundles/codemirror.js
@@ -35,29 +35,11 @@
 
 import {EditorView, basicSetup} from "codemirror";
 import {css} from "@codemirror/lang-css";
-import {json} from "@codemirror/lang-json";
-import {sql} from "@codemirror/lang-sql";
-import {highlightTree} from "@lezer/highlight";
-import {defaultHighlightStyle} from "@codemirror/language";
 
 window.CodeMirror = {
     EditorView: EditorView,
     setup:      basicSetup,
     languages:  {
-        css: css,
-        json: json,
-        sql: sql,
+        css: css
     },
-    defaultHighlightStyle: defaultHighlightStyle,
-    runMode: (textContent, language, callback) => {
-        // see https://discuss.codemirror.net/t/static-highlighting-using-cm-v6/3420
-        const tree = language.parser.parse(textContent);
-        let pos = 0;
-        highlightTree(tree, defaultHighlightStyle, (from, to, classes) => {
-            from > pos && callback(textContent.slice(pos, from), null, pos, from);
-            callback(textContent.slice(from, to), classes, from, to);
-            pos = to;
-        });
-        pos !== tree.length && callback(textContent.slice(pos, tree.length), null, pos, tree.length);
-    }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,6 @@
             "dependencies": {
                 "@algolia/autocomplete-js": "^1.12.1",
                 "@codemirror/lang-css": "^6.2.1",
-                "@codemirror/lang-json": "^6.0.1",
-                "@codemirror/lang-sql": "^6.5.4",
-                "@codemirror/language": "^6.9.3",
                 "@fontsource/inter": "^4.5.15",
                 "@fortawesome/fontawesome-free": "^6.5.1",
                 "@fullcalendar/bootstrap": "^4.4.2",
@@ -24,7 +21,6 @@
                 "@fullcalendar/rrule": "^4.4.2",
                 "@fullcalendar/timegrid": "^4.4.2",
                 "@fullcalendar/timeline": "^4.4.3",
-                "@lezer/highlight": "^1.2.0",
                 "@tabler/core": "^1.0.0-beta20",
                 "@tabler/icons-webfont": "^2.42.0",
                 "animate.css": "^4.1.1",
@@ -107,8 +103,8 @@
                 "webpack-cli": "^5.1.4"
             },
             "engines": {
-                "node": ">= 16.11",
-                "npm": ">= 8.0"
+                "node": ">= 20.9",
+                "npm": ">= 10.1"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -2071,27 +2067,6 @@
                 "@lezer/css": "^1.0.0"
             }
         },
-        "node_modules/@codemirror/lang-json": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.1.tgz",
-            "integrity": "sha512-+T1flHdgpqDDlJZ2Lkil/rLiRy684WMLc74xUnjJH48GQdfJo/pudlTRreZmKwzP8/tGdKf83wlbAdOCzlJOGQ==",
-            "dependencies": {
-                "@codemirror/language": "^6.0.0",
-                "@lezer/json": "^1.0.0"
-            }
-        },
-        "node_modules/@codemirror/lang-sql": {
-            "version": "6.5.4",
-            "resolved": "https://registry.npmjs.org/@codemirror/lang-sql/-/lang-sql-6.5.4.tgz",
-            "integrity": "sha512-5Gq7fYtT/5HbNyIG7a8vYaqOYQU3JbgtBe3+derkrFUXRVcjkf8WVgz++PIbMFAQsOFMDdDR+uiNM8ZRRuXH+w==",
-            "dependencies": {
-                "@codemirror/autocomplete": "^6.0.0",
-                "@codemirror/language": "^6.0.0",
-                "@codemirror/state": "^6.0.0",
-                "@lezer/highlight": "^1.0.0",
-                "@lezer/lr": "^1.0.0"
-            }
-        },
         "node_modules/@codemirror/language": {
             "version": "6.9.3",
             "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.9.3.tgz",
@@ -3454,15 +3429,6 @@
             "integrity": "sha512-WrS5Mw51sGrpqjlh3d4/fOwpEV2Hd3YOkp9DBt4k8XZQcoTHZFB7sx030A6OcahF4J1nDQAa3jXlTVVYH50IFA==",
             "dependencies": {
                 "@lezer/common": "^1.0.0"
-            }
-        },
-        "node_modules/@lezer/json": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.0.tgz",
-            "integrity": "sha512-zbAuUY09RBzCoCA3lJ1+ypKw5WSNvLqGMtasdW6HvVOqZoCpPr8eWrsGnOVWGKGn8Rh21FnrKRVlJXrGAVUqRw==",
-            "dependencies": {
-                "@lezer/highlight": "^1.0.0",
-                "@lezer/lr": "^1.0.0"
             }
         },
         "node_modules/@lezer/lr": {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,6 @@
     "dependencies": {
         "@algolia/autocomplete-js": "^1.12.1",
         "@codemirror/lang-css": "^6.2.1",
-        "@codemirror/lang-json": "^6.0.1",
-        "@codemirror/lang-sql": "^6.5.4",
-        "@codemirror/language": "^6.9.3",
         "@fontsource/inter": "^4.5.15",
         "@fortawesome/fontawesome-free": "^6.5.1",
         "@fullcalendar/bootstrap": "^4.4.2",
@@ -26,7 +23,6 @@
         "@fullcalendar/rrule": "^4.4.2",
         "@fullcalendar/timegrid": "^4.4.2",
         "@fullcalendar/timeline": "^4.4.3",
-        "@lezer/highlight": "^1.2.0",
         "@tabler/core": "^1.0.0-beta20",
         "@tabler/icons-webfont": "^2.42.0",
         "animate.css": "^4.1.1",

--- a/src/Html.php
+++ b/src/Html.php
@@ -1196,7 +1196,7 @@ HTML;
                 Html::requireJs('charts');
             }
 
-            if (in_array('codemirror', $jslibs) || $_SESSION['glpi_use_mode'] === Session::DEBUG_MODE) {
+            if (in_array('codemirror', $jslibs)) {
                 Html::requireJs('codemirror');
             }
 
@@ -1204,7 +1204,7 @@ HTML;
                 Html::requireJs('cable');
             }
 
-            if (in_array('monaco', $jslibs)) {
+            if (in_array('monaco', $jslibs) || $_SESSION['glpi_use_mode'] === Session::DEBUG_MODE) {
                 Html::requireJs('monaco');
                 $tpl_vars['js_modules'][] = ['path' => 'js/modules/Monaco/MonacoEditor.js'];
                 $tpl_vars['css_files'][] = ['path' => 'public/lib/monaco.css'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In the debug bar, Codemirror was used for syntax highlighting of SQL queries and to show globals data as JSON with highlighting and folding. Unfortunately Codemirror 6 made it complicated to simply apply syntax highlighting to some text without using a full editor, and it also struggles with simple code folding (You have to view the entire section for it to be loaded and able to be folded).

Monaco has neither weakness and doesn't require 4 extra dependencies just to accomplish standalone syntax highlighting.