### PR TITLE
fix(datatable): search in key instead of value

### DIFF
--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -119,7 +119,7 @@
                                        <select name="filters[{{ colkey }}][]"
                                             class="form-select filter-select-multiple" multiple>
                                         {% for field, value in columns_values[colkey] %}
-                                            <option value="{{ field }}" {{ filters[colkey] is defined and value in filters[colkey] ? 'selected' : '' }}>
+                                            <option value="{{ field }}" {{ filters[colkey] is defined and field in filters[colkey] ? 'selected' : '' }}>
                                                 {{ value }}
                                             </option>
                                         {% endfor %}


### PR DESCRIPTION
Search selected value (from filter list) by ```key``` instead of ```value``` when filter is a 'real' dropdown (```key => val``` / ```0 => 'foo'```)

 dropdown is created like this 

```php
Array
  (
      [2] => 16780900
      [1] => stanislas-asus-desktop-2022-09-20-16-43-09
  )
```

and filter is created like this

```php
Array
  (
      [agents_id] => Array
          (
              [0] => 2
          )
  )
```

Actually, only ```Item_Processes``` and ```Item_Environment``` use ```dropdown``` filter , but in each case ```key``` is equal to ```value```

```php
Array
  (
      [root] => root
      [systemd+] => systemd+
      [avahi] => avahi
      [message+] => message+
      [syslog] => syslog
      [rtkit] => rtkit
      [kernoops] => kernoops
      [postfix] => postfix
      [lp] => lp
      [colord] => colord
      [stanisl+] => stanisl+
      [mysql] => mysql
  )
```


Need by  : https://github.com/pluginsGLPI/deploy/pull/13


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
