### PR TITLE
Multiple RuleRight test fixes

### DIFF
--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -50,7 +50,7 @@ class RuleCollection extends CommonDBTM
     public $use_output_rule_process_as_next_input = false;
    /// Rule collection can be replay (for dictionary)
     public $can_replay_rules                      = false;
-   /// List of rules of the rule collection
+    /** @var SingletonRuleList $RuleList List of rules of the rule collection */
     public $RuleList                              = null;
    /// Menu type
     public $menu_type                             = "rule";
@@ -1694,6 +1694,7 @@ JAVASCRIPT;
         $input = $this->prepareInputDataForTestProcess($condition);
 
         if (count($input)) {
+            /** @var Rule $rule */
             $rule      = $this->getRuleClass();
             $criterias = $rule->getAllCriteria();
             echo "<form name='testrule_form' id='testrulesengine_form' method='post' action='$target'>";
@@ -1701,7 +1702,7 @@ JAVASCRIPT;
             echo "<table class='tab_cadre_fixe'>";
             echo "<tr><th colspan='2'>" . _n('Criterion', 'Criteria', Session::getPluralNumber()) . "</th></tr>\n";
 
-           //Brower all criterias
+            //Brower all criterias
             foreach ($input as $criteria) {
                 echo "<tr class='tab_bg_1'>";
 
@@ -1953,7 +1954,11 @@ JAVASCRIPT;
 
         $output        = $this->cleanTestOutputCriterias($output);
         unset($output["result"]);
-        $global_result = (count($output) ? 1 : 0);
+        if (count($output) === 1 && ($output['_no_rule_matches'] ?? false)) {
+            $global_result = 0;
+        } else {
+            $global_result = (count($output) ? 1 : 0);
+        }
 
         echo "<br><table class='tab_cadrehov'>";
         $this->showTestResults($rule, $output, $global_result);

--- a/src/RuleRightCollection.php
+++ b/src/RuleRightCollection.php
@@ -234,6 +234,7 @@ class RuleRightCollection extends RuleCollection
             'TYPE'       => $params_lower["type"] ?? "",
             'LOGIN'      => $params_lower["login"] ?? "",
             'MAIL_EMAIL' => $params_lower["email"] ?? $params_lower["mail_email"] ?? "",
+            '_groups_id' => !empty($params_lower['_groups_id']) ? $params_lower['_groups_id'] : $groups,
         ]);
 
         // IMAP/POP login method

--- a/src/RuleRightCollection.php
+++ b/src/RuleRightCollection.php
@@ -229,23 +229,23 @@ class RuleRightCollection extends RuleCollection
         // Some of the rule criteria is uppercase, but most other rule criterias are lowercase only
         $params_lower = array_change_key_case($params, CASE_LOWER);
 
-       //common parameters
-        $rule_parameters = array_merge($params_lower, [
+        // common parameters
+        $rule_parameters = array_replace($params_lower, [
             'TYPE'       => $params_lower["type"] ?? "",
             'LOGIN'      => $params_lower["login"] ?? "",
             'MAIL_EMAIL' => $params_lower["email"] ?? $params_lower["mail_email"] ?? "",
         ]);
 
-       //IMAP/POP login method
+        // IMAP/POP login method
         if ($rule_parameters["TYPE"] == Auth::MAIL) {
             $rule_parameters["MAIL_SERVER"] = $params_lower["mail_server"] ?? "";
         }
 
         //LDAP type method
-        //Get all the field to retrieve to be able to process rule matching
-        $rule_fields = $this->getFieldsToLookFor();
-        if ($rule_parameters["TYPE"] == Auth::LDAP && count($rule_fields)) {
+        // Get all the field to retrieve to be able to process rule matching
+        if ($rule_parameters["TYPE"] == Auth::LDAP) {
            //Get all the data we need from ldap to process the rules
+            $rule_fields = $this->getFieldsToLookFor();
             $sz = @ldap_read(
                 $params_lower["connection"],
                 $params_lower["userdn"],

--- a/src/RuleRightCollection.php
+++ b/src/RuleRightCollection.php
@@ -81,12 +81,10 @@ class RuleRightCollection extends RuleCollection
         if (isset($output["_ldap_rules"]["rules_entities"])) {
             echo "<tr class='tab_bg_2'>";
             echo "<td class='center' colspan='4'>" . __('Entities assignment') . "</td>";
-            foreach ($output["_ldap_rules"]["rules_entities"] as $entities) {
-                foreach ($entities as $entity) {
-                    $this->displayActionByName("entity", $entity[0]);
-                    if (isset($entity[1])) {
-                        $this->displayActionByName("recursive", $entity[1]);
-                    }
+            foreach ($output["_ldap_rules"]["rules_entities"] as $entity) {
+                $this->displayActionByName("entity", $entity[0]);
+                if (isset($entity[1])) {
+                    $this->displayActionByName("recursive", $entity[1]);
                 }
             }
         }
@@ -232,23 +230,21 @@ class RuleRightCollection extends RuleCollection
         $params_lower = array_change_key_case($params, CASE_LOWER);
 
        //common parameters
-        $rule_parameters = [
+        $rule_parameters = array_merge($params_lower, [
             'TYPE'       => $params_lower["type"] ?? "",
             'LOGIN'      => $params_lower["login"] ?? "",
             'MAIL_EMAIL' => $params_lower["email"] ?? $params_lower["mail_email"] ?? "",
-            '_groups_id' => $groups
-        ];
+        ]);
 
        //IMAP/POP login method
-        if ($params_lower["type"] == Auth::MAIL) {
+        if ($rule_parameters["TYPE"] == Auth::MAIL) {
             $rule_parameters["MAIL_SERVER"] = $params_lower["mail_server"] ?? "";
         }
 
-       //LDAP type method
-        if ($params_lower["type"] == Auth::LDAP) {
-           //Get all the field to retrieve to be able to process rule matching
-            $rule_fields = $this->getFieldsToLookFor();
-
+        //LDAP type method
+        //Get all the field to retrieve to be able to process rule matching
+        $rule_fields = $this->getFieldsToLookFor();
+        if ($rule_parameters["TYPE"] == Auth::LDAP && count($rule_fields)) {
            //Get all the data we need from ldap to process the rules
             $sz = @ldap_read(
                 $params_lower["connection"],

--- a/src/SingletonRuleList.php
+++ b/src/SingletonRuleList.php
@@ -35,7 +35,7 @@
 
 class SingletonRuleList
 {
-   /// Items list
+    /** @var Rule[] $list Rule list */
     public $list = [];
    /// Items loaded ?
     public $load = 0;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14059

Issues:
- Global result of tests incorrect. When nothing matches and '_no_rule_matches' was returned in the rule output, it was being treated as a success.
- Attempt to access 'type' rule parameter which isn't always available in the test. Switching from using $params to the prepared $rule_parameters array which adds a default value avoids the PHP warning.
- Entity assignment results incorrect. An incorrect use of an inner for loop was causing the recursive flag to be read as an entity and thus showing an assignment of the Root Entity when in fact it is assigning a different entity non-recursively.