### PR TITLE
Fix printer counters history chart

### DIFF
--- a/src/PrinterLog.php
+++ b/src/PrinterLog.php
@@ -188,7 +188,11 @@ class PrinterLog extends CommonDBChild
                 }
             }
         }
-
+		foreach ($series as $key => $value) {
+			if (array_sum($value['data']) == 0) {
+				unset($series[$key]);
+			}
+		}
         $bar_conf = [
             'data'  => [
                 'labels' => $labels,

--- a/src/PrinterLog.php
+++ b/src/PrinterLog.php
@@ -182,7 +182,7 @@ class PrinterLog extends CommonDBChild
 
             foreach ($metrics as $key => $value) {
                 $label = $this->getLabelFor($key);
-                if ($label && $value > 0) {
+                if ($label && array_sum($metrics) > 0) {
                     $series[$key]['name'] = $label;
                     $series[$key]['data'][] = $value;
                 }

--- a/src/PrinterLog.php
+++ b/src/PrinterLog.php
@@ -188,11 +188,11 @@ class PrinterLog extends CommonDBChild
                 }
             }
         }
-		foreach ($series as $key => $value) {
-			if (array_sum($value['data']) == 0) {
-				unset($series[$key]);
-			}
-		}
+        foreach ($series as $key => $value) {
+            if (array_sum($value['data']) == 0) {
+                unset($series[$key]);
+            }
+        }
         $bar_conf = [
             'data'  => [
                 'labels' => $labels,

--- a/src/PrinterLog.php
+++ b/src/PrinterLog.php
@@ -190,7 +190,7 @@ class PrinterLog extends CommonDBChild
                 }
             }
         }
-        // If the metric has a value of 0 for all dates, remove it from the data set 
+        // If the metric has a value of 0 for all dates, remove it from the data set
         foreach ($series as $key => $value) {
             if (array_sum($value['data']) == 0) {
                 unset($series[$key]);

--- a/src/PrinterLog.php
+++ b/src/PrinterLog.php
@@ -181,7 +181,7 @@ class PrinterLog extends CommonDBChild
             unset($metrics['id'], $metrics['date'], $metrics['printers_id']);
 
             // Keep values if at least 1 label is greater than 0
-            $valuesum = array_sum($metrics)
+            $valuesum = array_sum($metrics);
             foreach ($metrics as $key => $value) {
                 $label = $this->getLabelFor($key);
                 if ($label && $valuesum > 0) {

--- a/src/PrinterLog.php
+++ b/src/PrinterLog.php
@@ -180,14 +180,17 @@ class PrinterLog extends CommonDBChild
             $labels[] = $fmt->format($date);
             unset($metrics['id'], $metrics['date'], $metrics['printers_id']);
 
+            // Keep values if at least 1 label is greater than 0
+            $valuesum = array_sum($metrics)
             foreach ($metrics as $key => $value) {
                 $label = $this->getLabelFor($key);
-                if ($label && array_sum($metrics) > 0) {
+                if ($label && $valuesum > 0) {
                     $series[$key]['name'] = $label;
                     $series[$key]['data'][] = $value;
                 }
             }
         }
+        // If the metric has a value of 0 for all dates, remove it from the data set 
         foreach ($series as $key => $value) {
             if (array_sum($value['data']) == 0) {
                 unset($series[$key]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #16321 

the array_sum instead of $value > 0 allows you to keep the right number of points per line

before:
![image](https://github.com/glpi-project/glpi/assets/33253653/7435c8a9-4a63-4134-bc9e-3a8bdda20eb2)

after:
![image](https://github.com/glpi-project/glpi/assets/33253653/9af79b6b-1d13-463e-a134-25447eafb0a6)
