### PR TITLE
Allow usage of node 18.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,8 +101,8 @@
                 "webpack-cli": "^5.1.4"
             },
             "engines": {
-                "node": ">= 20.9",
-                "npm": ">= 10.1"
+                "node": ">= 18.12",
+                "npm": ">= 8.19"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "description": "GLPI dependencies",
     "license": "GPL-3.0-or-later",
     "engines": {
-        "node": ">= 20.9",
-        "npm": ">= 10.1"
+        "node": ">= 18.12",
+        "npm": ">= 8.19"
     },
     "dependencies": {
         "@algolia/autocomplete-js": "^1.12.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`dependabot` is still not yet compatible with node 20, meaning that `dependabot` updates are not done on main branch as expected. All out dependencies are compatible with node 18, so we can allow it until https://github.com/dependabot/dependabot-core/pull/8275 is merged.