### PR TITLE
fix(LDAP sync): connection lost

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -1919,14 +1919,13 @@ class AuthLDAP extends CommonDBTM
                 ) {
                     // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
                     if (ldap_errno($ds) !== 32) {
-                        trigger_error(
+                        throw new \RuntimeException(
                             static::buildError(
                                 $ds,
                                 sprintf('LDAP search with base DN `%s` and filter `%s` failed', $values['basedn'], $filter)
                             ),
                             E_USER_WARNING
                         );
-                        throw new \RuntimeException(ldap_error($ds));
                     }
                     return false;
                 }
@@ -1940,7 +1939,7 @@ class AuthLDAP extends CommonDBTM
                 if ($sr === false) {
                     // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
                     if (ldap_errno($ds) !== 32) {
-                        trigger_error(
+                        throw new \RuntimeException(
                             static::buildError(
                                 $ds,
                                 sprintf('LDAP search with base DN `%s` and filter `%s` failed', $values['basedn'], $filter)
@@ -2635,7 +2634,7 @@ class AuthLDAP extends CommonDBTM
                 ) {
                     // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
                     if (ldap_errno($ldap_connection) !== 32) {
-                        trigger_error(
+                        throw new \RuntimeException(
                             static::buildError(
                                 $ldap_connection,
                                 sprintf('LDAP search with base DN `%s` and filter `%s` failed', $config_ldap->fields['basedn'], $filter)
@@ -2655,7 +2654,7 @@ class AuthLDAP extends CommonDBTM
                 if ($sr === false) {
                     // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
                     if (ldap_errno($ldap_connection) !== 32) {
-                        trigger_error(
+                        throw new \RuntimeException(
                             static::buildError(
                                 $ldap_connection,
                                 sprintf('LDAP search with base DN `%s` and filter `%s` failed', $config_ldap->fields['basedn'], $filter)
@@ -3588,7 +3587,7 @@ class AuthLDAP extends CommonDBTM
         if ($result === false) {
             // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
             if (ldap_errno($ds) !== 32) {
-                trigger_error(
+                throw new \RuntimeException(
                     static::buildError(
                         $ds,
                         sprintf('LDAP search with base DN `%s` and filter `%s` failed', $values['basedn'], $filter)

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -1917,21 +1917,25 @@ class AuthLDAP extends CommonDBTM
                     $sr === false
                     || @ldap_parse_result($ds, $sr, $errcode, $matcheddn, $errmsg, $referrals, $controls) === false
                 ) {
-                    // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
-                    $error_code = ldap_errno($ds);
-                    if (ldap_errno($ds) !== 32) {
-                        $error_message = sprintf('LDAP search with base DN `%s` and filter `%s` failed', $values['basedn'], $filter);
-                        if ($error_code === -1) {
-                            $error_message = ldap_error($ds);
-                        }
+                    if (ldap_errno($ds) === -1) {
                         trigger_error(
                             static::buildError(
                                 $ds,
-                                $error_message
+                                ldap_error($ds)
                             ),
                             E_USER_WARNING
                         );
                         exit;
+                    }
+                    // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
+                    if (ldap_errno($ds) !== 32) {
+                        trigger_error(
+                            static::buildError(
+                                $ds,
+                                sprintf('LDAP search with base DN `%s` and filter `%s` failed', $values['basedn'], $filter)
+                            ),
+                            E_USER_WARNING
+                        );
                     }
                     return false;
                 }
@@ -1943,21 +1947,25 @@ class AuthLDAP extends CommonDBTM
             } else {
                 $sr = @ldap_search($ds, $values['basedn'], $filter, $attrs);
                 if ($sr === false) {
-                    // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
-                    $error_code = ldap_errno($ds);
-                    if (ldap_errno($ds) !== 32) {
-                        $error_message = sprintf('LDAP search with base DN `%s` and filter `%s` failed', $values['basedn'], $filter);
-                        if ($error_code === -1) {
-                            $error_message = ldap_error($ds);
-                        }
+                    if (ldap_errno($ds) === -1) {
                         trigger_error(
                             static::buildError(
                                 $ds,
-                                $error_message
+                                ldap_error($ds)
                             ),
                             E_USER_WARNING
                         );
                         exit;
+                    }
+                    // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
+                    if (ldap_errno($ds) !== 32) {
+                        trigger_error(
+                            static::buildError(
+                                $ds,
+                                sprintf('LDAP search with base DN `%s` and filter `%s` failed', $values['basedn'], $filter)
+                            ),
+                            E_USER_WARNING
+                        );
                     }
                     return false;
                 }
@@ -3596,21 +3604,25 @@ class AuthLDAP extends CommonDBTM
 
         $result = @ldap_search($ds, $values['basedn'], $filter, $attrs);
         if ($result === false) {
-            // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
-            $error_code = ldap_errno($ds);
-            if (ldap_errno($ds) !== 32) {
-                $error_message = sprintf('LDAP search with base DN `%s` and filter `%s` failed', $values['basedn'], $filter);
-                if ($error_code === -1) {
-                    $error_message = ldap_error($ds);
-                }
+            if (ldap_errno($ds) === -1) {
                 trigger_error(
                     static::buildError(
                         $ds,
-                        $error_message
+                        ldap_error($ds)
                     ),
                     E_USER_WARNING
                 );
                 exit;
+            }
+            // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
+            if (ldap_errno($ds) !== 32) {
+                trigger_error(
+                    static::buildError(
+                        $ds,
+                        sprintf('LDAP search with base DN `%s` and filter `%s` failed', $values['basedn'], $filter)
+                    ),
+                    E_USER_WARNING
+                );
             }
             return false;
         }
@@ -3651,21 +3663,25 @@ class AuthLDAP extends CommonDBTM
 
         $result = @ldap_read($ds, Sanitizer::unsanitize($dn), $condition, $attrs);
         if ($result === false) {
-            // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
-            $error_code = ldap_errno($ds);
-            if (ldap_errno($ds) !== 32) {
-                $error_message = sprintf('LDAP search with base DN `%s` and filter `%s` failed', $dn, $condition);
-                if ($error_code === -1) {
-                    $error_message = ldap_error($ds);
-                }
+            if (ldap_errno($ds) === -1) {
                 trigger_error(
                     static::buildError(
                         $ds,
-                        $error_message
+                        ldap_error($ds)
                     ),
                     E_USER_WARNING
                 );
                 exit;
+            }
+            // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
+            if (ldap_errno($ds) !== 32) {
+                trigger_error(
+                    static::buildError(
+                        $ds,
+                        sprintf('Unable to get LDAP object having DN `%s` with filter `%s`', $dn, $condition)
+                    ),
+                    E_USER_WARNING
+                );
             }
             return false;
         }

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -1918,14 +1918,20 @@ class AuthLDAP extends CommonDBTM
                     || @ldap_parse_result($ds, $sr, $errcode, $matcheddn, $errmsg, $referrals, $controls) === false
                 ) {
                     // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
+                    $error_code = ldap_errno($ds);
                     if (ldap_errno($ds) !== 32) {
+                        $error_message = sprintf('LDAP search with base DN `%s` and filter `%s` failed', $values['basedn'], $filter);
+                        if ($error_code === -1) {
+                            $error_message = ldap_error($ds);
+                        }
                         trigger_error(
                             static::buildError(
                                 $ds,
-                                sprintf('LDAP search with base DN `%s` and filter `%s` failed', $values['basedn'], $filter)
+                                $error_message
                             ),
                             E_USER_WARNING
                         );
+                        exit;
                     }
                     return false;
                 }
@@ -1938,14 +1944,20 @@ class AuthLDAP extends CommonDBTM
                 $sr = @ldap_search($ds, $values['basedn'], $filter, $attrs);
                 if ($sr === false) {
                     // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
+                    $error_code = ldap_errno($ds);
                     if (ldap_errno($ds) !== 32) {
+                        $error_message = sprintf('LDAP search with base DN `%s` and filter `%s` failed', $values['basedn'], $filter);
+                        if ($error_code === -1) {
+                            $error_message = ldap_error($ds);
+                        }
                         trigger_error(
                             static::buildError(
                                 $ds,
-                                sprintf('LDAP search with base DN `%s` and filter `%s` failed', $values['basedn'], $filter)
+                                $error_message
                             ),
                             E_USER_WARNING
                         );
+                        exit;
                     }
                     return false;
                 }
@@ -3585,14 +3597,20 @@ class AuthLDAP extends CommonDBTM
         $result = @ldap_search($ds, $values['basedn'], $filter, $attrs);
         if ($result === false) {
             // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
+            $error_code = ldap_errno($ds);
             if (ldap_errno($ds) !== 32) {
+                $error_message = sprintf('LDAP search with base DN `%s` and filter `%s` failed', $values['basedn'], $filter);
+                if ($error_code === -1) {
+                    $error_message = ldap_error($ds);
+                }
                 trigger_error(
                     static::buildError(
                         $ds,
-                        sprintf('LDAP search with base DN `%s` and filter `%s` failed', $values['basedn'], $filter)
+                        $error_message
                     ),
                     E_USER_WARNING
                 );
+                exit;
             }
             return false;
         }
@@ -3634,14 +3652,20 @@ class AuthLDAP extends CommonDBTM
         $result = @ldap_read($ds, Sanitizer::unsanitize($dn), $condition, $attrs);
         if ($result === false) {
             // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
+            $error_code = ldap_errno($ds);
             if (ldap_errno($ds) !== 32) {
+                $error_message = sprintf('LDAP search with base DN `%s` and filter `%s` failed', $dn, $condition);
+                if ($error_code === -1) {
+                    $error_message = ldap_error($ds);
+                }
                 trigger_error(
                     static::buildError(
                         $ds,
-                        sprintf('Unable to get LDAP object having DN `%s` with filter `%s`', $dn, $condition)
+                        $error_message
                     ),
                     E_USER_WARNING
                 );
+                exit;
             }
             return false;
         }

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -3663,7 +3663,12 @@ class AuthLDAP extends CommonDBTM
             return false;
         }
 
-        $info = self::get_entries_clean($ds, $result);
+        $info = self::get_entries_clean($ds, $result, $error);
+
+        if ($error === true) {
+            return false;
+        }
+
         if (is_array($info) && ($info['count'] == 1)) {
             return $info[0];
         }

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -1917,16 +1917,6 @@ class AuthLDAP extends CommonDBTM
                     $sr === false
                     || @ldap_parse_result($ds, $sr, $errcode, $matcheddn, $errmsg, $referrals, $controls) === false
                 ) {
-                    if (ldap_errno($ds) === -1) {
-                        trigger_error(
-                            static::buildError(
-                                $ds,
-                                ldap_error($ds)
-                            ),
-                            E_USER_WARNING
-                        );
-                        exit;
-                    }
                     // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
                     if (ldap_errno($ds) !== 32) {
                         trigger_error(
@@ -1936,6 +1926,7 @@ class AuthLDAP extends CommonDBTM
                             ),
                             E_USER_WARNING
                         );
+                        throw new \RuntimeException(ldap_error($ds));
                     }
                     return false;
                 }
@@ -1947,16 +1938,6 @@ class AuthLDAP extends CommonDBTM
             } else {
                 $sr = @ldap_search($ds, $values['basedn'], $filter, $attrs);
                 if ($sr === false) {
-                    if (ldap_errno($ds) === -1) {
-                        trigger_error(
-                            static::buildError(
-                                $ds,
-                                ldap_error($ds)
-                            ),
-                            E_USER_WARNING
-                        );
-                        exit;
-                    }
                     // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
                     if (ldap_errno($ds) !== 32) {
                         trigger_error(
@@ -1966,6 +1947,7 @@ class AuthLDAP extends CommonDBTM
                             ),
                             E_USER_WARNING
                         );
+                        throw new \RuntimeException(ldap_error($ds));
                     }
                     return false;
                 }
@@ -3604,16 +3586,6 @@ class AuthLDAP extends CommonDBTM
 
         $result = @ldap_search($ds, $values['basedn'], $filter, $attrs);
         if ($result === false) {
-            if (ldap_errno($ds) === -1) {
-                trigger_error(
-                    static::buildError(
-                        $ds,
-                        ldap_error($ds)
-                    ),
-                    E_USER_WARNING
-                );
-                exit;
-            }
             // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
             if (ldap_errno($ds) !== 32) {
                 trigger_error(
@@ -3623,6 +3595,7 @@ class AuthLDAP extends CommonDBTM
                     ),
                     E_USER_WARNING
                 );
+                throw new \RuntimeException(ldap_error($ds));
             }
             return false;
         }
@@ -3663,16 +3636,6 @@ class AuthLDAP extends CommonDBTM
 
         $result = @ldap_read($ds, Sanitizer::unsanitize($dn), $condition, $attrs);
         if ($result === false) {
-            if (ldap_errno($ds) === -1) {
-                trigger_error(
-                    static::buildError(
-                        $ds,
-                        ldap_error($ds)
-                    ),
-                    E_USER_WARNING
-                );
-                exit;
-            }
             // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
             if (ldap_errno($ds) !== 32) {
                 trigger_error(
@@ -3682,6 +3645,7 @@ class AuthLDAP extends CommonDBTM
                     ),
                     E_USER_WARNING
                 );
+                throw new \RuntimeException(ldap_error($ds));
             }
             return false;
         }

--- a/src/User.php
+++ b/src/User.php
@@ -2192,7 +2192,8 @@ class User extends CommonDBTM
         if ($sr === false) {
             // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
             if (ldap_errno($ds) !== 32) {
-                throw new \RuntimeException(
+                $error = true;
+                trigger_error(
                     AuthLDAP::buildError(
                         $ds,
                         sprintf('LDAP search with base DN `%s` and filter `%s` failed', $ldap_base_dn, $filter)

--- a/src/User.php
+++ b/src/User.php
@@ -2190,21 +2190,25 @@ class User extends CommonDBTM
         $sr = @ldap_search($ds, $ldap_base_dn, $filter, $attrs);
 
         if ($sr === false) {
-            // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
-            $error_code = ldap_errno($ds);
-            if (ldap_errno($ds) !== 32) {
-                $error_message = sprintf('LDAP search with base DN `%s` and filter `%s` failed', $ldap_base_dn, $filter);
-                if ($error_code === -1) {
-                    $error_message = ldap_error($ds);
-                }
+            if (ldap_errno($ds) === -1) {
                 trigger_error(
                     AuthLDAP::buildError(
                         $ds,
-                        $error_message
+                        ldap_error($ds)
                     ),
                     E_USER_WARNING
                 );
                 exit;
+            }
+            // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
+            if (ldap_errno($ds) !== 32) {
+                trigger_error(
+                    AuthLDAP::buildError(
+                        $ds,
+                        sprintf('LDAP search with base DN `%s` and filter `%s` failed', $ldap_base_dn, $filter)
+                    ),
+                    E_USER_WARNING
+                );
             }
             return $groups;
         }

--- a/src/User.php
+++ b/src/User.php
@@ -2192,14 +2192,13 @@ class User extends CommonDBTM
         if ($sr === false) {
             // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
             if (ldap_errno($ds) !== 32) {
-                trigger_error(
+                throw new \RuntimeException(
                     AuthLDAP::buildError(
                         $ds,
                         sprintf('LDAP search with base DN `%s` and filter `%s` failed', $ldap_base_dn, $filter)
                     ),
                     E_USER_WARNING
                 );
-                throw new \RuntimeException(ldap_error($ds));
             }
             return $groups;
         }

--- a/src/User.php
+++ b/src/User.php
@@ -2192,7 +2192,6 @@ class User extends CommonDBTM
         if ($sr === false) {
             // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
             if (ldap_errno($ds) !== 32) {
-                $error = true;
                 trigger_error(
                     AuthLDAP::buildError(
                         $ds,

--- a/src/User.php
+++ b/src/User.php
@@ -2190,16 +2190,6 @@ class User extends CommonDBTM
         $sr = @ldap_search($ds, $ldap_base_dn, $filter, $attrs);
 
         if ($sr === false) {
-            if (ldap_errno($ds) === -1) {
-                trigger_error(
-                    AuthLDAP::buildError(
-                        $ds,
-                        ldap_error($ds)
-                    ),
-                    E_USER_WARNING
-                );
-                exit;
-            }
             // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
             if (ldap_errno($ds) !== 32) {
                 trigger_error(
@@ -2209,6 +2199,7 @@ class User extends CommonDBTM
                     ),
                     E_USER_WARNING
                 );
+                throw new \RuntimeException(ldap_error($ds));
             }
             return $groups;
         }

--- a/src/User.php
+++ b/src/User.php
@@ -2191,14 +2191,20 @@ class User extends CommonDBTM
 
         if ($sr === false) {
             // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
+            $error_code = ldap_errno($ds);
             if (ldap_errno($ds) !== 32) {
+                $error_message = sprintf('LDAP search with base DN `%s` and filter `%s` failed', $ldap_base_dn, $filter);
+                if ($error_code === -1) {
+                    $error_message = ldap_error($ds);
+                }
                 trigger_error(
                     AuthLDAP::buildError(
                         $ds,
-                        sprintf('LDAP search with base DN `%s` and filter `%s` failed', $ldap_base_dn, $filter)
+                        $error_message
                     ),
                     E_USER_WARNING
                 );
+                exit;
             }
             return $groups;
         }


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !31097

When the connection to LDAP is lost during synchronization, synchronization continues, treating the users as deleted.
