### PR TITLE
Fix item ticket tabs

### DIFF
--- a/src/Appliance.php
+++ b/src/Appliance.php
@@ -78,7 +78,7 @@ class Appliance extends CommonDBTM
          ->addStandardTab('Certificate_Item', $ong, $options)
          ->addStandardTab('Domain_Item', $ong, $options)
          ->addStandardTab('KnowbaseItem_Item', $ong, $options)
-         ->addStandardTab('Ticket', $ong, $options)
+         ->addStandardTab('Item_Ticket', $ong, $options)
          ->addStandardTab('Item_Problem', $ong, $options)
          ->addStandardTab('Change_Item', $ong, $options)
          ->addStandardTab('ManualLink', $ong, $options)

--- a/src/Asset/AssetDefinitionManager.php
+++ b/src/Asset/AssetDefinitionManager.php
@@ -42,7 +42,6 @@ use Glpi\Asset\Capacity\CapacityInterface;
 use Item_Problem;
 use Item_Ticket;
 use ReflectionClass;
-use Ticket;
 
 final class AssetDefinitionManager
 {
@@ -165,10 +164,10 @@ final class AssetDefinitionManager
 
         // Register IITL tabs, which will only be displayed if some condition
         // are met (see the shouldDisplayTabForAsset method in
-        // CommonItilObject_Item and Ticket classes).
+        // CommonItilObject_Item).
         CommonGLPI::registerStandardTab(
             $asset_class_name,
-            Ticket::class, // TODO: Why not Item_Ticket ?
+            Item_Ticket::class,
             51
         );
         CommonGLPI::registerStandardTab(

--- a/src/Asset/AssetDefinitionManager.php
+++ b/src/Asset/AssetDefinitionManager.php
@@ -40,6 +40,7 @@ use CommonGLPI;
 use DirectoryIterator;
 use Glpi\Asset\Capacity\CapacityInterface;
 use Item_Problem;
+use Item_Ticket;
 use ReflectionClass;
 use Ticket;
 

--- a/src/Cable.php
+++ b/src/Cable.php
@@ -61,7 +61,7 @@ class Cable extends CommonDBTM
         $ong = [];
         $this->addDefaultFormTab($ong)
          ->addStandardTab('Infocom', $ong, $options)
-         ->addStandardTab('Ticket', $ong, $options)
+         ->addStandardTab('Item_Ticket', $ong, $options)
          ->addStandardTab('Item_Problem', $ong, $options)
          ->addStandardTab('Change_Item', $ong, $options)
          ->addStandardTab('Log', $ong, $options);

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -462,7 +462,7 @@ class Certificate extends CommonDBTM
          ->addStandardTab('Contract_Item', $ong, $options)
          ->addStandardTab('Document_Item', $ong, $options)
          ->addStandardTab('KnowbaseItem_Item', $ong, $options)
-         ->addStandardTab('Ticket', $ong, $options)
+         ->addStandardTab('Item_Ticket', $ong, $options)
          ->addStandardTab('Item_Problem', $ong, $options)
          ->addStandardTab('Change_Item', $ong, $options)
          ->addStandardTab('ManualLink', $ong, $options)

--- a/src/Cluster.php
+++ b/src/Cluster.php
@@ -65,7 +65,7 @@ class Cluster extends CommonDBTM
          ->addStandardTab('NetworkPort', $ong, $options)
          ->addStandardTab('Contract_Item', $ong, $options)
          ->addStandardTab('Document_Item', $ong, $options)
-         ->addStandardTab('Ticket', $ong, $options)
+         ->addStandardTab('Item_Ticket', $ong, $options)
          ->addStandardTab('Item_Problem', $ong, $options)
          ->addStandardTab('Change_Item', $ong, $options)
          ->addStandardTab('Appliance_Item', $ong, $options)

--- a/src/Computer.php
+++ b/src/Computer.php
@@ -122,7 +122,7 @@ class Computer extends CommonDBTM
          ->addStandardTab('ComputerVirtualMachine', $ong, $options)
          ->addStandardTab('ItemAntivirus', $ong, $options)
          ->addStandardTab('KnowbaseItem_Item', $ong, $options)
-         ->addStandardTab('Ticket', $ong, $options)
+         ->addStandardTab('Item_Ticket', $ong, $options)
          ->addStandardTab('Item_Problem', $ong, $options)
          ->addStandardTab('Change_Item', $ong, $options)
          ->addStandardTab('ManualLink', $ong, $options)

--- a/src/DCRoom.php
+++ b/src/DCRoom.php
@@ -64,7 +64,7 @@ class DCRoom extends CommonDBTM
          ->addStandardTab('Contract_Item', $ong, $options)
          ->addStandardTab('Document_Item', $ong, $options)
          ->addStandardTab('ManualLink', $ong, $options)
-         ->addStandardTab('Ticket', $ong, $options)
+         ->addStandardTab('Item_Ticket', $ong, $options)
          ->addStandardTab('Item_Problem', $ong, $options)
          ->addStandardTab('Change_Item', $ong, $options)
          ->addStandardTab('Log', $ong, $options);

--- a/src/Database.php
+++ b/src/Database.php
@@ -60,7 +60,7 @@ class Database extends CommonDBChild
          ->addStandardTab('Infocom', $ong, $options)
          ->addStandardTab('Document_Item', $ong, $options)
          ->addStandardTab('KnowbaseItem_Item', $ong, $options)
-         ->addStandardTab('Ticket', $ong, $options)
+         ->addStandardTab('Item_Ticket', $ong, $options)
          ->addStandardTab('Item_Problem', $ong, $options)
          ->addStandardTab('Change_Item', $ong, $options)
          ->addStandardTab('Lock', $ong, $options)

--- a/src/DatabaseInstance.php
+++ b/src/DatabaseInstance.php
@@ -82,7 +82,7 @@ class DatabaseInstance extends CommonDBTM
          ->addStandardTab('Contract_Item', $ong, $options)
          ->addStandardTab('Document_Item', $ong, $options)
          ->addStandardTab('KnowbaseItem_Item', $ong, $options)
-         ->addStandardTab('Ticket', $ong, $options)
+         ->addStandardTab('Item_Ticket', $ong, $options)
          ->addStandardTab('Item_Problem', $ong, $options)
          ->addStandardTab('Change_Item', $ong, $options)
          ->addStandardTab('Certificate_Item', $ong, $options)

--- a/src/Domain.php
+++ b/src/Domain.php
@@ -299,7 +299,7 @@ class Domain extends CommonDBTM
         $this->addStandardTab('DomainRecord', $ong, $options);
         $this->addStandardTab('Domain_Item', $ong, $options);
         $this->addStandardTab('Infocom', $ong, $options);
-        $this->addStandardTab('Ticket', $ong, $options);
+        $this->addStandardTab('Item_Ticket', $ong, $options);
         $this->addStandardTab('Item_Problem', $ong, $options);
         $this->addStandardTab('Change_Item', $ong, $options);
         $this->addStandardTab('Contract_Item', $ong, $options);

--- a/src/DomainRecord.php
+++ b/src/DomainRecord.php
@@ -238,7 +238,7 @@ class DomainRecord extends CommonDBChild
     {
         $ong = [];
         $this->addDefaultFormTab($ong);
-        $this->addStandardTab('Ticket', $ong, $options);
+        $this->addStandardTab('Item_Ticket', $ong, $options);
         $this->addStandardTab('Item_Problem', $ong, $options);
         $this->addStandardTab('Document_Item', $ong, $options);
         $this->addStandardTab('ManualLink', $ong, $options);

--- a/src/Enclosure.php
+++ b/src/Enclosure.php
@@ -72,7 +72,7 @@ class Enclosure extends CommonDBTM
          ->addStandardTab('Infocom', $ong, $options)
          ->addStandardTab('Contract_Item', $ong, $options)
          ->addStandardTab('Document_Item', $ong, $options)
-         ->addStandardTab('Ticket', $ong, $options)
+         ->addStandardTab('Item_Ticket', $ong, $options)
          ->addStandardTab('Item_Problem', $ong, $options)
          ->addStandardTab('Change_Item', $ong, $options)
          ->addStandardTab('Log', $ong, $options);

--- a/src/Monitor.php
+++ b/src/Monitor.php
@@ -103,7 +103,7 @@ class Monitor extends CommonDBTM
         $this->addStandardTab('Contract_Item', $ong, $options);
         $this->addStandardTab('Document_Item', $ong, $options);
         $this->addStandardTab('KnowbaseItem_Item', $ong, $options);
-        $this->addStandardTab('Ticket', $ong, $options);
+        $this->addStandardTab('Item_Ticket', $ong, $options);
         $this->addStandardTab('Item_Problem', $ong, $options);
         $this->addStandardTab('Change_Item', $ong, $options);
         $this->addStandardTab('ManualLink', $ong, $options);

--- a/src/NetworkEquipment.php
+++ b/src/NetworkEquipment.php
@@ -127,7 +127,7 @@ class NetworkEquipment extends CommonDBTM
          ->addStandardTab('Contract_Item', $ong, $options)
          ->addStandardTab('Document_Item', $ong, $options)
          ->addStandardTab('KnowbaseItem_Item', $ong, $options)
-         ->addStandardTab('Ticket', $ong, $options)
+         ->addStandardTab('Item_Ticket', $ong, $options)
          ->addStandardTab('Item_Problem', $ong, $options)
          ->addStandardTab('Change_Item', $ong, $options)
          ->addStandardTab('ManualLink', $ong, $options)

--- a/src/PDU.php
+++ b/src/PDU.php
@@ -70,7 +70,7 @@ class PDU extends CommonDBTM
          ->addStandardTab('Infocom', $ong, $options)
          ->addStandardTab('Contract_Item', $ong, $options)
          ->addStandardTab('Document_Item', $ong, $options)
-         ->addStandardTab('Ticket', $ong, $options)
+         ->addStandardTab('Item_Ticket', $ong, $options)
          ->addStandardTab('Item_Problem', $ong, $options)
          ->addStandardTab('Change_Item', $ong, $options)
          ->addStandardTab('Log', $ong, $options);

--- a/src/PassiveDCEquipment.php
+++ b/src/PassiveDCEquipment.php
@@ -62,7 +62,7 @@ class PassiveDCEquipment extends CommonDBTM
          ->addStandardTab('Infocom', $ong, $options)
          ->addStandardTab('Contract_Item', $ong, $options)
          ->addStandardTab('Document_Item', $ong, $options)
-         ->addStandardTab('Ticket', $ong, $options)
+         ->addStandardTab('Item_Ticket', $ong, $options)
          ->addStandardTab('Item_Problem', $ong, $options)
          ->addStandardTab('Change_Item', $ong, $options)
          ->addStandardTab('Log', $ong, $options);

--- a/src/Peripheral.php
+++ b/src/Peripheral.php
@@ -107,7 +107,7 @@ class Peripheral extends CommonDBTM
         $this->addStandardTab('Contract_Item', $ong, $options);
         $this->addStandardTab('Document_Item', $ong, $options);
         $this->addStandardTab('KnowbaseItem_Item', $ong, $options);
-        $this->addStandardTab('Ticket', $ong, $options);
+        $this->addStandardTab('Item_Ticket', $ong, $options);
         $this->addStandardTab('Item_Problem', $ong, $options);
         $this->addStandardTab('Change_Item', $ong, $options);
         $this->addStandardTab('ManualLink', $ong, $options);

--- a/src/Phone.php
+++ b/src/Phone.php
@@ -115,7 +115,7 @@ class Phone extends CommonDBTM
         $this->addStandardTab('Document_Item', $ong, $options);
         $this->addStandardTab('ItemAntivirus', $ong, $options);
         $this->addStandardTab('KnowbaseItem_Item', $ong, $options);
-        $this->addStandardTab('Ticket', $ong, $options);
+        $this->addStandardTab('Item_Ticket', $ong, $options);
         $this->addStandardTab('Item_Problem', $ong, $options);
         $this->addStandardTab('Change_Item', $ong, $options);
         $this->addStandardTab('ManualLink', $ong, $options);

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -112,7 +112,7 @@ class Printer extends CommonDBTM
         $this->addStandardTab('Contract_Item', $ong, $options);
         $this->addStandardTab('Document_Item', $ong, $options);
         $this->addStandardTab('KnowbaseItem_Item', $ong, $options);
-        $this->addStandardTab('Ticket', $ong, $options);
+        $this->addStandardTab('Item_Ticket', $ong, $options);
         $this->addStandardTab('Item_Problem', $ong, $options);
         $this->addStandardTab('Change_Item', $ong, $options);
         $this->addStandardTab('ManualLink', $ong, $options);

--- a/src/Rack.php
+++ b/src/Rack.php
@@ -75,7 +75,7 @@ class Rack extends CommonDBTM
          ->addStandardTab('Infocom', $ong, $options)
          ->addStandardTab('Contract_Item', $ong, $options)
          ->addStandardTab('Document_Item', $ong, $options)
-         ->addStandardTab('Ticket', $ong, $options)
+         ->addStandardTab('Item_Ticket', $ong, $options)
          ->addStandardTab('Item_Problem', $ong, $options)
          ->addStandardTab('Change_Item', $ong, $options)
          ->addStandardTab('Reservation', $ong, $options)

--- a/src/Software.php
+++ b/src/Software.php
@@ -117,7 +117,7 @@ class Software extends CommonDBTM
         $this->addStandardTab('Contract_Item', $ong, $options);
         $this->addStandardTab('Document_Item', $ong, $options);
         $this->addStandardTab('KnowbaseItem_Item', $ong, $options);
-        $this->addStandardTab('Ticket', $ong, $options);
+        $this->addStandardTab('Item_Ticket', $ong, $options);
         $this->addStandardTab('Item_Problem', $ong, $options);
         $this->addStandardTab('Change_Item', $ong, $options);
         $this->addStandardTab('ManualLink', $ong, $options);

--- a/src/SoftwareLicense.php
+++ b/src/SoftwareLicense.php
@@ -273,7 +273,7 @@ class SoftwareLicense extends CommonTreeDropdown
         $this->addStandardTab('Contract_Item', $ong, $options);
         $this->addStandardTab('Document_Item', $ong, $options);
         $this->addStandardTab('KnowbaseItem_Item', $ong, $options);
-        $this->addStandardTab('Ticket', $ong, $options);
+        $this->addStandardTab('Item_Ticket', $ong, $options);
         $this->addStandardTab('Item_Problem', $ong, $options);
         $this->addStandardTab('Change_Item', $ong, $options);
         $this->addStandardTab('Notepad', $ong, $options);

--- a/tests/functional/Glpi/Asset/AssetDefinitionManager.php
+++ b/tests/functional/Glpi/Asset/AssetDefinitionManager.php
@@ -111,7 +111,7 @@ class AssetDefinitionManager extends DbTestCase
         yield [
             $definition,
             $subject,
-            ["Ticket$1"]
+            ["Item_Ticket$1"]
         ];
 
         // Link subject to problem
@@ -127,7 +127,7 @@ class AssetDefinitionManager extends DbTestCase
         yield [
             $definition,
             $subject,
-            ["Ticket$1", "Item_Problem$1"]
+            ["Item_Ticket$1", "Item_Problem$1"]
         ];
 
         // Link subject to change
@@ -143,7 +143,7 @@ class AssetDefinitionManager extends DbTestCase
         yield [
             $definition,
             $subject,
-            ["Ticket$1", "Item_Problem$1", "Change_Item$1"]
+            ["Item_Ticket$1", "Item_Problem$1", "Change_Item$1"]
         ];
 
         // Create a separate definition to test rights as tabs are not removed
@@ -173,7 +173,7 @@ class AssetDefinitionManager extends DbTestCase
         yield [
             $definition,
             $subject,
-            ["Ticket$1", "Item_Problem$1", "Change_Item$1"]
+            ["Item_Ticket$1", "Item_Problem$1", "Change_Item$1"]
         ];
     }
 


### PR DESCRIPTION
Need #16518 to be merged first.

Use the correct `Item_Ticket` tab when needed, to be consistent with usage of the `Item_Problem`  and `Change_Item` tabs.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
