### PR TITLE
Fix missing reactive behaviors in debug toolbar

### DIFF
--- a/js/src/vue/Debug/Widget/Globals.vue
+++ b/js/src/vue/Debug/Widget/Globals.vue
@@ -1,5 +1,5 @@
 <script setup>
-    import {onMounted} from "vue";
+    import {onMounted, watch} from "vue";
 
     const props = defineProps({
         current_profile: {
@@ -16,6 +16,7 @@
             return;
         }
 
+        container.empty();
         let data_string = data;
         try {
             data_string = JSON.stringify(data, null, ' ');
@@ -52,12 +53,18 @@
 
     const rand = Math.floor(Math.random() * 1000000);
 
-    const globals = props.current_profile.globals;
+    function refreshGlobals() {
+        appendGlobals(props.current_profile.globals['post'], $(`#debugpanel${rand} #debugpost${rand}`));
+        appendGlobals(props.current_profile.globals['get'], $(`#debugpanel${rand} #debugget${rand}`));
+        appendGlobals(props.current_profile.globals['session'], $(`#debugpanel${rand} #debugsession${rand}`));
+        appendGlobals(props.current_profile.globals['server'], $(`#debugpanel${rand} #debugserver${rand}`));
+    }
+
     onMounted(() => {
-        appendGlobals(globals['post'], $(`#debugpanel${rand} #debugpost${rand}`));
-        appendGlobals(globals['get'], $(`#debugpanel${rand} #debugget${rand}`));
-        appendGlobals(globals['session'], $(`#debugpanel${rand} #debugsession${rand}`));
-        appendGlobals(globals['server'], $(`#debugpanel${rand} #debugserver${rand}`));
+        refreshGlobals();
+    });
+    watch(() => props.current_profile.globals, () => {
+        refreshGlobals();
     });
 </script>
 

--- a/js/src/vue/Debug/Widget/Profiler.vue
+++ b/js/src/vue/Debug/Widget/Profiler.vue
@@ -1,5 +1,5 @@
 <script setup>
-    import {ref} from "vue";
+    import {computed, ref} from "vue";
 
     const props = defineProps({
         current_profile: {
@@ -7,7 +7,9 @@
             required: true
         },
     });
-    const profiler_sections = Object.values(props.current_profile.profiler || {}).sort((a, b) => a.start - b.start);;
+    const profiler_sections = computed(() => {
+        return Object.values(props.current_profile.profiler || {}).sort((a, b) => a.start - b.start);
+    });
     const hide_instant_sections = ref(true);
 </script>
 
@@ -18,7 +20,7 @@
             <input type="checkbox" name="hide_instant_sections" v-model="hide_instant_sections">
         </label>
         <widget-profiler-table :parent_duration="0" :nest_level="0" :profiler_sections="profiler_sections" :parent_id="null"
-            :hide_instant_sections="hide_instant_sections"></widget-profiler-table>
+                               :hide_instant_sections="hide_instant_sections"></widget-profiler-table>
     </div>
 </template>
 

--- a/js/src/vue/Debug/Widget/ProfilerTable.vue
+++ b/js/src/vue/Debug/Widget/ProfilerTable.vue
@@ -1,5 +1,5 @@
 <script setup>
-    import {onMounted} from "vue";
+    import {computed} from "vue";
 
     const props = defineProps({
         parent_id: {
@@ -90,7 +90,9 @@
         }
         return sections_data;
     }
-    const top_level_data = getProfilerData(props.parent_id);
+    const top_level_data = computed(() => {
+        return getProfilerData(props.parent_id);
+    });
 
     const instant_threshold = 1.0;
 
@@ -111,20 +113,20 @@
 <template>
     <table class="table table-striped card-table" v-show="hasUnfilteredSections(top_level_data)">
         <thead>
-        <tr>
-            <th class="nesting-spacer" v-for="i in nest_level"></th>
-            <th>Category</th>
-            <th>Name</th>
-            <th>Start</th>
-            <th>End</th>
-            <th>Duration</th>
-            <th>Percent of parent</th>
-        </tr>
+            <tr>
+                <th class="nesting-spacer" v-for="i in nest_level" :key="i"></th>
+                <th>Category</th>
+                <th>Name</th>
+                <th>Start</th>
+                <th>End</th>
+                <th>Duration</th>
+                <th>Percent of parent</th>
+            </tr>
         </thead>
         <tbody>
             <template v-for="section in top_level_data">
                 <tr :data-profiler-section-id="section.id" v-show="!props.hide_instant_sections || (section.duration > instant_threshold)">
-                    <td class="nesting-spacer" v-for="i in nest_level"></td>
+                    <td class="nesting-spacer" v-for="i in nest_level" :key="i"></td>
                     <td>
                         <span class="category-badge" :style="`background-color: ${section.bg_color}; color: ${section.text_color}`">
                             {{ section.category }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Changing the selected HTTP request in the debug toolbar wasn't triggering an update of the globals and profiler sub-widgets.