### PR TITLE
IP Address list to twig datatable

### DIFF
--- a/src/IPAddress.php
+++ b/src/IPAddress.php
@@ -306,7 +306,7 @@ class IPAddress extends CommonDBChild
             'order' => $order,
             'columns' => [
                 'ipaddress' => self::getTypeName(1),
-                'item' => __('Item'),
+                'item' => _n('Item', 'Items', 1),
                 'port_id' => NetworkPort::getTypeName(Session::getPluralNumber()),
                 'name_id' => NetworkName::getTypeName(1),
                 'entity' => Entity::getTypeName(1),

--- a/src/IPAddress.php
+++ b/src/IPAddress.php
@@ -33,6 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryUnion;
 
@@ -63,15 +64,35 @@ class IPAddress extends CommonDBChild
 
     public $history_blacklist     = ['binary_0', 'binary_1', 'binary_2', 'binary_3'];
 
-   /// $version (integer) : version of the adresse. Should be 4 or 6, or empty if not valid address
+    /**
+     * Version of the address. Should be 4 or 6, or empty if not valid address
+     * @var integer|string
+     * @phpstan-var 4|6|''
+     */
     protected $version = '';
-   /// $this->textual (string) : human readable of the IP adress (for instance : 192.168.0.0,
-   /// 2001:db8:0:85a3\::ac1f:8001)
+
+    /**
+     * Human-readable representation of the IP address.
+     *
+     * Examples:
+     * - 192.168.0.0
+     * - 2001:db8:0:85a3\::ac1f:8001
+     * @var string
+     */
     protected $textual = '';
-   /// $this->binary (bytes[4]) : binary version for the SQL requests. For IPv4 addresses, the
-   /// first three bytes are set to [0, 0, 0xffff]
+
+    /**
+     * The binary representation of the IP address.
+     *
+     * For IPv4 addresses, the first three bytes are set to [0, 0, 0xffff]
+     * This is used for SQL requests.
+     * @var int[]
+     */
     protected $binary  = [0, 0, 0, 0];
-   //to know is IPV4 is Dotted quoad Format
+
+    /**
+     * @var bool Is the IPv4 address in dotted quoad format?
+     */
     protected $isDottedQuoadFormat = false;
 
     public static $rightname  = 'internet';
@@ -107,12 +128,10 @@ class IPAddress extends CommonDBChild
         }
     }
 
-
     public static function getTypeName($nb = 0)
     {
         return _n('IP address', 'IP addresses', $nb);
     }
-
 
     /**
      * @param $input
@@ -163,19 +182,15 @@ class IPAddress extends CommonDBChild
         return array_merge($input, $this->setArrayFromAddress($input, "version", "name", "binary"));
     }
 
-
     public function prepareInputForAdd($input)
     {
-
         return parent::prepareInputForAdd($this->prepareInput($input));
     }
-
 
     public function prepareInputForUpdate($input)
     {
         return parent::prepareInputForUpdate($this->prepareInput($input));
     }
-
 
     public function post_addItem()
     {
@@ -183,10 +198,8 @@ class IPAddress extends CommonDBChild
         parent::post_addItem();
     }
 
-
     public function post_updateItem($history = true)
     {
-
         if (
             (isset($this->oldvalues['name']))
             || (isset($this->oldvalues['entities_id']))
@@ -199,10 +212,8 @@ class IPAddress extends CommonDBChild
         parent::post_updateItem($history);
     }
 
-
     public function cleanDBonPurge()
     {
-
         $this->deleteChildrenAndRelationsFromDb(
             [
                 IPAddress_IPNetwork::class,
@@ -210,113 +221,111 @@ class IPAddress extends CommonDBChild
         );
     }
 
-
     public function post_getFromDB()
     {
-
-       // Don't forget set local object from DB field
+        // Don't forget set local object from DB field
         $this->setAddressFromArray($this->fields, "version", "name", "binary");
     }
 
-
     public static function showForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        /** @var array $CFG_GLPI */
-        global $CFG_GLPI;
+        /**
+         * @var \DBmysql $DB
+         */
+        global $DB;
 
-        if ($item->getType() == 'IPNetwork') {
-            if (isset($_GET["start"])) {
-                $start = $_GET["start"];
-            } else {
-                $start = 0;
-            }
-
-            if (!empty($_GET["order"])) {
-                $table_options['order'] = $_GET["order"];
-            } else {
-                $table_options['order'] = 'ip';
-            }
-
-            $order_by_itemtype             = ($table_options['order'] == 'itemtype');
-
-            $table_options['SQL_options']  = [
-                'LIMIT'  => $_SESSION['glpilist_limit'],
-                'START'  => $start
-            ];
-
-            $table           = new HTMLTableMain();
-            $content         = "<a href='javascript:reloadTab(\"order=ip\");'>" .
-                              self::getTypeName(Session::getPluralNumber()) . "</a>";
-            $internet_column = $table->addHeader('IP Address', $content);
-            $content         = sprintf(
-                __('%1$s - %2$s'),
-                _n('Item', 'Items', Session::getPluralNumber()),
-                "<a href='javascript:reloadTab(\"order=itemtype\");'>" .
-                __('Order by item type') . "</a>"
-            );
-            $item_column     = $table->addHeader('Item', $content);
-
-            if ($order_by_itemtype) {
-                foreach ($CFG_GLPI["networkport_types"] as $itemtype) {
-                    $table_options['group_' . $itemtype] = $table->createGroup(
-                        $itemtype,
-                        $itemtype::getTypeName(Session::getPluralNumber())
-                    );
-
-                    self::getHTMLTableHeader(
-                        $item->getType(),
-                        $table_options['group_' . $itemtype],
-                        $item_column,
-                        null,
-                        $table_options
-                    );
-                }
-            }
-
-            $table_options['group_None'] = $table->createGroup('Main', __('Other kind of items'));
-
-            self::getHTMLTableHeader(
-                $item->getType(),
-                $table_options['group_None'],
-                $item_column,
-                null,
-                $table_options
-            );
-
-            self::getHTMLTableCellsForItem(null, $item, null, $table_options);
-
-            if ($table->getNumberOfRows() > 0) {
-                 $count = self::countForItem($item);
-                 Html::printAjaxPager(self::getTypeName(Session::getPluralNumber()), $start, $count);
-
-                 Session::initNavigateListItems(
-                     __CLASS__,
-                     //TRANS : %1$s is the itemtype name,
-                                           //        %2$s is the name of the item (used for headings of a list)
-                                           sprintf(
-                                               __('%1$s = %2$s'),
-                                               $item->getTypeName(1),
-                                               $item->getName()
-                                           )
-                 );
-                 $table->display(['display_title_for_each_group' => $order_by_itemtype,
-                     'display_super_for_each_group' => false,
-                     'display_tfoot'                => false
-                 ]);
-
-                 Html::printAjaxPager(self::getTypeName(Session::getPluralNumber()), $start, $count);
-            } else {
-                echo "<table class='tab_cadre_fixe'>";
-                echo "<tr><th>" . __('No IP address found') . "</th></tr>";
-                echo "</table>";
-            }
+        if ($item::class !== IPNetwork::class) {
+            // Not supported
+            return;
         }
-    }
 
+        $rand = mt_rand();
+        $start       = (int) ($_GET["start"] ?? 0);
+        $sort        = $_GET["sort"] ?? "";
+        $order       = strtoupper($_GET["order"] ?? "");
+
+        if ($sort === '') {
+            $sort = 'ipaddress';
+        }
+        if ($order === '') {
+            $order = 'ASC';
+        }
+
+        $orderby = match ($sort) {
+            'ipaddress' => [
+                "binary_0 $order",
+                "binary_1 $order",
+                "binary_2 $order",
+                "binary_3 $order",
+            ],
+            'item' => [
+                "item_type $order",
+                "item_id $order",
+            ],
+            default => "$sort $order",
+        };
+
+        $criteria = self::getCriteriaLinkedToNetwork($item);
+        $criteria['START'] = $start;
+        $criteria['LIMIT'] = $_SESSION['glpilist_limit'];
+        $criteria['ORDER'] = $orderby;
+
+        $entries = [];
+        $it = $DB->request($criteria);
+
+        $item_objs = [];
+        $networkport = new NetworkPort();
+        $networkname = new NetworkName();
+        foreach ($it as $data) {
+            if (!array_key_exists($data['item_type'], $item_objs)) {
+                $item_objs[$data['item_type']] = new $data['item_type']();
+            }
+            $linked_item = $item_objs[$data['item_type']];
+            $linked_item->getFromDB($data['item_id']);
+            $networkport->getFromDB($data['port_id']);
+            $networkname->getFromDB($data['name_id']);
+
+            $entries[] = [
+                'itemtype' => self::class,
+                'id'       => $data['id'],
+                'ipaddress' => $data['ip'],
+                'item' => $linked_item->getLink(),
+                'port_id' => $networkport->getLink(),
+                'name_id' => $networkname->getLink(),
+                'entity' => $data['entity'],
+                'is_dynamic' => Dropdown::getYesNo($data['is_dynamic']),
+            ];
+        }
+
+        TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
+            'is_tab' => true,
+            'nofilter' => true,
+            'start' => $start,
+            'limit' => $_SESSION['glpilist_limit'],
+            'sort' => $sort,
+            'order' => $order,
+            'columns' => [
+                'ipaddress' => self::getTypeName(1),
+                'item' => __('Item'),
+                'port_id' => NetworkPort::getTypeName(Session::getPluralNumber()),
+                'name_id' => NetworkName::getTypeName(1),
+                'entity' => Entity::getTypeName(1),
+                'is_dynamic' => __('Automatic inventory'),
+            ],
+            'formatters' => [
+                'item' => 'raw_html',
+                'port_id' => 'raw_html',
+                'name_id' => 'raw_html',
+            ],
+            'entries' => $entries,
+            'total_number' => count($entries),
+            'filtered_number' => count($entries),
+            'showmassiveactions' => false,
+        ]);
+    }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
     {
-
         switch ($item->getType()) {
             case 'IPNetwork':
                 self::showForItem($item, $withtemplate);
@@ -324,7 +333,6 @@ class IPAddress extends CommonDBChild
         }
         return true;
     }
-
 
     /**
      * @param $item      CommonDBTM object
@@ -346,7 +354,6 @@ class IPAddress extends CommonDBChild
                 return $result['cpt'];
         }
     }
-
 
     /**
      * @param $item           CommonGLPI object
@@ -370,7 +377,6 @@ class IPAddress extends CommonDBChild
         return '';
     }
 
-
    //////////////////////////////////////////////////////////////////////////////
    // IP address specific methods (check, transformation ...)
    //////////////////////////////////////////////////////////////////////////////
@@ -381,12 +387,10 @@ class IPAddress extends CommonDBChild
      **/
     public function disableAddress()
     {
-
         $this->version = '';
         $this->textual = '';
         $this->binary  = '';
     }
-
 
     /**
      * \brief Fill an array from the the local address object
@@ -405,7 +409,6 @@ class IPAddress extends CommonDBChild
      **/
     public function setArrayFromAddress(array $array, $versionField, $textualField, $binaryField)
     {
-
         if (!empty($versionField)) {
             $version = $this->getVersion();
             if ($version !== false) {
@@ -436,7 +439,6 @@ class IPAddress extends CommonDBChild
         }
         return $array;
     }
-
 
     /**
      * \brief Fill the local address object from an array
@@ -483,7 +485,6 @@ class IPAddress extends CommonDBChild
         return true;
     }
 
-
     /**
      * Check address validity
      **/
@@ -492,48 +493,30 @@ class IPAddress extends CommonDBChild
         return (($this->version != '') && ($this->textual != '') && ($this->binary != ''));
     }
 
-
     public function getVersion()
     {
-
-        if ($this->version != '') {
-            return $this->version;
-        }
-        return false;
+        return $this->version !== '' ? $this->version : false;
     }
-
 
     public function is_ipv4()
     {
         return ($this->getVersion() == 4);
     }
 
-
     public function is_ipv6()
     {
         return ($this->getVersion() == 6);
     }
 
-
     public function getTextual()
     {
-
-        if ($this->textual != '') {
-            return $this->textual;
-        }
-        return false;
+        return $this->textual !== '' ? $this->textual : false;
     }
-
 
     public function getBinary()
     {
-
-        if ($this->binary != '') {
-            return $this->binary;
-        }
-        return false;
+        return $this->binary !== '' ? $this->binary : false;
     }
-
 
     /**
      * Transform an IPv4 address to IPv6
@@ -544,7 +527,6 @@ class IPAddress extends CommonDBChild
      **/
     public static function getIPv4ToIPv6Address($address)
     {
-
         if (is_numeric($address)) {
             return [0, 0, 0xffff, $address];
         }
@@ -553,7 +535,6 @@ class IPAddress extends CommonDBChild
         }
         return false;
     }
-
 
     /**
      * Check an address to see if it is IPv4 mapped to IPv6 address
@@ -574,7 +555,6 @@ class IPAddress extends CommonDBChild
         return false;
     }
 
-
     /**
      * Replace textual representation by its canonical form.
      *
@@ -584,7 +564,6 @@ class IPAddress extends CommonDBChild
     {
         $this->setAddressFromBinary($this->getBinary());
     }
-
 
     /**
      * \brief define an address from a string
@@ -622,7 +601,7 @@ class IPAddress extends CommonDBChild
         ) {
             $iterator = $DB->request([
                 'SELECT' => 'id',
-                'FROM'   => $this->getTable(),
+                'FROM'   => static::getTable(),
                 'WHERE'  => [
                     'items_id'  => $items_id,
                     'itemtype'  => $itemtype,
@@ -630,7 +609,7 @@ class IPAddress extends CommonDBChild
                 ]
             ]);
 
-            if (count($iterator) == 1) {
+            if (count($iterator) === 1) {
                 $line = $iterator->current();
                 if ($this->getFromDB($line["id"])) {
                     return true;
@@ -650,18 +629,18 @@ class IPAddress extends CommonDBChild
         $binary = null;
         $singletons = explode(".", $address);
        // First, check to see if it is an IPv4 address
-        if (count($singletons) == 4) {
+        if (count($singletons) === 4) {
             $binary = 0;
             foreach ($singletons as $singleton) {
                 if (!is_numeric($singleton)) {
                     return false;
                 }
-                $singleton = intval($singleton);
+                $singleton = (int) $singleton;
                 if (($singleton < 0) || ($singleton > 255)) {
                     return false;
                 }
                 $binary *= 256;
-                $binary += intval($singleton);
+                $binary += (int) $singleton;
             }
             $binary  = self::getIPv4ToIPv6Address($binary);
         }
@@ -769,7 +748,6 @@ class IPAddress extends CommonDBChild
         return false;
     }
 
-
     /**
      * \brief define an address from a binary
      * Convert a binary address (bytes[4]) to textual one. Opposite function that
@@ -808,11 +786,11 @@ class IPAddress extends CommonDBChild
 
             $iterator = $DB->request([
                 'SELECT' => 'id',
-                'FROM'   => $this->getTable(),
+                'FROM'   => static::getTable(),
                 'WHERE'  => $where
             ]);
 
-            if (count($iterator) == 1) {
+            if (count($iterator) === 1) {
                 $line = $iterator->current();
                 if ($this->getFromDB($line["id"])) {
                     return true;
@@ -847,7 +825,7 @@ class IPAddress extends CommonDBChild
             }
         }
 
-        if (count($binary) == 4) {
+        if (count($binary) === 4) {
             if (self::isIPv4MappedToIPv6Address($binary)) {
                 $this->version = 4;
             } else {
@@ -875,11 +853,11 @@ class IPAddress extends CommonDBChild
                 $pos = strpos($currentNull, $elt);
                 if ($pos !== false) {
                     $first = array_slice($textual, 0, $pos);
-                    if (count($first) == 0) {
+                    if (count($first) === 0) {
                         $first = [""];
                     }
                     $second = array_slice($textual, $pos + strlen($elt));
-                    if (count($second) == 0) {
+                    if (count($second) === 0) {
                         $second = [""];
                     }
                     $textual = array_merge($first, [""], $second);
@@ -899,7 +877,6 @@ class IPAddress extends CommonDBChild
         $this->textual = $prefix . $textual;
         return true;
     }
-
 
     /**
      * \brief add value to the address for iterator on addresses
@@ -938,7 +915,6 @@ class IPAddress extends CommonDBChild
         return true;
     }
 
-
     /**
      * \brief get absolute value of an integer
      * Convert a negative integer to positiv float. That is usefull as integer, in PHP are signed 32
@@ -953,9 +929,8 @@ class IPAddress extends CommonDBChild
      **/
     public static function convertNegativeIntegerToPositiveFloat($value)
     {
-
-        if (intval($value) && ($value < 0)) {
-            $value = floatval($value) + floatval(0x80000000 * 2);
+        if ((int) $value && ($value < 0)) {
+            $value = (float) $value + (float) 0x80000000 * 2;
         }
         return $value;
     }
@@ -1006,7 +981,6 @@ class IPAddress extends CommonDBChild
         return $addressesWithItems;
     }
 
-
     /**
      * Get an Object ID by its IP address (only if one result is found in the entity)
      *
@@ -1055,7 +1029,6 @@ class IPAddress extends CommonDBChild
         return [];
     }
 
-
     /**
      * Check if two addresses are equals
      *
@@ -1066,13 +1039,13 @@ class IPAddress extends CommonDBChild
     public function equals($ipaddress)
     {
 
-       // To normalise the address, just make new one
+        // To normalise the address, just make new one
         $ipaddress = new self($ipaddress);
 
         if (
             !is_array($this->binary)
-            || (count($this->binary) != 4)
-            || (count($ipaddress->binary) != 4)
+            || (count($this->binary) !== 4)
+            || (count($ipaddress->binary) !== 4)
             || ($this->version != $ipaddress->version)
         ) {
             return false;
@@ -1086,7 +1059,6 @@ class IPAddress extends CommonDBChild
 
         return true;
     }
-
 
     /**
      * @param $itemtype
@@ -1136,117 +1108,71 @@ class IPAddress extends CommonDBChild
         }
     }
 
-
     /**
-     * @param $row                HTMLTableRow object (default NULL)
-     * @param $item               CommonDBTM object (default NULL)
-     * @param $father             HTMLTableCell object (default NULL)
-     * @param $options   array
-     **/
-    public static function getHTMLTableCellsForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
-        array $options = []
-    ) {
+     * Get the SQL criteria required to show a list of IP Addresses linked to the given IPNetwork
+     *
+     * @param IPNetwork $network
+     * @return array
+     */
+    private static function getCriteriaLinkedToNetwork(IPNetwork $network): array
+    {
         /**
-         * @var array $CFG_GLPI
          * @var \DBmysql $DB
+         * @var array $CFG_GLPI
          */
         global $CFG_GLPI, $DB;
 
-        if (
-            ($item !== null)
-            && ($item->getType() == 'IPNetwork')
-        ) {
-            $queries = [];
-            $main_criteria = [
-                'SELECT'       => [
-                    'ADDR.binary_0 AS binary_0',
-                    'ADDR.binary_1 AS binary_1',
-                    'ADDR.binary_2 AS binary_2',
-                    'ADDR.binary_3 AS binary_3',
-                    'ADDR.name AS ip',
-                    'ADDR.id AS id',
-                    'ADDR.itemtype AS addr_item_type',
-                    'ADDR.items_id AS addr_item_id',
-                    'glpi_entities.completename AS entity',
-                ],
-                'FROM'         => 'glpi_ipaddresses_ipnetworks AS LINK',
-                'INNER JOIN'   => [
-                    'glpi_ipaddresses AS ADDR' => [
-                        'ON' => [
-                            'ADDR'   => 'id',
-                            'LINK'   => 'ipaddresses_id', [
-                                'AND' => [
-                                    'ADDR.itemtype' => 'NetworkName',
-                                    'ADDR.is_deleted' => 0
-                                ]
+        $queries = [];
+        $main_criteria = [
+            'SELECT'       => [
+                'ADDR.binary_0 AS binary_0',
+                'ADDR.binary_1 AS binary_1',
+                'ADDR.binary_2 AS binary_2',
+                'ADDR.binary_3 AS binary_3',
+                'ADDR.name AS ip',
+                'ADDR.id AS id',
+                'ADDR.itemtype AS addr_item_type',
+                'ADDR.items_id AS addr_item_id',
+                'ADDR.is_dynamic AS is_dynamic',
+                'glpi_entities.completename AS entity',
+            ],
+            'FROM'         => 'glpi_ipaddresses_ipnetworks AS LINK',
+            'INNER JOIN'   => [
+                'glpi_ipaddresses AS ADDR' => [
+                    'ON' => [
+                        'ADDR'   => 'id',
+                        'LINK'   => 'ipaddresses_id', [
+                            'AND' => [
+                                'ADDR.itemtype' => 'NetworkName',
+                                'ADDR.is_deleted' => 0
                             ]
                         ]
                     ]
-                ],
-                'LEFT JOIN'    => [
-                    'glpi_entities'             => [
-                        'ON' => [
-                            'ADDR'            => 'entities_id',
-                            'glpi_entities'   => 'id'
-                        ]
-                    ]
-                ],
-                'WHERE'        => [
-                    'LINK.ipnetworks_id' => $item->getID(),
                 ]
-            ];
-
-            foreach ($CFG_GLPI["networkport_types"] as $itemtype) {
-                $table = getTableForItemType($itemtype);
-                $criteria = $main_criteria;
-                $criteria['SELECT'] = array_merge($criteria['SELECT'], [
-                    'NAME.id AS name_id',
-                    'PORT.id AS port_id',
-                    'ITEM.id AS item_id',
-                    new QueryExpression("'$itemtype' AS " . $DB->quoteName('item_type'))
-                ]);
-                $criteria['INNER JOIN'] = $criteria['INNER JOIN'] + [
-                    'glpi_networknames AS NAME'   => [
-                        'ON' => [
-                            'NAME'   => 'id',
-                            'ADDR'   => 'items_id', [
-                                'AND' => [
-                                    'NAME.itemtype' => 'NetworkPort'
-                                ]
-                            ]
-                        ]
-                    ],
-                    'glpi_networkports AS PORT'   => [
-                        'ON' => [
-                            'NAME'   => 'items_id',
-                            'PORT'   => 'id', [
-                                'AND' => [
-                                    'PORT.itemtype' => $itemtype
-                                ]
-                            ]
-                        ]
-                    ],
-                    "$table AS ITEM"              => [
-                        'ON' => [
-                            'ITEM'   => 'id',
-                            'PORT'   => 'items_id'
-                        ]
+            ],
+            'LEFT JOIN'    => [
+                'glpi_entities'             => [
+                    'ON' => [
+                        'ADDR'            => 'entities_id',
+                        'glpi_entities'   => 'id'
                     ]
-                ];
-                $queries[] = $criteria;
-            }
+                ]
+            ],
+            'WHERE'        => [
+                'LINK.ipnetworks_id' => $network->getID(),
+            ]
+        ];
 
+        foreach ($CFG_GLPI["networkport_types"] as $itemtype) {
+            $table = getTableForItemType($itemtype);
             $criteria = $main_criteria;
             $criteria['SELECT'] = array_merge($criteria['SELECT'], [
                 'NAME.id AS name_id',
                 'PORT.id AS port_id',
-                new QueryExpression('NULL AS ' . $DB->quoteName('item_id')),
-                new QueryExpression("NULL AS " . $DB->quoteName('item_type')),
+                'ITEM.id AS item_id',
+                new QueryExpression($DB::quoteValue($itemtype), 'item_type')
             ]);
-            $criteria['INNER JOIN'] = $criteria['INNER JOIN'] + [
+            $criteria['INNER JOIN'] += [
                 'glpi_networknames AS NAME'   => [
                     'ON' => [
                         'NAME'   => 'id',
@@ -1262,51 +1188,108 @@ class IPAddress extends CommonDBChild
                         'NAME'   => 'items_id',
                         'PORT'   => 'id', [
                             'AND' => [
-                                'NOT' => [
-                                    'PORT.itemtype' => $CFG_GLPI['networkport_types']
-                                ]
+                                'PORT.itemtype' => $itemtype
                             ]
                         ]
                     ]
-                ]
-            ];
-            $queries[] = $criteria;
-
-            $criteria = $main_criteria;
-            $criteria['SELECT'] = array_merge($criteria['SELECT'], [
-                'NAME.id AS name_id',
-                new QueryExpression("NULL AS " . $DB->quoteName('port_id')),
-                new QueryExpression('NULL AS ' . $DB->quoteName('item_id')),
-                new QueryExpression("NULL AS " . $DB->quoteName('item_type'))
-            ]);
-            $criteria['INNER JOIN'] = $criteria['INNER JOIN'] + [
-                'glpi_networknames AS NAME'   => [
+                ],
+                "$table AS ITEM"              => [
                     'ON' => [
-                        'NAME'   => 'id',
-                        'ADDR'   => 'items_id', [
-                            'AND' => [
-                                'NAME.itemtype' => ['!=', 'NetworkPort']
-                            ]
-                        ]
+                        'ITEM'   => 'id',
+                        'PORT'   => 'items_id'
                     ]
                 ]
             ];
             $queries[] = $criteria;
+        }
 
-            $criteria = $main_criteria;
-            $criteria['SELECT'] = array_merge($criteria['SELECT'], [
-                new QueryExpression("NULL AS name_id"),
-                new QueryExpression("NULL AS port_id"),
-                new QueryExpression('NULL AS item_id'),
-                new QueryExpression("NULL AS item_type")
-            ]);
-            $criteria['INNER JOIN']['glpi_ipaddresses AS ADDR']['ON'][0]['AND']['ADDR.itemtype'] = ['!=', 'NetworkName'];
-            $queries[] = $criteria;
+        $criteria = $main_criteria;
+        $criteria['SELECT'] = array_merge($criteria['SELECT'], [
+            'NAME.id AS name_id',
+            'PORT.id AS port_id',
+            new QueryExpression('NULL', 'item_id'),
+            new QueryExpression('NULL', 'item_type'),
+        ]);
+        $criteria['INNER JOIN'] += [
+            'glpi_networknames AS NAME'   => [
+                'ON' => [
+                    'NAME'   => 'id',
+                    'ADDR'   => 'items_id', [
+                        'AND' => [
+                            'NAME.itemtype' => 'NetworkPort'
+                        ]
+                    ]
+                ]
+            ],
+            'glpi_networkports AS PORT'   => [
+                'ON' => [
+                    'NAME'   => 'items_id',
+                    'PORT'   => 'id', [
+                        'AND' => [
+                            'NOT' => [
+                                'PORT.itemtype' => $CFG_GLPI['networkport_types']
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+        $queries[] = $criteria;
 
-            $union = new QueryUnion($queries);
-            $criteria = [
-                'FROM'   => $union,
-            ];
+        $criteria = $main_criteria;
+        $criteria['SELECT'] = array_merge($criteria['SELECT'], [
+            'NAME.id AS name_id',
+            new QueryExpression('NULL', 'port_id'),
+            new QueryExpression('NULL', 'item_id'),
+            new QueryExpression('NULL', 'item_type')
+        ]);
+        $criteria['INNER JOIN'] += [
+            'glpi_networknames AS NAME'   => [
+                'ON' => [
+                    'NAME'   => 'id',
+                    'ADDR'   => 'items_id', [
+                        'AND' => [
+                            'NAME.itemtype' => ['!=', 'NetworkPort']
+                        ]
+                    ]
+                ]
+            ]
+        ];
+        $queries[] = $criteria;
+
+        $criteria = $main_criteria;
+        $criteria['SELECT'] = array_merge($criteria['SELECT'], [
+            new QueryExpression('NULL', 'name_id'),
+            new QueryExpression('NULL', 'port_id'),
+            new QueryExpression('NULL', 'item_id'),
+            new QueryExpression('NULL', 'item_type')
+        ]);
+        $criteria['INNER JOIN']['glpi_ipaddresses AS ADDR']['ON'][0]['AND']['ADDR.itemtype'] = ['!=', 'NetworkName'];
+        $queries[] = $criteria;
+
+        $union = new QueryUnion($queries);
+        return [
+            'FROM'   => $union,
+        ];
+    }
+
+    /**
+     * @param HTMLTableRow $row
+     * @param CommonDBTM $item
+     * @param HTMLTableCell $father
+     * @param array $options
+     **/
+    public static function getHTMLTableCellsForItem(
+        HTMLTableRow $row = null,
+        CommonDBTM $item = null,
+        HTMLTableCell $father = null,
+        array $options = []
+    ) {
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        if ($item instanceof IPNetwork) {
+            $criteria = self::getCriteriaLinkedToNetwork($item);
 
             if (
                 ($options['order'] == 'ip')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

Replace use of HTMLTable* classes to display the list of IP Addresses on the IP Addresses tab of IP Networks with a Twig datatable.

Before:
![Selection_216](https://github.com/glpi-project/glpi/assets/17678637/26ff6f7a-112e-4734-a056-0713227f108d)

After:
![Selection_217](https://github.com/glpi-project/glpi/assets/17678637/cde7e883-cfd0-4ea3-a086-9a0df64b2eab)

The "Automatic Inventory" column *was* possible to show using the HTMLTable methods but it was hidden behind an option which was never set anywhere. The old HTMLTable methods were left in place as they were used in at least one other location for another table. That other table wasn't migrated yet as it relies on special grouping/rowspan behavior which is not possible in the datatable template yet.