### PR TITLE
Fix CAS authentication service_base_url

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -544,12 +544,14 @@ class Auth extends CommonGLPI
                 } else {
                     // Starting from version 1.6.0, `$service_base_url` argument was added at 5th position, and `$changeSessionID`
                     // was moved at 6th position.
+                    $url_base = parse_url($CFG_GLPI["url_base"]);
+                    $service_base_url = $url_base["scheme"] . "://" . $url_base["host"] . (isset($url_base["port"]) ? ":" . $url_base["port"] : "");
                     phpCAS::client(
                         constant($CFG_GLPI["cas_version"]),
                         $CFG_GLPI["cas_host"],
                         intval($CFG_GLPI["cas_port"]),
                         $CFG_GLPI["cas_uri"],
-                        $CFG_GLPI["url_base"],
+                        $service_base_url,
                         false
                     );
                 }


### PR DESCRIPTION
when GLPI is not installed at the webserver's root phpcas receives an incorrect value for `service_base_url`, leading to a bad redirection after authentication. `path` and following data must be removed from `url_base` configuration value

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a