### PR TITLE
fix(DCRoom): add missing search option

### DIFF
--- a/src/Computer.php
+++ b/src/Computer.php
@@ -608,6 +608,8 @@ class Computer extends CommonDBTM
 
         $tab = array_merge($tab, Agent::rawSearchOptionsToAdd());
 
+        $tab = array_merge($tab, DCRoom::rawSearchOptionsToAdd());
+
         return $tab;
     }
 

--- a/src/DCRoom.php
+++ b/src/DCRoom.php
@@ -329,6 +329,42 @@ class DCRoom extends CommonDBTM
         return $tab;
     }
 
+    public static function rawSearchOptionsToAdd()
+    {
+        $tab = [];
+
+        // separator
+        $tab[] = [
+            'id'   => 'dcroom',
+            'name' => self::getTypeName(1),
+        ];
+
+        $tab[] = [
+            'id'                 => '1500',
+            'table'              => 'glpi_dcrooms',
+            'field'              => 'name',
+            'datatype'           => 'itemlink',
+            'name'               => DCRoom::getTypeName(1),
+            'massiveaction'      => false,
+            'joinparams'         => [
+                'beforejoin'         => [
+                    'table'              => 'glpi_racks',
+                    'linkfield'          => 'racks_id',
+                    'joinparams'         => [
+                        'beforejoin'         => [
+                            'table'              => 'glpi_items_racks',
+                            'joinparams'         => [
+                                'jointype'           => 'itemtype_item'
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        return $tab;
+    }
+
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
 

--- a/src/DCRoom.php
+++ b/src/DCRoom.php
@@ -340,7 +340,7 @@ class DCRoom extends CommonDBTM
         ];
 
         $tab[] = [
-            'id'                 => '1500',
+            'id'                 => '1450',
             'table'              => 'glpi_dcrooms',
             'field'              => 'name',
             'datatype'           => 'itemlink',

--- a/src/Enclosure.php
+++ b/src/Enclosure.php
@@ -228,6 +228,8 @@ class Enclosure extends CommonDBTM
 
         $tab = array_merge($tab, Rack::rawSearchOptionsToAdd(get_class($this)));
 
+        $tab = array_merge($tab, DCRoom::rawSearchOptionsToAdd());
+
         return $tab;
     }
 

--- a/src/Monitor.php
+++ b/src/Monitor.php
@@ -459,6 +459,8 @@ class Monitor extends CommonDBTM
 
         $tab = array_merge($tab, Rack::rawSearchOptionsToAdd(get_class($this)));
 
+        $tab = array_merge($tab, DCRoom::rawSearchOptionsToAdd());
+
         return $tab;
     }
 

--- a/src/NetworkEquipment.php
+++ b/src/NetworkEquipment.php
@@ -505,6 +505,8 @@ class NetworkEquipment extends CommonDBTM
 
         $tab = array_merge($tab, SNMPCredential::rawSearchOptionsToAdd());
 
+        $tab = array_merge($tab, DCRoom::rawSearchOptionsToAdd());
+
         return $tab;
     }
 

--- a/src/PDU.php
+++ b/src/PDU.php
@@ -212,6 +212,8 @@ class PDU extends CommonDBTM
 
         $tab = array_merge($tab, Rack::rawSearchOptionsToAdd(get_class($this)));
 
+        $tab = array_merge($tab, DCRoom::rawSearchOptionsToAdd());
+
         return $tab;
     }
 

--- a/src/PassiveDCEquipment.php
+++ b/src/PassiveDCEquipment.php
@@ -211,6 +211,8 @@ class PassiveDCEquipment extends CommonDBTM
 
         $tab = array_merge($tab, Socket::rawSearchOptionsToAdd());
 
+        $tab = array_merge($tab, DCRoom::rawSearchOptionsToAdd());
+
         return $tab;
     }
 

--- a/src/Peripheral.php
+++ b/src/Peripheral.php
@@ -372,6 +372,8 @@ class Peripheral extends CommonDBTM
         $tab = array_merge($tab, Rack::rawSearchOptionsToAdd(get_class($this)));
 
         $tab = array_merge($tab, Socket::rawSearchOptionsToAdd());
+
+        $tab = array_merge($tab, DCRoom::rawSearchOptionsToAdd());
         return $tab;
     }
 

--- a/tests/functional/Search.php
+++ b/tests/functional/Search.php
@@ -4433,6 +4433,17 @@ class Search extends DbTestCase
             $this->string($this->cleanSQL($data['sql']['search']))->contains($expected_where);
         }
     }
+
+    public function testDCRoomSearchOption()
+    {
+        global $CFG_GLPI;
+        foreach ($CFG_GLPI['rackable_types'] as $rackable_type) {
+            $item = new $rackable_type();
+            $so = $item->rawSearchOptions();
+            //check if search option separator 'dcroom' exist
+            $this->variable(array_search('dcroom', array_column($so, 'id')))->isNotEqualTo(false, $item->getTypeName() . ' should use \'$tab = array_merge($tab, DCRoom::rawSearchOptionsToAdd());');
+        }
+    }
 }
 
 // @codingStandardsIgnoreStart


### PR DESCRIPTION
same as https://github.com/glpi-project/glpi/pull/16390

but more generic:

1. use of ```rawSearchOptionsToAdd```.
2. call from ```Computer```, ```Monitor```, ```NetworkEquipment```, ```Peripheral```, ```Enclosure```, ```PDU```, ```PassiveDCEquipment```.

![image](https://github.com/glpi-project/glpi/assets/7335054/e8f6e7d9-f569-4997-a23a-d96bbb4cd560)

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
