### PR TITLE
Review budget and cost UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The present file will list all changes made to the project; according to the
 - Project description field is now a rich text field.
 - Entity, profile, debug mode flag, and language are restored after ending impersonation.
 - Volumes now show `Used percentage` instead of `Free percentage`.
+- Budget "Main" tab now shows negative values for "Total remaining in the budget" in parentheses instead of with a negative sign to align with typical accounting practices.
 
 ### Deprecated
 - Survey URL tags `TICKETCATEGORY_ID` and `TICKETCATEGORY_NAME` are deprecated and replaced by `ITILCATEGORY_ID` and `ITILCATEGORY_NAME` respectively.

--- a/src/Budget.php
+++ b/src/Budget.php
@@ -274,6 +274,7 @@ class Budget extends CommonDropdown
      */
     private function getItemListCriteria(bool $entity_restrict = true): QueryUnion
     {
+        /** @var \DBmysql $DB */
         global $DB;
 
         $budgets_id = $this->fields['id'];

--- a/src/Budget.php
+++ b/src/Budget.php
@@ -328,7 +328,7 @@ class Budget extends CommonDropdown
                 'WHERE'        => [
                     'glpi_infocoms.itemtype'            => $itemtype,
                     'glpi_infocoms.budgets_id'          => $budgets_id
-                ] + getEntitiesRestrictCriteria($item_table),
+                ],
                 'ORDERBY'      => [
                     $item_table . '.entities_id'
                 ]
@@ -368,7 +368,7 @@ class Budget extends CommonDropdown
                 ],
                 'WHERE' => [
                     $cost_table . '.budgets_id' => $budgets_id,
-                ] + getEntitiesRestrictCriteria($item_table),
+                ],
                 'GROUPBY'      => [
                     $item_table . '.id',
                     $item_table . '.entities_id'
@@ -525,14 +525,21 @@ class Budget extends CommonDropdown
         ]);
 
         $itemtypes = [];
-        $entities = [];
+        $entities = [
+            -1 => [
+                'name' => __('Other entities'),
+                'itemtypes' => [],
+                'total' => 0,
+            ]
+        ];
         $entries = [];
         $itemtype_totals = [];
         $grand_total = 0;
+        $active_entities = $_SESSION['glpiactiveentities'];
 
         foreach ($iterator as $data) {
             $itemtype = $data['_itemtype'];
-            $entity = $data['entities_id'];
+            $entity = in_array($data['entities_id'], $active_entities, false) ? $data['entities_id'] : -1;
             if (!in_array($itemtype, $itemtypes, true)) {
                 $itemtypes[] = $itemtype;
             }

--- a/src/Budget.php
+++ b/src/Budget.php
@@ -267,7 +267,12 @@ class Budget extends CommonDropdown
         return $tab;
     }
 
-    private function getItemListCriteria(): QueryUnion
+    /**
+     * Get the SQL union query to get the list of items on a budget and the associated costs
+     * @param bool $entity_restrict Whether to restrict the items to the current entity
+     * @return QueryUnion
+     */
+    private function getItemListCriteria(bool $entity_restrict = true): QueryUnion
     {
         global $DB;
 
@@ -333,6 +338,9 @@ class Budget extends CommonDropdown
                     $item_table . '.entities_id'
                 ]
             ];
+            if ($entity_restrict) {
+                $criteria['WHERE'] += getEntitiesRestrictCriteria($item_table);
+            }
 
             /** @var CommonDBTM $item */
             $item = new $itemtype();
@@ -378,6 +386,9 @@ class Budget extends CommonDropdown
                     $item_table . '.name'
                 ]
             ];
+            if ($entity_restrict) {
+                $criteria['WHERE'] += getEntitiesRestrictCriteria($item_table);
+            }
             if ($item instanceof Item_Devices) {
                 $criteria['ORDERBY'][] = $item_table . '.itemtype';
             } else {
@@ -521,7 +532,7 @@ class Budget extends CommonDropdown
         }
 
         $iterator = $DB->request([
-            'FROM' => $this->getItemListCriteria()
+            'FROM' => $this->getItemListCriteria(false)
         ]);
 
         $itemtypes = [];

--- a/src/Budget.php
+++ b/src/Budget.php
@@ -395,6 +395,10 @@ class Budget extends CommonDropdown
             };
             $criteria['SELECT'][$item_table][] = $item->maybeDeleted() ? 'is_deleted' : '0 AS is_deleted';
 
+            if ($item->maybeTemplate()) {
+                $criteria['WHERE'][$item_table . '.is_template'] = 0;
+            }
+
             $queries[] = new \Glpi\DBAL\QuerySubQuery($criteria);
         }
 

--- a/src/Budget.php
+++ b/src/Budget.php
@@ -33,8 +33,10 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryUnion;
 
 /**
  * Budget class
@@ -63,7 +65,6 @@ class Budget extends CommonDropdown
         return _n('Budget', 'Budgets', $nb);
     }
 
-
     public function defineTabs($options = [])
     {
 
@@ -79,7 +80,6 @@ class Budget extends CommonDropdown
         return $ong;
     }
 
-
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
 
@@ -93,7 +93,6 @@ class Budget extends CommonDropdown
         }
         return '';
     }
-
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
     {
@@ -112,7 +111,6 @@ class Budget extends CommonDropdown
         return true;
     }
 
-
     /**
      * Print the contact form
      *
@@ -125,60 +123,15 @@ class Budget extends CommonDropdown
      **/
     public function showForm($ID, array $options = [])
     {
-
-        $rowspan = 3;
-        if ($ID > 0) {
-            $rowspan++;
-        }
-
-        $this->initForm($ID, $options);
-        $this->showFormHeader($options);
-
-        echo "<tr class='tab_bg_1'>";
-        echo "<td>" . __('Name') . "</td>";
-        echo "<td>";
-        echo Html::input('name', ['value' => $this->fields['name']]);
-        echo "</td>";
-
-        echo "<td>" . _n('Type', 'Types', 1) . "</td>";
-        echo "<td>";
-        Dropdown::show('BudgetType', ['value' => $this->fields['budgettypes_id']]);
-        echo "</td></tr>";
-
-        echo "<tr class='tab_bg_1'>";
-        echo "<td>" . _x('price', 'Value') . "</td>";
-        echo "<td><input type='text' name='value' size='14'
-                 value='" . Html::formatNumber($this->fields["value"], true) . "' class='form-control'></td>";
-
-                 echo "<td rowspan='$rowspan' class='middle right'>" . __('Comments') . "</td>";
-                 echo "<td class='center middle' rowspan='$rowspan'>" .
-                      "<textarea class='form-control' name='comment' >" . $this->fields["comment"] . "</textarea>" .
-                      "</td></tr>";
-
-        echo "<tr class='tab_bg_1'>";
-        echo "<td>" . __('Start date') . "</td>";
-        echo "<td>";
-        Html::showDateField("begin_date", ['value' => $this->fields["begin_date"]]);
-        echo "</td></tr>";
-
-        echo "<tr class='tab_bg_1'>";
-        echo "<td>" . __('End date') . "</td>";
-        echo "<td>";
-        Html::showDateField("end_date", ['value' => $this->fields["end_date"]]);
-        echo "</td></tr>";
-
-        echo "<tr class='tab_bg_1'>";
-        echo "<td>" . Location::getTypeName(1) . "</td>";
-        echo "<td>";
-        Location::dropdown(['value'  => $this->fields["locations_id"],
-            'entity' => $this->fields["entities_id"]
+        TemplateRenderer::getInstance()->display('pages/management/budget.html.twig', [
+            'item' => $this,
+            'no_header' => true,
+            'params' => [
+                'canedit' => $this->canUpdateItem()
+            ]
         ]);
-        echo "</td><td colspan='2'></td></tr>";
-
-        $this->showFormButtons($options);
         return true;
     }
-
 
     public function prepareInputForAdd($input)
     {
@@ -191,7 +144,6 @@ class Budget extends CommonDropdown
 
         return $input;
     }
-
 
     public function rawSearchOptions()
     {
@@ -315,6 +267,138 @@ class Budget extends CommonDropdown
         return $tab;
     }
 
+    private function getItemListCriteria(): QueryUnion
+    {
+        global $DB;
+
+        $budgets_id = $this->fields['id'];
+
+        // Get a list of possible itemtypes first, so we can filter them by read permissions
+        $iterator = $DB->request([
+            'SELECT'          => 'itemtype',
+            'DISTINCT'        => true,
+            'FROM'            => 'glpi_infocoms',
+            'WHERE'           => [
+                'budgets_id'   => $budgets_id,
+                'NOT'          => ['itemtype' => ['ConsumableItem', 'CartridgeItem', 'Software']]
+            ],
+            'ORDER'           => 'itemtype'
+        ]);
+        $itemtypes = [
+            // These types shouldn't be in the glpi_infocoms table, but have their costs elsewhere
+            'Contract', 'Ticket', 'Problem', 'Change', 'Project'
+        ];
+        foreach ($iterator as $row) {
+            $itemtypes[] = $row['itemtype'];
+        }
+        $itemtypes = array_filter($itemtypes, static fn($itemtype) => $itemtype::canView());
+        $infocom_itemtypes = [];
+        $other_cost_tables = [
+            'Contract' => ContractCost::getTable(),
+            'Ticket' => TicketCost::getTable(),
+            'Problem' => ProblemCost::getTable(),
+            'Change' => ChangeCost::getTable(),
+            'Project' => ProjectCost::getTable(),
+        ];
+        foreach ($itemtypes as $itemtype) {
+            if (!in_array($itemtype, ['Contract', 'Ticket', 'Problem', 'Change', 'Project'], true)) {
+                $infocom_itemtypes[] = $itemtype;
+            }
+        }
+
+        $queries = [];
+
+        foreach ($infocom_itemtypes as $itemtype) {
+            $item_table = $itemtype::getTable();
+            $criteria = [
+                'SELECT'       => [
+                    new QueryExpression($DB::quoteValue($itemtype), '_itemtype'),
+                    $item_table => ['id', 'entities_id'],
+                    'glpi_infocoms.value',
+                ],
+                'FROM'         => 'glpi_infocoms',
+                'INNER JOIN'   => [
+                    $item_table => [
+                        'ON' => [
+                            $item_table => 'id',
+                            'glpi_infocoms'   => 'items_id'
+                        ]
+                    ]
+                ],
+                'WHERE'        => [
+                    'glpi_infocoms.itemtype'            => $itemtype,
+                    'glpi_infocoms.budgets_id'          => $budgets_id
+                ] + getEntitiesRestrictCriteria($item_table),
+                'ORDERBY'      => [
+                    $item_table . '.entities_id'
+                ]
+            ];
+
+            /** @var CommonDBTM $item */
+            $item = new $itemtype();
+
+            $criteria['SELECT'][$item_table][] = $item->maybeDeleted() ? 'is_deleted' : new QueryExpression('0', 'is_deleted');
+            $criteria['SELECT'][$item_table][] = $item->isField('serial') ? 'serial' : new QueryExpression('NULL', 'serial');
+            $criteria['SELECT'][$item_table][] = $item->isField('otherserial') ? 'otherserial' : new QueryExpression('NULL', 'otherserial');
+            if ($item->maybeTemplate()) {
+                $criteria['WHERE'][$item_table . '.is_template'] = 0;
+            }
+
+            $queries[] = new \Glpi\DBAL\QuerySubQuery($criteria);
+        }
+
+        foreach ($other_cost_tables as $itemtype => $cost_table) {
+            $item_table = $itemtype::getTable();
+            $criteria = [
+                'SELECT' => [
+                    new QueryExpression($DB::quoteValue($itemtype), '_itemtype'),
+                    $item_table => ['id', 'entities_id'],
+                    new QueryExpression('NULL', 'serial'),
+                    new QueryExpression('NULL', 'otherserial'),
+                ],
+                'FROM' => $cost_table,
+                'INNER JOIN' => [
+                    $item_table => [
+                        'ON' => [
+                            $item_table => 'id',
+                            $cost_table => $itemtype::getForeignKeyField()
+                        ]
+                    ]
+                ],
+                'WHERE' => [
+                    $cost_table . '.budgets_id' => $budgets_id,
+                ] + getEntitiesRestrictCriteria($item_table),
+                'GROUPBY'      => [
+                    $item_table . '.id',
+                    $item_table . '.entities_id'
+                ],
+                'ORDERBY'      => [
+                    $item_table . '.entities_id',
+                    $item_table . '.name'
+                ]
+            ];
+            if ($item instanceof Item_Devices) {
+                $criteria['ORDERBY'][] = $item_table . '.itemtype';
+            } else {
+                $criteria['ORDERBY'][] = $item_table . '.name';
+            }
+
+            $criteria['SELECT'][] = match ($itemtype) {
+                'Ticket', 'Problem', 'Change' => QueryFunction::sum(
+                    expression: new QueryExpression($DB::quoteName("$cost_table.actiontime") . " * " . $DB::quoteName("$cost_table.cost_time") . "/" . HOUR_TIMESTAMP . "
+                                      + " . $DB::quoteName("$cost_table.cost_fixed") . "
+                                      + " . $DB::quoteName("$cost_table.cost_material")),
+                    alias: 'value'
+                ),
+                default => QueryFunction::sum(expression: "{$cost_table}.cost", alias: 'value'),
+            };
+            $criteria['SELECT'][$item_table][] = $item->maybeDeleted() ? 'is_deleted' : '0 AS is_deleted';
+
+            $queries[] = new \Glpi\DBAL\QuerySubQuery($criteria);
+        }
+
+        return new QueryUnion($queries);
+    }
 
     /**
      * Print the HTML array of Items on a budget
@@ -332,334 +416,89 @@ class Budget extends CommonDropdown
             return false;
         }
 
-        $iterator = $DB->request([
-            'SELECT'          => 'itemtype',
-            'DISTINCT'        => true,
-            'FROM'            => 'glpi_infocoms',
-            'WHERE'           => [
-                'budgets_id'   => $budgets_id,
-                'NOT'          => ['itemtype' => ['ConsumableItem', 'CartridgeItem', 'Software']]
-            ],
-            'ORDER'           => 'itemtype'
-        ]);
+        $start = $_GET['start'] ?? 0;
 
-        $number = count($iterator);
+        $criteria = [
+            'FROM' => $this->getItemListCriteria(),
+            'START' => $start,
+            'LIMIT' => $_SESSION['glpilist_limit'],
+        ];
+        $iterator = $DB->request($criteria);
 
-        echo "<div class='spaced'><table class='tab_cadre_fixe'>";
-        echo "<tr><th colspan='2'>";
-        Html::printPagerForm();
-        echo "</th><th colspan='4'>";
-        if ($number == 0) {
-            echo __('No associated item');
-        } else {
-            echo _n('Associated item', 'Associated items', $number);
-        }
-        echo "</th></tr>";
+        $count_criteria = $criteria;
+        unset($count_criteria['START'], $count_criteria['LIMIT']);
+        $count_criteria['COUNT'] = 'cpt';
+        $total_count = $DB->request($count_criteria)->current()['cpt'];
 
-        echo "<tr><th>" . _n('Type', 'Types', 1) . "</th>";
-        echo "<th>" . Entity::getTypeName(1) . "</th>";
-        echo "<th>" . __('Name') . "</th>";
-        echo "<th>" . __('Serial number') . "</th>";
-        echo "<th>" . __('Inventory number') . "</th>";
-        echo "<th>" . _x('price', 'Value') . "</th>";
-        echo "</tr>";
+        $entries = [];
+        $entity_names = [];
+        /** @var CommonDBTM[] $items */
+        $items = [];
+        foreach ($iterator as $data) {
+            $itemtype = $data['_itemtype'];
+            $entry = [
+                'itemtype' => $itemtype,
+                'id' => $data['id'],
+                'type' => $itemtype::getTypeName(1),
+                'serial' => $data['serial'] ?? '-',
+                'otherserial' => $data['otherserial'] ?? '-',
+                'value' => $data['value'] ? Html::formatNumber($data['value']) : '-',
+            ];
 
-        $num       = 0;
-        $itemtypes = [];
-        foreach ($iterator as $row) {
-            $itemtypes[] = $row['itemtype'];
-        }
-        $itemtypes[] = 'Contract';
-        $itemtypes[] = 'Ticket';
-        $itemtypes[] = 'Problem';
-        $itemtypes[] = 'Change';
-        $itemtypes[] = 'Project';
-
-        foreach ($itemtypes as $itemtype) {
-            if (!($item = getItemForItemtype($itemtype))) {
-                continue;
+            if (!array_key_exists($itemtype, $items)) {
+                $items[$itemtype] = new $itemtype();
             }
 
-            if ($item->canView()) {
-                switch ($itemtype) {
-                    case 'Contract':
-                        $criteria = [
-                            'SELECT'       => [
-                                $item->getTable() . '.id',
-                                $item->getTable() . '.entities_id',
-                                'SUM' => 'glpi_contractcosts.cost AS value'
-                            ],
-                            'FROM'         => 'glpi_contractcosts',
-                            'INNER JOIN'   => [
-                                $item->getTable() => [
-                                    'ON' => [
-                                        $item->getTable()    => 'id',
-                                        'glpi_contractcosts' => 'contracts_id'
-                                    ]
-                                ]
-                            ],
-                            'WHERE'        => [
-                                'glpi_contractcosts.budgets_id'     => $budgets_id,
-                                $item->getTable() . '.is_template'  => 0
-                            ] + getEntitiesRestrictCriteria($item->getTable()),
-                            'GROUPBY'      => [
-                                $item->getTable() . '.id',
-                                $item->getTable() . '.entities_id'
-                            ],
-                            'ORDERBY'      => [
-                                $item->getTable() . '.entities_id',
-                                $item->getTable() . '.name'
-                            ]
-                        ];
-                        break;
-
-                    case 'Ticket':
-                    case 'Problem':
-                    case 'Change':
-                        $costtable = getTableForItemType($item->getType() . 'Cost');
-
-                        $sum = QueryFunction::sum(
-                            expression: new QueryExpression($DB::quoteName("$costtable.actiontime") . " * " . $DB::quoteName("$costtable.cost_time") . "/" . HOUR_TIMESTAMP . "
-                                          + " . $DB::quoteName("$costtable.cost_fixed") . "
-                                          + " . $DB::quoteName("$costtable.cost_material")),
-                            alias: 'value'
-                        );
-                        $criteria = [
-                            'SELECT'       => [
-                                $item->getTable() . '.id',
-                                $item->getTable() . '.entities_id',
-                                $sum
-                            ],
-                            'FROM'         => $costtable,
-                            'INNER JOIN'   => [
-                                $item->getTable() => [
-                                    'ON' => [
-                                        $item->getTable()    => 'id',
-                                        $costtable           => $item->getForeignKeyField()
-                                    ]
-                                ]
-                            ],
-                            'WHERE'        => [
-                                $costtable . '.budgets_id' => $budgets_id
-                            ] + getEntitiesRestrictCriteria($item->getTable()),
-                            'GROUPBY'      => [
-                                $item->getTable() . '.id',
-                                $item->getTable() . '.entities_id'
-                            ],
-                            'ORDERBY'      => [
-                                $item->getTable() . '.entities_id',
-                                $item->getTable() . '.name'
-                            ]
-                        ];
-                        break;
-
-                    case 'Project':
-                        $criteria = [
-                            'SELECT'       => [
-                                $item->getTable() . '.id',
-                                $item->getTable() . '.entities_id',
-                                'SUM' => 'glpi_projectcosts.cost AS value'
-                            ],
-                            'FROM'         => 'glpi_projectcosts',
-                            'INNER JOIN'   => [
-                                $item->getTable() => [
-                                    'ON' => [
-                                        $item->getTable()    => 'id',
-                                        'glpi_projectcosts'  => 'projects_id'
-                                    ]
-                                ]
-                            ],
-                            'WHERE'        => [
-                                'glpi_projectcosts.budgets_id'  => $budgets_id
-                            ] + getEntitiesRestrictCriteria($item->getTable()),
-                            'GROUPBY'      => [
-                                $item->getTable() . '.id',
-                                $item->getTable() . '.entities_id'
-                            ],
-                            'ORDERBY'      => [
-                                $item->getTable() . '.entities_id',
-                                $item->getTable() . '.name'
-                            ]
-                        ];
-                        break;
-
-                    case 'Cartridge':
-                        $criteria = [
-                            'SELECT'       => [
-                                $item->getTable() . '.*',
-                                'glpi_cartridgeitems.name',
-                                'glpi_infocoms.value'
-                            ],
-                            'FROM'         => 'glpi_infocoms',
-                            'INNER JOIN'   => [
-                                $item->getTable() => [
-                                    'ON' => [
-                                        $item->getTable() => 'id',
-                                        'glpi_infocoms'   => 'items_id'
-                                    ]
-                                ],
-                                'glpi_cartridgeitems'   => [
-                                    'ON' => [
-                                        $item->getTable()       => 'cartridgeitems_id',
-                                        'glpi_cartridgeitems'   => 'id'
-                                    ]
-                                ]
-                            ],
-                            'WHERE'        => [
-                                'glpi_infocoms.itemtype'   => $itemtype,
-                                'glpi_infocoms.budgets_id' => $budgets_id
-                            ] + getEntitiesRestrictCriteria($item->getTable()),
-                            'ORDERBY'      => [
-                                'entities_id',
-                                'glpi_cartridgeitems.name'
-                            ]
-                        ];
-                        break;
-
-                    case 'Consumable':
-                        $criteria = [
-                            'SELECT'       => [
-                                $item->getTable() . '.*',
-                                'glpi_consumableitems.name',
-                                'glpi_infocoms.value'
-                            ],
-                            'FROM'         => 'glpi_infocoms',
-                            'INNER JOIN'   => [
-                                $item->getTable() => [
-                                    'ON' => [
-                                        $item->getTable() => 'id',
-                                        'glpi_infocoms'   => 'items_id'
-                                    ]
-                                ],
-                                'glpi_consumableitems'   => [
-                                    'ON' => [
-                                        $item->getTable()       => 'consumableitems_id',
-                                        'glpi_consumableitems'  => 'id'
-                                    ]
-                                ]
-                            ],
-                            'WHERE'        => [
-                                'glpi_infocoms.itemtype'   => $itemtype,
-                                'glpi_infocoms.budgets_id' => $budgets_id
-                            ] + getEntitiesRestrictCriteria($item->getTable()),
-                            'ORDERBY'      => [
-                                'entities_id',
-                                'glpi_consumableitems.name'
-                            ]
-                        ];
-                        break;
-
-                    default:
-                        $criteria = [
-                            'SELECT'       => [
-                                $item->getTable() . '.*',
-                                'glpi_infocoms.value',
-                            ],
-                            'FROM'         => 'glpi_infocoms',
-                            'INNER JOIN'   => [
-                                $item->getTable() => [
-                                    'ON' => [
-                                        $item->getTable() => 'id',
-                                        'glpi_infocoms'   => 'items_id'
-                                    ]
-                                ]
-                            ],
-                            'WHERE'        => [
-                                'glpi_infocoms.itemtype'            => $itemtype,
-                                'glpi_infocoms.budgets_id'          => $budgets_id
-                            ] + getEntitiesRestrictCriteria($item->getTable()),
-                            'ORDERBY'      => [
-                                $item->getTable() . '.entities_id'
-                            ]
-                        ];
-                        if ($item->maybeTemplate()) {
-                            $criteria['WHERE'][$item->getTable() . '.is_template'] = 0;
-                        }
-
-                        if ($item instanceof Item_Devices) {
-                            $criteria['ORDERBY'][] = $item->getTable() . '.itemtype';
-                        } else {
-                            $criteria['ORDERBY'][] = $item->getTable() . '.name';
-                        }
-                        break;
-                }
-
-                $iterator = $DB->request($criteria);
-                $nb = count($iterator);
-                if ($nb > $_SESSION['glpilist_limit']) {
-                    echo "<tr class='tab_bg_1'>";
-                    $name = $item->getTypeName($nb);
-                   //TRANS: %1$s is a name, %2$s is a number
-                    echo "<td class='center'>" . sprintf(__('%1$s: %2$s'), $name, $nb) . "</td>";
-                    echo "<td class='center' colspan='2'>";
-
-                    $opt = ['order'      => 'ASC',
-                        'is_deleted' => 0,
-                        'reset'      => 'reset',
-                        'start'      => 0,
-                        'sort'       => 80,
-                        'criteria'   => [0 => ['value'      => '$$$$' . $budgets_id,
-                            'searchtype' => 'contains',
-                            'field'      => 50
-                        ]
-                        ]
-                    ];
-
-                    echo "<a href='" . $item->getSearchURL() . "?" . Toolbox::append_params($opt) . "'>" .
-                     __('Device list') . "</a></td>";
-                    echo "<td class='center'>-</td><td class='center'>-</td><td class='center'>-" .
-                     "</td></tr>";
-                } else if ($nb) {
-                    for ($prem = true; $iterator->valid(); $prem = false) {
-                        $data = $iterator->current();
-                        $name = NOT_AVAILABLE;
-                        if ($item->getFromDB($data["id"])) {
-                            if ($item instanceof Item_Devices) {
-                                $tmpitem = new $item::$itemtype_2();
-                                if ($tmpitem->getFromDB($data[$item::$items_id_2])) {
-                                      $name = $tmpitem->getLink(['additional' => true]);
-                                }
-                            } else {
-                                $name = $item->getLink(['additional' => true]);
-                            }
-                        }
-                        echo "<tr class='tab_bg_1'>";
-                        if ($prem) {
-                            $typename = $item->getTypeName($nb);
-                            echo "<td class='center top' rowspan='$nb'>" .
-                            ($nb > 1 ? sprintf(__('%1$s: %2$s'), $typename, $nb) : $typename) . "</td>";
-                        }
-                        echo "<td class='center'>" . Dropdown::getDropdownName(
-                            "glpi_entities",
-                            $data["entities_id"]
-                        );
-                        echo "</td><td class='center";
-                        echo (isset($data['is_deleted']) && $data['is_deleted'] ? " tab_bg_2_2'" : "'");
-                        echo ">" . $name . "</td>";
-                        echo "<td class='center'>" . (isset($data["serial"]) ? "" . $data["serial"] . "" : "-");
-                        echo "</td>";
-                        echo "<td class='center'>" .
-                           (isset($data["otherserial"]) ? "" . $data["otherserial"] . "" : "-") . "</td>";
-                        echo "<td class='center'>" .
-                           (isset($data["value"]) ? "" . Html::formatNumber($data["value"], true) . ""
-                                                : "-");
-
-                        echo "</td></tr>";
-                        $iterator->next();
+            $name = NOT_AVAILABLE;
+            if ($items[$itemtype]->getFromDB($data["id"])) {
+                if ($items[$itemtype] instanceof Item_Devices) {
+                    $tmpitem = new $items[$itemtype]::$itemtype_2();
+                    if ($tmpitem->getFromDB($data[$items[$itemtype]::$items_id_2])) {
+                        $name = $tmpitem->getLink(['additional' => true]);
                     }
+                } else {
+                    $name = $items[$itemtype]->getLink(['additional' => true]);
                 }
-                $num += $nb;
             }
+            $entry['name'] = $name;
+
+            if (!array_key_exists($data['entities_id'], $entity_names)) {
+                $entity_names[$data['entities_id']] = Dropdown::getDropdownName(
+                    "glpi_entities",
+                    $data["entities_id"]
+                );
+            }
+            $entry['entity'] = $entity_names[$data['entities_id']];
+            if (isset($data['is_deleted']) && $data['is_deleted']) {
+                $entry['row_class'] = 'table-danger';
+            }
+
+            $entries[] = $entry;
         }
 
-        if ($num > 0) {
-            echo "<tr class='tab_bg_2'>";
-            echo "<td class='center b'>" . sprintf(__('%1$s = %2$s'), __('Total'), $num) . "</td>";
-            echo "<td colspan='5'>&nbsp;</td></tr> ";
-        }
-        echo "</table></div>";
+        TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
+            'start' => $start,
+            'limit' => $_SESSION['glpilist_limit'],
+            'is_tab' => true,
+            'nofilter' => true,
+            'columns' => [
+                'type' => _n('Type', 'Types', 1),
+                'entity' => Entity::getTypeName(1),
+                'name' => __('Name'),
+                'serial' => __('Serial number'),
+                'otherserial' => __('Inventory number'),
+                'value' => _x('price', 'Value'),
+            ],
+            'formatters' => [
+                'name' => 'raw_html',
+                'value' => 'raw_html',
+            ],
+            'entries' => $entries,
+            'total_number' => $total_count,
+            'filtered_number' => $total_count,
+            'showmassiveactions' => false,
+        ]);
     }
-
 
     /**
      * Print the HTML array of value consumed for a budget
@@ -677,248 +516,105 @@ class Budget extends CommonDropdown
             return false;
         }
 
-        $types_iterator = Infocom::getTypes(
-            [
-                'budgets_id' => $budgets_id
-            ] + getEntitiesRestrictCriteria('glpi_infocoms', 'entities_id')
-        );
+        $iterator = $DB->request([
+            'FROM' => $this->getItemListCriteria()
+        ]);
 
-        $total               = 0;
-        $totalbytypes        = [];
+        $itemtypes = [];
+        $entities = [];
+        $entries = [];
+        $itemtype_totals = [];
+        $grand_total = 0;
 
-        $itemtypes           = [];
+        foreach ($iterator as $data) {
+            $itemtype = $data['_itemtype'];
+            $entity = $data['entities_id'];
+            if (!in_array($itemtype, $itemtypes, true)) {
+                $itemtypes[] = $itemtype;
+            }
 
-        $entities_values     = [];
-        $entitiestype_values = [];
-        $found_types         = [];
-
-        foreach ($types_iterator as $types) {
-            $itemtypes[] = $types['itemtype'];
+            if (!array_key_exists($entity, $entities)) {
+                $entities[$entity] = [
+                    'name' => Dropdown::getDropdownName(
+                        "glpi_entities",
+                        $data["entities_id"]
+                    ),
+                    'itemtypes' => [],
+                    'total' => 0,
+                ];
+            }
+            if (!array_key_exists($itemtype, $entities[$entity]['itemtypes'])) {
+                $entities[$entity]['itemtypes'][$itemtype] = 0;
+            }
+            if (!array_key_exists($itemtype, $itemtype_totals)) {
+                $itemtype_totals[$itemtype] = 0;
+            }
+            $entities[$entity]['itemtypes'][$itemtype] += $data['value'];
+            $entities[$entity]['total'] += $data['value'];
+            $itemtype_totals[$itemtype] += $data['value'];
+            $grand_total += $data['value'];
         }
 
-        $itemtypes[] = 'Contract';
-        $itemtypes[] = 'Ticket';
-        $itemtypes[] = 'Problem';
-        $itemtypes[] = 'Project';
-        $itemtypes[] = 'Change';
+        foreach ($entities as $entities_id => $entity) {
+            $entry = [
+                'itemtype' => Entity::class,
+                'id' => $entities_id,
+                'entity' => $entity['name'],
+            ];
+            foreach ($itemtypes as $itemtype) {
+                $entry[$itemtype] = $entity['itemtypes'][$itemtype] ?? 0;
+            }
+            $entry['total'] = $entity['total'];
+            $entries[] = $entry;
+        }
 
+        $columns = [
+            'entity' => Entity::getTypeName(1),
+        ];
+        $formatters = [
+            'total' => 'number',
+        ];
         foreach ($itemtypes as $itemtype) {
-            if (!($item = getItemForItemtype($itemtype))) {
-                continue;
-            }
+            $columns[$itemtype] = $itemtype::getTypeName(1);
+            $formatters[$itemtype] = 'number';
+        }
+        $columns['total'] = _x('price', 'Total');
 
-            $table = getTableForItemType($itemtype);
-            switch ($itemtype) {
-                case 'Contract':
-                    $criteria = [
-                        'SELECT'       => [
-                            $table . '.entities_id',
-                            'SUM' => 'glpi_contractcosts.cost AS sumvalue'
-                        ],
-                        'FROM'         => 'glpi_contractcosts',
-                        'INNER JOIN'   => [
-                            $table => [
-                                'ON' => [
-                                    $table               => 'id',
-                                    'glpi_contractcosts' => 'contracts_id'
-                                ]
-                            ]
-                        ],
-                        'WHERE'        => [
-                            'glpi_contractcosts.budgets_id'     => $budgets_id
-                        ],
-                        'GROUPBY'      => [
-                            $table . '.entities_id'
-                        ]
-                    ];
-                    break;
+        $footer = [
+            _x('price', 'Total'),
+        ];
+        foreach ($itemtypes as $itemtype) {
+            $footer[] = Html::formatNumber($itemtype_totals[$itemtype]);
+        }
+        $footer[] = Html::formatNumber($grand_total);
+        $col_count = count($columns);
 
-                case 'Project':
-                    $costtable   = getTableForItemType($item->getType() . 'Cost');
-                    $criteria = [
-                        'SELECT'       => [
-                            $table . '.entities_id',
-                            'SUM' => 'glpi_projectcosts.cost AS sumvalue'
-                        ],
-                        'FROM'         => 'glpi_projectcosts',
-                        'INNER JOIN'   => [
-                            $table => [
-                                'ON' => [
-                                    $table               => 'id',
-                                    'glpi_projectcosts'  => 'projects_id'
-                                ]
-                            ]
-                        ],
-                        'WHERE'        => [
-                            'glpi_projectcosts.budgets_id'  => $budgets_id
-                        ],
-                        'GROUPBY'      => [
-                            $item->getTable() . '.entities_id'
-                        ]
-                    ];
-                    break;
-
-                case 'Ticket':
-                case 'Problem':
-                case 'Change':
-                    $costtable   = getTableForItemType($item->getType() . 'Cost');
-                    $sum = QueryFunction::sum(
-                        expression: new QueryExpression($DB::quoteName("$costtable.actiontime") . " * " . $DB::quoteName("$costtable.cost_time") . "/" . HOUR_TIMESTAMP . "
-                                           + " . $DB::quoteName("$costtable.cost_fixed") . "
-                                           + " . $DB::quoteName("$costtable.cost_material")),
-                        alias: 'sumvalue'
-                    );
-
-                    $criteria = [
-                        'SELECT'       => [
-                            $item->getTable() . '.entities_id',
-                            $sum
-                        ],
-                        'FROM'         => $costtable,
-                        'INNER JOIN'   => [
-                            $table => [
-                                'ON' => [
-                                    $table      => 'id',
-                                    $costtable  => $item->getForeignKeyField()
-                                ]
-                            ]
-                        ],
-                        'WHERE'        => [
-                            $costtable . '.budgets_id' => $budgets_id
-                        ],
-                        'GROUPBY'      => [
-                            $item->getTable() . '.entities_id'
-                        ]
-                    ];
-                    break;
-
-                default:
-                    $criteria = [
-                        'SELECT'       => [
-                            $table . '.entities_id',
-                            'SUM' => 'glpi_infocoms.value AS sumvalue',
-                        ],
-                        'FROM'         => $table,
-                        'INNER JOIN'   => [
-                            'glpi_infocoms' => [
-                                'ON' => [
-                                    $table            => 'id',
-                                    'glpi_infocoms'   => 'items_id'
-                                ]
-                            ]
-                        ],
-                        'WHERE'        => [
-                            'glpi_infocoms.itemtype'            => $itemtype,
-                            'glpi_infocoms.budgets_id'          => $budgets_id
-                        ],
-                        'GROUPBY'      => [
-                            $table . '.entities_id'
-                        ]
-                    ];
-                    if ($item->maybeTemplate()) {
-                        $criteria['WHERE'][$table . '.is_template'] = 0;
-                    }
-                    break;
-            }
-
-            $iterator = $DB->request($criteria);
-            $nb = count($iterator);
-            if ($nb) {
-                $found_types[$itemtype]  = $item->getTypeName(1);
-                $totalbytypes[$itemtype] = 0;
-               //Store, for each entity, the budget spent
-                foreach ($iterator as $values) {
-                    if (in_array($values['entities_id'], $_SESSION['glpiactiveentities'])) {
-                        if (!isset($entities_values[$values['entities_id']])) {
-                            $entities_values[$values['entities_id']] = 0;
-                        }
-                        if (!isset($entitiestype_values[$values['entities_id']][$itemtype])) {
-                            $entitiestype_values[$values['entities_id']][$itemtype] = 0;
-                        }
-                        $entities_values[$values['entities_id']]                 += $values['sumvalue'];
-                        $entitiestype_values[$values['entities_id']][$itemtype]  += $values['sumvalue'];
-                        $totalbytypes[$itemtype]                                 += $values['sumvalue'];
-                    } else {
-                        if (!isset($entities_values[-1])) {
-                            $entities_values[-1] = 0;
-                        }
-                        $entities_values[-1]                 += $values['sumvalue'];
-                        $entitiestype_values[-1][$itemtype] = '-';
-                    }
-                    $total += $values['sumvalue'];
-                }
-            }
+        $budget_remaining = $this->fields['value'] - $grand_total;
+        $overbudget = $budget_remaining < 0;
+        $budget_remaining = Html::formatNumber(abs($budget_remaining));
+        if ($overbudget) {
+            $budget_remaining = '(' . $budget_remaining . ')';
         }
 
-        $budget = new self();
-        $budget->getFromDB($budgets_id);
-
-        $colspan = count($found_types) + 2;
-        echo "<div class='spaced'><table class='tab_cadre_fixehov'>";
-        echo "<tr class='noHover'><th colspan='$colspan'>" . __('Total spent on the budget') . "</th></tr>";
-        echo "<tr><th>" . Entity::getTypeName(1) . "</th>";
-        if (count($found_types)) {
-            foreach ($found_types as $type => $typename) {
-                echo "<th class='right'>$typename</th>";
-            }
-        }
-        echo "<th class='right'>" . __('Total') . "</th>";
-        echo "</tr>";
-
-       // get all entities ordered by names
-        $allentities = getAllDataFromTable('glpi_entities', ['ORDER' => 'completename'], true);
-        $allentities[-1] = -1;
-        ksort($allentities);
-
-        foreach (array_keys($allentities) as $entity) {
-            if (isset($entities_values[$entity])) {
-                echo "<tr class='tab_bg_1'>";
-                echo "<td class='b'>";
-                if ($entity == -1) {
-                    echo __('Other entities');
-                } else {
-                    echo Dropdown::getDropdownName('glpi_entities', $entity);
-                }
-                echo "</td>";
-                if (count($found_types)) {
-                    foreach ($found_types as $type => $typename) {
-                        echo "<td class='numeric'>";
-                        $typevalue = 0;
-                        if (isset($entitiestype_values[$entity][$type])) {
-                             $typevalue = $entitiestype_values[$entity][$type];
-                        }
-                        echo Html::formatNumber($typevalue);
-                        echo "</td>";
-                    }
-                }
-
-                echo "<td class='right b'>" . Html::formatNumber($entities_values[$entity]) . "</td>";
-                echo "</tr>";
-            }
-        }
-        if (count($found_types)) {
-            echo "<tr class='tab_bg_1'>";
-            echo "<td class='right b'>" . __('Total') . "</td>";
-            foreach ($found_types as $type => $typename) {
-                echo "<td class='numeric b'>";
-                echo Html::formatNumber($totalbytypes[$type]);
-                echo "</td>";
-            }
-            echo "<td class='numeric b'>" . Html::formatNumber($total) . "</td>";
-            echo "</tr>";
-        }
-        echo "<tr class='tab_bg_1 noHover'><th colspan='$colspan'><br></th></tr>";
-        echo "<tr class='tab_bg_1 noHover'>";
-        echo "<td class='right' colspan='" . ($colspan - 1) . "'>" . __('Total spent on the budget') . "</td>";
-        echo "<td class='numeric b'>" . Html::formatNumber($total) . "</td></tr>";
-        echo "<tr class='tab_bg_1 noHover'>";
-        echo "<td class='right' colspan='" . ($colspan - 1) . "'>" . __('Total remaining on the budget') .
-            "</td>";
-        echo "<td class='numeric b'>" . Html::formatNumber($budget->fields['value'] - $total) .
-            "</td></tr>";
-        echo "</table></div>";
+        TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
+            'is_tab' => true,
+            'nofilter' => true,
+            'nopager' => true,
+            'super_header' => __('Total spent on the budget'),
+            'columns' => $columns,
+            'formatters' => $formatters,
+            'entries' => $entries,
+            'footers' => [
+                $footer,
+                array_pad([__('Total spent on the budget'), Html::formatNumber($grand_total)], -$col_count, ''),
+                array_pad([__('Total remaining on the budget'), $budget_remaining], -$col_count, ''),
+            ],
+            'footer_class' => 'fw-bold',
+            'total_number' => count($entries),
+            'filtered_number' => count($entries),
+            'showmassiveactions' => false,
+        ]);
     }
-
 
     public static function getIcon()
     {

--- a/src/Budget.php
+++ b/src/Budget.php
@@ -291,7 +291,7 @@ class Budget extends CommonDropdown
         foreach ($iterator as $row) {
             $itemtypes[] = $row['itemtype'];
         }
-        $itemtypes = array_filter($itemtypes, static fn($itemtype) => $itemtype::canView());
+        $itemtypes = array_filter($itemtypes, static fn($itemtype) => is_a($itemtype, CommonDBTM::class, true) && $itemtype::canView());
         $infocom_itemtypes = [];
         $other_cost_tables = [
             'Contract' => ContractCost::getTable(),

--- a/src/Budget.php
+++ b/src/Budget.php
@@ -496,7 +496,6 @@ class Budget extends CommonDropdown
             ],
             'formatters' => [
                 'name' => 'raw_html',
-                'value' => 'raw_html',
             ],
             'entries' => $entries,
             'total_number' => $total_count,

--- a/src/Budget.php
+++ b/src/Budget.php
@@ -349,6 +349,7 @@ class Budget extends CommonDropdown
 
         foreach ($other_cost_tables as $itemtype => $cost_table) {
             $item_table = $itemtype::getTable();
+            $item = new $itemtype();
             $criteria = [
                 'SELECT' => [
                     new QueryExpression($DB::quoteValue($itemtype), '_itemtype'),

--- a/src/CommonITILCost.php
+++ b/src/CommonITILCost.php
@@ -509,7 +509,7 @@ abstract class CommonITILCost extends CommonDBChild
                 'id'        => $ID,
                 'rand'      => $rand,
                 'type'      => static::getType(),
-                'parenttype'=> static::$itemtype,
+                'parenttype' => static::$itemtype,
                 'items_id'  => static::$items_id,
                 'add_new_label' => __('Add a new cost'),
             ];
@@ -539,7 +539,6 @@ abstract class CommonITILCost extends CommonDBChild
                     </div>
                 {% endif %}
 TWIG, $twig_params);
-
         }
 
         $total          = 0;
@@ -560,44 +559,44 @@ TWIG, $twig_params);
         $ticket_links = [];
         $budget_links = [];
         foreach ($iterator as $data) {
-             $name = (empty($data['name']) ? sprintf(__('%1$s (%2$s)'), $data['name'], $data['id']) : $data['name']);
+            $name = (empty($data['name']) ? sprintf(__('%1$s (%2$s)'), $data['name'], $data['id']) : $data['name']);
 
-             $total_time += $data['actiontime'];
-             $total_costtime += ($data['actiontime'] * $data['cost_time'] / HOUR_TIMESTAMP);
-             $total_fixed += $data['cost_fixed'];
-             $total_material += $data['cost_material'];
-             $cost            = self::computeTotalCost(
-                 $data['actiontime'],
-                 $data['cost_time'],
-                 $data['cost_fixed'],
-                 $data['cost_material']
-             );
-             $total += (float) $cost;
-             if (!array_key_exists($data['budgets_id'], $budget_links)) {
-                 $budget->getFromDB($data['budgets_id']);
-                 $budget_links[$data['budgets_id']] = $budget->getLink();
-             }
-             $entry = [
-                 'itemtype' => static::getType(),
-                 'id'       => $data['id'],
-                 'name'     => sprintf(__('%1$s %2$s'), $name, Html::showToolTip($data['comment'], ['display' => false])),
-                 'begin_date' => $data['begin_date'],
-                 'end_date' => $data['end_date'],
-                 'budget' => $budget_links[$data['budgets_id']],
-                 'actiontime' => CommonITILObject::getActionTime($data['actiontime']),
-                 'cost_time' => $data['cost_time'],
-                 'cost_fixed' => $data['cost_fixed'],
-                 'cost_material' => $data['cost_material'],
-                 'totalcost' => $cost,
-             ];
-             if ($forproject) {
-                 if (!array_key_exists($data[static::$items_id], $ticket_links)) {
-                     $ticket->getFromDB($data[static::$items_id]);
-                     $ticket_links[$data[static::$items_id]] = $ticket->getLink();
-                 }
-                 $entry['ticket'] = $ticket_links[$data[static::$items_id]];
-             }
-             $entries[] = $entry;
+            $total_time += $data['actiontime'];
+            $total_costtime += ($data['actiontime'] * $data['cost_time'] / HOUR_TIMESTAMP);
+            $total_fixed += $data['cost_fixed'];
+            $total_material += $data['cost_material'];
+            $cost = self::computeTotalCost(
+                $data['actiontime'],
+                $data['cost_time'],
+                $data['cost_fixed'],
+                $data['cost_material']
+            );
+            $total += (float) $cost;
+            if (!array_key_exists($data['budgets_id'], $budget_links)) {
+                $budget->getFromDB($data['budgets_id']);
+                $budget_links[$data['budgets_id']] = $budget->getLink();
+            }
+            $entry = [
+                'itemtype' => static::getType(),
+                'id'       => $data['id'],
+                'name'     => sprintf(__('%1$s %2$s'), $name, Html::showToolTip($data['comment'], ['display' => false])),
+                'begin_date' => $data['begin_date'],
+                'end_date' => $data['end_date'],
+                'budget' => $budget_links[$data['budgets_id']],
+                'actiontime' => CommonITILObject::getActionTime($data['actiontime']),
+                'cost_time' => $data['cost_time'],
+                'cost_fixed' => $data['cost_fixed'],
+                'cost_material' => $data['cost_material'],
+                'totalcost' => $cost,
+            ];
+            if ($forproject) {
+                if (!array_key_exists($data[static::$items_id], $ticket_links)) {
+                    $ticket->getFromDB($data[static::$items_id]);
+                    $ticket_links[$data[static::$items_id]] = $ticket->getLink();
+                }
+                $entry['ticket'] = $ticket_links[$data[static::$items_id]];
+            }
+            $entries[] = $entry;
         }
 
         $columns = [
@@ -678,7 +677,6 @@ TWIG, $twig_params);
                     });
                 });
 JS);
-
         }
         return $total;
     }
@@ -752,11 +750,9 @@ JS);
      *
      * @return string total cost formatted string
      **/
-    public static function computeTotalCost($actiontime, $cost_time, $cost_fixed, $cost_material, $edit = true) {
-
-        return Html::formatNumber(
-            ($actiontime * $cost_time / HOUR_TIMESTAMP) + $cost_fixed + $cost_material,
-            $edit
-        );
+    public static function computeTotalCost($actiontime, $cost_time, $cost_fixed, $cost_material, $edit = true)
+    {
+        $cost = ($actiontime * $cost_time / HOUR_TIMESTAMP) + $cost_fixed + $cost_material;
+        return Html::formatNumber($cost, $edit);
     }
 }

--- a/src/CommonITILCost.php
+++ b/src/CommonITILCost.php
@@ -33,6 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
 
@@ -58,9 +59,8 @@ abstract class CommonITILCost extends CommonDBChild
 
     public function getItilObjectItemType()
     {
-        return str_replace('Cost', '', $this->getType());
+        return str_replace('Cost', '', static::class);
     }
-
 
     /**
      * @see CommonGLPI::getTabNameForItem()
@@ -68,7 +68,7 @@ abstract class CommonITILCost extends CommonDBChild
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
 
-       // can exists for template
+        // can exists for template
         if (
             (get_class($item) == static::$itemtype)
             && static::canView()
@@ -76,8 +76,8 @@ abstract class CommonITILCost extends CommonDBChild
             $nb = 0;
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = countElementsInTable(
-                    $this->getTable(),
-                    [$item->getForeignKeyField() => $item->getID()]
+                    static::getTable(),
+                    [$item::getForeignKeyField() => $item->getID()]
                 );
             }
             return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
@@ -85,19 +85,16 @@ abstract class CommonITILCost extends CommonDBChild
         return '';
     }
 
-
     /**
-     * @param $item            CommonGLPI object
-     * @param $tabnum          (default 1)
-     * @param $withtemplate    (default 0)
+     * @param CommonGLPI $item object
+     * @param integer $tabnum          (default 1)
+     * @param integer $withtemplate    (default 0)
      **/
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
     {
-
         self::showForObject($item, $withtemplate);
         return true;
     }
-
 
     public function rawSearchOptions()
     {
@@ -110,7 +107,7 @@ abstract class CommonITILCost extends CommonDBChild
 
         $tab[] = [
             'id'                 => '1',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'name',
             'name'               => __('Title'),
             'searchtype'         => 'contains',
@@ -120,7 +117,7 @@ abstract class CommonITILCost extends CommonDBChild
 
         $tab[] = [
             'id'                 => '2',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'id',
             'name'               => __('ID'),
             'massiveaction'      => false,
@@ -129,7 +126,7 @@ abstract class CommonITILCost extends CommonDBChild
 
         $tab[] = [
             'id'                 => '16',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'comment',
             'name'               => __('Comments'),
             'datatype'           => 'text'
@@ -137,7 +134,7 @@ abstract class CommonITILCost extends CommonDBChild
 
         $tab[] = [
             'id'                 => '12',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'begin_date',
             'name'               => __('Begin date'),
             'datatype'           => 'datetime'
@@ -145,7 +142,7 @@ abstract class CommonITILCost extends CommonDBChild
 
         $tab[] = [
             'id'                 => '10',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'end_date',
             'name'               => __('End date'),
             'datatype'           => 'datetime'
@@ -153,7 +150,7 @@ abstract class CommonITILCost extends CommonDBChild
 
         $tab[] = [
             'id'                 => '11',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'actiontime',
             'name'               => __('Duration'),
             'datatype'           => 'timestamp'
@@ -161,7 +158,7 @@ abstract class CommonITILCost extends CommonDBChild
 
         $tab[] = [
             'id'                 => '14',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'cost_time',
             'name'               => __('Time cost'),
             'datatype'           => 'decimal'
@@ -169,7 +166,7 @@ abstract class CommonITILCost extends CommonDBChild
 
         $tab[] = [
             'id'                 => '15',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'cost_fixed',
             'name'               => __('Fixed cost'),
             'datatype'           => 'decimal'
@@ -177,7 +174,7 @@ abstract class CommonITILCost extends CommonDBChild
 
         $tab[] = [
             'id'                 => '19',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'cost_material',
             'name'               => __('Material cost'),
             'datatype'           => 'decimal'
@@ -185,7 +182,7 @@ abstract class CommonITILCost extends CommonDBChild
 
         $tab[] = [
             'id'                 => '18',
-            'table'              => 'glpi_budgets',
+            'table'              => Budget::getTable(),
             'field'              => 'name',
             'name'               => Budget::getTypeName(1),
             'datatype'           => 'dropdown'
@@ -193,7 +190,7 @@ abstract class CommonITILCost extends CommonDBChild
 
         $tab[] = [
             'id'                 => '80',
-            'table'              => 'glpi_entities',
+            'table'              => Entity::getTable(),
             'field'              => 'completename',
             'name'               => Entity::getTypeName(1),
             'massiveaction'      => false,
@@ -202,7 +199,6 @@ abstract class CommonITILCost extends CommonDBChild
 
         return $tab;
     }
-
 
     public static function rawSearchOptionsToAdd()
     {
@@ -319,7 +315,6 @@ abstract class CommonITILCost extends CommonDBChild
         return $tab;
     }
 
-
     /**
      * Init cost for creation based on previous cost
      **/
@@ -360,11 +355,10 @@ abstract class CommonITILCost extends CommonDBChild
         }
     }
 
-
     /**
-     * Get total actiNULL        11400   0.0000  0.0000  0.0000  on time used on costs for an item
+     * Get total action time used on costs for an item
      *
-     * @param $items_id        integer  ID of the item
+     * @param integer $items_id ID of the item
      **/
     public function getTotalActionTimeForItem($items_id)
     {
@@ -373,17 +367,16 @@ abstract class CommonITILCost extends CommonDBChild
 
         $result = $DB->request([
             'SELECT' => ['SUM' => 'actiontime AS sumtime'],
-            'FROM'   => $this->getTable(),
+            'FROM'   => static::getTable(),
             'WHERE'  => [static::$items_id => $items_id]
         ])->current();
         return $result['sumtime'];
     }
 
-
     /**
      * Get last datas for an item
      *
-     * @param $items_id        integer  ID of the item
+     * @param integer $items_id ID of the item
      **/
     public function getLastCostForItem($items_id)
     {
@@ -391,7 +384,7 @@ abstract class CommonITILCost extends CommonDBChild
         global $DB;
 
         $result = $DB->request([
-            'FROM'   => $this->getTable(),
+            'FROM'   => static::getTable(),
             'WHERE'  => [
                 static::$items_id => $items_id
             ],
@@ -403,12 +396,11 @@ abstract class CommonITILCost extends CommonDBChild
         return $result;
     }
 
-
     /**
      * Print the item cost form
      *
-     * @param $ID        integer  ID of the item
-     * @param $options   array    options used
+     * @param integer $ID ID of the item
+     * @param array $options options used
      **/
     public function showForm($ID, array $options = [])
     {
@@ -438,80 +430,24 @@ abstract class CommonITILCost extends CommonDBChild
             return false;
         }
 
-        $this->showFormHeader($options);
-        echo "<tr class='tab_bg_1'>";
-        echo "<td>" . __('Name') . "</td>";
-        echo "<td>";
-        echo "<input type='hidden' name='" . static::$items_id . "' value='" . $item->fields['id'] . "'>";
-
-        echo Html::input('name', ['value' => $this->fields['name']]);
-        echo "</td>";
-        echo "<td>" . __('Begin date') . "</td>";
-        echo "<td>";
-        Html::showDateField("begin_date", ['value' => $this->fields['begin_date']]);
-        echo "</td>";
-        echo "</tr>";
-
-        echo "<tr class='tab_bg_1'>";
-        echo "<td>" . __('Duration') . "</td>";
-        echo "<td>";
-        Dropdown::showTimeStamp('actiontime', ['value'           => $this->fields['actiontime'],
-            'addfirstminutes'      => true,
-            'min'                  => DAY_TIMESTAMP,
-            'max'                  => DAY_TIMESTAMP * 50,
-            'step'                 => DAY_TIMESTAMP,
+        TemplateRenderer::getInstance()->display('pages/management/cost.html.twig', [
+            'item' => $this,
+            'no_header' => true,
+            'items_id_field' => static::$items_id,
+            'parent_id' => $item->getID(),
+            'params' => [
+                'canedit' => $this->canUpdateItem(),
+            ]
         ]);
-        echo "</td>";
-        echo "<td>" . __('End date') . "</td>";
-        echo "<td>";
-        Html::showDateField("end_date", ['value' => $this->fields['end_date']]);
-        echo "</td>";
-        echo "</tr>";
-
-        echo "<tr class='tab_bg_1'>";
-        echo "<td>" . __('Time cost') . "</td><td>";
-        echo "<input type='text' class='form-control' size='15' name='cost_time' value='" .
-             Html::formatNumber($this->fields["cost_time"], true) . "'>";
-        echo "</td>";
-        $rowspan = 4;
-        echo "<td rowspan='$rowspan'>" . __('Comments') . "</td>";
-        echo "<td rowspan='$rowspan' class='middle'>";
-        echo "<textarea class='form-control' name='comment' >" . $this->fields["comment"] .
-           "</textarea>";
-        echo "</td></tr>\n";
-
-        echo "<tr class='tab_bg_1'>";
-        echo "<td>" . __('Fixed cost') . "</td><td>";
-        echo "<input type='text' class='form-control' size='15' name='cost_fixed' value='" .
-             Html::formatNumber($this->fields["cost_fixed"], true) . "'>";
-        echo "</td>";
-        echo "</tr>";
-
-        echo "<tr class='tab_bg_1'>";
-        echo "<td>" . __('Material cost') . "</td><td>";
-        echo "<input type='text' class='form-control' size='15' name='cost_material' value='" .
-             Html::formatNumber($this->fields["cost_material"], true) . "'>";
-        echo "</td>";
-        echo "</tr>";
-
-        echo "<tr class='tab_bg_1'><td>" . Budget::getTypeName(1) . "</td>";
-        echo "<td>";
-        Budget::dropdown(['value'  => $this->fields["budgets_id"],
-            'entity' => $this->fields["entities_id"]
-        ]);
-        echo "</td></tr>";
-
-        $this->showFormButtons($options);
 
         return true;
     }
 
-
     /**
      * Print the item costs
      *
-     * @param $item                  CommonITILObject object or Project
-     * @param $withtemplate boolean  Template or basic item (default 0)
+     * @param CommonITILObject $item object or Project
+     * @param boolean $withtemplate Template or basic item (default 0)
      *
      * @return false|integer total cost
      **/
@@ -542,14 +478,16 @@ abstract class CommonITILCost extends CommonDBChild
             $canedit = $item->canAddItem(__CLASS__);
         }
 
-        echo "<div class='center'>";
-
         $items_ids = $ID;
         if ($forproject) {
             $alltickets = ProjectTask::getAllTicketsForProject($ID);
             $items_ids = (count($alltickets) ? $alltickets : 0);
         }
         $iterator = $DB->request([
+            'SELECT' => [
+                static::$items_id, 'id', 'name', 'begin_date', 'end_date', 'actiontime',
+                'budgets_id', 'cost_time', 'cost_fixed', 'cost_material', 'comment'
+            ],
             'FROM'   => static::getTable(),
             'WHERE'  => [
                 static::$items_id   => $items_ids
@@ -566,26 +504,42 @@ abstract class CommonITILCost extends CommonDBChild
                 $item->getSolvedStatusArray()
             ))
         ) {
-            echo "<div id='viewcost" . $ID . "_$rand'></div>\n";
-            echo "<script type='text/javascript' >\n";
-            echo "function viewAddCost" . $ID . "_$rand() {\n";
-            $params = ['type'             => static::getType(),
-                'parenttype'       => static::$itemtype,
-                static::$items_id  => $ID,
-                'id'               => -1
+            $twig_params = [
+                'cancreate' => static::canCreate(),
+                'id'        => $ID,
+                'rand'      => $rand,
+                'type'      => static::getType(),
+                'parenttype'=> static::$itemtype,
+                'items_id'  => static::$items_id,
+                'add_new_label' => __('Add a new cost'),
             ];
-            Ajax::updateItemJsCode(
-                "viewcost" . $ID . "_$rand",
-                $CFG_GLPI["root_doc"] . "/ajax/viewsubitem.php",
-                $params
-            );
-            echo "};";
-            echo "</script>\n";
-            if (static::canCreate()) {
-                echo "<div class='center firstbloc'>" .
-                   "<a class='btn btn-primary' href='javascript:viewAddCost" . $ID . "_$rand();'>";
-                echo __('Add a new cost') . "</a></div>\n";
-            }
+            echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
+                <div id='viewcost{{ id }}_{{ rand }}'></div>
+                <script>
+                    function viewAddCost{{ id }}_{{ rand }} (btn) {
+                        // Hide the triggering button
+                        $(btn).hide();
+                        {% do call('Ajax::updateItemJsCode', [
+                            'viewcost' ~ id ~ '_' ~ rand,
+                            config('root_doc') ~ '/ajax/viewsubitem.php',
+                            {
+                                'type': type,
+                                'parenttype': parenttype,
+                                (items_id): id,
+                                'id': -1
+                            }
+                        ]) %}
+                    }
+                </script>
+                {% if cancreate %}
+                    <div class="text-center mt-1 mb-3">
+                        <button type="button" class="btn btn-primary" onclick="viewAddCost{{ id }}_{{ rand }}(this);">
+                            {{ add_new_label }}
+                        </button>
+                    </div>
+                {% endif %}
+TWIG, $twig_params);
+
         }
 
         $total          = 0;
@@ -594,132 +548,149 @@ abstract class CommonITILCost extends CommonDBChild
         $total_fixed    = 0;
         $total_material = 0;
 
-        echo "<table class='tab_cadre_fixehov'>";
-        echo "<tr class='noHover'>";
         if ($forproject) {
-            echo "<th colspan='10'>" . _n('Ticket cost', 'Ticket costs', count($iterator)) . "</th>";
+            $super_header = _n('Ticket cost', 'Ticket costs', count($iterator));
         } else {
-            echo "<th colspan='7'>" . self::getTypeName(count($iterator)) . "</th>";
-            echo "<th>" . __('Item duration') . "</th>";
-            echo "<th>" . CommonITILObject::getActionTime($item->fields['actiontime']) . "</th>";
+            $super_header = sprintf(__('%1$s: %2$s'), __('Item duration'), CommonITILObject::getActionTime($item->fields['actiontime']));
         }
-        echo "</tr>";
 
-        if (count($iterator)) {
-            echo "<tr>";
-            if ($forproject) {
-                echo "<th>" . Ticket::getTypeName(1) . "</th>";
-                $ticket = new Ticket();
-            }
-            echo "<th>" . __('Name') . "</th>";
-            echo "<th>" . __('Begin date') . "</th>";
-            echo "<th>" . __('End date') . "</th>";
-            echo "<th>" . Budget::getTypeName(1) . "</th>";
-            echo "<th>" . __('Duration') . "</th>";
-            echo "<th>" . __('Time cost') . "</th>";
-            echo "<th>" . __('Fixed cost') . "</th>";
-            echo "<th>" . __('Material cost') . "</th>";
-            echo "<th>" . __('Total cost') . "</th>";
-            echo "</tr>";
+        $entries = [];
+        $ticket = new Ticket();
+        $budget = new Budget();
+        $ticket_links = [];
+        $budget_links = [];
+        foreach ($iterator as $data) {
+             $name = (empty($data['name']) ? sprintf(__('%1$s (%2$s)'), $data['name'], $data['id']) : $data['name']);
 
-            Session::initNavigateListItems(
-                static::getType(),
-                //TRANS : %1$s is the itemtype name,
-                           //        %2$s is the name of the item (used for headings of a list)
-                                          sprintf(
-                                              __('%1$s = %2$s'),
-                                              $item->getTypeName(1),
-                                              $item->getName()
-                                          )
-            );
-
-            foreach ($iterator as $data) {
-                echo "<tr class='tab_bg_2' " .
-                     ($canedit
-                     ? "style='cursor:pointer' onClick=\"viewEditCost" . $data[static::$items_id] . "_" .
-                        $data['id'] . "_$rand();\"" : '') . ">";
-                 $name = (empty($data['name']) ? sprintf(
-                     __('%1$s (%2$s)'),
-                     $data['name'],
-                     $data['id']
-                 )
-                                          : $data['name']);
-
-                if ($forproject) {
-                     $ticket->getFromDB($data['tickets_id']);
-                     echo "<td>" . $ticket->getLink() . "</td>";
-                }
-                 echo "<td>";
-                 printf(
-                     __('%1$s %2$s'),
-                     $name,
-                     Html::showToolTip($data['comment'], ['display' => false])
-                 );
-                if ($canedit) {
-                     echo "\n<script type='text/javascript' >\n";
-                     echo "function viewEditCost" . $data[static::$items_id] . "_" . $data["id"] . "_$rand() {\n";
-                     $params = ['type'            => static::getType(),
-                         'parenttype'       => static::$itemtype,
-                         static::$items_id  => $data[static::$items_id],
-                         'id'               => $data["id"]
-                     ];
-                     Ajax::updateItemJsCode(
-                         "viewcost" . $ID . "_$rand",
-                         $CFG_GLPI["root_doc"] . "/ajax/viewsubitem.php",
-                         $params
-                     );
-                     echo "};";
-                     echo "</script>\n";
-                }
-                 echo "</td>";
-                 echo "<td>" . Html::convDate($data['begin_date']) . "</td>";
-                 echo "<td>" . Html::convDate($data['end_date']) . "</td>";
-                 echo "<td>" . Dropdown::getDropdownName('glpi_budgets', $data['budgets_id']) . "</td>";
-                 echo "<td>" . CommonITILObject::getActionTime($data['actiontime']) . "</td>";
-                 $total_time += $data['actiontime'];
-                 echo "<td class='numeric'>" . Html::formatNumber($data['cost_time']) . "</td>";
-                 $total_costtime += ($data['actiontime'] * $data['cost_time'] / HOUR_TIMESTAMP);
-                 echo "<td class='numeric'>" . Html::formatNumber($data['cost_fixed']) . "</td>";
-                 $total_fixed += $data['cost_fixed'];
-                 echo "<td class='numeric'>" . Html::formatNumber($data['cost_material']) . "</td>";
-                 $total_material += $data['cost_material'];
-                 $cost            = self::computeTotalCost(
-                     $data['actiontime'],
-                     $data['cost_time'],
-                     $data['cost_fixed'],
-                     $data['cost_material']
-                 );
-                 echo "<td class='numeric'>" . Html::formatNumber($cost) . "</td>";
-                 $total += $cost;
-                 echo "</tr>";
-                 Session::addToNavigateListItems(static::getType(), $data['id']);
-            }
-            $colspan = 4;
-            if ($forproject) {
-                $colspan++;
-            }
-            echo "<tr class='b noHover'><td colspan='$colspan' class='right'>" . __('Total') . '</td>';
-            echo "<td>" . CommonITILObject::getActionTime($total_time) . "</td>";
-            echo "<td class='numeric'>" . Html::formatNumber($total_costtime) . "</td>";
-            echo "<td class='numeric'>" . Html::formatNumber($total_fixed) . '</td>';
-            echo "<td class='numeric'>" . Html::formatNumber($total_material) . '</td>';
-            echo "<td class='numeric'>" . Html::formatNumber($total) . '</td></tr>';
-        } else {
-            echo "<tr><th colspan='9'>" . __('No item found') . "</th></tr>";
+             $total_time += $data['actiontime'];
+             $total_costtime += ($data['actiontime'] * $data['cost_time'] / HOUR_TIMESTAMP);
+             $total_fixed += $data['cost_fixed'];
+             $total_material += $data['cost_material'];
+             $cost            = self::computeTotalCost(
+                 $data['actiontime'],
+                 $data['cost_time'],
+                 $data['cost_fixed'],
+                 $data['cost_material']
+             );
+             $total += (float) $cost;
+             if (!array_key_exists($data['budgets_id'], $budget_links)) {
+                 $budget->getFromDB($data['budgets_id']);
+                 $budget_links[$data['budgets_id']] = $budget->getLink();
+             }
+             $entry = [
+                 'itemtype' => static::getType(),
+                 'id'       => $data['id'],
+                 'name'     => sprintf(__('%1$s %2$s'), $name, Html::showToolTip($data['comment'], ['display' => false])),
+                 'begin_date' => $data['begin_date'],
+                 'end_date' => $data['end_date'],
+                 'budget' => $budget_links[$data['budgets_id']],
+                 'actiontime' => CommonITILObject::getActionTime($data['actiontime']),
+                 'cost_time' => $data['cost_time'],
+                 'cost_fixed' => $data['cost_fixed'],
+                 'cost_material' => $data['cost_material'],
+                 'totalcost' => $cost,
+             ];
+             if ($forproject) {
+                 if (!array_key_exists($data[static::$items_id], $ticket_links)) {
+                     $ticket->getFromDB($data[static::$items_id]);
+                     $ticket_links[$data[static::$items_id]] = $ticket->getLink();
+                 }
+                 $entry['ticket'] = $ticket_links[$data[static::$items_id]];
+             }
+             $entries[] = $entry;
         }
-        echo "</table>";
-        echo "</div><br>";
+
+        $columns = [
+            'name' => __('Name'),
+            'begin_date' => __('Begin date'),
+            'end_date' => __('End date'),
+            'budget' => Budget::getTypeName(1),
+            'actiontime' => __('Duration'),
+            'cost_time' => __('Time cost'),
+            'cost_fixed' => __('Fixed cost'),
+            'cost_material' => __('Material cost'),
+            'totalcost' => __('Total cost'),
+        ];
+        $footer = [
+            'name' => '',
+            'begin_date' => '',
+            'end_date' => '',
+            'budget' => '',
+            'actiontime' => CommonITILObject::getActionTime($total_time),
+            'cost_time' => Html::formatNumber($total_costtime),
+            'cost_fixed' => Html::formatNumber($total_fixed),
+            'cost_material' => Html::formatNumber($total_material),
+            'totalcost' => Html::formatNumber($total),
+        ];
+        if ($forproject) {
+            $columns = [
+                'ticket' => Ticket::getTypeName(1)
+            ] + $columns;
+            $footer = [
+                'ticket' => '',
+            ] + $footer;
+        }
+        TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
+            'datatable_id' => 'datatable_costs' . $ID . $rand,
+            'is_tab' => true,
+            'nofilter' => true,
+            'nopager' => true,
+            'super_header' => $super_header,
+            'columns' => $columns,
+            'formatters' => [
+                'ticket' => 'raw_html',
+                'name' => 'raw_html',
+                'begin_date' => 'date',
+                'end_date' => 'date',
+                'budget' => 'raw_html',
+                'cost_time' => 'number',
+                'cost_fixed' => 'number',
+                'cost_material' => 'number',
+                'totalcost' => 'number',
+            ],
+            'footers' => [$footer],
+            'entries' => $entries,
+            'row_class' => $canedit ? 'cursor-pointer' : '',
+            'total_number' => count($entries),
+            'filtered_number' => count($entries),
+            'showmassiveactions' => false,
+        ]);
+        if ($canedit) {
+            $cost_class = static::class;
+            $parent_class = static::$itemtype;
+            $items_id_field = static::$items_id;
+            echo Html::scriptBlock(<<<JS
+                $(() => {
+                    $('#datatable_costs{$ID}{$rand}').on('click', 'tbody tr', (e) => {
+                        //ignore click in first column (the massive action checkbox)
+                        if ($(e.target).closest('td').is('td:first-child')) {
+                            return;
+                        }
+                        const cost_id = $(e.currentTarget).data('id');
+                        if (cost_id) {
+                            $('#viewcost{$ID}_{$rand}').load('/ajax/viewsubitem.php',{
+                                type: "{$cost_class}",
+                                parenttype: "{$parent_class}",
+                                {$items_id_field}: $ID,
+                                id: cost_id
+                            });
+                        }
+                    });
+                });
+JS);
+
+        }
         return $total;
     }
-
 
     /**
      * Get costs summary values
      *
-     * @param $type    string  type
-     * @param $ID      integer ID of the ticket
+     * @param string $type type
+     * @param integer $ID ID of the ticket
      *
      * @return array of costs and actiontime
+     * @used-by src/NotificationTargetCommonITILObject.php
      **/
     public static function getCostsSummary($type, $ID)
     {
@@ -728,6 +699,12 @@ abstract class CommonITILCost extends CommonDBChild
 
         $result = $DB->request(
             [
+                'SELECT'    => [
+                    'actiontime',
+                    'cost_time',
+                    'cost_fixed',
+                    'cost_material'
+                ],
                 'FROM'      => getTableForItemType($type),
                 'WHERE'     => [
                     static::$items_id      => $ID,
@@ -767,21 +744,15 @@ abstract class CommonITILCost extends CommonDBChild
     /**
      * Computer total cost of a item
      *
-     * @param $actiontime      float    actiontime
-     * @param $cost_time       float    time cost
-     * @param $cost_fixed      float    fixed cost
-     * @param $cost_material   float    material cost
-     * @param $edit            boolean  used for edit of computation ? (true by default)
+     * @param float $actiontime actiontime
+     * @param float $cost_time time cost
+     * @param float $cost_fixed fixed cost
+     * @param float $cost_material material cost
+     * @param boolean $edit used for edit of computation ? (true by default)
      *
      * @return string total cost formatted string
      **/
-    public static function computeTotalCost(
-        $actiontime,
-        $cost_time,
-        $cost_fixed,
-        $cost_material,
-        $edit = true
-    ) {
+    public static function computeTotalCost($actiontime, $cost_time, $cost_fixed, $cost_material, $edit = true) {
 
         return Html::formatNumber(
             ($actiontime * $cost_time / HOUR_TIMESTAMP) + $cost_fixed + $cost_material,

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -615,7 +615,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
     /**
      * Get all linked tickets for a project
      *
-     * @param $ID        integer  Id of the project
+     * @param integer $ID Id of the project
      *
      * @return array of tickets
      **/

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -37,11 +37,13 @@
       {{ __('No data') }}
    </div>
 {% else %}
-    {{ include('components/pager.html.twig', {
-        'count': filtered_number,
-        'additional_params': additional_params ~ '&sort=' ~ sort ~ '&order=' ~ order
-    }) }}
     {% set total_cols = columns|length + (showmassiveactions ? 1 : 0) + (nofilter ? 0 : 1) %}
+    {% if not nopager %}
+        {{ include('components/pager.html.twig', {
+            'count': filtered_number,
+            'additional_params': additional_params ~ '&sort=' ~ sort ~ '&order=' ~ order
+        }) }}
+    {% endif %}
 
     <div class="table-responsive" {% if showmassiveactions %} id="{{ massiveactionparams['container'] }}" {% endif %}>
         {% if showmassiveactions %}
@@ -196,6 +198,8 @@
                                             {{ call("Html::convDateTime", [entry[colkey]])|raw }}
                                         {% elseif formatter == "bytesize" %}
                                             {{ call("Toolbox::getSize", [entry[colkey]])|raw }}
+                                        {% elseif formatter == 'number' %}
+                                            {{ entry[colkey]|formatted_number }}
                                         {% elseif formatter == "raw_html" %}
                                             {{ entry[colkey]|raw }}
                                         {% elseif formatter == 'avatar' %}
@@ -232,13 +236,26 @@
                     </tr>
                 {% endif %}
             </tbody>
+            {% if footers %}
+                <tfoot class="{{ footer_class|default('') }}">
+                    {% for footer in footers %}
+                        <tr>
+                            {% for footer_col, footerval in footer %}
+                                <td>{{ footerval }}</td>
+                            {% endfor %}
+                        </tr>
+                    {% endfor %}
+                </tfoot>
+            {% endif %}
         </table>
     </div>
 
-    {% set limitdropdown = include('components/dropdown/limit.html.twig') %}
-    <div class="ms-auto d-inline-flex align-items-center d-none d-md-block my-2">
-        {{ __('Show %s entries')|format(limitdropdown)|raw }}
-    </div>
+    {% if not nopager %}
+        {% set limitdropdown = include('components/dropdown/limit.html.twig') %}
+        <div class="ms-auto d-inline-flex align-items-center d-none d-md-block my-2">
+            {{ __('Show %s entries')|format(limitdropdown)|raw }}
+        </div>
+    {% endif %}
 
     <script type="text/javascript">
     $(function() {

--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -234,16 +234,13 @@
     {% endif %}
 
     {# Do not handle this in the input macro (would show a plain checkbox to clear) #}
-    {% set clearable = options.clearable %}
-    {% set options = options|merge({
-        clearable: false
-    }) %}
     <div class="btn-group flex-grow-1 flatpickr" id="{{ options.id }}">
         {{ _self.input(name, value, options|merge({
             'type': 'text',
             'id': options.id ~ '_input',
             'additional_attributes': {'data-input': ''},
             'input_addclass': options.input_addclass ~ final_expiration_class
+            'clearable': false
         })) }}
 
         {% if not options.readonly %}
@@ -252,7 +249,7 @@
                 <i class="{{ calendar_icon }}"></i>
             </button>
             {# maybeempty has no distinct purpose, but it was here first #}
-            {% if clearable or options.maybeempty %}
+            {% if options.clearable or options.maybeempty %}
                 <i class="input-group-text fas fa-times-circle pointer" data-clear
                     title="{{ __('Clear') }}"></i>
             {% endif %}

--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -232,6 +232,10 @@
         {% endif %}
     {% endif %}
 
+    {% set clearable = options.clearable|default('false') %}
+    {% set options = options|merge({
+        clearable: false
+    }) %}
     <div class="btn-group flex-grow-1 flatpickr" id="{{ options.id }}">
         {{ _self.input(name, value, options|merge({
             'type': 'text',
@@ -245,10 +249,9 @@
             <button type="button" class="btn btn-outline-secondary btn-sm" data-toggle>
                 <i class="{{ calendar_icon }}"></i>
             </button>
-            {% if options.maybeempty %}
-                <button type="button" class="btn btn-outline-secondary btn-sm" title="{{ __('Clear') }}">
-                    <i class="ti ti-circle-x-filled" data-clear></i>
-                </button>
+            {% if clearable %}
+                <i class="input-group-text fas fa-times-circle pointer" data-clear
+                    title="{{ __('Clear') }}"></i>
             {% endif %}
         {% endif %}
     </div>

--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -209,6 +209,7 @@
         'rand': random(),
         'enableTime': false,
         'checkIsExpired ': false,
+        'clearable': false,
     }|merge(options) %}
 
     {% set options = {
@@ -232,7 +233,7 @@
         {% endif %}
     {% endif %}
 
-    {% set clearable = options.clearable|default('false') %}
+    {# Do not handle this in the input macro (would show a plain checkbox to clear) #}
     {% set options = options|merge({
         clearable: false
     }) %}
@@ -249,7 +250,8 @@
             <button type="button" class="btn btn-outline-secondary btn-sm" data-toggle>
                 <i class="{{ calendar_icon }}"></i>
             </button>
-            {% if clearable %}
+            {# maybeempty has no distinct purpose, but it was here first #}
+            {% if options.clearable or options.maybeempty %}
                 <i class="input-group-text fas fa-times-circle pointer" data-clear
                     title="{{ __('Clear') }}"></i>
             {% endif %}

--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -233,7 +233,6 @@
         {% endif %}
     {% endif %}
 
-    {# Do not handle this in the input macro (would show a plain checkbox to clear) #}
     <div class="btn-group flex-grow-1 flatpickr" id="{{ options.id }}">
         {{ _self.input(name, value, options|merge({
             'type': 'text',

--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -234,6 +234,7 @@
     {% endif %}
 
     {# Do not handle this in the input macro (would show a plain checkbox to clear) #}
+    {% set clearable = options.clearable %}
     {% set options = options|merge({
         clearable: false
     }) %}
@@ -251,7 +252,7 @@
                 <i class="{{ calendar_icon }}"></i>
             </button>
             {# maybeempty has no distinct purpose, but it was here first #}
-            {% if options.clearable or options.maybeempty %}
+            {% if clearable or options.maybeempty %}
                 <i class="input-group-text fas fa-times-circle pointer" data-clear
                     title="{{ __('Clear') }}"></i>
             {% endif %}

--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -238,7 +238,7 @@
             'type': 'text',
             'id': options.id ~ '_input',
             'additional_attributes': {'data-input': ''},
-            'input_addclass': options.input_addclass ~ final_expiration_class
+            'input_addclass': options.input_addclass ~ final_expiration_class,
             'clearable': false
         })) }}
 

--- a/templates/pages/management/budget.html.twig
+++ b/templates/pages/management/budget.html.twig
@@ -33,7 +33,6 @@
 
 {% extends 'generic_show_form.html.twig' %}
 {% import 'components/form/fields_macros.html.twig' as fields %}
-{% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
 
 {% block form_fields %}
     {{ fields.textField('name', item.fields['name'], __('Name')) }}

--- a/templates/pages/management/budget.html.twig
+++ b/templates/pages/management/budget.html.twig
@@ -1,0 +1,59 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% extends 'generic_show_form.html.twig' %}
+{% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
+
+{% block form_fields %}
+    {{ fields.textField('name', item.fields['name'], __('Name')) }}
+    {{ fields.dropdownField('BudgetType', 'budgettypes_id', item.fields['budgettypes_id'], _n('Type', 'Types', 1)) }}
+
+    {{ fields.numberField('value', item.fields['value'], __('Value'), {
+        min: 0,
+        max: constant('PHP_INT_MAX'),
+        step: 0.0001
+    }) }}
+    {{ fields.textareaField('comment', item.fields['comment'], __('Comments')) }}
+
+    {{ fields.dateField('begin_date', item.fields['begin_date'], __('Begin date'), {
+        clearable: true
+    }) }}
+    {{ fields.dateField('end_date', item.fields['end_date'], __('End date'), {
+        clearable: true
+    }) }}
+
+    {{ fields.dropdownField('Location', 'locations_id', item.fields['locations_id'], 'Location'|itemtype_name, {
+        entity: item.fields['entities_id'],
+    }) }}
+{% endblock %}

--- a/templates/pages/management/cost.html.twig
+++ b/templates/pages/management/cost.html.twig
@@ -61,7 +61,7 @@
         step: 0.0001
     }) }}
 
-    {{ fields.textareaField('comment', item.fields['comment'], __('Comment')) }}
+    {{ fields.textareaField('comment', item.fields['comment'], _n('Comment', 'Comments', get_plural_number())) }}
     {{ fields.numberField('cost_fixed', item.fields['cost_fixed'], __('Fixed cost'), {
         min: 0,
         max: constant('PHP_INT_MAX'),

--- a/templates/pages/management/cost.html.twig
+++ b/templates/pages/management/cost.html.twig
@@ -1,0 +1,77 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% extends 'generic_show_form.html.twig' %}
+{% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
+
+{% block form_fields %}
+    {{ inputs.hidden(items_id_field, parent_id) }}
+    {{ fields.textField('name', item.fields['name'], __('Name')) }}
+    {{ fields.dropdownField('Budget', 'budgets_id', item.fields['budgets_id'], 'Budget'|itemtype_name(1), {
+        entity: item.fields['entities_id'],
+    }) }}
+
+    {{ fields.dateField('begin_date', item.fields['begin_date'], __('Begin date'), {
+        clearable: true
+    }) }}
+    {{ fields.dropdownTimestampField('actiontime', item.fields['actiontime'], __('Duration'), {
+        addfirstminutes: true,
+        min: constant('DAY_TIMESTAMP'),
+        max: constant('DAY_TIMESTAMP') * 50,
+        step: constant('DAY_TIMESTAMP'),
+    }) }}
+
+    {{ fields.dateField('end_date', item.fields['end_date'], __('End date'), {
+        clearable: true
+    }) }}
+    {{ fields.numberField('cost_time', item.fields['cost_time'], __('Time cost'), {
+        min: 0,
+        max: constant('PHP_INT_MAX'),
+        step: 0.0001
+    }) }}
+
+    {{ fields.textareaField('comment', item.fields['comment'], __('Comment')) }}
+    {{ fields.numberField('cost_fixed', item.fields['cost_fixed'], __('Fixed cost'), {
+        min: 0,
+        max: constant('PHP_INT_MAX'),
+        step: 0.0001
+    }) }}
+    {{ fields.nullField() }}
+    {{ fields.numberField('cost_material', item.fields['cost_material'], __('Material cost'), {
+        min: 0,
+        max: constant('PHP_INT_MAX'),
+        step: 0.0001
+    }) }}
+
+{% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

- Migrate budget/cost UI to twig
- Refactor SQL queries for items/entities related to a budget
- Budget "Main" tab now shows negative values for "Total remaining in the budget" in parentheses instead of with a negative sign to align with typical accounting practices.
- Added flag to allow hiding the pager in datatables
- Fixed handling of a clearable `date` field.
- Added ability to specify a super-header and footers for datatables
- Some minor code cleanup/PHPDoc fixes