### PR TITLE
Feat/enhanced datatable twig

### DIFF
--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -119,7 +119,7 @@
                                        <select name="filters[{{ colkey }}][]"
                                             class="form-select filter-select-multiple" multiple>
                                         {% for field, value in columns_values[colkey] %}
-                                            <option value="{{ field }}" {{ filters[colkey] is defined and value in filters[colkey] ? 'selected' : '' }}>
+                                            <option value="{{ field }}" {{ filters[colkey] is defined and field in filters[colkey] ? 'selected' : '' }}>
                                                 {{ value }}
                                             </option>
                                         {% endfor %}
@@ -172,7 +172,7 @@
                                 <td>
                                     {% if colkey in entry|keys %}
 
-                                        {% set formatter = formatters[colkey] %}
+                                        {% set formatter = row_formatters[colkey]|default(formatters[colkey]) %}
 
                                         {% if formatter == "maintext" %}
                                             <span class="d-inline-block bg-blue-lt p-1 text-truncate"
@@ -212,7 +212,7 @@
                                                    {% endif %}
                                                 </span>
                                         {% else %}
-                                            {{ entry[colkey] }}
+                                            {{ entry[colkey]}}
                                         {% endif %}
                                     {% endif %}
                                 </td>


### PR DESCRIPTION
First commit allow you to display HTML in table row content

Before : 

![image](https://github.com/glpi-project/glpi/assets/7335054/8fc5f96e-2568-4198-a548-95d62bc971c3)

After : 

![image](https://github.com/glpi-project/glpi/assets/7335054/d4aba9c8-3f2b-4928-952b-c1bf9c9c725a)

The second commit search selected value (from filter list) by ```key``` instead of ```value``` when filter is a 'real' dropdown (```key => val``` / ```0 => 'foo'```)

 dropdown is created like this 

```php
Array
  (
      [2] => 16780900
      [1] => stanislas-asus-desktop-2022-09-20-16-43-09
  )
```

and filter is created like this

```php
Array
  (
      [agents_id] => Array
          (
              [0] => 2
          )
  )
```

See  : https://github.com/pluginsGLPI/deploy/pull/13

Actually, only ```Item_Processes``` and ```Item_Environment``` use ```dropdown``` filter , but in each case ```key``` is equal to ```value```

```php
Array
  (
      [root] => root
      [systemd+] => systemd+
      [avahi] => avahi
      [message+] => message+
      [syslog] => syslog
      [rtkit] => rtkit
      [kernoops] => kernoops
      [postfix] => postfix
      [lp] => lp
      [colord] => colord
      [stanisl+] => stanisl+
      [mysql] => mysql
  )
```


Need by  : https://github.com/pluginsGLPI/deploy/pull/13

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
