### PR TITLE
Remove configurable API url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The present file will list all changes made to the project; according to the
 - Manage tab for Knowledgebase (Unpublished is now a toggle in the browse tab).
 - The database "master" property in the status checker (/status.php and glpi:system:status), replaced by "main".
 - The database "slaves" property in the status checker (/status.php and glpi:system:status), replaced by "replicas".
+- API URL is no longer customizable within GLPI. Use alias/rewrite rules in your web server configuration instead if needed.
 
 ### API changes
 

--- a/inc/autoload.function.php
+++ b/inc/autoload.function.php
@@ -60,22 +60,11 @@ function isAPI()
     /** @var array $CFG_GLPI */
     global $CFG_GLPI;
 
-    $called_url = (!empty($_SERVER['HTTPS'] ?? "") && ($_SERVER['HTTPS'] ?? "") !== 'off'
-                     ? 'https'
-                     : 'http') .
-                 '://' . ($_SERVER['HTTP_HOST'] ?? "") .
-                 ($_SERVER['REQUEST_URI'] ?? "");
-
-    $base_api_url = $CFG_GLPI['url_base_api'] ?? ""; // $CFG_GLPI may be not defined if DB is not available
-    if (!empty($base_api_url) && strpos($called_url, $base_api_url) !== false) {
-        return true;
-    }
-
     $script = isset($_SERVER['SCRIPT_FILENAME']) ? $_SERVER['SCRIPT_FILENAME'] : '';
-    if (strpos($script, 'api.php') !== false) {
+    if (str_contains($script, 'api.php')) {
         return true;
     }
-    if (strpos($script, 'apirest.php') !== false) {
+    if (str_contains($script, 'apirest.php')) {
         return true;
     }
 

--- a/inc/autoload.function.php
+++ b/inc/autoload.function.php
@@ -57,9 +57,6 @@ function isCommandLine()
  */
 function isAPI()
 {
-    /** @var array $CFG_GLPI */
-    global $CFG_GLPI;
-
     $script = isset($_SERVER['SCRIPT_FILENAME']) ? $_SERVER['SCRIPT_FILENAME'] : '';
     if (str_contains($script, 'api.php')) {
         return true;

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -290,7 +290,6 @@ $empty_data_builder = new class
             'enable_api' => '0',
             'enable_api_login_credentials' => '0',
             'enable_api_login_external_token' => '1',
-            'url_base_api' => 'http://localhost/glpi/api',
             'login_remember_time' => '604800',
             'login_remember_default' => '1',
             'use_notifications' => '0',

--- a/install/migrations/update_10.0.x_to_10.1.0/configs.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/configs.php
@@ -48,3 +48,5 @@ $migration->addField('glpi_users', 'toast_location', 'string');
 
 $migration->addField('glpi_users', 'set_followup_tech', 'tinyint DEFAULT NULL');
 $migration->addField('glpi_users', 'set_solution_tech', 'tinyint DEFAULT NULL');
+
+$migration->removeConfig(['url_base_api']);

--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -50,6 +50,7 @@ use Config;
 use Contract;
 use Document;
 use Dropdown;
+use Glpi\Api\HL\Router;
 use Glpi\DBAL\QueryExpression;
 use Glpi\Search\Provider\SQLProvider;
 use Glpi\Search\SearchOption;
@@ -159,7 +160,9 @@ abstract class API
         }
 
        // construct api url
-        self::$api_url = trim($CFG_GLPI['url_base_api'], "/");
+        $api_version_info = array_filter(Router::getAPIVersions(), static fn ($info) => (int) $info['api_version'] === 1);
+        $api_version_info = reset($api_version_info);
+        self::$api_url = trim($api_version_info['endpoint'], "/");
 
        // Don't display error in result
         ini_set('display_errors', 'Off');

--- a/src/Api/HL/Router.php
+++ b/src/Api/HL/Router.php
@@ -137,7 +137,7 @@ EOT;
                 'api_version' => '1',
                 'version'    => '1.0.0',
                 'description' => str_replace(PHP_EOL, ' ', $low_level_api_description),
-                'endpoint'   => $CFG_GLPI['url_base_api'],
+                'endpoint'   => $CFG_GLPI['url_base'] . '/api.php/v1',
             ],
             [
                 'api_version' => $current_version_major,

--- a/src/Config.php
+++ b/src/Config.php
@@ -186,13 +186,6 @@ class Config extends CommonDBTM
             }
         }
 
-        if (isset($input["url_base_api"]) && !empty($input["url_base_api"])) {
-            if (!Toolbox::isValidWebUrl($input["url_base_api"])) {
-                Session::addMessageAfterRedirect(__('Invalid API base URL!'), false, ERROR);
-                return false;
-            }
-        }
-
         $input = $this->handleSmtpInput($input);
 
         if (isset($input["proxy_passwd"]) && empty($input["proxy_passwd"])) {
@@ -538,6 +531,8 @@ class Config extends CommonDBTM
 
         // Options just for new API
         $api_versions = \Glpi\Api\HL\Router::getAPIVersions();
+        $legacy_version = array_filter($api_versions, static fn ($version) => $version['api_version'] === '1');
+        $legacy_version = reset($legacy_version);
         $current_version = array_filter($api_versions, static fn ($version) => $version['version'] === \Glpi\Api\HL\Router::API_VERSION);
         $current_version = reset($current_version);
         $getting_started_doc = $current_version['endpoint'] . '/getting-started';
@@ -549,8 +544,8 @@ class Config extends CommonDBTM
             'getting_started_doc_url' => $getting_started_doc,
             'endpoint_doc_url' => $endpoint_doc,
             'api_url' => $current_version['endpoint'],
-            'legacy_doc_url' => trim($CFG_GLPI['url_base_api'], '/') . "/",
-            'legacy_api_url' => $CFG_GLPI["url_base_api"],
+            'legacy_doc_url' => $legacy_version['endpoint'],
+            'legacy_api_url' => $legacy_version['endpoint'],
         ]);
         TemplateRenderer::getInstance()->display('pages/setup/general/api_apiclients_section.html.twig');
     }

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -1122,7 +1122,7 @@ class Migration
     /**
      * Remove configuration value(s) to current context; @see Migration::removeConfig()
      *
-     * @since 9.2
+     * @since 10.1.0
      *
      * @param array  $values  Value(s) to remove
      * @param string $context Context to remove on (optional)

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -1120,6 +1120,26 @@ class Migration
     }
 
     /**
+     * Remove configuration value(s) to current context; @see Migration::removeConfig()
+     *
+     * @since 9.2
+     *
+     * @param array  $values  Value(s) to remove
+     * @param string $context Context to remove on (optional)
+     *
+     * @return Migration
+     */
+    public function removeConfig($values, $context = null)
+    {
+        $context = $context ?? $this->context;
+        if (!isset($this->configs[$context])) {
+            $this->configs[$context] = [];
+        }
+        $this->configs[$context] += (array)$values;
+        return $this;
+    }
+
+    /**
      * Store configuration values that does not exists
      *
      * @since 9.2

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -1125,17 +1125,27 @@ class Migration
      * @since 10.1.0
      *
      * @param array  $values  Value(s) to remove
-     * @param string $context Context to remove on (optional)
+     * @param ?string $context Context to remove on. Defaults to the context of this migration instance.
      *
      * @return Migration
      */
-    public function removeConfig($values, $context = null)
+    public function removeConfig(array $values, ?string $context = null)
     {
-        $context = $context ?? $this->context;
-        if (!isset($this->configs[$context])) {
-            $this->configs[$context] = [];
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        if (empty($values)) {
+            return $this;
         }
-        $this->configs[$context] += (array)$values;
+
+        $context = $context ?? $this->context;
+        $DB->delete(
+            'glpi_configs',
+            [
+                'context' => $context,
+                'name'    => $values
+            ]
+        );
         return $this;
     }
 

--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -1271,4 +1271,33 @@ class Migration extends \GLPITestCase
             ]
         ]);
     }
+
+    public function testRemoveConfig()
+    {
+        global $DB;
+
+        $this->variable($DB->insert('glpi_configs', [
+            'name' => __FUNCTION__,
+            'value' => 'test',
+            'context' => 'test'
+        ]))->isNotEqualTo(false);
+
+        $this->migration->removeConfig([__FUNCTION__]);
+        // Shouldn't be deleted. Wrong context
+        $this->integer(count($DB->request([
+            'FROM' => 'glpi_configs',
+            'WHERE' => [
+                'name' => __FUNCTION__
+            ]
+        ])))->isEqualTo(1);
+
+        $this->migration->removeConfig([__FUNCTION__], 'test');
+        // Should be deleted
+        $this->integer(count($DB->request([
+            'FROM' => 'glpi_configs',
+            'WHERE' => [
+                'name' => __FUNCTION__
+            ]
+        ])))->isEqualTo(0);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -

Since the documentation and endpoint links were added for the new API, the legacy API URL was made read-only. This PR fully drops the ability to change the legacy API URL. As noted in #14509, users can accomplish this within their web server configuration instead. Now, the legacy API URL will always be `/api.php/v1`. The old endpoint `/apirest.php` still works. The `api.php` script will simply hand all of the data off to the `apirest.php` script when version 1 is specified.