### PR TITLE
Forms: questions categories

### DIFF
--- a/install/migrations/update_10.0.x_to_10.1.0/form.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/form.php
@@ -90,7 +90,6 @@ if (!$DB->tableExists('glpi_forms_questions')) {
             `forms_sections_id` int {$default_key_sign} NOT NULL DEFAULT '0',
             `name` varchar(255) NOT NULL DEFAULT '',
             `type` varchar(255) NOT NULL DEFAULT '',
-            `subtype` varchar(255) NOT NULL DEFAULT '',
             `is_mandatory` tinyint NOT NULL DEFAULT '0',
             `rank` int NOT NULL DEFAULT '0',
             `description` longtext,
@@ -138,4 +137,33 @@ if (GLPI_VERSION == "10.1.0-dev") {
     $migration->changeField("glpi_forms_forms", "header", "header", "longtext");
     $migration->changeField("glpi_forms_sections", "description", "description", "longtext");
     $migration->changeField("glpi_forms_questions", "description", "description", "longtext");
+
+    // Deletion of subtype, use final type in `type` field instead
+    if ($DB->fieldExists("glpi_forms_questions", "subtype")) {
+        $migration->dropField("glpi_forms_questions", "subtype");
+
+        // Set a concrete type instead the "parent type" that was used before this migration
+        $questions = $DB->request([
+            'SELECT' => ['id', 'type'],
+            'FROM' => 'glpi_forms_questions',
+        ]);
+        foreach ($questions as $question) {
+            if ($question['type'] == "Glpi\Form\QuestionType\QuestionTypeShortAnswer") {
+                // Default subtype for short answers
+                $new_type = "Glpi\Form\QuestionType\QuestionTypeShortAnswerText";
+            } elseif ($question['type'] == "Glpi\Form\QuestionType\QuestionTypeLongAnswer") {
+                // Long answers have no sub types, use parent
+                $new_type = $question['type'];
+            } else {
+                // Unknown type
+                continue;
+            }
+
+            $migration->addPostQuery($DB->buildUpdate(
+                'glpi_forms_questions',
+                ['type' => $new_type],
+                ['id' => $question['id']]
+            ));
+        }
+    }
 }

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9511,7 +9511,6 @@ CREATE TABLE `glpi_forms_questions` (
     `forms_sections_id` int unsigned NOT NULL DEFAULT '0',
     `name` varchar(255) NOT NULL DEFAULT '',
     `type` varchar(255) NOT NULL DEFAULT '',
-    `subtype` varchar(255) NOT NULL DEFAULT '',
     `is_mandatory` tinyint NOT NULL DEFAULT '0',
     `rank` int NOT NULL DEFAULT '0',
     `description` longtext,

--- a/js/form_editor_controller.js
+++ b/js/form_editor_controller.js
@@ -212,6 +212,14 @@ class GlpiFormEditorController
                 this.#computeDynamicInputSize(target[0]);
                 break;
 
+            // Change the type category of the target question
+            case "change-question-type-category":
+                this.#changeQuestionTypeCategory(
+                    target.closest("[data-glpi-form-editor-question]"),
+                    target.val()
+                );
+                break;
+
             // Change the type of the target question
             case "change-question-type":
                 this.#changeQuestionType(
@@ -604,9 +612,42 @@ class GlpiFormEditorController
     }
 
     /**
+     * Change the type category of the given question.
+     * @param {jQuery} question  Question to update
+     * @param {string} category  New category
+     */
+    #changeQuestionTypeCategory(question, category) {
+        // Find types available in the new category
+        const e_category = $.escapeSelector(category);
+        const new_options = $(this.#templates)
+            .find(`option[data-glpi-form-editor-question-type=${e_category}]`);
+
+        // Remove current types options
+        const types_select = question
+            .find("[data-glpi-form-editor-question-type-selector]");
+        types_select.children().remove();
+
+        // Copy the new types options into the dropdown
+        this.#copy_template(
+            new_options,
+            types_select,
+        );
+
+        // Hide type selector if only one type is available
+        if (new_options.length <= 1) {
+            types_select.addClass("d-none");
+        } else {
+            types_select.removeClass("d-none");
+        }
+
+        // Trigger type change
+        types_select.trigger("change");
+    }
+
+    /**
      * Change the type of the given question.
      * @param {jQuery} question Question to update
-     * @param {string} type     New parent type
+     * @param {string} type     New type
      */
     #changeQuestionType(question, type) {
         // Clear the specific form of the question

--- a/src/Form/AnswersHandler/AnswersHandler.php
+++ b/src/Form/AnswersHandler/AnswersHandler.php
@@ -37,6 +37,7 @@ namespace Glpi\Form\AnswersHandler;
 
 use Glpi\Form\AnswersSet;
 use Glpi\Form\Form;
+use Glpi\Form\QuestionType\QuestionTypeInterface;
 use Session;
 
 /**
@@ -99,5 +100,30 @@ class AnswersHandler
         ]);
 
         return $id !== false ? $answers_set : false;
+    }
+
+    /**
+     * Insert additionnal data into the given raw answers array to be used when rendering
+     *
+     * @param array $answers The raw answers array
+     *
+     * @return array The formatted answers array
+     */
+    public function prepareAnswersForDisplay(array $answers): array
+    {
+        $computed_answers = [];
+
+        // Insert types objects which will be used to render the answers
+        foreach ($answers as $answer) {
+            $type = $answer['type'] ?? "";
+            if (!is_a($answer['type'], QuestionTypeInterface::class, true)) {
+                continue;
+            }
+
+            $answer['type'] = new $type();
+            $computed_answers[] = $answer;
+        }
+
+        return $computed_answers;
     }
 }

--- a/src/Form/AnswersSet.php
+++ b/src/Form/AnswersSet.php
@@ -38,7 +38,7 @@ namespace Glpi\Form;
 use CommonDBChild;
 use CommonGLPI;
 use Glpi\Application\View\TemplateRenderer;
-use Glpi\Form\QuestionType\QuestionTypesLoader;
+use Glpi\Form\AnswersHandler\AnswersHandler;
 use Log;
 use Search;
 use User;
@@ -152,12 +152,14 @@ class AnswersSet extends CommonDBChild
         $this->getFromDB($id);
         $this->initForm($id, $options);
 
+        $answer_handler = new AnswersHandler();
+
         // Render twig template
         $twig = TemplateRenderer::getInstance();
         $twig->display('pages/admin/form/display_answers.html.twig', [
-            'item'           => $this,
-            'params'         => $options,
-            'question_types' => (new QuestionTypesLoader())->getQuestionTypes(),
+            'item'    => $this,
+            'answers' => $answer_handler->prepareAnswersForDisplay($this->fields['answers']),
+            'params'  => $options,
         ]);
         return true;
     }

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -40,8 +40,8 @@ use Entity;
 use Glpi\Application\View\TemplateRenderer;
 use Html;
 use Glpi\DBAL\QuerySubQuery;
-use Glpi\Form\QuestionType\QuestionTypeShortAnswer;
-use Glpi\Form\QuestionType\QuestionTypesLoader;
+use Glpi\Form\QuestionType\QuestionTypeShortAnswerText;
+use Glpi\Form\QuestionType\QuestionTypesManager;
 use Log;
 
 /**
@@ -101,10 +101,9 @@ class Form extends CommonDBTM
         // Render twig template
         $twig = TemplateRenderer::getInstance();
         $twig->display('pages/admin/form/form_editor.html.twig', [
-            'item'                  => $this,
-            'params'                => $options,
-            'question_types'        => (new QuestionTypesLoader())->getQuestionTypes(),
-            'default_question_type' => QuestionTypeShortAnswer::class,
+            'item'                   => $this,
+            'params'                 => $options,
+            'question_types_manager' => QuestionTypesManager::getInstance(),
         ]);
         return true;
     }

--- a/src/Form/Question.php
+++ b/src/Form/Question.php
@@ -36,6 +36,7 @@
 namespace Glpi\Form;
 
 use CommonDBChild;
+use Glpi\Form\QuestionType\QuestionTypeInterface;
 
 /**
  * Question of a given helpdesk form's section
@@ -44,4 +45,20 @@ class Question extends CommonDBChild
 {
     public static $itemtype = Section::class;
     public static $items_id = 'forms_sections_id';
+
+    /**
+     * Get type object for the current object.
+     *
+     * @return QuestionTypeInterface|null
+     */
+    public function getQuestionType(): ?QuestionTypeInterface
+    {
+        $type = $this->fields['type'] ?? "";
+
+        if (!is_a($type, QuestionTypeInterface::class, true)) {
+            return null;
+        }
+
+        return new $type();
+    }
 }

--- a/src/Form/QuestionType/QuestionTypeCategory.php
+++ b/src/Form/QuestionType/QuestionTypeCategory.php
@@ -36,22 +36,29 @@
 namespace Glpi\Form\QuestionType;
 
 /**
- * Helper class to load all available question types
- * TODO: singleton
+ * List of valid question types categories
  */
-class QuestionTypesLoader
+enum QuestionTypesCategory: string
 {
     /**
-     * Return an array of question types instance, using their classes name as
-     * keys
-     *
-     * @return QuestionTypeInterface[]
+     * Questions that expect short single line answers (text, number, ...)
      */
-    public function getQuestionTypes(): array
+    case SHORT_ANSWER = "short_answer";
+
+    /**
+     * Question that expect long detailled answers (textarea)
+     */
+    case LONG_ANSWER = "long_answer";
+
+    /**
+     * Get category label
+     * @return string
+     */
+    public function getLabel(): string
     {
-        return [
-            QuestionTypeShortAnswer::class => new QuestionTypeShortAnswer(),
-            QuestionTypeLongAnswer::class => new QuestionTypeLongAnswer(),
-        ];
+        return match ($this) {
+            self::SHORT_ANSWER => __("Short answer"),
+            self::LONG_ANSWER  => __("Long answer"),
+        };
     }
 }

--- a/src/Form/QuestionType/QuestionTypeInterface.php
+++ b/src/Form/QuestionType/QuestionTypeInterface.php
@@ -78,4 +78,11 @@ interface QuestionTypeInterface
      * @return string
      */
     public function getName(): string;
+
+    /**
+     * Get the category of this question type.
+     *
+     * @return QuestionTypesCategory
+     */
+    public function getCategory(): QuestionTypesCategory;
 }

--- a/src/Form/QuestionType/QuestionTypeInterface.php
+++ b/src/Form/QuestionType/QuestionTypeInterface.php
@@ -42,6 +42,8 @@ use Glpi\Form\Question;
  */
 interface QuestionTypeInterface
 {
+    public function __construct();
+
     /**
      * Render the administration template for the given question.
      * This template is used on the form editor page.

--- a/src/Form/QuestionType/QuestionTypeLongAnswer.php
+++ b/src/Form/QuestionType/QuestionTypeLongAnswer.php
@@ -45,6 +45,11 @@ use Override;
 class QuestionTypeLongAnswer implements QuestionTypeInterface
 {
     #[Override]
+    public function __construct()
+    {
+    }
+
+    #[Override]
     public function renderAdminstrationTemplate(?Question $question): string
     {
         $template = <<<TWIG

--- a/src/Form/QuestionType/QuestionTypeLongAnswer.php
+++ b/src/Form/QuestionType/QuestionTypeLongAnswer.php
@@ -37,12 +37,14 @@ namespace Glpi\Form\QuestionType;
 
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Form\Question;
+use Override;
 
 /**
  * Long answers are multiple lines inputs used to answer questions with as much details as needed.
  */
 class QuestionTypeLongAnswer implements QuestionTypeInterface
 {
+    #[Override]
     public function renderAdminstrationTemplate(?Question $question): string
     {
         $template = <<<TWIG
@@ -72,6 +74,7 @@ TWIG;
         ]);
     }
 
+    #[Override]
     public function renderEndUserTemplate(Question $question): string
     {
         // TODO: handle required
@@ -100,6 +103,7 @@ TWIG;
         ]);
     }
 
+    #[Override]
     public function renderAnswerTemplate($answer): string
     {
         $template = <<<TWIG
@@ -112,8 +116,15 @@ TWIG;
         ]);
     }
 
+    #[Override]
     public function getName(): string
     {
         return __("Long answer");
+    }
+
+    #[Override]
+    public function getCategory(): QuestionTypesCategory
+    {
+        return QuestionTypesCategory::LONG_ANSWER;
     }
 }

--- a/src/Form/QuestionType/QuestionTypeShortAnswer.php
+++ b/src/Form/QuestionType/QuestionTypeShortAnswer.php
@@ -44,6 +44,11 @@ use Override;
  */
 abstract class QuestionTypeShortAnswer implements QuestionTypeInterface
 {
+    #[Override]
+    public function __construct()
+    {
+    }
+
     /**
      * Specific input type for child classes
      *

--- a/src/Form/QuestionType/QuestionTypeShortAnswer.php
+++ b/src/Form/QuestionType/QuestionTypeShortAnswer.php
@@ -37,37 +37,50 @@ namespace Glpi\Form\QuestionType;
 
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Form\Question;
+use Override;
 
 /**
  * Short answers are single line inputs used to answer simple questions.
  */
-class QuestionTypeShortAnswer implements QuestionTypeInterface
+abstract class QuestionTypeShortAnswer implements QuestionTypeInterface
 {
-    public function renderAdminstrationTemplate(?Question $question): string
-    {
+    /**
+     * Specific input type for child classes
+     *
+     * @return string
+     */
+    abstract public function getInputType(): string;
+
+    #[Override]
+    public function renderAdminstrationTemplate(
+        ?Question $question = null,
+        ?string $input_prefix = null
+    ): string {
         $template = <<<TWIG
             <input
                 class="form-control mb-2"
-                type="text"
+                type="{{ input_type|e('html_attr') }}"
                 name="default_value"
-                placeholder="{{ placehoder|e('html_attr') }}"
+                placeholder="{{ input_placeholder|e('html_attr') }}"
                 value="{{ question is not null ? question.fields.default_value|e('html_attr') : '' }}"
             />
 TWIG;
 
         $twig = TemplateRenderer::getInstance();
         return $twig->renderFromStringTemplate($template, [
-            'question'   => $question,
-            'placehoder' => __('No default value'),
+            'question'          => $question,
+            'input_type'        => $this->getInputType(),
+            'input_placeholder' => $this->getName(),
         ]);
     }
 
+    #[Override]
     public function renderEndUserTemplate(
         Question $question,
     ): string {
         $template = <<<TWIG
             <input
-                type="text"
+                type="{{ input_type|e('html_attr') }}"
                 class="form-control"
                 name="answers[{{ question.fields.id|e('html_attr') }}]"
                 value="{{ question.fields.default_value|e('html_attr') }}"
@@ -77,10 +90,12 @@ TWIG;
 
         $twig = TemplateRenderer::getInstance();
         return $twig->renderFromStringTemplate($template, [
-            'question' => $question,
+            'question'   => $question,
+            'input_type' => $this->getInputType(),
         ]);
     }
 
+    #[Override]
     public function renderAnswerTemplate($answer): string
     {
         $template = <<<TWIG
@@ -93,8 +108,9 @@ TWIG;
         ]);
     }
 
-    public function getName(): string
+    #[Override]
+    public function getCategory(): QuestionTypesCategory
     {
-        return __("Short answer");
+        return QuestionTypesCategory::SHORT_ANSWER;
     }
 }

--- a/src/Form/QuestionType/QuestionTypeShortAnswerEmail.php
+++ b/src/Form/QuestionType/QuestionTypeShortAnswerEmail.php
@@ -33,30 +33,22 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Form\Renderer;
+namespace Glpi\Form\QuestionType;
 
-use Glpi\Application\View\TemplateRenderer;
-use Glpi\Form\Form;
+use Override;
+use Session;
 
-/**
- * Utility class used to easily render a form
- * TODO: could be a singleton to hightlight its role as a service and support
- * DI in the future
- */
-final class FormRenderer
+class QuestionTypeShortAnswerEmail extends QuestionTypeShortAnswer
 {
-    /**
-     * Render the given form.
-     *
-     * @param Form $form
-     *
-     * @return string
-     */
-    public function render(Form $form): string
+    #[Override]
+    public function getInputType(): string
     {
-        $twig = TemplateRenderer::getInstance();
-        return $twig->render('pages/form_renderer.html.twig', [
-            'form' => $form,
-        ]);
+        return 'email';
+    }
+
+    #[Override]
+    public function getName(): string
+    {
+        return _n('Email', 'Emails', Session::getPluralNumber());
     }
 }

--- a/src/Form/QuestionType/QuestionTypeShortAnswerNumber.php
+++ b/src/Form/QuestionType/QuestionTypeShortAnswerNumber.php
@@ -33,30 +33,21 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Form\Renderer;
+namespace Glpi\Form\QuestionType;
 
-use Glpi\Application\View\TemplateRenderer;
-use Glpi\Form\Form;
+use Override;
 
-/**
- * Utility class used to easily render a form
- * TODO: could be a singleton to hightlight its role as a service and support
- * DI in the future
- */
-final class FormRenderer
+class QuestionTypeShortAnswerNumber extends QuestionTypeShortAnswer
 {
-    /**
-     * Render the given form.
-     *
-     * @param Form $form
-     *
-     * @return string
-     */
-    public function render(Form $form): string
+    #[Override]
+    public function getInputType(): string
     {
-        $twig = TemplateRenderer::getInstance();
-        return $twig->render('pages/form_renderer.html.twig', [
-            'form' => $form,
-        ]);
+        return 'number';
+    }
+
+    #[Override]
+    public function getName(): string
+    {
+        return __("Number");
     }
 }

--- a/src/Form/QuestionType/QuestionTypeShortAnswerText.php
+++ b/src/Form/QuestionType/QuestionTypeShortAnswerText.php
@@ -33,30 +33,21 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Form\Renderer;
+namespace Glpi\Form\QuestionType;
 
-use Glpi\Application\View\TemplateRenderer;
-use Glpi\Form\Form;
+use Override;
 
-/**
- * Utility class used to easily render a form
- * TODO: could be a singleton to hightlight its role as a service and support
- * DI in the future
- */
-final class FormRenderer
+class QuestionTypeShortAnswerText extends QuestionTypeShortAnswer
 {
-    /**
-     * Render the given form.
-     *
-     * @param Form $form
-     *
-     * @return string
-     */
-    public function render(Form $form): string
+    #[Override]
+    public function getInputType(): string
     {
-        $twig = TemplateRenderer::getInstance();
-        return $twig->render('pages/form_renderer.html.twig', [
-            'form' => $form,
-        ]);
+        return 'text';
+    }
+
+    #[Override]
+    public function getName(): string
+    {
+        return __("Text");
     }
 }

--- a/src/Form/QuestionType/QuestionTypesManager.php
+++ b/src/Form/QuestionType/QuestionTypesManager.php
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\QuestionType;
+
+use DirectoryIterator;
+use ReflectionClass;
+
+/**
+ * Helper class to load all available question types
+ */
+final class QuestionTypesManager
+{
+    /**
+     * Singleton instance
+     * @var QuestionTypesManager|null
+     */
+    public static ?QuestionTypesManager $instance = null;
+
+    /**
+     * Available question types
+     * @var QuestionTypeInterface[]
+     */
+    protected array $question_types = [];
+
+    /**
+     * Private constructor to prevent instantiation (singleton)
+     */
+    private function __construct()
+    {
+        self::loadQuestionsTypes();
+    }
+
+    /**
+     * Get the default question type class
+     *
+     * @return string
+     */
+    public function getDefaultTypeClass(): string
+    {
+        return QuestionTypeShortAnswerText::class;
+    }
+
+    /**
+     * Get the singleton instance
+     *
+     * @return QuestionTypesManager
+     */
+    public static function getInstance(): QuestionTypesManager
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Get all available question categories
+     *
+     * @return iterable<QuestionTypesCategory>
+     */
+    public function getCategories(): iterable
+    {
+        return QuestionTypesCategory::cases();
+    }
+
+    /**
+     * Get all available question categories
+     *
+     * @return QuestionTypeInterface[]
+     */
+    public function getQuestionTypes(): array
+    {
+        return $this->question_types;
+    }
+
+    /**
+     * Get available types for a given parent category
+     *
+     * @param QuestionTypesCategory $category Parent category
+     *
+     * @return QuestionTypeInterface[]
+     */
+    public function getTypesForCategory(QuestionTypesCategory $category): array
+    {
+        return array_filter(
+            $this->question_types,
+            fn(QuestionTypeInterface $type) => $type->getCategory() === $category
+        );
+    }
+
+    /**
+     * Automatically build core questions type list.
+     *
+     * TODO: Would be better to do it with a DI auto-discovery feature, but
+     * it is not possible yet.
+     *
+     * @return void
+     */
+    protected function loadQuestionsTypes(): void
+    {
+        // Get files in the current directory
+        $directory_iterator = new DirectoryIterator(__DIR__);
+
+        /** @var \SplFileObject $file */
+        foreach ($directory_iterator as $file) {
+            // Compute class name with the expected namespace
+            $classname = $file->getExtension() === 'php'
+                ? 'Glpi\\Form\\QuestionType\\' . $file->getBasename('.php')
+                : null;
+
+            // Validate that the class is a valid question type
+            if (
+                $classname !== null
+                && class_exists($classname)
+                && is_subclass_of($classname, QuestionTypeInterface::class)
+                && (new ReflectionClass($classname))->isAbstract() === false
+            ) {
+                $this->question_types[$classname] = new $classname();
+            }
+        }
+    }
+}

--- a/templates/pages/admin/form/display_answers.html.twig
+++ b/templates/pages/admin/form/display_answers.html.twig
@@ -55,14 +55,13 @@
             </div>
         </div>
 
-        {% for answer in item.fields.answers %}
+        {% for answer in answers %}
             {% if answer.value is not empty %}
                 <div class="mb-3">
                     <label class="form-label">
                         {{ answer.label }}
                     </label>
-                    {% set question_type = question_types[answer.type] %}
-                    {{ question_type.renderAnswerTemplate(answer.value)|raw }}
+                    {{ answer.type.renderAnswerTemplate(answer.value)|raw }}
                 </div>
             {% endif %}
         {% endfor %}

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -31,6 +31,10 @@
  # ---------------------------------------------------------------------
  #}
 
+{# @var item   Glpi\Form\Form #}
+{# @var params array #}
+{# @var question_types_manager Glpi\Form\QuestionType\QuestionTypesManager #}
+
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
 {% set base_field_options = {
@@ -130,9 +134,9 @@
                             {% for question in section.getQuestions() %}
                                 {# Render admin template for the given question type #}
                                 {{ include('pages/admin/form/form_question.html.twig', {
-                                    'question_types': question_types,
-                                    'question_type' : question_types[question.fields.type],
-                                    'question'      : question,
+                                    'question_types_manager': question_types_manager,
+                                    'question_type'         : question.getQuestionType(),
+                                    'question'              : question,
                                 }, with_context = false) }}
                             {% endfor %}
                         {% endfor %}
@@ -283,18 +287,29 @@
     <div data-glpi-form-editor-templates class="d-none">
 
         {# Load all possible questions types as hidden DOM content that is ready to be copied for a new question #}
-        <div id="question_type_model_container" class="d-none">
-            {% for key, question_type in question_types %}
-                <div data-glpi-form-editor-question-template="{{ key }}">
-                    {# Render admin template for the given question type #}
-                    {{ include('pages/admin/form/form_question.html.twig', {
-                        'question_types': question_types,
-                        'question_type': question_type,
-                        'question': null,
-                    }, with_context = false) }}
-                </div>
+        {% for key, question_type in question_types_manager.getQuestionTypes() %}
+            <div data-glpi-form-editor-question-template="{{ key }}">
+                {# Render admin template for the given question type #}
+                {{ include('pages/admin/form/form_question.html.twig', {
+                    'question_types_manager' : question_types_manager,
+                    'question_type'          : question_type,
+                    'question'               : null,
+                    'section'                : null,
+                }, with_context = false) }}
+            </div>
+        {% endfor %}
+
+        {# Load all possible question types values #}
+        <select data-glpi-form-editor-question-types-values>
+            {% for key, question_type in question_types_manager.getQuestionTypes() %}
+                <option
+                    data-glpi-form-editor-question-type="{{ question_type.getCategory().value }}"
+                    value="{{ key }}"
+                >
+                    {{ question_type.getName() }}
+                </option>
             {% endfor %}
-        </div>
+        </select>
 
     </div>
 {% endif %}
@@ -315,7 +330,7 @@
     new GlpiFormEditorController(
         "[data-glpi-form-editor-container]",
         {{ item.fields.is_draft ? "true" : "false" }},
-        "{{ default_question_type|escape('js') }}",
+        "{{ question_types_manager.getDefaultTypeClass()|escape('js') }}",
         "[data-glpi-form-editor-templates]"
     );
 </script>

--- a/templates/pages/admin/form/form_question.html.twig
+++ b/templates/pages/admin/form/form_question.html.twig
@@ -31,9 +31,9 @@
  # ---------------------------------------------------------------------
  #}
 
-{# @var question_types Glpi\Form\QuestionType\QuestionTypeInterface[] #}
-{# @var question_type Glpi\Form\QuestionType\QuestionTypeInterface #}
-{# @var question      Glpi\Form\Question|null #}
+{# @var question_types_manager Glpi\Form\QuestionType\QuestionTypeInterface[] #}
+{# @var question_type          Glpi\Form\QuestionType\QuestionTypeInterface #}
+{# @var question               Glpi\Form\Question|null #}
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
@@ -100,14 +100,35 @@
             data-glpi-form-editor-question-extra-details
         >
             <select
-                name="type"
-                class="form-select form-select-sm"
+                {# Note: _type_category is not saved by the backend as we can guess it from the type itself #}
+                name="_type_category"
+                class="form-select form-select-sm me-2"
                 aria-label="{{ __('Question type') }}"
+                style="width: auto;"
+                data-glpi-form-editor-on-change="change-question-type-category"
+            >
+
+                {% for category in question_types_manager.getCategories() %}
+                    {# TODO: add icon, use select2 ? #}
+                     <option
+                        value="{{ category.value }}"
+                        {{ category.value == question_type.getCategory().value ? 'selected' : '' }}
+                    >
+                        {{ category.getLabel() }}
+                    </option>
+                {% endfor %}
+            </select>
+
+            {% set types = question_types_manager.getTypesForCategory(question_type.getCategory()) %}
+            <select
+                name="type"
+                class="form-select form-select-sm {{ types|length == 1 ? 'd-none' : '' }}"
+                aria-label="{{ __('Question sub type') }}"
                 style="width: auto;"
                 data-glpi-form-editor-on-change="change-question-type"
                 data-glpi-form-editor-question-type-selector
             >
-                {% for possible_question_type in question_types %}
+                {% for possible_question_type in types %}
                     {# TODO: add icon, use select2 ? #}
                     <option
                         value="{{ get_class(possible_question_type) }}"

--- a/templates/pages/form_renderer.html.twig
+++ b/templates/pages/form_renderer.html.twig
@@ -49,17 +49,20 @@
 
             {% for section in form.getSections() %}
                 {% for question in section.getQuestions() %}
-                    {% set question_type = question_types[question.fields.type] %}
-                    <div class="mb-3">
-                        <label class="form-label">
-                            {{ question.fields.name }}
-                            {% if question.fields.is_mandatory %}
-                                <span class="text-danger">*</span>
-                            {% endif %}
-                        </label>
-                        {{ question_type.renderEndUserTemplate(question)|raw }}
-                        <div class="form-text">{{ question.fields.description|safe_html }}</div>
-                    </div>
+                    {% set question_type = question.getQuestionType() %}
+                    {# Skip unknown types (may be a disabled plugin) #}
+                    {% if question_type is not null %}
+                        <div class="mb-3">
+                            <label class="form-label">
+                                {{ question.fields.name }}
+                                {% if question.fields.is_mandatory %}
+                                    <span class="text-danger">*</span>
+                                {% endif %}
+                            </label>
+                            {{ question_type.renderEndUserTemplate(question)|raw }}
+                            <div class="form-text">{{ question.fields.description|safe_html }}</div>
+                        </div>
+                    {% endif %}
                 {% endfor %}
             {% endfor %}
 


### PR DESCRIPTION
Split questions types into separate categories.

This avoid showing too many options at once for the users.

![image](https://github.com/glpi-project/glpi/assets/42734840/645f1f8f-6108-4b28-a9ca-456f5da0a7fb)

Initially, I thought that we were going to save the `type` and `subtype` into the database but it is not very useful in the end as only the "sub type" interest us and we can compute the parent category from it.
Thus, I've removed the `subtype` column.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
