### PR TITLE
Add icon selector and search for asset definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,7 @@ The present file will list all changes made to the project; according to the
 - `Toolbox::seems_utf8()`
 - `Toolbox::stripslashes_deep()`
 - `Search::getOptions()` no longer returns a reference
+- `js/Forms/FaIconSelector.js` has been deprecated and replaced by `js/modules/Form/WebIconSelector.js`
 
 #### Removed
 - Usage of `csrf_compliant` plugins hook.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,7 +184,7 @@ The present file will list all changes made to the project; according to the
 - `Toolbox::seems_utf8()`
 - `Toolbox::stripslashes_deep()`
 - `Search::getOptions()` no longer returns a reference
-- `js/Forms/FaIconSelector.js` has been deprecated and replaced by `js/modules/Form/WebIconSelector.js`
+- `js/Forms/FaIconSelector.js` and therefore `window.GLPI.Forms.FaIconSelector` has been deprecated and replaced by `js/modules/Form/WebIconSelector.js`
 
 #### Removed
 - Usage of `csrf_compliant` plugins hook.

--- a/js/modules/Form/WebIconSelector.js
+++ b/js/modules/Form/WebIconSelector.js
@@ -31,49 +31,51 @@
  * ---------------------------------------------------------------------
  */
 
-var GLPI = GLPI || {};
-GLPI.Forms = GLPI.Forms || {};
-
 /**
- * Font-Awesome icon selector component.
+ * Web icon selector component.
+ * This class can handle both Tabler and FontAwesome icons.
  *
- * @since 10.0.0
- * @deprecated 10.1.0 Use `modules/Form/WebIconSelector.js` instead.
+ * @since 10.1.0
  */
-GLPI.Forms.FaIconSelector = class {
+export class WebIconSelector {
 
     /**
-    * @param {HTMLSelectElement} selectElement
-    */
-    constructor(selectElement) {
+     * @param {HTMLSelectElement} selectElement The select element to use.
+     * @param {array} icon_sets The icon sets to use.
+     *                          Valid icon sets are 'ti' (Tabler) and 'fa' (FontAwesome).
+     *                          The tabler icon set is the preferred one.
+     */
+    constructor(selectElement, icon_sets = ['ti']) {
         this.selectElement = selectElement;
+        this.icon_sets = icon_sets;
     }
 
     /**
-    * Initialize the component.
-    *
-    * @returns {void}
-    */
+     * Initialize the component.
+     *
+     * @returns {void}
+     */
     init() {
-        const icons = this.fetchAvailableIcons();
+        const icons = this.#fetchAvailableIcons();
         $(this.selectElement).select2(
             {
                 data: icons,
-                templateResult: this.renderIcon,
-                templateSelection: this.renderIcon
+                templateResult: this.#renderIcon,
+                templateSelection: this.#renderIcon
             }
         );
     }
 
     /**
-    * Fetch available icons list from declared CSS.
-    *
-    * @private
-    *
-    * @returns {array}
-    */
-    fetchAvailableIcons() {
-        var icons = [];
+     * Fetch available icons list from declared CSS.
+     *
+     * @private
+     *
+     * @returns {array}
+     */
+    #fetchAvailableIcons() {
+        const icons = [];
+        const iconset_regex = new RegExp('^.(' + this.icon_sets.join('|') + '-[a-z-]+)::before$');
 
         for (let i = 0; i < document.styleSheets.length; i++) {
             const rules = document.styleSheets[i].cssRules;
@@ -84,10 +86,10 @@ GLPI.Forms.FaIconSelector = class {
                 }
                 // On minified CSS, similar icons will be grouped,
                 // e.g. `.fa-arrow-turn-right::before,.fa-mail-forward::before,.fa-share::before`.
-                // Split them to handle the separately.
+                // Split them to handle them separately.
                 const selectors = rule.selectorText.split(',');
                 for(let k = 0; k < selectors.length; k++) {
-                    let matches = selectors[k].trim().match(/^\.(fa-[a-z-]+)::before$/);
+                    let matches = selectors[k].trim().match(iconset_regex);
                     if (matches !== null) {
                         const cls = matches[1];
                         const entry = {
@@ -106,17 +108,22 @@ GLPI.Forms.FaIconSelector = class {
     }
 
     /**
-    * Render an icon entry..
-    *
-    * @private
-    *
-    * @returns {HTMLElement}
-    */
-    renderIcon(option) {
-        // Forces font family values to fallback on ".fab" family font if char is not available in ".fas" family.
-        const faFontFamilies = '\'Font Awesome 6 Free\', \'Font Awesome 6 Brands\'';
-        let container = document.createElement('span');
-        container.innerHTML = `<i class="fa-lg fa-fw fa ${option.id}" style="font-family:${faFontFamilies};"></i> ${option.id}`;
-        return container;
+     * Render an icon entry.
+     *
+     * @private
+     *
+     * @returns {HTMLElement}
+     */
+    #renderIcon(option) {
+        if (typeof option.id !== 'undefined') {
+            let container = document.createElement('span');
+            const iconset_prefix = option.id.split('-')[0];
+            container.innerHTML = `<i class="${iconset_prefix} ${option.id}"></i> ${option.id}`;
+            return container;
+        } else {
+            return option.text;
+        }
     }
-};
+}
+
+export default WebIconSelector;

--- a/js/modules/Form/WebIconSelector.js
+++ b/js/modules/Form/WebIconSelector.js
@@ -75,7 +75,7 @@ export class WebIconSelector {
      */
     #fetchAvailableIcons() {
         const icons = [];
-        const iconset_regex = new RegExp('^.(' + this.icon_sets.join('|') + '-[a-z-]+)::before$');
+        const iconset_regex = new RegExp('^.((?:' + this.icon_sets.join('|') + ')-[a-z-]+)::before$');
 
         for (let i = 0; i < document.styleSheets.length; i++) {
             const rules = document.styleSheets[i].cssRules;

--- a/src/Asset/AssetDefinition.php
+++ b/src/Asset/AssetDefinition.php
@@ -507,7 +507,7 @@ final class AssetDefinition extends CommonDBTM
      */
     public function getAssetsIcon(): string
     {
-        return $this->fields['icon'] ?: 'ti ti-box';
+        return 'ti ' . ($this->fields['icon'] ?: 'ti-box');
     }
 
     public function rawSearchOptions()
@@ -555,6 +555,7 @@ final class AssetDefinition extends CommonDBTM
             'field'         => 'icon',
             'name'          => __('Icon'),
             'datatype'      => 'specific',
+            'searchtype'    => ['equals'],
         ];
 
         $search_options[] = [
@@ -607,8 +608,7 @@ final class AssetDefinition extends CommonDBTM
         switch ($field) {
             case 'icon':
                 $value = htmlspecialchars($values[$field]);
-                return sprintf('<i class="%s"></i>', $value);
-                break;
+                return sprintf('<i class="ti %s"></i>', $value);
         }
         return parent::getSpecificValueToDisplay($field, $values, $options);
     }
@@ -621,8 +621,11 @@ final class AssetDefinition extends CommonDBTM
 
         switch ($field) {
             case 'icon':
-                // TODO Show icon selector
-                break;
+                $value = htmlspecialchars($values[$field]) ?? '';
+                return TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
+                    {% import 'components/form/fields_macros.html.twig' as fields %}
+                    {{ fields.dropdownWebIcons(name, value, '', {no_label: true, width: '200px'}) }}
+TWIG, ['name' => $name, 'value' => $value]);
         }
         return parent::getSpecificValueToSelect($field, $name, $values, $options);
     }

--- a/src/Asset/AssetDefinition.php
+++ b/src/Asset/AssetDefinition.php
@@ -621,7 +621,7 @@ final class AssetDefinition extends CommonDBTM
 
         switch ($field) {
             case 'icon':
-                $value = htmlspecialchars($values[$field]) ?? '';
+                $value = htmlspecialchars($values[$field] ?? '');
                 return TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
                     {% import 'components/form/fields_macros.html.twig' as fields %}
                     {{ fields.dropdownWebIcons(name, value, '', {no_label: true, width: '200px'}) }}

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -2203,6 +2203,10 @@ JAVASCRIPT;
         } else {
             $output  .= "<select name='$field_name' id='$field_id'";
 
+            if ($param['width'] !== '') {
+                $output .= " style='width: " . $param['width'] . "'";
+            }
+
             if ($param['tooltip']) {
                 $output .= ' title="' . Html::entities_deep($param['tooltip']) . '"';
             }

--- a/src/ManualLink.php
+++ b/src/ManualLink.php
@@ -159,6 +159,7 @@ class ManualLink extends CommonDBChild
         );
         echo '</td>';
         echo '</tr>';
+        //TODO Replace this with the WebIconSelector module via the dropdownWebIcons macro when this gets migrated to twig
         echo Html::script('js/Forms/FaIconSelector.js');
         echo Html::scriptBlock(<<<JAVASCRIPT
          $(

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -591,7 +591,6 @@
     <script type="module">
         import('{{ js_path('js/modules/Form/WebIconSelector.js') }}').then((m) => {
             const dropdown_id = '{{ ('dropdown_' ~ name ~ options.rand)|replace({'[': '_', ']': '_'}) }}';
-            console.log(dropdown_id);
             const selector = new m.default(document.getElementById(dropdown_id), ['ti']);
             selector.init();
         });

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -578,6 +578,26 @@
    {{ _self.field(name, field, label, options|merge({'id': 'dropdown_' ~ name ~ options.rand})) }}
 {% endmacro %}
 
+{% macro dropdownWebIcons(name, value, label = '', options = {}) %}
+    {% set options = {
+        rand: random(),
+    }|merge(options|merge({
+        noselect2: true,
+    })) %}
+    {# Trim 'ti ' prefix if it exists in the value #}
+    {% set value = value|replace({'ti ': ''}) %}
+
+    {{ _self.dropdownArrayField(name, value, {(value): value}, label, options) }}
+    <script type="module">
+        import('{{ js_path('js/modules/Form/WebIconSelector.js') }}').then((m) => {
+            const dropdown_id = '{{ ('dropdown_' ~ name ~ options.rand)|replace({'[': '_', ']': '_'}) }}';
+            console.log(dropdown_id);
+            const selector = new m.default(document.getElementById(dropdown_id), ['ti']);
+            selector.init();
+        });
+    </script>
+{% endmacro %}
+
 {% macro dropdownHoursField(name, value, label = '', options = {}) %}
     {% set options = {
         'rand': random(),

--- a/templates/pages/admin/assetdefinition/main.html.twig
+++ b/templates/pages/admin/assetdefinition/main.html.twig
@@ -75,8 +75,7 @@
 {% endblock %}
 
 {% block more_fields %}
-    {# TODO Replace it by a reusable "icon" field macro (based on tabler icons) #}
-    {{ fields.textField(
+    {{ fields.dropdownWebIcons(
         'icon',
         item.fields['icon'],
         __('Icon'),

--- a/tests/js/bootstrap.mjs
+++ b/tests/js/bootstrap.mjs
@@ -38,7 +38,8 @@ await import('jquery').then((jquery) => {
 });
 await import('@tabler/core');
 await import('select2/dist/js/select2.full').then((select2) => {
-    $.fn.select2 = select2;
+    // Select2 exports a function that registers itself as a jQuery plugin
+    select2.default();
 });
 
 // Add a flag variable to know in other scripts if they are run in tests. Should not affect how they behave, just how functions/vars in non-modules are bound.

--- a/tests/js/modules/Form/WebIconSelector.test.js
+++ b/tests/js/modules/Form/WebIconSelector.test.js
@@ -1,0 +1,126 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { WebIconSelector } from '../../../../js/modules/Form/WebIconSelector.js';
+
+describe('Web Icon Selector', () => {
+    beforeEach(() => {
+        $('body').empty();
+        // Mock the existance of the fontawesome and tabler css by manually crafting fake css rules and adding them to the document
+        const style = document.createElement('style');
+        style.type = 'text/css';
+        style.innerHTML = `
+            .ti-home::before{content: "\\e600";}
+            .fa-home::before{content: "\\f015";}
+            .fa-arrow-turn-right::before,.fa-mail-forward::before,.fa-share::before{content: "\\f064";}
+        `;
+        $('head').empty();
+        document.getElementsByTagName('head')[0].appendChild(style);
+    });
+    test('Class exists', () => {
+        expect(WebIconSelector).toBeDefined();
+    });
+    test('Constructor', () => {
+        const selectElement = document.createElement('select');
+        const webIconSelector = new WebIconSelector(selectElement);
+        expect(webIconSelector.selectElement).toBe(selectElement);
+        expect(webIconSelector.icon_sets).toEqual(['ti']);
+
+        const webIconSelector2 = new WebIconSelector(selectElement, ['ti', 'fa']);
+        expect(webIconSelector2.selectElement).toBe(selectElement);
+        expect(webIconSelector2.icon_sets).toEqual(['ti', 'fa']);
+
+        const webIconSelector3 = new WebIconSelector(selectElement, ['fa']);
+        expect(webIconSelector3.selectElement).toBe(selectElement);
+        expect(webIconSelector3.icon_sets).toEqual(['fa']);
+    });
+    test('Init select2', () => {
+        $('body').append('<select id="test"></select>');
+        const webIconSelector = new WebIconSelector(document.getElementById('test'));
+        webIconSelector.init();
+
+        expect($(webIconSelector.selectElement).data('select2')).toBeDefined();
+    });
+    test('Select2 data', async () => {
+        $('body')
+            .append('<select id="test"></select>')
+            .append('<select id="test2"></select>')
+            .append('<select id="test3"></select>');
+        const webIconSelector = new WebIconSelector(document.getElementById('test'));
+        webIconSelector.init();
+        await new Promise(process.nextTick);
+
+        const select2_options = $('#test').data('select2').results.data._dataToConvert;
+        expect(select2_options).toBeDefined();
+        expect(select2_options.length).toBe(1);
+        // each option id and text should match and contain 'ti-'
+        select2_options.forEach((option) => {
+            expect(option.id).toBe(option.text);
+            expect(option.id).toContain('ti-');
+        });
+
+        // Test with FontAwesome
+        const webIconSelector2 = new WebIconSelector(document.getElementById('test2'), ['fa']);
+        webIconSelector2.init();
+
+        const select2_options2 = $('#test2').data('select2').results.data._dataToConvert;
+        expect(select2_options2).toBeDefined();
+        expect(select2_options2.length).toBe(4);
+        // each option id and text should match and contain 'fa-'
+        select2_options2.forEach((option) => {
+            expect(option.id).toBe(option.text);
+            expect(option.id).toContain('fa-');
+        });
+
+        // Test with both icon sets
+        const webIconSelector3 = new WebIconSelector(document.getElementById('test3'), ['ti', 'fa']);
+        webIconSelector3.init();
+
+        let has_ti = false;
+        let has_fa = false;
+        const select2_options3 = $('#test3').data('select2').results.data._dataToConvert;
+        expect(select2_options3).toBeDefined();
+        expect(select2_options3.length).toBe(5);
+        // each option id and text should match and contain 'fa-' or 'ti-' and both types of icons should be present
+        select2_options3.forEach((option) => {
+            expect(option.id).toBe(option.text);
+            if (option.id.includes('fa-')) {
+                has_fa = true;
+            } else if (option.id.includes('ti-')) {
+                has_ti = true;
+            }
+        });
+        expect(has_ti).toBeTrue();
+        expect(has_fa).toBeTrue();
+    });
+});


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

- Add WebIconSelector JS module/class based on `FaIconSelector.js` which can handle both Tabler and FontAwesome icons but defaults to only Tabler icons. FaIconSelector is now deprecated but remains as it was so non-module code can still import it and use the global set on `window`.
- Finished `icon` search option to show the web icon selector in the search criteria.
- Added reminder to replace the FaIconSelector usage by ManualLink when the form is moved to twig.