### PR TITLE
Batch debug data requests

### DIFF
--- a/ajax/debug.php
+++ b/ajax/debug.php
@@ -47,23 +47,20 @@ if ($_SESSION['glpi_use_mode'] !== Session::DEBUG_MODE) {
 
 \Glpi\Debug\Profiler::getInstance()->disable();
 
-if (isset($_GET['ajax_id'])) {
-    // Get debug data for a specific ajax call
-    $ajax_id = $_GET['ajax_id'];
-    $profile = \Glpi\Debug\Profile::pull($ajax_id);
-
+if (isset($_GET['ajax_ids']) && is_array($_GET['ajax_ids'])) {
+    $profiles = \Glpi\Debug\Profile::pull($_GET['ajax_ids']);
     // Close session ASAP to not block other requests.
     // DO NOT do it before call to `\Glpi\Debug\Profile::pull()`,
     // as we have to delete profile from `$_SESSION` during the pull operation.
     session_write_close();
-
-    if ($profile) {
-        $data = $profile->getDebugInfo();
-        if ($data) {
-            header('Content-Type: application/json');
-            echo json_encode($data);
-            die();
+    if (count($profiles)) {
+        $data = [];
+        foreach ($profiles as $profile) {
+            $data[$profile->getId()] = $profile->getDebugInfo();
         }
+        header('Content-Type: application/json');
+        echo json_encode($data);
+        die();
     }
     http_response_code(404);
     die();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Reduce the number of requests to `ajax/debug.php` for debug data by queuing up requests and sending them in batches no more than once a second. If there are performance issues for you because of a large session, this should help with the debug requests blocking others.