### PR TITLE
Unregister asset from global definition when a capacity is disabled

### DIFF
--- a/src/Asset/AssetDefinitionManager.php
+++ b/src/Asset/AssetDefinitionManager.php
@@ -112,10 +112,6 @@ final class AssetDefinitionManager
      */
     public function boostrapAssets(): void
     {
-        /** @var array $CFG_GLPI */
-        global $CFG_GLPI;
-
-
         foreach ($this->getDefinitions() as $definition) {
             if (!$definition->isActive()) {
                 continue;

--- a/src/Asset/Capacity/AbstractCapacity.php
+++ b/src/Asset/Capacity/AbstractCapacity.php
@@ -38,8 +38,6 @@ namespace Glpi\Asset\Capacity;
 use DisplayPreference;
 use Glpi\Asset\Asset;
 use Log;
-use Profile;
-use ProfileRight;
 
 /**
  * Abstract capacity that provides, among others, an empty implementation
@@ -221,5 +219,42 @@ abstract class AbstractCapacity implements CapacityInterface
         }
 
         return $ids;
+    }
+
+    /**
+     * Register the given itemtype to a type configuration.
+     *
+     * @param string $config_name
+     * @param string $itemtype
+     * @return void
+     */
+    protected function registerToTypeConfig(string $config_name, string $itemtype): void
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        if (!in_array($itemtype, $CFG_GLPI[$config_name])) {
+            $CFG_GLPI[$config_name][] = $itemtype;
+        }
+    }
+
+    /**
+     * Unregister the given itemtype from a type configuration.
+     *
+     * @param string $config_name
+     * @param string $itemtype
+     * @return void
+     */
+    protected function unregisterFromTypeConfig(string $config_name, string $itemtype): void
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        $CFG_GLPI[$config_name] = array_values(
+            array_diff(
+                $CFG_GLPI[$config_name],
+                [$itemtype]
+            )
+        );
     }
 }

--- a/src/Asset/Capacity/HasDocumentsCapacity.php
+++ b/src/Asset/Capacity/HasDocumentsCapacity.php
@@ -49,16 +49,16 @@ class HasDocumentsCapacity extends AbstractCapacity
 
     public function onClassBootstrap(string $classname): void
     {
-        /** @var array $CFG_GLPI */
-        global $CFG_GLPI;
-
-        $CFG_GLPI['document_types'][] = $classname;
+        $this->registerToTypeConfig('document_types', $classname);
 
         CommonGLPI::registerStandardTab($classname, Document_Item::class, 55);
     }
 
     public function onCapacityDisabled(string $classname): void
     {
+        // Unregister from document types
+        $this->unregisterFromTypeConfig('document_types', $classname);
+
         // Delete relations to documents
         $document_item = new Document_Item();
         $document_item->deleteByCriteria(['itemtype' => $classname], force: true, history: false);

--- a/src/Asset/Capacity/HasInfocomCapacity.php
+++ b/src/Asset/Capacity/HasInfocomCapacity.php
@@ -47,16 +47,16 @@ class HasInfocomCapacity extends AbstractCapacity
 
     public function onClassBootstrap(string $classname): void
     {
-        /** @var array $CFG_GLPI */
-        global $CFG_GLPI;
-
-        $CFG_GLPI['infocom_types'][] = $classname;
+        $this->registerToTypeConfig('infocom_types', $classname);
 
         CommonGLPI::registerStandardTab($classname, Infocom::class, 50);
     }
 
     public function onCapacityDisabled(string $classname): void
     {
+        // Unregister from infocom types
+        $this->unregisterFromTypeConfig('infocom_types', $classname);
+
         // Delete related infocom data
         $infocom = new Infocom();
         $infocom->deleteByCriteria(['itemtype' => $classname], force: true, history: false);

--- a/src/Asset/Capacity/HasOperatingSystemCapacity.php
+++ b/src/Asset/Capacity/HasOperatingSystemCapacity.php
@@ -50,11 +50,7 @@ class HasOperatingSystemCapacity extends AbstractCapacity
     // #Override
     public function onClassBootstrap(string $classname): void
     {
-        /** @var array $CFG_GLPI */
-        global $CFG_GLPI;
-
-        // Allow our item to be linked to an operating system
-        $CFG_GLPI['operatingsystem_types'][] = $classname;
+        $this->registerToTypeConfig('operatingsystem_types', $classname);
 
         // Register the operating system tab into our item
         CommonGLPI::registerStandardTab(
@@ -73,14 +69,8 @@ class HasOperatingSystemCapacity extends AbstractCapacity
     // #Override
     public function onCapacityDisabled(string $classname): void
     {
-        /** @var array $CFG_GLPI */
-        global $CFG_GLPI;
-
         // Unregister from operating system types
-        $CFG_GLPI['operatingsystem_types'] = array_diff(
-            $CFG_GLPI['operatingsystem_types'],
-            [$classname]
-        );
+        $this->unregisterFromTypeConfig('operatingsystem_types', $classname);
 
         // Delete related operating system data
         $item_os = new Item_OperatingSystem();

--- a/src/Asset/Capacity/HasVolumesCapacity.php
+++ b/src/Asset/Capacity/HasVolumesCapacity.php
@@ -53,16 +53,16 @@ class HasVolumesCapacity extends AbstractCapacity
 
     public function onClassBootstrap(string $classname): void
     {
-        /** @var array $CFG_GLPI */
-        global $CFG_GLPI;
-
-        $CFG_GLPI['disk_types'][] = $classname;
+        $this->registerToTypeConfig('disk_types', $classname);
 
         CommonGLPI::registerStandardTab($classname, Item_Disk::class, 55);
     }
 
     public function onCapacityDisabled(string $classname): void
     {
+        // Unregister from operating system types
+        $this->unregisterFromTypeConfig('disk_types', $classname);
+
         //Delete related disks
         $disks = new Item_Disk();
         $disks->deleteByCriteria(['itemtype' => $classname], force: true, history: false);

--- a/tests/functional/Glpi/Asset/Capacity/HasDocumentsCapacity.php
+++ b/tests/functional/Glpi/Asset/Capacity/HasDocumentsCapacity.php
@@ -113,6 +113,9 @@ class HasDocumentsCapacity extends DbTestCase
 
     public function testCapacityDeactivation(): void
     {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
         $root_entity_id = getItemByTypeName(Entity::class, '_test_root_entity', true);
 
         $definition_1 = $this->initAssetDefinition(
@@ -187,24 +190,28 @@ class HasDocumentsCapacity extends DbTestCase
             'itemtype_link' => $classname_2,
         ];
 
-        // Ensure relation, display preferences and logs exists
+        // Ensure relation, display preferences and logs exists, and class is registered to global config
         $this->object(Document_Item::getById($document_item_1->getID()))->isInstanceOf(Document_Item::class);
         $this->object(DisplayPreference::getById($displaypref_1->getID()))->isInstanceOf(DisplayPreference::class);
         $this->integer(countElementsInTable(Log::getTable(), $item_1_logs_criteria))->isEqualTo(1);
         $this->object(Document_Item::getById($document_item_2->getID()))->isInstanceOf(Document_Item::class);
         $this->object(DisplayPreference::getById($displaypref_2->getID()))->isInstanceOf(DisplayPreference::class);
         $this->integer(countElementsInTable(Log::getTable(), $item_2_logs_criteria))->isEqualTo(1);
+        $this->array($CFG_GLPI['document_types'])->contains($classname_1);
+        $this->array($CFG_GLPI['document_types'])->contains($classname_2);
 
-        // Disable capacity and check that relations have been cleaned
+        // Disable capacity and check that relations have been cleaned, and class is unregistered from global config
         $this->boolean($definition_1->update(['id' => $definition_1->getID(), 'capacities' => []]))->isTrue();
         $this->boolean(Document_Item::getById($document_item_1->getID()))->isFalse();
         $this->boolean(DisplayPreference::getById($displaypref_1->getID()))->isFalse();
         $this->integer(countElementsInTable(Log::getTable(), $item_1_logs_criteria))->isEqualTo(0);
+        $this->array($CFG_GLPI['document_types'])->notContains($classname_1);
 
-        // Ensure relations and logs are preserved for other definition
+        // Ensure relations, logs and global registration are preserved for other definition
         $this->object(Document_Item::getById($document_item_2->getID()))->isInstanceOf(Document_Item::class);
         $this->object(DisplayPreference::getById($displaypref_2->getID()))->isInstanceOf(DisplayPreference::class);
         $this->integer(countElementsInTable(Log::getTable(), $item_2_logs_criteria))->isEqualTo(1);
+        $this->array($CFG_GLPI['document_types'])->contains($classname_2);
     }
 
     public function test_Document_Item_getTypeItems(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

It will probably have no effect, except on edge cases, but as it was already done for the `HasOperatingSystem` capacity, I applied this behaviour to all capacities.