### PR TITLE
Group some dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,11 @@ updates:
     target-branch: "10.0/bugfixes"
     versioning-strategy: "increase"
     rebase-strategy: "disabled"
+    groups:
+      dev-dependencies:
+        patterns:
+          - "*"
+
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
@@ -29,6 +34,10 @@ updates:
     target-branch: "10.0/bugfixes"
     versioning-strategy: "increase"
     rebase-strategy: "disabled"
+    groups:
+      dev-dependencies:
+        patterns:
+          - "*"
 
 
   # Update production dependencies on future release branch (main).
@@ -42,6 +51,24 @@ updates:
     target-branch: "main"
     versioning-strategy: "increase"
     rebase-strategy: "disabled"
+    groups:
+      cytoscape:
+        patterns:
+          - "cytoscape"
+          - "cytoscape-*"
+      leaflet:
+        patterns:
+          - "leaflet"
+          - "leaflet-*"
+          - "leaflet.*"
+      fullcalendar:
+        patterns:
+          - "@fullcalendar/*"
+      tabler:
+        patterns:
+          - "@tabler/*"
+          - "bootstrap"
+
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
@@ -52,3 +79,21 @@ updates:
     target-branch: "main"
     versioning-strategy: "increase"
     rebase-strategy: "disabled"
+    groups:
+      guzzlehttp:
+        patterns:
+          - "guzzlehttp/*"
+      sabre:
+        patterns:
+          - "sabre/*"
+      symfony:
+        patterns:
+          - "symfony/*"
+        exclude-patterns:
+          - "symfony/polyfill-*"
+      symfony-polyfills:
+        patterns:
+          - "symfony/polyfill-*"
+      twig:
+        patterns:
+          - "twig/*"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Alternative to #16156 .

In #16156, the proposal will result in a unique PR containing an update of all dependencies. I think it is not a good idea as sometimes we may want to exclude some libs update. For instance, we currently blocked the `fullcalendar` libs update and in the past we ignored some `gridstack` versions as it required many manual changes.

I propose to only use the following grouping (all other libraries will be updated into separate PRs):
 - one group for all npm dev dependencies (most of the time, we accept all of them as soon as the CI checks are OK)
 - one group for all composer dev dependencies (most of the time, we accept all of them as soon as the CI checks are OK)
 - one group for `cytoscape` and its plugins
 - one group for `leaflet` and its plugins
 - one group for all `fullcalendar` components (their sources are managed into the same mono repository)
 - one group for `tabler` and `bootstrap` components (it seems better to update both of them together)
 - one group for `guzzle` components (they are ofter interdependent)
 - one group for `sabre` components (they are ofter interdependent)
 - one group for `symfony` components (their sources are managed into the same mono repository)
 - one group for `symfony` polyfills (their sources are managed into the same mono repository)
 - one group for `twig` components (their sources are managed into the same mono repository)

For the other libraries, it is preferable to not group them. Indeed, they have most of the time their own versionning schedule and can be updated independently from each other.