### PR TITLE
Fix scrolling in requests debug widget

### DIFF
--- a/js/src/vue/Debug/Widget/HTTPRequests.vue
+++ b/js/src/vue/Debug/Widget/HTTPRequests.vue
@@ -190,7 +190,7 @@
 </script>
 
 <template>
-    <div ref="content_area" @mousemove="onMouseMove($event)" @mouseup="onMouseUp()">
+    <div class="h-100" ref="content_area" @mousemove="onMouseMove($event)" @mouseup="onMouseUp()">
         <div class="request-timeline" v-if="is_mounted && show_timeline">
             <RequestTimeline :initial_request="initial_request" :ajax_requests="props.ajax_requests" :content_area="content_area"
                              @change_request="onRequestChanged"></RequestTimeline>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

It was impossible to scroll the request list or sub-widgets like the profiler separately. Scrolling in either panel would scroll the entire content area due to a missing height property on one of the divs between the scrollable containers and the element with the non-percentage height.