### PR TITLE
More sublists to twig datatables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The present file will list all changes made to the project; according to the
 - Public reminders in central view now include public reminders regardless of who created them.
 - Project description field is now a rich text field.
 - Entity, profile, debug mode flag, and language are restored after ending impersonation.
+- Volumes now show `Used percentage` instead of `Free percentage`.
 
 ### Deprecated
 - Survey URL tags `TICKETCATEGORY_ID` and `TICKETCATEGORY_NAME` are deprecated and replaced by `ITILCATEGORY_ID` and `ITILCATEGORY_NAME` respectively.

--- a/src/Appliance_Item.php
+++ b/src/Appliance_Item.php
@@ -33,6 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 
 class Appliance_Item extends CommonDBRelation
@@ -173,67 +174,60 @@ class Appliance_Item extends CommonDBRelation
             echo "</div>";
         }
 
-        $items = iterator_to_array($items);
-
-        if (!count($items)) {
-            echo "<table class='tab_cadre_fixe'><tr><th>" . __('No item found') . "</th></tr>";
-            echo "</table>";
-        } else {
-            if ($canedit) {
-                Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
-                $massiveactionparams = [
-                    'num_displayed'   => min($_SESSION['glpilist_limit'], count($items)),
-                    'container'       => 'mass' . __CLASS__ . $rand
-                ];
-                Html::showMassiveActions($massiveactionparams);
-            }
-
-            echo "<table class='tab_cadre_fixehov'>";
-            $header = "<tr>";
-            if ($canedit) {
-                $header .= "<th width='10'>";
-                $header .= Html::getCheckAllAsCheckbox('mass' . __CLASS__ . $rand);
-                $header .= "</th>";
-            }
-            $header .= "<th>" . __('Itemtype') . "</th>";
-            $header .= "<th>" . _n('Item', 'Items', 1) . "</th>";
-            $header .= "<th>" . __("Serial") . "</th>";
-            $header .= "<th>" . __("Inventory number") . "</th>";
-            $header .= "<th>" . Appliance_Item_Relation::getTypeName(Session::getPluralNumber()) . "</th>";
-            $header .= "</tr>";
-            echo $header;
-
-            foreach ($items as $row) {
-                $item = new $row['itemtype']();
-                $item->getFromDB($row['items_id']);
-                echo "<tr lass='tab_bg_1'>";
-                if ($canedit) {
-                    echo "<td>";
-                    Html::showMassiveActionCheckBox(__CLASS__, $row["id"]);
-                    echo "</td>";
-                }
-                echo "<td>" . $item->getTypeName(1) . "</td>";
-                echo "<td>" . $item->getLink() . "</td>";
-                echo "<td>" . ($item->fields['serial'] ?? "") . "</td>";
-                echo "<td>" . ($item->fields['otherserial'] ?? "") . "</td>";
-                echo "<td class='relations_list'>";
-                echo Appliance_Item_Relation::showListForApplianceItem($row["id"], $canedit);
-                echo "</td>";
-                echo "</tr>";
-            }
-            echo $header;
-            echo "</table>";
-
-            if ($canedit && count($items)) {
-                $massiveactionparams['ontop'] = false;
-                Html::showMassiveActions($massiveactionparams);
-            }
-            if ($canedit) {
-                Html::closeForm();
-            }
-
-            echo Appliance_Item_Relation::getListJSForApplianceItem($appliance, $canedit);
+        echo "<table class='tab_cadre_fixehov'>";
+        $header = "<tr>";
+        if ($canedit) {
+            $header .= "<th width='10'>";
+            $header .= Html::getCheckAllAsCheckbox('mass' . __CLASS__ . $rand);
+            $header .= "</th>";
         }
+        $header .= "<th>" . __('Itemtype') . "</th>";
+        $header .= "<th>" . _n('Item', 'Items', 1) . "</th>";
+        $header .= "<th>" . __("Serial") . "</th>";
+        $header .= "<th>" . __("Inventory number") . "</th>";
+        $header .= "<th>" . Appliance_Item_Relation::getTypeName(Session::getPluralNumber()) . "</th>";
+        $header .= "</tr>";
+        echo $header;
+
+        $entries = [];
+        foreach ($items as $row) {
+            $item = new $row['itemtype']();
+            $item->getFromDB($row['items_id']);
+            $entries[] = [
+                'itemtype' => self::class,
+                'id' => $row['id'],
+                'item_type' => $item->getTypeName(1),
+                'item' => $item->getLink(),
+                'serial' => $item->fields['serial'] ?? "",
+                'otherserial' => $item->fields['otherserial'] ?? "",
+                'relations' => "<div class='relations_list'>" . Appliance_Item_Relation::showListForApplianceItem($row["id"], $canedit) . "</div>"
+            ];
+        }
+
+        TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
+            'is_tab' => true,
+            'nofilter' => true,
+            'columns' => [
+                'item_type' => __('Itemtype'),
+                'item' => _n('Item', 'Items', 1),
+                'serial' => __('Serial'),
+                'otherserial' => __('Inventory number'),
+                'relations' => Appliance_Item_Relation::getTypeName(Session::getPluralNumber())
+            ],
+            'formatters' => [
+                'item' => 'raw_html',
+                'relations' => 'raw_html'
+            ],
+            'entries' => $entries,
+            'total_number' => count($entries),
+            'filtered_number' => count($entries),
+            'showmassiveactions' => $canedit,
+            'massiveactionparams' => [
+                'num_displayed' => min($_SESSION['glpilist_limit'], count($entries)),
+                'container'     => 'mass' . static::class . $rand
+            ],
+        ]);
+        echo Appliance_Item_Relation::getListJSForApplianceItem($appliance, $canedit);
     }
 
     /**
@@ -263,7 +257,6 @@ class Appliance_Item extends CommonDBRelation
         $rand = mt_rand();
 
         $iterator = self::getListForItem($item);
-        $number = count($iterator);
 
         $appliances = [];
         $used      = [];
@@ -272,7 +265,7 @@ class Appliance_Item extends CommonDBRelation
             $used[$data['id']]      = $data['id'];
         }
         if ($canedit && ($withtemplate != 2)) {
-            echo "<div class='firstbloc'>";
+            echo "<div class='mt-1 mb-3 text-center'>";
             echo "<form name='applianceitem_form$rand' id='applianceitem_form$rand' method='post'
                 action='" . Toolbox::getItemTypeFormURL(__CLASS__) . "'>";
             echo "<input type='hidden' name='items_id' value='$ID'>";
@@ -295,83 +288,40 @@ class Appliance_Item extends CommonDBRelation
             echo "</div>";
         }
 
-        echo "<div class='spaced'>";
-        if ($withtemplate != 2) {
-            if ($canedit && $number) {
-                Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
-                $massiveactionparams = ['num_displayed' => min($_SESSION['glpilist_limit'], $number),
-                    'container'     => 'mass' . __CLASS__ . $rand
-                ];
-                Html::showMassiveActions($massiveactionparams);
-            }
-        }
-        echo "<table class='tab_cadre_fixehov'>";
+        $entries = [];
+        foreach ($appliances as $data) {
+            $assocID = $data["linkid"];
+            $app = new Appliance();
+            $app->getFromResultSet($data);
 
-        $header = "<tr>";
-        if ($canedit && $number && ($withtemplate != 2)) {
-            $header    .= "<th width='10'>" . Html::getCheckAllAsCheckbox('mass' . __CLASS__ . $rand);
-            $header    .= "</th>";
+            $entries[] = [
+                'itemtype' => self::class,
+                'id' => $assocID,
+                'name' => $app->getLink(),
+                'relations' => "<div class='relations_list'>" . Appliance_Item_Relation::showListForApplianceItem($assocID, $canedit) . "</div>"
+            ];
         }
 
-        $header .= "<th>" . __('Name') . "</th>";
-        $header .= "<th>" . Appliance_Item_Relation::getTypeName(Session::getPluralNumber()) . "</th>";
-        $header .= "</tr>";
-
-        if ($number > 0) {
-            echo $header;
-            Session::initNavigateListItems(
-                __CLASS__,
-                //TRANS : %1$s is the itemtype name,
-                              //         %2$s is the name of the item (used for headings of a list)
-                                        sprintf(
-                                            __('%1$s = %2$s'),
-                                            $item->getTypeName(1),
-                                            $item->getName()
-                                        )
-            );
-            foreach ($appliances as $data) {
-                $cID         = $data["id"];
-                Session::addToNavigateListItems(__CLASS__, $cID);
-                $assocID     = $data["linkid"];
-                $app         = new Appliance();
-                $app->getFromResultSet($data);
-                echo "<tr class='tab_bg_1" . ($app->fields["is_deleted"] ? "_2" : "") . "'>";
-                if ($canedit && ($withtemplate != 2)) {
-                    echo "<td width='10'>";
-                    Html::showMassiveActionCheckBox(__CLASS__, $assocID);
-                    echo "</td>";
-                }
-                echo "<td class='b'>";
-                $name = $app->fields["name"];
-                if (
-                    $_SESSION["glpiis_ids_visible"]
-                    || empty($app->fields["name"])
-                ) {
-                    $name = sprintf(__('%1$s (%2$s)'), $name, $app->fields["id"]);
-                }
-                echo "<a href='" . Appliance::getFormURLWithID($cID) . "'>" . $name . "</a>";
-                echo "</td>";
-                echo "<td class='relations_list'>";
-                echo Appliance_Item_Relation::showListForApplianceItem($assocID, $canedit);
-                echo "</td>";
-
-                echo "</tr>";
-            }
-            echo $header;
-            echo "</table>";
-        } else {
-            echo "<table class='tab_cadre_fixe'>";
-            echo "<tr><th>" . __('No item found') . "</th></tr></table>";
-        }
-
-        echo "</table>";
-        if ($canedit && $number && ($withtemplate != 2)) {
-            $massiveactionparams['ontop'] = false;
-            Html::showMassiveActions($massiveactionparams);
-            Html::closeForm();
-        }
-        echo "</div>";
-
+        TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
+            'is_tab' => true,
+            'nofilter' => true,
+            'columns' => [
+                'name' => __('Name'),
+                'relations' => Appliance_Item_Relation::getTypeName(Session::getPluralNumber())
+            ],
+            'formatters' => [
+                'name' => 'raw_html',
+                'relations' => 'raw_html'
+            ],
+            'entries' => $entries,
+            'total_number' => count($entries),
+            'filtered_number' => count($entries),
+            'showmassiveactions' => $canedit,
+            'massiveactionparams' => [
+                'num_displayed' => min($_SESSION['glpilist_limit'], count($entries)),
+                'container'     => 'mass' . static::class . $rand
+            ],
+        ]);
         echo Appliance_Item_Relation::getListJSForApplianceItem($item, $canedit);
     }
 

--- a/src/Appliance_Item_Relation.php
+++ b/src/Appliance_Item_Relation.php
@@ -169,7 +169,6 @@ class Appliance_Item_Relation extends CommonDBRelation
         return parent::countForMainItem($item, $extra_types_where);
     }
 
-
     /**
      * return an array of relations for a given Appliance_Item's id
      *
@@ -183,6 +182,7 @@ class Appliance_Item_Relation extends CommonDBRelation
         global $DB;
 
         $iterator = $DB->request([
+            'SELECT' => ['id', 'itemtype', 'items_id'],
             'FROM'   => self::getTable(),
             'WHERE'  => [
                 Appliance_Item::getForeignKeyField() => $appliances_items_id
@@ -217,18 +217,17 @@ class Appliance_Item_Relation extends CommonDBRelation
     public static function showListForApplianceItem(int $appliances_items_id = 0, bool $canedit = true)
     {
         $relations_str = "";
-        foreach (Appliance_Item_Relation::getForApplianceItem($appliances_items_id) as $rel_id => $link) {
+        foreach (self::getForApplianceItem($appliances_items_id) as $rel_id => $link) {
             $del = "";
             if ($canedit) {
-                $del = "<i class='delete_relation pointer fas fa-times'
-                       data-relations-id='$rel_id'></i>";
+                $del = "<i class='delete_relation pointer fas fa-times' data-relations-id='$rel_id'></i>";
             }
             $relations_str .= "<li>$link $del</li>";
         }
 
         return "<ul>$relations_str</ul>
-         <span class='pointer add_relation' data-appliances-items-id='{$appliances_items_id}'>
-            <i class='fa fa-plus' title='" . __('New relation') . "'></i>
+         <span class='cursor-pointer add_relation' data-appliances-items-id='{$appliances_items_id}'>
+            <i class='ti ti-plus' title='" . __('New relation') . "'></i>
             <span class='sr-only'>" . __('New relation') . "</span>
          </span>
       </td>";

--- a/src/Item_DeviceCamera_ImageFormat.php
+++ b/src/Item_DeviceCamera_ImageFormat.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\View\TemplateRenderer;
+
 class Item_DeviceCamera_ImageFormat extends CommonDBRelation
 {
     public static $itemtype_1 = 'Item_DeviceCamera';
@@ -88,10 +90,9 @@ class Item_DeviceCamera_ImageFormat extends CommonDBRelation
     public static function showItems(DeviceCamera $camera)
     {
         /**
-         * @var array $CFG_GLPI
          * @var \DBmysql $DB
          */
-        global $CFG_GLPI, $DB;
+        global $DB;
 
         $ID = $camera->getID();
         $rand = mt_rand();
@@ -105,76 +106,43 @@ class Item_DeviceCamera_ImageFormat extends CommonDBRelation
         $canedit = $camera->canEdit($ID);
 
         $items = $DB->request([
-            'FROM'   => Item_DeviceCamera_ImageFormat::getTable(),
+            'SELECT' => ['id', 'imageformats_id', 'is_dynamic'],
+            'FROM'   => self::getTable(),
             'WHERE'  => [
                 'items_devicecameras_id' => $camera->getID()
             ]
         ]);
-        $link = new self();
 
-        echo "<div>";
-
-        if (!count($items)) {
-            echo "<table class='tab_cadre_fixe'><tr><th>" . __('No item found') . "</th></tr>";
-            echo "</table>";
-        } else {
-            Session::initNavigateListItems(
-                self::getType(),
-                //TRANS : %1$s is the itemtype name,
-                //        %2$s is the name of the item (used for headings of a list)
-                sprintf(
-                    __('%1$s = %2$s'),
-                    $camera->getTypeName(1),
-                    $camera->getName()
-                )
-            );
-
-            if ($canedit) {
-                Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
-                $massiveactionparams = [
-                    'num_displayed'   => min($_SESSION['glpilist_limit'], count($items)),
-                    'container'       => 'mass' . __CLASS__ . $rand
-                ];
-                Html::showMassiveActions($massiveactionparams);
-            }
-
-            echo "<table class='tab_cadre_fixehov'>";
-            $header = "<tr>";
-            if ($canedit) {
-                $header .= "<th width='10'>";
-                $header .= Html::getCheckAllAsCheckbox('mass' . __CLASS__ . $rand);
-                $header .= "</th>";
-            }
-            $header .= "<th>" . ImageFormat::getTypeName(1) . "</th>";
-            $header .= "<th>" . __('Is dynamic') . "</th>";
-            $header .= "</tr>";
-
-            echo $header;
-            foreach ($items as $row) {
-                $item = new ImageFormat();
-                $item->getFromDB($row['imageformats_id']);
-                echo "<tr lass='tab_bg_1'>";
-                if ($canedit) {
-                    echo "<td>";
-                    Html::showMassiveActionCheckBox(__CLASS__, $row["id"]);
-                    echo "</td>";
-                }
-                echo "<td>" . $item->getLink() . "</td>";
-                echo "<td>{$row['is_dynamic']}</td>";
-                echo "</tr>";
-            }
-            echo $header;
-            echo "</table>";
-
-            if ($canedit && count($items)) {
-                $massiveactionparams['ontop'] = false;
-                Html::showMassiveActions($massiveactionparams);
-            }
-            if ($canedit) {
-                Html::closeForm();
-            }
+        $entries = [];
+        foreach ($items as $row) {
+            $item = new ImageFormat();
+            $item->getFromDB($row['imageformats_id']);
+            $entries[] = [
+                'itemtype' => self::class,
+                'id' => $row['id'],
+                'imageformats_id' => $item->getLink(),
+                'is_dynamic' => $row['is_dynamic']
+            ];
         }
 
-        echo "</div>";
+        TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
+            'is_tab' => true,
+            'nofilter' => true,
+            'columns' => [
+                'imageformats_id' => ImageFormat::getTypeName(1),
+                'is_dynamic' => __('Is dynamic')
+            ],
+            'formatters' => [
+                'imageformats_id' => 'raw_html'
+            ],
+            'entries' => $entries,
+            'total_number' => count($entries),
+            'filtered_number' => count($entries),
+            'showmassiveactions' => $canedit,
+            'massiveactionparams' => [
+                'num_displayed' => min($_SESSION['glpilist_limit'], count($entries)),
+                'container'     => 'mass' . static::class . $rand
+            ],
+        ]);
     }
 }

--- a/src/Item_DeviceCamera_ImageResolution.php
+++ b/src/Item_DeviceCamera_ImageResolution.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\View\TemplateRenderer;
+
 class Item_DeviceCamera_ImageResolution extends CommonDBRelation
 {
     public static $itemtype_1 = 'Item_DeviceCamera';
@@ -88,10 +90,9 @@ class Item_DeviceCamera_ImageResolution extends CommonDBRelation
     public static function showItems(DeviceCamera $camera)
     {
         /**
-         * @var array $CFG_GLPI
          * @var \DBmysql $DB
          */
-        global $CFG_GLPI, $DB;
+        global $DB;
 
         $ID = $camera->getID();
         $rand = mt_rand();
@@ -119,76 +120,40 @@ class Item_DeviceCamera_ImageResolution extends CommonDBRelation
                 'items_devicecameras_id' => $camera->getID()
             ]
         ]);
-        $link = new self();
 
-        echo "<div>";
+        $entries = [];
+        foreach ($items as $row) {
+            $item = new ImageResolution();
+            $item->getFromDB($row['imageresolutions_id']);
 
-        if (!count($items)) {
-            echo "<table class='tab_cadre_fixe'><tr><th>" . __('No item found') . "</th></tr>";
-            echo "</table>";
-        } else {
-            Session::initNavigateListItems(
-                self::getType(),
-                //TRANS : %1$s is the itemtype name,
-                //        %2$s is the name of the item (used for headings of a list)
-                sprintf(
-                    __('%1$s = %2$s'),
-                    $camera->getTypeName(1),
-                    $camera->getName()
-                )
-            );
-
-            if ($canedit) {
-                Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
-                $massiveactionparams = [
-                    'num_displayed'   => min($_SESSION['glpilist_limit'], count($items)),
-                    'container'       => 'mass' . __CLASS__ . $rand
-                ];
-                Html::showMassiveActions($massiveactionparams);
-            }
-
-            echo "<table class='tab_cadre_fixehov'>";
-            $header = "<tr>";
-            if ($canedit) {
-                $header .= "<th width='10'>";
-                $header .= Html::getCheckAllAsCheckbox('mass' . __CLASS__ . $rand);
-                $header .= "</th>";
-            }
-            $header .= "<th>" . ImageResolution::getTypeName(1) . "</th>";
-            $header .= "<th>" . __('Is Video') . "</th>";
-            $header .= "<th>" . __('Is dynamic') . "</th>";
-            $header .= "</tr>";
-
-            echo $header;
-            foreach ($items as $row) {
-                $item = new ImageResolution();
-                $item->getFromDB($row['imageresolutions_id']);
-                echo "<tr lass='tab_bg_1'>";
-                if ($canedit) {
-                    echo "<td>";
-                    Html::showMassiveActionCheckBox(__CLASS__, $row["id"]);
-                    echo "</td>";
-                }
-
-                $is_video =  $row['is_video'] ? __('Yes') : __('No');
-
-                echo "<td>" . $item->getLink() . "</td>";
-                echo "<td>" . $is_video . "</td>";
-                echo "<td>{$row['is_dynamic']}</td>";
-                echo "</tr>";
-            }
-            echo $header;
-            echo "</table>";
-
-            if ($canedit && count($items)) {
-                $massiveactionparams['ontop'] = false;
-                Html::showMassiveActions($massiveactionparams);
-            }
-            if ($canedit) {
-                Html::closeForm();
-            }
+            $entries[] = [
+                'itemtype' => self::class,
+                'id' => $row['id'],
+                'imageresolutions_id' => $item->getLink(),
+                'is_video' => Dropdown::getYesNo($row['is_video']),
+                'is_dynamic' => $row['is_dynamic']
+            ];
         }
 
-        echo "</div>";
+        TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
+            'is_tab' => true,
+            'nofilter' => true,
+            'columns' => [
+                'imageresolutions_id' => ImageResolution::getTypeName(1),
+                'is_video' => __('Is Video'),
+                'is_dynamic' => __('Is dynamic')
+            ],
+            'formatters' => [
+                'imageresolutions_id' => 'raw_html'
+            ],
+            'entries' => $entries,
+            'total_number' => count($entries),
+            'filtered_number' => count($entries),
+            'showmassiveactions' => $canedit,
+            'massiveactionparams' => [
+                'num_displayed' => min($_SESSION['glpilist_limit'], count($entries)),
+                'container'     => 'mass' . static::class . $rand
+            ],
+        ]);
     }
 }

--- a/src/Item_Disk.php
+++ b/src/Item_Disk.php
@@ -42,12 +42,12 @@ use Glpi\DBAL\QueryFunction;
  **/
 class Item_Disk extends CommonDBChild
 {
-   // From CommonDBChild
+    // From CommonDBChild
     public static $itemtype = 'itemtype';
     public static $items_id = 'items_id';
     public $dohistory       = true;
 
-   // Encryption status
+    // Encryption status
     const ENCRYPTION_STATUS_NO = 0;
     const ENCRYPTION_STATUS_YES = 1;
     const ENCRYPTION_STATUS_PARTIALLY = 2;
@@ -64,22 +64,18 @@ class Item_Disk extends CommonDBChild
 
     public function post_getEmpty()
     {
-
         $this->fields["totalsize"] = '0';
         $this->fields["freesize"]  = '0';
     }
-
 
     public function useDeletedToLockIfDynamic()
     {
         return false;
     }
 
-
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-
-       // can exists for template
+        // can exists for template
         if ($item::canView()) {
             $nb = 0;
             if ($_SESSION['glpishow_count_on_tabs']) {
@@ -97,23 +93,19 @@ class Item_Disk extends CommonDBChild
         return '';
     }
 
-
     /**
-     * @param $item            CommonGLPI object
+     * @param CommonGLPI $item object
      * @param $tabnum          (default 1)
      * @param $withtemplate    (default 0)
      */
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
     {
-
         self::showForItem($item, $withtemplate);
         return true;
     }
 
-
     public function defineTabs($options = [])
     {
-
         $ong = [];
         $this->addDefaultFormTab($ong);
         $this->addStandardTab('Lock', $ong, $options);
@@ -125,8 +117,8 @@ class Item_Disk extends CommonDBChild
     /**
      * Print the version form
      *
-     * @param $ID        integer ID of the item
-     * @param $options   array
+     * @param integer $ID ID of the item
+     * @param array $options
      *     - target for the Form
      *     - itemtype type of the item for add process
      *     - items_id ID of the item for add process
@@ -219,6 +211,7 @@ class Item_Disk extends CommonDBChild
     {
         $ID = $item->fields['id'];
         $itemtype = $item->getType();
+        $rand = mt_rand();
 
         if (
             !$item->getFromDB($ID)
@@ -232,100 +225,90 @@ class Item_Disk extends CommonDBChild
             $canedit
             && !(!empty($withtemplate) && ($withtemplate == 2))
         ) {
-            echo "<div class='center firstbloc'>" .
+            echo "<div class='mt-1 mb-3 text-center'>" .
                "<a class='btn btn-primary' href='" . self::getFormURL() . "?itemtype=$itemtype&items_id=$ID&amp;withtemplate=" .
                   $withtemplate . "'>";
             echo __('Add a volume');
             echo "</a></div>\n";
         }
 
-        echo "<div class='center table-responsive'>";
-
         $iterator = self::getFromItem($item);
-        echo "<table class='tab_cadre_fixehov'>";
-        $colspan = 9;
-        echo "<tr class='noHover'><th colspan='$colspan'>" . self::getTypeName(count($iterator)) .
-            "</th></tr>";
 
-        if (count($iterator)) {
-            $header = "<tr><th>" . __('Name') . "</th>";
-            $header .= "<th>" . __('Automatic inventory') . "</th>";
-            $header .= "<th>" . __('Partition') . "</th>";
-            $header .= "<th>" . __('Mount point') . "</th>";
-            $header .= "<th>" . Filesystem::getTypeName(1) . "</th>";
-            $header .= "<th>" . __('Global size') . "</th>";
-            $header .= "<th>" . __('Free size') . "</th>";
-            $header .= "<th>" . __('Free percentage') . "</th>";
-            $header .= "<th>" . __('Encryption') . "</th>";
-            $header .= "</tr>";
-            echo $header;
-
-            Session::initNavigateListItems(
-                __CLASS__,
-                //TRANS : %1$s is the itemtype name,
-                           //        %2$s is the name of the item (used for headings of a list)
-                                          sprintf(
-                                              __('%1$s = %2$s'),
-                                              $item::getTypeName(1),
-                                              $item->getName()
-                                          )
-            );
-
-            $disk = new self();
-            foreach ($iterator as $data) {
-                $disk->getFromResultSet($data);
-                echo "<tr class='tab_bg_2" . (isset($data['is_deleted']) && $data['is_deleted'] ? " tab_bg_2_2'" : "'") . "'>";
-                echo "<td>" . $disk->getLink() . "</td>";
-                echo "<td>" . Dropdown::getYesNo($data['is_dynamic']) . "</td>";
-                echo "<td>" . $data['device'] . "</td>";
-                echo "<td>" . $data['mountpoint'] . "</td>";
-                echo "<td>" . $data['fsname'] . "</td>";
-                //TRANS: %s is a size
-                $tmp = Toolbox::getSize($data['totalsize'] * 1024 * 1024);
-                echo "<td>$tmp</td>";
-                $tmp = Toolbox::getSize($data['freesize'] * 1024 * 1024);
-                echo "<td>$tmp</td>";
-                echo "<td>";
-                $percent = 0;
-                if ($data['totalsize'] > 0) {
-                    $percent = round(100 * $data['freesize'] / $data['totalsize']);
-                }
-                $rand = mt_rand();
-                Html::progressBar("percent$rand", [
-                    'create'  => true,
-                    'percent' => $percent,
-                    'message' => "$percent %",
-                ]);
-                 echo "</td>";
-                 echo "<td class=\"center\">";
-
-                if ($data['encryption_status'] != self::ENCRYPTION_STATUS_NO) {
-                     $encryptionTooltip = "<strong>" . __('Partial encryption') . "</strong> : " .
-                        Dropdown::getYesNo($data['encryption_status'] == self::ENCRYPTION_STATUS_PARTIALLY) .
-                        "<br/>" .
-                        "<strong>" . __('Encryption tool') . "</strong> : " . $data['encryption_tool'] .
-                        "</br>" .
-                        "<strong>" . __('Encryption algorithm') . "</strong> : " .
-                        $data['encryption_algorithm'] . "</br>" .
-                        "<strong>" . __('Encryption type') . "</strong> : " . $data['encryption_type'] .
-                        "</br>";
-
-                     Html::showTooltip($encryptionTooltip, [
-                         'awesome-class' => "fas fa-lock"
-                     ]);
-                }
-
-                 echo "</td>";
-                 echo "</tr>";
-                 Session::addToNavigateListItems(__CLASS__, $data['id']);
+        $disk = new self();
+        $entries = [];
+        foreach ($iterator as $data) {
+            $disk->getFromResultSet($data);
+            $used = $data['totalsize'] - $data['freesize'];
+            $usedpercent = 0;
+            if ($data['totalsize'] > 0) {
+                $usedpercent = round(100 * $used / $data['totalsize']);
             }
-            echo $header;
-        } else {
-            echo "<tr class='tab_bg_2'><th colspan='$colspan'>" . __('No item found') . "</th></tr>";
+
+            $encryption_label = '';
+            if ($data['encryption_status'] !== self::ENCRYPTION_STATUS_NO) {
+                $twig_params = [
+                    'encryption_status' => Dropdown::getYesNo($data['encryption_status'] === self::ENCRYPTION_STATUS_YES),
+                    'encryption_tool' => $data['encryption_tool'],
+                    'encryption_algorithm' => $data['encryption_algorithm'],
+                    'encryption_type' => $data['encryption_type'],
+                ];
+                $encryptionTooltip = TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
+                    <strong>{{ __('Partial encryption') }}</strong> : {{ encryption_status }}<br/>
+                    <strong>{{ __('Encryption tool') }}</strong> : {{ encryption_tool }}</br>
+                    <strong>{{ __('Encryption algorithm') }}</strong> : {{ encryption_algorithm }}</br>
+                    <strong>{{ __('Encryption type') }}</strong> : {{ encryption_type }}
+TWIG, $twig_params);
+
+                $encryption_label = Html::showTooltip($encryptionTooltip, [
+                    'awesome-class' => "fas fa-lock",
+                    'display' => false
+                ]);
+            }
+            $entries[] = [
+                'itemtype' => self::class,
+                'id' => $data['id'],
+                'name' => $disk->getLink(),
+                'is_dynamic' => Dropdown::getYesNo($data['is_dynamic']),
+                'device' => $data['device'],
+                'mountpoint' => $data['mountpoint'],
+                'fsname' => $data['fsname'],
+                'totalsize' => $data['totalsize'],
+                'freesize' => $data['freesize'],
+                'usedpercent' => $usedpercent,
+                'encryption_status' => $encryption_label,
+            ];
         }
 
-        echo "</table>";
-        echo "</div>";
+        TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
+            'is_tab' => true,
+            'nofilter' => true,
+            'columns' => [
+                'name' => __('Name'),
+                'is_dynamic' => __('Automatic inventory'),
+                'device' => __('Partition'),
+                'mountpoint' => __('Mount point'),
+                'fsname' => Filesystem::getTypeName(1),
+                'totalsize' => __('Global size'),
+                'freesize' => __('Free size'),
+                'usedpercent' => __('Used percentage'),
+                'encryption_status' => __('Encryption'),
+            ],
+            'formatters' => [
+                'name' => 'raw_html',
+                'totalsize' => 'bytesize',
+                'freesize' => 'bytesize',
+                'usedpercent' => 'progress',
+                'encryption_status' => 'raw_html',
+            ],
+            'entries' => $entries,
+            'total_number' => count($entries),
+            'filtered_number' => count($entries),
+            'showmassiveactions' => $canedit,
+            'massiveactionparams' => [
+                'num_displayed' => min($_SESSION['glpilist_limit'], count($entries)),
+                'container'     => 'mass' . static::class . $rand
+            ],
+        ]);
     }
 
     public function rawSearchOptions()
@@ -586,6 +569,8 @@ class Item_Disk extends CommonDBChild
     /**
      * Get the correct label for each encryption status
      *
+     * @param integer $status The status
+     * @phpstan-param self::ENCRYPTION_STATUS_* $status
      * @return string The appropriate label
      */
     public static function getEncryptionStatus($status)
@@ -619,10 +604,7 @@ class Item_Disk extends CommonDBChild
      */
     public static function getEncryptionStatusDropdown($value = self::ENCRYPTION_STATUS_NO, $options = [])
     {
-        $name = 'encryption_status';
-        if (isset($options['name'])) {
-            $name = $options['name'];
-        }
+        $name = $options['name'] ?? 'encryption_status';
         $values = self::getAllEncryptionStatus();
 
         return Dropdown::showFromArray(

--- a/src/Item_Rack.php
+++ b/src/Item_Rack.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\View\TemplateRenderer;
+
 class Item_Rack extends CommonDBRelation
 {
     public static $itemtype_1 = 'Rack';
@@ -118,127 +120,65 @@ class Item_Rack extends CommonDBRelation
         parent::processMassiveActionsForOneItemtype($ma, $item, $ids);
     }
 
-    /**
-     * Print racks items
-     * @param  Rack   $rack the current rack instance
-     * @return void
-     */
-    public static function showItems(Rack $rack)
+    private static function showItemsList(Rack $rack, iterable $items): void
     {
-        /**
-         * @var array $CFG_GLPI
-         * @var \DBmysql $DB
-         */
-        global $CFG_GLPI, $DB;
-
-        $ID = $rack->getID();
         $rand = mt_rand();
-
-        if (
-            !$rack->getFromDB($ID)
-            || !$rack->can($ID, READ)
-        ) {
-            return false;
-        }
-        $canedit = $rack->canEdit($ID);
-
-        $items = $DB->request([
-            'FROM'   => self::getTable(),
-            'WHERE'  => [
-                'racks_id' => $rack->getID()
-            ],
-            'ORDER' => 'position DESC'
-        ]);
-        $link = new self();
-
-        if ($canedit) {
-            Session::initNavigateListItems(
-                self::getType(),
-                //TRANS : %1$s is the itemtype name,
-                //        %2$s is the name of the item (used for headings of a list)
-                sprintf(
-                    __('%1$s = %2$s'),
-                    $rack->getTypeName(1),
-                    $rack->getName()
-                )
-            );
-        }
-
-        echo "<div id='switchview'>";
-        echo "<i id='sviewlist' class='pointer ti ti-list' title='" . __('View as list') . "'></i>";
-        echo "<i id='sviewgraph' class='pointer ti ti-server selected' title='" . __('View graphical representation') . "'></i>";
-        echo "</div>";
-
-        $items = iterator_to_array($items);
-        echo "<div id='viewlist'>";
+        $canedit = $rack->canEdit($rack->getID());
 
         echo "<h2>" . __("Racked items") . "</h2>";
-        if (!count($items)) {
-            echo "<table class='tab_cadre_fixe'><tr><th>" . __('No item found') . "</th></tr>";
-            echo "</table>";
-        } else {
-            if ($canedit) {
-                Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
-                $massiveactionparams = [
-                    'num_displayed'   => min($_SESSION['glpilist_limit'], count($items)),
-                    'container'       => 'mass' . __CLASS__ . $rand
-                ];
-                Html::showMassiveActions($massiveactionparams);
-            }
 
-            echo "<table class='tab_cadre_fixehov'>";
-            $header = "<tr>";
-            if ($canedit) {
-                $header .= "<th width='10'>";
-                $header .= Html::getCheckAllAsCheckbox('mass' . __CLASS__ . $rand);
-                $header .= "</th>";
-            }
-            $header .= "<th>" . _n('Item', 'Items', 1) . "</th>";
-            $header .= "<th>" . __('Position') . "</th>";
-            $header .= "<th>" . __('Orientation') . "</th>";
-            $header .= "</tr>";
-
-            echo $header;
-            foreach ($items as $row) {
-                $item = new $row['itemtype']();
-                $item->getFromDB($row['items_id']);
-                echo "<tr lass='tab_bg_1'>";
-                if ($canedit) {
-                    echo "<td>";
-                    Html::showMassiveActionCheckBox(__CLASS__, $row["id"]);
-                    echo "</td>";
-                }
-                echo "<td>" . $item->getLink() . "</td>";
-                echo "<td>{$row['position']}</td>";
-                $txt_orientation = $row['orientation'] == Rack::FRONT ? __('Front') : __('Rear');
-                echo "<td>$txt_orientation</td>";
-                echo "</tr>";
-            }
-            echo $header;
-            echo "</table>";
-
-            if ($canedit && count($items)) {
-                $massiveactionparams['ontop'] = false;
-                Html::showMassiveActions($massiveactionparams);
-            }
-            if ($canedit) {
-                Html::closeForm();
-            }
+        $entries = [];
+        foreach ($items as $row) {
+            $item = new $row['itemtype']();
+            $item->getFromDB($row['items_id']);
+            $entries[] = [
+                'itemtype' => self::class,
+                'id' => $row['id'],
+                'item' => $item->getLink(),
+                'position' => $row['position'],
+                'orientation' => $row['orientation'] === Rack::FRONT ? __('Front') : __('Rear'),
+                'side' => $row['hpos'] === Rack::POS_LEFT ? __('Left') : __('Right'),
+            ];
         }
 
-        PDU_Rack::showListForRack($rack);
+        TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
+            'is_tab' => true,
+            'nofilter' => true,
+            'columns' => [
+                'item' => _n('Item', 'Items', 1),
+                'position' => __('Position'),
+                'orientation' => __('Orientation'),
+                'side' => __('Side'),
+            ],
+            'formatters' => [
+                'item' => 'raw_html'
+            ],
+            'entries' => $entries,
+            'total_number' => count($entries),
+            'filtered_number' => count($entries),
+            'showmassiveactions' => $canedit,
+            'massiveactionparams' => [
+                'num_displayed' => min($_SESSION['glpilist_limit'], count($entries)),
+                'container'     => 'mass' . static::class . $rand
+            ],
+        ]);
 
-        echo "</div>";
-        echo "<div id='viewgraph'>";
+        PDU_Rack::showListForRack($rack);
+    }
+
+    private static function showItemsGraph(Rack $rack, iterable $items): void
+    {
+        $canedit = $rack->canEdit($rack->getID());
+        $link = new self();
 
         $data = [];
-       //all rows; empty
+        //all rows; empty
         for ($i = (int)$rack->fields['number_units']; $i > 0; --$i) {
             $data[Rack::FRONT][$i] = false;
             $data[Rack::REAR][$i] = false;
         }
 
-       //fill rows
+        //fill rows
         $outbound = [];
         foreach ($items as $row) {
             $rel  = new self();
@@ -274,8 +214,8 @@ class Item_Rack extends CommonDBRelation
                 if ($model->fields['required_units'] > 1) {
                     $gs_item['height'] = $model->fields['required_units'];
                     $gs_item['y']      = $rack->fields['number_units'] + 1
-                                    - $row['position']
-                                    - $model->fields['required_units'];
+                        - $row['position']
+                        - $model->fields['required_units'];
                 }
 
                 if ($model->fields['is_half_rack'] == 1) {
@@ -305,7 +245,7 @@ class Item_Rack extends CommonDBRelation
                     'gs_item' => $gs_item
                 ];
 
-               //add to other side if needed
+                //add to other side if needed
                 if (
                     $model == null
                     || $model->fields['depth'] >= 1
@@ -314,7 +254,7 @@ class Item_Rack extends CommonDBRelation
                     $flip_orientation = (int) !((bool) $row['orientation']);
                     if ($gs_item['half_rack']) {
                         $gs_item['x'] = (int) !((bool) $gs_item['x']);
-                       //$row['position'] = substr($row['position'], 0, -2)."_".$gs_item['x'];
+                        //$row['position'] = substr($row['position'], 0, -2)."_".$gs_item['x'];
                     }
                     $data[$flip_orientation][$row['position']] = [
                         'row'     => $row,
@@ -357,7 +297,7 @@ class Item_Rack extends CommonDBRelation
          <div class="racks_col">
          <h2>' . __('Front') . '</h2>
          <div class="rack_side rack_front">';
-       // append some spaces on top for having symetrical view between front and rear
+        // append some spaces on top for having symetrical view between front and rear
         for ($i = 0; $i < $nb_top_pdu; $i++) {
             echo "<div class='virtual_pdu_space'></div>";
         }
@@ -379,7 +319,7 @@ class Item_Rack extends CommonDBRelation
                     gs-h="1" gs-w="2" gs-x="0" gs-y="' . $rack->fields['number_units'] . '"></div>
             </div>
             <ul class="indexes"></ul>';
-       // append some spaces on bottom for having symetrical view between front and rear
+        // append some spaces on bottom for having symetrical view between front and rear
         for ($i = 0; $i < $nb_bot_pdu; $i++) {
             echo "<div class='virtual_pdu_space'></div>";
         }
@@ -420,6 +360,63 @@ class Item_Rack extends CommonDBRelation
         echo '</div>'; // .racks_col
         echo '</div>'; // .racks_row
         echo "<div id='grid-dialog'></div>";
+    }
+
+    /**
+     * Print racks items
+     * @param  Rack   $rack the current rack instance
+     * @return void
+     */
+    public static function showItems(Rack $rack)
+    {
+        /**
+         * @var array $CFG_GLPI
+         * @var \DBmysql $DB
+         */
+        global $CFG_GLPI, $DB;
+
+        $ID = $rack->getID();
+
+        if (
+            !$rack->getFromDB($ID)
+            || !$rack->can($ID, READ)
+        ) {
+            return false;
+        }
+        $canedit = $rack->canEdit($ID);
+
+        $items = $DB->request([
+            'FROM'   => self::getTable(),
+            'WHERE'  => [
+                'racks_id' => $rack->getID()
+            ],
+            'ORDER' => 'position DESC'
+        ]);
+        $link = new self();
+
+        if ($canedit) {
+            Session::initNavigateListItems(
+                self::getType(),
+                //TRANS : %1$s is the itemtype name,
+                //        %2$s is the name of the item (used for headings of a list)
+                sprintf(
+                    __('%1$s = %2$s'),
+                    $rack->getTypeName(1),
+                    $rack->getName()
+                )
+            );
+        }
+
+        echo "<div id='switchview'>";
+        echo "<i id='sviewlist' class='pointer ti ti-list' title='" . __('View as list') . "'></i>";
+        echo "<i id='sviewgraph' class='pointer ti ti-server selected' title='" . __('View graphical representation') . "'></i>";
+        echo "</div>";
+
+        echo "<div id='viewlist'>";
+        self::showItemsList($rack, $items);
+        echo "</div>";
+        echo "<div id='viewgraph'>";
+        self::showItemsGraph($rack, $items);
         echo "</div>"; // #viewgraph
 
         $rack_add_tip = __s('Insert an item here');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Replacing a few more sublists with Twig datatables.

Changes besides UI:
- Add missing "Side" column for rack item list
- Change "Free percentage" progress bar to "Used percentage". Having a progress bar that indicates how free a disk is is the opposite of the typical visuals shown on a computer relating to disk space.
- Separate code for displaying the rack item list and graph views to improve readability

A  pass will be done later to work on any form that may be present above the sublists.