### PR TITLE
Add deny login action to authorization rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The present file will list all changes made to the project; according to the
 - Log viewer for logs in `files/_log` directory.
 - Custom palette/theme support (uses `files/_themes` directory by default).
 - Two-Factor Authentication (2FA) support via Time-based One-time Password (TOTP).
+- `Deny login` authorization rule action to deny login for a user, but not prevent the import/existence of the user in GLPI.
 
 ### Changed
 - ITIL Objects can now be linked to any other ITIL Objects similar to the previous Ticket/Ticket links.

--- a/src/RuleRight.php
+++ b/src/RuleRight.php
@@ -381,6 +381,10 @@ class RuleRight extends Rule
         $actions['timezone']['name']                          = __('Timezone');
         $actions['timezone']['type']                          = 'timezone';
 
+        $actions['_deny_login']['name']                       = __('Deny login');
+        $actions['_deny_login']['type']                       = 'yesonly';
+        $actions['_deny_login']['table']                      = '';
+
         return $actions;
     }
 

--- a/tests/units/RuleRight.php
+++ b/tests/units/RuleRight.php
@@ -52,7 +52,7 @@ class RuleRight extends DbTestCase
     {
         $rule = new \RuleRight();
         $actions  = $rule->getActions();
-        $this->array($actions)->size->isGreaterThan(11);
+        $this->array($actions)->size->isGreaterThan(12);
     }
 
     public function testDefaultRuleExists()
@@ -220,5 +220,44 @@ class RuleRight extends DbTestCase
 
        // Clean session
         $this->login();
+    }
+
+    public function testDenyLogin()
+    {
+        $rule = new \RuleRight();
+        $this->integer($rules_id = $rule->add([
+            'sub_type'     => 'RuleRight',
+            'name'         => 'deny login',
+            'match'        => 'AND',
+            'is_active'    => 1,
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+        ]));
+        $criteria = new \RuleCriteria();
+        $this->integer($criteria->add([
+            'rules_id'  => $rules_id,
+            'criteria'  => 'LOGIN',
+            'condition' => \Rule::PATTERN_IS,
+            'pattern'   => TU_USER,
+        ]))->isGreaterThan(0);
+
+        $actions = new \RuleAction();
+        $this->integer($actions->add([
+            'rules_id'    => $rules_id,
+            'action_type' => 'assign',
+            'field'       => '_deny_login',
+            'value'       => 1,
+        ]))->isGreaterThan(0);
+
+        $this->login(TU_USER, TU_PASS, true, false);
+        $events = getAllDataFromTable('glpi_events', [
+            'service' => 'login',
+            'type' => 'system',
+            'items_id' => 0,
+        ]);
+        $username = TU_USER;
+        $this->array(array_filter($events, static function ($event) use ($username) {
+            return str_starts_with($event['message'], "Login for {$username} denied by authorization rules from IP ");
+        }))->size->isIdenticalTo(1);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Add a new "Deny login" action to the authorization rules. This can allow the import/existence of users within GLPI and the assignment of entities, while at the same time denying their ability to log into GLPI. In some cases, you may want certain types of users to be active within GLPI so they can be assigned to assets or delegated as a requester on a ticket, but not let them login themselves. If you manually created the account, you could randomize the password. However, for external authentication sources like LDAP, that wasn't an option.