### PR TITLE
Fix satisfaction survey max close date saving when configuration is not inherited

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -6054,7 +6054,6 @@ JAVASCRIPT;
 
             $nb            = 0;
             $max_closedate = '';
-
             foreach ($iterator as $tick) {
                 $max_closedate = $tick['closedate'];
                 if (mt_rand(1, 100) <= $rate) {
@@ -6070,13 +6069,18 @@ JAVASCRIPT;
                 }
             }
 
-           // conservation de toutes les max_closedate des entites filles
+            // keep all max_closedate of child entities
             if (
                 !empty($max_closedate)
                 && (!isset($maxentity[$parent])
                  || ($max_closedate > $maxentity[$parent]))
             ) {
                 $maxentity[$parent] = $max_closedate;
+            }
+            if (!empty($max_closedate)) {
+                // Save children's max_closedate to avoid testing the same tickets twice
+                $conf->getFromDB($entity);
+                $conf->update(['id' => $conf->fields['id'], 'max_closedate' => $max_closedate]);
             }
 
             if ($nb) {
@@ -6090,7 +6094,7 @@ JAVASCRIPT;
             }
         }
 
-       // Sauvegarde du max_closedate pour ne pas tester les m??me tickets 2 fois
+        // Save max_closedate to avoid testing the same tickets twice
         foreach ($maxentity as $parent => $maxdate) {
             $conf->getFromDB($parent);
             $conf->update(['id'            => $conf->fields['id'],

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -5991,7 +5991,6 @@ JAVASCRIPT;
         /** @var \DBmysql $DB */
         global $DB;
 
-        $conf        = new Entity();
         $inquest     = new TicketSatisfaction();
         $tot         = 0;
         $maxentity   = [];
@@ -6004,19 +6003,17 @@ JAVASCRIPT;
 
         foreach ($DB->request('glpi_entities') as $entity) {
             $rate   = Entity::getUsedConfig('inquest_config', $entity['id'], 'inquest_rate');
-            $parent = Entity::getUsedConfig('inquest_config', $entity['id'], 'entities_id');
 
             if ($rate > 0) {
                 $tabentities[$entity['id']] = $rate;
             }
         }
 
-        foreach ($tabentities as $entity => $rate) {
-            $parent        = Entity::getUsedConfig('inquest_config', $entity, 'entities_id');
-            $delay         = Entity::getUsedConfig('inquest_config', $entity, 'inquest_delay');
-            $duration      = Entity::getUsedConfig('inquest_config', $entity, 'inquest_duration');
-            $type          = Entity::getUsedConfig('inquest_config', $entity);
-            $max_closedate = Entity::getUsedConfig('inquest_config', $entity, 'max_closedate');
+        foreach ($tabentities as $entity_id => $rate) {
+            $delay         = Entity::getUsedConfig('inquest_config', $entity_id, 'inquest_delay');
+            $duration      = Entity::getUsedConfig('inquest_config', $entity_id, 'inquest_duration');
+            $type          = Entity::getUsedConfig('inquest_config', $entity_id);
+            $max_closedate = Entity::getUsedConfig('inquest_config', $entity_id, 'max_closedate');
 
             $table = self::getTable();
             $iterator = $DB->request([
@@ -6041,7 +6038,7 @@ JAVASCRIPT;
                     ]
                 ],
                 'WHERE'     => [
-                    "$table.entities_id"          => $entity,
+                    "$table.entities_id"          => $entity_id,
                     "$table.is_deleted"           => 0,
                     "$table.status"               => self::CLOSED,
                     "$table.closedate"            => ['>', $max_closedate],
@@ -6069,18 +6066,20 @@ JAVASCRIPT;
                 }
             }
 
-            // keep all max_closedate of child entities
-            if (
-                !empty($max_closedate)
-                && (!isset($maxentity[$parent])
-                 || ($max_closedate > $maxentity[$parent]))
-            ) {
-                $maxentity[$parent] = $max_closedate;
-            }
+            // keep max_closedate
             if (!empty($max_closedate)) {
-                // Save children's max_closedate to avoid testing the same tickets twice
-                $conf->getFromDB($entity);
-                $conf->update(['id' => $conf->fields['id'], 'max_closedate' => $max_closedate]);
+                $entity = new Entity();
+                $entity->getFromDB($entity_id);
+                // If the inquest configuration is inherited, then the `max_closedate` value should be updated
+                // on the entity that hosts the configuration, otherwise, it have to be stored on current entity.
+                // It is necessary to ensure that `Entity::getUsedConfig('inquest_config', $entity_id, 'max_closedate')`
+                // will return the expected value.
+                $target_entity_id = $entity->fields['inquest_config'] === Entity::CONFIG_PARENT
+                    ? Entity::getUsedConfig('inquest_config', $entity_id, 'entities_id', 0)
+                    : $entity_id;
+                if (!array_key_exists($target_entity_id, $maxentity) || $max_closedate > $maxentity[$target_entity_id]) {
+                    $maxentity[$target_entity_id] = $max_closedate;
+                }
             }
 
             if ($nb) {
@@ -6088,17 +6087,17 @@ JAVASCRIPT;
                 $task->addVolume($nb);
                 $task->log(sprintf(
                     __('%1$s: %2$s'),
-                    Dropdown::getDropdownName('glpi_entities', $entity),
+                    Dropdown::getDropdownName('glpi_entities', $entity_id),
                     $nb
                 ));
             }
         }
 
         // Save max_closedate to avoid testing the same tickets twice
-        foreach ($maxentity as $parent => $maxdate) {
-            $conf->getFromDB($parent);
-            $conf->update(['id'            => $conf->fields['id'],
-                             //'entities_id'   => $parent,
+        foreach ($maxentity as $entity_id => $maxdate) {
+            $entity = new Entity();
+            $entity->update([
+                'id'            => $entity_id,
                 'max_closedate' => $maxdate
             ]);
         }

--- a/tests/DbTestCase.php
+++ b/tests/DbTestCase.php
@@ -119,7 +119,7 @@ class DbTestCase extends \GLPITestCase
     {
         $input = Sanitizer::dbUnescapeRecursive($input); // slashes in input should not be stored in DB
 
-        $this->integer((int)$id)->isGreaterThan(0);
+        $this->integer($id)->isGreaterThan($object instanceof Entity ? -1 : 0);
         $this->boolean($object->getFromDB($id))->isTrue();
         $this->variable($object->getField('id'))->isEqualTo($id);
 

--- a/tests/functional/Ticket.php
+++ b/tests/functional/Ticket.php
@@ -39,6 +39,7 @@ use CommonDBTM;
 use CommonITILActor;
 use CommonITILObject;
 use Computer;
+use CronTask;
 use DbTestCase;
 use Entity;
 use Glpi\Team\Team;
@@ -4927,49 +4928,138 @@ HTML
 
     public function testCronSurveyCreation()
     {
-        global $DB;
         $this->login();
-        // Since processing is too fast, we need to set the current time to a time before it was started.
-        $_SESSION['glpi_currenttime'] = date("Y-m-d H:i:s", strtotime('-2 second'));
-        $entity = new \Entity();
-        //create entity with inquest_rate > 0
-        $this->boolean($entity->update([
-            'id'                => 0,
-            'inquest_config'    => 1,
-            'inquest_rate'      => 100,
-            'inquest_delay'     => 0,
-            'max_closedate'     => $_SESSION['glpi_currenttime']
-        ]))->isTrue();
 
-        // Recover glpi_currentitme base value
-        $_SESSION['glpi_currenttime'] = date("Y-m-d H:i:s");
+        $root_entity_id    = getItemByTypeName('Entity', '_test_root_entity', true);
+        $child_1_entity_id = getItemByTypeName('Entity', '_test_child_1', true);
+        $child_2_entity_id = getItemByTypeName('Entity', '_test_child_2', true);
 
-       // create ticket closed for survey
-        $ticket = new \Ticket();
-        $tickets_id_1 = $ticket->add([
-            'name'        => "test survey 1",
-            'content'     => "test survey 1",
-            'entities_id' => 0,
-            'status'      => \CommonITILObject::CLOSED
-        ]);
-        $this->integer((int)$tickets_id_1)->isGreaterThan(0);
+        $now              = $_SESSION['glpi_currenttime'];
+        $twelve_hours_ago = date("Y-m-d H:i:s", strtotime('-12 hours'));
+        $six_hours_ago    = date("Y-m-d H:i:s", strtotime('-4 hours'));
+        $four_hours_ago   = date("Y-m-d H:i:s", strtotime('-4 hours'));
+        $two_hours_ago    = date("Y-m-d H:i:s", strtotime('-2 hours'));
 
+        $this->updateItem(
+            Entity::class,
+            0,
+            [
+                'inquest_config' => 1, // GLPI native survey
+                'inquest_rate'   => 100, // always generate a survey for closed tickets
+                'inquest_delay'  => 0, // instant survey generation
+            ]
+        );
+        $this->updateItem(
+            Entity::class,
+            $root_entity_id,
+            [
+                'inquest_config' => Entity::CONFIG_PARENT, // inherits
+            ]
+        );
+        $this->updateItem(
+            Entity::class,
+            $child_1_entity_id,
+            [
+                'inquest_config' => Entity::CONFIG_PARENT, // inherits
+            ]
+        );
+        $this->updateItem(
+            Entity::class,
+            $child_2_entity_id,
+            [
+                'inquest_config' => 1, // GLPI native survey
+                'inquest_rate'   => 100, // always generate a survey for closed tickets
+                'inquest_delay'  => 0, // instant survey generation
+            ]
+        );
+
+        foreach ([0, $root_entity_id, $child_1_entity_id, $child_2_entity_id] as $entity_id) {
+            // Ensure `max_closedate` is in the past
+            $this->updateItem(
+                Entity::class,
+                $entity_id,
+                [
+                    'max_closedate'  => $twelve_hours_ago,
+                ]
+            );
+        }
+
+        // Create a closed ticket on test root entity
+        $_SESSION['glpi_currenttime'] = $six_hours_ago;
+        $root_ticket = $this->createItem(
+            \Ticket::class,
+            [
+                'name'        => "test root entity survey",
+                'content'     => "test root entity survey",
+                'entities_id' => $root_entity_id,
+                'status'      => CommonITILObject::CLOSED
+            ]
+        );
+
+        // Create a closed ticket on test child entity 1
+        $_SESSION['glpi_currenttime'] = $four_hours_ago;
+        $child_1_ticket = $this->createItem(
+            \Ticket::class,
+            [
+                'name'        => "test child entity 1 survey",
+                'content'     => "test child entity 1 survey",
+                'entities_id' => $child_1_entity_id,
+                'status'      => CommonITILObject::CLOSED
+            ]
+        );
+
+        // Create a closed ticket on test child entity 2
+        $_SESSION['glpi_currenttime'] = $two_hours_ago;
+        $child_1_ticket = $this->createItem(
+            \Ticket::class,
+            [
+                'name'        => "test child entity 2 survey",
+                'content'     => "test child entity 2 survey",
+                'entities_id' => $child_2_entity_id,
+                'status'      => CommonITILObject::CLOSED
+            ]
+        );
+
+        // Ensure no survey has been created yet
         $ticket_satisfaction = new \TicketSatisfaction();
-        $this->integer(count($ticket_satisfaction->find(['tickets_id' => $tickets_id_1])))->isEqualTo(0);
+        $this->integer(count($ticket_satisfaction->find(['tickets_id' => $root_ticket->getID()])))->isEqualTo(0);
+        $this->integer(count($ticket_satisfaction->find(['tickets_id' => $child_1_ticket->getID()])))->isEqualTo(0);
 
-        // launch Cron for survey creation
-        $mode = - \CronTask::MODE_INTERNAL; // force
-        \CronTask::launch($mode, 1, 'createinquest');
+        // Launch cron to create surveys
+        CronTask::launch(
+            - CronTask::MODE_INTERNAL, // force
+            1,
+            'createinquest'
+        );
 
-        // Get current entity max_closedate
-        $this->boolean($entity->getFromDB(0))->isTrue();
+        // Ensure survey has been created
+        $ticket_satisfaction = new \TicketSatisfaction();
+        $this->integer(count($ticket_satisfaction->find(['tickets_id' => $root_ticket->getID()])))->isEqualTo(1);
+        $this->integer(count($ticket_satisfaction->find(['tickets_id' => $child_1_ticket->getID()])))->isEqualTo(1);
 
-        // check survey has been created
-        $this->integer(count($ticket_satisfaction->find(['tickets_id' => $tickets_id_1])))->isGreaterThan(0);
+        // Check `max_closedate` values in DB
+        $expected_db_values = [
+            0                  => $four_hours_ago,   // last ticket closedate from entities that inherits the config
+            $root_entity_id    => $twelve_hours_ago, // not updated as it inherits the config
+            $child_1_entity_id => $twelve_hours_ago, // not updated as it inherits the config
+            $child_2_entity_id => $two_hours_ago,    // last ticket closedate from self as it has its own config
+        ];
+        foreach ($expected_db_values as $entity_id => $date) {
+            $entity = new Entity();
+            $this->boolean($entity->getFromDB($entity_id))->isTrue();
+            $this->string($entity->fields['max_closedate'])->isEqualTo($date);
+        }
 
-        // check entity max_closedate has been updated
-        $this->boolean($ticket->getFromDB($tickets_id_1))->isTrue();
-        $this->string($entity->fields['max_closedate'])->isEqualTo($ticket->fields['closedate']);
+        // Check `max_closedate` returned by `Entity::getUsedConfig()`
+        $expected_config_values = [
+            0                  => $four_hours_ago, // last ticket closedate from entities that inherits the config
+            $root_entity_id    => $four_hours_ago, // inherited value
+            $child_1_entity_id => $four_hours_ago, // inherited value
+            $child_2_entity_id => $two_hours_ago,  // last ticket closedate from self as it has its own config
+        ];
+        foreach ($expected_config_values as $entity_id => $date) {
+            $this->string(Entity::getUsedConfig('inquest_config', $entity_id, 'max_closedate'))->isEqualTo($date);
+        }
     }
 
     public function testAddAssignWithoutUpdateRight()

--- a/tests/functional/Ticket.php
+++ b/tests/functional/Ticket.php
@@ -4926,15 +4926,15 @@ HTML
         $this->integer($it->count())->isEqualTo(1);
     }
 
-    public function testCronSurveyCreation()
+    public function testCronSurveyCreation(): void
     {
         $this->login();
 
-        $root_entity_id    = getItemByTypeName('Entity', '_test_root_entity', true);
+        $root_entity_id    = $this->getTestRootEntity(true);
         $child_1_entity_id = getItemByTypeName('Entity', '_test_child_1', true);
         $child_2_entity_id = getItemByTypeName('Entity', '_test_child_2', true);
 
-        $now              = $_SESSION['glpi_currenttime'];
+        $now              = \Session::getCurrentTime();
         $twelve_hours_ago = date("Y-m-d H:i:s", strtotime('-12 hours'));
         $six_hours_ago    = date("Y-m-d H:i:s", strtotime('-4 hours'));
         $four_hours_ago   = date("Y-m-d H:i:s", strtotime('-4 hours'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14707

When generating surveys, the max close date of the ticket is stored during a loop, the code updates the parent entity maxdate but never the code never update the current/child entity.
