### PR TITLE
Fallback to default language if user preferences are invalid

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -249,6 +249,11 @@ class User extends CommonDBTM
         if ($CFG_GLPI['show_count_on_tabs'] == -1) {
             $this->fields['show_count_on_tabs'] = 0;
         }
+
+        // Fallback for invalid language
+        if (!isset($CFG_GLPI['languages'][$this->fields["language"]])) {
+            $this->fields["language"] = $CFG_GLPI["language"];
+        }
     }
 
     /**
@@ -3127,7 +3132,7 @@ HTML;
                 echo "<td><label for='dropdown_language$langrand'>" . __('Language') . "</label></td><td>";
                // Language is stored as null in DB if value is same as the global config.
                 $language = $this->fields["language"];
-                if (null === $this->fields["language"]) {
+                if (null === $this->fields["language"] || !isset($CFG_GLPI['languages'][$this->fields["language"]])) {
                     $language = $CFG_GLPI['language'];
                 }
                 Dropdown::showLanguages(


### PR DESCRIPTION
I've found some invalid language values in a production database:

![image](https://github.com/glpi-project/glpi/assets/42734840/e3589fea-ca2f-4ca2-93ff-77c13cfb3f70)

The empty strings are unexpected (empty value should be NULL) and not handled correctly by GLPI.
Since I do not know where these invalide values came from, I can only make sure GLPI handle them better by falling back to the default language from the general config.

This is done by adding a safety check to the `computePreferences` methods.
Ironically, this method doesn't seem to be called on the personal preferences page so it needed its own individual safety check to display the proper fallback value.

| Q             | A
| ------------- | ---
| Bug fix?      | yes/
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !31053
