### PR TITLE
Fix resetting of search criteria in some cases

### DIFF
--- a/templates/components/search/query_builder/main.html.twig
+++ b/templates/components/search/query_builder/main.html.twig
@@ -123,7 +123,7 @@
                 {% if p['showreset'] %}
                 <a class="btn btn-sm btn-icon px-2 search-reset"
                    data-bs-toggle="tooltip" data-bs-placement="bottom"
-                   href="{{ p['target'] ~ ('?' in p['target'] ? '&amp;' : '?') ~ "reset=reset" }}" title="{{ __('Blank') }}">
+                   href="{{ p['target'] ~ ('?' in p['target'] ? '&' : '?') ~ "reset=reset" }}" title="{{ __('Blank') }}">
                     <i class="ti ti-square-x"></i>
                 </a>
                 {% elseif p['forcereset'] %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Bad encoding of a "&" separator in the search reset URL causes the reset of search criteria to fail when there are already query parameters present in the URL. For example with custom assets, `/front/asset/asset.php?class=Car&amp;reset=reset`.