### PR TITLE
Update GLPI_YEAR

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -50,7 +50,7 @@ if (!defined('GLPI_MARKETPLACE_PRERELEASES')) {
 
 define('GLPI_MIN_PHP', '7.4.0'); // Must also be changed in top of index.php
 define('GLPI_MAX_PHP', '8.4.0'); // (Exclusive) Must also be changed in top of index.php
-define('GLPI_YEAR', '2023');
+define('GLPI_YEAR', '2024');
 
 //Define a global recipient address for email notifications
 //define('GLPI_FORCE_MAIL', 'me@localhost');

--- a/tests/units/GLPI.php
+++ b/tests/units/GLPI.php
@@ -64,4 +64,14 @@ class GLPI extends \GLPITestCase
             "Locales files present in directory are missing from configuration:\n" . print_r($cfg_missing, true)
         );
     }
+
+    /**
+     * Verify the value of the GLPI_YEAR const
+     *
+     * @return void
+     */
+    public function test_GlpiYear(): void
+    {
+        $this->string(GLPI_YEAR)->isEqualTo(date('Y'));
+    }
 }


### PR DESCRIPTION
Just noticed this wasn't changed in the "Happy new year" PR ;)

Should I add a unit test that check if GLPI_YEAR == current year to make sure we never forget about it ?

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
