### PR TITLE
Check LDAP connection state during user synchronization

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -2867,7 +2867,11 @@ class AuthLDAP extends CommonDBTM
 
         $search_parameters = [];
        //Connect to the directory
-        if (isset(self::$conn_cache[$ldap_server])) {
+        if (
+            isset(self::$conn_cache[$ldap_server])
+            // check that connection is still alive
+            && @ldap_read(self::$conn_cache[$ldap_server], '', '(objectclass=*)', ['dn'], 0, 1) !== false
+        ) {
             $ds = self::$conn_cache[$ldap_server];
         } else {
             $ds = $config_ldap->connect();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30554

During LDAP mass synchronization, the `LDAP\Connection` object is cached to be able to reuse the same connection for every synchronized user reading operation. The longer the synchronization, the higher the probability of losing the connection between each operation.

Before reusing the connection, executing an unfiltered read operation can be made to ensure that it does not fail with an error.

On my local machine, a synchronization of 900 users takes almost the same time with and without this patch.