### PR TITLE
Use `atoum/stubs`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,6 +78,7 @@
     "require-dev": {
         "ext-xml": "*",
         "atoum/atoum": "^4.1",
+        "atoum/stubs": "^2.6",
         "friendsoftwig/twigcs": "^6.1",
         "glpi-project/tools": "^0.7",
         "maglnet/composer-require-checker": "^3.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "826b306b3c00eed0615a2f68c33dcace",
+    "content-hash": "07e200b68a65785b0b35e84c42f59131",
     "packages": [
         {
             "name": "brick/math",
@@ -5243,6 +5243,57 @@
                 "source": "https://github.com/atoum/atoum/tree/4.1"
             },
             "time": "2022-11-20T20:18:31+00:00"
+        },
+        {
+            "name": "atoum/stubs",
+            "version": "2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/atoum/stubs.git",
+                "reference": "df8b73b0358de7283ecba91d8f4a9683f583993d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/atoum/stubs/zipball/df8b73b0358de7283ecba91d8f4a9683f583993d",
+                "reference": "df8b73b0358de7283ecba91d8f4a9683f583993d",
+                "shasum": ""
+            },
+            "suggest": {
+                "atoum/atoum": "Include atoum in your projet dependencies"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Julien Bianchi",
+                    "email": "julien.bianchi@atoum.org"
+                },
+                {
+                    "name": "Ludovic Fleury",
+                    "email": "ludovic.fleury@atoum.org"
+                }
+            ],
+            "description": "Stubs for atoum, the simple modern and intuitive unit testing framework for PHP 5.3+",
+            "homepage": "http://www.atoum.org",
+            "keywords": [
+                "TDD",
+                "atoum",
+                "test",
+                "unit testing"
+            ],
+            "support": {
+                "issues": "https://github.com/atoum/stubs/issues",
+                "source": "https://github.com/atoum/stubs/tree/master"
+            },
+            "time": "2018-01-29T22:41:37+00:00"
         },
         {
             "name": "friendsoftwig/twigcs",

--- a/tests/GLPITestCase.php
+++ b/tests/GLPITestCase.php
@@ -33,7 +33,6 @@
  * ---------------------------------------------------------------------
  */
 
-use atoum\atoum;
 use Glpi\Tests\Log\TestHandler;
 use Monolog\Logger;
 use Psr\Log\LogLevel;


### PR DESCRIPTION
Our tests extends `atoum\atoum` which doesn't seem to exist.

I suppose there is some black magic somewhere (as our tests obviously works) but it isn't known to VSCode which does not recognize any atoum method.

Using the correct `atoum` import fix the issue on VSCode and does not impact our tests.
This is the import used in the official documentation (https://atoum.readthedocs.io/en/latest/first_test.html#first-tests).

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | on
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
