### PR TITLE
Skip checking GLPI_SESSION_DIR if not using "files" save handler

### DIFF
--- a/front/login.php
+++ b/front/login.php
@@ -48,7 +48,7 @@ include('../inc/includes.php');
 
 
 if (!isset($_SESSION["glpicookietest"]) || ($_SESSION["glpicookietest"] != 'testcookie')) {
-    if (!is_writable(GLPI_SESSION_DIR)) {
+    if (!Session::canWriteSessionFiles()) {
         Html::redirect($CFG_GLPI['root_doc'] . "/index.php?error=2");
     } else {
         Html::redirect($CFG_GLPI['root_doc'] . "/index.php?error=1");

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -380,7 +380,7 @@ class Application extends BaseApplication
     private function initSession()
     {
 
-        if (!is_writable(GLPI_SESSION_DIR)) {
+        if (!Session::canWriteSessionFiles()) {
             throw new \Symfony\Component\Console\Exception\RuntimeException(
                 sprintf(__('Cannot write in "%s" directory.'), GLPI_SESSION_DIR)
             );

--- a/src/Session.php
+++ b/src/Session.php
@@ -2159,4 +2159,15 @@ class Session
         // TODO (10.1 refactoring): replace references to $_SESSION['glpi_currenttime'] by a call to this function
         return $_SESSION['glpi_currenttime'] ?? null;
     }
+
+    /**
+     * Checks if the GLPI sessions directory can be written to if the PHP session save handler is set to "files".
+     * @return bool True if the directory is writable, or if the session save handler is not set to "files".
+     */
+    public static function canWriteSessionFiles(): bool
+    {
+        $session_handler = ini_get('session.save_handler');
+        return $session_handler !== false
+            && (strtolower($session_handler) !== 'files' || is_writable(GLPI_SESSION_DIR));
+    }
 }

--- a/src/System/Requirement/DirectoryWriteAccess.php
+++ b/src/System/Requirement/DirectoryWriteAccess.php
@@ -90,6 +90,9 @@ class DirectoryWriteAccess extends AbstractRequirement
                 break;
             case realpath(GLPI_SESSION_DIR):
                 $title = __('Permissions for session files');
+                $session_handler = ini_get('session.save_handler');
+                $optional = $session_handler !== false && strtolower($session_handler) !== 'files';
+                $description = __('If you have "session.save_handler" set to something besides "files" in your php.ini, this is not required.');
                 break;
             case realpath(GLPI_TMP_DIR):
                 $title = __('Permissions for temporary files');

--- a/src/System/Status/StatusChecker.php
+++ b/src/System/Status/StatusChecker.php
@@ -518,19 +518,24 @@ final class StatusChecker
                     'status' => self::STATUS_OK
                 ]
             ];
-           // Check session dir (useful when NFS mounted))
-            if (!is_dir(GLPI_SESSION_DIR)) {
-                $status['session_dir'] = [
-                    'status' => self::STATUS_PROBLEM,
-                    'status_msg'   => sprintf(_x('glpi_status', '%s variable is not a directory'), 'GLPI_SESSION_DIR')
-                ];
-                $status['status'] = self::STATUS_PROBLEM;
-            } else if (!is_writable(GLPI_SESSION_DIR)) {
-                $status['session_dir'] = [
-                    'status' => self::STATUS_PROBLEM,
-                    'status_msg'   => sprintf(_x('glpi_status', '%s variable is not writable'), 'GLPI_SESSION_DIR')
-                ];
-                $status['status'] = self::STATUS_PROBLEM;
+            $session_handler = ini_get('session.save_handler');
+            if ($session_handler !== false && strtolower($session_handler) === 'files') {
+                // Check session dir (useful when NFS mounted))
+                if (!is_dir(GLPI_SESSION_DIR)) {
+                    $status['session_dir'] = [
+                        'status' => self::STATUS_PROBLEM,
+                        'status_msg'   => sprintf(_x('glpi_status', '%s variable is not a directory'), 'GLPI_SESSION_DIR')
+                    ];
+                    $status['status'] = self::STATUS_PROBLEM;
+                } else if (!is_writable(GLPI_SESSION_DIR)) {
+                    $status['session_dir'] = [
+                        'status' => self::STATUS_PROBLEM,
+                        'status_msg'   => sprintf(_x('glpi_status', '%s variable is not writable'), 'GLPI_SESSION_DIR')
+                    ];
+                    $status['status'] = self::STATUS_PROBLEM;
+                }
+            } else {
+                $status['session_dir']['status_msg'] = _x('glpi_status', 'PHP is not configured to use the "files" session save handler');
             }
         }
 

--- a/src/Update.php
+++ b/src/Update.php
@@ -80,7 +80,7 @@ class Update
      */
     public function initSession()
     {
-        if (is_writable(GLPI_SESSION_DIR)) {
+        if (Session::canWriteSessionFiles()) {
             Session::setPath();
         } else {
             if (isCommandLine()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

If PHP is configured to use "redis" for example as the session save handler instead of the default of "files", the `is_writable` checks on GLPI_SESSION_DIR shouldn't be required and can be skipped. This PR also makes sure that the Status Checker returns a message along with an OK status for the session directory check to explain that the "files" handler is not being used.