### PR TITLE
Hide ITIL tabs if empty

### DIFF
--- a/src/Change_Item.php
+++ b/src/Change_Item.php
@@ -226,10 +226,13 @@ class Change_Item extends CommonItilObject_Item
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        /** @var \DBmysql $DB */
-        global $DB;
+        /**
+         * @var \DBmysql $DB
+         * @var array $CFG_GLPI
+         **/
+        global $DB, $CFG_GLPI;
 
-        if ($item instanceof Asset && !$this->shouldDisplayTabForAsset($item)) {
+        if (in_array($item::getType(), $CFG_GLPI['asset_types']) && !$this->shouldDisplayTabForAsset($item)) {
             return '';
         }
 

--- a/src/CommonItilObject_Item.php
+++ b/src/CommonItilObject_Item.php
@@ -39,7 +39,6 @@
  * Relation between CommonItilObject_Item and Items
  */
 use Glpi\Application\View\TemplateRenderer;
-use Glpi\Asset\Asset;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryUnion;
 
@@ -1579,15 +1578,15 @@ abstract class CommonItilObject_Item extends CommonDBRelation
     }
 
     /**
-     * ITIL tabs for generic assets should only be displayed if the asset already
+     * ITIL tabs for assets should only be displayed if the asset already
      * has associated ITIL items OR if the current user profile is allowed to
      * link this asset to ITIL items
      *
-     * @param Asset $asset
+     * @param CommonDBTM $asset
      *
      * @return bool
      */
-    protected function shouldDisplayTabForAsset(Asset $asset): bool
+    protected function shouldDisplayTabForAsset(CommonDBTM $asset): bool
     {
         // Always display tab if the current profile is allowed to link ITIL
         // items to this asset

--- a/src/Item_Problem.php
+++ b/src/Item_Problem.php
@@ -222,10 +222,13 @@ class Item_Problem extends CommonItilObject_Item
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        /** @var \DBmysql $DB */
-        global $DB;
+        /**
+         * @var \DBmysql $DB
+         * @var array $CFG_GLPI
+         **/
+        global $DB, $CFG_GLPI;
 
-        if ($item instanceof Asset && !$this->shouldDisplayTabForAsset($item)) {
+        if (in_array($item::getType(), $CFG_GLPI['asset_types']) && !$this->shouldDisplayTabForAsset($item)) {
             return '';
         }
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -700,9 +700,12 @@ class Ticket extends CommonITILObject
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
         /** @var CommonDBTM $item */
         if (static::canView()) {
-            if ($item instanceof Asset && !$this->shouldDisplayTabForAsset($item)) {
+            if (in_array($item::getType(), $CFG_GLPI['asset_types']) && !$this->shouldDisplayTabForAsset($item)) {
                 return '';
             }
 
@@ -6478,15 +6481,15 @@ JAVASCRIPT;
      *
      * ------------------------------------------------------------
      *
-     * ITIL tabs for generic assets should only be displayed if the asset already
+     * ITIL tabs for assets should only be displayed if the asset already
      * has associated ITIL items OR if the current user profile is allowed to
      * link this asset to ITIL items
      *
-     * @param Asset $asset
+     * @param CommonDBTM $asset
      *
      * @return bool
      */
-    protected function shouldDisplayTabForAsset(Asset $asset): bool
+    protected function shouldDisplayTabForAsset(CommonDBTM $asset): bool
     {
         // Always display tab if the current profile is allowed to link ITIL
         // items to this asset


### PR DESCRIPTION
As discussed in #16432, extends the visibility condition of the ITIL tabs to all assets (instead of just generic assets).

As a reminder, the tabs are now only shown if:
* The current profile is allowed to link the given asset to ITIL items
* (OR) There are already linked ITIL items for the given asset

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
