### PR TITLE
Add recipient exclusions for notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ The present file will list all changes made to the project; according to the
 - The debug tab that was present, for some items, when the debug mode was active, no longer exists. The corresponding features have been either moved, either removed.
 - `Group` and `Group in charge` fields for assets may now contain multiple groups.
 - "If software are no longer used" transfer option is now taken into account rather than always preserving.
+- Notifications can now specify exclusions for recipients.
 
 ### Deprecated
 - Survey URL tags `TICKETCATEGORY_ID` and `TICKETCATEGORY_NAME` are deprecated and replaced by `ITILCATEGORY_ID` and `ITILCATEGORY_NAME` respectively.
@@ -94,6 +95,7 @@ The present file will list all changes made to the project; according to the
 - `phpCAS` library is now bundled in GLPI, to prevent version compatibility issues.
 - `Glpi\DBAL\QueryFunction` class with multiple static methods for building SQL query function strings in an abstract way.
 - `fetchSessionMessages()` global JS function to display new session messages as toast notifications without requiring a page reload.
+- `is_exclusion` column added to `glpi_notificationtargets` table.
 
 #### Changes
 - Many methods have their signature changed to specify both their return type and the types of their parameters.

--- a/install/migrations/update_10.0.x_to_11.0.0/notifications.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/notifications.php
@@ -317,3 +317,6 @@ $migration->addKey(
     "item_trigger"
 );
 /** /Add handling of source item of attached documents in notification */
+
+$migration->addField('glpi_notificationtargets', 'is_exclusion', 'boolean');
+$migration->addKey('glpi_notificationtargets', ['is_exclusion'], 'is_exclusion');

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -5003,9 +5003,11 @@ CREATE TABLE `glpi_notificationtargets` (
   `items_id` int unsigned NOT NULL DEFAULT '0',
   `type` int NOT NULL DEFAULT '0',
   `notifications_id` int unsigned NOT NULL DEFAULT '0',
+  `is_exclusion` tinyint NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `items` (`type`,`items_id`),
-  KEY `notifications_id` (`notifications_id`)
+  KEY `notifications_id` (`notifications_id`),
+  KEY `is_exclusion` (`is_exclusion`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 

--- a/phpunit/functional/NotificationTargetTest.php
+++ b/phpunit/functional/NotificationTargetTest.php
@@ -586,27 +586,27 @@ class NotificationTargetTest extends DbTestCase
         $user = new \User();
 
         // Create new user with a fake email
-        $this->integer($users_id = $user->add([
+        $this->assertGreaterThan(0, $users_id = $user->add([
             'name'     => __FUNCTION__,
-        ]))->isGreaterThan(0);
+        ]));
         $useremail = new \UserEmail();
-        $this->integer($useremail->add([
+        $this->assertGreaterThan(0, $useremail->add([
             'users_id' => $users_id,
             'email'    => __FUNCTION__ . '@localhost',
             'is_default' => 1,
-        ]))->isGreaterThan(0);
+        ]));
         // Create a new group for this user
-        $this->integer($groups_id = $group->add([
+        $this->assertGreaterThan(0, $groups_id = $group->add([
             'name'     => __FUNCTION__,
-        ]))->isGreaterThan(0);
+        ]));
         $group_user = new \Group_User();
-        $this->integer($group_user->add([
+        $this->assertGreaterThan(0, $group_user->add([
             'groups_id' => $groups_id,
             'users_id'  => $users_id,
-        ]))->isGreaterThan(0);
+        ]));
 
         $notification = new \Notification();
-        $this->integer($fake_notification_id = $notification->add([
+        $this->assertGreaterThan(0, $fake_notification_id = $notification->add([
             'itemtype' => 'Ticket',
             'event'    => 'new',
         ]));
@@ -624,18 +624,18 @@ class NotificationTargetTest extends DbTestCase
             'users_id' => $users_id,
             'usertype' => \NotificationTarget::GLPI_USER,
         ]);
-        $this->array($notification_target->getTargets())->size->isEqualTo(2);
+        $this->assertCount(2, $notification_target->getTargets());
 
-        $this->integer($notification_target->add([
+        $this->assertGreaterThan(0, $notification_target->add([
             'notifications_id' => $fake_notification_id,
             'type' => \Notification::GROUP_TYPE,
             'items_id' => $groups_id,
             'is_exclusion' => 1,
-        ]))->isGreaterThan(0);
+        ]));
         // Only TU_USER should be in the list
         $targets = $notification_target->getTargets();
-        $this->array($targets)->size->isEqualTo(1);
+        $this->assertCount(1, $targets);
         $target = reset($targets);
-        $this->integer($target['users_id'])->isEqualTo(getItemByTypeName('User', TU_USER, true));
+        $this->assertEquals(getItemByTypeName('User', TU_USER, true), $target['users_id']);
     }
 }

--- a/phpunit/functional/NotificationTargetTest.php
+++ b/phpunit/functional/NotificationTargetTest.php
@@ -575,4 +575,67 @@ class NotificationTargetTest extends DbTestCase
         $messageid = $instance->getMessageIdForEvent($itemtype, $items_id, $event);
         $this->assertMatchesRegularExpression($expected, $messageid);
     }
+
+    public function testGetTargetsWithExclusions()
+    {
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        $notification_target = new \NotificationTarget();
+        $group = new \Group();
+        $user = new \User();
+
+        // Create new user with a fake email
+        $this->integer($users_id = $user->add([
+            'name'     => __FUNCTION__,
+        ]))->isGreaterThan(0);
+        $useremail = new \UserEmail();
+        $this->integer($useremail->add([
+            'users_id' => $users_id,
+            'email'    => __FUNCTION__ . '@localhost',
+            'is_default' => 1,
+        ]))->isGreaterThan(0);
+        // Create a new group for this user
+        $this->integer($groups_id = $group->add([
+            'name'     => __FUNCTION__,
+        ]))->isGreaterThan(0);
+        $group_user = new \Group_User();
+        $this->integer($group_user->add([
+            'groups_id' => $groups_id,
+            'users_id'  => $users_id,
+        ]))->isGreaterThan(0);
+
+        $notification = new \Notification();
+        $this->integer($fake_notification_id = $notification->add([
+            'itemtype' => 'Ticket',
+            'event'    => 'new',
+        ]));
+        $notification_target->data = [
+            'notifications_id' => $fake_notification_id,
+        ];
+        $rc = new \ReflectionClass($notification_target);
+        $rc->getProperty('event')->setValue($notification_target, \NotificationEventMailing::class);
+
+        $notification_target->addToRecipientsList([
+            'users_id' => getItemByTypeName('User', TU_USER, true),
+            'usertype' => \NotificationTarget::GLPI_USER,
+        ]);
+        $notification_target->addToRecipientsList([
+            'users_id' => $users_id,
+            'usertype' => \NotificationTarget::GLPI_USER,
+        ]);
+        $this->array($notification_target->getTargets())->size->isEqualTo(2);
+
+        $this->integer($notification_target->add([
+            'notifications_id' => $fake_notification_id,
+            'type' => \Notification::GROUP_TYPE,
+            'items_id' => $groups_id,
+            'is_exclusion' => 1,
+        ]))->isGreaterThan(0);
+        // Only TU_USER should be in the list
+        $targets = $notification_target->getTargets();
+        $this->array($targets)->size->isEqualTo(1);
+        $target = reset($targets);
+        $this->integer($target['users_id'])->isEqualTo(getItemByTypeName('User', TU_USER, true));
+    }
 }

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -438,10 +438,21 @@ class NotificationTarget extends CommonDBChild
             $canedit = $notification->can($notifications_id, UPDATE);
 
             $values = [];
+            $allowed_exclusion_types = [
+                Notification::PROFILE_TYPE,
+                Notification::GROUP_TYPE,
+            ];
+            $all_exclusion_targets = [];
             foreach ($this->notification_targets as $key => $val) {
                 [$type, $id] = explode('_', $key);
-                $values[$key] = $this->notification_targets_labels[$type][$id];
+                $label = $this->notification_targets_labels[$type][$id];
+                if (in_array((int) $type, $allowed_exclusion_types, true)) {
+                    $all_exclusion_targets[$key] = $label;
+                } else {
+                    $values[$key] = $label;
+                }
             }
+
             $targets = getAllDataFromTable(
                 self::getTable(),
                 [
@@ -449,16 +460,24 @@ class NotificationTarget extends CommonDBChild
                 ]
             );
             $actives = [];
+            $exclusions = [];
             if (count($targets)) {
                 foreach ($targets as $data) {
-                    $actives[$data['type'] . '_' . $data['items_id']] = $data['type'] . '_' . $data['items_id'];
+                    $target_key = $data['type'] . '_' . $data['items_id'];
+                    if ($data['is_exclusion']) {
+                        $exclusions[$target_key] = $target_key;
+                    } else {
+                        $actives[$target_key] = $target_key;
+                    }
                 }
             }
             TemplateRenderer::getInstance()->display('pages/setup/notification/recipients.html.twig', [
                 'item' => $this,
                 'notification' => $notification,
                 'all_targets' => $values,
+                'all_exclusion_targets' => $all_exclusion_targets,
                 'active_targets' => $actives,
+                'excluded_targets' => $exclusions,
                 'params' => [
                     'canedit' => $canedit
                 ]
@@ -512,7 +531,26 @@ class NotificationTarget extends CommonDBChild
             }
         }
 
-       // Drop others
+        if (isset($input['_exclusions']) && count($input['_exclusions'])) {
+            $input['_exclusions'] = array_unique($input['_exclusions']);
+            // Remove exclusions already set in _targets
+            $input['_exclusions'] = array_diff($input['_exclusions'], $input['_targets'] ?? []);
+            foreach ($input['_exclusions'] as $val) {
+               // Add if not set
+                if (!isset($actives[$val])) {
+                    list($type, $items_id)   = explode("_", $val);
+                    $tmp                     = [];
+                    $tmp['items_id']         = $items_id;
+                    $tmp['type']             = $type;
+                    $tmp['notifications_id'] = $input['notifications_id'];
+                    $tmp['is_exclusion']     = 1;
+                    $target->add($tmp);
+                }
+                unset($actives[$val]);
+            }
+        }
+
+        // Drop others
         if (count($actives)) {
             foreach ($actives as $val) {
                 list($type, $items_id) = explode("_", $val);
@@ -1348,9 +1386,82 @@ class NotificationTarget extends CommonDBChild
 
     final public function getTargets()
     {
-        return $this->target;
+        return $this->removeExcludedTargets($this->target);
     }
 
+    private function removeExcludedTargets(array $target_list)
+    {
+        /** @var \DBmysql $DB */
+        global $DB;
+        $exclusions = iterator_to_array($DB->request([
+            'SELECT' => ['type', 'items_id'],
+            'FROM'   => self::getTable(),
+            'WHERE'  => [
+                'is_exclusion'     => 1,
+                'notifications_id' => $this->data['notifications_id']
+            ]
+        ]));
+        if (empty($exclusions)) {
+            // No exclusion, no need to filter
+            return $target_list;
+        }
+        $user_ids = [];
+        foreach ($target_list as $target) {
+            if (isset($target['users_id'])) {
+                $user_ids[] = $target['users_id'];
+            }
+        }
+        if (empty($user_ids)) {
+            // Cannot filter targets without a user id
+            return $target_list;
+        }
+
+        // Criteria to get any user IDs that are excluded
+        $criteria = [
+            'SELECT' => [User::getTableField('id')],
+            'FROM' => User::getTable(),
+            'INNER JOIN' => [
+                Profile_User::getTable() => [
+                    'ON' => [
+                        Profile_User::getTable() => 'users_id',
+                        User::getTable()         => 'id'
+                    ]
+                ],
+                Group_User::getTable() => [
+                    'ON' => [
+                        Group_User::getTable() => 'users_id',
+                        User::getTable()       => 'id'
+                    ]
+                ]
+            ],
+            'WHERE' => [
+                'OR' => [
+                    [
+                        Profile_User::getTableField('profiles_id') => array_column($exclusions, 'items_id'),
+                        Profile_User::getTableField('users_id') => $user_ids
+                    ],
+                    [
+                        Group_User::getTableField('groups_id') => array_column($exclusions, 'items_id'),
+                        Group_User::getTableField('users_id') => $user_ids
+                    ]
+                ],
+            ]
+        ];
+
+        $excluded_user_ids = [];
+        $it = $DB->request($criteria);
+        foreach ($it as $data) {
+            $excluded_user_ids[] = $data['id'];
+        }
+
+        foreach ($target_list as $key => $target) {
+            if (isset($target['users_id']) && in_array($target['users_id'], $excluded_user_ids, true)) {
+                unset($target_list[$key]);
+            }
+        }
+
+        return $target_list;
+    }
 
     public function getEntity()
     {
@@ -1568,7 +1679,8 @@ class NotificationTarget extends CommonDBChild
                     Notification::SUPERVISOR_GROUP_TYPE,
                     Notification::GROUP_TYPE
                 ],
-                'items_id'  => $group->getID()
+                'items_id'  => $group->getID(),
+                'is_exclusion' => 0,
             ] + getEntitiesRestrictCriteria(Notification::getTable(), '', '', true)
         ])->current();
         return $count['cpt'];
@@ -1609,7 +1721,8 @@ class NotificationTarget extends CommonDBChild
                     Notification::SUPERVISOR_GROUP_TYPE,
                     Notification::GROUP_TYPE
                 ],
-                'items_id'  => $group->getID()
+                'items_id'  => $group->getID(),
+                'is_exclusion' => 0,
             ] + getEntitiesRestrictCriteria(Notification::getTable(), '', '', true)
         ]);
 

--- a/templates/pages/setup/notification/recipients.html.twig
+++ b/templates/pages/setup/notification/recipients.html.twig
@@ -51,7 +51,13 @@
                   }) }}
 
                   {{ fields.nullField() }}
+                  {{ fields.dropdownArrayField('_exclusions', null, all_exclusion_targets, _n('Exclusion', 'Exclusions', get_plural_number()), {
+                     multiple: true,
+                     readonly: not params['canedit'],
+                     values: excluded_targets
+                  }) }}
                   {{ fields.nullField() }}
+                   {{ fields.nullField() }}
                   {{ fields.htmlField('', inputs.submit('update', _x('button', 'Update'), 1), '') }}
                </div>
             </div>

--- a/tests/functional/NotificationTargetKnowbaseItem.php
+++ b/tests/functional/NotificationTargetKnowbaseItem.php
@@ -107,7 +107,8 @@ class NotificationTargetKnowbaseItem extends DbTestCase
                     'id' => $ntarget->fields['id'],
                     'items_id' => $group->fields['id'],
                     'type' => Notification::GROUP_TYPE,
-                    'notifications_id' => $kbnotif['id']
+                    'notifications_id' => $kbnotif['id'],
+                    'is_exclusion' => 0,
                 ]
             );
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Adds a new field to the Recipients tab of notifications to allow specifying exclusions. For example, the "New Ticket" notification may be configured to be sent to the ticket's requesters. However, there may be a specific group or profile that you don't want to be notified about this event. A real-life case is within an education environment where students report issues to a physical helpdesk. They may have user accounts within GLPI from LDAP and therefore also emails. Previously, you couldn't have the students added to the tickets as the requester for tracking purposes and also avoid sending them the emails when the staff at the physical helpdesk is supposed to act as the middle-man. In some cases, you may only want specific notifications like the ticket closed notification or one with a specific criteria filter to go to them.

![image](https://github.com/glpi-project/glpi/assets/17678637/1c7ec54b-8238-428d-87a2-a69410d66c85)
