### PR TITLE
Add WiFi 7 version

### DIFF
--- a/src/WifiNetwork.php
+++ b/src/WifiNetwork.php
@@ -54,12 +54,14 @@ class WifiNetwork extends CommonDropdown
         return [
             ''          => '',
             'a'         => 'a',
+            'b'         => 'b',
             'a/b'       => 'a/b',
             'a/b/g'     => 'a/b/g',
             'a/b/g/n'   => 'a/b/g/n',
             'a/b/g/n/y' => 'a/b/g/n/y',
-            'ac'        => 'ac',
-            'ax'        => 'ax',
+            'ac'        => 'ac', // Wifi 5
+            'ax'        => 'ax', // Wifi 6/6E
+            'be'        => 'be', // Wifi 7
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Add "be" WiFi card version to hard-coded list to support new/upcoming WiFi 7 devices.