### PR TITLE
fix(DataCenter): add missing search option

### DIFF
--- a/src/Datacenter.php
+++ b/src/Datacenter.php
@@ -133,15 +133,16 @@ class Datacenter extends CommonDBTM
         return $tab;
     }
 
-
     public static function rawSearchOptionsToAdd($itemtype)
     {
-        return [
-            [
-                'id'                 => 'datacenter',
-                'name'               => _n('Data center', 'Data centers', Session::getPluralNumber())
-            ],
-            [
+        $tab = [];
+
+        $tab[] = [
+            'id'                 => 'datacenter',
+            'name'               => _n('Data center', 'Data centers', Session::getPluralNumber())
+        ];
+
+        $tab[] = [
                 'id'                 => '178',
                 'table'              => $itemtype::getTable(),
                 'field'              => '_virtual_datacenter_position', // virtual field
@@ -154,8 +155,41 @@ class Datacenter extends CommonDBTM
                 'nosearch'           => true,
                 'nosort'             => true,
                 'massiveaction'      => false
-            ],
         ];
+
+        if (($itemtype != Rack::getType()) && ($itemtype != DCRoom::getType())) {
+            $tab[] = [
+                    'id'            => '1451',
+                    'table'         => Datacenter::getTable(),
+                    'field'         => 'name',
+                    'datatype'      => 'dropdown',
+                    'linkfield'     => 'datacenters_id',
+                    'name'          => Datacenter::getTypeName(1),
+                    'massiveaction' => false,
+                    'joinparams'    => [
+                        'beforejoin'    => [
+                            'table'         => DCRoom::getTable(),
+                            'linkfield'     => 'dcrooms_id',
+                            'joinparams'    => [
+                                'beforejoin'    => [
+                                    'table'         => Rack::getTable(),
+                                    'linkfield'     => 'racks_id',
+                                    'joinparams'    => [
+                                        'beforejoin'    => [
+                                            'table'         => Item_Rack::getTable(),
+                                            'joinparams'    => [
+                                                'jointype'      => 'itemtype_item'
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+            ];
+        }
+    
+        return $tab;
     }
 
     public static function getAdditionalMenuLinks()

--- a/src/Datacenter.php
+++ b/src/Datacenter.php
@@ -143,52 +143,52 @@ class Datacenter extends CommonDBTM
         ];
 
         $tab[] = [
-                'id'                 => '178',
-                'table'              => $itemtype::getTable(),
-                'field'              => '_virtual_datacenter_position', // virtual field
-                'additionalfields'   => [
-                    'id',
-                    'name'
-                ],
-                'name'               => __('Data center position'),
-                'datatype'           => 'specific',
-                'nosearch'           => true,
-                'nosort'             => true,
-                'massiveaction'      => false
+            'id'                 => '178',
+            'table'              => $itemtype::getTable(),
+            'field'              => '_virtual_datacenter_position', // virtual field
+            'additionalfields'   => [
+                'id',
+                'name'
+            ],
+            'name'               => __('Data center position'),
+            'datatype'           => 'specific',
+            'nosearch'           => true,
+            'nosort'             => true,
+            'massiveaction'      => false
         ];
 
         if (($itemtype != Rack::getType()) && ($itemtype != DCRoom::getType())) {
             $tab[] = [
-                    'id'            => '1451',
-                    'table'         => Datacenter::getTable(),
-                    'field'         => 'name',
-                    'datatype'      => 'dropdown',
-                    'linkfield'     => 'datacenters_id',
-                    'name'          => Datacenter::getTypeName(1),
-                    'massiveaction' => false,
-                    'joinparams'    => [
-                        'beforejoin'    => [
-                            'table'         => DCRoom::getTable(),
-                            'linkfield'     => 'dcrooms_id',
-                            'joinparams'    => [
-                                'beforejoin'    => [
-                                    'table'         => Rack::getTable(),
-                                    'linkfield'     => 'racks_id',
-                                    'joinparams'    => [
-                                        'beforejoin'    => [
-                                            'table'         => Item_Rack::getTable(),
-                                            'joinparams'    => [
-                                                'jointype'      => 'itemtype_item'
-                                            ]
+                'id'            => '1451',
+                'table'         => Datacenter::getTable(),
+                'field'         => 'name',
+                'datatype'      => 'dropdown',
+                'linkfield'     => 'datacenters_id',
+                'name'          => Datacenter::getTypeName(1),
+                'massiveaction' => false,
+                'joinparams'    => [
+                    'beforejoin'    => [
+                        'table'         => DCRoom::getTable(),
+                        'linkfield'     => 'dcrooms_id',
+                        'joinparams'    => [
+                            'beforejoin'    => [
+                                'table'         => Rack::getTable(),
+                                'linkfield'     => 'racks_id',
+                                'joinparams'    => [
+                                    'beforejoin'    => [
+                                        'table'         => Item_Rack::getTable(),
+                                        'joinparams'    => [
+                                            'jointype'      => 'itemtype_item'
                                         ]
                                     ]
                                 ]
                             ]
                         ]
                     ]
+                ]
             ];
         }
-    
+
         return $tab;
     }
 

--- a/src/Rack.php
+++ b/src/Rack.php
@@ -288,6 +288,19 @@ class Rack extends CommonDBTM
             'datatype'           => 'dropdown'
         ];
 
+        $tab[] = [
+            'id'                 => '81',
+            'table'              => Datacenter::getTable(),
+            'field'              => 'name',
+            'name'               => Datacenter::getTypeName(1),
+            'datatype'           => 'dropdown',
+            'joinparams'         => [
+                'beforejoin'         => [
+                    'table'              => DCRoom::getTable(),
+                ]
+            ]
+        ];
+
         $tab = array_merge($tab, Notepad::rawSearchOptionsToAdd());
 
         $tab = array_merge($tab, Datacenter::rawSearchOptionsToAdd(get_class($this)));

--- a/tests/functional/Search.php
+++ b/tests/functional/Search.php
@@ -4444,6 +4444,17 @@ class Search extends DbTestCase
             $this->variable(array_search('dcroom', array_column($so, 'id')))->isNotEqualTo(false, $item->getTypeName() . ' should use \'$tab = array_merge($tab, DCRoom::rawSearchOptionsToAdd());');
         }
     }
+
+    public function testDataCenterSearchOption()
+    {
+        global $CFG_GLPI;
+        foreach ($CFG_GLPI['rackable_types'] as $rackable_type) {
+            $item = new $rackable_type();
+            $so = $item->rawSearchOptions();
+            //check if search option separator 'datacenter' exist
+            $this->variable(array_search('datacenter', array_column($so, 'id')))->isNotEqualTo(false, $item->getTypeName() . ' should use \'$tab = array_merge($tab, DataCenter::rawSearchOptionsToAdd());');
+        }
+    }
 }
 
 // @codingStandardsIgnoreStart


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

- Add Datacenter search option to Racks
- Add Datacenter search option for items in `Datacenter::rawSearchOptionsToAdd()`, excluding racks and server rooms (they have separate search options for datacenters).
- Add test case

So now you can search rackable items, racks, and server rooms by which DataCenter they are assigned to.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #16415
