### PR TITLE
Implement isRecursive for SoftwareLicense

### DIFF
--- a/src/SoftwareLicense.php
+++ b/src/SoftwareLicense.php
@@ -332,6 +332,24 @@ class SoftwareLicense extends CommonTreeDropdown
         return true;
     }
 
+    /**
+     * Is the license recursive ?
+     *
+     * @return boolean
+     **/
+    public function isRecursive()
+    {
+        $soft = new Software();
+        if (
+            isset($this->fields["softwares_id"])
+            && $soft->getFromDB($this->fields["softwares_id"])
+        ) {
+            return $soft->isRecursive();
+        }
+
+        return false;
+    }
+
 
     public function rawSearchOptions()
     {


### PR DESCRIPTION
Fix the following fatal error when executing the `software` automatic action:

```
[2024-01-04 05:32:56] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "is_recursive" in /mnt/diskhome/home/teclib/htdocs/src/CommonDBTM.php at line 3202
  Backtrace :
  src/NotificationTarget.php:1757                    CommonDBTM->isRecursive()
  src/NotificationTarget.php:591                     NotificationTarget->isTargetItemRecursive()
  src/NotificationTarget.php:730                     NotificationTarget->addToRecipientsList()
  src/NotificationTarget.php:1251                    NotificationTarget->addAdmin()
  src/NotificationEventAbstract.php:98               NotificationTarget->addForTarget()
  src/NotificationEvent.php:188                      NotificationEventAbstract::raise()
  src/SoftwareLicense.php:807                        NotificationEvent::raiseEvent()
  src/CronTask.php:1037                              SoftwareLicense::cronSoftware()
  front/crontask.form.php:52                         CronTask::launch()

[2024-01-04 05:32:56] glpiphplog.CRITICAL:   *** Uncaught Exception TypeError: NotificationTarget::isTargetItemRecursive(): Return value must be of type bool, null returned in /mnt/diskhome/home/teclib/htdocs/src/NotificationTarget.php at line 1757
  Backtrace :
  src/NotificationTarget.php:591                     NotificationTarget->isTargetItemRecursive()
  src/NotificationTarget.php:730                     NotificationTarget->addToRecipientsList()
  src/NotificationTarget.php:1251                    NotificationTarget->addAdmin()
  src/NotificationEventAbstract.php:98               NotificationTarget->addForTarget()
  src/NotificationEvent.php:188                      NotificationEventAbstract::raise()
  src/SoftwareLicense.php:807                        NotificationEvent::raiseEvent()
  src/CronTask.php:1037                              SoftwareLicense::cronSoftware()
  front/crontask.form.php:52                         CronTask::launch()
```

The issue was that `SoftwareLicense` redefine the `maybeRecursive` function with some custom code (checking the `is_recursive` field of the parent software), which may then return true and trigger GLPI to call the `isRecursive` function.

Since `isRecursive` is not redefined here it fallback to the default behavior, which mean here checking for a field that does not exist.

If `maybeRecursive` is redefined to rely on some external object data then `isRecursive` should also be redefined with the same behavior.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !31049
