### PR TITLE
Upgrade node/npm requirement to 18.12 LTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "description": "GLPI dependencies",
     "license": "GPL-3.0-or-later",
     "engines": {
-        "node": ">= 16.11",
-        "npm": ">= 8.0"
+        "node": ">= 18.12",
+        "npm": ">= 8.19"
     },
     "dependencies": {
         "@fontsource/inter": "^4.5.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Node 16.x is not maintained anymore (see https://nodejs.org/en/about/previous-releases) and some package maintainers already removed support of it. We cannot upgrade some of our build dependencies, see https://github.com/glpi-project/glpi/actions/runs/7473091177/job/20336579990?pr=16338 .

We use it only to build our dependencies, so changing this requirement will only impact developers. The 18.12 LTS version was released on Oct 25, 2022. I guess most of GLPI developers have already this version, or an higher one, installed on their machine.