### PR TITLE
Prevent FullCalendar failure when default view is invalid

### DIFF
--- a/js/planning.js
+++ b/js/planning.js
@@ -85,6 +85,21 @@ var GLPIPlanning  = {
         var hidden_days = all_days.filter(day => !enabled_days.some(n => n == day));
         var loadedLocales = Object.keys(FullCalendarLocales);
 
+        // We need to check that the default view is valid to avoid errors
+        // FullCalendar does not seem to offer a method to check if a view is
+        // valid or list all possible views.
+        // It seems the only way to validate our view is to try to create a fake
+        // Calendar instance
+        try {
+            new FullCalendar.Calendar("fake_calendar", { // Invalid selector does not matter
+                defaultView: options.default_view,
+                plugins: options.plugins,
+            });
+        } catch (e) {
+            // Invalid view type, fallback to default
+            options.default_view = default_options.default_view;
+        }
+
         this.calendar = new FullCalendar.Calendar(document.getElementById(GLPIPlanning.dom_id), {
             plugins:     options.plugins,
             height:      options.height,

--- a/js/planning.js
+++ b/js/planning.js
@@ -85,28 +85,12 @@ var GLPIPlanning  = {
         var hidden_days = all_days.filter(day => !enabled_days.some(n => n == day));
         var loadedLocales = Object.keys(FullCalendarLocales);
 
-        // We need to check that the default view is valid to avoid errors
-        // FullCalendar does not seem to offer a method to check if a view is
-        // valid or list all possible views.
-        // It seems the only way to validate our view is to try to create a fake
-        // Calendar instance
-        try {
-            new FullCalendar.Calendar("fake_calendar", { // Invalid selector does not matter
-                defaultView: options.default_view,
-                plugins: options.plugins,
-            });
-        } catch (e) {
-            // Invalid view type, fallback to default
-            options.default_view = default_options.default_view;
-        }
-
         this.calendar = new FullCalendar.Calendar(document.getElementById(GLPIPlanning.dom_id), {
             plugins:     options.plugins,
             height:      options.height,
             timeZone:    'UTC',
             theme:       true,
             weekNumbers: options.full_view ? true : false,
-            defaultView: options.default_view,
             timeFormat:  'H:mm',
             eventLimit:  true, // show 'more' button when too mmany events
             minTime:     CFG_GLPI.planning_begin,
@@ -629,6 +613,12 @@ var GLPIPlanning  = {
                 GLPIPlanning.calendar.unselect();
             }
         });
+
+        // Load the last known view only if it is valid (else load default view)
+        const view = this.calendar.isValidViewType(options.default_view) ?
+            options.default_view :
+            default_options.default_view;
+        this.calendar.changeView(view);
 
         $('.planning_on_central a')
             .mousedown(function() {


### PR DESCRIPTION
The planning page will fail if the default view is unknown to fullcalendar.

For example, the https://github.com/pluginsGLPI/advancedplanning plugin add a new "Timeline week" view, which users may select.
If the plugin is disabled later on, users that were using this view are stuck with an error on the callendar page (which become unusable).

![image](https://github.com/glpi-project/glpi/assets/42734840/bd90992d-498e-4b03-988c-5c269a0209b6)

To fix this, I've added a fallback to the default view.
This is done using a "fake" calendar initialisation in a try/catch block (an invalid view will trigger the catch block, which will revert to the default view before we initialize the real calendar).

It would be cleaner if we could check if a view exist by using an official FullCalendar method but i didn't find anything useful for this purpose in their documentation.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
