### PR TITLE
fix: translation in color palettes

### DIFF
--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -395,6 +395,8 @@
             showInput: true,
             preferredFormat: "hex",
             type: "text",
+            cancelText: "{{ __('Cancel') }}",
+            chooseText: "{{ __('Validate') }}",
             change: function(color) {
                 if (color !== null && color.getAlpha() !== 1) {
                     let hex = color.toHexString();


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !31313

Context: GLPI in English - browser in French

In the dashboards, when changing the color of a tile, the cancel/validate buttons remain in French, even though GLPI is in English.

![image](https://github.com/glpi-project/glpi/assets/8530352/0b209b60-e6d4-4543-bc21-5c6fe0db2b95)

