### PR TITLE
fix(knowbase): prevent sql error

### DIFF
--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -2144,10 +2144,10 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
         ];
 
         if ($type == "recent") {
-            $criteria['ORDERBY'] = 'date_creation DESC';
+            $criteria['ORDERBY'] = self::getTable() . '.date_creation DESC';
             $title   = __('Recent entries');
         } else if ($type == 'lastupdate') {
-            $criteria['ORDERBY'] = 'date_mod DESC';
+            $criteria['ORDERBY'] = self::getTable() . '.date_mod DESC';
             $title   = __('Last updated entries');
         } else {
             $criteria['ORDERBY'] = 'view DESC';


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

![image](https://github.com/glpi-project/glpi/assets/8530352/bbb1ac32-8961-489c-9683-e287378d3f76)

```
[2024-01-18 09:12:04] glpisqllog.ERROR: DBmysql::doQuery() in .../src/DBmysql.php line 403
  *** MySQL query error:
  SQL: SELECT DISTINCT `glpi_knowbaseitems`.`id`, `glpi_knowbaseitems`.`name`, `glpi_knowbaseitems`.`is_faq`, `glpi_knowbaseitemtranslations`.`name` AS `transname`, `glpi_knowbaseitemtranslations`.`answer` AS `transanswer` FROM `glpi_knowbaseitems` LEFT JOIN `glpi_knowbaseitems_users` ON (`glpi_knowbaseitems_users`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`) LEFT JOIN `glpi_groups_knowbaseitems` ON (`glpi_groups_knowbaseitems`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`) LEFT JOIN `glpi_knowbaseitems_profiles` ON (`glpi_knowbaseitems_profiles`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`) LEFT JOIN `glpi_entities_knowbaseitems` ON (`glpi_entities_knowbaseitems`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`) LEFT JOIN `glpi_knowbaseitemtranslations` ON (`glpi_knowbaseitems`.`id` = `glpi_knowbaseitemtranslations`.`knowbaseitems_id` AND `glpi_knowbaseitemtranslations`.`language` = 'en_GB') WHERE (1) AND ( NOT (`glpi_entities_knowbaseitems`.`entities_id` IS NULL AND `glpi_knowbaseitems_profiles`.`profiles_id` IS NULL AND `glpi_groups_knowbaseitems`.`groups_id` IS NULL AND `glpi_knowbaseitems_users`.`users_id` IS NULL)) AND (((`glpi_knowbaseitems`.`begin_date` IS NULL) OR (`glpi_knowbaseitems`.`begin_date` < NOW()))) AND (((`glpi_knowbaseitems`.`end_date` IS NULL) OR (`glpi_knowbaseitems`.`end_date` > NOW()))) ORDER BY `date_creation` DESC LIMIT 10
  Error: Column 'date_creation' in order clause is ambiguous
  Backtrace :
  src/DBmysqlIterator.php:112                        DBmysql->doQuery()
  src/DBmysql.php:1109                               DBmysqlIterator->execute()
  src/KnowbaseItem.php:2220                          DBmysql->request()
  src/Knowbase.php:132                               KnowbaseItem::showRecentPopular()
  src/Knowbase.php:84                                Knowbase::showSearchView()
  src/CommonGLPI.php:694                             Knowbase::displayTabContentForItem()
  ajax/common.tabs.php:120                           CommonGLPI::displayStandardTab()
  public/index.php:82                                require()
  {"user":"2@teclib"} 
[2024-01-18 09:12:04] glpisqllog.ERROR: DBmysql::doQuery() in .../src/DBmysql.php line 403
  *** MySQL query error:
  SQL: SELECT DISTINCT `glpi_knowbaseitems`.`id`, `glpi_knowbaseitems`.`name`, `glpi_knowbaseitems`.`is_faq`, `glpi_knowbaseitemtranslations`.`name` AS `transname`, `glpi_knowbaseitemtranslations`.`answer` AS `transanswer` FROM `glpi_knowbaseitems` LEFT JOIN `glpi_knowbaseitems_users` ON (`glpi_knowbaseitems_users`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`) LEFT JOIN `glpi_groups_knowbaseitems` ON (`glpi_groups_knowbaseitems`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`) LEFT JOIN `glpi_knowbaseitems_profiles` ON (`glpi_knowbaseitems_profiles`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`) LEFT JOIN `glpi_entities_knowbaseitems` ON (`glpi_entities_knowbaseitems`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`) LEFT JOIN `glpi_knowbaseitemtranslations` ON (`glpi_knowbaseitems`.`id` = `glpi_knowbaseitemtranslations`.`knowbaseitems_id` AND `glpi_knowbaseitemtranslations`.`language` = 'en_GB') WHERE (1) AND ( NOT (`glpi_entities_knowbaseitems`.`entities_id` IS NULL AND `glpi_knowbaseitems_profiles`.`profiles_id` IS NULL AND `glpi_groups_knowbaseitems`.`groups_id` IS NULL AND `glpi_knowbaseitems_users`.`users_id` IS NULL)) AND (((`glpi_knowbaseitems`.`begin_date` IS NULL) OR (`glpi_knowbaseitems`.`begin_date` < NOW()))) AND (((`glpi_knowbaseitems`.`end_date` IS NULL) OR (`glpi_knowbaseitems`.`end_date` > NOW()))) ORDER BY `date_mod` DESC LIMIT 10
  Error: Column 'date_mod' in order clause is ambiguous
  Backtrace :
  src/DBmysqlIterator.php:112                        DBmysql->doQuery()
  src/DBmysql.php:1109                               DBmysqlIterator->execute()
  src/KnowbaseItem.php:2220                          DBmysql->request()
  src/Knowbase.php:134                               KnowbaseItem::showRecentPopular()
  src/Knowbase.php:84                                Knowbase::showSearchView()
  src/CommonGLPI.php:694                             Knowbase::displayTabContentForItem()
  ajax/common.tabs.php:120                           CommonGLPI::displayStandardTab()
  public/index.php:82                                require()
  {"user":"2@teclib","mem_usage":"0.003\", 4.48Mio)"} 

```
