### PR TITLE
allow use of certificate type in notification

### DIFF
--- a/src/NotificationTargetCertificate.php
+++ b/src/NotificationTargetCertificate.php
@@ -126,7 +126,7 @@ class NotificationTargetCertificate extends NotificationTarget
 
         $tags = ['certificate.expirationdate' => __('Expiration date'),
             'certificate.name'           => __('Name'),
-            'certificate.type'         => __('Type'),
+            'certificate.type'         => _n('Type', 'Types', 1),
             'certificate.serial'         => __('Serial number'),
             'certificate.url'            => __('URL'),
             'certificate.entity'         => Entity::getTypeName(1),

--- a/src/NotificationTargetCertificate.php
+++ b/src/NotificationTargetCertificate.php
@@ -92,7 +92,7 @@ class NotificationTargetCertificate extends NotificationTarget
         $this->data['##certificate.type##'] = Dropdown::getDropdownName(
             'glpi_certificatetypes',
             $certificate->fields['certificatetypes_id']
-          );
+        );
         $this->data['##certificate.expirationdate##'] = Html::convDate($certificate->fields["date_expiration"]);
         $this->data['##certificate.url##']            = $this->formatURL(
             $options['additionnaloption']['usertype'],

--- a/src/NotificationTargetCertificate.php
+++ b/src/NotificationTargetCertificate.php
@@ -89,6 +89,10 @@ class NotificationTargetCertificate extends NotificationTarget
 
         $this->data['##certificate.name##']           = $certificate->fields['name'];
         $this->data['##certificate.serial##']         = $certificate->fields['serial'];
+        $this->data['##certificate.type##'] = Dropdown::getDropdownName(
+            'glpi_certificatetypes',
+            $certificate->fields['certificatetypes_id']
+          );
         $this->data['##certificate.expirationdate##'] = Html::convDate($certificate->fields["date_expiration"]);
         $this->data['##certificate.url##']            = $this->formatURL(
             $options['additionnaloption']['usertype'],
@@ -122,6 +126,7 @@ class NotificationTargetCertificate extends NotificationTarget
 
         $tags = ['certificate.expirationdate' => __('Expiration date'),
             'certificate.name'           => __('Name'),
+            'certificate.type'         => __('Type'),
             'certificate.serial'         => __('Serial number'),
             'certificate.url'            => __('URL'),
             'certificate.entity'         => Entity::getTypeName(1),


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

This PR allows the use of "certificate.type" in the notifications. This field can be used for instance to keep the PKI name.
