### PR TITLE
Fix getItemTypeForTable when using relation table

### DIFF
--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -320,7 +320,7 @@ final class DbUtils
                     // NOT Glpi\Namespace1\Namespace2\Item\Filter
                     // To avoid this, we can revert the last '_' and check if the itemtype exists
                     $check_alternative = $is_plugin
-                        ? substr_count($table, '_') > 1 // for plugin classes, always keep the first+second namespace levels (GlpiPlugin\\PluginName\\)
+                        ? substr_count($table, '_') >= 1 // for plugin classes, always keep the first+second namespace levels (GlpiPlugin\\PluginName\\)
                         : substr_count($table, '_') > 0 // for GLPI classes, always keep the first namespace level (Glpi\\)
                     ;
                     if ($check_alternative) {

--- a/tests/fixtures/pluginfoo_item_filter.php
+++ b/tests/fixtures/pluginfoo_item_filter.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Foo;
+
+class Item_Filter extends \CommonDBTM
+{
+}

--- a/tests/functional/DbUtils.php
+++ b/tests/functional/DbUtils.php
@@ -147,6 +147,7 @@ class DbUtils extends DbTestCase
         require_once __DIR__ . '/../fixtures/pluginfoobar.php';
         require_once __DIR__ . '/../fixtures/pluginfooservice.php';
         require_once __DIR__ . '/../fixtures/pluginfoo_search_item_filter.php';
+        require_once __DIR__ . '/../fixtures/pluginfoo_item_filter.php';
         require_once __DIR__ . '/../fixtures/pluginfoo_search_a_b_c_d_e_f_g_bar.php';
         require_once __DIR__ . '/../fixtures/test_a_b.php';
 
@@ -163,6 +164,7 @@ class DbUtils extends DbTestCase
             ['glpi_plugin_foo_bazs', 'PluginFooBaz', false], // class not exists
             ['glpi_plugin_foo_services', 'PluginFooService', false], // not a CommonGLPI should not be valid
             ['glpi_plugin_foo_searches_items_filters', 'GlpiPlugin\Foo\Search\Item_Filter', true], // Multi-level namespace + CommonDBRelation
+            ['glpi_plugin_foo_items_filters', 'GlpiPlugin\Foo\Item_Filter', true], // Single level namespace + CommonDBRelation
             ['glpi_anothers_tests', 'Glpi\Another_Test', true], // Single level namespace + CommonDBRelation
             ['glpi_tests_as_bs', 'Glpi\Test\A_B', true], // Multi-level namespace + CommonDBRelation
             ['glpi_plugin_foo_as_bs_cs_ds_es_fs_gs_bars', 'GlpiPlugin\Foo\A\B\C\D\E\F\G\Bar', true], // Long namespace
@@ -1459,6 +1461,10 @@ class DbUtils extends DbTestCase
                 'itemtype' => 'glpiplugin\\foo\\models\\foo\\bar_item',
                 'expected' => 'GlpiPlugin\\Foo\\Models\\Foo\\Bar_Item',
             ],
+            [
+                'itemtype' => 'glpiplugin\\foo\\relation_item',
+                'expected' => 'GlpiPlugin\\Foo\\Relation_Item',
+            ],
          // Good case (should not be altered)
             [
                 'itemtype' => 'MyClass',
@@ -1517,6 +1523,7 @@ class DbUtils extends DbTestCase
                                 ],
                             ],
                             'NamespacedBar.php' => '',
+                            'Relation_Item.php' => '',
                             'PluginFooBarItem.php' => '',
                         ],
                     ],


### PR DESCRIPTION
Same as  https://github.com/glpi-project/glpi/pull/14566

But handle single level namespace + CommonDBRelation from Plugin context

Ex : 
```php
GlpiPlugin\\Foo\\Relation_Item
```


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
