### PR TITLE
Add screen capture feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The present file will list all changes made to the project; according to the
 - Custom palette/theme support (uses `files/_themes` directory by default).
 - Two-Factor Authentication (2FA) support via Time-based One-time Password (TOTP).
 - `Deny login` authorization rule action to deny login for a user, but not prevent the import/existence of the user in GLPI.
+- Directly capture screenshots or screen recordings from the "Add a document" form in tickets.
 
 ### Changed
 - ITIL Objects can now be linked to any other ITIL Objects similar to the previous Ticket/Ticket links.

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -179,7 +179,7 @@ var deleteImagePasted = function(elementsIdToRemove, tagToRemove, editor) {
         $('#'+element).remove();
     });
 
-    if (typeof editor !== "undefined"
+    if (typeof editor !== "undefined" && editor !== null
        && typeof editor.dom !== "undefined") {
         var regex = new RegExp('#', 'g');
         editor.dom.remove(tagToRemove.replace(regex, ''));

--- a/js/modules/ITIL/Timeline/DocumentForm.js
+++ b/js/modules/ITIL/Timeline/DocumentForm.js
@@ -34,6 +34,7 @@
 import Screenshot  from '../../Screenshot/Screenshot.js';
 
 if (Screenshot.isSupported()) {
+    $('.document_item .upload-from-section').removeClass('d-none');
     $('.document_item .fileupload').each((i, fileupload) => {
         Screenshot.listenOnFileUpload(fileupload);
     });

--- a/js/modules/ITIL/Timeline/DocumentForm.js
+++ b/js/modules/ITIL/Timeline/DocumentForm.js
@@ -1,0 +1,92 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import Screenshot  from '../../Screenshot/Screenshot.js';
+
+if (Screenshot.isSupported()) {
+    $('.document_item .fileupload').each((i, fileupload) => {
+        Screenshot.listenOnFileUpload(fileupload);
+    });
+    const btn_screenshot = $('.document_item button[name="add_screenshot"]');
+    const btn_screenrecording = $('.document_item button[name="add_screenrecording"]');
+    const btn_stop_recording = $('.document_item button[name="stop_recording"]');
+    const preview_container = $('#screen_capture_preview');
+    btn_screenshot.removeClass('d-none');
+    btn_screenrecording.removeClass('d-none');
+
+    btn_screenshot.on('click', function() {
+        btn_stop_recording.addClass('d-none');
+        Screenshot.captureScreenshot().then((temp_canvas) => {
+            const img_index = preview_container.find('.previews').children().length;
+            const fake_filename = `screenshot${img_index}.png`;
+            Screenshot.appendPreviewImg(preview_container.find('.previews'), temp_canvas, '200px', fake_filename);
+            // Add the blob to the file upload control
+            temp_canvas.toBlob((blob) => {
+                // Add fake name to the blob with '.png' extension as matching on "blob.type" isn't working
+                blob.name = fake_filename;
+                window.uploadFile(blob, {
+                    getElement: () => {
+                        return preview_container.get(0);
+                    }
+                });
+                temp_canvas.remove();
+            }, 'image/png');
+        });
+    });
+
+    btn_screenrecording.on('click', function() {
+        const chunks = [];
+        Screenshot.startRecording().then((recorder) => {
+            btn_stop_recording.removeClass('d-none');
+            recorder.ondataavailable = (e) => {
+                // No time slice specified when starting the recorder, so this event fires only once when the recording stops
+                chunks.push(e.data);
+                const img_index = preview_container.find('.previews').children().length;
+                const fake_filename = `screen_capture${img_index}.webm`;
+                e.data.name = fake_filename;
+                Screenshot.appendPreviewVideo(preview_container.find('.previews'), e.data, '200px', fake_filename);
+                window.uploadFile(e.data, {
+                    getElement: () => {
+                        return preview_container.get(0);
+                    }
+                });
+            };
+            btn_stop_recording.on('click', () => {
+                recorder.stop();
+                recorder.stream.getTracks().forEach((track) => track.stop());
+                btn_stop_recording.addClass('d-none');
+            });
+        });
+    });
+}
+

--- a/js/modules/Screenshot/Screenshot.js
+++ b/js/modules/Screenshot/Screenshot.js
@@ -40,7 +40,7 @@ class Screenhot {
 
     /**
      * Listen on the file upload element to handle removal of previews when the file is removed.
-     * @param {HTMLElement} fileupload_element
+     * @param {HTMLElement} fileupload_element The file upload element to listen on.
      * */
     listenOnFileUpload(fileupload_element) {
         // Need to use a mutation observer as click handlers added after the upload is done are not triggered
@@ -74,6 +74,11 @@ class Screenhot {
         observer.observe(fileupload_element, {childList: true, subtree: true});
     }
 
+    /**
+     * Check if the browser supports and will allow the required APIs to be used.
+     * This includes a secure context check and a check that the user agent is not a mobile device.
+     * @return {boolean}
+     */
     isSupported() {
         // if not secure context, we can't use the screen capture API
         if (!window.isSecureContext) {
@@ -141,6 +146,11 @@ class Screenhot {
         });
     }
 
+    /**
+     * Return a bitrate value based on the track's resolution and framerate, and a hard-coded motion factor.
+     * @param {MediaStreamTrack} track The track
+     * @return {number} Bitrate
+     */
     getPreferredBitrate(track) {
         // Reference Bitrates based on YouTube recommendations
         // 360@30 - 1 Mbps   | 360@60 - 1.5 Mbps | Pixel Count - 230400
@@ -158,8 +168,8 @@ class Screenhot {
 
     /**
      * Get a codec supported by the browser for the requested format.
-     * @param requested_format
-     * @return {string}
+     * @param requested_format Requested mime type
+     * @return {string} Codec
      */
     getRecordingCodec(requested_format) {
         const codecs = ['vp9', 'vp8'];
@@ -183,6 +193,13 @@ class Screenhot {
         });
     }
 
+    /**
+     * Add a preview image item to the preview container.
+     * @param preview_container The preview container element
+     * @param canvas The canvas element with the preview data
+     * @param height The height of the preview item
+     * @param filename The filename of the preview item
+     */
     appendPreviewImg(preview_container, canvas, height, filename) {
         const preview_item = $(`
             <div class="position-relative d-inline-block overflow-hidden upload-preview-item" data-filename="${filename}" style="height: ${height}">
@@ -206,6 +223,13 @@ class Screenhot {
         });
     }
 
+    /**
+     * Add a preview video item to the preview container.
+     * @param preview_container The preview container element
+     * @param blob The blob with the video data
+     * @param height The height of the preview item
+     * @param filename The filename of the preview item
+     */
     appendPreviewVideo(preview_container, blob, height, filename) {
         const preview_item = $(`
             <div class="position-relative d-inline-block overflow-hidden upload-preview-item" data-filename="${filename}" style="height: ${height}">

--- a/js/modules/Screenshot/Screenshot.js
+++ b/js/modules/Screenshot/Screenshot.js
@@ -126,10 +126,10 @@ class Screenhot {
                 return new Promise((resolve, reject) => {
                     try {
                         video.addEventListener('loadeddata', () => {
-                            video.play().then(() => {
+                            return video.play().then(() => {
                                 this.updateCanvas(video, temp_canvas);
                                 track.stop();
-                                return temp_canvas;
+                                resolve(temp_canvas);
                             });
                         });
                     } catch(error) {

--- a/js/modules/Screenshot/Screenshot.js
+++ b/js/modules/Screenshot/Screenshot.js
@@ -1,0 +1,196 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/* global GLPI_PLUGINS_PATH */
+class Screenhot {
+
+    constructor() {
+        /**
+         * Array storing the size used for the preview canvas in the format [width, height].
+         * @type {number[]}
+         */
+        this.preview_size = [200, 180];
+    }
+
+    isSupported() {
+        // if not secure context, we can't use the screen capture API
+        if (!window.isSecureContext) {
+            return false;
+        }
+        const userAgent = navigator.userAgent.toLowerCase();
+        return !userAgent.match(/ipad|iphone|ipod|android/i);
+    }
+
+    /**
+     * Update a preview and full-size canvas based on the supplied image.
+     * The canvas is used as an in-between step to convert the image to a blob.
+     *
+     * @param {ImageBitmap|HTMLVideoElement} img The image or video to draw into the canvas.
+     * @param {HTMLCanvasElement} canvas The canvas that temporarily stores the image/frame data.
+     */
+    updateCanvas(img, canvas = null) {
+        const sourceWidth = img.videoWidth ?? img.width;
+        const sourceHeight = img.videoHeight ?? img.height;
+        canvas.width = sourceWidth;
+        canvas.height = sourceHeight;
+        canvas.getContext('2d').clearRect(0, 0, sourceWidth, sourceHeight);
+        canvas.getContext('2d').drawImage(img, 0, 0, sourceWidth, sourceHeight, 0, 0, sourceWidth, sourceHeight);
+    }
+
+    /**
+     * Prompt the user to select a screen device, grab the first frame only, and return a temporary canvas with the image within a promise.
+     */
+    async captureScreenshot() {
+        return navigator.mediaDevices.getDisplayMedia({video: true}).then(mediaStream => {
+            const track = mediaStream.getVideoTracks()[0];
+            // Create new canvas outside of the DOM
+            const temp_canvas = document.createElement('canvas');
+            temp_canvas.width = track.getSettings().width;
+            temp_canvas.height = track.getSettings().height;
+
+            if (typeof ImageCapture !== "undefined") {
+                // If the browser supports ImageCapture (preferred method, but currently experimental web API), we will use that to grab the first frame from the track.
+                const imageCapture = new ImageCapture(track);
+                return imageCapture.grabFrame().then(img => {
+                    this.updateCanvas(img, temp_canvas);
+                    track.stop();
+                    return temp_canvas;
+                });
+            } else {
+                // Fall back to using a video element to grab the first frame from the track. Currently required for Firefox.
+                const video = document.createElement('video');
+                video.srcObject = mediaStream;
+
+                return new Promise((resolve, reject) => {
+                    try {
+                        video.addEventListener('loadeddata', () => {
+                            video.play().then(() => {
+                                this.updateCanvas(video, temp_canvas);
+                                track.stop();
+                                return temp_canvas;
+                            });
+                        });
+                    } catch(error) {
+                        track.stop();
+                        reject(error);
+                    }
+                });
+            }
+        });
+    }
+
+    getPreferredBitrate(track) {
+        // Reference Bitrates based on YouTube recommendations
+        // 360@30 - 1 Mbps   | 360@60 - 1.5 Mbps | Pixel Count - 230400
+        // 720@30 - 5 Mbps   | 720@60 - 7.5 Mbps | Pixel Count - 921600
+        // 1080@30 - 8 Mbps  | 1080@60 - 12 Mbps | Pixel Count - 2073600
+        // 1440@30 - 16 Mbps | 1440@60 - 24 Mbps | Pixel Count - 3686400
+        // 2160@30 - 40 Mbps | 2160@60 - 60 Mbps | Pixel Count - 8294400
+
+        const motion_factor = 0.5; // Weight value. How much activity we expect
+        // br = (pixels * f * motion_factor) / 10;
+
+        const settings = track.getSettings();
+        return ((settings.width * settings.height) * settings.frameRate * motion_factor) / 10;
+    }
+
+    /**
+     * Get a codec supported by the browser for the requested format.
+     * @param requested_format
+     * @return {string}
+     */
+    getRecordingCodec(requested_format) {
+        const codecs = ['vp9', 'vp8'];
+        return codecs.find(c => MediaRecorder.isTypeSupported(requested_format + ';codecs=' + c));
+    }
+
+    /**
+     * Prompt the user to select a screen device, start the MediaRecorder and then return the recorder.
+     * Then, this will continually grab frames from the video stream at a rate of 10 FPS and update the preview canvas until the user stops the recording.
+     */
+    startRecording() {
+        return navigator.mediaDevices.getDisplayMedia({video: true, frameRate: 10}).then(mediaStream => {
+            const track = mediaStream.getVideoTracks()[0];
+
+            const recorder = new MediaRecorder(mediaStream, {
+                mimeType: 'video/webm;codecs=' + this.getRecordingCodec('video/webm'),
+                videoBitsPerSecond: this.getPreferredBitrate(track),
+            });
+            recorder.start();
+            return recorder;
+        });
+    }
+
+    appendPreviewImg(preview_container, canvas, height, filename) {
+        const preview_item = $(`
+            <div class="position-relative d-inline-block overflow-hidden" style="height: ${height}">
+                <button class="btn btn-sm btn-danger position-absolute top-0 start-0" type="button" title="${__('Delete')}">
+                    <i class="ti ti-x"></i>
+                </button>
+            </div>
+        `).appendTo(preview_container);
+        const img = document.createElement('img');
+        img.src = canvas.toDataURL();
+        img.style.height = '200px';
+        img.classList.add('mx-2');
+        preview_item.append(img);
+        preview_item.find('button').on('click', () => {
+            preview_container.closest('form').find('.fileupload input[name^="_filename"][value$="' + filename + '"]')
+                .parent().find('.ti-circle-x').click();
+            preview_item.remove();
+        });
+    }
+
+    appendPreviewVideo(preview_container, blob, height, filename) {
+        const preview_item = $(`
+            <div class="position-relative d-inline-block overflow-hidden" style="height: ${height}">
+                <button class="btn btn-sm btn-danger position-absolute top-0 start-0" type="button" title="${__('Delete')}">
+                    <i class="ti ti-x"></i>
+                </button>
+            </div>
+        `).appendTo(preview_container);
+        const video = document.createElement('video');
+        video.src = URL.createObjectURL(blob);
+        video.style.height = '200px';
+        video.classList.add('mx-2');
+        video.controls = true;
+        preview_item.append(video);
+        preview_item.find('button').on('click', () => {
+            preview_container.closest('form').find('.fileupload input[name^="_filename"][value$="' + filename + '"]')
+                .parent().find('.ti-circle-x').click();
+            preview_item.remove();
+        });
+    }
+}
+
+export default new Screenhot();

--- a/src/Application/View/Extension/DocumentExtension.php
+++ b/src/Application/View/Extension/DocumentExtension.php
@@ -49,7 +49,6 @@ class DocumentExtension extends AbstractExtension
         return [
             new TwigFilter('document_icon', [$this, 'getDocumentIcon']),
             new TwigFilter('document_size', [$this, 'getDocumentSize']),
-            new TwigFilter('is_valid_doc', [\Document::class, 'isValidDoc'])
         ];
     }
 

--- a/src/Application/View/Extension/DocumentExtension.php
+++ b/src/Application/View/Extension/DocumentExtension.php
@@ -49,6 +49,7 @@ class DocumentExtension extends AbstractExtension
         return [
             new TwigFilter('document_icon', [$this, 'getDocumentIcon']),
             new TwigFilter('document_size', [$this, 'getDocumentSize']),
+            new TwigFilter('is_valid_doc', [\Document::class, 'isValidDoc'])
         ];
     }
 

--- a/templates/components/itilobject/timeline/form_document_item.html.twig
+++ b/templates/components/itilobject/timeline/form_document_item.html.twig
@@ -172,65 +172,7 @@
             </form>
         </div>
         <script type="module">
-            import('{{ js_path('js/modules/Screenshot/Screenshot.js') }}').then((m) => {
-                const screenshot = m.default;
-                if (screenshot.isSupported()) {
-                    $('.document_item .fileupload').each((i, fileupload) => {
-                        screenshot.listenOnFileUpload(fileupload);
-                    });
-                    const btn_screenshot = $('.document_item button[name="add_screenshot"]');
-                    const btn_screenrecording = $('.document_item button[name="add_screenrecording"]');
-                    const btn_stop_recording = $('.document_item button[name="stop_recording"]');
-                    const preview_container = $('#screen_capture_preview');
-                    btn_screenshot.removeClass('d-none');
-                    btn_screenrecording.removeClass('d-none');
-
-                    btn_screenshot.on('click', function() {
-                        btn_stop_recording.addClass('d-none');
-                        screenshot.captureScreenshot().then((temp_canvas) => {
-                            const img_index = preview_container.find('.previews').children().length;
-                            const fake_filename = `screenshot${img_index}.png`;
-                            screenshot.appendPreviewImg(preview_container.find('.previews'), temp_canvas, '200px', fake_filename);
-                            // Add the blob to the file upload control
-                            temp_canvas.toBlob((blob) => {
-                                // Add fake name to the blob with '.png' extension as matching on "blob.type" isn't working
-                                blob.name = fake_filename;
-                                window.uploadFile(blob, {
-                                    getElement: () => {
-                                        return preview_container.get(0)
-                                    }
-                                });
-                                temp_canvas.remove();
-                            }, 'image/png');
-                        });
-                    });
-
-                    btn_screenrecording.on('click', function() {
-                        const chunks = [];
-                        screenshot.startRecording().then((recorder) => {
-                            btn_stop_recording.removeClass('d-none');
-                            recorder.ondataavailable = (e) => {
-                                // No time slice specified when starting the recorder, so this event fires only once when the recording stops
-                                chunks.push(e.data);
-                                const img_index = preview_container.find('.previews').children().length;
-                                const fake_filename = `screen_capture${img_index}.webm`;
-                                e.data.name = fake_filename;
-                                screenshot.appendPreviewVideo(preview_container.find('.previews'), e.data, '200px', fake_filename);
-                                window.uploadFile(e.data, {
-                                    getElement: () => {
-                                        return preview_container.get(0)
-                                    }
-                                });
-                            };
-                            btn_stop_recording.on('click', () => {
-                                recorder.stop();
-                                recorder.stream.getTracks().forEach((track) => track.stop());
-                                btn_stop_recording.addClass('d-none');
-                            });
-                        });
-                    });
-                }
-            });
+            import('{{ js_path('js/modules/ITIL/Timeline/DocumentForm.js') }}');
         </script>
    {% endif %}
 {% endblock %}

--- a/templates/components/itilobject/timeline/form_document_item.html.twig
+++ b/templates/components/itilobject/timeline/form_document_item.html.twig
@@ -174,6 +174,9 @@
             import('{{ js_path('js/modules/Screenshot/Screenshot.js') }}').then((m) => {
                 const screenshot = m.default;
                 if (screenshot.isSupported()) {
+                    $('.document_item .fileupload').each((i, fileupload) => {
+                        screenshot.listenOnFileUpload(fileupload);
+                    });
                     const btn_screenshot = $('.document_item button[name="add_screenshot"]');
                     const btn_screenrecording = $('.document_item button[name="add_screenrecording"]');
                     const btn_stop_recording = $('.document_item button[name="stop_recording"]');

--- a/templates/components/itilobject/timeline/form_document_item.html.twig
+++ b/templates/components/itilobject/timeline/form_document_item.html.twig
@@ -226,6 +226,7 @@
                             btn_stop_recording.on('click', () => {
                                 recorder.stop();
                                 recorder.stream.getTracks().forEach((track) => track.stop());
+                                btn_stop_recording.addClass('d-none');
                             });
                         });
                     });

--- a/templates/components/itilobject/timeline/form_document_item.html.twig
+++ b/templates/components/itilobject/timeline/form_document_item.html.twig
@@ -102,6 +102,25 @@
                 <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
                 {{ call_plugin_hook('pre_item_form', {"item": subitem, 'options': params}) }}
 
+                <label id="upload_source_label" class="form-label">{{ __("Upload from") }}</label>
+                <div class="d-inline" role="group" aria-labelledby="upload_source_label">
+                    <button class="btn btn-sm btn-secondary me-2 d-none" type="button" name="add_screenshot">
+                        <i class="ti ti-photo"></i>
+                        <span>{{ __('Screenshot') }}</span>
+                    </button>
+                    {% if '.webm'|is_valid_doc is not empty %}
+                        {# TODO hide the screen recording option behind a permission? #}
+                        <button class="btn btn-sm btn-secondary me-2 d-none" type="button" name="add_screenrecording">
+                            <i class="ti ti-camera"></i>
+                            <span>{{ __('Screen recording') }}</span>
+                        </button>
+                    {% endif %}
+                </div>
+                <div id="screen_capture_preview" class="w-100">
+                    <div class="previews overflow-x-scroll my-2 d-flex px-2"></div>
+                    <button type="button" name="stop_recording" class="btn btn-secondary d-none">{{ __('Stop recording') }}</button>
+                </div>
+                <hr class="my-1">
                 {% if get_current_interface() == 'central' %}
                     {{ fields.dropdownField(
                         'DocumentCategory',
@@ -151,5 +170,62 @@
                 </div>
             </form>
         </div>
+        <script type="module">
+            import('{{ js_path('js/modules/Screenshot/Screenshot.js') }}').then((m) => {
+                const screenshot = m.default;
+                if (screenshot.isSupported()) {
+                    const btn_screenshot = $('.document_item button[name="add_screenshot"]');
+                    const btn_screenrecording = $('.document_item button[name="add_screenrecording"]');
+                    const btn_stop_recording = $('.document_item button[name="stop_recording"]');
+                    const preview_container = $('#screen_capture_preview');
+                    btn_screenshot.removeClass('d-none');
+                    btn_screenrecording.removeClass('d-none');
+
+                    btn_screenshot.on('click', function() {
+                        btn_stop_recording.addClass('d-none');
+                        screenshot.captureScreenshot().then((temp_canvas) => {
+                            const img_index = preview_container.find('.previews').children().length;
+                            const fake_filename = `screenshot${img_index}.png`;
+                            screenshot.appendPreviewImg(preview_container.find('.previews'), temp_canvas, '200px', fake_filename);
+                            // Add the blob to the file upload control
+                            temp_canvas.toBlob((blob) => {
+                                // Add fake name to the blob with '.png' extension as matching on "blob.type" isn't working
+                                blob.name = fake_filename;
+                                window.uploadFile(blob, {
+                                    getElement: () => {
+                                        return preview_container.get(0)
+                                    }
+                                });
+                                temp_canvas.remove();
+                            }, 'image/png');
+                        });
+                    });
+
+                    btn_screenrecording.on('click', function() {
+                        const chunks = [];
+                        screenshot.startRecording().then((recorder) => {
+                            btn_stop_recording.removeClass('d-none');
+                            recorder.ondataavailable = (e) => {
+                                // No time slice specified when starting the recorder, so this event fires only once when the recording stops
+                                chunks.push(e.data);
+                                const img_index = preview_container.find('.previews').children().length;
+                                const fake_filename = `screen_capture${img_index}.webm`;
+                                e.data.name = fake_filename;
+                                screenshot.appendPreviewVideo(preview_container.find('.previews'), e.data, '200px', fake_filename);
+                                window.uploadFile(e.data, {
+                                    getElement: () => {
+                                        return preview_container.get(0)
+                                    }
+                                });
+                            };
+                            btn_stop_recording.on('click', () => {
+                                recorder.stop();
+                                recorder.stream.getTracks().forEach((track) => track.stop());
+                            });
+                        });
+                    });
+                }
+            });
+        </script>
    {% endif %}
 {% endblock %}

--- a/templates/components/itilobject/timeline/form_document_item.html.twig
+++ b/templates/components/itilobject/timeline/form_document_item.html.twig
@@ -104,10 +104,12 @@
 
                 <label id="upload_source_label" class="form-label">{{ __("Upload from") }}</label>
                 <div class="d-inline" role="group" aria-labelledby="upload_source_label">
-                    <button class="btn btn-sm btn-secondary me-2 d-none" type="button" name="add_screenshot">
-                        <i class="ti ti-photo"></i>
-                        <span>{{ __('Screenshot') }}</span>
-                    </button>
+                    {% if '.png'|is_valid_doc is not empty %}
+                        <button class="btn btn-sm btn-secondary me-2 d-none" type="button" name="add_screenshot">
+                            <i class="ti ti-photo"></i>
+                            <span>{{ __('Screenshot') }}</span>
+                        </button>
+                    {% endif %}
                     {% if '.webm'|is_valid_doc is not empty %}
                         {# TODO hide the screen recording option behind a permission? #}
                         <button class="btn btn-sm btn-secondary me-2 d-none" type="button" name="add_screenrecording">

--- a/templates/components/itilobject/timeline/form_document_item.html.twig
+++ b/templates/components/itilobject/timeline/form_document_item.html.twig
@@ -104,13 +104,13 @@
 
                 <label id="upload_source_label" class="form-label">{{ __("Upload from") }}</label>
                 <div class="d-inline" role="group" aria-labelledby="upload_source_label">
-                    {% if '.png'|is_valid_doc is not empty %}
+                    {% if call('Document::isValidDoc', ['.png']) is not empty %}
                         <button class="btn btn-sm btn-secondary me-2 d-none" type="button" name="add_screenshot">
                             <i class="ti ti-photo"></i>
                             <span>{{ __('Screenshot') }}</span>
                         </button>
                     {% endif %}
-                    {% if '.webm'|is_valid_doc is not empty %}
+                    {% if call('Document::isValidDoc', ['.webm']) is not empty %}
                         <button class="btn btn-sm btn-secondary me-2 d-none" type="button" name="add_screenrecording">
                             <i class="ti ti-camera"></i>
                             <span>{{ __('Screen recording') }}</span>

--- a/templates/components/itilobject/timeline/form_document_item.html.twig
+++ b/templates/components/itilobject/timeline/form_document_item.html.twig
@@ -102,26 +102,31 @@
                 <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
                 {{ call_plugin_hook('pre_item_form', {"item": subitem, 'options': params}) }}
 
-                <label id="upload_source_label" class="form-label">{{ __("Upload from") }}</label>
-                <div class="d-inline" role="group" aria-labelledby="upload_source_label">
-                    {% if call('Document::isValidDoc', ['.png']) is not empty %}
-                        <button class="btn btn-sm btn-secondary me-2 d-none" type="button" name="add_screenshot">
-                            <i class="ti ti-photo"></i>
-                            <span>{{ __('Screenshot') }}</span>
-                        </button>
-                    {% endif %}
-                    {% if call('Document::isValidDoc', ['.webm']) is not empty %}
-                        <button class="btn btn-sm btn-secondary me-2 d-none" type="button" name="add_screenrecording">
-                            <i class="ti ti-camera"></i>
-                            <span>{{ __('Screen recording') }}</span>
-                        </button>
-                    {% endif %}
-                </div>
-                <div id="screen_capture_preview" class="w-100">
-                    <div class="previews overflow-x-scroll my-2 d-flex px-2"></div>
-                    <button type="button" name="stop_recording" class="btn btn-secondary d-none">{{ __('Stop recording') }}</button>
-                </div>
-                <hr class="my-1">
+                {% set can_screenshot = call('Document::isValidDoc', ['.png']) is not empty %}
+                {% set can_screenrecord = call('Document::isValidDoc', ['.webm']) is not empty %}
+
+                {% if can_screenshot or can_screenrecord %}
+                    <label id="upload_source_label" class="form-label">{{ __("Upload from") }}</label>
+                    <div class="d-inline" role="group" aria-labelledby="upload_source_label">
+                        {% if can_screenshot %}
+                            <button class="btn btn-sm btn-secondary me-2 d-none" type="button" name="add_screenshot">
+                                <i class="ti ti-photo"></i>
+                                <span>{{ __('Screenshot') }}</span>
+                            </button>
+                        {% endif %}
+                        {% if can_screenrecord %}
+                            <button class="btn btn-sm btn-secondary me-2 d-none" type="button" name="add_screenrecording">
+                                <i class="ti ti-camera"></i>
+                                <span>{{ __('Screen recording') }}</span>
+                            </button>
+                        {% endif %}
+                    </div>
+                    <div id="screen_capture_preview" class="w-100">
+                        <div class="previews overflow-x-scroll my-2 d-flex px-2"></div>
+                        <button type="button" name="stop_recording" class="btn btn-secondary d-none">{{ __('Stop recording') }}</button>
+                    </div>
+                    <hr class="my-1">
+                {% endif %}
                 {% if get_current_interface() == 'central' %}
                     {{ fields.dropdownField(
                         'DocumentCategory',

--- a/templates/components/itilobject/timeline/form_document_item.html.twig
+++ b/templates/components/itilobject/timeline/form_document_item.html.twig
@@ -111,7 +111,6 @@
                         </button>
                     {% endif %}
                     {% if '.webm'|is_valid_doc is not empty %}
-                        {# TODO hide the screen recording option behind a permission? #}
                         <button class="btn btn-sm btn-secondary me-2 d-none" type="button" name="add_screenrecording">
                             <i class="ti ti-camera"></i>
                             <span>{{ __('Screen recording') }}</span>

--- a/templates/components/itilobject/timeline/form_document_item.html.twig
+++ b/templates/components/itilobject/timeline/form_document_item.html.twig
@@ -106,26 +106,28 @@
                 {% set can_screenrecord = call('Document::isValidDoc', ['.webm']) is not empty %}
 
                 {% if can_screenshot or can_screenrecord %}
-                    <label id="upload_source_label" class="form-label">{{ __("Upload from") }}</label>
-                    <div class="d-inline" role="group" aria-labelledby="upload_source_label">
-                        {% if can_screenshot %}
-                            <button class="btn btn-sm btn-secondary me-2 d-none" type="button" name="add_screenshot">
-                                <i class="ti ti-photo"></i>
-                                <span>{{ __('Screenshot') }}</span>
-                            </button>
-                        {% endif %}
-                        {% if can_screenrecord %}
-                            <button class="btn btn-sm btn-secondary me-2 d-none" type="button" name="add_screenrecording">
-                                <i class="ti ti-camera"></i>
-                                <span>{{ __('Screen recording') }}</span>
-                            </button>
-                        {% endif %}
+                    <div class="upload-from-section d-none">
+                        <label id="upload_source_label" class="form-label">{{ __("Upload from") }}</label>
+                        <div class="d-inline" role="group" aria-labelledby="upload_source_label">
+                            {% if can_screenshot %}
+                                <button class="btn btn-sm btn-secondary me-2 d-none" type="button" name="add_screenshot">
+                                    <i class="ti ti-photo"></i>
+                                    <span>{{ __('Screenshot') }}</span>
+                                </button>
+                            {% endif %}
+                            {% if can_screenrecord %}
+                                <button class="btn btn-sm btn-secondary me-2 d-none" type="button" name="add_screenrecording">
+                                    <i class="ti ti-camera"></i>
+                                    <span>{{ __('Screen recording') }}</span>
+                                </button>
+                            {% endif %}
+                        </div>
+                        <div id="screen_capture_preview" class="w-100">
+                            <div class="previews overflow-x-scroll my-2 d-flex px-2"></div>
+                            <button type="button" name="stop_recording" class="btn btn-secondary d-none">{{ __('Stop recording') }}</button>
+                        </div>
+                        <hr class="my-1">
                     </div>
-                    <div id="screen_capture_preview" class="w-100">
-                        <div class="previews overflow-x-scroll my-2 d-flex px-2"></div>
-                        <button type="button" name="stop_recording" class="btn btn-secondary d-none">{{ __('Stop recording') }}</button>
-                    </div>
-                    <hr class="my-1">
                 {% endif %}
                 {% if get_current_interface() == 'central' %}
                     {{ fields.dropdownField(

--- a/tests/js/modules/Screenshot/Screenshot.test.js
+++ b/tests/js/modules/Screenshot/Screenshot.test.js
@@ -194,4 +194,50 @@ describe('Screenshot', () => {
         expect($('#screenshot-previews').children().length).toBe(0);
         expect($('#screenshot-previews').parent().find('.fileupload').children().length).toBe(0);
     });
+
+    test('Screenshot preview removed after file deleted', async () => {
+        $('body').append(`
+            <form>
+                <div id="screenshot-previews"></div>
+                <div class="fileupload">
+                    <div id="doc_uploader_filename89f8sef9s8df9j">
+                        <input type="hidden" name="_filename[0]" value="randomprefixtest.png">
+                        <span class="ti ti-circle-x" onclick="$(this).parent().remove()"></span>
+                    </div>
+                </div>
+            </form>
+        `);
+        const fake_canvas = {
+            toDataURL: () => {
+                return 'data:image/png;base64,FAKE_BASE64_DATA';
+            }
+        };
+        Screenshot.listenOnFileUpload(document.querySelector('.fileupload'));
+        Screenshot.appendPreviewImg($('#screenshot-previews'), fake_canvas, '200px', 'test.png');
+        expect($('#screenshot-previews').children().length).toBe(1);
+        $('.fileupload .ti-circle-x').click();
+        await new Promise(process.nextTick);
+        expect($('#screenshot-previews').children().length).toBe(0);
+    });
+
+    test('Recording preview removed after file deleted', async () => {
+        $('body').append(`
+            <form>
+                <div id="screenshot-previews"></div>
+                <div class="fileupload">
+                    <div id="doc_uploader_filename89f8sef9s8df9j">
+                        <input type="hidden" name="_filename[0]" value="randomprefixtest.webm">
+                        <span class="ti ti-circle-x" onclick="$(this).parent().remove()"></span>
+                    </div>
+                </div>
+            </form>
+        `);
+        const fake_blob = new Blob(['FAKE_BLOB_DATA'], {type: 'video/webm'});
+        Screenshot.listenOnFileUpload(document.querySelector('.fileupload'));
+        Screenshot.appendPreviewVideo($('#screenshot-previews'), fake_blob, '200px', 'test.webm');
+        expect($('#screenshot-previews').children().length).toBe(1);
+        $('.fileupload .ti-circle-x').click();
+        await new Promise(process.nextTick);
+        expect($('#screenshot-previews').children().length).toBe(0);
+    });
 });

--- a/tests/js/modules/Screenshot/Screenshot.test.js
+++ b/tests/js/modules/Screenshot/Screenshot.test.js
@@ -1,0 +1,197 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import Screenshot from '../../../../js/modules/Screenshot/Screenshot.js';
+import {jest} from '@jest/globals';
+
+describe('Screenshot', () => {
+    let user_agent_getter;
+
+    beforeEach(() => {
+        user_agent_getter = jest.spyOn(navigator, 'userAgent', 'get');
+        window.isSecureContext = true;
+        $('body').empty();
+    });
+
+    test('getPreferredBitrate', () => {
+        expect(Screenshot.getPreferredBitrate({
+            getSettings: () => {
+                return {
+                    width: 1920,
+                    height: 1080,
+                    frameRate: 10
+                };
+            }
+        })).toBe(1036800);
+        expect(Screenshot.getPreferredBitrate({
+            getSettings: () => {
+                return {
+                    width: 1280,
+                    height: 720,
+                    frameRate: 30
+                };
+            }
+        })).toBe(1382400);
+    });
+
+    test('Secure context support check', () => {
+        window.isSecureContext = false;
+        expect(Screenshot.isSupported()).toBe(false);
+        window.isSecureContext = true;
+        expect(Screenshot.isSupported()).toBe(true);
+    });
+
+    test('Mobile browser support check', () => {
+        user_agent_getter.mockReturnValue('Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Mobile Safari/537.36');
+        expect(Screenshot.isSupported()).toBe(false);
+        user_agent_getter.mockReturnValue('Mozilla/5.0 (Linux; Android 13; SM-S901B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Mobile Safari/537.36');
+        expect(Screenshot.isSupported()).toBe(false);
+        user_agent_getter.mockReturnValue('Mozilla/5.0 (iPhone14,3; U; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) Version/10.0 Mobile/19A346 Safari/602.1');
+        expect(Screenshot.isSupported()).toBe(false);
+        user_agent_getter.mockReturnValue('Mozilla/5.0 (iPhone12,1; U; CPU iPhone OS 13_0 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) Version/10.0 Mobile/15E148 Safari/602.1');
+        expect(Screenshot.isSupported()).toBe(false);
+        user_agent_getter.mockReturnValue('Mozilla/5.0 (Linux; Android 11; Lenovo YT-J706X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.45 Safari/537.36');
+        expect(Screenshot.isSupported()).toBe(false);
+    });
+
+    test('Desktop browser support check', () => {
+        user_agent_getter.mockReturnValue('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246');
+        expect(Screenshot.isSupported()).toBe(true);
+        user_agent_getter.mockReturnValue('Mozilla/5.0 (X11; CrOS x86_64 8172.45.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.64 Safari/537.36');
+        expect(Screenshot.isSupported()).toBe(true);
+        user_agent_getter.mockReturnValue('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/601.3.9 (KHTML, like Gecko) Version/9.0.2 Safari/601.3.9');
+        expect(Screenshot.isSupported()).toBe(true);
+        user_agent_getter.mockReturnValue('Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 Safari/537.36');
+        expect(Screenshot.isSupported()).toBe(true);
+        user_agent_getter.mockReturnValue('Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1');
+        expect(Screenshot.isSupported()).toBe(true);
+    });
+
+    test('Get recording codec', () => {
+        // MediaRecorder not defined in jest environment
+        window.MediaRecorder = {
+            isTypeSupported: () => {
+            }
+        };
+        const type_supported = jest.spyOn(window.MediaRecorder, 'isTypeSupported');
+        type_supported.mockReturnValueOnce(true);
+        expect(Screenshot.getRecordingCodec('video/webm')).toBe('vp9');
+        type_supported.mockReturnValueOnce(false);
+        type_supported.mockReturnValueOnce(true);
+        expect(Screenshot.getRecordingCodec('video/webm')).toBe('vp8');
+    });
+
+    test('Show screenshot preview', () => {
+        $('body').append('<div id="screenshot-previews"></div>');
+        const fake_canvas = {
+            toDataURL: () => {
+                return 'data:image/png;base64,FAKE_BASE64_DATA';
+            }
+        };
+        Screenshot.appendPreviewImg($('#screenshot-previews'), fake_canvas, '200px', 'test.png');
+        expect($('#screenshot-previews').children().length).toBe(1);
+        const preview_item = $('#screenshot-previews').children().first();
+        expect(preview_item.hasClass('position-relative')).toBe(true);
+        expect(preview_item.css('height')).toBe('200px');
+        expect(preview_item.children().length).toBe(2);
+        const delete_button = preview_item.children().first();
+        expect(delete_button.hasClass('btn')).toBe(true);
+        const img = preview_item.children().last();
+        expect(img.prop('tagName')).toBe('IMG');
+        expect(img.css('height')).toBe('200px');
+        expect(img.attr('src')).toBe('data:image/png;base64,FAKE_BASE64_DATA');
+    });
+
+    test('Show recording preview', () => {
+        const fake_blob = new Blob(['FAKE_BLOB_DATA'], {type: 'video/webm'});
+        $('body').append('<div id="screenshot-previews"></div>');
+        URL.createObjectURL = jest.fn().mockReturnValueOnce('blob:FAKE_BLOB_DATA');
+        Screenshot.appendPreviewVideo($('#screenshot-previews'), fake_blob, '200px', 'test.webm');
+        expect($('#screenshot-previews').children().length).toBe(1);
+        const preview_item = $('#screenshot-previews').children().first();
+        expect(preview_item.hasClass('position-relative')).toBe(true);
+        expect(preview_item.css('height')).toBe('200px');
+        expect(preview_item.children().length).toBe(2);
+        const delete_button = preview_item.children().first();
+        expect(delete_button.hasClass('btn')).toBe(true);
+        const video = preview_item.children().last();
+        expect(video.prop('tagName')).toBe('VIDEO');
+        expect(video.css('height')).toBe('200px');
+        expect(video.attr('src')).toBe('blob:FAKE_BLOB_DATA');
+        expect(video.attr('controls')).toBeDefined();
+    });
+
+    test('Screenshot preview delete button', () => {
+        $('body').append(`
+            <form>
+                <div id="screenshot-previews"></div>
+                <div class="fileupload">
+                    <div>
+                        <input type="hidden" name="_filename[0]" value="randomprefixtest.png">
+                        <span class="ti ti-circle-x" onclick="$(this).parent().remove()"></span>
+                    </div>
+                </div>
+            </form>
+        `);
+        const fake_canvas = {
+            toDataURL: () => {
+                return 'data:image/png;base64,FAKE_BASE64_DATA';
+            }
+        };
+        Screenshot.appendPreviewImg($('#screenshot-previews'), fake_canvas, '200px', 'test.png');
+        const delete_button = $('#screenshot-previews').find('button').first();
+        delete_button.click();
+        expect($('#screenshot-previews').children().length).toBe(0);
+        expect($('#screenshot-previews').parent().find('.fileupload').children().length).toBe(0);
+    });
+
+    test('Recording preview delete button', () => {
+        $('body').append(`
+            <form>
+                <div id="screenshot-previews"></div>
+                <div class="fileupload">
+                    <div>
+                        <input type="hidden" name="_filename[0]" value="randomprefixtest.webm">
+                        <span class="ti ti-circle-x" onclick="$(this).parent().remove()"></span>
+                    </div>
+                </div>
+            </form>
+        `);
+        const fake_blob = new Blob(['FAKE_BLOB_DATA'], {type: 'video/webm'});
+        Screenshot.appendPreviewVideo($('#screenshot-previews'), fake_blob, '200px', 'test.webm');
+        const delete_button = $('#screenshot-previews').find('button').first();
+        delete_button.click();
+        expect($('#screenshot-previews').children().length).toBe(0);
+        expect($('#screenshot-previews').parent().find('.fileupload').children().length).toBe(0);
+    });
+});


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Integration of `screenshot` plugin. Unlike the plugin where the screenshot and recording buttons were separate timeline actions, these buttons now exist within the document item timeline form. That also means users can attach any number of screenshots, recordings, or uploaded files and they all get processed at once. Screenshots and recordings both have previews shown within the form and they can be removed by clicking the "x" on the preview or within the file upload control.

![Selection_211](https://github.com/glpi-project/glpi/assets/17678637/a9d51ff5-b45e-4bd4-b28e-af9076c2cc3c)

This feature only works within "secure contexts". Typically that means you connect over HTTPS or are connecting to `localhost`. If your browser doesn't consider your connection to be a secure context, the screenshot and recording options will be hidden. The browser wouldn't allow access to the required APIs in that case anyways. Further, if GLPI doesn't allow uploading the type of file used by one of the options, that option will not show. It uses PNG for screenshots and WEBM for recordings.

Also, the plugin had restricted screen recordings with a new permission. My reasoning was that the convenience of creating and adding a video, which would be a large file, may not be desired to be accessible to certain users.
**My question is where this permission would fit in. There are no document permissions within simplified interface profiles currently.**