### PR TITLE
Add missing global var

### DIFF
--- a/src/Asset/AssetDefinitionManager.php
+++ b/src/Asset/AssetDefinitionManager.php
@@ -134,6 +134,9 @@ final class AssetDefinitionManager
      */
     private function boostrapConcreteClass(AssetDefinition $definition): void
     {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
         $capacities = $this->getAvailableCapacities();
 
         $concrete_class_name = $definition->getConcreteClassName();


### PR DESCRIPTION
Found this mistake while digging into the asset composition code.

It prevent common stuff like locations to be applied to all generic assets.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
