### PR TITLE
fix: make the items section visible in the right-hand panel of the ticket when it is closed

### DIFF
--- a/src/Item_Ticket.php
+++ b/src/Item_Ticket.php
@@ -210,9 +210,10 @@ class Item_Ticket extends CommonItilObject_Item
             return false;
         }
 
+        $ticket_is_closed = in_array($ticket->fields['status'], $ticket->getClosedStatusArray());
         $can_add_items = $_SESSION["glpiactiveprofile"]["helpdesk_hardware"] & pow(2, Ticket::HELPDESK_MY_HARDWARE) || $_SESSION["glpiactiveprofile"]["helpdesk_hardware"] & pow(2, Ticket::HELPDESK_ALL_HARDWARE);
         $canedit = ($can_add_items && $ticket->can($params['id'], UPDATE)
-                  && $params['_canupdate']);
+                  && $params['_canupdate'] && !$ticket_is_closed);
 
        // Ticket update case
         $usedcount = 0;
@@ -290,8 +291,8 @@ class Item_Ticket extends CommonItilObject_Item
 
        // Display list
         if (!empty($params['items_id'])) {
-           // No delete if mandatory and only one item
-            $delete = $ticket->canAddItem(__CLASS__);
+            // No delete if mandatory and only one item or if ticket is closed
+            $delete = $ticket->canAddItem(__CLASS__) && !$ticket_is_closed;
             $cpt = 0;
             foreach ($params['items_id'] as $itemtype => $items) {
                 $cpt += count($items);

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4400,18 +4400,15 @@ JAVASCRIPT;
                         || (Session::getCurrentInterface() == "central"
                             && $this->canUpdateItem());
         $can_requester = $this->canRequesterUpdateItem();
+        $canpriority   = (bool) Session::haveRight(self::$rightname, self::CHANGEPRIORITY);
         $canassign     = $this->canAssign();
         $canassigntome = $this->canAssignToMe();
 
-        $item_ticket = null;
         if ($ID && in_array($this->fields['status'], $this->getClosedStatusArray())) {
             $canupdate = false;
             // No update for actors
             $options['_noupdate'] = true;
             $canpriority = false;
-        } else {
-            $item_ticket = new Item_Ticket();
-            $canpriority   = (bool) Session::haveRight(self::$rightname, self::CHANGEPRIORITY);
         }
 
         $sla = new SLA();
@@ -4421,6 +4418,11 @@ JAVASCRIPT;
             $options['_canupdate'] = Session::haveRight('ticket', CREATE);
         } else {
             $options['_canupdate'] = Session::haveRight('ticket', UPDATE);
+        }
+
+        $item_ticket = null;
+        if ($options['_canupdate']) {
+            $item_ticket = new Item_Ticket();
         }
 
         TemplateRenderer::getInstance()->display('components/itilobject/layout.html.twig', [


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !31506

This PR addresses an issue where linked items section were not visible in the right-hand panel of a ticket when it was closed.
The non-display of the section was introduced by PR #16056 to prevent items from being added or deleted once the ticket has been closed.
Here the behavior has been modified so that when the ticket is closed, only the list of linked objects is displayed, as shown in the screenshot below.

![image](https://github.com/glpi-project/glpi/assets/42278610/85c9ac09-d555-45d1-a210-27c29f7fc7ce)

