### PR TITLE
Increase some text column lengths

### DIFF
--- a/install/migrations/update_10.0.x_to_10.1.0/text_cols.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/text_cols.php
@@ -42,7 +42,6 @@ $text_cols = [
     ['glpi_notificationtemplatetranslations', 'content_text', 'longtext'],
     ['glpi_notificationtemplatetranslations', 'content_html', 'longtext'],
     ['glpi_items_kanbans', 'state', 'mediumtext'],
-    ['glpi_webhooks', 'payload', 'longtext'],
 ];
 
 foreach ($text_cols as $data) {

--- a/install/migrations/update_10.0.x_to_10.1.0/text_cols.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/text_cols.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var \DBmysql $DB
+ * @var \Migration $migration
+ */
+
+$text_cols = [
+    ['glpi_notificationtemplatetranslations', 'content_text', 'longtext'],
+    ['glpi_notificationtemplatetranslations', 'content_html', 'longtext'],
+    ['glpi_items_kanbans', 'state', 'mediumtext'],
+    ['glpi_webhooks', 'payload', 'longtext'],
+];
+
+foreach ($text_cols as $data) {
+    [$table, $column, $type] = $data;
+    $migration->changeField($table, $column, $column, $type);
+}

--- a/install/migrations/update_10.0.x_to_10.1.0/webhook.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/webhook.php
@@ -51,7 +51,7 @@ if (!$DB->tableExists('glpi_webhooks')) {
       `comment` text,
       `itemtype` varchar(255) DEFAULT NULL,
       `event` varchar(255) DEFAULT NULL,
-      `payload` text,
+      `payload` longtext,
       `use_default_payload` tinyint NOT NULL DEFAULT '1',
       `custom_headers` text,
       `url` varchar(255) DEFAULT NULL,

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -5044,8 +5044,8 @@ CREATE TABLE `glpi_notificationtemplatetranslations` (
   `notificationtemplates_id` int unsigned NOT NULL DEFAULT '0',
   `language` varchar(10) NOT NULL DEFAULT '',
   `subject` varchar(255) NOT NULL,
-  `content_text` text,
-  `content_html` text,
+  `content_text` longtext,
+  `content_html` longtext,
   PRIMARY KEY (`id`),
   KEY `notificationtemplates_id` (`notificationtemplates_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
@@ -8760,7 +8760,7 @@ CREATE TABLE `glpi_items_kanbans` (
   `itemtype` varchar(100) NOT NULL,
   `items_id` int unsigned DEFAULT NULL,
   `users_id` int unsigned NOT NULL,
-  `state` text,
+  `state` mediumtext,
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
@@ -9663,7 +9663,7 @@ CREATE TABLE `glpi_webhooks` (
   `comment` text,
   `itemtype` varchar(255) DEFAULT NULL,
   `event` varchar(255) DEFAULT NULL,
-  `payload` text,
+  `payload` longtext,
   `use_default_payload` tinyint NOT NULL DEFAULT '1',
   `custom_headers` text,
   `url` varchar(255) DEFAULT NULL,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12698

Some text columns in the database are likely to benefit from having the a larger text datatype. Specifically, the content columns for notification templates (queued notification table already had them set to longtext), webhook payload, and the kanban view state data.