### PR TITLE
Small refactor of dropdown translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,8 @@ The present file will list all changes made to the project; according to the
 - `DBmysql::truncate()`
 - `DBmysql::truncateOrDie()`
 - `Document::getImage()`
+- `DropdownTranslation::canBeTranslated()`
+- `DropdownTranslation::isDropdownTranslationActive()`
 - `Glpi\Application\View\Extension::getVerbatimValue()`
 - `Glpi\Event::showList()`
 - `Glpi\Features\DCBreadcrumb::getDcBreadcrumb()`
@@ -164,6 +166,10 @@ The present file will list all changes made to the project; according to the
 - `Knowbase::showBrowseView()`
 - `Knowbase::showManageView()`
 - `KnowbaseItem::showManageForm()`
+- `KnowbaseItemTranslation::canBeTranslated()`
+- `KnowbaseItemTranslation::isKbTranslationActive()`
+- `ReminderTranslation::canBeTranslated()`
+- `ReminderTranslation::isReminderTranslationActive()`
 - `Ticket` `link_to_problem` massive action is deprecated. Use `CommonITILObject_CommonITILObject` `add` massive action instead.
 - `Ticket_Ticket` `add` massive action is deprecated. Use `CommonITILObject_CommonITILObject` `add` massive action instead.
 - `Ticket_Ticket::checkParentSon()`

--- a/install/migrations/update_10.0.x_to_10.1.0/translations.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/translations.php
@@ -33,7 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
-Config::deleteConfigurationValues('core', [
+/**
+ * @var \Migration $migration
+ */
+
+$migration->removeConfig([
     'translate_dropdowns',
     'translate_kb',
     'translate_reminders',

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1004,17 +1004,6 @@ class CommonDBTM extends CommonGLPI
     }
 
     /**
-     * Is translation enabled for this itemtype
-     *
-     * @return true if translation is available, false otherwise
-     **/
-    public function maybeTranslated()
-    {
-        return false;
-    }
-
-
-    /**
      * Clean translations associated to a dropdown
      *
      * @since 0.85
@@ -1025,7 +1014,7 @@ class CommonDBTM extends CommonGLPI
     {
 
        //Do not try to clean is dropdown translation is globally off
-        if ($this->maybeTranslated()) {
+        if ($this instanceof CommonDropdown && $this->maybeTranslated()) {
             $translation = new DropdownTranslation();
             $translation->deleteByCriteria(['itemtype' => get_class($this),
                 'items_id' => $this->getID()

--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -215,7 +215,7 @@ abstract class CommonDropdown extends CommonDBTM
             $this->addStandardTab('Log', $ong, $options);
         }
 
-        if (DropdownTranslation::canBeTranslated($this)) {
+        if ($this->maybeTranslated()) {
             $this->addStandardTab('DropdownTranslation', $ong, $options);
         }
 

--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -69,7 +69,7 @@ abstract class CommonTreeDropdown extends CommonDropdown
             $this->addStandardTab('Log', $ong, $options);
         }
 
-        if (DropdownTranslation::canBeTranslated($this)) {
+        if ($this->maybeTranslated()) {
             $this->addStandardTab('DropdownTranslation', $ong, $options);
         }
 

--- a/src/DropdownTranslation.php
+++ b/src/DropdownTranslation.php
@@ -683,6 +683,10 @@ JAVASCRIPT
         /** @var \DBmysql $DB */
         global $DB;
 
+        if (!is_a($itemtype, CommonDropdown::class, true)) {
+            return $value;
+        }
+
         if ($language == '') {
             $language = $_SESSION['glpilanguage'];
         }

--- a/src/DropdownTranslation.php
+++ b/src/DropdownTranslation.php
@@ -74,7 +74,7 @@ class DropdownTranslation extends CommonDBChild
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
 
-        if (self::canBeTranslated($item)) {
+        if ($item instanceof CommonDropdown && $item->maybeTranslated()) {
             $nb = 0;
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = self::getNumberOfTranslationsForItem($item);
@@ -93,7 +93,7 @@ class DropdownTranslation extends CommonDBChild
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
     {
 
-        if (DropdownTranslation::canBeTranslated($item)) {
+        if ($item instanceof CommonDropdown && $item->maybeTranslated()) {
             DropdownTranslation::showTranslations($item);
         }
         return true;
@@ -786,9 +786,12 @@ JAVASCRIPT
      * @param CommonGLPI $item the item to check
      *
      * @return boolean true if item can be translated, false otherwise
+     *
+     * @deprecated 10.1.0
      **/
     public static function canBeTranslated(CommonGLPI $item)
     {
+        Toolbox::deprecated();
 
         return ($item instanceof CommonDropdown) && $item->maybeTranslated();
     }

--- a/src/Features/TreeBrowse.php
+++ b/src/Features/TreeBrowse.php
@@ -36,6 +36,7 @@
 namespace Glpi\Features;
 
 use CommonDBTM;
+use CommonDropdown;
 use CommonITILObject;
 use CommonTreeDropdown;
 use DropdownTranslation;
@@ -272,7 +273,7 @@ JAVASCRIPT;
         $categories = [];
         $parents = [];
         foreach ($cat_iterator as $category) {
-            if (DropdownTranslation::canBeTranslated($inst)) {
+            if ($category instanceof CommonDropdown && $category->maybeTranslated()) {
                 $tname = DropdownTranslation::getTranslatedValue(
                     $category['id'],
                     $inst->getType()

--- a/src/Knowbase.php
+++ b/src/Knowbase.php
@@ -293,7 +293,7 @@ JAVASCRIPT;
         $inst = new KnowbaseItemCategory();
         $categories = [];
         foreach ($cat_iterator as $category) {
-            if (DropdownTranslation::canBeTranslated($inst)) {
+            if ($inst->maybeTranslated()) {
                 $tname = DropdownTranslation::getTranslatedValue(
                     $category['id'],
                     $inst->getType()

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -79,11 +79,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
 
     public function getName($options = [])
     {
-        if (KnowbaseItemTranslation::canBeTranslated($this)) {
-            return KnowbaseItemTranslation::getTranslatedValue($this);
-        }
-
-        return parent::getName();
+        return KnowbaseItemTranslation::getTranslatedValue($this);
     }
 
 
@@ -1217,11 +1213,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
         $out .= "</th></tr>";
 
         $out .= "<tr><td class='left' colspan='4'><h2>" . __('Subject') . "</h2>";
-        if (KnowbaseItemTranslation::canBeTranslated($this)) {
-            $out .= KnowbaseItemTranslation::getTranslatedValue($this, 'name');
-        } else {
-            $out .= $this->fields["name"];
-        }
+        $out .= KnowbaseItemTranslation::getTranslatedValue($this, 'name');
 
         $out .= "</td></tr>";
         $out .= "<tr><td class='left' colspan='4'><h2>" . __('Content') . "</h2>\n";
@@ -2501,11 +2493,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
      */
     public function getAnswer()
     {
-        if (KnowbaseItemTranslation::canBeTranslated($this)) {
-            $answer = KnowbaseItemTranslation::getTranslatedValue($this, 'answer');
-        } else {
-            $answer = $this->fields["answer"];
-        }
+        $answer = KnowbaseItemTranslation::getTranslatedValue($this, 'answer');
         $answer = RichText::getEnhancedHtml($answer, [
             'text_maxsize' => 0 // Show all text without read more button
         ]);

--- a/src/KnowbaseItemTranslation.php
+++ b/src/KnowbaseItemTranslation.php
@@ -98,7 +98,7 @@ class KnowbaseItemTranslation extends CommonDBChild
             }
         }
 
-        if (self::canBeTranslated($item)) {
+        if ($item instanceof KnowbaseItem) {
             $nb = 0;
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = self::getNumberOfTranslationsForItem($item);
@@ -132,7 +132,7 @@ class KnowbaseItemTranslation extends CommonDBChild
                     $item->showForm($item->getID(), ['parent' => $item]);
                     break;
             }
-        } else if (self::canBeTranslated($item)) {
+        } else if ($item instanceof KnowbaseItem) {
             self::showTranslations($item);
         }
         return true;
@@ -392,9 +392,12 @@ class KnowbaseItemTranslation extends CommonDBChild
      * @param item the item to check
      *
      * @return true if item can be translated, false otherwise
+     *
+     * @deprecated 10.1.0
      **/
     public static function canBeTranslated(CommonGLPI $item)
     {
+        Toolbox::deprecated();
 
         return $item instanceof KnowbaseItem;
     }

--- a/src/ReminderTranslation.php
+++ b/src/ReminderTranslation.php
@@ -79,7 +79,7 @@ class ReminderTranslation extends CommonDBChild
     {
 
         if (
-            self::canBeTranslated($item)
+            $item instanceof Reminder
             && Session::getCurrentInterface() != "helpdesk"
         ) {
             $nb = 0;
@@ -104,10 +104,7 @@ class ReminderTranslation extends CommonDBChild
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
     {
 
-        if (
-            $item->getType() == "Reminder"
-            && self::canBeTranslated($item)
-        ) {
+        if ($item instanceof Reminder) {
             self::showTranslations($item);
         }
         return true;
@@ -316,9 +313,12 @@ class ReminderTranslation extends CommonDBChild
      * @param item the item to check
      *
      * @return true if item can be translated, false otherwise
+     *
+     * @deprecated 10.1.0
      **/
     public static function canBeTranslated(CommonGLPI $item)
     {
+        Toolbox::deprecated();
 
         return ($item instanceof Reminder);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -

Follows #13643.

1. Drop `CommonDBTM::maybeTranslated()` as it would probably never be used.
2. In migration, use dedicated method to remove configuration entries. 
3. Deprecate `canBeTranslated()` methods that are not anymore usefull.
4. Add deprecated methods to changelog.