### PR TITLE
Improve SQL performance in item_rack form

### DIFF
--- a/src/Item_Rack.php
+++ b/src/Item_Rack.php
@@ -595,9 +595,8 @@ JAVASCRIPT;
         foreach ($iterator as $row) {
             if ($row['is_reserved']) {
                 $used_reserved[$row['itemtype']][] = $row['items_id'];
-            } else {
-                $used[$row['itemtype']][] = $row['items_id'];
             }
+            $used[$row['itemtype']][] = $row['items_id'];
         }
         // find used pdu (not racked)
         foreach (PDU_Rack::getUsed(['pdus_id']) as $used_pdu) {

--- a/src/Item_Rack.php
+++ b/src/Item_Rack.php
@@ -589,28 +589,24 @@ JAVASCRIPT;
        //get all used items
         $used = $used_reserved = [];
         $iterator = $DB->request([
-            'FROM' => $this->getTable()
+            'SELECT' => ['itemtype', 'items_id', 'is_reserved'],
+            'FROM' => static::getTable()
         ]);
         foreach ($iterator as $row) {
-            $used[$row['itemtype']][] = $row['items_id'];
+            if ($row['is_reserved']) {
+                $used_reserved[$row['itemtype']][] = $row['items_id'];
+            } else {
+                $used[$row['itemtype']][] = $row['items_id'];
+            }
         }
-       // find used pdu (not racked)
+        // find used pdu (not racked)
         foreach (PDU_Rack::getUsed() as $used_pdu) {
             $used['PDU'][] = $used_pdu['pdus_id'];
-        }
-       // get all reserved items
-        $iterator = $DB->request([
-            'FROM'  => $this->getTable(),
-            'WHERE' => [
-                'is_reserved' => true
-            ]
-        ]);
-        foreach ($iterator as $row) {
-            $used_reserved[$row['itemtype']][] = $row['items_id'];
         }
 
        //items part of an enclosure should not be listed
         $iterator = $DB->request([
+            'SELECT' => ['itemtype', 'items_id'],
             'FROM'   => Item_Enclosure::getTable()
         ]);
         foreach ($iterator as $row) {

--- a/src/Item_Rack.php
+++ b/src/Item_Rack.php
@@ -600,7 +600,7 @@ JAVASCRIPT;
             }
         }
         // find used pdu (not racked)
-        foreach (PDU_Rack::getUsed() as $used_pdu) {
+        foreach (PDU_Rack::getUsed(['pdus_id']) as $used_pdu) {
             $used['PDU'][] = $used_pdu['pdus_id'];
         }
 

--- a/src/PDU_Rack.php
+++ b/src/PDU_Rack.php
@@ -718,14 +718,16 @@ JAVASCRIPT;
     /**
      * Return an iterator for all used pdu in all racks
      *
-     * @return  Iterator
+     * @param array $fields_requested Fields to request
+     * @return DBmysqlIterator
      */
-    public static function getUsed()
+    public static function getUsed($fields_requested = ['*'])
     {
         /** @var \DBmysql $DB */
         global $DB;
 
         return $DB->request([
+            'SELECT' => $fields_requested,
             'FROM'  => self::getTable()
         ]);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Issue:
Showing the form for Item_Rack (items in a rack) performs 2 full scans of the `glpi_items_racks` table, a full scan of the `glpi_items_enclosures` table and a full scan of the `glpi_pdus_racks` table. In every case, it also requests every column from those tables.

Solution:
The 2 scans of the `glpi_items_racks` table have been combined. All full table requests have also been limited to only return the data we use.