### PR TITLE
Custom asset models and types

### DIFF
--- a/front/asset/asset.form.php
+++ b/front/asset/asset.form.php
@@ -49,7 +49,7 @@ if (array_key_exists('id', $_REQUEST)) {
 } else {
     $definition = new AssetDefinition();
     $classname  = array_key_exists('class', $_GET) && $definition->getFromDBBySystemName((string)$_GET['class'])
-        ? $definition->getConcreteClassName()
+        ? $definition->getAssetClassName()
         : null;
     $asset      = $classname !== null && class_exists($classname)
         ? new $classname()

--- a/front/asset/asset.php
+++ b/front/asset/asset.php
@@ -41,7 +41,7 @@ include('../../inc/includes.php');
 
 $definition = new AssetDefinition();
 $classname  = array_key_exists('class', $_GET) && $definition->getFromDBBySystemName((string)$_GET['class'])
-    ? $definition->getConcreteClassName()
+    ? $definition->getAssetClassName()
     : null;
 
 if ($classname === null || !class_exists($classname)) {

--- a/front/asset/assetmodel.form.php
+++ b/front/asset/assetmodel.form.php
@@ -39,6 +39,7 @@
 
 use Glpi\Asset\AssetDefinition;
 use Glpi\Asset\AssetModel;
+use Glpi\Http\Response;
 
 include('../../inc/includes.php');
 
@@ -47,12 +48,16 @@ if (array_key_exists('id', $_REQUEST)) {
 } else {
     $definition = new AssetDefinition();
     $classname  = array_key_exists('class', $_GET) && $definition->getFromDBBySystemName((string)$_GET['class'])
-        ? $definition->getConcreteClassName()
+        ? $definition->getAssetModelClassName()
         : null;
-    $classname .= 'Model';
     $asset_model = $classname !== null && class_exists($classname)
         ? new $classname()
         : null;
 }
+
+if ($asset_model === null) {
+    Response::sendError(400, 'Bad request', Response::CONTENT_TYPE_TEXT_HTML);
+}
+
 $dropdown = $asset_model;
 include(GLPI_ROOT . "/front/dropdown.common.form.php");

--- a/front/asset/assetmodel.form.php
+++ b/front/asset/assetmodel.form.php
@@ -34,14 +34,25 @@
  */
 
 /**
- * @var \Migration $migration
+ * @var array $CFG_GLPI
  */
 
-$dc_model_dropdowns = [
-    'EnclosureModel', 'PeripheralModel', 'PDUModel', 'NetworkEquipmentModel', 'MonitorModel', 'ComputerModel',
-    'PassiveDCEquipmentModel'
-];
+use Glpi\Asset\AssetDefinition;
+use Glpi\Asset\AssetModel;
 
-foreach ($dc_model_dropdowns as $model_dropdown) {
-    $migration->changeSearchOption($model_dropdown, 130, 3);
+include('../../inc/includes.php');
+
+if (array_key_exists('id', $_REQUEST)) {
+    $asset_model = AssetModel::getById($_REQUEST['id']);
+} else {
+    $definition = new AssetDefinition();
+    $classname  = array_key_exists('class', $_GET) && $definition->getFromDBBySystemName((string)$_GET['class'])
+        ? $definition->getConcreteClassName()
+        : null;
+    $classname .= 'Model';
+    $asset_model = $classname !== null && class_exists($classname)
+        ? new $classname()
+        : null;
 }
+$dropdown = $asset_model;
+include(GLPI_ROOT . "/front/dropdown.common.form.php");

--- a/front/asset/assetmodel.php
+++ b/front/asset/assetmodel.php
@@ -34,14 +34,18 @@
  */
 
 use Glpi\Asset\AssetDefinition;
+use Glpi\Http\Response;
 
 include('../../inc/includes.php');
 
 $definition = new AssetDefinition();
 $classname  = array_key_exists('class', $_GET) && $definition->getFromDBBySystemName((string)$_GET['class'])
-    ? $definition->getConcreteClassName()
+    ? $definition->getAssetModelClassName()
     : null;
-$classname .= 'Model';
+
+if ($classname === null || !class_exists($classname)) {
+    Response::sendError(400, 'Bad request', Response::CONTENT_TYPE_TEXT_HTML);
+}
 
 $dropdown = new $classname();
 include(GLPI_ROOT . "/front/dropdown.common.php");

--- a/front/asset/assetmodel.php
+++ b/front/asset/assetmodel.php
@@ -33,15 +33,15 @@
  * ---------------------------------------------------------------------
  */
 
-/**
- * @var \Migration $migration
- */
+use Glpi\Asset\AssetDefinition;
 
-$dc_model_dropdowns = [
-    'EnclosureModel', 'PeripheralModel', 'PDUModel', 'NetworkEquipmentModel', 'MonitorModel', 'ComputerModel',
-    'PassiveDCEquipmentModel'
-];
+include('../../inc/includes.php');
 
-foreach ($dc_model_dropdowns as $model_dropdown) {
-    $migration->changeSearchOption($model_dropdown, 130, 3);
-}
+$definition = new AssetDefinition();
+$classname  = array_key_exists('class', $_GET) && $definition->getFromDBBySystemName((string)$_GET['class'])
+    ? $definition->getConcreteClassName()
+    : null;
+$classname .= 'Model';
+
+$dropdown = new $classname();
+include(GLPI_ROOT . "/front/dropdown.common.php");

--- a/front/asset/assettype.form.php
+++ b/front/asset/assettype.form.php
@@ -39,6 +39,7 @@
 
 use Glpi\Asset\AssetDefinition;
 use Glpi\Asset\AssetType;
+use Glpi\Http\Response;
 
 include('../../inc/includes.php');
 
@@ -47,12 +48,16 @@ if (array_key_exists('id', $_REQUEST)) {
 } else {
     $definition = new AssetDefinition();
     $classname  = array_key_exists('class', $_GET) && $definition->getFromDBBySystemName((string)$_GET['class'])
-        ? $definition->getConcreteClassName()
+        ? $definition->getAssetTypeClassName()
         : null;
-    $classname .= 'Type';
     $asset_type = $classname !== null && class_exists($classname)
         ? new $classname()
         : null;
 }
+
+if ($asset_type === null) {
+    Response::sendError(400, 'Bad request', Response::CONTENT_TYPE_TEXT_HTML);
+}
+
 $dropdown = $asset_type;
 include(GLPI_ROOT . "/front/dropdown.common.form.php");

--- a/front/asset/assettype.form.php
+++ b/front/asset/assettype.form.php
@@ -34,14 +34,25 @@
  */
 
 /**
- * @var \Migration $migration
+ * @var array $CFG_GLPI
  */
 
-$dc_model_dropdowns = [
-    'EnclosureModel', 'PeripheralModel', 'PDUModel', 'NetworkEquipmentModel', 'MonitorModel', 'ComputerModel',
-    'PassiveDCEquipmentModel'
-];
+use Glpi\Asset\AssetDefinition;
+use Glpi\Asset\AssetType;
 
-foreach ($dc_model_dropdowns as $model_dropdown) {
-    $migration->changeSearchOption($model_dropdown, 130, 3);
+include('../../inc/includes.php');
+
+if (array_key_exists('id', $_REQUEST)) {
+    $asset_type = AssetType::getById($_REQUEST['id']);
+} else {
+    $definition = new AssetDefinition();
+    $classname  = array_key_exists('class', $_GET) && $definition->getFromDBBySystemName((string)$_GET['class'])
+        ? $definition->getConcreteClassName()
+        : null;
+    $classname .= 'Type';
+    $asset_type = $classname !== null && class_exists($classname)
+        ? new $classname()
+        : null;
 }
+$dropdown = $asset_type;
+include(GLPI_ROOT . "/front/dropdown.common.form.php");

--- a/front/asset/assettype.php
+++ b/front/asset/assettype.php
@@ -34,14 +34,18 @@
  */
 
 use Glpi\Asset\AssetDefinition;
+use Glpi\Http\Response;
 
 include('../../inc/includes.php');
 
 $definition = new AssetDefinition();
 $classname  = array_key_exists('class', $_GET) && $definition->getFromDBBySystemName((string)$_GET['class'])
-    ? $definition->getConcreteClassName()
+    ? $definition->getAssetTypeClassName()
     : null;
-$classname .= 'Type';
+
+if ($classname === null || !class_exists($classname)) {
+    Response::sendError(400, 'Bad request', Response::CONTENT_TYPE_TEXT_HTML);
+}
 
 $dropdown = new $classname();
 include(GLPI_ROOT . "/front/dropdown.common.php");

--- a/front/asset/assettype.php
+++ b/front/asset/assettype.php
@@ -33,15 +33,15 @@
  * ---------------------------------------------------------------------
  */
 
-/**
- * @var \Migration $migration
- */
+use Glpi\Asset\AssetDefinition;
 
-$dc_model_dropdowns = [
-    'EnclosureModel', 'PeripheralModel', 'PDUModel', 'NetworkEquipmentModel', 'MonitorModel', 'ComputerModel',
-    'PassiveDCEquipmentModel'
-];
+include('../../inc/includes.php');
 
-foreach ($dc_model_dropdowns as $model_dropdown) {
-    $migration->changeSearchOption($model_dropdown, 130, 3);
-}
+$definition = new AssetDefinition();
+$classname  = array_key_exists('class', $_GET) && $definition->getFromDBBySystemName((string)$_GET['class'])
+    ? $definition->getConcreteClassName()
+    : null;
+$classname .= 'Type';
+
+$dropdown = new $classname();
+include(GLPI_ROOT . "/front/dropdown.common.php");

--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -103,6 +103,8 @@ $RELATION = [
 
     'glpi_assets_assetdefinitions' => [
         '_glpi_assets_assets' => 'assets_assetdefinitions_id',
+        '_glpi_assets_assetmodels' => 'assets_assetdefinitions_id',
+        '_glpi_assets_assettypes' => 'assets_assetdefinitions_id',
     ],
 
     'glpi_databaseinstancetypes' => [

--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -107,6 +107,14 @@ $RELATION = [
         '_glpi_assets_assettypes' => 'assets_assetdefinitions_id',
     ],
 
+    'glpi_assets_assetmodels' => [
+        'glpi_assets_assets' => 'assets_assetmodels_id',
+    ],
+
+    'glpi_assets_assettypes' => [
+        'glpi_assets_assets' => 'assets_assettypes_id',
+    ],
+
     'glpi_databaseinstancetypes' => [
         'glpi_databaseinstances' => 'databaseinstancetypes_id'
     ],

--- a/install/migrations/update_10.0.x_to_10.1.0/assets.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/assets.php
@@ -74,6 +74,8 @@ if (!$DB->tableExists('glpi_assets_assets')) {
         CREATE TABLE `glpi_assets_assets` (
             `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
             `assets_assetdefinitions_id` int {$default_key_sign} NOT NULL,
+            `assets_assetmodels_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+            `assets_assettypes_id` int {$default_key_sign} NOT NULL DEFAULT '0',
             `name` varchar(255) DEFAULT NULL,
             `comment` text,
             `serial` varchar(255) DEFAULT NULL,
@@ -94,6 +96,8 @@ if (!$DB->tableExists('glpi_assets_assets')) {
             `date_mod` timestamp NULL DEFAULT NULL,
             PRIMARY KEY (`id`),
             KEY `assets_assetdefinitions_id` (`assets_assetdefinitions_id`),
+            KEY `assets_assetmodels_id` (`assets_assetmodels_id`),
+            KEY `assets_assettypes_id` (`assets_assettypes_id`),
             KEY `name` (`name`),
             KEY `users_id` (`users_id`),
             KEY `groups_id` (`groups_id`),
@@ -110,6 +114,11 @@ if (!$DB->tableExists('glpi_assets_assets')) {
         ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;
 SQL;
     $DB->doQueryOrDie($query);
+} else {
+    $migration->addField('glpi_assets_assets', 'assets_assetmodels_id', 'fkey');
+    $migration->addKey('glpi_assets_assets', 'assets_assetmodels_id');
+    $migration->addField('glpi_assets_assets', 'assets_assettypes_id', 'fkey');
+    $migration->addKey('glpi_assets_assets', 'assets_assettypes_id');
 }
 
 if (!$DB->tableExists('glpi_assets_assetmodels')) {

--- a/install/migrations/update_10.0.x_to_10.1.0/assets.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/assets.php
@@ -111,3 +111,52 @@ if (!$DB->tableExists('glpi_assets_assets')) {
 SQL;
     $DB->doQueryOrDie($query);
 }
+
+if (!$DB->tableExists('glpi_assets_assetmodels')) {
+    $query = <<<SQL
+        CREATE TABLE `glpi_assets_assetmodels` (
+          `id` int unsigned NOT NULL AUTO_INCREMENT,
+          `assets_assetdefinitions_id` int {$default_key_sign} NOT NULL,
+          `name` varchar(255) DEFAULT NULL,
+          `comment` text,
+          `product_number` varchar(255) DEFAULT NULL,
+          `weight` int NOT NULL DEFAULT '0',
+          `required_units` int NOT NULL DEFAULT '1',
+          `depth` float NOT NULL DEFAULT '1',
+          `power_connections` int NOT NULL DEFAULT '0',
+          `power_consumption` int NOT NULL DEFAULT '0',
+          `is_half_rack` tinyint NOT NULL DEFAULT '0',
+          `picture_front` text,
+          `picture_rear` text,
+          `pictures` text,
+          `date_mod` timestamp NULL DEFAULT NULL,
+          `date_creation` timestamp NULL DEFAULT NULL,
+          PRIMARY KEY (`id`),
+          KEY `assets_assetdefinitions_id` (`assets_assetdefinitions_id`),
+          KEY `name` (`name`),
+          KEY `date_mod` (`date_mod`),
+          KEY `date_creation` (`date_creation`),
+          KEY `product_number` (`product_number`)
+        ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;
+SQL;
+    $DB->doQueryOrDie($query);
+}
+
+if (!$DB->tableExists('glpi_assets_assettypes')) {
+    $query = <<<SQL
+        CREATE TABLE `glpi_assets_assettypes` (
+          `id` int unsigned NOT NULL AUTO_INCREMENT,
+          `assets_assetdefinitions_id` int {$default_key_sign} NOT NULL,
+          `name` varchar(255) DEFAULT NULL,
+          `comment` text,
+          `date_mod` timestamp NULL DEFAULT NULL,
+          `date_creation` timestamp NULL DEFAULT NULL,
+          PRIMARY KEY (`id`),
+          KEY `assets_assetdefinitions_id` (`assets_assetdefinitions_id`),
+          KEY `name` (`name`),
+          KEY `date_mod` (`date_mod`),
+          KEY `date_creation` (`date_creation`)
+        ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;
+SQL;
+    $DB->doQueryOrDie($query);
+}

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9765,6 +9765,8 @@ DROP TABLE IF EXISTS `glpi_assets_assets`;
 CREATE TABLE `glpi_assets_assets` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `assets_assetdefinitions_id` int unsigned NOT NULL,
+  `assets_assetmodels_id` int unsigned NOT NULL DEFAULT '0',
+  `assets_assettypes_id` int unsigned NOT NULL DEFAULT '0',
   `name` varchar(255) DEFAULT NULL,
   `comment` text,
   `serial` varchar(255) DEFAULT NULL,
@@ -9785,6 +9787,8 @@ CREATE TABLE `glpi_assets_assets` (
   `date_mod` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `assets_assetdefinitions_id` (`assets_assetdefinitions_id`),
+  KEY `assets_assetmodels_id` (`assets_assetmodels_id`),
+  KEY `assets_assettypes_id` (`assets_assettypes_id`),
   KEY `name` (`name`),
   KEY `users_id` (`users_id`),
   KEY `groups_id` (`groups_id`),

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9800,4 +9800,45 @@ CREATE TABLE `glpi_assets_assets` (
   KEY `date_mod` (`date_mod`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
+DROP TABLE IF EXISTS `glpi_assets_assetmodels`;
+CREATE TABLE `glpi_assets_assetmodels` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `assets_assetdefinitions_id` int unsigned NOT NULL,
+  `name` varchar(255) DEFAULT NULL,
+  `comment` text,
+  `product_number` varchar(255) DEFAULT NULL,
+  `weight` int NOT NULL DEFAULT '0',
+  `required_units` int NOT NULL DEFAULT '1',
+  `depth` float NOT NULL DEFAULT '1',
+  `power_connections` int NOT NULL DEFAULT '0',
+  `power_consumption` int NOT NULL DEFAULT '0',
+  `is_half_rack` tinyint NOT NULL DEFAULT '0',
+  `picture_front` text,
+  `picture_rear` text,
+  `pictures` text,
+  `date_mod` timestamp NULL DEFAULT NULL,
+  `date_creation` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `assets_assetdefinitions_id` (`assets_assetdefinitions_id`),
+  KEY `name` (`name`),
+  KEY `date_mod` (`date_mod`),
+  KEY `date_creation` (`date_creation`),
+  KEY `product_number` (`product_number`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+
+DROP TABLE IF EXISTS `glpi_assets_assettypes`;
+CREATE TABLE `glpi_assets_assettypes` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `assets_assetdefinitions_id` int unsigned NOT NULL,
+  `name` varchar(255) DEFAULT NULL,
+  `comment` text,
+  `date_mod` timestamp NULL DEFAULT NULL,
+  `date_creation` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `assets_assetdefinitions_id` (`assets_assetdefinitions_id`),
+  KEY `name` (`name`),
+  KEY `date_mod` (`date_mod`),
+  KEY `date_creation` (`date_creation`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+
 SET FOREIGN_KEY_CHECKS=1;

--- a/src/Asset/Asset.php
+++ b/src/Asset/Asset.php
@@ -145,24 +145,30 @@ abstract class Asset extends CommonDBTM
         $search_options = array_merge($search_options, Location::rawSearchOptionsToAdd());
 
         /** @var AssetModel $asset_model_class */
-        $asset_model_class = static::class . 'Model';
+        $asset_model_class = $this->getDefinition()->getAssetModelClassName();
         /** @var AssetType $asset_type_class */
-        $asset_type_class = static::class . 'Type';
+        $asset_type_class = $this->getDefinition()->getAssetTypeClassName();
 
         $search_options[] = [
-            'id' => '4',
-            'table' => $asset_type_class::getTable(),
-            'field' => 'name',
-            'name' => $asset_type_class::getTypeName(1),
-            'datatype' => 'dropdown',
+            'id'        => '4',
+            'table'     => $asset_type_class::getTable(),
+            'field'     => 'name',
+            'name'      => $asset_type_class::getTypeName(1),
+            'datatype'  => 'dropdown',
+            // Search class could not be able to retrieve the concrete type class when using `getItemTypeForTable()`
+            // so we have to define an `itemtype` here.
+            'itemtype'  => $asset_type_class,
         ];
 
         $search_options[] = [
-            'id' => '40',
-            'table' => $asset_model_class::getTable(),
-            'field' => 'name',
-            'name' => $asset_model_class::getTypeName(1),
-            'datatype' => 'dropdown',
+            'id'        => '40',
+            'table'     => $asset_model_class::getTable(),
+            'field'     => 'name',
+            'name'      => $asset_model_class::getTypeName(1),
+            'datatype'  => 'dropdown',
+            // Search class could not be able to retrieve the concrete model class when using `getItemTypeForTable()`
+            // so we have to define an `itemtype` here.
+            'itemtype'  => $asset_model_class,
         ];
 
         $search_options[] = [

--- a/src/Asset/Asset.php
+++ b/src/Asset/Asset.php
@@ -91,13 +91,13 @@ abstract class Asset extends CommonDBTM
     public static function getSearchURL($full = true)
     {
         return Toolbox::getItemTypeSearchURL(self::class, $full)
-            . '?class=' . static::getDefinition()->getConcreteClassName(false);
+            . '?class=' . static::getDefinition()->getAssetClassName(false);
     }
 
     public static function getFormURL($full = true)
     {
         return Toolbox::getItemTypeFormURL(self::class, $full)
-            . '?class=' . static::getDefinition()->getConcreteClassName(false);
+            . '?class=' . static::getDefinition()->getAssetClassName(false);
     }
 
     public static function getById(?int $id)
@@ -129,7 +129,7 @@ abstract class Asset extends CommonDBTM
         }
 
         // Instanciate concrete class
-        $asset_class = $definition->getConcreteClassName(true);
+        $asset_class = $definition->getAssetClassName(true);
         $asset = new $asset_class();
         if (!$asset->getFromDB($id)) {
             return false;

--- a/src/Asset/Asset.php
+++ b/src/Asset/Asset.php
@@ -64,7 +64,7 @@ abstract class Asset extends CommonDBTM
         $definition = static::$definition ?? null;
 
         if (!($definition instanceof AssetDefinition)) {
-            throw new \RuntimeException('Asset definition is expected to de defined in concrete class.');
+            throw new \RuntimeException('Asset definition is expected to be defined in concrete class.');
         }
 
         return $definition;
@@ -144,9 +144,26 @@ abstract class Asset extends CommonDBTM
 
         $search_options = array_merge($search_options, Location::rawSearchOptionsToAdd());
 
-        // TODO 4 for type
+        /** @var AssetModel $asset_model_class */
+        $asset_model_class = static::class . 'Model';
+        /** @var AssetType $asset_type_class */
+        $asset_type_class = static::class . 'Type';
 
-        // TODO 40 for model
+        $search_options[] = [
+            'id' => '4',
+            'table' => $asset_type_class::getTable(),
+            'field' => 'name',
+            'name' => $asset_type_class::getTypeName(1),
+            'datatype' => 'dropdown',
+        ];
+
+        $search_options[] = [
+            'id' => '40',
+            'table' => $asset_model_class::getTable(),
+            'field' => 'name',
+            'name' => $asset_model_class::getTypeName(1),
+            'datatype' => 'dropdown',
+        ];
 
         $search_options[] = [
             'id'                 => '31',

--- a/src/Asset/AssetDefinition.php
+++ b/src/Asset/AssetDefinition.php
@@ -291,7 +291,7 @@ final class AssetDefinition extends CommonDBTM
     {
         if (
             array_key_exists('system_name', $input)
-            && (!is_string($input['system_name']) || preg_match('/^[a-z]+$/i', $input['system_name']) !== 1)
+            && (!is_string($input['system_name']) || preg_match('/^[A-Za-z]+(?<!Model|Type)$/i', $input['system_name']) !== 1)
         ) {
             Session::addMessageAfterRedirect(
                 sprintf(

--- a/src/Asset/AssetDefinition.php
+++ b/src/Asset/AssetDefinition.php
@@ -379,7 +379,7 @@ final class AssetDefinition extends CommonDBTM
                     // can be null if provided by a plugin that is no longer active
                     continue;
                 }
-                $capacity->onCapacityDisabled($this->getConcreteClassName());
+                $capacity->onCapacityDisabled($this->getAssetClassName());
                 array_push($rights_to_remove, ...$capacity->getSpecificRights());
             }
 
@@ -422,7 +422,7 @@ final class AssetDefinition extends CommonDBTM
 
     public function cleanDBonPurge()
     {
-        $asset_classname = $this->getConcreteClassName();
+        $asset_classname = $this->getAssetClassName();
         /** @var Asset $asset */
         $asset = new $asset_classname();
         $asset->deleteByCriteria(['assets_assetdefinitions_id' => $this->getID()], force: true, history: false);
@@ -625,7 +625,7 @@ final class AssetDefinition extends CommonDBTM
      * @param bool $with_namespace
      * @return string
      */
-    public function getConcreteClassName(bool $with_namespace = true): string
+    public function getAssetClassName(bool $with_namespace = true): string
     {
         $classname = $this->fields['system_name'];
 
@@ -634,6 +634,28 @@ final class AssetDefinition extends CommonDBTM
         }
 
         return $classname;
+    }
+
+    /**
+     * Get the definition's concrete asset model class name.
+     *
+     * @param bool $with_namespace
+     * @return string
+     */
+    public function getAssetModelClassName(bool $with_namespace = true): string
+    {
+        return $this->getAssetClassName($with_namespace) . 'Model';
+    }
+
+    /**
+     * Get the definition's concrete asset type class name.
+     *
+     * @param bool $with_namespace
+     * @return string
+     */
+    public function getAssetTypeClassName(bool $with_namespace = true): string
+    {
+        return $this->getAssetClassName($with_namespace) . 'Type';
     }
 
     /**
@@ -681,7 +703,7 @@ final class AssetDefinition extends CommonDBTM
      */
     private function getPossibleAssetRights(): array
     {
-        $class = $this->getConcreteClassName();
+        $class = $this->getAssetClassName();
         $object = new $class();
         return $object->getRights();
     }

--- a/src/Asset/AssetDefinition.php
+++ b/src/Asset/AssetDefinition.php
@@ -422,10 +422,18 @@ final class AssetDefinition extends CommonDBTM
 
     public function cleanDBonPurge()
     {
-        $asset_classname = $this->getAssetClassName();
-        /** @var Asset $asset */
-        $asset = new $asset_classname();
-        $asset->deleteByCriteria(['assets_assetdefinitions_id' => $this->getID()], force: true, history: false);
+        $related_classes = [
+            $this->getAssetClassName(),
+            $this->getAssetModelClassName(),
+            $this->getAssetTypeClassName(),
+        ];
+        foreach ($related_classes as $classname) {
+            (new $classname())->deleteByCriteria(
+                ['assets_assetdefinitions_id' => $this->getID()],
+                force: true,
+                history: false
+            );
+        }
     }
 
     /**

--- a/src/Asset/AssetDefinitionManager.php
+++ b/src/Asset/AssetDefinitionManager.php
@@ -301,8 +301,6 @@ PHP
      */
     private function loadConcreteModelClass(AssetDefinition $definition): void
     {
-        $rightname = $definition->getAssetRightname();
-
         eval(<<<PHP
 namespace Glpi\\CustomAsset;
 
@@ -311,7 +309,6 @@ use Glpi\\Asset\\AssetDefinition;
 
 final class {$definition->getAssetModelClassName(false)} extends AssetModel {
     protected static AssetDefinition \$definition;
-    public static \$rightname = '{$rightname}';
 }
 PHP
         );
@@ -328,8 +325,6 @@ PHP
      */
     private function loadConcreteTypeClass(AssetDefinition $definition): void
     {
-        $rightname = $definition->getAssetRightname();
-
         eval(<<<PHP
 namespace Glpi\\CustomAsset;
 
@@ -338,7 +333,6 @@ use Glpi\\Asset\\AssetDefinition;
 
 final class {$definition->getAssetTypeClassName(false)} extends AssetType {
     protected static AssetDefinition \$definition;
-    public static \$rightname = '{$rightname}';
 }
 PHP
         );

--- a/src/Asset/AssetDefinitionManager.php
+++ b/src/Asset/AssetDefinitionManager.php
@@ -193,7 +193,7 @@ final class AssetDefinitionManager
      * @param bool $with_namespace
      * @return array
      */
-    public function getConcreteClassesNames(bool $with_namespace = true): array
+    public function getAssetClassesNames(bool $with_namespace = true): array
     {
         $classes = [];
 
@@ -202,6 +202,46 @@ final class AssetDefinitionManager
                 continue;
             }
             $classes[] = $definition->getAssetClassName($with_namespace);
+        }
+
+        return $classes;
+    }
+
+    /**
+     * Get the classes names of all assets models concrete classes.
+     *
+     * @param bool $with_namespace
+     * @return array
+     */
+    public function getAssetModelsClassesNames(bool $with_namespace = true): array
+    {
+        $classes = [];
+
+        foreach ($this->getDefinitions() as $definition) {
+            if (!$definition->isActive()) {
+                continue;
+            }
+            $classes[] = $definition->getAssetModelClassName($with_namespace);
+        }
+
+        return $classes;
+    }
+
+    /**
+     * Get the classes names of all assets types concrete classes.
+     *
+     * @param bool $with_namespace
+     * @return array
+     */
+    public function getAssetTypesClassesNames(bool $with_namespace = true): array
+    {
+        $classes = [];
+
+        foreach ($this->getDefinitions() as $definition) {
+            if (!$definition->isActive()) {
+                continue;
+            }
+            $classes[] = $definition->getAssetTypeClassName($with_namespace);
         }
 
         return $classes;

--- a/src/Asset/AssetDefinitionManager.php
+++ b/src/Asset/AssetDefinitionManager.php
@@ -135,7 +135,7 @@ final class AssetDefinitionManager
 
         $capacities = $this->getAvailableCapacities();
 
-        $concrete_class_name = $definition->getConcreteClassName();
+        $concrete_class_name = $definition->getAssetClassName();
 
         // Register asset into configuration entries related to the capacities that cannot be disabled
         $config_keys = [
@@ -201,7 +201,7 @@ final class AssetDefinitionManager
             if (!$definition->isActive()) {
                 continue;
             }
-            $classes[] = $definition->getConcreteClassName($with_namespace);
+            $classes[] = $definition->getAssetClassName($with_namespace);
         }
 
         return $classes;
@@ -279,7 +279,7 @@ namespace Glpi\\CustomAsset;
 use Glpi\\Asset\\Asset;
 use Glpi\\Asset\\AssetDefinition;
 
-final class {$definition->getConcreteClassName(false)} extends Asset {
+final class {$definition->getAssetClassName(false)} extends Asset {
     protected static AssetDefinition \$definition;
     public static \$rightname = '{$rightname}';
 }
@@ -289,7 +289,7 @@ PHP
         // Set the definition of the concrete class using reflection API.
         // It permits to directly store a pointer to the definition on the object without having
         // to make the property publicly writable.
-        $reflected_class = new ReflectionClass($definition->getConcreteClassName());
+        $reflected_class = new ReflectionClass($definition->getAssetClassName());
         $reflected_class->setStaticPropertyValue('definition', $definition);
     }
 
@@ -309,14 +309,14 @@ namespace Glpi\\CustomAsset;
 use Glpi\\Asset\\AssetModel;
 use Glpi\\Asset\\AssetDefinition;
 
-final class {$definition->getConcreteClassName(false)}Model extends AssetModel {
+final class {$definition->getAssetModelClassName(false)} extends AssetModel {
     protected static AssetDefinition \$definition;
     public static \$rightname = '{$rightname}';
 }
 PHP
         );
 
-        $reflected_class = new ReflectionClass($definition->getConcreteClassName() . 'Model');
+        $reflected_class = new ReflectionClass($definition->getAssetModelClassName());
         $reflected_class->setStaticPropertyValue('definition', $definition);
     }
 
@@ -336,14 +336,14 @@ namespace Glpi\\CustomAsset;
 use Glpi\\Asset\\AssetType;
 use Glpi\\Asset\\AssetDefinition;
 
-final class {$definition->getConcreteClassName(false)}Type extends AssetType {
+final class {$definition->getAssetTypeClassName(false)} extends AssetType {
     protected static AssetDefinition \$definition;
     public static \$rightname = '{$rightname}';
 }
 PHP
         );
 
-        $reflected_class = new ReflectionClass($definition->getConcreteClassName() . 'Type');
+        $reflected_class = new ReflectionClass($definition->getAssetTypeClassName());
         $reflected_class->setStaticPropertyValue('definition', $definition);
     }
 }

--- a/src/Asset/AssetModel.php
+++ b/src/Asset/AssetModel.php
@@ -77,12 +77,12 @@ abstract class AssetModel extends \CommonDCModelDropdown
 
     public static function getSearchURL($full = true)
     {
-        return Toolbox::getItemTypeSearchURL(self::class, $full) . '?class=' . static::getDefinition()->getConcreteClassName(false);
+        return Toolbox::getItemTypeSearchURL(self::class, $full) . '?class=' . static::getDefinition()->getAssetClassName(false);
     }
 
     public static function getFormURL($full = true)
     {
-        return Toolbox::getItemTypeFormURL(self::class, $full) . '?class=' . static::getDefinition()->getConcreteClassName(false);
+        return Toolbox::getItemTypeFormURL(self::class, $full) . '?class=' . static::getDefinition()->getAssetClassName(false);
     }
 
     public static function getById(?int $id)
@@ -111,7 +111,7 @@ abstract class AssetModel extends \CommonDCModelDropdown
         }
 
         // Instanciate concrete class
-        $asset_model_class = $definition->getConcreteClassName(true) . 'Model';
+        $asset_model_class = $definition->getAssetModelClassName(true);
         $asset_model = new $asset_model_class();
         if (!$asset_model->getFromDB($id)) {
             return false;

--- a/src/Asset/AssetModel.php
+++ b/src/Asset/AssetModel.php
@@ -1,0 +1,315 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Asset;
+
+use CommonDropdown;
+use Glpi\Application\View\TemplateRenderer;
+use Toolbox;
+
+abstract class AssetModel extends \CommonDCModelDropdown
+{
+    /**
+     * Get the asset definition related to concrete class.
+     *
+     * @return AssetDefinition
+     */
+    public static function getDefinition(): AssetDefinition
+    {
+        $definition = static::$definition ?? null;
+
+        if (!($definition instanceof AssetDefinition)) {
+            throw new \RuntimeException('Asset definition is expected to be defined in concrete class.');
+        }
+
+        return $definition;
+    }
+
+    public static function getTypeName($nb = 0)
+    {
+        return sprintf(_n('%s model', '%s models', $nb), static::getDefinition()->getTranslatedName());
+    }
+
+    public static function getIcon()
+    {
+        return static::getDefinition()->getAssetsIcon();
+    }
+
+    public static function getTable($classname = null)
+    {
+        if (is_a($classname ?? static::class, self::class, true)) {
+            return parent::getTable(self::class);
+        }
+        return parent::getTable($classname);
+    }
+
+    public static function getSearchURL($full = true)
+    {
+        return Toolbox::getItemTypeSearchURL(self::class, $full) . '?class=' . static::getDefinition()->getConcreteClassName(false);
+    }
+
+    public static function getFormURL($full = true)
+    {
+        return Toolbox::getItemTypeFormURL(self::class, $full) . '?class=' . static::getDefinition()->getConcreteClassName(false);
+    }
+
+    public static function getById(?int $id)
+    {
+        if ($id === null) {
+            return false;
+        }
+
+        // Load the asset definition corresponding to given asset ID
+        $definition_request = [
+            'INNER JOIN' => [
+                self::getTable()  => [
+                    'ON'  => [
+                        self::getTable()            => AssetDefinition::getForeignKeyField(),
+                        AssetDefinition::getTable() => AssetDefinition::getIndexName(),
+                    ]
+                ],
+            ],
+            'WHERE' => [
+                self::getTableField(self::getIndexName()) => $id,
+            ],
+        ];
+        $definition = new AssetDefinition();
+        if (!$definition->getFromDBByRequest($definition_request)) {
+            return false;
+        }
+
+        // Instanciate concrete class
+        $asset_model_class = $definition->getConcreteClassName(true) . 'Model';
+        $asset_model = new $asset_model_class();
+        if (!$asset_model->getFromDB($id)) {
+            return false;
+        }
+
+        return $asset_model;
+    }
+
+    public static function getSystemSQLCriteria(?string $tablename = null): array
+    {
+        $table_prefix = $tablename !== null
+            ? $tablename . '.'
+            : '';
+
+        // Keep only items from current definition must be shown.
+        $criteria = [
+            $table_prefix . AssetDefinition::getForeignKeyField() => static::getDefinition()->getID(),
+        ];
+
+        // Add another layer to the array to prevent losing duplicates keys if the
+        // result of the function is merged with another array.
+        $criteria = [crc32(serialize($criteria)) => $criteria];
+
+        return $criteria;
+    }
+
+    public function prepareInputForAdd($input)
+    {
+        return $this->prepareDefinitionInput($input);
+    }
+
+    public function prepareInputForUpdate($input)
+    {
+        return $this->prepareDefinitionInput($input);
+    }
+
+    /**
+     * Ensure definition input corresponds to the current concrete class.
+     *
+     * @param array $input
+     * @return array
+     */
+    private function prepareDefinitionInput(array $input): array
+    {
+        $definition_fkey = AssetDefinition::getForeignKeyField();
+        $definition_id   = static::getDefinition()->getID();
+
+        if (
+            array_key_exists($definition_fkey, $input)
+            && (int)$input[$definition_fkey] !== $definition_id
+        ) {
+            throw new \RuntimeException('Asset definition does not match the current concrete class.');
+        }
+
+        if (
+            !$this->isNewItem()
+            && (int)$this->fields[$definition_fkey] !== $definition_id
+        ) {
+            throw new \RuntimeException('Asset definition cannot be changed.');
+        }
+
+        $input[$definition_fkey] = $definition_id;
+
+        return $input;
+    }
+
+    public function rawSearchOptions()
+    {
+        // Get parent search options, but skip the ones from the immediate CommonDCModelDropdown parent
+        $options = CommonDropdown::rawSearchOptions();
+        $table   = static::getTable();
+
+        //TODO Replace with HasRackableCapacity capacity check
+        $rackable = false;
+
+        if ($rackable) {
+            $options[] = [
+                'id'       => '131',
+                'table'    => $table,
+                'field'    => 'weight',
+                'name'     => __('Weight'),
+                'datatype' => 'decimal'
+            ];
+            $options[] = [
+                'id'       => '132',
+                'table'    => $table,
+                'field'    => 'required_units',
+                'name'     => __('Required units'),
+                'datatype' => 'number'
+            ];
+            $options[] = [
+                'id'       => '133',
+                'table'    => $table,
+                'field'    => 'depth',
+                'name'     => __('Depth'),
+            ];
+            $options[] = [
+                'id'       => '134',
+                'table'    => $table,
+                'field'    => 'power_connections',
+                'name'     => __('Power connections'),
+                'datatype' => 'number'
+            ];
+            $options[] = [
+                'id'       => '135',
+                'table'    => $table,
+                'field'    => 'power_consumption',
+                'name'     => __('Power consumption'),
+                'datatype' => 'decimal'
+            ];
+            $options[] = [
+                'id'       => '136',
+                'table'    => $table,
+                'field'    => 'is_half_rack',
+                'name'     => __('Is half rack'),
+                'datatype' => 'bool'
+            ];
+        } else {
+            $options = array_filter($options, static function ($option) {
+                $field = $option['field'] ?? null;
+                return $field !== 'picture_front' && $field !== 'picture_rear';
+            });
+        }
+
+        foreach ($options as &$option) {
+            if (
+                is_array($option)
+                && array_key_exists('table', $option)
+                && $option['table'] === static::getTable()
+            ) {
+                // Search class could not be able to retrieve the concrete class when using `getItemTypeForTable()`,
+                // so we have to define an `itemtype` here.
+                $option['itemtype'] = static::class;
+            }
+        }
+
+
+        return $options;
+    }
+
+    public function getAdditionalFields()
+    {
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        $fields = CommonDropdown::getAdditionalFields();
+        //TODO Replace with HasRackableCapacity capacity check
+        $rackable = false;
+
+        if ($rackable) {
+            $fields[] = [
+                'name'   => 'weight',
+                'type'   => 'integer',
+                'label'  => __('Weight'),
+                'min'    => 0,
+            ];
+            $fields[] = [
+                'name'   => 'required_units',
+                'type'   => 'integer',
+                'min'    => 1,
+                'label'  => __('Required units')
+            ];
+            $fields[] = [
+                'name'   => 'depth',
+                'type'   => 'depth',
+                'label'  => __('Depth')
+            ];
+            $fields[] = [
+                'name'   => 'power_connections',
+                'type'   => 'integer',
+                'label'  => __('Power connections'),
+                'min'    => 0,
+            ];
+            $fields[] = [
+                'name'   => 'power_consumption',
+                'type'   => 'integer',
+                'label'  => __('Power consumption'),
+                'unit'   => __('watts'),
+                'min'    => 0,
+            ];
+            $fields[] = [
+                'name'   => 'max_power',
+                'type'   => 'integer',
+                'label'  => __('Max. power (in watts)'),
+                'unit'   => __('watts'),
+                'min'    => 0,
+            ];
+            $fields[] = [
+                'name'   => 'is_half_rack',
+                'type'   => 'bool',
+                'label'  => __('Is half rack')
+            ];
+        } else {
+            $fields = array_filter($fields, static function ($option) {
+                return $option['name'] !== 'picture_front' && $option['name'] !== 'picture_rear';
+            });
+        }
+
+        return $fields;
+    }
+}

--- a/src/Asset/AssetModel.php
+++ b/src/Asset/AssetModel.php
@@ -36,7 +36,6 @@
 namespace Glpi\Asset;
 
 use CommonDropdown;
-use Glpi\Application\View\TemplateRenderer;
 use Toolbox;
 
 abstract class AssetModel extends \CommonDCModelDropdown
@@ -91,7 +90,7 @@ abstract class AssetModel extends \CommonDCModelDropdown
             return false;
         }
 
-        // Load the asset definition corresponding to given asset ID
+        // Load the asset definition corresponding to given asset model ID
         $definition_request = [
             'INNER JOIN' => [
                 self::getTable()  => [

--- a/src/Asset/AssetModel.php
+++ b/src/Asset/AssetModel.php
@@ -139,12 +139,14 @@ abstract class AssetModel extends \CommonDCModelDropdown
 
     public function prepareInputForAdd($input)
     {
-        return $this->prepareDefinitionInput($input);
+        $input = $this->prepareDefinitionInput($input);
+        return parent::prepareInputForAdd($input);
     }
 
     public function prepareInputForUpdate($input)
     {
-        return $this->prepareDefinitionInput($input);
+        $input = $this->prepareDefinitionInput($input);
+        return parent::prepareInputForUpdate($input);
     }
 
     /**

--- a/src/Asset/AssetType.php
+++ b/src/Asset/AssetType.php
@@ -35,9 +35,7 @@
 
 namespace Glpi\Asset;
 
-use CommonDropdown;
 use CommonType;
-use Glpi\Application\View\TemplateRenderer;
 use Toolbox;
 
 abstract class AssetType extends CommonType
@@ -92,7 +90,7 @@ abstract class AssetType extends CommonType
             return false;
         }
 
-        // Load the asset definition corresponding to given asset ID
+        // Load the asset definition corresponding to given asset type ID
         $definition_request = [
             'INNER JOIN' => [
                 self::getTable()  => [

--- a/src/Asset/AssetType.php
+++ b/src/Asset/AssetType.php
@@ -78,12 +78,12 @@ abstract class AssetType extends CommonType
 
     public static function getSearchURL($full = true)
     {
-        return Toolbox::getItemTypeSearchURL(self::class, $full) . '?class=' . static::getDefinition()->getConcreteClassName(false);
+        return Toolbox::getItemTypeSearchURL(self::class, $full) . '?class=' . static::getDefinition()->getAssetClassName(false);
     }
 
     public static function getFormURL($full = true)
     {
-        return Toolbox::getItemTypeFormURL(self::class, $full) . '?class=' . static::getDefinition()->getConcreteClassName(false);
+        return Toolbox::getItemTypeFormURL(self::class, $full) . '?class=' . static::getDefinition()->getAssetClassName(false);
     }
 
     public static function getById(?int $id)
@@ -112,7 +112,7 @@ abstract class AssetType extends CommonType
         }
 
         // Instanciate concrete class
-        $asset_type_class = $definition->getConcreteClassName(true) . 'Type';
+        $asset_type_class = $definition->getAssetTypeClassName(true);
         $asset_type = new $asset_type_class();
         if (!$asset_type->getFromDB($id)) {
             return false;

--- a/src/Asset/AssetType.php
+++ b/src/Asset/AssetType.php
@@ -1,0 +1,181 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Asset;
+
+use CommonDropdown;
+use CommonType;
+use Glpi\Application\View\TemplateRenderer;
+use Toolbox;
+
+abstract class AssetType extends CommonType
+{
+    /**
+     * Get the asset definition related to concrete class.
+     *
+     * @return AssetDefinition
+     */
+    public static function getDefinition(): AssetDefinition
+    {
+        $definition = static::$definition ?? null;
+
+        if (!($definition instanceof AssetDefinition)) {
+            throw new \RuntimeException('Asset definition is expected to be defined in concrete class.');
+        }
+
+        return $definition;
+    }
+
+    public static function getTypeName($nb = 0)
+    {
+        return sprintf(_n('%s type', '%s types', $nb), static::getDefinition()->getTranslatedName());
+    }
+
+    public static function getIcon()
+    {
+        return static::getDefinition()->getAssetsIcon();
+    }
+
+    public static function getTable($classname = null)
+    {
+        if (is_a($classname ?? static::class, self::class, true)) {
+            return parent::getTable(self::class);
+        }
+        return parent::getTable($classname);
+    }
+
+    public static function getSearchURL($full = true)
+    {
+        return Toolbox::getItemTypeSearchURL(self::class, $full) . '?class=' . static::getDefinition()->getConcreteClassName(false);
+    }
+
+    public static function getFormURL($full = true)
+    {
+        return Toolbox::getItemTypeFormURL(self::class, $full) . '?class=' . static::getDefinition()->getConcreteClassName(false);
+    }
+
+    public static function getById(?int $id)
+    {
+        if ($id === null) {
+            return false;
+        }
+
+        // Load the asset definition corresponding to given asset ID
+        $definition_request = [
+            'INNER JOIN' => [
+                self::getTable()  => [
+                    'ON'  => [
+                        self::getTable()            => AssetDefinition::getForeignKeyField(),
+                        AssetDefinition::getTable() => AssetDefinition::getIndexName(),
+                    ]
+                ],
+            ],
+            'WHERE' => [
+                self::getTableField(self::getIndexName()) => $id,
+            ],
+        ];
+        $definition = new AssetDefinition();
+        if (!$definition->getFromDBByRequest($definition_request)) {
+            return false;
+        }
+
+        // Instanciate concrete class
+        $asset_type_class = $definition->getConcreteClassName(true) . 'Type';
+        $asset_type = new $asset_type_class();
+        if (!$asset_type->getFromDB($id)) {
+            return false;
+        }
+
+        return $asset_type;
+    }
+
+    public static function getSystemSQLCriteria(?string $tablename = null): array
+    {
+        $table_prefix = $tablename !== null
+            ? $tablename . '.'
+            : '';
+
+        // Keep only items from current definition must be shown.
+        $criteria = [
+            $table_prefix . AssetDefinition::getForeignKeyField() => static::getDefinition()->getID(),
+        ];
+
+        // Add another layer to the array to prevent losing duplicates keys if the
+        // result of the function is merged with another array.
+        $criteria = [crc32(serialize($criteria)) => $criteria];
+
+        return $criteria;
+    }
+
+    public function prepareInputForAdd($input)
+    {
+        return $this->prepareDefinitionInput($input);
+    }
+
+    public function prepareInputForUpdate($input)
+    {
+        return $this->prepareDefinitionInput($input);
+    }
+
+    /**
+     * Ensure definition input corresponds to the current concrete class.
+     *
+     * @param array $input
+     * @return array
+     */
+    private function prepareDefinitionInput(array $input): array
+    {
+        $definition_fkey = AssetDefinition::getForeignKeyField();
+        $definition_id   = static::getDefinition()->getID();
+
+        if (
+            array_key_exists($definition_fkey, $input)
+            && (int)$input[$definition_fkey] !== $definition_id
+        ) {
+            throw new \RuntimeException('Asset definition does not match the current concrete class.');
+        }
+
+        if (
+            !$this->isNewItem()
+            && (int)$this->fields[$definition_fkey] !== $definition_id
+        ) {
+            throw new \RuntimeException('Asset definition cannot be changed.');
+        }
+
+        $input[$definition_fkey] = $definition_id;
+
+        return $input;
+    }
+}

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5172,7 +5172,7 @@ class CommonDBTM extends CommonGLPI
                     if (!isset($options['entity'])) {
                         $options['entity'] = $_SESSION['glpiactiveentities'];
                     }
-                    $itemtype = getItemTypeForTable($searchoptions['table']);
+                    $itemtype = $searchoptions['itemtype'] ?? getItemTypeForTable($searchoptions['table']);
 
                     return $itemtype::dropdown($options);
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -1100,19 +1100,6 @@ JAVASCRIPT;
     {
         static $optgroup = null;
 
-        $custom_asset_models = [];
-        $custom_asset_classes = AssetDefinitionManager::getInstance()->getConcreteClassesNames();
-        foreach ($custom_asset_classes as $custom_asset_class) {
-            $model_class = $custom_asset_class . 'Model';
-            $custom_asset_models[$model_class] = null;
-        }
-
-        $custom_asset_types = [];
-        foreach ($custom_asset_classes as $custom_asset_class) {
-            $type_class = $custom_asset_class . 'Type';
-            $custom_asset_types[$type_class] = null;
-        }
-
         if (is_null($optgroup)) {
             $optgroup = [
                 __('Common') => [
@@ -1171,7 +1158,7 @@ JAVASCRIPT;
                     'PassiveDCEquipmentType' => null,
                     'ClusterType' => null,
                     'DatabaseInstanceType' => null
-                ] + $custom_asset_types,
+                ] + array_fill_keys(AssetDefinitionManager::getInstance()->getAssetTypesClassesNames(), null),
 
                 _n('Model', 'Models', Session::getPluralNumber()) => [
                     'ComputerModel' => null,
@@ -1201,7 +1188,7 @@ JAVASCRIPT;
                     'EnclosureModel' => null,
                     'PDUModel' => null,
                     'PassiveDCEquipmentModel' => null,
-                ] + $custom_asset_models,
+                ] + array_fill_keys(AssetDefinitionManager::getInstance()->getAssetModelsClassesNames(), null),
 
                 _n('Virtual machine', 'Virtual machines', Session::getPluralNumber()) => [
                     'VirtualMachineType' => null,

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Asset\AssetDefinitionManager;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
 use Glpi\Features\DCBreadcrumb;
@@ -1099,6 +1100,19 @@ JAVASCRIPT;
     {
         static $optgroup = null;
 
+        $custom_asset_models = [];
+        $custom_asset_classes = AssetDefinitionManager::getInstance()->getConcreteClassesNames();
+        foreach ($custom_asset_classes as $custom_asset_class) {
+            $model_class = $custom_asset_class . 'Model';
+            $custom_asset_models[$model_class] = null;
+        }
+
+        $custom_asset_types = [];
+        foreach ($custom_asset_classes as $custom_asset_class) {
+            $type_class = $custom_asset_class . 'Type';
+            $custom_asset_types[$type_class] = null;
+        }
+
         if (is_null($optgroup)) {
             $optgroup = [
                 __('Common') => [
@@ -1157,7 +1171,7 @@ JAVASCRIPT;
                     'PassiveDCEquipmentType' => null,
                     'ClusterType' => null,
                     'DatabaseInstanceType' => null
-                ],
+                ] + $custom_asset_types,
 
                 _n('Model', 'Models', Session::getPluralNumber()) => [
                     'ComputerModel' => null,
@@ -1187,7 +1201,7 @@ JAVASCRIPT;
                     'EnclosureModel' => null,
                     'PDUModel' => null,
                     'PassiveDCEquipmentModel' => null,
-                ],
+                ] + $custom_asset_models,
 
                 _n('Virtual machine', 'Virtual machines', Session::getPluralNumber()) => [
                     'VirtualMachineType' => null,

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -489,7 +489,7 @@ class Dropdown
 
         $itemtype = getItemTypeForTable($table);
 
-        if (!is_a($itemtype, CommonDropdown::class, true)) {
+        if (!is_a($itemtype, CommonDBTM::class, true)) {
             return $default;
         }
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -487,13 +487,13 @@ class Dropdown
         /** @var \DBmysql $DB */
         global $DB;
 
-        $item = getItemForItemtype(getItemTypeForTable($table));
+        $itemtype = getItemTypeForTable($table);
 
-        if (!is_object($item)) {
+        if (!is_a($itemtype, CommonDropdown::class, true)) {
             return $default;
         }
 
-        if ($item instanceof CommonTreeDropdown) {
+        if (is_a($itemtype, CommonTreeDropdown::class, true)) {
             return getTreeValueCompleteName($table, $id, $withcomment, $translate, $tooltip, $default);
         }
 
@@ -565,7 +565,7 @@ class Dropdown
                 if ($translate && !empty($data['transname'])) {
                     $name = $data['transname'];
                 } else {
-                    $name = $data[$item->getNameField()];
+                    $name = $data[$itemtype::getNameField()];
                 }
                 if (isset($data["comment"])) {
                     if ($translate && !empty($data['transcomment'])) {

--- a/src/Html.php
+++ b/src/Html.php
@@ -1326,7 +1326,7 @@ HTML;
                         'CartridgeItem', 'ConsumableItem', 'Phone',
                         'Rack', 'Enclosure', 'PDU', 'PassiveDCEquipment', 'Unmanaged', 'Cable',
                     ],
-                    AssetDefinitionManager::getInstance()->getConcreteClassesNames(),
+                    AssetDefinitionManager::getInstance()->getAssetClassesNames(),
                     $CFG_GLPI['devices_in_menu']
                 ),
                 'icon'    => 'ti ti-package'

--- a/templates/pages/admin/assetdefinition/main.html.twig
+++ b/templates/pages/admin/assetdefinition/main.html.twig
@@ -50,8 +50,8 @@
             __('System name'),
             {
                 'required': true,
-                'pattern': '[A-Za-z]+',
-                'helper': __('The system name corresponds to the customizable part of the asset class which will correspond to the current definition. For example, assets linked to the system name "%s" will have the class "%s".')|format('Laptop', 'Glpi\\CustomAsset\\Laptop') ~ ' ' ~ __('The value must contains only letters.')
+                'pattern': '^[A-Za-z]+(?<!Model|Type)$',
+                'helper': __('The system name corresponds to the customizable part of the asset class which will correspond to the current definition. For example, assets linked to the system name "%s" will have the class "%s".')|format('Laptop', 'Glpi\\CustomAsset\\Laptop') ~ ' ' ~ __('The value must contains only letters and must not end by "Model" or "Type".')
             }
         ) }}
     {% else %}

--- a/tests/DbTestCase.php
+++ b/tests/DbTestCase.php
@@ -334,6 +334,8 @@ class DbTestCase extends \GLPITestCase
 
         $manager = \Glpi\Asset\AssetDefinitionManager::getInstance();
         $this->callPrivateMethod($manager, 'loadConcreteClass', $definition);
+        $this->callPrivateMethod($manager, 'loadConcreteModelClass', $definition);
+        $this->callPrivateMethod($manager, 'loadConcreteTypeClass', $definition);
         $this->callPrivateMethod($manager, 'boostrapConcreteClass', $definition);
 
         return $definition;

--- a/tests/functional/Glpi/Asset/Asset.php
+++ b/tests/functional/Glpi/Asset/Asset.php
@@ -42,10 +42,10 @@ class Asset extends DbTestCase
     protected function getByIdProvider(): iterable
     {
         $foo_definition = $this->initAssetDefinition();
-        $foo_classname = $foo_definition->getConcreteClassName();
+        $foo_classname = $foo_definition->getAssetClassName();
 
         $bar_definition = $this->initAssetDefinition();
-        $bar_classname = $bar_definition->getConcreteClassName();
+        $bar_classname = $bar_definition->getAssetClassName();
 
         // Loop to ensure that switching between definition does not cause any issue
         for ($i = 0; $i < 2; $i++) {
@@ -89,7 +89,7 @@ class Asset extends DbTestCase
     public function testPrepareInputDefinition(): void
     {
         $definition = $this->initAssetDefinition();
-        $classname = $definition->getConcreteClassName();
+        $classname = $definition->getAssetClassName();
         $asset = new $classname();
 
         foreach (['prepareInputForAdd','prepareInputForUpdate'] as $method) {
@@ -109,9 +109,9 @@ class Asset extends DbTestCase
     public function testUpdateWithWrongDefinition(): void
     {
         $definition_1 = $this->initAssetDefinition();
-        $classname_1  = $definition_1->getConcreteClassName();
+        $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition();
-        $classname_2  = $definition_2->getConcreteClassName();
+        $classname_2  = $definition_2->getAssetClassName();
 
         $asset = $this->createItem($classname_1, ['name' => 'new asset']);
 

--- a/tests/functional/Glpi/Asset/AssetDefinition.php
+++ b/tests/functional/Glpi/Asset/AssetDefinition.php
@@ -292,7 +292,7 @@ class AssetDefinition extends DbTestCase
         \Glpi\Asset\AssetDefinitionManager::getInstance()->boostrapAssets();
 
         $this->createItem(
-            $definition->getConcreteClassName(),
+            $definition->getAssetClassName(),
             [
                 'name' => 'test',
             ]

--- a/tests/functional/Glpi/Asset/AssetDefinition.php
+++ b/tests/functional/Glpi/Asset/AssetDefinition.php
@@ -234,6 +234,56 @@ class AssetDefinition extends DbTestCase
             }
         }
 
+        // System name must not end with `Model` suffix
+        yield [
+            'input'    => [
+                'system_name' => 'TestAssetModel',
+            ],
+            'output'   => false,
+            'messages' => [
+                ERROR => [
+                    'The following field has an incorrect value: "System name".',
+                ],
+            ],
+        ];
+        // but system name can contains `Model`
+        yield [
+            'input'    => [
+                'system_name' => 'TestAssetModeling',
+            ],
+            'output'   => [
+                'system_name' => 'TestAssetModeling',
+                'capacities'  => '[]',
+                'profiles'    => '[]',
+            ],
+            'messages' => [],
+        ];
+
+        // System name must not end with `Type` suffix
+        yield [
+            'input'    => [
+                'system_name' => 'TestAssetType',
+            ],
+            'output'   => false,
+            'messages' => [
+                ERROR => [
+                    'The following field has an incorrect value: "System name".',
+                ],
+            ],
+        ];
+        // but system name can contains `Type`
+        yield [
+            'input'    => [
+                'system_name' => 'TestAssetTyped',
+            ],
+            'output'   => [
+                'system_name' => 'TestAssetTyped',
+                'capacities'  => '[]',
+                'profiles'    => '[]',
+            ],
+            'messages' => [],
+        ];
+
         foreach ($this->updateInputProvider() as $data) {
             if (!array_key_exists('system_name', $data['input'])) {
                 // `system_name` is mandatory on add

--- a/tests/functional/Glpi/Asset/AssetModel.php
+++ b/tests/functional/Glpi/Asset/AssetModel.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Asset;
+
+use DbTestCase;
+
+class AssetModel extends DbTestCase
+{
+    protected function getByIdProvider(): iterable
+    {
+        $foo_definition = $this->initAssetDefinition();
+        $foo_classname = $foo_definition->getConcreteClassName() . 'Model';
+
+        $bar_definition = $this->initAssetDefinition();
+        $bar_classname = $bar_definition->getConcreteClassName() . 'Model';
+
+        // Loop to ensure that switching between definition does not cause any issue
+        for ($i = 0; $i < 2; $i++) {
+            $fields = [
+                'name' => 'Foo asset model' . $i,
+            ];
+            $asset_model = $this->createItem($foo_classname, $fields);
+            yield [
+                'id'              => $asset_model->getID(),
+                'expected_class'  => $foo_classname,
+                'expected_fields' => $fields,
+            ];
+
+            $fields = [
+                'name' => 'Bar asset model' . $i,
+            ];
+            $asset_model = $this->createItem($bar_classname, $fields);
+            yield [
+                'id'              => $asset_model->getID(),
+                'expected_class'  => $bar_classname,
+                'expected_fields' => $fields,
+            ];
+        }
+    }
+
+    /**
+     * @dataProvider getByIdProvider
+     */
+    public function testGetById(int $id, string $expected_class, array $expected_fields): void
+    {
+        $asset_model = \Glpi\Asset\AssetModel::getById($id);
+
+        $this->object($asset_model)->isInstanceOf($expected_class);
+
+        foreach ($expected_fields as $name => $value) {
+            $this->array($asset_model->fields)->hasKey($name);
+            $this->variable($asset_model->fields[$name])->isEqualTo($value);
+        }
+    }
+
+    public function testPrepareInputDefinition(): void
+    {
+        $definition = $this->initAssetDefinition();
+        $classname = $definition->getConcreteClassName() . 'Model';
+        $asset_model = new $classname();
+
+        foreach (['prepareInputForAdd','prepareInputForUpdate'] as $method) {
+            // definition is automatically set if missing
+            $this->array($asset_model->{$method}([]))->isEqualTo(['assets_assetdefinitions_id' => $definition->getID()]);
+            $this->array($asset_model->{$method}(['name' => 'test']))->isEqualTo(['name' => 'test', 'assets_assetdefinitions_id' => $definition->getID()]);
+
+            // an exception is thrown if definition is invalid
+            $this->exception(
+                function () use ($asset_model, $method, $definition) {
+                    $asset_model->{$method}(['assets_assetdefinitions_id' => $definition->getID() + 1]);
+                }
+            )->message->contains('Asset definition does not match the current concrete class.');
+        }
+    }
+
+    public function testUpdateWithWrongDefinition(): void
+    {
+        $definition_1 = $this->initAssetDefinition();
+        $classname_1  = $definition_1->getConcreteClassName() . 'Model';
+        $definition_2 = $this->initAssetDefinition();
+        $classname_2  = $definition_2->getConcreteClassName() . 'Model';
+
+        $asset_model = $this->createItem($classname_1, ['name' => 'new asset model']);
+
+        $this->exception(
+            function () use ($asset_model, $classname_2) {
+                $asset_2 = new $classname_2();
+                $asset_2->update(['id' => $asset_model->getID(), 'name' => 'updated']);
+            }
+        )->message->contains('Asset definition cannot be changed.');
+    }
+}

--- a/tests/functional/Glpi/Asset/AssetModel.php
+++ b/tests/functional/Glpi/Asset/AssetModel.php
@@ -42,10 +42,10 @@ class AssetModel extends DbTestCase
     protected function getByIdProvider(): iterable
     {
         $foo_definition = $this->initAssetDefinition();
-        $foo_classname = $foo_definition->getConcreteClassName() . 'Model';
+        $foo_classname = $foo_definition->getAssetModelClassName();
 
         $bar_definition = $this->initAssetDefinition();
-        $bar_classname = $bar_definition->getConcreteClassName() . 'Model';
+        $bar_classname = $bar_definition->getAssetModelClassName();
 
         // Loop to ensure that switching between definition does not cause any issue
         for ($i = 0; $i < 2; $i++) {
@@ -89,7 +89,7 @@ class AssetModel extends DbTestCase
     public function testPrepareInputDefinition(): void
     {
         $definition = $this->initAssetDefinition();
-        $classname = $definition->getConcreteClassName() . 'Model';
+        $classname = $definition->getAssetModelClassName();
         $asset_model = new $classname();
 
         foreach (['prepareInputForAdd','prepareInputForUpdate'] as $method) {
@@ -109,9 +109,9 @@ class AssetModel extends DbTestCase
     public function testUpdateWithWrongDefinition(): void
     {
         $definition_1 = $this->initAssetDefinition();
-        $classname_1  = $definition_1->getConcreteClassName() . 'Model';
+        $classname_1  = $definition_1->getAssetModelClassName();
         $definition_2 = $this->initAssetDefinition();
-        $classname_2  = $definition_2->getConcreteClassName() . 'Model';
+        $classname_2  = $definition_2->getAssetModelClassName();
 
         $asset_model = $this->createItem($classname_1, ['name' => 'new asset model']);
 

--- a/tests/functional/Glpi/Asset/AssetType.php
+++ b/tests/functional/Glpi/Asset/AssetType.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Asset;
+
+use DbTestCase;
+
+class AssetType extends DbTestCase
+{
+    protected function getByIdProvider(): iterable
+    {
+        $foo_definition = $this->initAssetDefinition();
+        $foo_classname = $foo_definition->getConcreteClassName() . 'Type';
+
+        $bar_definition = $this->initAssetDefinition();
+        $bar_classname = $bar_definition->getConcreteClassName() . 'Type';
+
+        // Loop to ensure that switching between definition does not cause any issue
+        for ($i = 0; $i < 2; $i++) {
+            $fields = [
+                'name' => 'Foo asset type' . $i,
+            ];
+            $asset_type = $this->createItem($foo_classname, $fields);
+            yield [
+                'id'              => $asset_type->getID(),
+                'expected_class'  => $foo_classname,
+                'expected_fields' => $fields,
+            ];
+
+            $fields = [
+                'name' => 'Bar asset type' . $i,
+            ];
+            $asset_type = $this->createItem($bar_classname, $fields);
+            yield [
+                'id'              => $asset_type->getID(),
+                'expected_class'  => $bar_classname,
+                'expected_fields' => $fields,
+            ];
+        }
+    }
+
+    /**
+     * @dataProvider getByIdProvider
+     */
+    public function testGetById(int $id, string $expected_class, array $expected_fields): void
+    {
+        $asset_type = \Glpi\Asset\AssetType::getById($id);
+
+        $this->object($asset_type)->isInstanceOf($expected_class);
+
+        foreach ($expected_fields as $name => $value) {
+            $this->array($asset_type->fields)->hasKey($name);
+            $this->variable($asset_type->fields[$name])->isEqualTo($value);
+        }
+    }
+
+    public function testPrepareInputDefinition(): void
+    {
+        $definition = $this->initAssetDefinition();
+        $classname = $definition->getConcreteClassName() . 'Type';
+        $asset_type = new $classname();
+
+        foreach (['prepareInputForAdd','prepareInputForUpdate'] as $method) {
+            // definition is automatically set if missing
+            $this->array($asset_type->{$method}([]))->isEqualTo(['assets_assetdefinitions_id' => $definition->getID()]);
+            $this->array($asset_type->{$method}(['name' => 'test']))->isEqualTo(['name' => 'test', 'assets_assetdefinitions_id' => $definition->getID()]);
+
+            // an exception is thrown if definition is invalid
+            $this->exception(
+                function () use ($asset_type, $method, $definition) {
+                    $asset_type->{$method}(['assets_assetdefinitions_id' => $definition->getID() + 1]);
+                }
+            )->message->contains('Asset definition does not match the current concrete class.');
+        }
+    }
+
+    public function testUpdateWithWrongDefinition(): void
+    {
+        $definition_1 = $this->initAssetDefinition();
+        $classname_1  = $definition_1->getConcreteClassName() . 'Type';
+        $definition_2 = $this->initAssetDefinition();
+        $classname_2  = $definition_2->getConcreteClassName() . 'Type';
+
+        $asset_type = $this->createItem($classname_1, ['name' => 'new asset type']);
+
+        $this->exception(
+            function () use ($asset_type, $classname_2) {
+                $asset_2 = new $classname_2();
+                $asset_2->update(['id' => $asset_type->getID(), 'name' => 'updated']);
+            }
+        )->message->contains('Asset definition cannot be changed.');
+    }
+}

--- a/tests/functional/Glpi/Asset/AssetType.php
+++ b/tests/functional/Glpi/Asset/AssetType.php
@@ -42,10 +42,10 @@ class AssetType extends DbTestCase
     protected function getByIdProvider(): iterable
     {
         $foo_definition = $this->initAssetDefinition();
-        $foo_classname = $foo_definition->getConcreteClassName() . 'Type';
+        $foo_classname = $foo_definition->getAssetTypeClassName();
 
         $bar_definition = $this->initAssetDefinition();
-        $bar_classname = $bar_definition->getConcreteClassName() . 'Type';
+        $bar_classname = $bar_definition->getAssetTypeClassName();
 
         // Loop to ensure that switching between definition does not cause any issue
         for ($i = 0; $i < 2; $i++) {
@@ -89,7 +89,7 @@ class AssetType extends DbTestCase
     public function testPrepareInputDefinition(): void
     {
         $definition = $this->initAssetDefinition();
-        $classname = $definition->getConcreteClassName() . 'Type';
+        $classname = $definition->getAssetTypeClassName();
         $asset_type = new $classname();
 
         foreach (['prepareInputForAdd','prepareInputForUpdate'] as $method) {
@@ -109,9 +109,9 @@ class AssetType extends DbTestCase
     public function testUpdateWithWrongDefinition(): void
     {
         $definition_1 = $this->initAssetDefinition();
-        $classname_1  = $definition_1->getConcreteClassName() . 'Type';
+        $classname_1  = $definition_1->getAssetTypeClassName();
         $definition_2 = $this->initAssetDefinition();
-        $classname_2  = $definition_2->getConcreteClassName() . 'Type';
+        $classname_2  = $definition_2->getAssetTypeClassName();
 
         $asset_type = $this->createItem($classname_1, ['name' => 'new asset type']);
 

--- a/tests/functional/Glpi/Asset/Capacity/HasDocumentsCapacity.php
+++ b/tests/functional/Glpi/Asset/Capacity/HasDocumentsCapacity.php
@@ -57,20 +57,20 @@ class HasDocumentsCapacity extends DbTestCase
                 \Glpi\Asset\Capacity\HasNotepadCapacity::class,
             ]
         );
-        $classname_1  = $definition_1->getConcreteClassName();
+        $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
                 \Glpi\Asset\Capacity\HasHistoryCapacity::class,
             ]
         );
-        $classname_2  = $definition_2->getConcreteClassName();
+        $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
                 \Glpi\Asset\Capacity\HasDocumentsCapacity::class,
                 \Glpi\Asset\Capacity\HasHistoryCapacity::class,
             ]
         );
-        $classname_3  = $definition_3->getConcreteClassName();
+        $classname_3  = $definition_3->getAssetClassName();
 
         $has_documents_mapping = [
             $classname_1 => true,
@@ -124,14 +124,14 @@ class HasDocumentsCapacity extends DbTestCase
                 \Glpi\Asset\Capacity\HasHistoryCapacity::class,
             ]
         );
-        $classname_1  = $definition_1->getConcreteClassName();
+        $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
                 \Glpi\Asset\Capacity\HasDocumentsCapacity::class,
                 \Glpi\Asset\Capacity\HasHistoryCapacity::class,
             ]
         );
-        $classname_2  = $definition_2->getConcreteClassName();
+        $classname_2  = $definition_2->getAssetClassName();
 
         $item_1          = $this->createItem(
             $classname_1,
@@ -223,7 +223,7 @@ class HasDocumentsCapacity extends DbTestCase
                 \Glpi\Asset\Capacity\HasDocumentsCapacity::class,
             ]
         );
-        $classname  = $definition->getConcreteClassName();
+        $classname  = $definition->getAssetClassName();
 
         $item     = $this->createItem(
             $classname,

--- a/tests/functional/Glpi/Asset/Capacity/HasHistoryCapacity.php
+++ b/tests/functional/Glpi/Asset/Capacity/HasHistoryCapacity.php
@@ -51,20 +51,20 @@ class HasHistoryCapacity extends DbTestCase
                 \Glpi\Asset\Capacity\HasNotepadCapacity::class,
             ]
         );
-        $classname_1  = $definition_1->getConcreteClassName();
+        $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
                 \Glpi\Asset\Capacity\HasNotepadCapacity::class,
             ]
         );
-        $classname_2  = $definition_2->getConcreteClassName();
+        $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
                 \Glpi\Asset\Capacity\HasDocumentsCapacity::class,
                 \Glpi\Asset\Capacity\HasHistoryCapacity::class,
             ]
         );
-        $classname_3  = $definition_3->getConcreteClassName();
+        $classname_3  = $definition_3->getAssetClassName();
 
         $has_history_mapping = [
             $classname_1 => true,
@@ -94,13 +94,13 @@ class HasHistoryCapacity extends DbTestCase
                 \Glpi\Asset\Capacity\HasHistoryCapacity::class,
             ]
         );
-        $classname_1  = $definition_1->getConcreteClassName();
+        $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
                 \Glpi\Asset\Capacity\HasHistoryCapacity::class,
             ]
         );
-        $classname_2  = $definition_2->getConcreteClassName();
+        $classname_2  = $definition_2->getAssetClassName();
 
         $item_1          = $this->createItem(
             $classname_1,
@@ -148,7 +148,7 @@ class HasHistoryCapacity extends DbTestCase
                 \Glpi\Asset\Capacity\HasHistoryCapacity::class,
             ]
         );
-        $classname  = $definition->getConcreteClassName();
+        $classname  = $definition->getAssetClassName();
 
         $item = $this->createItem(
             $classname,

--- a/tests/functional/Glpi/Asset/Capacity/HasInfocomCapacity.php
+++ b/tests/functional/Glpi/Asset/Capacity/HasInfocomCapacity.php
@@ -55,20 +55,20 @@ class HasInfocomCapacity extends DbTestCase
                 \Glpi\Asset\Capacity\HasInfocomCapacity::class,
             ]
         );
-        $classname_1  = $definition_1->getConcreteClassName();
+        $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
                 \Glpi\Asset\Capacity\HasNotepadCapacity::class,
             ]
         );
-        $classname_2  = $definition_2->getConcreteClassName();
+        $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
                 \Glpi\Asset\Capacity\HasDocumentsCapacity::class,
                 \Glpi\Asset\Capacity\HasInfocomCapacity::class,
             ]
         );
-        $classname_3  = $definition_3->getConcreteClassName();
+        $classname_3  = $definition_3->getAssetClassName();
 
         $has_infocom_mapping = [
             $classname_1 => true,
@@ -145,14 +145,14 @@ class HasInfocomCapacity extends DbTestCase
                 \Glpi\Asset\Capacity\HasInfocomCapacity::class,
             ]
         );
-        $classname_1  = $definition_1->getConcreteClassName();
+        $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
                 \Glpi\Asset\Capacity\HasHistoryCapacity::class,
                 \Glpi\Asset\Capacity\HasInfocomCapacity::class,
             ]
         );
-        $classname_2  = $definition_2->getConcreteClassName();
+        $classname_2  = $definition_2->getAssetClassName();
 
         $item_1          = $this->createItem(
             $classname_1,

--- a/tests/functional/Glpi/Asset/Capacity/HasLinksCapacity.php
+++ b/tests/functional/Glpi/Asset/Capacity/HasLinksCapacity.php
@@ -54,20 +54,20 @@ class HasLinksCapacity extends DbTestCase
                 \Glpi\Asset\Capacity\HasNotepadCapacity::class,
             ]
         );
-        $classname_1  = $definition_1->getConcreteClassName();
+        $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
                 \Glpi\Asset\Capacity\HasHistoryCapacity::class,
             ]
         );
-        $classname_2  = $definition_2->getConcreteClassName();
+        $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
                 \Glpi\Asset\Capacity\HasLinksCapacity::class,
                 \Glpi\Asset\Capacity\HasHistoryCapacity::class,
             ]
         );
-        $classname_3  = $definition_3->getConcreteClassName();
+        $classname_3  = $definition_3->getAssetClassName();
 
         $has_capacity_mapping = [
             $classname_1 => true,
@@ -115,14 +115,14 @@ class HasLinksCapacity extends DbTestCase
                 \Glpi\Asset\Capacity\HasHistoryCapacity::class,
             ]
         );
-        $classname_1  = $definition_1->getConcreteClassName();
+        $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
                 \Glpi\Asset\Capacity\HasLinksCapacity::class,
                 \Glpi\Asset\Capacity\HasHistoryCapacity::class,
             ]
         );
-        $classname_2  = $definition_2->getConcreteClassName();
+        $classname_2  = $definition_2->getAssetClassName();
 
         $item_1          = $this->createItem(
             $classname_1,

--- a/tests/functional/Glpi/Asset/Capacity/HasNotepadCapacity.php
+++ b/tests/functional/Glpi/Asset/Capacity/HasNotepadCapacity.php
@@ -64,13 +64,13 @@ class HasNotepadCapacity extends DbTestCase
             ],
             profiles: $profiles_matrix
         );
-        $classname_1  = $definition_1->getConcreteClassName();
+        $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
                 \Glpi\Asset\Capacity\HasDocumentsCapacity::class,
             ]
         );
-        $classname_2  = $definition_2->getConcreteClassName();
+        $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
                 \Glpi\Asset\Capacity\HasDocumentsCapacity::class,
@@ -78,7 +78,7 @@ class HasNotepadCapacity extends DbTestCase
             ],
             profiles: $profiles_matrix
         );
-        $classname_3  = $definition_3->getConcreteClassName();
+        $classname_3  = $definition_3->getAssetClassName();
 
         $has_notepad_mapping = [
             $classname_1 => true,
@@ -122,14 +122,14 @@ class HasNotepadCapacity extends DbTestCase
                 \Glpi\Asset\Capacity\HasNotepadCapacity::class,
             ]
         );
-        $classname_1  = $definition_1->getConcreteClassName();
+        $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
                 \Glpi\Asset\Capacity\HasHistoryCapacity::class,
                 \Glpi\Asset\Capacity\HasNotepadCapacity::class,
             ]
         );
-        $classname_2  = $definition_2->getConcreteClassName();
+        $classname_2  = $definition_2->getAssetClassName();
 
         $item_1          = $this->createItem(
             $classname_1,
@@ -216,7 +216,7 @@ class HasNotepadCapacity extends DbTestCase
                 \Glpi\Asset\Capacity\HasNotepadCapacity::class,
             ]
         );
-        $classname  = $definition->getConcreteClassName();
+        $classname  = $definition->getAssetClassName();
 
         $item = $this->createItem(
             $classname,

--- a/tests/functional/Glpi/Asset/Capacity/HasOperatingSystemCapacity.php
+++ b/tests/functional/Glpi/Asset/Capacity/HasOperatingSystemCapacity.php
@@ -66,7 +66,7 @@ class HasOperatingSystemCapacity extends DbTestCase
 
         // Create custom asset definition
         $definition = $this->initAssetDefinition();
-        $class = $definition->getConcreteClassName();
+        $class = $definition->getAssetClassName();
 
         // The capacity is not yet enabled, the itemtype should not be
         // registered in $CFG_GLPI["operatingsystem_types"]
@@ -97,7 +97,7 @@ class HasOperatingSystemCapacity extends DbTestCase
     {
         // Create custom asset definition
         $definition = $this->initAssetDefinition();
-        $class = $definition->getConcreteClassName();
+        $class = $definition->getAssetClassName();
 
         // Create our test subject
         $subject = $this->createItem($class, [
@@ -134,7 +134,7 @@ class HasOperatingSystemCapacity extends DbTestCase
     {
         // Create custom asset definition
         $definition = $this->initAssetDefinition();
-        $class = $definition->getConcreteClassName();
+        $class = $definition->getAssetClassName();
 
         // Check that we have some valid search options to add
         $item_os = new Item_OperatingSystem();
@@ -178,7 +178,7 @@ class HasOperatingSystemCapacity extends DbTestCase
         $definition = $this->initAssetDefinition(
             capacities: [$this->getTargetCapacity()]
         );
-        $class = $definition->getConcreteClassName();
+        $class = $definition->getAssetClassName();
 
         // Create our test subject
         $subject = $this->createItem($class, [
@@ -226,7 +226,7 @@ class HasOperatingSystemCapacity extends DbTestCase
                 HasHistoryCapacity::class
             ]
         );
-        $class = $definition->getConcreteClassName();
+        $class = $definition->getAssetClassName();
 
         // Create our test subject
         $subject = $this->createItem($class, [
@@ -287,7 +287,7 @@ class HasOperatingSystemCapacity extends DbTestCase
         $definition = $this->initAssetDefinition(
             capacities: [$this->getTargetCapacity()]
         );
-        $class = $definition->getConcreteClassName();
+        $class = $definition->getAssetClassName();
 
         // Create our test subject and enable the capacity
         $subject = $this->createItem($class, [

--- a/tests/functional/Glpi/Asset/Capacity/HasVolumesCapacity.php
+++ b/tests/functional/Glpi/Asset/Capacity/HasVolumesCapacity.php
@@ -62,13 +62,13 @@ class HasVolumesCapacity extends DbTestCase
             ],
             profiles: $profiles_matrix
         );
-        $classname_1  = $definition_1->getConcreteClassName();
+        $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
                 \Glpi\Asset\Capacity\HasHistoryCapacity::class,
             ]
         );
-        $classname_2  = $definition_2->getConcreteClassName();
+        $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
                 \Glpi\Asset\Capacity\HasVolumesCapacity::class,
@@ -76,7 +76,7 @@ class HasVolumesCapacity extends DbTestCase
             ],
             profiles: $profiles_matrix
         );
-        $classname_3  = $definition_3->getConcreteClassName();
+        $classname_3  = $definition_3->getAssetClassName();
 
         $has_capacity_mapping = [
             $classname_1 => true,
@@ -136,14 +136,14 @@ class HasVolumesCapacity extends DbTestCase
                 \Glpi\Asset\Capacity\HasHistoryCapacity::class,
             ]
         );
-        $classname_1  = $definition_1->getConcreteClassName();
+        $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
                 \Glpi\Asset\Capacity\HasVolumesCapacity::class,
                 \Glpi\Asset\Capacity\HasHistoryCapacity::class,
             ]
         );
-        $classname_2  = $definition_2->getConcreteClassName();
+        $classname_2  = $definition_2->getAssetClassName();
 
         $item_1          = $this->createItem(
             $classname_1,

--- a/tests/functional/Glpi/Asset/Capacity/IsReservableCapacity.php
+++ b/tests/functional/Glpi/Asset/Capacity/IsReservableCapacity.php
@@ -54,20 +54,20 @@ class IsReservableCapacity extends DbTestCase
                 \Glpi\Asset\Capacity\HasNotepadCapacity::class,
             ]
         );
-        $classname_1  = $definition_1->getConcreteClassName();
+        $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
                 \Glpi\Asset\Capacity\HasHistoryCapacity::class,
             ]
         );
-        $classname_2  = $definition_2->getConcreteClassName();
+        $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
                 \Glpi\Asset\Capacity\IsReservableCapacity::class,
                 \Glpi\Asset\Capacity\HasHistoryCapacity::class,
             ]
         );
-        $classname_3  = $definition_3->getConcreteClassName();
+        $classname_3  = $definition_3->getAssetClassName();
 
         $has_capacity_mapping = [
             $classname_1 => true,
@@ -115,14 +115,14 @@ class IsReservableCapacity extends DbTestCase
                 \Glpi\Asset\Capacity\HasHistoryCapacity::class,
             ]
         );
-        $classname_1  = $definition_1->getConcreteClassName();
+        $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
                 \Glpi\Asset\Capacity\IsReservableCapacity::class,
                 \Glpi\Asset\Capacity\HasHistoryCapacity::class,
             ]
         );
-        $classname_2  = $definition_2->getConcreteClassName();
+        $classname_2  = $definition_2->getAssetClassName();
 
         $item_1          = $this->createItem(
             $classname_1,

--- a/tests/functional/Search.php
+++ b/tests/functional/Search.php
@@ -3647,10 +3647,10 @@ class Search extends DbTestCase
         $document_3 = $this->createTxtDocument();
 
         $definition_1  = $this->initAssetDefinition(capacities: [HasDocumentsCapacity::class]);
-        $asset_class_1 = $definition_1->getConcreteClassName();
+        $asset_class_1 = $definition_1->getAssetClassName();
 
         $definition_2  = $this->initAssetDefinition(capacities: [HasDocumentsCapacity::class]);
-        $asset_class_2 = $definition_2->getConcreteClassName();
+        $asset_class_2 = $definition_2->getAssetClassName();
 
         // Assets for first class
         $asset_1_1 = $this->createItem(

--- a/tests/units/DB.php
+++ b/tests/units/DB.php
@@ -395,7 +395,7 @@ class DB extends \GLPITestCase
 
         // Tables that don't have an itemtype on purpose
         $excluded_tables = [
-            'glpi_assets_assets',
+            'glpi_assets_assets', 'glpi_assets_assetmodels', 'glpi_assets_assettypes',
             'glpi_appliancerelations', 'glpi_oauth_access_tokens', 'glpi_oauth_auth_codes',
             'glpi_oauth_refresh_tokens', 'glpi_stencils',
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Models for custom assets is actually a prerequisite for a rackable capacity as rack properties like pictures, weight, depth, etc are all handled through models in the standard asset itemtypes.