### PR TITLE
Fix entity selector

### DIFF
--- a/ajax/entitytreesons.php
+++ b/ajax/entitytreesons.php
@@ -55,22 +55,7 @@ if (Session::getCurrentInterface() == 'helpdesk') {
 
 $ancestors = getAncestorsOf('glpi_entities', $_SESSION['glpiactive_entity']);
 
-// Build cache key using last update date of every entity
-// This should trigger a cache refresh when an entity is created, updated or deleted
-global $DB;
-
-$data = $DB->request([
-    'SELECT' => 'date_mod',
-    'FROM'   => 'glpi_entities',
-]);
-$dates_hash = sha1(json_encode(iterator_to_array($data)));
-
-$ckey = 'entity_selector'
-    . sha1(json_encode($_SESSION['glpiactiveprofile']['entities']))
-    . sha1($base_path) // cached value contains links based on `$base_path`, so cache key should change when `$base_path` changes
-    . $dates_hash
-;
-
+$ckey = Session::getEntityTreeCacheKey($base_path);
 $entitiestree = $GLPI_CACHE->get($ckey);
 
 /* calculates the tree to save it in the cache if it is not already there */

--- a/ajax/entitytreesons.php
+++ b/ajax/entitytreesons.php
@@ -55,9 +55,20 @@ if (Session::getCurrentInterface() == 'helpdesk') {
 
 $ancestors = getAncestorsOf('glpi_entities', $_SESSION['glpiactive_entity']);
 
+// Build cache key using last update date of every entity
+// This should trigger a cache refresh when an entity is created, updated or deleted
+global $DB;
+
+$data = $DB->request([
+    'SELECT' => 'date_mod',
+    'FROM'   => 'glpi_entities',
+]);
+$dates_hash = sha1(json_encode(iterator_to_array($data)));
+
 $ckey = 'entity_selector'
     . sha1(json_encode($_SESSION['glpiactiveprofile']['entities']))
     . sha1($base_path) // cached value contains links based on `$base_path`, so cache key should change when `$base_path` changes
+    . $dates_hash
 ;
 
 $entitiestree = $GLPI_CACHE->get($ckey);

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -613,9 +613,6 @@ class Entity extends CommonTreeDropdown
         $_SESSION['glpiactiveentities_string']              .= ",'" . $this->fields['id'] . "'";
         // Root entity cannot be deleted, so if we added an entity this means GLPI is now multi-entity
         $_SESSION['glpi_multientitiesmode'] = 1;
-
-       // clean entity tree cache
-        $this->cleanEntitySelectorCache();
     }
 
     public function post_updateItem($history = true)
@@ -624,9 +621,6 @@ class Entity extends CommonTreeDropdown
         global $GLPI_CACHE;
 
         parent::post_updateItem($history);
-
-       // clean entity tree cache
-        $this->cleanEntitySelectorCache();
 
         // Delete any cache entry corresponding to an updated entity config
         // for current entities and all its children
@@ -671,25 +665,6 @@ class Entity extends CommonTreeDropdown
                 Entity_RSSFeed::class,
             ]
         );
-
-       // clean entity tree cache
-        $this->cleanEntitySelectorCache();
-    }
-
-
-    /**
-     * Clean caches related to entity selector.
-     *
-     * @since 10.0
-     *
-     * @return void
-     */
-    public function cleanEntitySelectorCache()
-    {
-        /** @var \Psr\SimpleCache\CacheInterface $GLPI_CACHE */
-        global $GLPI_CACHE;
-
-        $GLPI_CACHE->delete('entity_selector');
     }
 
     public function rawSearchOptions()

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -4112,4 +4112,17 @@ class Entity extends CommonTreeDropdown
         }
         return null;
     }
+
+    /**
+     * Clean caches related to entity selector.
+     *
+     * @since 10.0
+     *
+     * @return void
+     * @deprecated 10.0.12
+     */
+    public function cleanEntitySelectorCache()
+    {
+        Toolbox::deprecated('Entity::cleanEntitySelectorCache no longer has any effect as the entity selector is no longer cached as a unique entry');
+    }
 }

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -667,6 +667,19 @@ class Entity extends CommonTreeDropdown
         );
     }
 
+    /**
+     * Clean caches related to entity selector.
+     *
+     * @since 10.0
+     *
+     * @return void
+     * @deprecated 10.0.12
+     */
+    public function cleanEntitySelectorCache()
+    {
+        Toolbox::deprecated('Entity::cleanEntitySelectorCache no longer has any effect as the entity selector is no longer cached as a unique entry');
+    }
+
     public function rawSearchOptions()
     {
         $tab = [];
@@ -4111,18 +4124,5 @@ class Entity extends CommonTreeDropdown
             return self::badgeCompletenameLink($entity);
         }
         return null;
-    }
-
-    /**
-     * Clean caches related to entity selector.
-     *
-     * @since 10.0
-     *
-     * @return void
-     * @deprecated 10.0.12
-     */
-    public function cleanEntitySelectorCache()
-    {
-        Toolbox::deprecated('Entity::cleanEntitySelectorCache no longer has any effect as the entity selector is no longer cached as a unique entry');
     }
 }

--- a/src/Session.php
+++ b/src/Session.php
@@ -2051,6 +2051,7 @@ class Session
      */
     public static function getEntityTreeCacheKey(string $base_path): string
     {
+        /** @var \DBmysql $DB */
         global $DB;
 
         // Build cache key using last update date of every entity

--- a/src/Session.php
+++ b/src/Session.php
@@ -2040,4 +2040,31 @@ class Session
         // TODO (10.1 refactoring): replace references to $_SESSION['glpi_currenttime'] by a call to this function
         return $_SESSION['glpi_currenttime'] ?? null;
     }
+
+    /**
+     * Get the key cache used to store the entities tree
+     *
+     * @param string $base_path Cached value contains links based on `$base_path`,
+     *                          so cache key should change when `$base_path` changes
+     *
+     * @return string
+     */
+    public static function getEntityTreeCacheKey(string $base_path): string
+    {
+        global $DB;
+
+        // Build cache key using last update date of every entity
+        // This should trigger a cache refresh when an entity is created, updated or deleted
+        $data = $DB->request([
+            'SELECT' => 'date_mod',
+            'FROM'   => 'glpi_entities',
+        ]);
+        $dates_hash = sha1(json_encode(iterator_to_array($data)));
+
+        return 'entity_selector'
+            . sha1(json_encode($_SESSION['glpiactiveprofile']['entities']))
+            . sha1($base_path)
+            . $dates_hash
+        ;
+    }
 }

--- a/tests/functional/Session.php
+++ b/tests/functional/Session.php
@@ -480,7 +480,8 @@ class Session extends \DbTestCase
      *
      * @return void
      */
-    public function testGetEntityTreeCacheKey(): void {
+    public function testGetEntityTreeCacheKey(): void
+    {
         global $CFG_GLPI;
 
         $this->login();


### PR DESCRIPTION
The entity selector is never updated, meaning any new entities will never be visible.

This is caused by #15794, which did not take cache invalidation into account.

I've fixed this by adding a hash of every entities last update date into the selector.
This hash will change any time an entity is created, updated or deleted from the database.

I've also deleted references to the old cache key since it is not used anymore after #15794.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !31070
