### PR TITLE
Fix asset definition deletion

### DIFF
--- a/src/Asset/AssetDefinition.php
+++ b/src/Asset/AssetDefinition.php
@@ -420,6 +420,14 @@ final class AssetDefinition extends CommonDBTM
         $this->update(['id' => $this->getID(), 'profiles' => $profiles]);
     }
 
+    public function cleanRelationData()
+    {
+        $asset_classname = $this->getConcreteClassName();
+        /** @var Asset $asset */
+        $asset = new $asset_classname();
+        $asset->deleteByCriteria(['assets_assetdefinitions_id' => $this->getID()], force: true, history: false);
+    }
+
     /**
      * Synchronize `profiles` field with `ProfileRights` entries.
      *

--- a/tests/functional/Glpi/Asset/AssetDefinition.php
+++ b/tests/functional/Glpi/Asset/AssetDefinition.php
@@ -284,4 +284,25 @@ class AssetDefinition extends DbTestCase
         $this->boolean($updated)->isFalse();
         $this->hasSessionMessages(ERROR, ['The system name cannot be changed.']);
     }
+
+    public function testDelete()
+    {
+        /** @var \Glpi\Asset\AssetDefinition $definition */
+        $definition = $this->initAssetDefinition('test');;
+        \Glpi\Asset\AssetDefinitionManager::getInstance()->boostrapAssets();
+
+        $this->createItem(
+            $definition->getConcreteClassName(),
+            [
+                'name' => 'test',
+            ]
+        );
+
+        $this->boolean($definition->delete([
+            'id' => $definition->getID(),
+        ]))->isTrue();
+        $this->array(getAllDataFromTable('glpi_assets_assets', [
+            'assets_assetdefinitions_id' => $definition->getID(),
+        ]))->size->isEqualTo(0);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Default behavior of `cleanRelationData` does not make sense in this case, and won't work with the unique class/table structure of the generic assets anyways. Because Assets and Definitions are linked in the RELATIONS global, it was trying to handle cleaning the assets here (or rather simply unlinking them despite the name).

```
[2024-01-22 13:15:00] glpiphplog.CRITICAL:   *** Uncaught Exception RuntimeException: Asset definition is expected to de defined in concrete class. in /var/www/html/fix95/src/Asset/Asset.php at line 67
  Backtrace :
  src/Asset/Asset.php:52                             Glpi\Asset\Asset::getDefinition()
  src/CommonDBTM.php:937                             Glpi\Asset\Asset->__construct()
  src/CommonDBTM.php:796                             CommonDBTM->cleanRelationData()
  src/CommonDBTM.php:2113                            CommonDBTM->deleteFromDB()
  front/asset/assetdefinition.form.php:94            CommonDBTM->delete()
  public/index.php:82                                require()
```