### PR TITLE
Centralize guzzle client creation

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -706,17 +706,8 @@ class Agent extends CommonDBTM
                 'connect_timeout' => self::TIMEOUT,
             ];
 
-            // add proxy string if configured in glpi
-            if (!empty($CFG_GLPI["proxy_name"])) {
-                $proxy_creds      = !empty($CFG_GLPI["proxy_user"])
-                ? $CFG_GLPI["proxy_user"] . ":" . (new GLPIKey())->decrypt($CFG_GLPI["proxy_passwd"]) . "@"
-                : "";
-                $proxy_string     = "http://{$proxy_creds}" . $CFG_GLPI['proxy_name'] . ":" . $CFG_GLPI['proxy_port'];
-                $options['proxy'] = $proxy_string;
-            }
-
             // init guzzle client with base options
-            $httpClient = new Guzzle_Client($options);
+            $httpClient = Toolbox::getGuzzleClient($options);
             try {
                 $response = $httpClient->request('GET', $endpoint, []);
                 self::$found_address = $address;

--- a/src/Marketplace/Api/Plugins.php
+++ b/src/Marketplace/Api/Plugins.php
@@ -70,25 +70,11 @@ class Plugins
 
     public function __construct()
     {
-        /** @var array $CFG_GLPI */
-        global $CFG_GLPI;
-
-        $options = [
+        // init guzzle client with base options
+        $this->httpClient = Toolbox::getGuzzleClient([
             'base_uri'        => GLPI_MARKETPLACE_PLUGINS_API_URI,
             'connect_timeout' => self::TIMEOUT,
-        ];
-
-        // add proxy string if configured in glpi
-        if (!empty($CFG_GLPI["proxy_name"])) {
-            $proxy_creds      = !empty($CFG_GLPI["proxy_user"])
-                ? $CFG_GLPI["proxy_user"] . ":" . (new \GLPIKey())->decrypt($CFG_GLPI["proxy_passwd"]) . "@"
-                : "";
-            $proxy_string     = "http://{$proxy_creds}" . $CFG_GLPI['proxy_name'] . ":" . $CFG_GLPI['proxy_port'];
-            $options['proxy'] = $proxy_string;
-        }
-
-        // init guzzle client with base options
-        $this->httpClient = new Guzzle_Client($options);
+        ]);
     }
 
 

--- a/src/System/Diagnostic/SourceCodeIntegrityChecker.php
+++ b/src/System/Diagnostic/SourceCodeIntegrityChecker.php
@@ -187,21 +187,9 @@ class SourceCodeIntegrityChecker
         $version_to_get = VersionParser::getNormalizedVersion(GLPI_VERSION);
         $gh_releases_endpoint = 'https://api.github.com/repos/glpi-project/glpi/releases/tags/' . $version_to_get;
 
-        $options = [
+        $client = \Toolbox::getGuzzleClient([
             'connect_timeout' => 10, // 10 seconds timeout
-        ];
-        // add proxy string if configured in glpi
-        if (!empty($CFG_GLPI['proxy_name'])) {
-            $options['proxy'] = sprintf(
-                'http://%s%s:%d',
-                !empty($CFG_GLPI['proxy_user'])
-                    ? sprintf('%s:%s@', $CFG_GLPI['proxy_user'], (new GLPIKey())->decrypt($CFG_GLPI['proxy_passwd']))
-                    : '',
-                $CFG_GLPI['proxy_name'],
-                $CFG_GLPI['proxy_port']
-            );
-        }
-        $client = new Client($options);
+        ]);
 
         $dest = null;
         try {

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -40,6 +40,7 @@ use Glpi\Event;
 use Glpi\Http\Response;
 use Glpi\Mail\Protocol\ProtocolInterface;
 use Glpi\Rules\RulesManager;
+use GuzzleHttp\Client;
 use Laminas\Mail\Storage\AbstractStorage;
 use Mexitek\PHPColors\Color;
 use Psr\Log\LoggerInterface;
@@ -1277,6 +1278,26 @@ class Toolbox
         $curl_error = null;
         $content = self::callCurl($url, [], $msgerr, $curl_error, true);
         return $content;
+    }
+
+    /**
+     * Get a new Guzzle client with proxy if configured and the specified other options.
+     * @param array $extra_options Extra options to pass to the Guzzle client constructor
+     * @return Client Guzzle client
+     * @throws SodiumException
+     */
+    public static function getGuzzleClient(array $extra_options): Client
+    {
+        $options = $extra_options;
+        // add proxy string if configured in glpi
+        if (!empty($CFG_GLPI["proxy_name"])) {
+            $proxy_creds      = !empty($CFG_GLPI["proxy_user"])
+                ? $CFG_GLPI["proxy_user"] . ":" . (new \GLPIKey())->decrypt($CFG_GLPI["proxy_passwd"]) . "@"
+                : "";
+            $proxy_string     = "http://{$proxy_creds}" . $CFG_GLPI['proxy_name'] . ":" . $CFG_GLPI['proxy_port'];
+            $options['proxy'] = $proxy_string;
+        }
+        return new Client($options);
     }
 
     /**

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -1017,17 +1017,8 @@ class Webhook extends CommonDBTM implements FilterableInterface
             'connect_timeout' => 1,
         ];
 
-        // add proxy string if configured in glpi
-        if (!empty($CFG_GLPI["proxy_name"])) {
-            $proxy_creds      = !empty($CFG_GLPI["proxy_user"])
-            ? $CFG_GLPI["proxy_user"] . ":" . (new GLPIKey())->decrypt($CFG_GLPI["proxy_passwd"]) . "@"
-            : "";
-            $proxy_string     = "http://{$proxy_creds}" . $CFG_GLPI['proxy_name'] . ":" . $CFG_GLPI['proxy_port'];
-            $options['proxy'] = $proxy_string;
-        }
-
         // init guzzle client with base options
-        $httpClient = new Guzzle_Client($options);
+        $httpClient = Toolbox::getGuzzleClient($options);
         try {
             //prepare query / body
             $response = $httpClient->request('GET', '', [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Code that creates Guzzle clients all duplicates the proxy check and options building logic for the proxy. This PR creates a function that creates the Guzzle client with the proxy options set if a proxy is configured. This should make it easier for anything in the future that needs a client and easier in case we change proxy options or add new related options.