### PR TITLE
feat(simcard): distinguish between components and component elements

### DIFF
--- a/src/Item_DeviceSimcard.php
+++ b/src/Item_DeviceSimcard.php
@@ -52,7 +52,7 @@ class Item_DeviceSimcard extends Item_Devices
 
     public static function getTypeName($nb = 0)
     {
-        return _n('Simcard', 'Simcards', $nb);
+        return _n('Simcard: Item', 'Simcards: Items', $nb);
     }
 
     public static function getSpecificities($specif = '')

--- a/src/Item_DeviceSimcard.php
+++ b/src/Item_DeviceSimcard.php
@@ -50,11 +50,6 @@ class Item_DeviceSimcard extends Item_Devices
 
     public static $undisclosedFields      = ['pin', 'pin2', 'puk', 'puk2'];
 
-    public static function getTypeName($nb = 0)
-    {
-        return _n('Simcard item', 'Simcard items', $nb);
-    }
-
     public static function getSpecificities($specif = '')
     {
         return [

--- a/src/Item_DeviceSimcard.php
+++ b/src/Item_DeviceSimcard.php
@@ -52,7 +52,7 @@ class Item_DeviceSimcard extends Item_Devices
 
     public static function getTypeName($nb = 0)
     {
-        return _n('Simcard: Item', 'Simcards: Items', $nb);
+        return _n('Simcard item', 'Simcard items', $nb);
     }
 
     public static function getSpecificities($specif = '')


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !31204

It was the same type name for DeviceSimcard and Item_DevideSimcard. This made it difficult to distinguish them, for example, in the Fields plugin.
