### PR TITLE
Increase a bit the memory limit allowed to PHPStan

### DIFF
--- a/.github/actions/lint_php-lint.sh
+++ b/.github/actions/lint_php-lint.sh
@@ -21,6 +21,6 @@ vendor/bin/phpcs \
 echo "Run code static analysis"
 vendor/bin/phpstan analyze \
   --ansi \
-  --memory-limit=2G \
+  --memory-limit=2500M \
   --no-interaction \
   --no-progress


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Recently, on `main` branch, PHPStan checks on PHP 8.1 are sometimes crashing because the memory limit is reached.
```
+ vendor/bin/phpstan analyze --ansi --memory-limit=2G --no-interaction --no-progress
Run code static analysis
Note: Using configuration file /var/glpi/phpstan.neon.
 -- -------------------------------------------------------------------------- 
     Error                                                                     
 -- -------------------------------------------------------------------------- 
     Child process error: PHPStan process crashed because it                   
     reached configured PHP memory limit: 2G                                   
     Increase your memory limit in php.ini or run PHPStan with --memory-limit  
     CLI option.                                                               
                                                                               
 -- -------------------------------------------------------------------------- 
```