### PR TITLE
drop size field for database instances

### DIFF
--- a/install/migrations/update_10.0.x_to_10.1.0/databaseinstance.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/databaseinstance.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var \DBmysql $DB
+ * @var \Migration $migration
+ */
+
+// The size field seems to be unsused and rather a copy-paste from the glpi_databases table
+$migration->dropField('glpi_databaseinstances', 'size');

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9379,7 +9379,6 @@ CREATE TABLE `glpi_databaseinstances` (
   `version` varchar(255) NOT NULL DEFAULT '',
   `port` varchar(10) NOT NULL DEFAULT '',
   `path` varchar(255) NOT NULL DEFAULT '',
-  `size` int NOT NULL DEFAULT '0',
   `databaseinstancetypes_id` int unsigned NOT NULL DEFAULT '0',
   `databaseinstancecategories_id` int unsigned NOT NULL DEFAULT '0',
   `locations_id` int unsigned NOT NULL DEFAULT '0',

--- a/src/DatabaseInstance.php
+++ b/src/DatabaseInstance.php
@@ -317,11 +317,6 @@ class DatabaseInstance extends CommonDBTM
         if (isset($input['date_lastbackup']) && empty($input['date_lastbackup'])) {
             unset($input['date_lastbackup']);
         }
-
-        if (isset($input['size']) && empty($input['size'])) {
-            unset($input['size']);
-        }
-
         return $input;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

As discussed in #16364, the `size` field for DatabaseInstance seems unused and just a copy-paste from Database.