### PR TITLE
Fix monaco suggestions in new webhook form

### DIFF
--- a/ajax/webhook.php
+++ b/ajax/webhook.php
@@ -167,6 +167,7 @@ switch ($action) {
         }
         die();
     case 'get_monaco_suggestions':
+        header("Content-Type: application/json; charset=UTF-8");
         try {
             echo json_encode(Webhook::getMonacoSuggestions($_GET['itemtype']), JSON_THROW_ON_ERROR);
         } catch (JsonException $e) {

--- a/ajax/webhook.php
+++ b/ajax/webhook.php
@@ -39,7 +39,7 @@ Html::header_nocache();
 
 Session::checkRight("config", READ);
 
-$action = $_POST['action'] ?? null;
+$action = $_REQUEST['action'] ?? null;
 
 switch ($action) {
     case 'valide_cra_challenge':
@@ -164,6 +164,13 @@ switch ($action) {
             http_response_code(200);
         } else {
             http_response_code(400);
+        }
+        die();
+    case 'get_monaco_suggestions':
+        try {
+            echo json_encode(Webhook::getMonacoSuggestions($_GET['itemtype']), JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            http_response_code(500);
         }
         die();
 }

--- a/templates/pages/setup/webhook/webhook.html.twig
+++ b/templates/pages/setup/webhook/webhook.html.twig
@@ -112,7 +112,6 @@
                     action: 'get_monaco_suggestions',
                     itemtype: e.target.value
                 },
-                dataType: 'json',
                 success: (data) => {
                     const editors = window.monaco.editor.getEditors().filter((editor) => {
                         return editor._domElement.classList.contains('webhook_url');

--- a/templates/pages/setup/webhook/webhook.html.twig
+++ b/templates/pages/setup/webhook/webhook.html.twig
@@ -104,6 +104,26 @@
                 e.originalEvent.formData.append('url', editors[0].getValue());
             }
         });
+        $('#{{ url_editor_container_id }}').closest('form').find('select[name="itemtype"]').on('change', (e) => {
+            // Get new Monaco suggestions from the server and then recreate the editor while preserving the value
+            $.ajax({
+                url: '{{ config('root_doc') }}/ajax/webhook.php',
+                data: {
+                    action: 'get_monaco_suggestions',
+                    itemtype: e.target.value
+                },
+                dataType: 'json',
+                success: (data) => {
+                    const editors = window.monaco.editor.getEditors().filter((editor) => {
+                        return editor._domElement.classList.contains('webhook_url');
+                    });
+                    const url_field_editor = editors[0];
+                    const url_field_value = url_field_editor.getValue();
+                    url_field_editor.dispose();
+                    new window.GLPI.MonacoEditor('{{ url_editor_container_id }}', 'twig', url_field_value, data, editor_options);
+                }
+            });
+        });
     </script>
 
     {{ fields.dropdownArrayField(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When the showing a new webhook form, an error was thrown when it tried to get the Monaco suggestions because the itemtype was not yet set. This PR adds a null check for this and also reloads the suggestions when the itemtype dropdown is changed.