### PR TITLE
Replace APIGen link in tool script

### DIFF
--- a/tools/genapidoc.sh
+++ b/tools/genapidoc.sh
@@ -51,6 +51,6 @@ then
       --destination api
 
 else
-   echo -e "\nApiGen not found, see http://www.apigen.org/\n"
+   echo -e "\nApiGen not found, see https://github.com/ApiGen/ApiGen\n"
 
 fi


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

It looks like the owner of ApiGen let the domain expire some time before September 18th last year based on snapshots on the Wayback Machine and at some point someone else bought the domain and it now hosts a sketchy "gambling?" page. We probably shouldn't keep a link to this domain anymore. The project itself doesn't seem completely dead and the GitHub repo doesn't seem compromised, so if we need to keep a link, we could use that. Otherwise, maybe we should remove the link completely, or remove/change the script to use something else.