### PR TITLE
Socket Twig UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,8 @@ The present file will list all changes made to the project; according to the
 - `Glpi\Api\API::returnSanitizedContent()`
 - `Glpi\Dashboard\Widget::getCssGradientPalette()`
 - `Glpi\Inventory\Conf::importFile()`
+- `Glpi\Socket::executeAddMulti()`
+- `Glpi\Socket::showNetworkPortForm()`
 - `Glpi\System\Requirement\DataDirectoriesProtectedPath` class.
 - `Glpi\System\Requirement\ProtectedWebAccess` class.
 - `Glpi\System\Requirement\SafeDocumentRoot` class.

--- a/front/socket.form.php
+++ b/front/socket.form.php
@@ -161,7 +161,6 @@ if (isset($_POST["add"]) || isset($_POST["execute_single"]) || isset($_POST["exe
     }
 
    // Add a socket from item : format data
-   // see Socket::showNetworkPortForm()
     if (
         isset($_REQUEST['_add_fromitem'])
         && isset($_REQUEST['_from_itemtype'])

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -36,6 +36,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\Features\DCBreadcrumb;
 use Glpi\Plugin\Hooks;
 use Glpi\SocketModel;
 
@@ -367,7 +368,8 @@ class Dropdown
             }
 
             if ($params['display_dc_position']) {
-                if ($rack = $item->isRackPart($itemtype, $params['value'], true)) {
+                /** @var DCBreadcrumb $item */
+                if ($rack = $item->getParentRack()) {
                     $dc_icon = "<span id='" . $breadcrumb_id . "' title='" . __s('Display on datacenter') . "'>";
                     $dc_icon .= "&nbsp;<a class='fas fa-crosshairs' href='" . $rack->getLinkURL() . "'></a>";
                     $dc_icon .= "</span>";

--- a/templates/pages/assets/socket.html.twig
+++ b/templates/pages/assets/socket.html.twig
@@ -36,88 +36,53 @@
 {% set params  = params ?? [] %}
 
 {% block more_fields %}
-   <input type="hidden" name="itemtype" value="{{ params["itemtype"] }}">
-   <input type="hidden" name="items_id" value="{{ params["items_id"] }}">
+    <input type="hidden" name="itemtype" value="{{ parent["itemtype"] }}">
+    <input type="hidden" name="items_id" value="{{ parent["items_id"] }}">
 
-   {{ fields.nullField() }}
-   {% set add_several = params['several'] is defined and params['several'] %}
-
-   {# Do not display position if several mode, value is compute on add #}
-   {% if not add_several %}
-      {{ fields.numberField(
-         'position',
-         item.fields['position'],
-         __('Position'),
-         field_options
-      ) }}
-   {% else %}
     {{ fields.nullField() }}
-   {% endif %}
+    {% set add_several = params['several'] is defined and params['several'] %}
 
-   {% set wiring_side %}
-      {% do call('Glpi\\Socket::dropdownWiringSide', [
-         'wiring_side',
-         {
+    {# Do not display position if several mode, value is compute on add #}
+    {% if not add_several %}
+        {{ fields.numberField('position', item.fields['position'], __('Position'), field_options) }}
+    {% else %}
+        {{ fields.nullField() }}
+    {% endif %}
+
+    {% set wiring_side %}
+    {% do call('Glpi\\Socket::dropdownWiringSide', [
+        'wiring_side',
+        {
             'value': item.fields['wiring_side'],
-         },
-         add_several
-      ]) %}
-   {% endset %}
-   {{ fields.htmlField(
-      'wiring_side',
-      wiring_side,
-      __('Wiring side'),
-   ) }}
+        },
+        add_several
+    ]) %}
+    {% endset %}
+    {{ fields.htmlField('wiring_side', wiring_side, __('Wiring side')) }}
 
-   {% set networkports %}
-      {% do call('Glpi\\Socket::showNetworkPortForm', [
-         item.fields['itemtype'],
-         item.fields['items_id'],
-         item.fields['networkports_id'],
-         params
-      ]) %}
-   {% endset %}
-   {{ fields.htmlField(
-      'networkports_id',
-      networkports,
-      _n('Network port', 'Network ports', get_plural_number()),
-   ) }}
+    {% set networkports %}
+        {% set netport_params = params|merge({
+            'itemtype': parent['itemtype'],
+            'items_id': parent['items_id'],
+            'networkports_id': item.fields['networkports_id'],
+        }) %}
+        {% include 'pages/assets/socket_networkport.html.twig' with netport_params only %}
+    {% endset %}
+    {{ fields.htmlField('networkports_id', networkports, _n('Network port', 'Network ports', get_plural_number())) }}
 
-   {% if add_several %}
-
-      {{ fields.dropdownNumberField(
-         '_from',
-         1,
-         __('From'),
-         {
+    {% if add_several %}
+        {{ fields.dropdownNumberField('_from', 1, __('From'), {
             'min': 1
-         }
-      ) }}
+        }) }}
 
-      {{ fields.dropdownNumberField(
-         '_to',
-         1,
-         __('To'),
-         {
+        {{ fields.dropdownNumberField('_to', 1, __('To'), {
             'min': 1
-         }
-      ) }}
+        }) }}
 
-      {{ fields.textField(
-         '_before',
-         '',
-         __('Prefix'),
-         {}
-      ) }}
+        {{ fields.textField('_before', '', __('Prefix')) }}
 
-      {{ fields.textField(
-         '_after',
-         '',
-         __('Suffix'),
-         {}
-      ) }}
+        {{ fields.textField('_after', '', __('Suffix')) }}
 
-      <input type="hidden" name="execute_multi" value="1">
-   {% endif %}
-
+        <input type="hidden" name="execute_multi" value="1">
+    {% endif %}
 {% endblock %}

--- a/templates/pages/assets/socket_networkport.html.twig
+++ b/templates/pages/assets/socket_networkport.html.twig
@@ -1,0 +1,99 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
+{% set rand = random() %}
+{% set several = several|default(false) %}
+
+<span id="show_itemtype_field" class="input_listener">
+    {{ fields.dropdownArrayField('itemtype', itemtype, call('Glpi\\Socket::getSocketLinkTypes'), null, {
+        no_label: true,
+        rand: rand,
+        mb: '',
+        field_class: 'col-12'
+    }) }}
+</span>
+{% do call('Ajax::updateItemOnSelectEvent', [
+    'dropdown_itemtype' ~ rand,
+    'show_items_id_field',
+    CFG_GLPI.root_doc ~ '/ajax/cable.php',
+    {
+        itemtype: '__VALUE__',
+        dom_rand: rand,
+        dom_name: 'items_id',
+        action: 'get_items_from_itemtype'
+    }
+]) %}
+<span id="show_items_id_field" class="input_listener">
+    {% if itemtype is not empty %}
+        {{ fields.dropdownField(itemtype, 'items_id', items_id, null, {
+            no_label: true,
+            display_emptychoice: true,
+            display_dc_position: itemtype in config('rackable_types'),
+            rand: rand,
+            mb: '',
+            field_class: 'col-12'
+        }) }}
+    {% endif %}
+</span>
+{% if not several %}
+    <span id="show_networkport_field">
+        {{ fields.dropdownField('NetworkPort', 'networkports_id', networkports_id, null, {
+            no_label: true,
+            condition: {
+                items_id: items_id,
+                itemtype: itemtype
+            },
+            display_emptychoice: true,
+            comments: false,
+            mb: '',
+            field_class: 'col-12'
+        }) }}
+    </span>
+    <script>
+        // listener to remove socket selector and breadcrumb
+        $(document).on('change', '#dropdown_itemtype{{ rand }}', () => {
+            $('#show_front_asset_breadcrumb').empty();
+            $('#show_front_sockets_field').empty();
+        });
+
+        // listener to refresh socket selector and breadcrumb
+        $(document).on('change', '#dropdown_items_id{{ rand }}', () => {
+            const items_id = $('#dropdown_items_id{{ rand }}').find(':selected').val();
+            const itemtype = $('#dropdown_itemtype{{ rand }}').find(':selected').val();
+            refreshAssetBreadcrumb(itemtype, items_id, 'show_asset_breadcrumb');
+            refreshNetworkPortDropdown(itemtype, items_id, 'show_networkport_field');
+        });
+    </script>
+{% endif %}

--- a/templates/pages/assets/socket_short_form.html.twig
+++ b/templates/pages/assets/socket_short_form.html.twig
@@ -1,0 +1,140 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
+<form action="{{ 'Glpi\\Socket'|itemtype_form_path }}" method="post" data-submit-once>
+    <div>
+        {% if _add_fromitem['_from_itemtype'] == 'Location' %}
+            {{ inputs.hidden('locations_id', _add_fromitem['_from_items_id']) }}
+        {% else %}
+            {{ inputs.hidden('items_id', _add_fromitem['_from_items_id']) }}
+            {{ inputs.hidden('itemtype', _add_fromitem['_from_itemtype']) }}
+        {% endif %}
+        {{ inputs.hidden('_glpi_csrf_token', csrf_token()) }}
+        <div>
+            {{ fields.sliderField('_add_multiple', 0, __('Add several sockets')) }}
+            <script>
+                $(document).on('change', 'input[type="checkbox"][name="_add_multiple"]', (e) => {
+                    const chkbox = $(e.target);
+                    const form = chkbox.closest('form');
+                    if (chkbox.prop('checked')) {
+                        form.find('.single-add-inputs').addClass('d-none');
+                        form.find('.multi-add-inputs').removeClass('d-none');
+                        form.find('button[type="submit"]').attr('name', 'execute_multi');
+                    } else {
+                        form.find('.single-add-inputs').removeClass('d-none');
+                        form.find('.multi-add-inputs').addClass('d-none');
+                        form.find('button[type="submit"]').attr('name', 'execute_single');
+                    }
+                });
+            </script>
+        </div>
+        <div>
+            <div class="single-add-inputs">
+                {{ fields.textField('name', '', __('Name'), {
+                    label_class: 'col-xxl-2',
+                    field_class: 'col-xxl-10',
+                    full_width: true
+                }) }}
+            </div>
+            <div class="multi-add-inputs d-none">
+                {% set name_fields %}
+                    {{ fields.textField('_before', '', null, {
+                        no_label: true,
+                        'mb': '',
+                        field_class: '',
+                        additional_attributes: {
+                            placeholder: __('Prefix')
+                        }
+                    }) }}
+                    {{ fields.dropdownNumberField('_from', 0, null, {
+                        no_label: true,
+                        'mb': '',
+                        field_class: '',
+                        min: 0,
+                        max: 400
+                    }) }}
+                    <span class="mx-1 mt-2" style="white-space: nowrap">--&gt;</span>
+                    {{ fields.dropdownNumberField('_to', 0, null, {
+                        no_label: true,
+                        'mb': '',
+                        field_class: '',
+                        min: 0,
+                        max: 400
+                    }) }}
+                    {{ fields.textField('_after', '', null, {
+                        no_label: true,
+                        'mb': '',
+                        field_class: '',
+                        additional_attributes: {
+                            placeholder: __('Suffix')
+                        }
+                    }) }}
+                {% endset %}
+                {{ fields.htmlField('', name_fields, __('Name'), {
+                    wrapper_class: 'd-flex',
+                    label_class: 'col-xxl-2',
+                    field_class: 'col-xxl-10',
+                    full_width: true
+                }) }}
+            </div>
+            <div class="common-inputs d-flex flex-wrap">
+                {{ fields.dropdownField('Glpi\\SocketModel', 'socketmodels_id', 0, 'Glpi\\SocketModel'|itemtype_name, {
+                    label_class: 'col-xxl-4',
+                }) }}
+                {% set wiring_side_field %}
+                    {% do call('Glpi\\Socket::dropdownWiringSide', ['wiring_side']) %}
+                {% endset %}
+                {{ fields.htmlField('', wiring_side_field, __('Wiring side'), {
+                    label_class: 'col-xxl-3',
+                }) }}
+                {% if _add_fromitem['_from_itemtype'] == 'Location' %}
+                    {{ fields.dropdownItemsFromItemtypes('', __('Itemtype'), {
+                        label_class: 'col-xxl-4',
+                        itemtype: socket_itemtypes,
+                        default_itemtype: 'Computer',
+                        display_emptychoice: false
+                    }) }}
+                {% else %}
+                    {{ fields.dropdownField('Location', 'locations_id', 0, 'Location'|itemtype_name, {
+                        label_class: 'col-xxl-4',
+                    }) }}
+                {% endif %}
+            </div>
+            <div class="d-flex flex-row-reverse px-4 mb-4">
+                {{ inputs.submit('execute_single', _x('button', 'Add'), 1) }}
+            </div>
+        </div>
+    </div>
+</form>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Moved Socket-related UI to Twig templates.
Redesigned the form shown on the Sockets tab of Locations. Instead of two forms being shown at the same time, one for adding a single socket and another for adding multiple, there is now only a single form which can switch modes using a slider. For multi-add mode, I also added placeholder text for the two name textboxes to make it clearer to the user how the names are built.

![Selection_213](https://github.com/glpi-project/glpi/assets/17678637/1053eedc-7b1e-4f6b-bb11-e6277f650b23)
![Selection_215](https://github.com/glpi-project/glpi/assets/17678637/ac973a8f-f8d7-4288-9eff-40ee383d5903)
