### PR TITLE
Support standard SO operators for "decimal" SO

### DIFF
--- a/src/Search/SearchOption.php
+++ b/src/Search/SearchOption.php
@@ -487,6 +487,7 @@ final class SearchOption implements \ArrayAccess
                     case 'count':
                     case 'number':
                     case "integer":
+                    case 'decimal':
                         $opt = [
                             'contains'    => __('contains'),
                             'notcontains' => __('not contains'),


### PR DESCRIPTION
Following discussion in #16328.

It seems the `decimal` SO type was involuntarily omitted from the `getActionsFor` method.

Loose search (ignore decimal)
![image](https://github.com/glpi-project/glpi/assets/42734840/09c56862-bb8e-4598-a547-6ce029acf50d)

Precise searches:
![image](https://github.com/glpi-project/glpi/assets/42734840/d62bc6df-7600-410a-9dd1-16d944678c7e)
![image](https://github.com/glpi-project/glpi/assets/42734840/8cda30ce-b0e7-4da7-8f9c-01132e2d065b)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
