### PR TITLE
Fix namespace handling for metacriteria controls

### DIFF
--- a/src/Search/Input/QueryBuilder.php
+++ b/src/Search/Input/QueryBuilder.php
@@ -480,9 +480,6 @@ final class QueryBuilder implements SearchInputInterface
      */
     public static function displayMetaCriteria($request = [])
     {
-        /** @var array $CFG_GLPI */
-        global $CFG_GLPI;
-
         if (
             !isset($request["itemtype"])
             || !isset($request["num"])
@@ -518,7 +515,7 @@ final class QueryBuilder implements SearchInputInterface
         $linked =  SearchEngine::getMetaItemtypeAvailable($itemtype);
         $rand   = mt_rand();
 
-        $rowid  = 'metasearchrow' . $request['itemtype'] . $rand;
+        $rowid  = 'metasearchrow' . Toolbox::getNormalizedItemtype($request['itemtype']) . $rand;
         TemplateRenderer::getInstance()->display('components/search/query_builder/metacriteria.html.twig', [
             'row_id'       => $rowid,
             'metacriteria' => $metacriteria,
@@ -613,7 +610,7 @@ final class QueryBuilder implements SearchInputInterface
         $num         = (int) $request['num'];
         $p           = $request['p'];
         $randrow     = mt_rand();
-        $rowid       = 'searchrow' . $request['itemtype'] . $randrow;
+        $rowid       = 'searchrow' . Toolbox::getNormalizedItemtype($request['itemtype']) . $randrow;
         $prefix      = isset($p['prefix_crit']) ? htmlspecialchars($p['prefix_crit']) : '';
         $parents_num = isset($p['parents_num']) ? $p['parents_num'] : [];
 

--- a/templates/components/search/query_builder/metacriteria.html.twig
+++ b/templates/components/search/query_builder/metacriteria.html.twig
@@ -33,6 +33,7 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
+{% set normalized_itemtype = itemtype|replace({'\\': ''}) %}
 <div class="list-group-item border-0 metacriteria p-2" id="{{ row_id }}">
    <div class="row g-1">
       <div class="col-auto">
@@ -68,7 +69,7 @@
       <input type="hidden" name="criteria{{ prefix ~ "[" ~ num ~ "][meta]" }}" value="true">
       {% set clean_id_prefix = call('Html::cleanId', [prefix]) %}
       {% set field_id = "dropdown_criteria" ~ clean_id_prefix ~ "[" ~ num ~ "][itemtype]" ~ rand %}
-      {% set span_id = "show_" ~ itemtype ~ "_" ~ clean_id_prefix ~ num ~ "_" ~ rand %}
+      {% set span_id = "show_" ~ normalized_itemtype ~ "_" ~ clean_id_prefix ~ num ~ "_" ~ rand %}
       {% set params = {
          action: 'display_criteria',
          itemtype: '__VALUE__',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Namespaced itemtypes were not handled properly within the meta criteria template. Meta criteria controls would break on any namespaced itemtype.