### PR TITLE
fix(Notification): fix conversion of relative URLs to aboslue URLs

### DIFF
--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -298,7 +298,7 @@ class NotificationEventMailing extends NotificationEventAbstract
                     $matches = [];
                     if (
                         preg_match_all(
-                            "/<img[^>]*src=(\"|')[^\"']*document\.send\.php\?docid=([0-9]+)[^\"']*(\"|')[^<]*>/",
+                            "/<img[^>]*src=(\"|')[^\"']*document\.send\.php\?docid(?:=|&#61;)([0-9]+)[^\"']*(\"|')[^<]*>/",
                             $current->fields['body_html'],
                             $matches
                         )
@@ -375,8 +375,8 @@ class NotificationEventMailing extends NotificationEventAbstract
                     foreach ($inline_docs as $docID => $filename) {
                         $current->fields['body_html'] = preg_replace(
                             [
-                                '/src=["\'][^"\']*document\.send\.php\?docid=' . $docID . '(&[^"\']+)?["\']/',
-                                '/href=["\'][^"\']*document\.send\.php\?docid=' . $docID . '(&[^"\']+)?["\']/',
+                                '/src=["\'][^"\']*document\.send\.php\?docid(?:=|&#61;)' . $docID . '(&[^"\']+)?["\']/',
+                                '/href=["\'][^"\']*document\.send\.php\?docid(?:=|&#61;)' . $docID . '(&[^"\']+)?["\']/',
                             ],
                             [
                                 // 'cid' must be identical as second arg used in `embedFromPath` method


### PR DESCRIPTION
Since the replacement of ```htmlawed```

the ```symfony``` component used to make HTML ```safe``` encodes ```=``` with ```&#61;```

```
<a href="/front/document.send.php?docid&#61;9122&amp;itemtype&#61;Ticket&amp;items_id&#61;38142" target="_blank" rel="noopener"><img src="/front/document.send.php?docid&#61;9122&amp;itemtype&#61;Ticket&amp;items_id&#61;38142" alt="d40c9e53-f37490bd-63ec57f1a8efc3.58665698" width="4032" /></a>
```

GLPI's notification system tries to convert relative URLs into absolute URLs via a ```reg_replace```

```php
foreach ($inline_docs as $docID => $filename) {
    $current->fields['body_html'] = preg_replace(
        [
            '/src=["\'][^"\']*document\.send\.php\?docid=' . $docID . '(&[^"\']+)?["\']/',
            '/href=["\'][^"\']*document\.send\.php\?docid=' . $docID . '(&[^"\']+)?["\']/',
        ],
        [
            // 'cid' must be identical as second arg used in `embedFromPath` method
            // Symfony/Mime will then replace it by an auto-generated value
            // see Symfony\Mime\Email::prepareParts()
            'src="cid:' . $filename . '"',
            'href="' . $CFG_GLPI['url_base'] . '/front/document.send.php?docid=' . $docID . '$1"',
        ],
        $current->fields['body_html']
    );
}
```

Method no longer works due to the HTML encoding of ```=```

I'm not an expert in HTML encoding/decoding, so this commit is a first test to see how the unit tests behave.

Perhaps another solution would be to adapt the REGEXs to match ```&#61;```

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !28203
