### PR TITLE
Fix some badge text color

### DIFF
--- a/js/modules/SearchTokenizer/SearchInput.js
+++ b/js/modules/SearchTokenizer/SearchInput.js
@@ -411,7 +411,7 @@ export default class SearchInput {
         } else {
             style_overrides = tag_color_override ? `style="background-color: ${tag_color_override} !important"` : '';
         }
-        return `<span class="search-input-tag badge bg-secondary me-1" contenteditable="false" data-tag="${token.tag}" ${style_overrides}>
+        return `<span class="search-input-tag badge bg-secondary text-secondary-fg me-1" contenteditable="false" data-tag="${token.tag}" ${style_overrides}>
                   <span class="search-input-tag-value" contenteditable="false">${tag_display}${escapeMarkupText(token.term) || ''}</span>
                   <i class="ti ti-x cursor-pointer ms-1" title="${__('Delete')}" contenteditable="false"></i>
                </span>`;

--- a/js/src/vue/Debug/Widget/HTTPRequests.vue
+++ b/js/src/vue/Debug/Widget/HTTPRequests.vue
@@ -210,7 +210,7 @@
                                 <td>{{ request.number }}</td>
                                 <td :title="request.url"
                                     :data-truncated="urlNeedsTruncated(request.url)">{{ request.url.substring(0, REQUEST_PATH_LENGTH) }}<button
-                                        v-if="urlNeedsTruncated(request.url)" class="ms-1 badge bg-secondary" name="show_full_url"
+                                        v-if="urlNeedsTruncated(request.url)" class="ms-1 badge bg-secondary text-secondary-fg" name="show_full_url"
                                         @click="expandRequestURL($event)">
                                         <i class="ti ti-dots"></i>
                                     </button>

--- a/js/src/vue/Kanban/Column.vue
+++ b/js/src/vue/Kanban/Column.vue
@@ -197,7 +197,7 @@
                           :style="`${bg_color ? 'background-color:' + bg_color : 'transparent'}; ${text_color ? 'color:' + text_color : 'color: var(--tblr-body-color)'}`"></span>
                 </span>
                 <span class="content-right">
-                    <span class="kanban_nb badge bg-secondary" v-text="card_count"></span>
+                    <span class="kanban_nb badge bg-secondary text-secondary-fg" v-text="card_count"></span>
                     <span class="kanban-column-toolbar align-middle">
                         <template v-if="rights.canCreateItem() && (rights.getAllowedColumnsForNewCards().length === 0 || rights.getAllowedColumnsForNewCards().includes(column_id))">
                             <div class="dropdown d-inline-block">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The new version of Tabler changed the default styles of badges and the default text color is `--tblr-secondary`. For badges with `bg-secondary` this makes the text invisible.