### PR TITLE
fix(change + problem): adding readonly on fields when ITIL object is not editable

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -9911,4 +9911,27 @@ abstract class CommonITILObject extends CommonDBTM
         // All actions should be attached to thread instanciated by `new` event
         return 'new';
     }
+
+    /**
+     * Is the current user have right to update the current ITIL object ?
+     *
+     * @return boolean
+     **/
+    public function canUpdateItem()
+    {
+        if (!$this->checkEntity()) {
+            return false;
+        }
+
+        return self::canUpdate();
+    }
+
+    public function canDeleteItem()
+    {
+
+        if (!$this->checkEntity()) {
+            return false;
+        }
+        return self::canDelete();
+    }
 }

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -1905,6 +1905,7 @@ JAVASCRIPT;
         $params['width']               = '';
         $params['class']               = 'form-select';
         $params['allow_max_change']    = true;
+        $params['disabled']            = false;
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {
@@ -2014,6 +2015,7 @@ JAVASCRIPT;
             'rand'                => $params['rand'],
             'emptylabel'          => $params['emptylabel'],
             'class'               => $params['class'],
+            'disabled'            => $params['disabled'],
         ]);
     }
 


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !31117

When the user only has read-only access to changes or problems, the fields were not read-only, so he could modify the values, and click on the save or delete buttons. 
_Pressing these buttons displayed a message saying that the user was not authorized to do so._

