### PR TITLE
Enhance accuracy of debug mode dashboard card timings

### DIFF
--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -979,11 +979,8 @@ HTML;
             if ($html === '') {
                 return $notfound_html;
             }
-
-            $execution_time = round(microtime(true) - $start, 3);
         } catch (\Throwable $e) {
             $html = $render_error_html;
-            $execution_time = round(microtime(true) - $start, 3);
             // Log the error message without exiting
             /** @var \GLPI $GLPI */
             global $GLPI;
@@ -991,10 +988,12 @@ HTML;
         }
         Profiler::getInstance()->stop(__METHOD__ . ' get card data');
 
-        if ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE) {
+        if ($_SESSION['glpi_use_mode'] === Session::DEBUG_MODE) {
+            // Use the current PHP request duration as the execution time for a more accurate card loading time
+            $execution_time = Profiler::getInstance()->getCurrentDuration('php_request');
             $html .= <<<HTML
          <span class='debug-card'>
-            {$execution_time}s
+            {$execution_time}ms
          </span>
 HTML;
         }

--- a/src/Debug/Profiler.php
+++ b/src/Debug/Profiler.php
@@ -37,8 +37,7 @@ namespace Glpi\Debug;
 
 /**
  * Class that handles profiling sections of code.
- * The data is viewable in the debug bar only. If the current user is not in debug mode, the profiler is normally disabled.
- * This can also be used to simply time sections of code (even across functions) and use the result in the application even in debug mode.
+ * The data is viewable in the debug bar only. If the current user is not in debug mode, the profiler is disabled.
  */
 final class Profiler
 {
@@ -72,15 +71,12 @@ final class Profiler
      * Starts a new section in the profiler. This section will be stopped when Profiler::stop() is called with the same name.
      * @param string $name The name of the section. This name will be used to stop the section later.
      * @param string $category The category of the section. See Profiler::CATEGORY_* for some predefined categories.
-     * @param bool $force_start If true, the section will be started even if the user is not in debug mode.
-     *                           This is useful if the profiler is going to be used to simply time a section of code and
-     *                           the result will be used in the application.
      * @return void
      */
-    public function start(string $name, string $category = self::CATEGORY_CORE, bool $force_start = false): void
+    public function start(string $name, string $category = self::CATEGORY_CORE): void
     {
         $debug_mode_or_pre_session = !isset($_SESSION['glpi_use_mode']) || $_SESSION['glpi_use_mode'] === \Session::DEBUG_MODE;
-        if (!$force_start && ($this->disabled || !$debug_mode_or_pre_session)) {
+        if ($this->disabled || !$debug_mode_or_pre_session) {
             return;
         }
 

--- a/src/Debug/Profiler.php
+++ b/src/Debug/Profiler.php
@@ -126,10 +126,9 @@ final class Profiler
     /**
      * Stops a section started with Profiler::start()
      * @param string $name The name of the section to stop. This name must be the same as the one used in Profiler::start()
-     * @param bool $discard If true, the section will not be added to the debug information.
      * @return int The duration of the section in milliseconds
      */
-    public function stop(string $name, bool $discard = false): int
+    public function stop(string $name): int
     {
         // get the last section with the given name and stop it
         $section = array_filter($this->current_sections, static function (ProfilerSection $section) use ($name) {
@@ -141,9 +140,7 @@ final class Profiler
             $section->end(microtime(true) * 1000);
             $duration = $section->getDuration();
             unset($this->current_sections[$k]);
-            if (!$discard) {
-                Profile::getCurrent()->setData('profiler', $section->toArray());
-            }
+            Profile::getCurrent()->setData('profiler', $section->toArray());
         }
         return $duration ?? 0;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Use the current PHP request duration as the execution time on the dashboard cards in debug mode.