### PR TITLE
Fix `entities_id` value in entity forms

### DIFF
--- a/templates/components/form/header.html.twig
+++ b/templates/components/form/header.html.twig
@@ -40,16 +40,13 @@
 
 {% set entity_id = 0 %}
 {% set entity_name = '' %}
-{% if item.isEntityAssign() %}
-   {% if item.getType() == 'Entity' and item.fields['id'] == 0 %}
-      {% set entity_id = null %}
-   {% else %}
-      {% set entity_id = params['entities_id'] ?? item.getEntityID() ?? session('glpiactive_entity') %}
-   {% endif %}
-
-   {% if is_multi_entities_mode() %}
-      {% set entity_name = get_item_name('Entity', entity_id is not empty ? entity_id : null) %}
-   {% endif %}
+{% if item.getType() == 'Entity' %}
+    {% set entity_id = item.fields['id'] == 0 ? null : (params['entities_id'] ?? item.fields['entities_id'] ?? session('glpiactive_entity')) %}
+{% elseif item.isEntityAssign() %}
+    {% set entity_id = params['entities_id'] ?? item.getEntityID() ?? session('glpiactive_entity') %}
+{% endif %}
+{% if is_multi_entities_mode() %}
+    {% set entity_name = entity_id is not null ? get_item_name('Entity', entity_id) : null %}
 {% endif %}
 
 {% set no_header = no_header|default(false) %}

--- a/templates/components/form/header_content.html.twig
+++ b/templates/components/form/header_content.html.twig
@@ -40,18 +40,17 @@
 {% set in_navheader = in_navheader|default(false) %}
 
 {% set entity_name = entity_name|default('') %}
-{% if entity_id is not defined and item.isEntityAssign() %}
-   {% if item.getType() == 'Entity' and item.fields['id'] == 0 %}
-      {% set entity_id = null %}
-   {% else %}
-      {% set entity_id = params['entities_id'] ?? item.getEntityID() ?? session('glpiactive_entity') %}
-   {% endif %}
-
-   {% if is_multi_entities_mode() %}
-      {% set entity_name = get_item_name('Entity', item.getEntityID()) %}
-   {% endif %}
-{% elseif entity_id is not defined %}
-   {% set entity_id = 0 %}
+{% if entity_id is not defined %}
+    {% if item.getType() == 'Entity' %}
+        {% set entity_id = item.fields['id'] == 0 ? null : (params['entities_id'] ?? item.fields['entities_id'] ?? session('glpiactive_entity')) %}
+    {% elseif item.isEntityAssign() %}
+        {% set entity_id = params['entities_id'] ?? item.getEntityID() ?? session('glpiactive_entity') %}
+    {% else %}
+        {% set entity_id = 0 %}
+    {% endif %}
+    {% if is_multi_entities_mode() %}
+        {% set entity_name = entity_id is not null ? get_item_name('Entity', entity_id) : null %}
+    {% endif %}
 {% endif %}
 
 {% set template_name = item.fields['template_name'] %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

While testing #16288 yesterday, I figured out that I was not able to save the custom CSS for any entity except the root entity. After digging a bit, I figured out that the same issue was present for the `Address` tab.
The problem here was that the `entities_id` hidden field was getting its values from the `item.getEntityID()`, that correspond to the `id` field in case of an entity. I refactored this part to use the `entities_id` field when the form refers to an `Entity` item.

I kept the existing priority order: 
 - use `params['entities_id']` if defined/not null,
 - then use item etntity id  if defined/not null,
 - then fallback to `glpiactive_entity` session value.