### PR TITLE
feat(datatable): add capability to define row format

### DIFF
--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -172,7 +172,7 @@
                                 <td>
                                     {% if colkey in entry|keys %}
 
-                                        {% set formatter = formatters[colkey] %}
+                                        {% set formatter = row_formatters[colkey]|default(formatters[colkey]) %}
 
                                         {% if formatter == "maintext" %}
                                             <span class="d-inline-block bg-blue-lt p-1 text-truncate"


### PR DESCRIPTION
Add capability to define row format

Actually ```row``` format is based on ```filter``` format

But a filter based on dropdown (like ```User```) can be displayed as HTML link.

This PR is made for this.

Need by : https://github.com/pluginsGLPI/deploy/pull/13

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
