### PR TITLE
remove plain-scrollbar dependency

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -359,26 +359,6 @@ table {
     .fancytree-selected {
         background-color: var(--tblr-primary);
     }
-
-    .plain-scrollbar {
-        &[data-scrollable="false"] {
-            visibility: hidden;
-        }
-
-        &.scrollbar-vertical {
-            width: 8px;
-        }
-
-        .arrow-up,
-        .arrow-down {
-            display: none;
-        }
-
-        .slider-area {
-            top: 0 !important;
-            bottom: 0 !important;
-        }
-    }
 }
 
 .qtip-bootstrap,

--- a/lib/bundles/base.js
+++ b/lib/bundles/base.js
@@ -55,10 +55,6 @@ require('jquery.fancytree/dist/modules/jquery.fancytree.filter');
 require('jquery.fancytree/dist/modules/jquery.fancytree.glyph');
 require('jquery.fancytree/dist/modules/jquery.fancytree.persist');
 import 'jquery.fancytree/dist/skin-awesome/ui.fancytree.css';
-import PlainScrollbar from 'exports-loader?exports=default|PlainScrollbar!plain-scrollbar';
-import 'plain-scrollbar/plain-scrollbar.css';
-window.PlainScrollbar = PlainScrollbar;
-
 
 // jQuery UI widgets required by
 // - jquery-file-upload (widget)

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,6 @@
                 "monaco-editor": "^0.45.0",
                 "path-browserify": "^1.0.1",
                 "photoswipe": "^5.4.3",
-                "plain-scrollbar": "github:ewya/PlainScrollbar#35221e7c7fa9633d6f61bcd9d7b418b6de6da73b",
                 "prismjs": "^1.23.0",
                 "process": "^0.11.10",
                 "qtip2": "^3.0.3",
@@ -10271,11 +10270,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/plain-scrollbar": {
-            "resolved": "git+ssh://git@github.com/ewya/PlainScrollbar.git#35221e7c7fa9633d6f61bcd9d7b418b6de6da73b",
-            "integrity": "sha512-54M01mOeA9VfJjAEXkM6U5wpH0TGVKiftF/jQYM97U019vKKNc5FDtDq6kUTbCLFB0ABDtwHQ53ooMi7vRaJRQ==",
-            "license": "MIT"
         },
         "node_modules/po2json": {
             "version": "1.0.0-beta-3",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
         "monaco-editor": "^0.45.0",
         "path-browserify": "^1.0.1",
         "photoswipe": "^5.4.3",
-        "plain-scrollbar": "github:ewya/PlainScrollbar#35221e7c7fa9633d6f61bcd9d7b418b6de6da73b",
         "prismjs": "^1.23.0",
         "process": "^0.11.10",
         "qtip2": "^3.0.3",

--- a/templates/layout/parts/profile_selector.html.twig
+++ b/templates/layout/parts/profile_selector.html.twig
@@ -122,7 +122,10 @@
                 <tbody>
                 </tbody>
                 </table>
-                <div id="verticalScrollbar-{{ rand }}" style="height:100%;"></div>
+                <div id="verticalScrollbar-{{ rand }}" class="position-absolute overflow-auto" style="height:100%; width: 16px; top: 0; right: 0;">
+                    <div class="fake-scrollbar-inner" style="height: 100%; width: 100%;">
+                    </div>
+                </div>
             </div>
         </div>
     </div>
@@ -184,32 +187,13 @@
                     counter: false, // do not show counters when filtering entity tree
                 },
 
-                // load 3rd party scrollbar extension for viewport mode
-                preInit: function(event, data) {
-                    var tree = data.tree;
-
-                    tree.verticalScrollbar = new PlainScrollbar({
-                    alwaysVisible: true,
-                    arrows: true,
-                    orientation: "vertical",
-                    onSet: function(numberOfItems) {
-                        tree.setViewport({
-                            start: Math.round(numberOfItems.start),
-                        });
-                    },
-                    scrollbarElement: document.getElementById("verticalScrollbar-{{ rand }}"),
-                    });
-                },
-
                 // update scrollbar when viewport is updated
                 updateViewport: function(event, data) {
-                    var tree = data.tree;
-
-                    tree.verticalScrollbar.set({
-                    start: tree.viewport.start,
-                    total: tree.visibleNodeList.length,
-                    visible: tree.viewport.count,
-                    }, true);  // do not trigger `onSet`
+                    const fake_scrollbar = $("#verticalScrollbar-{{ rand }}");
+                    const item_height = $(data.tree.tbody).find('tr').height();
+                    block_fake_scrollbar_event = true;
+                    fake_scrollbar.find('.fake-scrollbar-inner').height(item_height * data.tree.visibleNodeList.length);
+                    fake_scrollbar.scrollTop(item_height * data.tree.viewport.start);
 
                     initTooltips();
                 },
@@ -220,6 +204,20 @@
                 },
             });
         };
+
+        //Sync viewport with fake scrollbar
+        $("#verticalScrollbar-{{ rand }}").on('scroll', function(e) {
+            if (block_fake_scrollbar_event) {
+                block_fake_scrollbar_event = false;
+                return;
+            }
+            const fake_scrollbar = $(e.target);
+            const item_height = fake_scrollbar.find('.fake-scrollbar-inner').height() / $.ui.fancytree.getTree("#tree_entity{{ rand }}").visibleNodeList.length;
+            const new_start = Math.round(fake_scrollbar.scrollTop() / item_height);
+            $.ui.fancytree.getTree("#tree_entity{{ rand }}").setViewport({
+                start: new_start,
+            });
+        });
 
       // init Entities tree only when user ask for it (when dropdown is opened)
         document.getElementById('entity-tree-dropdown-{{ rand }}')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

While working on the Cypress POC, the CI actions started failing with NPM complaining about tarball data being corrupted for this dependency and bad cache permissions. This library hasn't been updated in 2 years, but more worryingly, the maintainer hasn't been active on GitHub in the same amount of time. For the one specific feature we use it for (entity selector list), we should be able to use a simple custom solution as a replacement.

This alternative creates a small scrollable area along the right side of the list to make it look like the entity list is scrollable even though it uses DOM recycling (only adds the visible items to the DOM). When you "scroll" the list and the viewport updates, the scrollbar is adjusted to match. When the "fake" scrollable area is scrolled, the viewport is updated. This solution will probably only work as long as each list item is the same height (there is no wrapping currently).

If we need to use lists that operate this way with dynamic list elements for something else, there may be a different library that already has a solution for a functional scrollbar that can be used instead of this.