### PR TITLE
Expand read and update permissions for assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The present file will list all changes made to the project; according to the
 - `Deny login` authorization rule action to deny login for a user, but not prevent the import/existence of the user in GLPI.
 - Directly capture screenshots or screen recordings from the "Add a document" form in tickets.
 - With a clean install, dashboards now show fake/placeholder data by default with a message indicating you are viewing demonstration data and a button to disable it.
+- Assets that can be assigned to users/groups have new "View assigned" and "Update assigned" rights which give read/update access to users and groups assigned to the asset.
 
 ### Changed
 - ITIL Objects can now be linked to any other ITIL Objects similar to the previous Ticket/Ticket links.

--- a/front/cartridge.form.php
+++ b/front/cartridge.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRightsOr(Cartridge::$rightname, [READ, Cartridge::$read_assigned]);
+Session::checkRightsOr(Cartridge::$rightname, [READ, READ_ASSIGNED]);
 
 $cart    = new Cartridge();
 $cartype = new CartridgeItem();

--- a/front/cartridge.form.php
+++ b/front/cartridge.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRight("cartridge", READ);
+Session::checkRightsOr(Cartridge::$rightname, [READ, Cartridge::$read_assigned]);
 
 $cart    = new Cartridge();
 $cartype = new CartridgeItem();

--- a/front/cartridgeitem.form.php
+++ b/front/cartridgeitem.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRight("cartridge", READ);
+Session::checkRightsOr(Cartridge::$rightname, [READ, Cartridge::$read_assigned]);
 
 if (!isset($_GET["id"])) {
     $_GET["id"] = "";

--- a/front/cartridgeitem.form.php
+++ b/front/cartridgeitem.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRightsOr(Cartridge::$rightname, [READ, Cartridge::$read_assigned]);
+Session::checkRightsOr(Cartridge::$rightname, [READ, READ_ASSIGNED]);
 
 if (!isset($_GET["id"])) {
     $_GET["id"] = "";

--- a/front/cartridgeitem.php
+++ b/front/cartridgeitem.php
@@ -35,7 +35,7 @@
 
 include('../inc/includes.php');
 
-Session::checkRight("cartridge", READ);
+Session::checkRightsOr(Cartridge::$rightname, [READ, Cartridge::$read_assigned]);
 
 Html::header(Cartridge::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "cartridgeitem");
 

--- a/front/cartridgeitem.php
+++ b/front/cartridgeitem.php
@@ -35,7 +35,7 @@
 
 include('../inc/includes.php');
 
-Session::checkRightsOr(Cartridge::$rightname, [READ, Cartridge::$read_assigned]);
+Session::checkRightsOr(Cartridge::$rightname, [READ, READ_ASSIGNED]);
 
 Html::header(Cartridge::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "cartridgeitem");
 

--- a/front/computer.form.php
+++ b/front/computer.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRight("computer", READ);
+Session::checkRightsOr("computer", [READ, Computer::$read_assigned]);
 
 if (!isset($_GET["id"])) {
     $_GET["id"] = "";

--- a/front/computer.form.php
+++ b/front/computer.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRightsOr("computer", [READ, READ_ASSIGNED]);
+Session::checkRightsOr(Computer::$rightname, [READ, READ_ASSIGNED]);
 
 if (!isset($_GET["id"])) {
     $_GET["id"] = "";

--- a/front/computer.form.php
+++ b/front/computer.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRightsOr("computer", [READ, Computer::$read_assigned]);
+Session::checkRightsOr("computer", [READ, READ_ASSIGNED]);
 
 if (!isset($_GET["id"])) {
     $_GET["id"] = "";

--- a/front/computer.php
+++ b/front/computer.php
@@ -35,7 +35,7 @@
 
 include('../inc/includes.php');
 
-Session::checkRightsOr(Computer::$rightname, [READ, Computer::$read_assigned]);
+Session::checkRightsOr(Computer::$rightname, [READ, READ_ASSIGNED]);
 
 Html::header(Computer::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "computer");
 

--- a/front/computer.php
+++ b/front/computer.php
@@ -35,7 +35,7 @@
 
 include('../inc/includes.php');
 
-Session::checkRight("computer", READ);
+Session::checkRightsOr(Computer::$rightname, [READ, Computer::$read_assigned]);
 
 Html::header(Computer::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "computer");
 

--- a/front/consumable.form.php
+++ b/front/consumable.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRightsOr(Consumable::$rightname, [READ, Consumable::$read_assigned]);
+Session::checkRightsOr(Consumable::$rightname, [READ, READ_ASSIGNED]);
 
 $con      = new Consumable();
 $constype = new ConsumableItem();

--- a/front/consumable.form.php
+++ b/front/consumable.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRight("consumable", READ);
+Session::checkRightsOr(Consumable::$rightname, [READ, Consumable::$read_assigned]);
 
 $con      = new Consumable();
 $constype = new ConsumableItem();

--- a/front/consumableitem.form.php
+++ b/front/consumableitem.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRight("consumable", READ);
+Session::checkRightsOr(Consumable::$rightname, [READ, Consumable::$read_assigned]);
 
 if (!isset($_GET["id"])) {
     $_GET["id"] = "";

--- a/front/consumableitem.form.php
+++ b/front/consumableitem.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRightsOr(Consumable::$rightname, [READ, Consumable::$read_assigned]);
+Session::checkRightsOr(Consumable::$rightname, [READ, READ_ASSIGNED]);
 
 if (!isset($_GET["id"])) {
     $_GET["id"] = "";

--- a/front/consumableitem.php
+++ b/front/consumableitem.php
@@ -35,7 +35,7 @@
 
 include('../inc/includes.php');
 
-Session::checkRight("consumable", READ);
+Session::checkRightsOr(Consumable::$rightname, [READ, Consumable::$read_assigned]);
 
 Html::header(Consumable::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "consumableitem");
 

--- a/front/consumableitem.php
+++ b/front/consumableitem.php
@@ -35,7 +35,7 @@
 
 include('../inc/includes.php');
 
-Session::checkRightsOr(Consumable::$rightname, [READ, Consumable::$read_assigned]);
+Session::checkRightsOr(Consumable::$rightname, [READ, READ_ASSIGNED]);
 
 Html::header(Consumable::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "consumableitem");
 

--- a/front/monitor.form.php
+++ b/front/monitor.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRightsOr(Monitor::$rightname, [READ, Monitor::$read_assigned]);
+Session::checkRightsOr(Monitor::$rightname, [READ, READ_ASSIGNED]);
 
 if (empty($_GET["id"])) {
     $_GET["id"] = "";

--- a/front/monitor.form.php
+++ b/front/monitor.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRight("monitor", READ);
+Session::checkRightsOr(Monitor::$rightname, [READ, Monitor::$read_assigned]);
 
 if (empty($_GET["id"])) {
     $_GET["id"] = "";

--- a/front/monitor.php
+++ b/front/monitor.php
@@ -35,7 +35,7 @@
 
 include('../inc/includes.php');
 
-Session::checkRight("monitor", READ);
+Session::checkRightsOr(Monitor::$rightname, [READ, Monitor::$read_assigned]);
 
 Html::header(Monitor::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "monitor");
 

--- a/front/monitor.php
+++ b/front/monitor.php
@@ -35,7 +35,7 @@
 
 include('../inc/includes.php');
 
-Session::checkRightsOr(Monitor::$rightname, [READ, Monitor::$read_assigned]);
+Session::checkRightsOr(Monitor::$rightname, [READ, READ_ASSIGNED]);
 
 Html::header(Monitor::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "monitor");
 

--- a/front/networkequipment.form.php
+++ b/front/networkequipment.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRightsOr(NetworkEquipment::$rightname, [READ, NetworkEquipment::$read_assigned]);
+Session::checkRightsOr(NetworkEquipment::$rightname, [READ, READ_ASSIGNED]);
 
 if (!isset($_GET["id"])) {
     $_GET["id"] = "";

--- a/front/networkequipment.form.php
+++ b/front/networkequipment.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRight("networking", READ);
+Session::checkRightsOr(NetworkEquipment::$rightname, [READ, NetworkEquipment::$read_assigned]);
 
 if (!isset($_GET["id"])) {
     $_GET["id"] = "";

--- a/front/networkequipment.php
+++ b/front/networkequipment.php
@@ -35,7 +35,7 @@
 
 include('../inc/includes.php');
 
-Session::checkRightsOr(NetworkEquipment::$rightname, [READ, NetworkEquipment::$read_assigned]);
+Session::checkRightsOr(NetworkEquipment::$rightname, [READ, READ_ASSIGNED]);
 
 Html::header(NetworkEquipment::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "networkequipment");
 

--- a/front/networkequipment.php
+++ b/front/networkequipment.php
@@ -35,7 +35,7 @@
 
 include('../inc/includes.php');
 
-Session::checkRight("networking", READ);
+Session::checkRightsOr(NetworkEquipment::$rightname, [READ, NetworkEquipment::$read_assigned]);
 
 Html::header(NetworkEquipment::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "networkequipment");
 

--- a/front/networkname.form.php
+++ b/front/networkname.form.php
@@ -37,6 +37,8 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
+Session::checkRightsOr(NetworkName::$rightname, [READ, NetworkName::$read_assigned]);
+
 $nn = new NetworkName();
 
 if (isset($_POST["add"])) {

--- a/front/networkname.form.php
+++ b/front/networkname.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRightsOr(NetworkName::$rightname, [READ, NetworkName::$read_assigned]);
+Session::checkRight(NetworkName::$rightname, READ);
 
 $nn = new NetworkName();
 

--- a/front/networkname.php
+++ b/front/networkname.php
@@ -35,7 +35,7 @@
 
 include('../inc/includes.php');
 
-Session::checkRight("internet", READ);
+Session::checkRightsOr(NetworkName::$rightname, [READ, NetworkName::$read_assigned]);
 
 Html::header(
     NetworkName::getTypeName(Session::getPluralNumber()),

--- a/front/networkname.php
+++ b/front/networkname.php
@@ -35,7 +35,7 @@
 
 include('../inc/includes.php');
 
-Session::checkRightsOr(NetworkName::$rightname, [READ, NetworkName::$read_assigned]);
+Session::checkRight(NetworkName::$rightname, READ);
 
 Html::header(
     NetworkName::getTypeName(Session::getPluralNumber()),

--- a/front/peripheral.form.php
+++ b/front/peripheral.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRightsOr(Peripheral::$rightname, [READ, Peripheral::$read_assigned]);
+Session::checkRightsOr(Peripheral::$rightname, [READ, READ_ASSIGNED]);
 
 if (empty($_GET["id"])) {
     $_GET["id"] = "";

--- a/front/peripheral.form.php
+++ b/front/peripheral.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRight("peripheral", READ);
+Session::checkRightsOr(Peripheral::$rightname, [READ, Peripheral::$read_assigned]);
 
 if (empty($_GET["id"])) {
     $_GET["id"] = "";

--- a/front/peripheral.php
+++ b/front/peripheral.php
@@ -35,7 +35,7 @@
 
 include('../inc/includes.php');
 
-Session::checkRightsOr(Peripheral::$rightname, [READ, Peripheral::$read_assigned]);
+Session::checkRightsOr(Peripheral::$rightname, [READ, READ_ASSIGNED]);
 
 Html::header(Peripheral::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "peripheral");
 

--- a/front/peripheral.php
+++ b/front/peripheral.php
@@ -35,7 +35,7 @@
 
 include('../inc/includes.php');
 
-Session::checkRight("peripheral", READ);
+Session::checkRightsOr(Peripheral::$rightname, [READ, Peripheral::$read_assigned]);
 
 Html::header(Peripheral::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "peripheral");
 

--- a/front/phone.form.php
+++ b/front/phone.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRight("phone", READ);
+Session::checkRightsOr(Phone::$rightname, [READ, Phone::$read_assigned]);
 
 if (empty($_GET["id"])) {
     $_GET["id"] = "";

--- a/front/phone.form.php
+++ b/front/phone.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRightsOr(Phone::$rightname, [READ, Phone::$read_assigned]);
+Session::checkRightsOr(Phone::$rightname, [READ, READ_ASSIGNED]);
 
 if (empty($_GET["id"])) {
     $_GET["id"] = "";

--- a/front/phone.php
+++ b/front/phone.php
@@ -35,7 +35,7 @@
 
 include('../inc/includes.php');
 
-Session::checkRight("phone", READ);
+Session::checkRightsOr(Phone::$rightname, [READ, Phone::$read_assigned]);
 
 Html::header(Phone::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], 'assets', 'phone');
 

--- a/front/phone.php
+++ b/front/phone.php
@@ -35,7 +35,7 @@
 
 include('../inc/includes.php');
 
-Session::checkRightsOr(Phone::$rightname, [READ, Phone::$read_assigned]);
+Session::checkRightsOr(Phone::$rightname, [READ, READ_ASSIGNED]);
 
 Html::header(Phone::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], 'assets', 'phone');
 

--- a/front/printer.form.php
+++ b/front/printer.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRightsOr(Printer::$rightname, [READ, Printer::$read_assigned]);
+Session::checkRightsOr(Printer::$rightname, [READ, READ_ASSIGNED]);
 
 if (!isset($_GET["id"])) {
     $_GET["id"] = "";

--- a/front/printer.form.php
+++ b/front/printer.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRight("printer", READ);
+Session::checkRightsOr(Printer::$rightname, [READ, Printer::$read_assigned]);
 
 if (!isset($_GET["id"])) {
     $_GET["id"] = "";

--- a/front/printer.php
+++ b/front/printer.php
@@ -35,7 +35,7 @@
 
 include('../inc/includes.php');
 
-Session::checkRight("printer", READ);
+Session::checkRightsOr(Printer::$rightname, [READ, Printer::$read_assigned]);
 
 Html::header(Printer::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "printer");
 

--- a/front/printer.php
+++ b/front/printer.php
@@ -35,7 +35,7 @@
 
 include('../inc/includes.php');
 
-Session::checkRightsOr(Printer::$rightname, [READ, Printer::$read_assigned]);
+Session::checkRightsOr(Printer::$rightname, [READ, READ_ASSIGNED]);
 
 Html::header(Printer::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "printer");
 

--- a/front/software.form.php
+++ b/front/software.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRightsOr(Software::$rightname, [READ, Software::$read_assigned]);
+Session::checkRightsOr(Software::$rightname, [READ, READ_ASSIGNED]);
 
 if (!isset($_GET["id"])) {
     $_GET["id"] = "";

--- a/front/software.form.php
+++ b/front/software.form.php
@@ -37,7 +37,7 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRight("software", READ);
+Session::checkRightsOr(Software::$rightname, [READ, Software::$read_assigned]);
 
 if (!isset($_GET["id"])) {
     $_GET["id"] = "";

--- a/front/software.php
+++ b/front/software.php
@@ -35,7 +35,7 @@
 
 include('../inc/includes.php');
 
-Session::checkRightsOr(Software::$rightname, [READ, Software::$read_assigned]);
+Session::checkRightsOr(Software::$rightname, [READ, READ_ASSIGNED]);
 
 Html::header(Software::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "software");
 

--- a/front/software.php
+++ b/front/software.php
@@ -35,7 +35,7 @@
 
 include('../inc/includes.php');
 
-Session::checkRight("software", READ);
+Session::checkRightsOr(Software::$rightname, [READ, Software::$read_assigned]);
 
 Html::header(Software::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "software");
 

--- a/inc/define.php
+++ b/inc/define.php
@@ -65,6 +65,8 @@ define("ALLSTANDARDRIGHT", 31);
 define("READNOTE", 32);
 define("UPDATENOTE", 64);
 define("UNLOCK", 128);
+define("READ_ASSIGNED", 256);
+define("UPDATE_ASSIGNED", 512);
 
 // set the default app_name
 $CFG_GLPI['app_name'] = 'GLPI';

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -5700,43 +5700,43 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'computer',
-                'rights' => READ | READNOTE,
+                'rights' => READ | READNOTE | Computer::$read_assigned,
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'monitor',
-                'rights' => READ | READNOTE,
+                'rights' => READ | READNOTE | Monitor::$read_assigned,
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'software',
-                'rights' => READ | READNOTE,
+                'rights' => READ | READNOTE | Software::$read_assigned,
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'networking',
-                'rights' => READ | READNOTE,
+                'rights' => READ | READNOTE | NetworkEquipment::$read_assigned,
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'internet',
-                'rights' => READ,
+                'rights' => READ | NetworkName::$read_assigned,
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'printer',
-                'rights' => READ | READNOTE,
+                'rights' => READ | READNOTE | Printer::$read_assigned,
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'peripheral',
-                'rights' => READ | READNOTE,
+                'rights' => READ | READNOTE | Peripheral::$read_assigned,
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'cartridge',
-                'rights' => READ | READNOTE,
+                'rights' => READ | READNOTE | Cartridge::$read_assigned,
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'consumable',
-                'rights' => READ | READNOTE,
+                'rights' => READ | READNOTE | Consumable::$read_assigned,
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'phone',
-                'rights' => READ | READNOTE,
+                'rights' => READ | READNOTE | Phone::$read_assigned,
             ], [
                 'profiles_id' => self::PROFILE_HOTLINER,
                 'name' => 'queuednotification',
@@ -5996,43 +5996,43 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'computer',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Computer::$read_assigned | Computer::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'monitor',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Monitor::$read_assigned | Monitor::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'software',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Software::$read_assigned | Software::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'networking',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | NetworkEquipment::$read_assigned | NetworkEquipment::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'internet',
-                'rights' => ALLSTANDARDRIGHT,
+                'rights' => ALLSTANDARDRIGHT | NetworkName::$read_assigned | NetworkName::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'printer',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Printer::$read_assigned | Printer::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'peripheral',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Peripheral::$read_assigned | Peripheral::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'cartridge',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Cartridge::$read_assigned | Cartridge::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'consumable',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Consumable::$read_assigned | Consumable::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'phone',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Phone::$read_assigned | Phone::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'queuednotification',
@@ -6296,43 +6296,43 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'computer',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | Computer::$read_assigned | Computer::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'monitor',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | Monitor::$read_assigned | Monitor::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'software',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | Software::$read_assigned | Software::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'networking',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | NetworkEquipment::$read_assigned | NetworkEquipment::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'internet',
-                'rights' => ALLSTANDARDRIGHT | UNLOCK,
+                'rights' => ALLSTANDARDRIGHT | UNLOCK | NetworkName::$read_assigned | NetworkName::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'printer',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | Printer::$read_assigned | Printer::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'peripheral',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | Peripheral::$read_assigned | Peripheral::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'cartridge',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | Cartridge::$read_assigned | Cartridge::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'consumable',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | Consumable::$read_assigned | Consumable::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'phone',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | Phone::$read_assigned | Phone::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'contact_enterprise',
@@ -6881,43 +6881,43 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'computer',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Computer::$read_assigned | Computer::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'monitor',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Monitor::$read_assigned | Monitor::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'software',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Software::$read_assigned | Software::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'networking',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | NetworkEquipment::$read_assigned | NetworkEquipment::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'internet',
-                'rights' => ALLSTANDARDRIGHT,
+                'rights' => ALLSTANDARDRIGHT | NetworkName::$read_assigned | NetworkName::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'printer',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Printer::$read_assigned | Printer::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'peripheral',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Peripheral::$read_assigned | Peripheral::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'cartridge',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Cartridge::$read_assigned | Cartridge::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'consumable',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Consumable::$read_assigned | Consumable::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'phone',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Phone::$read_assigned | Phone::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'queuednotification',
@@ -7172,43 +7172,43 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'computer',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Computer::$read_assigned | Computer::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'monitor',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Monitor::$read_assigned | Monitor::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'software',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Software::$read_assigned | Software::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'networking',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | NetworkEquipment::$read_assigned | NetworkEquipment::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'internet',
-                'rights' => ALLSTANDARDRIGHT,
+                'rights' => ALLSTANDARDRIGHT | NetworkName::$read_assigned | NetworkName::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'printer',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Printer::$read_assigned | Printer::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'peripheral',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Peripheral::$read_assigned | Peripheral::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'cartridge',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Cartridge::$read_assigned | Cartridge::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'consumable',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Consumable::$read_assigned | Consumable::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'phone',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Phone::$read_assigned | Phone::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_SELF_SERVICE,
                 'name' => 'queuednotification',
@@ -7471,7 +7471,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'cartridge',
-                'rights' => READ | READNOTE,
+                'rights' => READ | READNOTE | Cartridge::$read_assigned,
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'change',
@@ -7483,7 +7483,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'computer',
-                'rights' => READ | READNOTE,
+                'rights' => READ | READNOTE | Computer::$read_assigned,
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'config',
@@ -7491,7 +7491,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'consumable',
-                'rights' => READ | READNOTE,
+                'rights' => READ | READNOTE | Consumable::$read_assigned,
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'contact_enterprise',
@@ -7539,7 +7539,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'internet',
-                'rights' => READ,
+                'rights' => READ | NetworkName::$read_assigned,
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'itilcategory',
@@ -7567,7 +7567,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'monitor',
-                'rights' => READ | READNOTE,
+                'rights' => READ | READNOTE | Monitor::$read_assigned,
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'cable_management',
@@ -7575,7 +7575,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'networking',
-                'rights' => READ | READNOTE,
+                'rights' => READ | READNOTE | NetworkEquipment::$read_assigned,
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'notification',
@@ -7587,11 +7587,11 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'peripheral',
-                'rights' => READ | READNOTE,
+                'rights' => READ | READNOTE | Peripheral::$read_assigned,
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'phone',
-                'rights' => READ | READNOTE,
+                'rights' => READ | READNOTE | Phone::$read_assigned,
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'planning',
@@ -7599,7 +7599,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'printer',
-                'rights' => READ | READNOTE,
+                'rights' => READ | READNOTE | Printer::$read_assigned,
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'problem',
@@ -7687,7 +7687,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'software',
-                'rights' => READ | READNOTE,
+                'rights' => READ | READNOTE | Software::$read_assigned,
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'solutiontemplate',

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -5700,19 +5700,19 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'computer',
-                'rights' => READ | READNOTE | Computer::$read_assigned,
+                'rights' => READ | READNOTE | READ_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'monitor',
-                'rights' => READ | READNOTE | Monitor::$read_assigned,
+                'rights' => READ | READNOTE | READ_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'software',
-                'rights' => READ | READNOTE | Software::$read_assigned,
+                'rights' => READ | READNOTE | READ_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'networking',
-                'rights' => READ | READNOTE | NetworkEquipment::$read_assigned,
+                'rights' => READ | READNOTE | READ_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'internet',
@@ -5720,23 +5720,23 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'printer',
-                'rights' => READ | READNOTE | Printer::$read_assigned,
+                'rights' => READ | READNOTE | READ_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'peripheral',
-                'rights' => READ | READNOTE | Peripheral::$read_assigned,
+                'rights' => READ | READNOTE | READ_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'cartridge',
-                'rights' => READ | READNOTE | CartridgeItem::$read_assigned,
+                'rights' => READ | READNOTE | READ_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'consumable',
-                'rights' => READ | READNOTE | ConsumableItem::$read_assigned,
+                'rights' => READ | READNOTE | READ_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'phone',
-                'rights' => READ | READNOTE | Phone::$read_assigned,
+                'rights' => READ | READNOTE | READ_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_HOTLINER,
                 'name' => 'queuednotification',
@@ -5996,19 +5996,19 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'computer',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Computer::$read_assigned | Computer::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'monitor',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Monitor::$read_assigned | Monitor::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'software',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Software::$read_assigned | Software::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'networking',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | NetworkEquipment::$read_assigned | NetworkEquipment::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'internet',
@@ -6016,23 +6016,23 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'printer',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Printer::$read_assigned | Printer::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'peripheral',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Peripheral::$read_assigned | Peripheral::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'cartridge',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | CartridgeItem::$read_assigned | CartridgeItem::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'consumable',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | ConsumableItem::$read_assigned | ConsumableItem::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'phone',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Phone::$read_assigned | Phone::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'queuednotification',
@@ -6296,19 +6296,19 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'computer',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | Computer::$read_assigned | Computer::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'monitor',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | Monitor::$read_assigned | Monitor::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'software',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | Software::$read_assigned | Software::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'networking',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | NetworkEquipment::$read_assigned | NetworkEquipment::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'internet',
@@ -6316,23 +6316,23 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'printer',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | Printer::$read_assigned | Printer::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'peripheral',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | Peripheral::$read_assigned | Peripheral::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'cartridge',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | CartridgeItem::$read_assigned | CartridgeItem::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'consumable',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | ConsumableItem::$read_assigned | ConsumableItem::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'phone',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | Phone::$read_assigned | Phone::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'contact_enterprise',
@@ -6881,19 +6881,19 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'computer',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Computer::$read_assigned | Computer::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'monitor',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Monitor::$read_assigned | Monitor::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'software',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Software::$read_assigned | Software::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'networking',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | NetworkEquipment::$read_assigned | NetworkEquipment::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'internet',
@@ -6901,23 +6901,23 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'printer',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Printer::$read_assigned | Printer::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'peripheral',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Peripheral::$read_assigned | Peripheral::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'cartridge',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | CartridgeItem::$read_assigned | CartridgeItem::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'consumable',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | ConsumableItem::$read_assigned | ConsumableItem::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'phone',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Phone::$read_assigned | Phone::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'queuednotification',
@@ -7172,19 +7172,19 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'computer',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Computer::$read_assigned | Computer::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'monitor',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Monitor::$read_assigned | Monitor::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'software',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Software::$read_assigned | Software::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'networking',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | NetworkEquipment::$read_assigned | NetworkEquipment::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'internet',
@@ -7192,23 +7192,23 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'printer',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Printer::$read_assigned | Printer::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'peripheral',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Peripheral::$read_assigned | Peripheral::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'cartridge',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | CartridgeItem::$read_assigned | CartridgeItem::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'consumable',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | ConsumableItem::$read_assigned | ConsumableItem::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'phone',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Phone::$read_assigned | Phone::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | READ_ASSIGNED | UPDATE_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_SELF_SERVICE,
                 'name' => 'queuednotification',
@@ -7471,7 +7471,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'cartridge',
-                'rights' => READ | READNOTE | CartridgeItem::$read_assigned,
+                'rights' => READ | READNOTE | READ_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'change',
@@ -7483,7 +7483,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'computer',
-                'rights' => READ | READNOTE | Computer::$read_assigned,
+                'rights' => READ | READNOTE | READ_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'config',
@@ -7491,7 +7491,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'consumable',
-                'rights' => READ | READNOTE | ConsumableItem::$read_assigned,
+                'rights' => READ | READNOTE | READ_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'contact_enterprise',
@@ -7567,7 +7567,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'monitor',
-                'rights' => READ | READNOTE | Monitor::$read_assigned,
+                'rights' => READ | READNOTE | READ_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'cable_management',
@@ -7575,7 +7575,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'networking',
-                'rights' => READ | READNOTE | NetworkEquipment::$read_assigned,
+                'rights' => READ | READNOTE | READ_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'notification',
@@ -7587,11 +7587,11 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'peripheral',
-                'rights' => READ | READNOTE | Peripheral::$read_assigned,
+                'rights' => READ | READNOTE | READ_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'phone',
-                'rights' => READ | READNOTE | Phone::$read_assigned,
+                'rights' => READ | READNOTE | READ_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'planning',
@@ -7599,7 +7599,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'printer',
-                'rights' => READ | READNOTE | Printer::$read_assigned,
+                'rights' => READ | READNOTE | READ_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'problem',
@@ -7687,7 +7687,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'software',
-                'rights' => READ | READNOTE | Software::$read_assigned,
+                'rights' => READ | READNOTE | READ_ASSIGNED,
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'solutiontemplate',

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -5716,7 +5716,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'internet',
-                'rights' => READ | NetworkName::$read_assigned,
+                'rights' => READ,
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'printer',
@@ -5728,11 +5728,11 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'cartridge',
-                'rights' => READ | READNOTE | Cartridge::$read_assigned,
+                'rights' => READ | READNOTE | CartridgeItem::$read_assigned,
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'consumable',
-                'rights' => READ | READNOTE | Consumable::$read_assigned,
+                'rights' => READ | READNOTE | ConsumableItem::$read_assigned,
             ], [
                 'profiles_id' => self::PROFILE_OBSERVER,
                 'name' => 'phone',
@@ -6012,7 +6012,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'internet',
-                'rights' => ALLSTANDARDRIGHT | NetworkName::$read_assigned | NetworkName::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT,
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'printer',
@@ -6024,11 +6024,11 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'cartridge',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Cartridge::$read_assigned | Cartridge::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | CartridgeItem::$read_assigned | CartridgeItem::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'consumable',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Consumable::$read_assigned | Consumable::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | ConsumableItem::$read_assigned | ConsumableItem::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_ADMIN,
                 'name' => 'phone',
@@ -6312,7 +6312,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'internet',
-                'rights' => ALLSTANDARDRIGHT | UNLOCK | NetworkName::$read_assigned | NetworkName::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | UNLOCK,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'printer',
@@ -6324,11 +6324,11 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'cartridge',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | Cartridge::$read_assigned | Cartridge::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | CartridgeItem::$read_assigned | CartridgeItem::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'consumable',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | Consumable::$read_assigned | Consumable::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | UNLOCK | ConsumableItem::$read_assigned | ConsumableItem::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'phone',
@@ -6897,7 +6897,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'internet',
-                'rights' => ALLSTANDARDRIGHT | NetworkName::$read_assigned | NetworkName::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT,
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'printer',
@@ -6909,11 +6909,11 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'cartridge',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Cartridge::$read_assigned | Cartridge::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | CartridgeItem::$read_assigned | CartridgeItem::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'consumable',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Consumable::$read_assigned | Consumable::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | ConsumableItem::$read_assigned | ConsumableItem::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'phone',
@@ -7188,7 +7188,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'internet',
-                'rights' => ALLSTANDARDRIGHT | NetworkName::$read_assigned | NetworkName::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT,
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'printer',
@@ -7200,11 +7200,11 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'cartridge',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Cartridge::$read_assigned | Cartridge::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | CartridgeItem::$read_assigned | CartridgeItem::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'consumable',
-                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | Consumable::$read_assigned | Consumable::$update_assigned,
+                'rights' => ALLSTANDARDRIGHT | READNOTE | UPDATENOTE | ConsumableItem::$read_assigned | ConsumableItem::$update_assigned,
             ], [
                 'profiles_id' => self::PROFILE_SUPERVISOR,
                 'name' => 'phone',
@@ -7471,7 +7471,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'cartridge',
-                'rights' => READ | READNOTE | Cartridge::$read_assigned,
+                'rights' => READ | READNOTE | CartridgeItem::$read_assigned,
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'change',
@@ -7491,7 +7491,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'consumable',
-                'rights' => READ | READNOTE | Consumable::$read_assigned,
+                'rights' => READ | READNOTE | ConsumableItem::$read_assigned,
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'contact_enterprise',
@@ -7539,7 +7539,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'internet',
-                'rights' => READ | NetworkName::$read_assigned,
+                'rights' => READ,
             ], [
                 'profiles_id' => self::PROFILE_READ_ONLY,
                 'name' => 'itilcategory',

--- a/install/migrations/update_10.0.x_to_11.0.0/assets.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/assets.php
@@ -212,7 +212,7 @@ foreach ($it as $data) {
 
 $assignable_asset_rights = [
     'computer', 'monitor', 'software', 'networking', 'printer',
-    'cartridge', 'consumable', 'phone', 'peripheral', 'internet'
+    'cartridge', 'consumable', 'phone', 'peripheral'
 ];
 foreach ($assignable_asset_rights as $rightname) {
     // Computer class used here for access to properties in AssignableAsset trait since direct access is deprecated by PHP

--- a/install/migrations/update_10.0.x_to_11.0.0/assets.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/assets.php
@@ -215,7 +215,6 @@ $assignable_asset_rights = [
     'cartridge', 'consumable', 'phone', 'peripheral'
 ];
 foreach ($assignable_asset_rights as $rightname) {
-    // Computer class used here for access to properties in AssignableAsset trait since direct access is deprecated by PHP
     $migration->addRight($rightname, READ_ASSIGNED, [$rightname => READ]);
     $migration->addRight($rightname, UPDATE_ASSIGNED, [$rightname => UPDATE]);
 }

--- a/install/migrations/update_10.0.x_to_11.0.0/assets.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/assets.php
@@ -209,3 +209,13 @@ foreach ($it as $data) {
         ]);
     }
 }
+
+$assignable_asset_rights = [
+    'computer', 'monitor', 'software', 'networking', 'printer',
+    'cartridge', 'consumable', 'phone', 'peripheral', 'internet'
+];
+foreach ($assignable_asset_rights as $rightname) {
+    // Computer class used here for access to properties in AssignableAsset trait since direct access is deprecated by PHP
+    $migration->addRight($rightname, Computer::$read_assigned, [$rightname => READ]);
+    $migration->addRight($rightname, Computer::$update_assigned, [$rightname => UPDATE]);
+}

--- a/install/migrations/update_10.0.x_to_11.0.0/assets.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/assets.php
@@ -216,6 +216,6 @@ $assignable_asset_rights = [
 ];
 foreach ($assignable_asset_rights as $rightname) {
     // Computer class used here for access to properties in AssignableAsset trait since direct access is deprecated by PHP
-    $migration->addRight($rightname, Computer::$read_assigned, [$rightname => READ]);
-    $migration->addRight($rightname, Computer::$update_assigned, [$rightname => UPDATE]);
+    $migration->addRight($rightname, READ_ASSIGNED, [$rightname => READ]);
+    $migration->addRight($rightname, UPDATE_ASSIGNED, [$rightname => UPDATE]);
 }

--- a/src/Cartridge.php
+++ b/src/Cartridge.php
@@ -42,6 +42,7 @@
 class Cartridge extends CommonDBRelation
 {
     use Glpi\Features\Clonable;
+    use Glpi\Features\AssignableAsset;
 
    // From CommonDBTM
     protected static $forward_entity_to = ['Infocom'];
@@ -1433,9 +1434,13 @@ class Cartridge extends CommonDBRelation
     public function getRights($interface = 'central')
     {
         $ci = new CartridgeItem();
-        return $ci->getRights($interface);
+        $rights = $ci->getRights($interface);
+        $rights[READ] = __('View all');
+        $rights[self::$read_assigned] = __('View assigned');
+        $rights[UPDATE] = __('Update all');
+        $rights[self::$update_assigned] = __('Update assigned');
+        return $rights;
     }
-
 
     public static function getIcon()
     {

--- a/src/Cartridge.php
+++ b/src/Cartridge.php
@@ -42,7 +42,6 @@
 class Cartridge extends CommonDBRelation
 {
     use Glpi\Features\Clonable;
-    use Glpi\Features\AssignableAsset;
 
    // From CommonDBTM
     protected static $forward_entity_to = ['Infocom'];
@@ -57,6 +56,8 @@ class Cartridge extends CommonDBRelation
     public static $itemtype_2 = 'Printer';
     public static $items_id_2 = 'printers_id';
     public static $mustBeAttached_2 = false;
+    public static int $read_assigned = 256;
+    public static int $update_assigned = 512;
 
     public function getCloneRelations(): array
     {
@@ -1433,13 +1434,7 @@ class Cartridge extends CommonDBRelation
 
     public function getRights($interface = 'central')
     {
-        $ci = new CartridgeItem();
-        $rights = $ci->getRights($interface);
-        $rights[READ] = __('View all');
-        $rights[self::$read_assigned] = __('View assigned');
-        $rights[UPDATE] = __('Update all');
-        $rights[self::$update_assigned] = __('Update assigned');
-        return $rights;
+        return (new CartridgeItem())->getRights($interface);
     }
 
     public static function getIcon()

--- a/src/Cartridge.php
+++ b/src/Cartridge.php
@@ -56,8 +56,6 @@ class Cartridge extends CommonDBRelation
     public static $itemtype_2 = 'Printer';
     public static $items_id_2 = 'printers_id';
     public static $mustBeAttached_2 = false;
-    public static int $read_assigned = 256;
-    public static int $update_assigned = 512;
 
     public function getCloneRelations(): array
     {

--- a/src/CartridgeItem.php
+++ b/src/CartridgeItem.php
@@ -37,6 +37,7 @@ use Glpi\DBAL\QueryExpression;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryFunction;
 use Glpi\Features\AssetImage;
+use Glpi\Features\AssignableAsset;
 
 /**
  * CartridgeItem Class
@@ -46,6 +47,7 @@ use Glpi\Features\AssetImage;
 class CartridgeItem extends CommonDBTM
 {
     use AssetImage;
+    use AssignableAsset;
 
    // From CommonDBTM
     protected static $forward_entity_to = ['Cartridge', 'Infocom'];

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -6724,6 +6724,6 @@ class CommonDBTM extends CommonGLPI
      */
     public static function getSystemSQLCriteria(?string $tablename = null): array
     {
-        return [new QueryExpression(1)];
+        return [];
     }
 }

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -6724,6 +6724,6 @@ class CommonDBTM extends CommonGLPI
      */
     public static function getSystemSQLCriteria(?string $tablename = null): array
     {
-        return [];
+        return [new QueryExpression(1)];
     }
 }

--- a/src/CommonItilObject_Item.php
+++ b/src/CommonItilObject_Item.php
@@ -1509,6 +1509,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
                 }
 
                 $types = static::$itemtype_1::getAllTypesForHelpdesk();
+                $types = array_filter($types, static fn ($k) => $k::canView(), ARRAY_FILTER_USE_KEY);
                 $emptylabel = __('General');
                 if ($params[static::$items_id_1] > 0) {
                     $emptylabel = Dropdown::EMPTY_VALUE;

--- a/src/Computer.php
+++ b/src/Computer.php
@@ -44,6 +44,7 @@ class Computer extends CommonDBTM
     use Glpi\Features\Clonable;
     use Glpi\Features\Inventoriable;
     use Glpi\Features\State;
+    use Glpi\Features\AssignableAsset;
 
    // From CommonDBTM
     public $dohistory                   = true;

--- a/src/Consumable.php
+++ b/src/Consumable.php
@@ -56,8 +56,6 @@ class Consumable extends CommonDBChild
    // From CommonDBChild
     public static $itemtype             = 'ConsumableItem';
     public static $items_id             = 'consumableitems_id';
-    public static int $read_assigned = 256;
-    public static int $update_assigned = 512;
 
     public function getCloneRelations(): array
     {

--- a/src/Consumable.php
+++ b/src/Consumable.php
@@ -46,7 +46,6 @@ use Glpi\Event;
 class Consumable extends CommonDBChild
 {
     use Glpi\Features\Clonable;
-    use Glpi\Features\AssignableAsset;
 
    // From CommonDBTM
     protected static $forward_entity_to = ['Infocom'];
@@ -57,6 +56,8 @@ class Consumable extends CommonDBChild
    // From CommonDBChild
     public static $itemtype             = 'ConsumableItem';
     public static $items_id             = 'consumableitems_id';
+    public static int $read_assigned = 256;
+    public static int $update_assigned = 512;
 
     public function getCloneRelations(): array
     {
@@ -1089,13 +1090,7 @@ class Consumable extends CommonDBChild
 
     public function getRights($interface = 'central')
     {
-        $ci = new ConsumableItem();
-        $rights = $ci->getRights($interface);
-        $rights[READ] = __('View all');
-        $rights[self::$read_assigned] = __('View assigned');
-        $rights[UPDATE] = __('Update all');
-        $rights[self::$update_assigned] = __('Update assigned');
-        return $rights;
+        return (new ConsumableItem())->getRights($interface);
     }
 
 

--- a/src/Consumable.php
+++ b/src/Consumable.php
@@ -46,6 +46,7 @@ use Glpi\Event;
 class Consumable extends CommonDBChild
 {
     use Glpi\Features\Clonable;
+    use Glpi\Features\AssignableAsset;
 
    // From CommonDBTM
     protected static $forward_entity_to = ['Infocom'];
@@ -1089,7 +1090,12 @@ class Consumable extends CommonDBChild
     public function getRights($interface = 'central')
     {
         $ci = new ConsumableItem();
-        return $ci->getRights($interface);
+        $rights = $ci->getRights($interface);
+        $rights[READ] = __('View all');
+        $rights[self::$read_assigned] = __('View assigned');
+        $rights[UPDATE] = __('Update all');
+        $rights[self::$update_assigned] = __('Update assigned');
+        return $rights;
     }
 
 

--- a/src/ConsumableItem.php
+++ b/src/ConsumableItem.php
@@ -464,16 +464,6 @@ class ConsumableItem extends CommonDBTM
         NotificationEvent::debugEvent($this, $options);
     }
 
-
-    public function canUpdateItem()
-    {
-
-        if (!$this->checkEntity(true)) { //check entities recursively
-            return false;
-        }
-        return true;
-    }
-
     public function showForm($ID, array $options = [])
     {
         $this->initForm($ID, $options);

--- a/src/ConsumableItem.php
+++ b/src/ConsumableItem.php
@@ -37,6 +37,7 @@ use Glpi\DBAL\QueryExpression;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryFunction;
 use Glpi\Features\AssetImage;
+use Glpi\Features\AssignableAsset;
 
 //!  ConsumableItem Class
 /**
@@ -47,6 +48,7 @@ use Glpi\Features\AssetImage;
 class ConsumableItem extends CommonDBTM
 {
     use AssetImage;
+    use AssignableAsset;
 
    // From CommonDBTM
     protected static $forward_entity_to = ['Consumable', 'Infocom'];

--- a/src/DeviceSimcard.php
+++ b/src/DeviceSimcard.php
@@ -118,9 +118,17 @@ class DeviceSimcard extends CommonDevice
         ];
     }
 
-
     public static function getIcon()
     {
         return "fas fa-sim-card";
+    }
+
+    public function getRights($interface = 'central')
+    {
+        $rights = parent::getRights($interface);
+        // Update labels to match other assets
+        $rights[READ] = __('View all');
+        $rights[UPDATE] = __('Update all');
+        return $rights;
     }
 }

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -38,6 +38,7 @@ use Glpi\Asset\AssetDefinitionManager;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
 use Glpi\Features\DCBreadcrumb;
+use Glpi\Features\AssignableAsset;
 use Glpi\Plugin\Hooks;
 use Glpi\SocketModel;
 
@@ -3385,6 +3386,10 @@ JAVASCRIPT;
                     }
             }
 
+            if (Toolbox::hasTrait($post['itemtype'], AssignableAsset::class)) {
+                $where[] = $post['itemtype']::getAssignableVisiblityCriteria();
+            }
+
             $criteria = array_merge(
                 $criteria,
                 [
@@ -3839,8 +3844,12 @@ JAVASCRIPT;
             $post['page_limit'] = $CFG_GLPI['dropdown_max'];
         }
 
-        $start = intval(($post['page'] - 1) * $post['page_limit']);
-        $limit = intval($post['page_limit']);
+        if (Toolbox::hasTrait($post['itemtype'], AssignableAsset::class)) {
+            $where[] = $post['itemtype']::getAssignableVisiblityCriteria();
+        }
+
+        $start = (int) (($post['page'] - 1) * $post['page_limit']);
+        $limit = (int) $post['page_limit'];
 
         $iterator = $DB->request([
             'FROM'   => $post['table'],

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -3774,7 +3774,8 @@ JAVASCRIPT;
             return;
         }
 
-        $where = [$post['itemtype']::getSystemSQLCriteria()];
+        $system_sql = $post['itemtype']::getSystemSQLCriteria();
+        $where = !empty($system_sql) ? [$system_sql] : [];
         if (isset($post['used']) && !empty($post['used'])) {
             $where['NOT'] = ['id' => $post['used']];
         }

--- a/src/Features/AssignableAsset.php
+++ b/src/Features/AssignableAsset.php
@@ -7,7 +7,7 @@
  *
  * http://glpi-project.org
  *
- * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2015-2024 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *

--- a/src/Features/AssignableAsset.php
+++ b/src/Features/AssignableAsset.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2023 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Features;
+
+use Glpi\DBAL\QueryExpression;
+use Session;
+
+trait AssignableAsset
+{
+    // TODO with PHP 8.2, we can use constants for these rights
+    public static int $read_assigned = 256;
+    public static int $update_assigned = 512;
+
+    public static function canView()
+    {
+        return Session::haveRightsOr(static::$rightname, [READ, self::$read_assigned]);
+    }
+
+    public function canViewItem()
+    {
+        if (!parent::canViewItem()) {
+            return false;
+        }
+
+        $is_assigned = $this->fields['users_id_tech'] === $_SESSION['glpiID'] ||
+            in_array((int) ($this->fields['groups_id_tech'] ?? 0), $_SESSION['glpigroups'], true);
+
+        if (!Session::haveRight(static::$rightname, READ)) {
+            return $is_assigned && Session::haveRight(static::$rightname, self::$read_assigned);
+        }
+
+        // Has global READ right
+        return true;
+    }
+
+    public static function canUpdate()
+    {
+        return Session::haveRightsOr(static::$rightname, [UPDATE, self::$update_assigned]);
+    }
+
+    public function canUpdateItem()
+    {
+        if (!parent::canUpdateItem()) {
+            return false;
+        }
+
+        $is_assigned = $this->fields['users_id_tech'] === $_SESSION['glpiID'] ||
+            in_array((int) ($this->fields['groups_id_tech'] ?? 0), $_SESSION['glpigroups'], true);
+
+        if (!Session::haveRight(static::$rightname, UPDATE)) {
+            return $is_assigned && Session::haveRight(static::$rightname, self::$update_assigned);
+        }
+
+        // Has global UPDATE right
+        return true;
+    }
+
+    public static function canDelete()
+    {
+        return parent::canDelete() && static::canUpdate();
+    }
+
+    public function canDeleteItem()
+    {
+        return parent::canDeleteItem() && $this->canUpdateItem();
+    }
+
+    public static function canPurge()
+    {
+        return parent::canPurge() && static::canUpdate();
+    }
+
+    public function canPurgeItem()
+    {
+        return parent::canPurgeItem() && $this->canUpdateItem();
+    }
+
+    public static function getAssignableVisiblityCriteria()
+    {
+        if (Session::haveRight(static::$rightname, READ)) {
+            return [new QueryExpression('1')];
+        }
+        if (Session::haveRight(static::$rightname, self::$read_assigned)) {
+            return [
+                'OR' => [
+                    'users_id_tech' => $_SESSION['glpiID'],
+                    'groups_id_tech' => $_SESSION['glpigroups'],
+                ],
+            ];
+        }
+        return [new QueryExpression('0')];
+    }
+
+    /**
+     * @param string $interface
+     * @phpstan-param 'central'|'helpdesk' $interface
+     * @return array
+     * @phpstan-return array<integer, string|array>
+     */
+    public function getRights($interface = 'central')
+    {
+        $rights = parent::getRights($interface);
+        $rights[READ] = __('View all');
+        $rights[self::$read_assigned] = __('View assigned');
+        $rights[UPDATE] = __('Update all');
+        $rights[self::$update_assigned] = __('Update assigned');
+        return $rights;
+    }
+}

--- a/src/Features/AssignableAsset.php
+++ b/src/Features/AssignableAsset.php
@@ -114,12 +114,15 @@ trait AssignableAsset
             return [new QueryExpression('1')];
         }
         if (Session::haveRight(static::$rightname, self::$read_assigned)) {
-            return [
+            $criteria = [
                 'OR' => [
                     'users_id_tech' => $_SESSION['glpiID'],
-                    'groups_id_tech' => $_SESSION['glpigroups'],
                 ],
             ];
+            if (count($_SESSION['glpigroups'])) {
+                $criteria['OR']['groups_id_tech'] = $_SESSION['glpigroups'];
+            }
+            return [$criteria];
         }
         return [new QueryExpression('0')];
     }

--- a/src/Features/AssignableAsset.php
+++ b/src/Features/AssignableAsset.php
@@ -56,7 +56,7 @@ trait AssignableAsset
         }
 
         $is_assigned = $this->fields['users_id_tech'] === $_SESSION['glpiID'] ||
-            in_array((int) ($this->fields['groups_id_tech'] ?? 0), $_SESSION['glpigroups'], true);
+            in_array((int) ($this->fields['groups_id_tech'] ?? 0), $_SESSION['glpigroups'] ?? [], true);
 
         if (!Session::haveRight(static::$rightname, READ)) {
             return $is_assigned && Session::haveRight(static::$rightname, self::$read_assigned);
@@ -78,7 +78,7 @@ trait AssignableAsset
         }
 
         $is_assigned = $this->fields['users_id_tech'] === $_SESSION['glpiID'] ||
-            in_array((int) ($this->fields['groups_id_tech'] ?? 0), $_SESSION['glpigroups'], true);
+            in_array((int) ($this->fields['groups_id_tech'] ?? 0), $_SESSION['glpigroups'] ?? [], true);
 
         if (!Session::haveRight(static::$rightname, UPDATE)) {
             return $is_assigned && Session::haveRight(static::$rightname, self::$update_assigned);

--- a/src/Features/AssignableAsset.php
+++ b/src/Features/AssignableAsset.php
@@ -40,13 +40,9 @@ use Session;
 
 trait AssignableAsset
 {
-    // TODO with PHP 8.2, we can use constants for these rights
-    public static int $read_assigned = 256;
-    public static int $update_assigned = 512;
-
     public static function canView()
     {
-        return Session::haveRightsOr(static::$rightname, [READ, self::$read_assigned]);
+        return Session::haveRightsOr(static::$rightname, [READ, READ_ASSIGNED]);
     }
 
     public function canViewItem()
@@ -59,7 +55,7 @@ trait AssignableAsset
             in_array((int) ($this->fields['groups_id_tech'] ?? 0), $_SESSION['glpigroups'] ?? [], true);
 
         if (!Session::haveRight(static::$rightname, READ)) {
-            return $is_assigned && Session::haveRight(static::$rightname, self::$read_assigned);
+            return $is_assigned && Session::haveRight(static::$rightname, READ_ASSIGNED);
         }
 
         // Has global READ right
@@ -68,7 +64,7 @@ trait AssignableAsset
 
     public static function canUpdate()
     {
-        return Session::haveRightsOr(static::$rightname, [UPDATE, self::$update_assigned]);
+        return Session::haveRightsOr(static::$rightname, [UPDATE, UPDATE_ASSIGNED]);
     }
 
     public function canUpdateItem()
@@ -81,7 +77,7 @@ trait AssignableAsset
             in_array((int) ($this->fields['groups_id_tech'] ?? 0), $_SESSION['glpigroups'] ?? [], true);
 
         if (!Session::haveRight(static::$rightname, UPDATE)) {
-            return $is_assigned && Session::haveRight(static::$rightname, self::$update_assigned);
+            return $is_assigned && Session::haveRight(static::$rightname, UPDATE_ASSIGNED);
         }
 
         // Has global UPDATE right
@@ -113,7 +109,7 @@ trait AssignableAsset
         if (Session::haveRight(static::$rightname, READ)) {
             return [new QueryExpression('1')];
         }
-        if (Session::haveRight(static::$rightname, self::$read_assigned)) {
+        if (Session::haveRight(static::$rightname, READ_ASSIGNED)) {
             $criteria = [
                 'OR' => [
                     'users_id_tech' => $_SESSION['glpiID'],
@@ -137,9 +133,9 @@ trait AssignableAsset
     {
         $rights = parent::getRights($interface);
         $rights[READ] = __('View all');
-        $rights[self::$read_assigned] = __('View assigned');
+        $rights[READ_ASSIGNED] = __('View assigned');
         $rights[UPDATE] = __('Update all');
-        $rights[self::$update_assigned] = __('Update assigned');
+        $rights[UPDATE_ASSIGNED] = __('Update assigned');
         return $rights;
     }
 }

--- a/src/Features/AssignableAsset.php
+++ b/src/Features/AssignableAsset.php
@@ -84,26 +84,6 @@ trait AssignableAsset
         return true;
     }
 
-    public static function canDelete()
-    {
-        return parent::canDelete() && static::canUpdate();
-    }
-
-    public function canDeleteItem()
-    {
-        return parent::canDeleteItem() && $this->canUpdateItem();
-    }
-
-    public static function canPurge()
-    {
-        return parent::canPurge() && static::canUpdate();
-    }
-
-    public function canPurgeItem()
-    {
-        return parent::canPurgeItem() && $this->canUpdateItem();
-    }
-
     public static function getAssignableVisiblityCriteria()
     {
         if (Session::haveRight(static::$rightname, READ)) {

--- a/src/Monitor.php
+++ b/src/Monitor.php
@@ -44,6 +44,7 @@ class Monitor extends CommonDBTM
     use Glpi\Features\Clonable;
     use Glpi\Features\Inventoriable;
     use Glpi\Features\State;
+    use Glpi\Features\AssignableAsset;
 
    // From CommonDBTM
     public $dohistory                   = true;
@@ -498,7 +499,6 @@ class Monitor extends CommonDBTM
 
         return $tab;
     }
-
 
     public static function getIcon()
     {

--- a/src/NetworkEquipment.php
+++ b/src/NetworkEquipment.php
@@ -46,6 +46,7 @@ class NetworkEquipment extends CommonDBTM
     use Glpi\Features\Clonable;
     use Glpi\Features\Inventoriable;
     use Glpi\Features\State;
+    use Glpi\Features\AssignableAsset;
 
    // From CommonDBTM
     public $dohistory                   = true;

--- a/src/NetworkName.php
+++ b/src/NetworkName.php
@@ -49,8 +49,6 @@ use Glpi\Application\View\TemplateRenderer;
  **/
 class NetworkName extends FQDNLabel
 {
-    use Glpi\Features\AssignableAsset;
-
    // From CommonDBChild
     public static $itemtype              = 'itemtype';
     public static $items_id              = 'items_id';
@@ -972,5 +970,14 @@ class NetworkName extends FQDNLabel
             return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
         }
         return '';
+    }
+
+    public function getRights($interface = 'central')
+    {
+        $rights = parent::getRights($interface);
+        // Rename READ and UPDATE right labels to match other assets
+        $rights['READ'] = __('View all');
+        $rights['UPDATE'] = __('Update all');
+        return $rights;
     }
 }

--- a/src/NetworkName.php
+++ b/src/NetworkName.php
@@ -49,6 +49,8 @@ use Glpi\Application\View\TemplateRenderer;
  **/
 class NetworkName extends FQDNLabel
 {
+    use Glpi\Features\AssignableAsset;
+
    // From CommonDBChild
     public static $itemtype              = 'itemtype';
     public static $items_id              = 'items_id';

--- a/src/NetworkName.php
+++ b/src/NetworkName.php
@@ -976,8 +976,8 @@ class NetworkName extends FQDNLabel
     {
         $rights = parent::getRights($interface);
         // Rename READ and UPDATE right labels to match other assets
-        $rights['READ'] = __('View all');
-        $rights['UPDATE'] = __('Update all');
+        $rights[READ] = __('View all');
+        $rights[UPDATE] = __('Update all');
         return $rights;
     }
 }

--- a/src/Peripheral.php
+++ b/src/Peripheral.php
@@ -44,6 +44,7 @@ class Peripheral extends CommonDBTM
     use Glpi\Features\Clonable;
     use Glpi\Features\Inventoriable;
     use Glpi\Features\State;
+    use Glpi\Features\AssignableAsset;
 
    // From CommonDBTM
     public $dohistory                   = true;
@@ -413,7 +414,6 @@ class Peripheral extends CommonDBTM
 
         return $tab;
     }
-
 
     public static function getIcon()
     {

--- a/src/Phone.php
+++ b/src/Phone.php
@@ -44,6 +44,7 @@ class Phone extends CommonDBTM
     use Glpi\Features\Clonable;
     use Glpi\Features\Inventoriable;
     use Glpi\Features\State;
+    use Glpi\Features\AssignableAsset;
 
    // From CommonDBTM
     public $dohistory                   = true;
@@ -516,7 +517,6 @@ class Phone extends CommonDBTM
 
         return $tab;
     }
-
 
     public static function getIcon()
     {

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -46,6 +46,7 @@ class Printer extends CommonDBTM
     use Glpi\Features\Clonable;
     use Glpi\Features\Inventoriable;
     use Glpi\Features\State;
+    use Glpi\Features\AssignableAsset;
 
    // From CommonDBTM
     public $dohistory                   = true;
@@ -808,7 +809,6 @@ class Printer extends CommonDBTM
     {
         return $this->restore(["id" => $ID]);
     }
-
 
     public static function getIcon()
     {

--- a/src/Search/Provider/SQLProvider.php
+++ b/src/Search/Provider/SQLProvider.php
@@ -42,6 +42,7 @@ use DBmysqlIterator;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Debug\Profiler;
 use Glpi\Form\Form;
+use Glpi\Features\AssignableAsset;
 use Glpi\RichText\RichText;
 use Glpi\Search\Input\QueryBuilder;
 use Glpi\Search\SearchEngine;
@@ -996,6 +997,11 @@ final class SQLProvider implements SearchProviderInterface
                     }
                 }
                 break;
+        }
+
+        if (Toolbox::hasTrait($itemtype, AssignableAsset::class)) {
+            /** @var AssignableAsset $itemtype */
+            $criteria[] = $itemtype::getAssignableVisiblityCriteria();
         }
 
         /* Hook to restrict user right on current itemtype */

--- a/src/Session.php
+++ b/src/Session.php
@@ -1392,7 +1392,7 @@ class Session
         }
 
         if (isset($_SESSION["glpiactiveprofile"][$module])) {
-            return intval($_SESSION["glpiactiveprofile"][$module]) & $right;
+            return (int)$_SESSION["glpiactiveprofile"][$module] & $right;
         }
 
         return false;

--- a/src/Software.php
+++ b/src/Software.php
@@ -43,6 +43,7 @@ class Software extends CommonDBTM
     use Glpi\Features\Clonable;
     use Glpi\Features\TreeBrowse;
     use AssetImage;
+    use Glpi\Features\AssignableAsset;
 
    // From CommonDBTM
     public $dohistory                   = true;

--- a/tests/functional/CommonDBTM.php
+++ b/tests/functional/CommonDBTM.php
@@ -1783,7 +1783,7 @@ class CommonDBTM extends DbTestCase
         $this->login();
 
         $this->boolean($itemtype::canView())->isTrue();
-        $_SESSION['glpiactiveprofile'][$itemtype::$rightname] = $itemtype::$read_assigned;
+        $_SESSION['glpiactiveprofile'][$itemtype::$rightname] = READ_ASSIGNED;
         $this->boolean($itemtype::canView())->isTrue();
         $_SESSION['glpiactiveprofile'][$itemtype::$rightname] = ALLSTANDARDRIGHT & ~READ;
         $this->boolean($itemtype::canView())->isFalse();
@@ -1804,7 +1804,7 @@ class CommonDBTM extends DbTestCase
         ]))->isGreaterThan(0);
 
         $this->boolean($item->canViewItem())->isTrue();
-        $_SESSION['glpiactiveprofile'][$itemtype::$rightname] = $itemtype::$read_assigned;
+        $_SESSION['glpiactiveprofile'][$itemtype::$rightname] = READ_ASSIGNED;
         $this->boolean($item->canViewItem())->isFalse();
         $this->boolean($item->update([
             'id' => $item->getID(),
@@ -1840,7 +1840,7 @@ class CommonDBTM extends DbTestCase
         $this->login();
 
         $this->boolean($itemtype::canUpdate())->isTrue();
-        $_SESSION['glpiactiveprofile'][$itemtype::$rightname] = $itemtype::$update_assigned;
+        $_SESSION['glpiactiveprofile'][$itemtype::$rightname] = UPDATE_ASSIGNED;
         $this->boolean($itemtype::canUpdate())->isTrue();
         $_SESSION['glpiactiveprofile'][$itemtype::$rightname] = ALLSTANDARDRIGHT & ~UPDATE;
         $this->boolean($itemtype::canUpdate())->isFalse();
@@ -1861,7 +1861,7 @@ class CommonDBTM extends DbTestCase
         ]))->isGreaterThan(0);
 
         $this->boolean($item->canUpdateItem())->isTrue();
-        $_SESSION['glpiactiveprofile'][$itemtype::$rightname] = $itemtype::$update_assigned;
+        $_SESSION['glpiactiveprofile'][$itemtype::$rightname] = UPDATE_ASSIGNED;
         $this->boolean($item->canUpdateItem())->isFalse();
         $this->boolean($item->update([
             'id' => $item->getID(),

--- a/tests/functional/CommonDBTM.php
+++ b/tests/functional/CommonDBTM.php
@@ -1766,4 +1766,126 @@ class CommonDBTM extends DbTestCase
         sort($expected_updates);
         $this->array($item->updates)->isEqualTo($expected_updates);
     }
+
+    protected function assignableAssetsProvider()
+    {
+        return [
+            [\CartridgeItem::class], [\Computer::class], [\ConsumableItem::class], [\Monitor::class], [\NetworkEquipment::class],
+            [\Peripheral::class], [\Phone::class], [\Printer::class], [\Software::class]
+        ];
+    }
+
+    /**
+     * @dataProvider assignableAssetsProvider
+     */
+    public function testCanViewAssignableAssets($itemtype)
+    {
+        $this->login();
+
+        $this->boolean($itemtype::canView())->isTrue();
+        $_SESSION['glpiactiveprofile'][$itemtype::$rightname] = $itemtype::$read_assigned;
+        $this->boolean($itemtype::canView())->isTrue();
+        $_SESSION['glpiactiveprofile'][$itemtype::$rightname] = ALLSTANDARDRIGHT & ~READ;
+        $this->boolean($itemtype::canView())->isFalse();
+    }
+
+    /**
+     * @dataProvider assignableAssetsProvider
+     */
+    public function testCanViewItemAssignableAssets($itemtype)
+    {
+        $this->login();
+
+        /** @var \CommonDBTM $item */
+        $item = new $itemtype();
+        $this->integer($item->add([
+            'name' => 'test',
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+        ]))->isGreaterThan(0);
+
+        $this->boolean($item->canViewItem())->isTrue();
+        $_SESSION['glpiactiveprofile'][$itemtype::$rightname] = $itemtype::$read_assigned;
+        $this->boolean($item->canViewItem())->isFalse();
+        $this->boolean($item->update([
+            'id' => $item->getID(),
+            'users_id_tech' => $_SESSION['glpiID'],
+        ]));
+        $this->boolean($item->canViewItem())->isTrue();
+
+        // Create group for the user
+        $group = new \Group();
+        $this->integer($groups_id = $group->add([
+            'name' => __FUNCTION__,
+            'entities_id' => $this->getTestRootEntity(true),
+            'is_recursive' => 1
+        ]))->isGreaterThan(0);
+        // Add user to group
+        $group_user = new \Group_User();
+        $this->integer($group_user->add(['groups_id' => $groups_id, 'users_id' => $_SESSION['glpiID']]))->isGreaterThan(0);
+        \Session::loadGroups();
+
+        $this->boolean($item->update([
+            'id' => $item->getID(),
+            'users_id_tech' => 0,
+            'groups_id_tech' => $groups_id,
+        ]));
+        $this->boolean($item->canViewItem())->isTrue();
+    }
+
+    /**
+     * @dataProvider assignableAssetsProvider
+     */
+    public function testCanUpdateAssignableAssets($itemtype)
+    {
+        $this->login();
+
+        $this->boolean($itemtype::canUpdate())->isTrue();
+        $_SESSION['glpiactiveprofile'][$itemtype::$rightname] = $itemtype::$update_assigned;
+        $this->boolean($itemtype::canUpdate())->isTrue();
+        $_SESSION['glpiactiveprofile'][$itemtype::$rightname] = ALLSTANDARDRIGHT & ~UPDATE;
+        $this->boolean($itemtype::canUpdate())->isFalse();
+    }
+
+    /**
+     * @dataProvider assignableAssetsProvider
+     */
+    public function testCanUpdateItemAssignableAssets($itemtype)
+    {
+        $this->login();
+
+        /** @var \CommonDBTM $item */
+        $item = new $itemtype();
+        $this->integer($item->add([
+            'name' => 'test',
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+        ]))->isGreaterThan(0);
+
+        $this->boolean($item->canUpdateItem())->isTrue();
+        $_SESSION['glpiactiveprofile'][$itemtype::$rightname] = $itemtype::$update_assigned;
+        $this->boolean($item->canUpdateItem())->isFalse();
+        $this->boolean($item->update([
+            'id' => $item->getID(),
+            'users_id_tech' => $_SESSION['glpiID'],
+        ]));
+        $this->boolean($item->canUpdateItem())->isTrue();
+
+        // Create group for the user
+        $group = new \Group();
+        $this->integer($groups_id = $group->add([
+            'name' => __FUNCTION__,
+            'entities_id' => $this->getTestRootEntity(true),
+            'is_recursive' => 1
+        ]))->isGreaterThan(0);
+        // Add user to group
+        $group_user = new \Group_User();
+        $this->integer($group_user->add(['groups_id' => $groups_id, 'users_id' => $_SESSION['glpiID']]))->isGreaterThan(0);
+        \Session::loadGroups();
+
+        $this->boolean($item->update([
+            'id' => $item->getID(),
+            'users_id_tech' => 0,
+            'groups_id_tech' => $groups_id,
+        ]));
+        $this->boolean($item->canUpdateItem())->isTrue();
+    }
 }

--- a/tests/functional/CommonDBTM.php
+++ b/tests/functional/CommonDBTM.php
@@ -435,6 +435,7 @@ class CommonDBTM extends DbTestCase
         );
         $this->boolean($res)->isTrue();
     }
+
     /**
      * Check right on Recursive object
      *
@@ -477,12 +478,12 @@ class CommonDBTM extends DbTestCase
         ]);
         $this->integer($id[3])->isGreaterThan(0);
 
-       // Super admin
+        // Super admin
         $this->login('glpi', 'glpi');
         $this->variable($_SESSION['glpiactiveprofile']['id'])->isEqualTo(4);
-        $this->variable($_SESSION['glpiactiveprofile']['printer'])->isEqualTo(255);
+        $this->variable($_SESSION['glpiactiveprofile']['printer'])->isEqualTo(1023);
 
-       // See all
+        // See all
         $this->boolean(\Session::changeActiveEntities('all'))->isTrue();
 
         $this->boolean($printer->can($id[0], READ))->isTrue("Fail can read Printer 1");
@@ -495,7 +496,7 @@ class CommonDBTM extends DbTestCase
         $this->boolean($printer->canEdit($id[2]))->isTrue("Fail can write Printer 3");
         $this->boolean($printer->canEdit($id[3]))->isTrue("Fail can write Printer 4");
 
-       // See only in main entity
+        // See only in main entity
         $this->boolean(\Session::changeActiveEntities($ent0))->isTrue();
 
         $this->boolean($printer->can($id[0], READ))->isTrue("Fail can read Printer 1");
@@ -508,7 +509,7 @@ class CommonDBTM extends DbTestCase
         $this->boolean($printer->canEdit($id[2]))->isFalse("Fail can't write Printer 3");
         $this->boolean($printer->canEdit($id[3]))->isFalse("Fail can't write Printer 4");
 
-       // See only in child entity 1 + parent if recursive
+        // See only in child entity 1 + parent if recursive
         $this->boolean(\Session::changeActiveEntities($ent1))->isTrue();
 
         $this->boolean($printer->can($id[0], READ))->isFalse("Fail can't read Printer 1");
@@ -521,7 +522,7 @@ class CommonDBTM extends DbTestCase
         $this->boolean($printer->canEdit($id[2]))->isTrue("Fail can write Printer 3");
         $this->boolean($printer->canEdit($id[3]))->isFalse("Fail can't write Printer 4");
 
-       // See only in child entity 2 + parent if recursive
+        // See only in child entity 2 + parent if recursive
         $this->boolean(\Session::changeActiveEntities($ent2))->isTrue();
 
         $this->boolean($printer->can($id[0], READ))->isFalse("Fail can't read Printer 1");

--- a/tests/functional/Dropdown.php
+++ b/tests/functional/Dropdown.php
@@ -1992,7 +1992,7 @@ class Dropdown extends DbTestCase
         $this->array(array_column($results[$optgroup_id]['children'], 'text'))->containsValues($expected);
 
         // Remove permission to read all items
-        $_SESSION['glpiactiveprofile'][$itemtype::$rightname] = $itemtype::$read_assigned;
+        $_SESSION['glpiactiveprofile'][$itemtype::$rightname] = READ_ASSIGNED;
         $results = \Dropdown::getDropdownValue([
             'itemtype' => $itemtype,
             'display_emptychoice' => 0,
@@ -2082,7 +2082,7 @@ class Dropdown extends DbTestCase
         $this->array(array_column($results, 'text'))->containsValues($expected);
 
         // Remove permission to read all items
-        $_SESSION['glpiactiveprofile'][$itemtype::$rightname] = $itemtype::$read_assigned;
+        $_SESSION['glpiactiveprofile'][$itemtype::$rightname] = READ_ASSIGNED;
         $results = \Dropdown::getDropdownFindNum([
             'itemtype' => $itemtype,
             'table' => $itemtype::getTable(),

--- a/tests/functional/Dropdown.php
+++ b/tests/functional/Dropdown.php
@@ -38,6 +38,7 @@ namespace tests\units;
 use DbTestCase;
 use Generator;
 use Glpi\Features\Clonable;
+use Glpi\Features\AssignableAsset;
 use Glpi\Socket;
 use Session;
 use State;
@@ -1926,5 +1927,193 @@ class Dropdown extends DbTestCase
         foreach ($original_fields as $field => $value) {
             $this->variable($item->fields[$field])->isEqualTo($value);
         }
+    }
+
+    protected function assignableAssetsProvider()
+    {
+        return [
+            [\CartridgeItem::class], [\Computer::class], [\ConsumableItem::class], [\Monitor::class], [\NetworkEquipment::class],
+            [\Peripheral::class], [\Phone::class], [\Printer::class], [\Software::class]
+        ];
+    }
+
+    /**
+     * @dataProvider assignableAssetsProvider
+     */
+    public function testGetDropdownValueAssignableAssets($itemtype)
+    {
+        $this->login();
+
+        $this->boolean(\Toolbox::hasTrait($itemtype, AssignableAsset::class))->isTrue();
+
+        // Create group for the user
+        $group = new \Group();
+        $this->integer($groups_id = $group->add([
+            'name' => __FUNCTION__,
+            'entities_id' => $this->getTestRootEntity(true),
+            'is_recursive' => 1
+        ]))->isGreaterThan(0);
+        // Add user to group
+        $group_user = new \Group_User();
+        $this->integer($group_user->add(['groups_id' => $groups_id, 'users_id' => $_SESSION['glpiID']]))->isGreaterThan(0);
+
+        Session::loadGroups();
+
+        // Create three items. One with the user assigned, one without, and one with a group assigned.
+        $item = new $itemtype();
+        $this->integer($item->add([
+            'name' => __FUNCTION__ . '1',
+            'entities_id' => $this->getTestRootEntity(true)
+        ]))->isGreaterThan(0);
+        $this->integer($item->add([
+            'name' => __FUNCTION__ . '2',
+            'entities_id' => $this->getTestRootEntity(true),
+            'users_id_tech' => $_SESSION['glpiID']
+        ]))->isGreaterThan(0);
+        $this->integer($item->add([
+            'name' => __FUNCTION__ . '3',
+            'entities_id' => $this->getTestRootEntity(true),
+            'groups_id_tech' => $groups_id
+        ]))->isGreaterThan(0);
+
+        $results = \Dropdown::getDropdownValue([
+            'itemtype' => $itemtype,
+            'display_emptychoice' => 0,
+            '_idor_token' => \Session::getNewIDORToken($itemtype)
+        ], false)['results'];
+        // get optgroup id (key in the results array) for the test root entity "_test_root_entity"
+        $optgroup_id = array_search("Root _test_root_entity", array_column($results, 'text'));
+
+        $expected = [
+            __FUNCTION__ . '1',
+            __FUNCTION__ . '2',
+            __FUNCTION__ . '3'
+        ];
+        $this->array(array_column($results[$optgroup_id]['children'], 'text'))->containsValues($expected);
+
+        // Remove permission to read all items
+        $_SESSION['glpiactiveprofile'][$itemtype::$rightname] = $itemtype::$read_assigned;
+        $results = \Dropdown::getDropdownValue([
+            'itemtype' => $itemtype,
+            'display_emptychoice' => 0,
+            '_idor_token' => \Session::getNewIDORToken($itemtype)
+        ], false)['results'];
+        $expected = [
+            __FUNCTION__ . '2',
+            __FUNCTION__ . '3'
+        ];
+        $not_expected = [
+            __FUNCTION__ . '1'
+        ];
+        $this->array(array_column($results[$optgroup_id]['children'], 'text'))->containsValues($expected);
+        $this->array(array_column($results[$optgroup_id]['children'], 'text'))->notContainsValues($not_expected);
+
+        // Remove permission to read assigned items
+        $_SESSION['glpiactiveprofile'][$itemtype::$rightname] = 0;
+        $results = \Dropdown::getDropdownValue([
+            'itemtype' => $itemtype,
+            'display_emptychoice' => 0,
+            '_idor_token' => \Session::getNewIDORToken($itemtype)
+        ], false)['results'];
+        $not_expected = [
+            __FUNCTION__ . '1',
+            __FUNCTION__ . '2',
+            __FUNCTION__ . '3'
+        ];
+        $children = $results[$optgroup_id]['children'] ?? null;
+        if ($children === null) {
+            $children = [];
+        }
+        $this->array($children)->notContainsValues($not_expected);
+    }
+
+    /**
+     * @dataProvider assignableAssetsProvider
+     */
+    public function testGetDropdownFindNumAssignableAssets($itemtype)
+    {
+        $this->login();
+
+        $this->boolean(\Toolbox::hasTrait($itemtype, AssignableAsset::class))->isTrue();
+
+        // Create group for the user
+        $group = new \Group();
+        $this->integer($groups_id = $group->add([
+            'name' => __FUNCTION__,
+            'entities_id' => $this->getTestRootEntity(true),
+            'is_recursive' => 1
+        ]))->isGreaterThan(0);
+        // Add user to group
+        $group_user = new \Group_User();
+        $this->integer($group_user->add(['groups_id' => $groups_id, 'users_id' => $_SESSION['glpiID']]))->isGreaterThan(0);
+
+        Session::loadGroups();
+
+        // Create three items. One with the user assigned, one without, and one with a group assigned.
+        $item = new $itemtype();
+        $this->integer($item->add([
+            'name' => __FUNCTION__ . '1',
+            'entities_id' => $this->getTestRootEntity(true)
+        ]))->isGreaterThan(0);
+        $this->integer($item->add([
+            'name' => __FUNCTION__ . '2',
+            'entities_id' => $this->getTestRootEntity(true),
+            'users_id_tech' => $_SESSION['glpiID']
+        ]))->isGreaterThan(0);
+        $this->integer($item->add([
+            'name' => __FUNCTION__ . '3',
+            'entities_id' => $this->getTestRootEntity(true),
+            'groups_id_tech' => $groups_id
+        ]))->isGreaterThan(0);
+
+        $results = \Dropdown::getDropdownFindNum([
+            'itemtype' => $itemtype,
+            'table' => $itemtype::getTable(),
+            '_idor_token' => \Session::getNewIDORToken($itemtype, [
+                'table' => $itemtype::getTable()
+            ])
+        ], false)['results'];
+
+        $expected = [
+            __FUNCTION__ . '1',
+            __FUNCTION__ . '2',
+            __FUNCTION__ . '3'
+        ];
+        $this->array(array_column($results, 'text'))->containsValues($expected);
+
+        // Remove permission to read all items
+        $_SESSION['glpiactiveprofile'][$itemtype::$rightname] = $itemtype::$read_assigned;
+        $results = \Dropdown::getDropdownFindNum([
+            'itemtype' => $itemtype,
+            'table' => $itemtype::getTable(),
+            '_idor_token' => \Session::getNewIDORToken($itemtype, [
+                'table' => $itemtype::getTable()
+            ])
+        ], false)['results'];
+        $expected = [
+            __FUNCTION__ . '2',
+            __FUNCTION__ . '3'
+        ];
+        $not_expected = [
+            __FUNCTION__ . '1'
+        ];
+        $this->array(array_column($results, 'text'))->containsValues($expected);
+        $this->array(array_column($results, 'text'))->notContainsValues($not_expected);
+
+        // Remove permission to read assigned items
+        $_SESSION['glpiactiveprofile'][$itemtype::$rightname] = 0;
+        $results = \Dropdown::getDropdownFindNum([
+            'itemtype' => $itemtype,
+            'table' => $itemtype::getTable(),
+            '_idor_token' => \Session::getNewIDORToken($itemtype, [
+                'table' => $itemtype::getTable()
+            ])
+        ], false)['results'];
+        $not_expected = [
+            __FUNCTION__ . '1',
+            __FUNCTION__ . '2',
+            __FUNCTION__ . '3'
+        ];
+        $this->array($results)->notContainsValues($not_expected);
     }
 }

--- a/tests/functional/MassiveAction.php
+++ b/tests/functional/MassiveAction.php
@@ -227,6 +227,7 @@ class MassiveAction extends DbTestCase
 
        // Set rights if needed
         if ($has_right) {
+            $this->login();
             $_SESSION['glpiactiveentities'] = [
                 $item->getEntityID()
             ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30462

Rename Read/Update permission for assets to "View all"/"Update all". Add new "View assigned" and "Update assigned" permissions relating to the technician and technician group fields on the assets.