### PR TITLE
Fix label for the "associable item to..." right

### DIFF
--- a/src/Profile.php
+++ b/src/Profile.php
@@ -1193,7 +1193,7 @@ class Profile extends CommonDBTM
         echo "</tr>";
 
         echo "<tr>";
-        echo "<td>" . __('Associable items to a ticket') . "</td>";
+        echo "<td>" . __('Associable items to tickets, changes and problems') . "</td>";
         echo "<td><input type='hidden' name='_helpdesk_item_types' value='1'>";
         self::dropdownHelpdeskItemtypes(['values' => $this->fields["helpdesk_item_type"]]);
 
@@ -1574,7 +1574,7 @@ class Profile extends CommonDBTM
         echo "</td></tr>";
 
         echo "<tr>";
-        echo "<td>" . __('Associable items to a ticket') . "</td>";
+        echo "<td>" . __('Associable items to tickets, changes and problems') . "</td>";
         echo "<td><input type='hidden' name='_helpdesk_item_types' value='1'>";
         self::dropdownHelpdeskItemtypes(['values' => $this->fields["helpdesk_item_type"]]);
         echo "</td>";
@@ -3245,7 +3245,7 @@ class Profile extends CommonDBTM
             'id'                 => '87',
             'table'              => $this->getTable(),
             'field'              => 'helpdesk_item_type',
-            'name'               => __('Associable items to a ticket'),
+            'name'               => __('Associable items to tickets, changes and problems'),
             'massiveaction'      => false,
             'datatype'           => 'specific'
         ];


### PR DESCRIPTION

![image](https://github.com/glpi-project/glpi/assets/42734840/648b87b5-a042-4a49-b0d4-44a60a559e4a)

Not sure if the label should say "tickets, changes and problems" or "ITIL items".
IMO, ITIL items is too vague and users might not know what it means, especially since we have an `ITIL objects` category on the same page which does not target the same items at all:

![image](https://github.com/glpi-project/glpi/assets/42734840/f1fcdd8a-4fa0-43c7-b84e-7c09639eeb4a)

If we want to use "ITIL items" for the right then this section should probably be renamed to avoid confusion.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
