### PR TITLE
fix: prevent unsupported operand types int + string

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -2365,7 +2365,7 @@ abstract class CommonITILObject extends CommonDBTM
                 $this->updates[]                 = "time_to_resolve";
                 $this->fields['time_to_resolve'] = $sla->computeDate(
                     $this->fields['date'],
-                    (int) $this->fields["sla_waiting_duration"]
+                    $this->fields["sla_waiting_duration"]
                 );
                // Add current level to do
                 $sla->addLevelToDo($this);
@@ -2413,7 +2413,7 @@ abstract class CommonITILObject extends CommonDBTM
                 $this->updates[]                          = "internal_time_to_resolve";
                 $this->fields['internal_time_to_resolve'] = $ola->computeDate(
                     $this->fields['ola_ttr_begin_date'],
-                    (int) $this->fields["ola_waiting_duration"]
+                    $this->fields["ola_waiting_duration"]
                 );
                // Add current level to do
                 $ola->addLevelToDo($this, $this->fields["olalevels_id_ttr"]);

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -2365,7 +2365,7 @@ abstract class CommonITILObject extends CommonDBTM
                 $this->updates[]                 = "time_to_resolve";
                 $this->fields['time_to_resolve'] = $sla->computeDate(
                     $this->fields['date'],
-                    $this->fields["sla_waiting_duration"]
+                    (int) $this->fields["sla_waiting_duration"]
                 );
                // Add current level to do
                 $sla->addLevelToDo($this);
@@ -2413,7 +2413,7 @@ abstract class CommonITILObject extends CommonDBTM
                 $this->updates[]                          = "internal_time_to_resolve";
                 $this->fields['internal_time_to_resolve'] = $ola->computeDate(
                     $this->fields['ola_ttr_begin_date'],
-                    $this->fields["ola_waiting_duration"]
+                    (int) $this->fields["ola_waiting_duration"]
                 );
                // Add current level to do
                 $ola->addLevelToDo($this, $this->fields["olalevels_id_ttr"]);

--- a/src/LevelAgreement.php
+++ b/src/LevelAgreement.php
@@ -842,7 +842,7 @@ abstract class LevelAgreement extends CommonDBChild
                     return $cal->computeEndDate(
                         $start_date,
                         $delay,
-                        $additional_delay,
+                        (int) $additional_delay,
                         $work_in_days,
                         $this->fields['end_of_working_day']
                     );
@@ -852,7 +852,7 @@ abstract class LevelAgreement extends CommonDBChild
            // No calendar defined or invalid calendar
             if ($this->fields['number_time'] >= 0) {
                 $starttime = strtotime($start_date);
-                $endtime   = $starttime + $delay + $additional_delay;
+                $endtime   = $starttime + $delay + (int) $additional_delay;
                 return date('Y-m-d H:i:s', $endtime);
             }
         }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -445,7 +445,7 @@ class Ticket extends CommonITILObject
                 $data["slalevels_id_ttr"] = SlaLevel::getFirstSlaLevel($slas_id);
             }
            // Compute time_to_resolve
-            $data['sla_waiting_duration'] = $this->fields['sla_waiting_duration'] ?? 0;
+            $data['sla_waiting_duration'] = $this->fields['sla_waiting_duration'] ?: 0;
             $data[$dateField]             = $sla->computeDate($date, $data['sla_waiting_duration']);
         } else {
             $data["slalevels_id_ttr"]     = 0;
@@ -490,7 +490,7 @@ class Ticket extends CommonITILObject
                 $data['ola_tto_begin_date'] = $date;
             }
            // Compute time_to_own
-            $data['ola_waiting_duration'] = $this->fields['ola_waiting_duration'] ?? 0;
+            $data['ola_waiting_duration'] = $this->fields['ola_waiting_duration'] ?: 0;
             $data[$dateField]             = $ola->computeDate($date, $data['ola_waiting_duration']);
         } else {
             $data["olalevels_id_ttr"]     = 0;

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -445,7 +445,7 @@ class Ticket extends CommonITILObject
                 $data["slalevels_id_ttr"] = SlaLevel::getFirstSlaLevel($slas_id);
             }
            // Compute time_to_resolve
-            $data['sla_waiting_duration'] = (int) ($this->fields['sla_waiting_duration'] ?: 0);
+            $data['sla_waiting_duration'] = (int) ($this->fields['sla_waiting_duration'] ?? 0);
             $data[$dateField]             = $sla->computeDate($date, $data['sla_waiting_duration']);
         } else {
             $data["slalevels_id_ttr"]     = 0;
@@ -490,7 +490,7 @@ class Ticket extends CommonITILObject
                 $data['ola_tto_begin_date'] = $date;
             }
            // Compute time_to_own
-            $data['ola_waiting_duration'] = (int) ($this->fields['ola_waiting_duration'] ?: 0);
+            $data['ola_waiting_duration'] = (int) ($this->fields['ola_waiting_duration'] ?? 0);
             $data[$dateField]             = $ola->computeDate($date, $data['ola_waiting_duration']);
         } else {
             $data["olalevels_id_ttr"]     = 0;

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -446,7 +446,7 @@ class Ticket extends CommonITILObject
             }
            // Compute time_to_resolve
             $data['sla_waiting_duration'] = $this->fields['sla_waiting_duration'] ?: 0;
-            $data[$dateField]             = $sla->computeDate($date, (int) $data['sla_waiting_duration']);
+            $data[$dateField]             = $sla->computeDate($date, $data['sla_waiting_duration']);
         } else {
             $data["slalevels_id_ttr"]     = 0;
             $data[$slaField]              = 0;
@@ -491,7 +491,7 @@ class Ticket extends CommonITILObject
             }
            // Compute time_to_own
             $data['ola_waiting_duration'] = $this->fields['ola_waiting_duration'] ?: 0;
-            $data[$dateField]             = $ola->computeDate($date, (int) $data['ola_waiting_duration']);
+            $data[$dateField]             = $ola->computeDate($date, $data['ola_waiting_duration']);
         } else {
             $data["olalevels_id_ttr"]     = 0;
             $data[$olaField]              = 0;

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -445,7 +445,7 @@ class Ticket extends CommonITILObject
                 $data["slalevels_id_ttr"] = SlaLevel::getFirstSlaLevel($slas_id);
             }
            // Compute time_to_resolve
-            $data['sla_waiting_duration'] = $this->fields['sla_waiting_duration'] ?? 0;
+            $data['sla_waiting_duration'] = (int) $this->fields['sla_waiting_duration'] ?? 0;
             $data[$dateField]             = $sla->computeDate($date, $data['sla_waiting_duration']);
         } else {
             $data["slalevels_id_ttr"]     = 0;
@@ -490,7 +490,7 @@ class Ticket extends CommonITILObject
                 $data['ola_tto_begin_date'] = $date;
             }
            // Compute time_to_own
-            $data['ola_waiting_duration'] = $this->fields['ola_waiting_duration'] ?? 0;
+            $data['ola_waiting_duration'] = (int) $this->fields['ola_waiting_duration'] ?? 0;
             $data[$dateField]             = $ola->computeDate($date, $data['ola_waiting_duration']);
         } else {
             $data["olalevels_id_ttr"]     = 0;

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -445,8 +445,8 @@ class Ticket extends CommonITILObject
                 $data["slalevels_id_ttr"] = SlaLevel::getFirstSlaLevel($slas_id);
             }
            // Compute time_to_resolve
-            $data['sla_waiting_duration'] = (int) $this->fields['sla_waiting_duration'] ?? 0;
-            $data[$dateField]             = $sla->computeDate($date, $data['sla_waiting_duration']);
+            $data['sla_waiting_duration'] = $this->fields['sla_waiting_duration'] ?? 0;
+            $data[$dateField]             = $sla->computeDate($date, (int) $data['sla_waiting_duration']);
         } else {
             $data["slalevels_id_ttr"]     = 0;
             $data[$slaField]              = 0;
@@ -490,8 +490,8 @@ class Ticket extends CommonITILObject
                 $data['ola_tto_begin_date'] = $date;
             }
            // Compute time_to_own
-            $data['ola_waiting_duration'] = (int) $this->fields['ola_waiting_duration'] ?? 0;
-            $data[$dateField]             = $ola->computeDate($date, $data['ola_waiting_duration']);
+            $data['ola_waiting_duration'] = $this->fields['ola_waiting_duration'] ?? 0;
+            $data[$dateField]             = $ola->computeDate($date, (int) $data['ola_waiting_duration']);
         } else {
             $data["olalevels_id_ttr"]     = 0;
             $data[$olaField]              = 0;

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -445,7 +445,7 @@ class Ticket extends CommonITILObject
                 $data["slalevels_id_ttr"] = SlaLevel::getFirstSlaLevel($slas_id);
             }
            // Compute time_to_resolve
-            $data['sla_waiting_duration'] = $this->fields['sla_waiting_duration'] ?: 0;
+            $data['sla_waiting_duration'] = (int) ($this->fields['sla_waiting_duration'] ?: 0);
             $data[$dateField]             = $sla->computeDate($date, $data['sla_waiting_duration']);
         } else {
             $data["slalevels_id_ttr"]     = 0;
@@ -490,7 +490,7 @@ class Ticket extends CommonITILObject
                 $data['ola_tto_begin_date'] = $date;
             }
            // Compute time_to_own
-            $data['ola_waiting_duration'] = $this->fields['ola_waiting_duration'] ?: 0;
+            $data['ola_waiting_duration'] = (int) ($this->fields['ola_waiting_duration'] ?: 0);
             $data[$dateField]             = $ola->computeDate($date, $data['ola_waiting_duration']);
         } else {
             $data["olalevels_id_ttr"]     = 0;

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -445,7 +445,7 @@ class Ticket extends CommonITILObject
                 $data["slalevels_id_ttr"] = SlaLevel::getFirstSlaLevel($slas_id);
             }
            // Compute time_to_resolve
-            $data['sla_waiting_duration'] = (int) ($this->fields['sla_waiting_duration'] ?: 0);
+            $data['sla_waiting_duration'] = $this->fields['sla_waiting_duration'] ?: 0;
             $data[$dateField]             = $sla->computeDate($date, (int) $data['sla_waiting_duration']);
         } else {
             $data["slalevels_id_ttr"]     = 0;

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -445,7 +445,7 @@ class Ticket extends CommonITILObject
                 $data["slalevels_id_ttr"] = SlaLevel::getFirstSlaLevel($slas_id);
             }
            // Compute time_to_resolve
-            $data['sla_waiting_duration'] = $this->fields['sla_waiting_duration'] ?: 0;
+            $data['sla_waiting_duration'] = $this->fields['sla_waiting_duration'] ?? 0;
             $data[$dateField]             = $sla->computeDate($date, $data['sla_waiting_duration']);
         } else {
             $data["slalevels_id_ttr"]     = 0;
@@ -490,7 +490,7 @@ class Ticket extends CommonITILObject
                 $data['ola_tto_begin_date'] = $date;
             }
            // Compute time_to_own
-            $data['ola_waiting_duration'] = $this->fields['ola_waiting_duration'] ?: 0;
+            $data['ola_waiting_duration'] = $this->fields['ola_waiting_duration'] ?? 0;
             $data[$dateField]             = $ola->computeDate($date, $data['ola_waiting_duration']);
         } else {
             $data["olalevels_id_ttr"]     = 0;

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -445,7 +445,7 @@ class Ticket extends CommonITILObject
                 $data["slalevels_id_ttr"] = SlaLevel::getFirstSlaLevel($slas_id);
             }
            // Compute time_to_resolve
-            $data['sla_waiting_duration'] = $this->fields['sla_waiting_duration'] ?? 0;
+            $data['sla_waiting_duration'] = (int) ($this->fields['sla_waiting_duration'] ?: 0);
             $data[$dateField]             = $sla->computeDate($date, (int) $data['sla_waiting_duration']);
         } else {
             $data["slalevels_id_ttr"]     = 0;
@@ -490,7 +490,7 @@ class Ticket extends CommonITILObject
                 $data['ola_tto_begin_date'] = $date;
             }
            // Compute time_to_own
-            $data['ola_waiting_duration'] = $this->fields['ola_waiting_duration'] ?? 0;
+            $data['ola_waiting_duration'] = $this->fields['ola_waiting_duration'] ?: 0;
             $data[$dateField]             = $ola->computeDate($date, (int) $data['ola_waiting_duration']);
         } else {
             $data["olalevels_id_ttr"]     = 0;


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/glpi-project/glpi/issues/16466 #16498

```
glpiphplog.CRITICAL: *** Uncaught Exception TypeError: Unsupported operand types: int + string in .../src/LevelAgreement.php at line 855
Backtrace :
src/Ticket.php:449 LevelAgreement->computeDate()
src/Ticket.php:1428 Ticket->getDatasToAddSLA()
src/Ticket.php:2027 Ticket->slaAffect()
src/CommonDBTM.php:1297 Ticket->prepareInputForAdd()
front/ticket.form.php:80 CommonDBTM->add()
```
