### PR TITLE
Profile assignment twig migration

### DIFF
--- a/src/CommonDBRelation.php
+++ b/src/CommonDBRelation.php
@@ -1903,18 +1903,26 @@ abstract class CommonDBRelation extends CommonDBConnexity
      * @since 9.3.1
      *
      * @param CommonDBTM $item Item instance
+     * @param integer    $start Start index
+     * @param integer    $limit Limit of results. If 0, no limit.
+     * @param array      $order The order for the results where the first element is the column name that will be sorted and the second element is the direction of the sorting (ASC or DESC)
      *
      * @return DBmysqlIterator
      */
-    public static function getListForItem(CommonDBTM $item)
+    public static function getListForItem(CommonDBTM $item, int $start = 0, int $limit = 0, array $order = [])
     {
         /** @var \DBmysql $DB */
         global $DB;
 
         $params = static::getListForItemParams($item);
-        $iterator = $DB->request($params);
-
-        return $iterator;
+        $params['START'] = $start;
+        if ($limit > 0) {
+            $params['LIMIT'] = $limit;
+        }
+        if (!empty($order)) {
+            $params['ORDER'] = $order;
+        }
+        return $DB->request($params);
     }
 
     /**

--- a/src/Profile_User.php
+++ b/src/Profile_User.php
@@ -168,7 +168,7 @@ class Profile_User extends CommonDBRelation
             }
             if ($canshowentity) {
                 $link = sprintf(
-                    '<a href="%s">%s</a>', 
+                    '<a href="%s">%s</a>',
                     htmlspecialchars(Entity::getFormURLWithID($data["entities_id"])),
                     htmlspecialchars($link)
                 );
@@ -177,7 +177,7 @@ class Profile_User extends CommonDBRelation
 
             if (Profile::canView()) {
                 $profile_name = sprintf(
-                    '<a href="%s">%s</a>', 
+                    '<a href="%s">%s</a>',
                     htmlspecialchars(Profile::getFormURLWithID($data['id'])),
                     htmlspecialchars($data['name'])
                 );
@@ -255,7 +255,8 @@ class Profile_User extends CommonDBRelation
         if ($canedit) {
             TemplateRenderer::getInstance()->display('pages/admin/add_profile_authorization.html.twig', [
                 'source_itemtype' => Entity::class,
-                'source_items_id' => $ID
+                'source_items_id' => $ID,
+                'used_users'      => [],
             ]);
         }
 
@@ -584,7 +585,7 @@ TWIG, $avatar_params) . $username;
             TemplateRenderer::getInstance()->display('pages/admin/add_profile_authorization.html.twig', [
                 'source_itemtype' => Profile::class,
                 'source_items_id' => $ID,
-                'used_users'     => $used_users,
+                'used_users'      => $used_users,
             ]);
         }
 

--- a/src/Profile_User.php
+++ b/src/Profile_User.php
@@ -33,6 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QuerySubQuery;
 
 /**
@@ -116,11 +117,10 @@ class Profile_User extends CommonDBRelation
         return parent::prepareInputForAdd($input);
     }
 
-
     /**
      * Show rights of a user
      *
-     * @param $user User object
+     * @param User $user object
      **/
     public static function showForUser(User $user)
     {
@@ -132,144 +132,106 @@ class Profile_User extends CommonDBRelation
         $canedit = $user->canEdit($ID);
 
         $strict_entities = self::getUserEntities($ID, false);
-        if (
-            !Session::haveAccessToOneOfEntities($strict_entities)
-            && !Session::canViewAllEntities()
-        ) {
+        if (!Session::haveAccessToOneOfEntities($strict_entities) && !Session::canViewAllEntities()) {
             $canedit = false;
         }
 
         $canshowentity = Entity::canView();
-        $rand          = mt_rand();
 
         if ($canedit) {
-            echo "<div class='firstbloc'>";
-            echo "<form name='entityuser_form$rand' id='entityuser_form$rand' method='post' action='";
-            echo Toolbox::getItemTypeFormURL(__CLASS__) . "'>";
-            echo "<table class='tab_cadre_fixe'>";
-            echo "<tr class='tab_bg_1'><th colspan='6'>" . __('Add an authorization to a user') . "</tr>";
-
-            echo "<tr class='tab_bg_2'><td class='center'>";
-            echo "<input type='hidden' name='users_id' value='$ID'>";
-            Entity::dropdown(['entity' => $_SESSION['glpiactiveentities']]);
-            echo "</td><td class='center'>" . self::getTypeName(1) . "</td><td>";
-            Profile::dropdownUnder(['value' => Profile::getDefault()]);
-            echo "</td><td>" . __('Recursive') . "</td><td>";
-            Dropdown::showYesNo("is_recursive", 0);
-            echo "</td><td class='center'>";
-            echo "<input type='submit' name='add' value=\"" . _sx('button', 'Add') . "\" class='btn btn-primary'>";
-            echo "</td></tr>";
-
-            echo "</table>";
-            Html::closeForm();
-            echo "</div>";
+            TemplateRenderer::getInstance()->display('pages/admin/add_profile_authorization.html.twig', [
+                'source_itemtype' => User::class,
+                'source_items_id' => $ID,
+            ]);
         }
 
-        $iterator = self::getListForItem($user);
-        $num = count($iterator);
+        $start       = (int) ($_GET["start"] ?? 0);
+        $limit       = $_SESSION["glpilist_limit"];
+        $sort        = $_GET["sort"] ?? "";
+        $order       = strtoupper($_GET["order"] ?? "");
+        $sort_params = [];
+        if ($sort !== '') {
+            $sort_params = [$sort => $order === 'DESC' ? 'DESC' : 'ASC'];
+        }
+        $iterator = self::getListForItem($user, $start, $limit, $sort_params);
+        $total_num = self::countForItem($user);
 
-        echo "<div class='spaced'>";
-        Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
-
-        if ($canedit && $num) {
-            $massiveactionparams = ['num_displayed' => min($_SESSION['glpilist_limit'], $num),
-                'container'     => 'mass' . __CLASS__ . $rand
+        $entries = [];
+        $entity_form_url = Toolbox::getItemTypeFormURL('Entity');
+        foreach ($iterator as $data) {
+            $entry = [
+                'itemtype' => __CLASS__,
+                'id'       => $data['linkid'],
             ];
-            Html::showMassiveActions($massiveactionparams);
-        }
-
-        if ($num > 0) {
-            echo "<table class='tab_cadre_fixehov'>";
-            $header_begin  = "<tr>";
-            $header_top    = '';
-            $header_bottom = '';
-            $header_end    = '';
-            if ($canedit) {
-                $header_begin  .= "<th>";
-                $header_top    .= Html::getCheckAllAsCheckbox('mass' . __CLASS__ . $rand);
-                $header_bottom .= Html::getCheckAllAsCheckbox('mass' . __CLASS__ . $rand);
-                $header_end    .= "</th>";
+            $link = $data["completename"];
+            if ($_SESSION["glpiis_ids_visible"]) {
+                $link = sprintf(__('%1$s (%2$s)'), $link, $data["entities_id"]);
             }
-            $header_end .= "<th>" . Entity::getTypeName(Session::getPluralNumber()) . "</th>";
-            $header_end .= "<th>" . sprintf(
-                __('%1$s (%2$s)'),
-                self::getTypeName(Session::getPluralNumber()),
-                __('D=Dynamic, R=Recursive')
-            );
-            $header_end .= "</th></tr>";
-            echo $header_begin . $header_top . $header_end;
-
-            foreach ($iterator as $data) {
-                echo "<tr class='tab_bg_1'>";
-                if ($canedit) {
-                    echo "<td width='10'>";
-                    if (in_array($data["entities_id"], $_SESSION['glpiactiveentities'])) {
-                        Html::showMassiveActionCheckBox(__CLASS__, $data["linkid"]);
-                    } else {
-                        echo "&nbsp;";
-                    }
-                    echo "</td>";
-                }
-                echo "<td>";
-
-                $link = $data["completename"];
-                if ($_SESSION["glpiis_ids_visible"]) {
-                    $link = sprintf(__('%1$s (%2$s)'), $link, $data["entities_id"]);
-                }
-
-                if ($canshowentity) {
-                     echo "<a href='" . Toolbox::getItemTypeFormURL('Entity') . "?id=" .
-                     $data["entities_id"] . "'>";
-                }
-                echo $link . ($canshowentity ? "</a>" : '');
-                echo "</td>";
-
-                if (Profile::canView()) {
-                    $entname = "<a href='" . Toolbox::getItemTypeFormURL('Profile') . "?id=" . $data["id"] . "'>" .
-                           $data["name"] . "</a>";
-                } else {
-                    $entname =  $data["name"];
-                }
-
-                if ($data["is_dynamic"] || $data["is_recursive"]) {
-                    $entname = sprintf(__('%1$s %2$s'), $entname, "<span class='b'>(");
-                    if ($data["is_dynamic"]) {
-                       //TRANS: letter 'D' for Dynamic
-                        $entname = sprintf(__('%1$s%2$s'), $entname, __('D'));
-                    }
-                    if ($data["is_dynamic"] && $data["is_recursive"]) {
-                        $entname = sprintf(__('%1$s%2$s'), $entname, ", ");
-                    }
-                    if ($data["is_recursive"]) {
-                        //TRANS: letter 'R' for Recursive
-                        $entname = sprintf(__('%1$s%2$s'), $entname, __('R'));
-                    }
-                    $entname = sprintf(__('%1$s%2$s'), $entname, ")</span>");
-                }
-                echo "<td>" . $entname . "</td>";
-                echo "</tr>";
+            if ($canshowentity) {
+                $link = "<a href='" . $entity_form_url . "?id=" . $data["entities_id"] . "'>" . $link . "</a>";
             }
-            echo $header_begin . $header_bottom . $header_end;
-            echo "</table>";
-        } else {
-            echo "<table class='tab_cadre_fixe'>";
-            echo "<tr><th>" . __('No item found') . "</th></tr>";
-            echo "</table>\n";
+            $entry['entity'] = $link;
+
+            if (Profile::canView()) {
+                $form_url = Toolbox::getItemTypeFormURL('Profile');
+                $profile_name = "<a href='{$form_url}?id={$data['id']}'>" . Html::entities_deep($data['name']) . "</a>";
+            } else {
+                $profile_name = Html::entities_deep($data['name']);
+            }
+
+            if ($data['is_dynamic'] || $data['is_recursive']) {
+                $profile_name = sprintf(__('%1$s %2$s'), $profile_name, "<span class='b'>(");
+                if ($data['is_dynamic']) {
+                    $profile_name = sprintf(__('%1$s%2$s'), $profile_name, __('D'));
+                }
+                if ($data['is_dynamic'] && $data['is_recursive']) {
+                    $profile_name = sprintf(__('%1$s%2$s'), $profile_name, ", ");
+                }
+                if ($data['is_recursive']) {
+                    $profile_name = sprintf(__('%1$s%2$s'), $profile_name, __('R'));
+                }
+                $profile_name = sprintf(__('%1$s%2$s'), $profile_name, ")</span>");
+            }
+            $entry['profile'] = $profile_name;
+            $entries[] = $entry;
         }
 
-        if ($canedit && $num) {
-            $massiveactionparams['ontop'] = false;
-            Html::showMassiveActions($massiveactionparams);
-        }
-        Html::closeForm();
-        echo "</div>";
+        TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
+            'start' => $start,
+            'limit' => $limit,
+            'sort' => $sort,
+            'order' => $order,
+            'is_tab' => true,
+            'nofilter' => true,
+            'columns' => [
+                'entity' => Entity::getTypeName(Session::getPluralNumber()),
+                'profile' => sprintf(
+                    __('%1$s (%2$s)'),
+                    self::getTypeName(Session::getPluralNumber()),
+                    __('D=Dynamic, R=Recursive')
+                )
+            ],
+            'formatters' => [
+                'entity' => 'raw_html',
+                'profile' => 'raw_html'
+            ],
+            'entries' => $entries,
+            'total_number' => $total_num,
+            'filtered_number' => $total_num,
+            'showmassiveactions' => $canedit,
+            'massiveactionparams' => [
+                'num_displayed'    => min($_SESSION['glpilist_limit'], count($entries)),
+                'container'        => 'mass' . __CLASS__ . mt_rand(),
+                'specific_actions' => ['purge' => _x('button', 'Delete permanently')]
+            ],
+        ]);
     }
 
 
     /**
      * Show users of an entity
      *
-     * @param $entity Entity object
+     * @param Entity $entity object
      **/
     public static function showForEntity(Entity $entity)
     {
@@ -282,44 +244,64 @@ class Profile_User extends CommonDBRelation
         }
 
         $canedit     = $entity->canEdit($ID);
-        $canshowuser = User::canView();
-        $nb_per_line = 3;
         $rand        = mt_rand();
 
         if ($canedit) {
-            $headerspan = $nb_per_line * 2;
-        } else {
-            $headerspan = $nb_per_line;
-        }
-
-        if ($canedit) {
-            echo "<div class='firstbloc'>";
-            echo "<form name='entityuser_form$rand' id='entityuser_form$rand' method='post' action='";
-            echo Toolbox::getItemTypeFormURL(__CLASS__) . "'>";
-            echo "<table class='tab_cadre_fixe'>";
-            echo "<tr class='tab_bg_1'><th colspan='6'>" . __('Add an authorization to a user') . "</tr>";
-            echo "<tr class='tab_bg_1'><td class='tab_bg_2 center'>" . User::getTypeName(1) . "&nbsp;";
-            echo "<input type='hidden' name='entities_id' value='$ID'>";
-            User::dropdown(['right' => 'all']);
-            echo "</td><td class='tab_bg_2 center'>" . self::getTypeName(1) . "</td><td>";
-            Profile::dropdownUnder(['value' => Profile::getDefault()]);
-            echo "</td><td class='tab_bg_2 center'>" . __('Recursive') . "</td><td>";
-            Dropdown::showYesNo("is_recursive", 0);
-            echo "</td><td class='tab_bg_2 center'>";
-            echo "<input type='submit' name='add' value=\"" . _sx('button', 'Add') . "\" class='btn btn-primary'>";
-            echo "</td></tr>";
-            echo "</table>";
-            Html::closeForm();
-            echo "</div>";
+            TemplateRenderer::getInstance()->display('pages/admin/add_profile_authorization.html.twig', [
+                'source_itemtype' => Entity::class,
+                'source_items_id' => $ID
+            ]);
         }
 
         $putable = Profile_User::getTable();
         $ptable = Profile::getTable();
         $utable = User::getTable();
+        $start       = (int) ($_GET["start"] ?? 0);
+        $limit       = $_SESSION["glpilist_limit"];
+        $sort        = $_GET["sort"] ?? "";
+        $order       = strtoupper($_GET["order"] ?? "");
+        $sort_params = [];
+        $filters = $_GET['filters'] ?? [];
 
-        $iterator = $DB->request([
+        if ($sort === 'name') {
+            $sort_params = [
+                "$utable.name $order",
+                "$utable.realname $order",
+                "$utable.firstname $order"
+            ];
+        } else if ($sort === 'profile') {
+            $sort_params = ["$ptable.name $order"];
+        } else if ($sort !== '') {
+            $sort_params = [$sort . ' ' . ($order === 'DESC' ? 'DESC' : 'ASC')];
+        }
+        if (empty($sort_params)) {
+            $sort_params = [
+                "$utable.name ASC",
+                "$utable.realname ASC",
+                "$utable.firstname ASC"
+            ];
+        }
+
+        $filter_conditions = [];
+        foreach ($filters as $k => $v) {
+            if ($k === 'name') {
+                $filter_conditions[] = [
+                    'OR' => [
+                        "$utable.name" => ['LIKE', "%$v%"],
+                        "$utable.realname" => ['LIKE', "%$v%"],
+                        "$utable.firstname" => ['LIKE', "%$v%"]
+                    ]
+                ];
+            } else if ($k === 'profile') {
+                $filter_conditions[] = [
+                    "$ptable.name" => ['LIKE', "%$v%"]
+                ];
+            }
+        }
+
+        $criteria = [
             'SELECT'       => [
-                "glpi_users.*",
+                "glpi_users" => ['id', 'name', 'realname', 'firstname', 'picture'],
                 "$putable.id AS linkid",
                 "$putable.is_recursive",
                 "$putable.is_dynamic",
@@ -345,123 +327,103 @@ class Profile_User extends CommonDBRelation
                 "$utable.is_deleted"    => 0,
                 "$putable.entities_id"  => $ID
             ],
-            'ORDERBY'      => [
-                "$putable.profiles_id",
-                "$utable.name",
-                "$utable.realname",
-                "$utable.firstname"
-            ]
-        ]);
-
+            'ORDER'      => $sort_params,
+            'START'      => $start,
+            'LIMIT'      => $limit
+        ];
+        if (count($filter_conditions)) {
+            $criteria['WHERE'] += $filter_conditions;
+        }
+        $iterator = $DB->request($criteria);
         $nb = count($iterator);
 
-        echo "<div class='spaced'>";
-        if ($canedit && $nb) {
-            Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
-            $massiveactionparams
-            = ['container'
-                        => 'mass' . __CLASS__ . $rand,
-                'specific_actions'
-                        => ['purge' => _x('button', 'Delete permanently')]
-            ];
-            Html::showMassiveActions($massiveactionparams);
-        }
-        echo "<table class='tab_cadre_fixehov'>";
-        echo "<thead><tr>";
+        $count_criteria = $criteria;
+        unset($count_criteria['START'], $count_criteria['LIMIT'], $count_criteria['SELECT']);
+        $count_criteria['COUNT'] = 'cpt';
+        $total_count = $DB->request($count_criteria)->current()['cpt'];
 
-        echo "<th class='noHover' colspan='$headerspan'>";
-        printf(__('%1$s (%2$s)'), User::getTypeName(Session::getPluralNumber()), __('D=Dynamic, R=Recursive'));
-        echo "</th></tr></thead>";
-
-        if ($nb) {
-            Session::initNavigateListItems(
-                'User',
-                //TRANS : %1$s is the itemtype name, %2$s is the name of the item (used for headings of a list)
-                sprintf(
-                    __('%1$s = %2$s'),
-                    Entity::getTypeName(1),
-                    $entity->getName()
-                )
+        $entries = [];
+        foreach ($iterator as $data) {
+            $username = formatUserName(
+                $data["id"],
+                $data["name"],
+                $data["realname"],
+                $data["firstname"],
+                1
             );
-
-            $current_pid = null;
-            $i = 0;
-            foreach ($iterator as $data) {
-                if ($data['pid'] != $current_pid) {
-                    echo "<tbody><tr class='noHover'>";
-                    $reduce_header = 0;
-                    if ($canedit && $nb) {
-                        echo "<th width='10'>";
-                        echo Html::getCheckAllAsCheckbox("profile" . $data['pid'] . "_$rand");
-                        echo "</th>";
-                        $reduce_header++;
-                    }
-                    echo "<th colspan='" . ($headerspan - $reduce_header) . "'>";
-                    printf(__('%1$s: %2$s'), Profile::getTypeName(1), $data["pname"]);
-                    echo "</th></tr></tbody>";
-                    echo "<tbody id='profile" . $data['pid'] . "_$rand'>";
-                    $i = 0;
+            if ($data["is_dynamic"] || $data["is_recursive"]) {
+                $username = sprintf(__('%1$s %2$s'), $username, "<span class='b'>(");
+                if ($data["is_dynamic"]) {
+                    $username = sprintf(__('%1$s%2$s'), $username, __('D'));
                 }
-
-                Session::addToNavigateListItems('User', $data["id"]);
-
-                if (($i % $nb_per_line) == 0) {
-                    if ($i  != 0) {
-                        echo "</tr>";
-                    }
-                    echo "<tr class='tab_bg_1'>";
+                if ($data["is_dynamic"] && $data["is_recursive"]) {
+                    $username = sprintf(__('%1$s%2$s'), $username, ", ");
                 }
-                if ($canedit) {
-                     echo "<td width='10'>";
-                     Html::showMassiveActionCheckBox(__CLASS__, $data["linkid"]);
-                     echo "</td>";
+                if ($data["is_recursive"]) {
+                    $username = sprintf(__('%1$s%2$s'), $username, __('R'));
                 }
-
-                $username = formatUserName(
-                    $data["id"],
-                    $data["name"],
-                    $data["realname"],
-                    $data["firstname"],
-                    $canshowuser
-                );
-
-                if ($data["is_dynamic"] || $data["is_recursive"]) {
-                     $username = sprintf(__('%1$s %2$s'), $username, "<span class='b'>(");
-                    if ($data["is_dynamic"]) {
-                        $username = sprintf(__('%1$s%2$s'), $username, __('D'));
-                    }
-                    if ($data["is_dynamic"] && $data["is_recursive"]) {
-                        $username = sprintf(__('%1$s%2$s'), $username, ", ");
-                    }
-                    if ($data["is_recursive"]) {
-                        $username = sprintf(__('%1$s%2$s'), $username, __('R'));
-                    }
-                    $username = sprintf(__('%1$s%2$s'), $username, ")</span>");
-                }
-                 echo "<td>" . $username . "</td>";
-                 $i++;
-
-                 $current_pid = $data['pid'];
-                if ($data['pid'] != $current_pid) {
-                    echo "</tr>";
-                    echo "</tbody>";
-                }
+                $username = sprintf(__('%1$s%2$s'), $username, ")</span>");
             }
-        }
-        echo "</table>";
-        if ($canedit && $nb) {
-            $massiveactionparams['ontop'] = false;
-            Html::showMassiveActions($massiveactionparams);
-            Html::closeForm();
-        }
-        echo "</div>";
-    }
+            $initials = User::getInitialsForUserName($data['name'], $data['firstname'] ?? '', $data['realname'] ?? '');
+            $avatar_params = [
+                'picture' => User::getThumbnailURLForPicture($data['picture'] ?? ''),
+                'initials' => $initials,
+                'initials_bg' => Toolbox::getColorForString($initials)
+            ];
+            $username = TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
+                {% set bg_color = picture is not empty ? 'inherit' : initials_bg %}
+                <span class="avatar avatar-md me-2"
+                    style="{% if picture is not null %} background-image: url({{ picture }}); {% endif %} background-color: {{ bg_color }}">
+                    {% if picture is empty %}
+                        {{ initials }}
+                    {% endif %}
+                </span>
+TWIG, $avatar_params) . $username;
 
+            $entries[] = [
+                'itemtype' => self::class,
+                'id' => $data['id'],
+                'name' => $username,
+                'profile' => $data['pname']
+            ];
+        }
+
+        $super_header = sprintf(
+            __('%1$s (%2$s)'),
+            User::getTypeName(Session::getPluralNumber()),
+            __('D=Dynamic, R=Recursive')
+        );
+        TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
+            'start' => $start,
+            'limit' => $limit,
+            'sort' => $sort,
+            'order' => $order,
+            'is_tab' => true,
+            'filters' => $filters,
+            'super_header' => $super_header,
+            'columns' => [
+                'name' => __('Name'),
+                'profile' => Profile::getTypeName(1),
+            ],
+            'formatters' => [
+                'name' => 'raw_html',
+            ],
+            'total_number' => $total_count,
+            'filtered_number' => $total_count,
+            'entries' => $entries,
+            'showmassiveactions' => $canedit,
+            'massiveactionparams' => [
+                'num_displayed'    => min($_SESSION['glpilist_limit'], $nb),
+                'container'        => 'mass' . __CLASS__ . $rand,
+                'specific_actions' => ['purge' => _x('button', 'Delete permanently')]
+            ],
+        ]);
+    }
 
     /**
      * Show the User having a profile, in allowed Entity
      *
-     * @param $prof Profile object
+     * @param Profile $prof object
      **/
     public static function showForProfile(Profile $prof)
     {
@@ -475,12 +437,51 @@ class Profile_User extends CommonDBRelation
             return false;
         }
 
+        $start       = (int) ($_GET["start"] ?? 0);
+        $limit       = $_SESSION["glpilist_limit"];
+        $sort        = $_GET["sort"] ?? "";
+        $order       = strtoupper($_GET["order"] ?? "");
+        $sort_params = [];
+        $filters = $_GET['filters'] ?? [];
         $utable = User::getTable();
         $putable = Profile_User::getTable();
         $etable = Entity::getTable();
-        $iterator = $DB->request([
+
+        if ($sort === 'name') {
+            $sort_params = [
+                "$utable.name $order",
+                "$utable.realname $order",
+                "$utable.firstname $order"
+            ];
+        } else if ($sort === 'entity') {
+            $sort_params = ["$etable.completename $order"];
+        } else if ($sort !== '') {
+            $sort_params = [$sort . ' ' . ($order === 'DESC' ? 'DESC' : 'ASC')];
+        }
+        if (empty($sort_params)) {
+            $sort_params = ["$etable.completename ASC"];
+        }
+
+        $filter_conditions = [];
+        foreach ($filters as $k => $v) {
+            if ($k === 'name') {
+                $filter_conditions[] = [
+                    'OR' => [
+                        "$utable.name" => ['LIKE', "%$v%"],
+                        "$utable.realname" => ['LIKE', "%$v%"],
+                        "$utable.firstname" => ['LIKE', "%$v%"]
+                    ]
+                ];
+            } else if ($k === 'entity') {
+                $filter_conditions[] = [
+                    "$etable.completename" => ['LIKE', "%$v%"]
+                ];
+            }
+        }
+
+        $criteria = [
             'SELECT'          => [
-                "$utable.*",
+                $utable => ['id', 'name', 'realname', 'firstname', 'picture'],
                 "$putable.entities_id AS entity",
                 "$putable.id AS linkid",
                 "$putable.is_dynamic",
@@ -506,171 +507,111 @@ class Profile_User extends CommonDBRelation
                 "$putable.profiles_id"  => $ID,
                 "$utable.is_deleted"    => 0
             ] + getEntitiesRestrictCriteria($putable, 'entities_id', $_SESSION['glpiactiveentities'], true),
-            'ORDERBY'         => "$etable.completename"
-        ]);
+            'ORDER'         => $sort_params,
+            'START'         => $start,
+            'LIMIT'         => $limit
+        ];
+        if (count($filter_conditions)) {
+            $criteria['WHERE'] += $filter_conditions;
+        }
+        $iterator = $DB->request($criteria);
 
         $nb = count($iterator);
 
-        if ($canedit) {
-            $used_users = array_column(iterator_to_array($iterator) ?? [], 'id');
-            echo "<div class='firstbloc'>";
-            echo "<form name='entityuser_form$rand' id='entityuser_form$rand' method='post' action='";
-            echo Toolbox::getItemTypeFormURL(__CLASS__) . "'>";
-            echo "<table class='tab_cadre_fixe'>";
-            echo "<tr class='tab_bg_1'><th colspan='6'>" . __('Add an authorization to a user') . "</tr>";
+        $count_criteria = $criteria;
+        unset($count_criteria['START'], $count_criteria['LIMIT'], $count_criteria['SELECT'], $count_criteria['DISTINCT']);
+        $count_criteria['COUNT'] = 'cpt';
+        $total_count = $DB->request($count_criteria)->current()['cpt'];
 
-            echo "<tr class='tab_bg_2'><td class='center'>";
-            echo "<input type='hidden' name='profiles_id' value='$ID'>";
-            Entity::dropdown(['entity' => $_SESSION['glpiactiveentities']]);
-            echo "</td><td class='center'>" . User::getTypeName(1) . "</td><td>";
-            User::dropdown([
-                'entity'    => $_SESSION['glpiactiveentities'],
-                'right'     => 'all',
-                'used'      => $used_users,
-            ]);
-            echo "</td><td>" . __('Recursive') . "</td><td>";
-            Dropdown::showYesNo("is_recursive", 0);
-            echo "</td><td class='center'>";
-            echo "<input type='submit' name='add' value=\"" . _sx('button', 'Add') . "\" class='btn btn-primary'>";
-            echo "</td></tr>";
-
-            echo "</table>";
-            Html::closeForm();
-            echo "</div>";
-        }
-
-        echo "<div class='spaced'>";
-
-        if ($canedit && $nb) {
-            Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
-            $massiveactionparams = ['num_displayed' => min($_SESSION['glpilist_limit'], $nb),
-                'container'     => 'mass' . __CLASS__ . $rand
+        $entries = [];
+        $entity_names = [];
+        $used_users = [];
+        foreach ($iterator as $data) {
+            $used_users[] = $data['id'];
+            if (!isset($entity_names[$data['entity']])) {
+                $entity_names[$data['entity']] = Dropdown::getDropdownName('glpi_entities', $data['entity']);
+            }
+            $username = formatUserName(
+                $data["id"],
+                $data["name"],
+                $data["realname"],
+                $data["firstname"],
+                1
+            );
+            if ($data["is_dynamic"] || $data["is_recursive"]) {
+                $username = sprintf(__('%1$s %2$s'), $username, "<span class='b'>(");
+                if ($data["is_dynamic"]) {
+                    $username = sprintf(__('%1$s%2$s'), $username, __('D'));
+                }
+                if ($data["is_dynamic"] && $data["is_recursive"]) {
+                    $username = sprintf(__('%1$s%2$s'), $username, ", ");
+                }
+                if ($data["is_recursive"]) {
+                    $username = sprintf(__('%1$s%2$s'), $username, __('R'));
+                }
+                $username = sprintf(__('%1$s%2$s'), $username, ")</span>");
+            }
+            $initials = User::getInitialsForUserName($data['name'], $data['firstname'] ?? '', $data['realname'] ?? '');
+            $avatar_params = [
+                'picture' => User::getThumbnailURLForPicture($data['picture'] ?? ''),
+                'initials' => $initials,
+                'initials_bg' => Toolbox::getColorForString($initials)
             ];
-            Html::showMassiveActions($massiveactionparams);
+            $username = TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
+                {% set bg_color = picture is not empty ? 'inherit' : initials_bg %}
+                <span class="avatar avatar-md me-2"
+                    style="{% if picture is not null %} background-image: url({{ picture }}); {% endif %} background-color: {{ bg_color }}">
+                    {% if picture is empty %}
+                        {{ initials }}
+                    {% endif %}
+                </span>
+TWIG, $avatar_params) . $username;
+            $entries[] = [
+                'itemtype' => self::class,
+                'id' => $data['id'],
+                'name' => $username,
+                'entity' => $entity_names[$data['entity']]
+            ];
         }
-        echo "<table class='tab_cadre_fixe'><tr>";
-        echo "<th>" . sprintf(__('%1$s: %2$s'), Profile::getTypeName(1), $prof->fields["name"]) . "</th></tr>\n";
 
-        echo "<tr><th colspan='2'>" . sprintf(
+        if ($canedit) {
+            TemplateRenderer::getInstance()->display('pages/admin/add_profile_authorization.html.twig', [
+                'source_itemtype' => Profile::class,
+                'source_items_id' => $ID,
+                'used_users'     => $used_users,
+            ]);
+        }
+
+        $super_header = sprintf(
             __('%1$s (%2$s)'),
             User::getTypeName(Session::getPluralNumber()),
             __('D=Dynamic, R=Recursive')
-        ) . "</th></tr>";
-        echo "</table>\n";
-        echo "<table class='tab_cadre_fixe'>";
-
-        $i              = 0;
-        $nb_per_line    = 3;
-        $rand           = mt_rand(); // Just to avoid IDE warning
-        $canedit_entity = false;
-
-        if ($nb) {
-            $temp = -1;
-
-            foreach ($iterator as $data) {
-                if ($data["entity"] != $temp) {
-                    while (($i % $nb_per_line) != 0) {
-                        if ($canedit_entity) {
-                            echo "<td width='10'>&nbsp;</td>";
-                        }
-                        echo "<td class='tab_bg_1'>&nbsp;</td>\n";
-                        $i++;
-                    }
-
-                    if ($i != 0) {
-                        echo "</table>";
-                        echo "</div>";
-                        echo "</td></tr>\n";
-                    }
-
-                   // New entity
-                    $i              = 0;
-                    $temp           = $data["entity"];
-                    $canedit_entity = $canedit && in_array($temp, $_SESSION['glpiactiveentities']);
-                    $rand           = mt_rand();
-                    echo "<tr class='tab_bg_2'>";
-                    echo "<td>";
-                    echo "<a href=\"javascript:showHideDiv('entity$temp$rand','imgcat$temp', '" .
-                        "fa-folder','fa-folder-open');\">";
-                    echo "<i id='imgcat$temp' class='fa fa-folder'></i>&nbsp;";
-                    echo "<span class='b'>" . Dropdown::getDropdownName('glpi_entities', $data["entity"]) .
-                     "</span>";
-                    echo "</a>";
-
-                    echo "</td></tr>\n";
-
-                    echo "<tr class='tab_bg_2'><td>";
-                    echo "<div class='center' id='entity$temp$rand' style='display:none;'>\n";
-                    echo Html::getCheckAllAsCheckbox("entity$temp$rand") . __('All');
-
-                    echo "<table class='tab_cadre_fixe'>\n";
-                }
-
-                if (($i % $nb_per_line) == 0) {
-                    if ($i != 0) {
-                        echo "</tr>\n";
-                    }
-                    echo "<tr class='tab_bg_1'>\n";
-                    $i = 0;
-                }
-
-                if ($canedit_entity) {
-                    echo "<td width='10'>";
-                    Html::showMassiveActionCheckBox(__CLASS__, $data["linkid"]);
-                    echo "</td>";
-                }
-
-                $username = formatUserName(
-                    $data["id"],
-                    $data["name"],
-                    $data["realname"],
-                    $data["firstname"],
-                    1
-                );
-
-                if ($data["is_dynamic"] || $data["is_recursive"]) {
-                     $username = sprintf(__('%1$s %2$s'), $username, "<span class='b'>(");
-                    if ($data["is_dynamic"]) {
-                        $username = sprintf(__('%1$s%2$s'), $username, __('D'));
-                    }
-                    if ($data["is_dynamic"] && $data["is_recursive"]) {
-                        $username = sprintf(__('%1$s%2$s'), $username, ", ");
-                    }
-                    if ($data["is_recursive"]) {
-                           $username = sprintf(__('%1$s%2$s'), $username, __('R'));
-                    }
-                    $username = sprintf(__('%1$s%2$s'), $username, ")</span>");
-                }
-                echo "<td class='tab_bg_1'>" . $username . "</td>\n";
-                $i++;
-            }
-
-            if (($i % $nb_per_line) != 0) {
-                while (($i % $nb_per_line) != 0) {
-                    if ($canedit_entity) {
-                        echo "<td width='10'>&nbsp;</td>";
-                    }
-                    echo "<td class='tab_bg_1'>&nbsp;</td>";
-                    $i++;
-                }
-            }
-
-            if ($i != 0) {
-                echo "</table>";
-                echo "</div>";
-                echo "</td></tr>\n";
-            }
-        } else {
-            echo "<tr class='tab_bg_2'><td class='tab_bg_1 center'>" . __('No user found') .
-               "</td></tr>\n";
-        }
-        echo "</table>";
-        if ($canedit && $nb) {
-            $massiveactionparams['ontop'] = false;
-            Html::showMassiveActions($massiveactionparams);
-            Html::closeForm();
-        }
-        echo "</div>\n";
+        );
+        TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
+            'start' => $start,
+            'limit' => $limit,
+            'sort' => $sort,
+            'order' => $order,
+            'is_tab' => true,
+            'filters' => $filters,
+            'super_header' => $super_header,
+            'columns' => [
+                'name' => __('Name'),
+                'entity' => Entity::getTypeName(1),
+            ],
+            'formatters' => [
+                'name' => 'raw_html',
+            ],
+            'total_number' => $total_count,
+            'filtered_number' => $total_count,
+            'entries' => $entries,
+            'showmassiveactions' => $canedit,
+            'massiveactionparams' => [
+                'num_displayed'    => min($_SESSION['glpilist_limit'], $nb),
+                'container'        => 'mass' . __CLASS__ . $rand,
+                'specific_actions' => ['purge' => _x('button', 'Delete permanently')]
+            ],
+        ]);
     }
 
 

--- a/src/Profile_User.php
+++ b/src/Profile_User.php
@@ -157,7 +157,6 @@ class Profile_User extends CommonDBRelation
         $total_num = self::countForItem($user);
 
         $entries = [];
-        $entity_form_url = Toolbox::getItemTypeFormURL('Entity');
         foreach ($iterator as $data) {
             $entry = [
                 'itemtype' => __CLASS__,
@@ -168,15 +167,22 @@ class Profile_User extends CommonDBRelation
                 $link = sprintf(__('%1$s (%2$s)'), $link, $data["entities_id"]);
             }
             if ($canshowentity) {
-                $link = "<a href='" . $entity_form_url . "?id=" . $data["entities_id"] . "'>" . $link . "</a>";
+                $link = sprintf(
+                    '<a href="%s">%s</a>', 
+                    htmlspecialchars(Entity::getFormURLWithID($data["entities_id"])),
+                    htmlspecialchars($link)
+                );
             }
             $entry['entity'] = $link;
 
             if (Profile::canView()) {
-                $form_url = Toolbox::getItemTypeFormURL('Profile');
-                $profile_name = "<a href='{$form_url}?id={$data['id']}'>" . Html::entities_deep($data['name']) . "</a>";
+                $profile_name = sprintf(
+                    '<a href="%s">%s</a>', 
+                    htmlspecialchars(Profile::getFormURLWithID($data['id'])),
+                    htmlspecialchars($data['name'])
+                
             } else {
-                $profile_name = Html::entities_deep($data['name']);
+                $profile_name = htmlspecialchars($data['name']);
             }
 
             if ($data['is_dynamic'] || $data['is_recursive']) {

--- a/src/Profile_User.php
+++ b/src/Profile_User.php
@@ -180,7 +180,7 @@ class Profile_User extends CommonDBRelation
                     '<a href="%s">%s</a>', 
                     htmlspecialchars(Profile::getFormURLWithID($data['id'])),
                     htmlspecialchars($data['name'])
-                
+                );
             } else {
                 $profile_name = htmlspecialchars($data['name']);
             }

--- a/src/User.php
+++ b/src/User.php
@@ -6898,9 +6898,18 @@ JAVASCRIPT;
             return mb_strtoupper(mb_substr($anon, 0, 2));
         }
 
-        $initials = mb_substr($this->fields['firstname'] ?? '', 0, 1) . mb_substr($this->fields['realname'] ?? '', 0, 1);
+        return self::getInitialsForUserName(
+            $this->fields['name'],
+            $this->fields['firstname'],
+            $this->fields['realname']
+        );
+    }
+
+    public static function getInitialsForUserName($name, $firstname, $realname): string
+    {
+        $initials = mb_substr($firstname ?? '', 0, 1) . mb_substr($realname ?? '', 0, 1);
         if (empty($initials)) {
-            $initials = mb_substr($this->fields['name'] ?? '', 0, 2);
+            $initials = mb_substr($name ?? '', 0, 2);
         }
         return mb_strtoupper($initials);
     }

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -32,7 +32,7 @@
  #}
 
 {% set datatable_id = datatable_id|default('datatable' ~ random()) %}
-{% if total_number < 1 %}
+{% if total_number < 1 and filters|length == 0 %}
    <div class="alert alert-info">
       {{ __('No data') }}
    </div>
@@ -41,6 +41,7 @@
         'count': filtered_number,
         'additional_params': additional_params ~ '&sort=' ~ sort ~ '&order=' ~ order
     }) }}
+    {% set total_cols = columns|length + (showmassiveactions ? 1 : 0) + (nofilter ? 0 : 1) %}
 
     <div class="table-responsive" {% if showmassiveactions %} id="{{ massiveactionparams['container'] }}" {% endif %}>
         {% if showmassiveactions %}
@@ -50,6 +51,13 @@
         {% endif %}
         <table id="{{ datatable_id }}" class="table table-hover">
             <thead>
+                {% if super_header is defined and super_header is not empty %}
+                    <tr>
+                        <th colspan="{{ total_cols }}">
+                            {{ super_header }}
+                        </th>
+                    </tr>
+                {% endif %}
                 <tr>
                     {% if showmassiveactions %}
                         <th style="width: 30px;">
@@ -137,6 +145,8 @@
                                         name="filters[{{ colkey }}]"
                                         value="{{ filters[colkey] ?? 0 }}"
                                         min="0" max="100" step="1">
+                                {% elseif formatter == 'avatar' %}
+                                    {# Cannot be filtered #}
                                 {% else %}
                                     <input type="text" class="form-control"
                                         name="filters[{{ colkey }}]"
@@ -148,53 +158,79 @@
                 {% endif %}
             </thead>
             <tbody>
-                {% for entry in entries %}
-                    <tr class="{{ row_class|default('') }}" data-itemtype="{{ entry['itemtype'] }}" data-id="{{ entry['id'] }}">
-                        {% if showmassiveactions %}
-                            <td width='10'>
-                                <input class="form-check-input massive_action_checkbox" type="checkbox" data-glpicore-ma-tags="common"
-                                    value="1" aria-label=""
-                                    name="item[{{ entry['itemtype'] }}][{{ entry['id'] }}]" />
-                            </td>
-                        {% endif %}
-                        {% for colkey, colum in columns %}
-                            <td>
-                                {% if colkey in entry|keys %}
+                {% if entries|length > 0 %}
+                    {% for entry in entries %}
+                        <tr class="{{ row_class|default('') }}" data-itemtype="{{ entry['itemtype'] }}" data-id="{{ entry['id'] }}">
+                            {% if showmassiveactions %}
+                                <td style="width: 10px">
+                                    <input class="form-check-input massive_action_checkbox" type="checkbox" data-glpicore-ma-tags="common"
+                                        value="1" aria-label=""
+                                        name="item[{{ entry['itemtype'] }}][{{ entry['id'] }}]" />
+                                </td>
+                            {% endif %}
+                            {% for colkey, colum in columns %}
+                                <td>
+                                    {% if colkey in entry|keys %}
 
-                                    {% set formatter = formatters[colkey] %}
+                                        {% set formatter = formatters[colkey] %}
 
-                                    {% if formatter == "maintext" %}
-                                        <span class="d-inline-block bg-blue-lt p-1 text-truncate"
-                                            title="{{ entry[colkey] }}"
-                                            data-bs-toggle="tooltip"
-                                            style="max-width: 250px;">
+                                        {% if formatter == "maintext" %}
+                                            <span class="d-inline-block bg-blue-lt p-1 text-truncate"
+                                                title="{{ entry[colkey] }}"
+                                                data-bs-toggle="tooltip"
+                                                style="max-width: 250px;">
+                                                {{ entry[colkey] }}
+                                            </span>
+                                        {% elseif formatter == "longtext" %}
+                                            <span class="d-inline-block text-truncate"
+                                                title="{{ entry[colkey] }}"
+                                                data-bs-toggle="tooltip"
+                                                style="max-width: 250px;">
+                                                {{ entry[colkey] }}
+                                            </span>
+                                        {% elseif formatter starts with "progress" %}
+                                            {{ call("Html::progress", [100, entry[colkey]])|raw }}
+                                        {% elseif formatter == "date" %}
+                                            {{ call("Html::convDate", [entry[colkey]])|raw }}
+                                        {% elseif formatter == "datetime" %}
+                                            {{ call("Html::convDateTime", [entry[colkey]])|raw }}
+                                        {% elseif formatter == "bytesize" %}
+                                            {{ call("Toolbox::getSize", [entry[colkey]])|raw }}
+                                        {% elseif formatter == "raw_html" %}
+                                            {{ entry[colkey]|raw }}
+                                        {% elseif formatter == 'avatar' %}
+                                            {#  Note: Does not support anonymization currently #}
+                                            {% set entry_data = entry[colkey] %}
+                                            {% set avatar_size = entry_data['avatar_size'] ?? 'avatar-md' %}
+                                            {% set img = entry_data['picture'] %}
+                                            {% set initials = entry_data['initials'] %}
+                                            {% set bg_color = img is not empty ? 'inherit' : entry_data['initials_bg'] %}
+                                            <span class="avatar {{ avatar_size }} rounded"
+                                                  style="{% if img is not null %} background-image: url({{ img }}); {% endif %} background-color: {{ bg_color }}">
+                                                   {% if img is empty %}
+                                                       {{ initials }}
+                                                   {% endif %}
+                                                </span>
+                                        {% else %}
                                             {{ entry[colkey] }}
-                                        </span>
-                                    {% elseif formatter == "longtext" %}
-                                        <span class="d-inline-block text-truncate"
-                                            title="{{ entry[colkey] }}"
-                                            data-bs-toggle="tooltip"
-                                            style="max-width: 250px;">
-                                            {{ entry[colkey] }}
-                                        </span>
-                                    {% elseif formatter starts with "progress" %}
-                                        {{ call("Html::progress", [100, entry[colkey]])|raw }}
-                                    {% elseif formatter == "date" %}
-                                        {{ call("Html::convDate", [entry[colkey]])|raw }}
-                                    {% elseif formatter == "datetime" %}
-                                        {{ call("Html::convDateTime", [entry[colkey]])|raw }}
-                                    {% elseif formatter == "bytesize" %}
-                                        {{ call("Toolbox::getSize", [entry[colkey]])|raw }}
-                                    {% elseif formatter == "raw_html" %}
-                                        {{ entry[colkey]|raw }}
-                                    {% else %}
-                                        {{ entry[colkey] }}
+                                        {% endif %}
                                     {% endif %}
-                                {% endif %}
-                            </td>
-                        {% endfor %}
+                                </td>
+                            {% endfor %}
+                            {% if not nofilter %}
+                                <td></td>
+                            {% endif %}
+                        </tr>
+                    {% endfor %}
+                {% else %}
+                    <tr>
+                        <td colspan="{{ total_cols }}">
+                            <div class="alert alert-info">
+                                {{ __('No data') }}
+                            </div>
+                        </td>
                     </tr>
-                {% endfor %}
+                {% endif %}
             </tbody>
         </table>
     </div>

--- a/templates/pages/admin/add_profile_authorization.html.twig
+++ b/templates/pages/admin/add_profile_authorization.html.twig
@@ -39,7 +39,7 @@
     'field_class': 'col-4',
 } %}
 <div>
-    <form name="entityuser_form{{ rand }}" id="entityuser_form{{ rand }}" method="post" action="{{ 'Profile_User'|itemtype_form_path }}" data-submit-once>
+    <form method="post" action="{{ 'Profile_User'|itemtype_form_path }}" data-submit-once>
         <div class="card-body d-flex flex-wrap p-0 mt-n3">
             <div class="col-12 flex-column">
                 <div class="d-flex flex-row flex-wrap flex-xl-nowrap">

--- a/templates/pages/admin/add_profile_authorization.html.twig
+++ b/templates/pages/admin/add_profile_authorization.html.twig
@@ -1,0 +1,82 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
+{% set rand = random() %}
+{% set field_options = {
+    'field_class': 'col-4',
+} %}
+<div>
+    <form name="entityuser_form{{ rand }}" id="entityuser_form{{ rand }}" method="post" action="{{ 'Profile_User'|itemtype_form_path }}" data-submit-once>
+        <div class="card-body d-flex flex-wrap p-0 mt-n3">
+            <div class="col-12 flex-column">
+                <div class="d-flex flex-row flex-wrap flex-xl-nowrap">
+                    <div class="row flex-row align-items-start flex-grow-1">
+                        <div class="row flex-row">
+                            {{ inputs.hidden('_glpi_csrf_token', csrf_token()) }}
+                            {{ inputs.hidden(source_itemtype|itemtype_foreign_key, source_items_id) }}
+                            {{ fields.largeTitle(__('Add an authorization to a user')) }}
+                            {% if source_itemtype != 'Entity' %}
+                                {{ fields.dropdownField('Entity', 'entities_id', session('glpiactive_entity'), 'Entity'|itemtype_name, {
+                                    'entity': session('glpiactiveentities')
+                                }|merge(field_options)) }}
+                            {% endif %}
+                            {% if source_itemtype != 'Profile' %}
+                                {{ fields.dropdownField('Profile', 'profiles_id', null, 'Profile'|itemtype_name, {
+                                    'condition': {
+                                        'WHERE': call('Profile::getUnderActiveProfileRestrictCriteria')
+                                    },
+                                    'display_emptychoice': false,
+                                }|merge(field_options)) }}
+                            {% endif %}
+                            {% if source_itemtype != 'User' %}
+                                {{ fields.dropdownField('User', 'users_id', null, 'User'|itemtype_name, {
+                                    'display_emptychoice': false,
+                                    'entity': session('glpiactiveentities'),
+                                    'right': 'all',
+                                    'used': used_users
+                                }|merge(field_options)) }}
+                            {% endif %}
+                            {{ fields.dropdownYesNo('is_recursive', 0, __('Recursive'), field_options) }}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="card-body mx-n2 border-top d-flex flex-row-reverse align-items-start flex-wrap py-2">
+            {{ inputs.submit('add', _x('button', 'Add')) }}
+        </div>
+    </form>
+</div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Migrates the forms to assign a profile to a user or a user to a profile to twig.
Migrates the list of profile assignments for a user to the twig datatable template.

Didn't migrate the view of users associated with a profile. I think this is the only case where we have a folder view for sub-items. Do we want to keep it, change it to a datatable, or change it in some other way?
![Selection_212](https://github.com/glpi-project/glpi/assets/17678637/513c19b4-e313-482b-bd2b-cb85b5a4b350)

