### PR TITLE
Improve asset definition deletion

### DIFF
--- a/js/glpi_dialog.js
+++ b/js/glpi_dialog.js
@@ -292,6 +292,7 @@ var glpi_confirm = function({
     confirm_label = _x('button', 'Confirm'),
     cancel_callback  = () => {},
     cancel_label  = _x('button', 'Cancel'),
+    close_callback  = () => {},
 } = {}) {
 
     glpi_html_dialog({
@@ -308,7 +309,8 @@ var glpi_confirm = function({
             click: function(event) {
                 cancel_callback(event);
             }
-        }]
+        }],
+        close: close_callback
     });
 
     return id;

--- a/src/Asset/AssetDefinition.php
+++ b/src/Asset/AssetDefinition.php
@@ -141,6 +141,23 @@ final class AssetDefinition extends CommonDBTM
     public function showForm($ID, array $options = [])
     {
         $this->initForm($ID, $options);
+        $options['candel'] = false;
+
+        if (!self::isNewID($ID)) {
+            // Add custom delete button that will show the number of assets using this definition and a link to their search page
+            $asset_count = countElementsInTable('glpi_assets_assets', ['assets_assetdefinitions_id' => $ID]);
+            $asset_class = $this->getAssetClassName();
+            $asset_search_url = $asset_class::getSearchURL();
+            $options['addbuttons'] = [
+                'purge' => [
+                    'title' => _x('button', 'Delete permanently'),
+                    'add_class' => 'btn-outline-danger',
+                    'icon' => 'ti ti-trash',
+                    'text' => _x('button', 'Delete permanently'),
+                    'type' => 'submit',
+                ]
+            ];
+        }
         TemplateRenderer::getInstance()->display(
             'pages/admin/assetdefinition/main.html.twig',
             [
@@ -148,6 +165,8 @@ final class AssetDefinition extends CommonDBTM
                 'params'                => $options,
                 'has_rights_enabled'    => $this->hasRightsEnabled(),
                 'reserved_system_names' => AssetDefinitionManager::getInstance()->getReservedAssetsSystemNames(),
+                'asset_count'        => $asset_count ?? 0,
+                'asset_search_url'   => $asset_search_url ?? '#',
             ]
         );
         return true;

--- a/src/Asset/AssetDefinition.php
+++ b/src/Asset/AssetDefinition.php
@@ -144,6 +144,8 @@ final class AssetDefinition extends CommonDBTM
         $this->initForm($ID, $options);
         $options['candel'] = false;
 
+        $asset_count = 0;
+
         if (!self::isNewID($ID)) {
             // Add custom delete button that will show the number of assets using this definition and a link to their search page
             $asset_count = countElementsInTable(
@@ -153,14 +155,6 @@ final class AssetDefinition extends CommonDBTM
                     'is_template' => 0
                 ]
             );
-            $asset_class = $this->getAssetClassName();
-            $asset_search_url = $asset_class::getSearchURL();
-            $params = [
-                'reset' => 'reset',
-                'criteria' => QueryBuilder::getDefaultCriteria($asset_class::getType())
-            ];
-            $asset_search_url .= '&' . \Toolbox::append_params($params);
-
             $options['addbuttons'] = [
                 'purge' => [
                     'title' => _x('button', 'Delete permanently'),
@@ -171,6 +165,7 @@ final class AssetDefinition extends CommonDBTM
                 ]
             ];
         }
+
         TemplateRenderer::getInstance()->display(
             'pages/admin/assetdefinition/main.html.twig',
             [
@@ -178,8 +173,7 @@ final class AssetDefinition extends CommonDBTM
                 'params'                => $options,
                 'has_rights_enabled'    => $this->hasRightsEnabled(),
                 'reserved_system_names' => AssetDefinitionManager::getInstance()->getReservedAssetsSystemNames(),
-                'asset_count'        => $asset_count ?? 0,
-                'asset_search_url'   => $asset_search_url ?? '#',
+                'asset_count'           => $asset_count,
             ]
         );
         return true;

--- a/src/Asset/AssetDefinition.php
+++ b/src/Asset/AssetDefinition.php
@@ -41,6 +41,7 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\Asset\Capacity\CapacityInterface;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\Search\Input\QueryBuilder;
 use Profile;
 use ProfileRight;
 use Session;
@@ -148,6 +149,12 @@ final class AssetDefinition extends CommonDBTM
             $asset_count = countElementsInTable('glpi_assets_assets', ['assets_assetdefinitions_id' => $ID]);
             $asset_class = $this->getAssetClassName();
             $asset_search_url = $asset_class::getSearchURL();
+            $params = [
+                'reset' => 'reset',
+                'criteria' => QueryBuilder::getDefaultCriteria($asset_class::getType())
+            ];
+            $asset_search_url .= '&' . \Toolbox::append_params($params);
+
             $options['addbuttons'] = [
                 'purge' => [
                     'title' => _x('button', 'Delete permanently'),

--- a/src/Asset/AssetDefinition.php
+++ b/src/Asset/AssetDefinition.php
@@ -146,7 +146,13 @@ final class AssetDefinition extends CommonDBTM
 
         if (!self::isNewID($ID)) {
             // Add custom delete button that will show the number of assets using this definition and a link to their search page
-            $asset_count = countElementsInTable('glpi_assets_assets', ['assets_assetdefinitions_id' => $ID]);
+            $asset_count = countElementsInTable(
+                table: 'glpi_assets_assets',
+                condition: [
+                    'assets_assetdefinitions_id' => $ID,
+                    'is_template' => 0
+                ]
+            );
             $asset_class = $this->getAssetClassName();
             $asset_search_url = $asset_class::getSearchURL();
             $params = [

--- a/templates/pages/admin/assetdefinition/main.html.twig
+++ b/templates/pages/admin/assetdefinition/main.html.twig
@@ -102,7 +102,7 @@
                 const handle_delete = (e) => {
                     e.preventDefault();
                     glpi_confirm({
-                        title: '{{ __('Confirm the final deletion?') }}',
+                        title: '{{ __('Confirm the final deletion?')|e('js') }}',
                         message: '{{ delete_msg|e('js') }}',
                         confirm_callback: () => {
                             // Our 'one' custom handler was already called, so this will call the default one

--- a/templates/pages/admin/assetdefinition/main.html.twig
+++ b/templates/pages/admin/assetdefinition/main.html.twig
@@ -97,29 +97,68 @@
                 </div>
             {% endif %}
         {% endset %}
+        <div class="modal fade" id="deletionWarningModal" tabindex="-1" role="dialog" aria-hidden="true">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <a type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ _x('button', 'Close') }}"></a>
+                    <div class="modal-status bg-danger"></div>
+                    <div class="modal-body text-center py-4">
+                        {# SVG Icon corresponding to the ti-alert-triangle icon #}
+                        <svg xmlns="http://www.w3.org/2000/svg" class="icon mb-2 text-danger icon-lg" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path d="M12 9v4"></path><path d="M10.363 3.591l-8.106 13.534a1.914 1.914 0 0 0 1.636 2.871h16.214a1.914 1.914 0 0 0 1.636 -2.87l-8.106 -13.536a1.914 1.914 0 0 0 -3.274 0z"></path><path d="M12 16h.01"></path></svg>
+
+                        <h3>{{ _x('button', 'Are you sure?') }}</h3>
+                        <div class="text-muted">
+                            {% if asset_count > 0 %}
+                                {{ __('This asset definition is used by %d assets.')|format(asset_count) }}
+                                <br>
+                                {% if item.fields['is_active'] %}
+                                    {# Can only view search page when the definition is active #}
+                                    <a href="{{ asset_search_url }}">{{ __('Show what would be deleted') }}</a>
+                                {% else %}
+                                    {{ __('All assets that are using this definition will also be deleted.') }}
+                                {% endif %}
+                            {% else %}
+                                {{ __('This asset definition is not used by any assets.') }}
+                            {% endif %}
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <div class="w-100">
+                            <div class="row">
+                                <div class="col">
+                                    <a class="btn w-100" data-bs-dismiss="modal">
+                                        {{ _x('button', 'Cancel') }}
+                                    </a>
+                                </div>
+                                <div class="col">
+                                    <button type="button" class="btn btn-danger w-100" name="save">
+                                        {{ _x('button', 'Yes, delete it!') }}
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
         <script>
-            $(() => {
-                const handle_delete = (e) => {
-                    e.preventDefault();
-                    glpi_confirm({
-                        title: '{{ __('Confirm the final deletion?')|e('js') }}',
-                        message: '{{ delete_msg|e('js') }}',
-                        confirm_callback: () => {
-                            // Our 'one' custom handler was already called, so this will call the default one
-                            $('.asset button[name="purge"]').click();
-                        },
-                        cancel_callback: () => {
-                            // Rebind our custom handler to be run once
-                            $('.asset button[name="purge"]').one('click', handle_delete);
-                        },
-                        close_callback: () => {
-                            // Rebind our custom handler to be run once if the modal is closed
-                            $('.asset button[name="purge"]').one('click', handle_delete);
-                        },
-                    });
+            $('#mainformtable button[name="purge"]').on('click', { is_from_modal: false }, (event, data) => {
+                data = data || event.data;
+
+                if (data.is_from_modal !== true) {
+                    event.preventDefault();
+                    $('#deletionWarningModal').modal('show');
                 }
-                // Using glpi_confirm modal instead of default `confirm` dialog because we have some HTML we want to show while the default window only supports text.
-                $('.asset button[name="purge"]').one('click', handle_delete);
+            });
+
+            $('#deletionWarningModal button[name="save"]').on('click', () => {
+                $('#deletionWarningModal').modal('hide');
+                $('#mainformtable button[name="purge"]').trigger(
+                    'click',
+                    {
+                        'is_from_modal': true,
+                    }
+                );
             });
         </script>
     {% endif %}

--- a/templates/pages/admin/assetdefinition/main.html.twig
+++ b/templates/pages/admin/assetdefinition/main.html.twig
@@ -77,26 +77,6 @@
     {% endif %}
 
     {% if not item.isNewItem() %}
-        {% set delete_msg %}
-            {% if asset_count > 0 %}
-                <div class="alert alert-warning">
-                    <div class="alert-title">{{ __('This asset definition is used by %d assets.')|format(asset_count) }}</div>
-                    <br>
-                    <div class="text-secondary">
-                        {% if item.fields['is_active'] %}
-                            {# Can only view search page when the definition is active #}
-                            <a href="{{ asset_search_url }}">{{ __('Show what would be deleted') }}</a>
-                        {% else %}
-                            {{ __('All assets that are using this definition will also be deleted.') }}
-                        {% endif %}
-                    </div>
-                </div>
-            {% else %}
-                <div class="alert alert-info">
-                    <div class="alert-title">{{ __('This asset definition is not used by any assets.') }}</div>
-                </div>
-            {% endif %}
-        {% endset %}
         <div class="modal fade" id="deletionWarningModal" tabindex="-1" role="dialog" aria-hidden="true">
             <div class="modal-dialog" role="document">
                 <div class="modal-content">
@@ -111,12 +91,7 @@
                             {% if asset_count > 0 %}
                                 {{ __('This asset definition is used by %d assets.')|format(asset_count) }}
                                 <br>
-                                {% if item.fields['is_active'] %}
-                                    {# Can only view search page when the definition is active #}
-                                    <a href="{{ asset_search_url }}">{{ __('Show what would be deleted') }}</a>
-                                {% else %}
-                                    {{ __('All assets that are using this definition will also be deleted.') }}
-                                {% endif %}
+                                {{ __('All assets that are using this definition will be deleted.') }}
                             {% else %}
                                 {{ __('This asset definition is not used by any assets.') }}
                             {% endif %}

--- a/templates/pages/admin/assetdefinition/main.html.twig
+++ b/templates/pages/admin/assetdefinition/main.html.twig
@@ -76,6 +76,53 @@
         ) }}
     {% endif %}
 
+    {% if not item.isNewItem() %}
+        {% set delete_msg %}
+            {% if asset_count > 0 %}
+                <div class="alert alert-warning">
+                    <div class="alert-title">{{ __('This asset definition is used by %d assets.')|format(asset_count) }}</div>
+                    <br>
+                    <div class="text-secondary">
+                        {% if item.fields['is_active'] %}
+                            {# Can only view search page when the definition is active #}
+                            <a href="{{ asset_search_url }}">{{ __('Show what would be deleted') }}</a>
+                        {% else %}
+                            {{ __('All assets that are using this definition will also be deleted.') }}
+                        {% endif %}
+                    </div>
+                </div>
+            {% else %}
+                <div class="alert alert-info">
+                    <div class="alert-title">{{ __('This asset definition is not used by any assets.') }}</div>
+                </div>
+            {% endif %}
+        {% endset %}
+        <script>
+            $(() => {
+                const handle_delete = (e) => {
+                    e.preventDefault();
+                    glpi_confirm({
+                        title: '{{ __('Confirm the final deletion?') }}',
+                        message: '{{ delete_msg|e('js') }}',
+                        confirm_callback: () => {
+                            // Our 'one' custom handler was already called, so this will call the default one
+                            $('.asset button[name="purge"]').click();
+                        },
+                        cancel_callback: () => {
+                            // Rebind our custom handler to be run once
+                            $('.asset button[name="purge"]').one('click', handle_delete);
+                        },
+                        close_callback: () => {
+                            // Rebind our custom handler to be run once if the modal is closed
+                            $('.asset button[name="purge"]').one('click', handle_delete);
+                        },
+                    });
+                }
+                // Using glpi_confirm modal instead of default `confirm` dialog because we have some HTML we want to show while the default window only supports text.
+                $('.asset button[name="purge"]').one('click', handle_delete);
+            });
+        </script>
+    {% endif %}
     {{ parent() }}
 {% endblock %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Replace use of the default confirmation dialog with one that says how many assets use the definition and would be deleted as a result of deleting the definition. If the definition is active, it shows a link to the asset search page so you can see what would be deleted. If the definition is inactive, they wouldn't have permission to view the search page so it simply says all assets using the definition will be deleted too.

Also changed the `glpi_confirm` function to allow specifying a callback to run when the modal is closed.