### PR TITLE
Rework canView global checks for ITIL sub-items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ The present file will list all changes made to the project; according to the
 - The `date_mod` property for historical entries returned by `Log::getHistoryData` is no longer formatted based on the user's preferences.
 - `Rule::dropdownRulesMatch()` has been made protected.
 - `ITILTemplateField::showForITILTemplate()` method is no longer abstract.
+- `CommonITILTask::getItilObjectItemType` is now static.
 
 #### Deprecated
 - Usage of `GLPI_USE_CSRF_CHECK` constant.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ The present file will list all changes made to the project; according to the
 - Entity, profile, debug mode flag, and language are restored after ending impersonation.
 - Volumes now show `Used percentage` instead of `Free percentage`.
 - Budget "Main" tab now shows negative values for "Total remaining in the budget" in parentheses instead of with a negative sign to align with typical accounting practices.
+- Followups and Tasks no longer visible without the "See public" or "See private" rights even if the user has permission to be assigned the parent ITIL Object.
+- Followups, Tasks and Solutions now check the `canView()` method of the parent ITIL Object rather than just the "See my/See author" right of the parent item.
+  This means they now take into account "See all", "See group", etc. rights for the global permission check.
+  Permission checks at the item-level have not been changed.
 
 ### Deprecated
 - Survey URL tags `TICKETCATEGORY_ID` and `TICKETCATEGORY_NAME` are deprecated and replaced by `ITILCATEGORY_ID` and `ITILCATEGORY_NAME` respectively.

--- a/ajax/webhook.php
+++ b/ajax/webhook.php
@@ -66,7 +66,7 @@ switch ($action) {
             $values = [];
             foreach ($data as $items_id => $items_data) {
                 if ($object instanceof CommonITILTask || $object instanceof CommonITILValidation) {
-                    $itil_type = $object->getItilObjectItemType();
+                    $itil_type = $object::getItilObjectItemType();
                     $foreign_key = getForeignKeyFieldForItemType($itil_type);
                     $values[$items_id] = $itil_type::getTypeName(0) . " " . $items_data[$foreign_key] . " => " . $object::getTypeName(0) . " " . $items_id;
                 } else {

--- a/front/commonitiltask.form.php
+++ b/front/commonitiltask.form.php
@@ -56,7 +56,7 @@ if (!$task->canView()) {
     Html::displayRightError();
 }
 
-$itemtype = $task->getItilObjectItemType();
+$itemtype = $task::getItilObjectItemType();
 $fk       = getForeignKeyFieldForItemType($itemtype);
 
 $track = new $itemtype();

--- a/front/commonitilvalidation.form.php
+++ b/front/commonitilvalidation.form.php
@@ -58,7 +58,7 @@ if (!$validation->canView()) {
     Html::displayRightError();
 }
 
-$itemtype = $validation->getItilObjectItemType();
+$itemtype = $validation::getItilObjectItemType();
 $fk       = getForeignKeyFieldForItemType($itemtype);
 
 if (isset($_POST["add"])) {

--- a/src/ChangeTask.php
+++ b/src/ChangeTask.php
@@ -50,13 +50,6 @@ class ChangeTask extends CommonITILTask
           || Session::haveRight(self::$rightname, parent::ADDALLITEM);
     }
 
-
-    public static function canView()
-    {
-        return Session::haveRightsOr('change', [Change::READALL, Change::READMY]);
-    }
-
-
     public static function canUpdate()
     {
         return Session::haveRight('change', UPDATE)

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -136,7 +136,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
 
     public static function canView()
     {
-        if (!Session::haveRightsOr(self::$rightname, [self::SEEPUBLIC, self::SEEPRIVATE])) {
+        if (!Session::haveRightsOr(static::$rightname, [self::SEEPUBLIC, self::SEEPRIVATE])) {
             return false;
         }
         $parent_type = static::getItilObjectItemType();

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -60,10 +60,9 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
     const SEEPRIVATE      = 8192;
 
 
-
-    public function getItilObjectItemType()
+    public static function getItilObjectItemType()
     {
-        return str_replace('Task', '', $this->getType());
+        return str_replace('Task', '', static::class);
     }
 
     public static function getNameField()
@@ -81,12 +80,10 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         return false;
     }
 
-
     public function canEditAll()
     {
         return false;
     }
-
 
     /**
      * Get the item associated with the current object.
@@ -97,15 +94,13 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
      **/
     public function getItem()
     {
-
-        if ($item = getItemForItemtype($this->getItilObjectItemType())) {
-            if ($item->getFromDB($this->fields[$item->getForeignKeyField()])) {
+        if ($item = getItemForItemtype(static::getItilObjectItemType())) {
+            if ($item->getFromDB($this->fields[$item::getForeignKeyField()])) {
                 return $item;
             }
         }
         return false;
     }
-
 
     /**
      * can read the parent ITIL Object ?
@@ -114,15 +109,13 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
      **/
     public function canReadITILItem()
     {
-
-        $itemtype = $this->getItilObjectItemType();
+        $itemtype = static::getItilObjectItemType();
         $item     = new $itemtype();
         if (!$item->can($this->getField($item->getForeignKeyField()), READ)) {
             return false;
         }
         return true;
     }
-
 
     /**
      * can update the parent ITIL Object ?
@@ -133,8 +126,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
      **/
     public function canUpdateITILItem()
     {
-
-        $itemtype = $this->getItilObjectItemType();
+        $itemtype = static::getItilObjectItemType();
         $item     = new $itemtype();
         if (!$item->can($this->getField($item->getForeignKeyField()), UPDATE)) {
             return false;
@@ -142,6 +134,14 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         return true;
     }
 
+    public static function canView()
+    {
+        if (!Session::haveRightsOr(self::$rightname, [self::SEEPUBLIC, self::SEEPRIVATE])) {
+            return false;
+        }
+        $parent_type = static::getItilObjectItemType();
+        return $parent_type::canView();
+    }
 
     /**
      * Name of the type
@@ -152,7 +152,6 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
     {
         return _n('Task', 'Tasks', $nb);
     }
-
 
     /**
      * @since 0.84
@@ -174,7 +173,6 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         }
         return parent::getSpecificValueToDisplay($field, $values, $options);
     }
-
 
     /**
      * @since 0.84
@@ -201,12 +199,11 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         return parent::getSpecificValueToSelect($field, $name, $values, $options);
     }
 
-
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         /** @var CommonDBTM $item */
         if (
-            ($item->getType() == $this->getItilObjectItemType())
+            ($item->getType() == static::getItilObjectItemType())
             && $this->canView()
         ) {
             $nb = 0;
@@ -229,17 +226,17 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         return '';
     }
 
-
     public function post_deleteFromDB()
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $itemtype = $this->getItilObjectItemType();
+        $itemtype = static::getItilObjectItemType();
         $item     = new $itemtype();
-        $item->getFromDB($this->fields[$item->getForeignKeyField()]);
-        $item->updateActiontime($this->fields[$item->getForeignKeyField()]);
-        $item->updateDateMod($this->fields[$item->getForeignKeyField()]);
+        $fk = $item::getForeignKeyField();
+        $item->getFromDB($this->fields[$fk]);
+        $item->updateActiontime($this->fields[$fk]);
+        $item->updateDateMod($this->fields[$fk]);
 
        // Add log entry in the ITIL object
         $changes = [
@@ -248,10 +245,10 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             $this->fields['id'],
         ];
         Log::history(
-            $this->getField($item->getForeignKeyField()),
-            $this->getItilObjectItemType(),
+            $this->getField($item::getForeignKeyField()),
+            $itemtype,
             $changes,
-            $this->getType(),
+            static::class,
             Log::HISTORY_DELETE_SUBITEM
         );
 
@@ -294,7 +291,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
     public function assignTechFromtask(array $input): void
     {
         //if user or group assigned to CommonITIL task, add it to the main item
-        $itemtype = $this->getItilObjectItemType();
+        $itemtype = static::getItilObjectItemType();
         $item = new $itemtype();
         $itemData = [
             'users_id_tech' => new $item->userlinkclass(),
@@ -329,7 +326,6 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         }
     }
 
-
     public function prepareInputForUpdate($input)
     {
         if (array_key_exists('content', $input) && empty($input['content'])) {
@@ -355,7 +351,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             $input["users_id_editor"] = $uid;
         }
 
-        $itemtype      = $this->getItilObjectItemType();
+        $itemtype      = static::getItilObjectItemType();
         $input["_job"] = new $itemtype();
 
         if (
@@ -424,7 +420,6 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         return $input;
     }
 
-
     public function post_updateItem($history = true)
     {
         /** @var array $CFG_GLPI */
@@ -447,7 +442,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         }
 
         $update_done = false;
-        $itemtype    = $this->getItilObjectItemType();
+        $itemtype    = static::getItilObjectItemType();
         $item        = new $itemtype();
 
         $this->input = PendingReason_Item::handleTimelineEdits($this);
@@ -475,7 +470,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
                 }
 
                // change ticket status (from splitted button)
-                $itemtype = $this->getItilObjectItemType();
+                $itemtype = static::getItilObjectItemType();
                 $this->input['_job'] = new $itemtype();
                 if (!$this->input['_job']->getFromDB($this->fields[$this->input['_job']->getForeignKeyField()])) {
                     return false;
@@ -537,11 +532,10 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         parent::post_updateItem($history);
     }
 
-
     public function prepareInputForAdd($input)
     {
 
-        $itemtype = $this->getItilObjectItemType();
+        $itemtype = static::getItilObjectItemType();
 
         // Handle template
         if (isset($input['_tasktemplates_id'])) {
@@ -646,7 +640,6 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         return $input;
     }
 
-
     public function post_addItem()
     {
         /** @var array $CFG_GLPI */
@@ -738,7 +731,6 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         parent::post_addItem();
     }
 
-
     public function post_getEmpty()
     {
 
@@ -755,7 +747,6 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         }
     }
 
-
     /**
      * @see CommonDBTM::cleanDBonPurge()
      *
@@ -770,7 +761,6 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             ]
         );
     }
-
 
    // SPECIFIC FUNCTIONS
     protected function computeFriendlyName()
@@ -787,7 +777,6 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         }
         return '';
     }
-
 
     public function rawSearchOptions()
     {
@@ -871,7 +860,6 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
 
         return $tab;
     }
-
 
     /**
      * @since 0.85
@@ -1124,7 +1112,6 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         return $tab;
     }
 
-
     /**
      * Current dates are valid ? begin before end
      *
@@ -1139,7 +1126,6 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
               && !empty($input["end"])
               && (strtotime($input["begin"]) < strtotime($input["end"])));
     }
-
 
     /**
      * Populate the planning with planned tasks
@@ -1181,7 +1167,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             return;
         }
 
-        $parentitemtype = $item->getItilObjectItemType();
+        $parentitemtype = $item::getItilObjectItemType();
         if (!$parentitem = getItemForItemtype($parentitemtype)) {
             return;
         }
@@ -1531,7 +1517,6 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         return $html;
     }
 
-
     /** form for Task
      *
      * @param $ID        Integer : Id of the task
@@ -1550,14 +1535,13 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         return true;
     }
 
-
     /**
      * Form for Ticket or Problem Task on Massive action
      */
     public function showMassiveActionAddTaskForm()
     {
         $twig = TemplateRenderer::getInstance();
-        $itemtype = $this->getItilObjectItemType();
+        $itemtype = static::getItilObjectItemType();
         $item = new $itemtype();
         $item->getEmpty();
         $twig->display('components/massive_action/add_task.html.twig', [
@@ -1625,7 +1609,6 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         $req = $DB->request($prep_req);
         return $req;
     }
-
 
     /**
      * Display tasks in homepage
@@ -1781,8 +1764,6 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         }
     }
 
-
-
     /**
      * Very short table to display the task
      *
@@ -1879,7 +1860,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         global $DB;
 
         $item = new static();
-        $parent_item = getItemForItemtype($item->getItilObjectItemType());
+        $parent_item = getItemForItemtype($item::getItilObjectItemType());
         if (!$parent_item) {
             return;
         }
@@ -1924,7 +1905,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             return null;
         }
 
-        $parent_item = getItemForItemtype($this->getItilObjectItemType());
+        $parent_item = getItemForItemtype(static::getItilObjectItemType());
         if (!$parent_item) {
             return null;
         }
@@ -1969,7 +1950,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
            // self::prepareInputForUpdate() expect these fields to be set in input.
            // We should be able to not pass these fields in input
            // but fixing self::prepareInputForUpdate() seems complex right now.
-            $itil_fkey = getForeignKeyFieldForItemType($this->getItilObjectItemType());
+            $itil_fkey = getForeignKeyFieldForItemType(static::getItilObjectItemType());
             $input[$itil_fkey] = $this->fields[$itil_fkey];
             $input['users_id_tech'] = $this->fields['users_id_tech'];
         }

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -67,9 +67,9 @@ abstract class CommonITILValidation extends CommonDBChild
         return 'ti ti-thumb-up';
     }
 
-    public function getItilObjectItemType()
+    public static function getItilObjectItemType()
     {
-        return str_replace('Validation', '', $this->getType());
+        return str_replace('Validation', '', static::class);
     }
 
     public static function getCreateRights()

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -437,7 +437,7 @@ class Document_Item extends CommonDBRelation
                         || $item instanceof CommonITILValidation
                     ) {
                         $linkname_extra = "(" . CommonITILTask::getTypeName(1) . ")";
-                        $itemtype = $item->getItilObjectItemType();
+                        $itemtype = $item::getItilObjectItemType();
                         $item = new $itemtype();
                         $item->getFromDB($data[$item->getForeignKeyField()]);
                         $data['id'] = $item->fields['id'];

--- a/src/Features/PlanningEvent.php
+++ b/src/Features/PlanningEvent.php
@@ -875,7 +875,7 @@ trait PlanningEvent
     {
         $itemtype = $this->getType();
         if ($item = getItemForItemtype($itemtype)) {
-            $objectitemtype = (method_exists($item, 'getItilObjectItemType') ? $item->getItilObjectItemType() : $itemtype);
+            $objectitemtype = (method_exists($item, 'getItilObjectItemType') ? $item::getItilObjectItemType() : $itemtype);
 
            //TRANS: %1$s is a type, %2$$ is a date, %3$s is a date
             $out  = sprintf(

--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -105,16 +105,23 @@ class ITILFollowup extends CommonDBChild
         return true;
     }
 
-
     public static function canView()
     {
-        return (Session::haveRightsOr(self::$rightname, [self::SEEPUBLIC, self::SEEPRIVATE])
-              || Session::haveRight('ticket', Ticket::OWN))
-              || Session::haveRight('ticket', READ)
-              || Session::haveRight('change', READ)
-              || Session::haveRight('problem', READ);
-    }
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
 
+        if (!Session::haveRightsOr(self::$rightname, [self::SEEPUBLIC, self::SEEPRIVATE])) {
+            return false;
+        }
+        $itil_types = $CFG_GLPI['itil_types'];
+        /** @var class-string<CommonITILObject> $type */
+        foreach ($itil_types as $type) {
+            if ($type::canView()) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     public static function canCreate()
     {

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -76,9 +76,16 @@ class ITILSolution extends CommonDBChild
 
     public static function canView()
     {
-        return Session::haveRight('ticket', READ)
-             || Session::haveRight('change', READ)
-             || Session::haveRight('problem', READ);
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+        $itil_types = $CFG_GLPI['itil_types'];
+        /** @var class-string<CommonITILObject> $type */
+        foreach ($itil_types as $type) {
+            if ($type::canView()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static function canUpdate()

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -2522,7 +2522,7 @@ JAVASCRIPT;
                      }
 
                      if (is_subclass_of($item, "CommonITILTask")) {
-                         $parentitemtype = $item->getItilObjectItemType();
+                         $parentitemtype = $item::getItilObjectItemType();
                          if (!$update["_job"] = getItemForItemtype($parentitemtype)) {
                              return;
                          }

--- a/src/ProblemTask.php
+++ b/src/ProblemTask.php
@@ -50,13 +50,6 @@ class ProblemTask extends CommonITILTask
           || Session::haveRight(self::$rightname, parent::ADDALLITEM);
     }
 
-
-    public static function canView()
-    {
-        return Session::haveRightsOr('problem', [Problem::READALL, Problem::READMY]);
-    }
-
-
     public static function canUpdate()
     {
         return Session::haveRight('problem', UPDATE)

--- a/src/RichText/UserMention.php
+++ b/src/RichText/UserMention.php
@@ -122,7 +122,7 @@ final class UserMention
                 'validation_status' => $item->fields['status']
             ];
 
-            $main_item = getItemForItemtype($item->getItilObjectItemType());
+            $main_item = getItemForItemtype($item::getItilObjectItemType());
             $main_item->getFromDB($item->fields[$item::$items_id]);
         } else if ($item instanceof ITILFollowup) {
             $options = [

--- a/src/Search/SearchEngine.php
+++ b/src/Search/SearchEngine.php
@@ -130,7 +130,7 @@ final class SearchEngine
 
             if ($key === 'itil_types') {
                 if (is_a($item, \CommonITILTask::class) || is_a($item, \CommonITILValidation::class)) {
-                    $linked[] = $item->getItilObjectItemType();
+                    $linked[] = $item::getItilObjectItemType();
                 } else {
                     $timeline_types = [\ITILFollowup::class, \ITILSolution::class];
                     foreach ($timeline_types as $timeline_type) {

--- a/src/TicketTask.php
+++ b/src/TicketTask.php
@@ -50,14 +50,6 @@ class TicketTask extends CommonITILTask
               || Session::haveRight('ticket', Ticket::OWN));
     }
 
-
-    public static function canView()
-    {
-        return (Session::haveRightsOr(self::$rightname, [parent::SEEPUBLIC, parent::SEEPRIVATE])
-              || Session::haveRight('ticket', Ticket::OWN));
-    }
-
-
     public static function canUpdate()
     {
         return (Session::haveRight(self::$rightname, parent::UPDATEALL)

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -688,7 +688,7 @@ class Webhook extends CommonDBTM implements FilterableInterface
                 $parent_name = $itemtypes[$controller]['main'][$itemtype_value]['name'];
                 $parent_id = $items_id_value;
             } else if ($item instanceof CommonITILTask) {
-                $parent_itemtype = $item->getItilObjectItemType();
+                $parent_itemtype = $item::getItilObjectItemType();
                 $parent_name = $itemtypes[$controller]['main'][$parent_itemtype]['name'];
                 $parent_id = $item->fields[$parent_itemtype::getForeignKeyField()];
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13904

Original reported issue was that documents attached to solutions were not visible to technicians with the "See my ticket" permission missing even though they instead had "See all" permission. While working on this fix, I found that the `canView` method for Followups, Tasks and Solutions all seemed inconsistent.

Changes in this PR:
- Followups and Tasks `canView` now checks permission to see public or private followups first. If that check fails, access is denied. Simply having the ability to view one of the parent types is no longer enough for the global check.
- Followups, Tasks and Solutions `canView` now checks the parent item(s) own `canView` method rather than just the "See my" right and the right to "Be in charge" (in the case of tickets).

So, having the permission to see your own tickets/changes/problems should no longer be a blocker for the `canView` global check when you can otherwise see those item types. However, not having permission to see public or private followups/tasks IS now a blocker for those types' `canView` global check.