### PR TITLE
fix(reminder): not visible on root entity with tree structure

### DIFF
--- a/src/Reminder.php
+++ b/src/Reminder.php
@@ -312,7 +312,12 @@ class Reminder extends CommonDBVisible implements
             ];
 
             $or = ['glpi_groups_reminders.no_entity_restriction' => 1];
-            $restrict = getEntitiesRestrictCriteria('glpi_groups_reminders', '', '', true);
+            $restrict = getEntitiesRestrictCriteria(
+                'glpi_groups_reminders',
+                '',
+                $_SESSION['glpiactiveentities'],
+                true
+            );
             if (count($restrict)) {
                 $or = $or + $restrict;
             }
@@ -338,7 +343,12 @@ class Reminder extends CommonDBVisible implements
             ];
 
             $or = ['glpi_profiles_reminders.no_entity_restriction' => 1];
-            $restrict = getEntitiesRestrictCriteria('glpi_profiles_reminders', '', '', true);
+            $restrict = getEntitiesRestrictCriteria(
+                'glpi_profiles_reminders',
+                '',
+                $_SESSION['glpiactiveentities'],
+                true
+            );
             if (count($restrict)) {
                 $or = $or + $restrict;
             }

--- a/tests/functional/Reminder.php
+++ b/tests/functional/Reminder.php
@@ -41,36 +41,57 @@ use DbTestCase;
 
 class Reminder extends DbTestCase
 {
-    public function testAddVisibilityRestrict()
-    {
-       //first, as a super-admin
-        $this->login();
-        $expected = "(`glpi_reminders`.`users_id` = '7' OR `glpi_reminders_users`.`users_id` = '7' OR (`glpi_profiles_reminders`.`profiles_id` = '4' AND (`glpi_profiles_reminders`.`no_entity_restriction` = '1' OR ((`glpi_profiles_reminders`.`entities_id` IN ('1', '2', '3') OR (`glpi_profiles_reminders`.`is_recursive` = '1' AND `glpi_profiles_reminders`.`entities_id` IN ('0')))))) OR ((`glpi_entities_reminders`.`entities_id` IN ('1', '2', '3') OR (`glpi_entities_reminders`.`is_recursive` = '1' AND `glpi_entities_reminders`.`entities_id` IN ('0')))))";
-        $this->string(\Reminder::addVisibilityRestrict())
-         ->isIdenticalTo($expected);
+     public function testAddVisibilityRestrict()
+     {
+          //first, as a super-admin
+          $this->login();
+          $expected = preg_replace('/\s+/', ' ', "(`glpi_reminders`.`users_id` = '7'
+               OR `glpi_reminders_users`.`users_id` = '7'
+               OR (`glpi_profiles_reminders`.`profiles_id` = '4'
+                    AND (`glpi_profiles_reminders`.`no_entity_restriction` = '1'
+                         OR ((`glpi_profiles_reminders`.`entities_id` IN ('1', '2', '3')
+                                   OR (`glpi_profiles_reminders`.`is_recursive` = '1'
+                                        AND `glpi_profiles_reminders`.`entities_id` IN ('0'))))))
+               OR ((`glpi_entities_reminders`.`entities_id` IN ('1', '2', '3')
+                         OR (`glpi_entities_reminders`.`is_recursive` = '1'
+                              AND `glpi_entities_reminders`.`entities_id` IN ('0')))))");
+          $this->string(\Reminder::addVisibilityRestrict())
+               ->isIdenticalTo($expected);
 
-        $this->login('normal', 'normal');
-        $this->string(trim(preg_replace('/\s+/', ' ', \Reminder::addVisibilityRestrict())))
-         ->isIdenticalTo("(`glpi_reminders`.`users_id` = '5' OR `glpi_reminders_users`.`users_id` = '5' OR (`glpi_profiles_reminders`.`profiles_id` = '2' AND (`glpi_profiles_reminders`.`no_entity_restriction` = '1')) OR (`glpi_entities_reminders`.`entities_id` IN ('0', '1', '2', '3')))");
+          $this->login('normal', 'normal');
+          $expected = preg_replace('/\s+/', ' ', "(`glpi_reminders`.`users_id` = '5'
+               OR `glpi_reminders_users`.`users_id` = '5'
+               OR (`glpi_profiles_reminders`.`profiles_id` = '2'
+                    AND (`glpi_profiles_reminders`.`no_entity_restriction` = '1'
+                         OR (`glpi_profiles_reminders`.`entities_id` IN ('0', '1', '2', '3'))))
+               OR (`glpi_entities_reminders`.`entities_id` IN ('0', '1', '2', '3')))");
+          $this->string(trim(preg_replace('/\s+/', ' ', \Reminder::addVisibilityRestrict())))
+               ->isIdenticalTo($expected);
 
-        $this->login('tech', 'tech');
-        $this->string(trim(preg_replace('/\s+/', ' ', \Reminder::addVisibilityRestrict())))
-         ->isIdenticalTo(preg_replace('/\s+/', ' ', "(`glpi_reminders`.`users_id` = '4'  OR `glpi_reminders_users`.`users_id` = '4'  OR (`glpi_profiles_reminders`.`profiles_id`
-                                 = '6'
-                            AND (`glpi_profiles_reminders`.`no_entity_restriction` = '1'))
-                                  OR  (`glpi_entities_reminders`.`entities_id` IN ('0', '1', '2', '3')))"));
+          $this->login('tech', 'tech');
+          $expected = preg_replace('/\s+/', ' ', "(`glpi_reminders`.`users_id` = '4'
+               OR `glpi_reminders_users`.`users_id` = '4'
+               OR (`glpi_profiles_reminders`.`profiles_id` = '6'
+                    AND (`glpi_profiles_reminders`.`no_entity_restriction` = '1'
+                         OR (`glpi_profiles_reminders`.`entities_id` IN ('0', '1', '2', '3'))))
+               OR (`glpi_entities_reminders`.`entities_id` IN ('0', '1', '2', '3')))");
+          $this->string(trim(preg_replace('/\s+/', ' ', \Reminder::addVisibilityRestrict())))
+               ->isIdenticalTo($expected);
 
-        $bkp_groups = $_SESSION['glpigroups'];
-        $_SESSION['glpigroups'] = [42, 1337];
-        $str = \Reminder::addVisibilityRestrict();
-        $_SESSION['glpigroups'] = $bkp_groups;
-        $this->string(trim(preg_replace('/\s+/', ' ', $str)))
-         ->isIdenticalTo(preg_replace('/\s+/', ' ', "(`glpi_reminders`.`users_id` = '4'  OR `glpi_reminders_users`.`users_id` = '4'  OR (`glpi_groups_reminders`.`groups_id`
-                                 IN ('42', '1337')
-                            AND (`glpi_groups_reminders`.`no_entity_restriction` = '1'))
-                                 OR (`glpi_profiles_reminders`.`profiles_id`
-                                 = '6'
-                            AND (`glpi_profiles_reminders`.`no_entity_restriction` = '1'))
-                               OR (`glpi_entities_reminders`.`entities_id` IN ('0', '1', '2', '3')))"));
-    }
+          $bkp_groups = $_SESSION['glpigroups'];
+          $_SESSION['glpigroups'] = [42, 1337];
+          $str = \Reminder::addVisibilityRestrict();
+          $_SESSION['glpigroups'] = $bkp_groups;
+          $expected = preg_replace('/\s+/', ' ', "(`glpi_reminders`.`users_id` = '4'
+               OR `glpi_reminders_users`.`users_id` = '4'
+               OR (`glpi_groups_reminders`.`groups_id` IN ('42', '1337')
+                    AND (`glpi_groups_reminders`.`no_entity_restriction` = '1'
+                         OR (`glpi_groups_reminders`.`entities_id` IN ('0', '1', '2', '3')))) 
+               OR (`glpi_profiles_reminders`.`profiles_id` = '6'
+                    AND (`glpi_profiles_reminders`.`no_entity_restriction` = '1'
+                         OR (`glpi_profiles_reminders`.`entities_id` IN ('0', '1', '2', '3'))))
+               OR (`glpi_entities_reminders`.`entities_id` IN ('0', '1', '2', '3')))");
+          $this->string(trim(preg_replace('/\s+/', ' ', $str)))
+               ->isIdenticalTo($expected);
+     }
 }

--- a/tests/functional/Reminder.php
+++ b/tests/functional/Reminder.php
@@ -41,11 +41,11 @@ use DbTestCase;
 
 class Reminder extends DbTestCase
 {
-     public function testAddVisibilityRestrict()
-     {
-          //first, as a super-admin
-          $this->login();
-          $expected = preg_replace('/\s+/', ' ', "(`glpi_reminders`.`users_id` = '7'
+    public function testAddVisibilityRestrict()
+    {
+         //first, as a super-admin
+         $this->login();
+         $expected = preg_replace('/\s+/', ' ', "(`glpi_reminders`.`users_id` = '7'
                OR `glpi_reminders_users`.`users_id` = '7'
                OR (`glpi_profiles_reminders`.`profiles_id` = '4'
                     AND (`glpi_profiles_reminders`.`no_entity_restriction` = '1'
@@ -55,34 +55,34 @@ class Reminder extends DbTestCase
                OR ((`glpi_entities_reminders`.`entities_id` IN ('1', '2', '3')
                          OR (`glpi_entities_reminders`.`is_recursive` = '1'
                               AND `glpi_entities_reminders`.`entities_id` IN ('0')))))");
-          $this->string(\Reminder::addVisibilityRestrict())
-               ->isIdenticalTo($expected);
+         $this->string(\Reminder::addVisibilityRestrict())
+              ->isIdenticalTo($expected);
 
-          $this->login('normal', 'normal');
-          $expected = preg_replace('/\s+/', ' ', "(`glpi_reminders`.`users_id` = '5'
+         $this->login('normal', 'normal');
+         $expected = preg_replace('/\s+/', ' ', "(`glpi_reminders`.`users_id` = '5'
                OR `glpi_reminders_users`.`users_id` = '5'
                OR (`glpi_profiles_reminders`.`profiles_id` = '2'
                     AND (`glpi_profiles_reminders`.`no_entity_restriction` = '1'
                          OR (`glpi_profiles_reminders`.`entities_id` IN ('0', '1', '2', '3'))))
                OR (`glpi_entities_reminders`.`entities_id` IN ('0', '1', '2', '3')))");
-          $this->string(trim(preg_replace('/\s+/', ' ', \Reminder::addVisibilityRestrict())))
-               ->isIdenticalTo($expected);
+         $this->string(trim(preg_replace('/\s+/', ' ', \Reminder::addVisibilityRestrict())))
+              ->isIdenticalTo($expected);
 
-          $this->login('tech', 'tech');
-          $expected = preg_replace('/\s+/', ' ', "(`glpi_reminders`.`users_id` = '4'
+         $this->login('tech', 'tech');
+         $expected = preg_replace('/\s+/', ' ', "(`glpi_reminders`.`users_id` = '4'
                OR `glpi_reminders_users`.`users_id` = '4'
                OR (`glpi_profiles_reminders`.`profiles_id` = '6'
                     AND (`glpi_profiles_reminders`.`no_entity_restriction` = '1'
                          OR (`glpi_profiles_reminders`.`entities_id` IN ('0', '1', '2', '3'))))
                OR (`glpi_entities_reminders`.`entities_id` IN ('0', '1', '2', '3')))");
-          $this->string(trim(preg_replace('/\s+/', ' ', \Reminder::addVisibilityRestrict())))
-               ->isIdenticalTo($expected);
+         $this->string(trim(preg_replace('/\s+/', ' ', \Reminder::addVisibilityRestrict())))
+              ->isIdenticalTo($expected);
 
-          $bkp_groups = $_SESSION['glpigroups'];
-          $_SESSION['glpigroups'] = [42, 1337];
-          $str = \Reminder::addVisibilityRestrict();
-          $_SESSION['glpigroups'] = $bkp_groups;
-          $expected = preg_replace('/\s+/', ' ', "(`glpi_reminders`.`users_id` = '4'
+         $bkp_groups = $_SESSION['glpigroups'];
+         $_SESSION['glpigroups'] = [42, 1337];
+         $str = \Reminder::addVisibilityRestrict();
+         $_SESSION['glpigroups'] = $bkp_groups;
+         $expected = preg_replace('/\s+/', ' ', "(`glpi_reminders`.`users_id` = '4'
                OR `glpi_reminders_users`.`users_id` = '4'
                OR (`glpi_groups_reminders`.`groups_id` IN ('42', '1337')
                     AND (`glpi_groups_reminders`.`no_entity_restriction` = '1'
@@ -91,7 +91,7 @@ class Reminder extends DbTestCase
                     AND (`glpi_profiles_reminders`.`no_entity_restriction` = '1'
                          OR (`glpi_profiles_reminders`.`entities_id` IN ('0', '1', '2', '3'))))
                OR (`glpi_entities_reminders`.`entities_id` IN ('0', '1', '2', '3')))");
-          $this->string(trim(preg_replace('/\s+/', ' ', $str)))
-               ->isIdenticalTo($expected);
-     }
+         $this->string(trim(preg_replace('/\s+/', ' ', $str)))
+              ->isIdenticalTo($expected);
+    }
 }


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !31521 #13650

When the target of the note is a profile or group on the recursive root entity. The note was visible from the `Root entity` or a child, but not from the `Root entity (tree structure)`.

OK:
![image](https://github.com/glpi-project/glpi/assets/8530352/f40d8e3b-5c9c-4039-80c9-3be8f1f26f36)

Not OK:
![image](https://github.com/glpi-project/glpi/assets/8530352/9386a76c-6bdb-4e1d-9ff4-c8f1ff06fb95)


