### PR TITLE
Fix missing parent item data for webhook headers and url

### DIFF
--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -486,8 +486,10 @@ class Webhook extends CommonDBTM implements FilterableInterface
     {
         $data = $api_data;
         if ($data !== null) {
+            $data['item'] = $api_data;
+            $data['event'] = $event;
+            $this->addParentItemData($data, $itemtype, $items_id);
             if ($raw_output) {
-                $data['event'] = $event;
                 return json_encode($data, JSON_PRETTY_PRINT);
             } else {
                 $payload_template = isset($this->fields['payload']) ? $this->fields['payload'] : null;
@@ -508,11 +510,6 @@ class Webhook extends CommonDBTM implements FilterableInterface
                     };
                     $data = $fn_desanitize($data);
                     try {
-                        $data = [
-                            'item' => $data
-                        ];
-                        $this->addParentItemData($data, $itemtype, $items_id);
-                        $data['event'] = $event;
                         $env = new \Twig\Environment(
                             new \Twig\Loader\ArrayLoader([
                                 'payload' => $payload_template
@@ -524,7 +521,6 @@ class Webhook extends CommonDBTM implements FilterableInterface
                         return null;
                     }
                 } else {
-                    $data['event'] = $event;
                     return json_encode($data, JSON_PRETTY_PRINT);
                 }
             }
@@ -1149,11 +1145,11 @@ class Webhook extends CommonDBTM implements FilterableInterface
             ];
 
             $api_data = [
+                'event' => $event,
                 'item' => $api_data
             ];
             $webhook->addParentItemData($api_data, $item::getType(), $item->getID());
 
-            $api_data['event'] = $event;
             $custom_headers = $webhook->fields['custom_headers'];
             foreach ($custom_headers as $key => $value) {
                 $env = new \Twig\Environment(

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -1151,6 +1151,8 @@ class Webhook extends CommonDBTM implements FilterableInterface
             $api_data = [
                 'item' => $api_data
             ];
+            $webhook->addParentItemData($api_data, $item::getType(), $item->getID());
+
             $api_data['event'] = $event;
             $custom_headers = $webhook->fields['custom_headers'];
             foreach ($custom_headers as $key => $value) {

--- a/tests/functional/Webhook.php
+++ b/tests/functional/Webhook.php
@@ -71,4 +71,158 @@ class Webhook extends \DbTestCase
             $this->variable($id_opt_num)->isNotNull();
         }
     }
+
+    public function testGetWebhookBody()
+    {
+        $this->login();
+
+        $ticket = $this->createItem('Ticket', [
+            'name' => 'Test ticket',
+            'content' => 'Test ticket content',
+            'externalid' => 'ext1234',
+            'entities_id' => $_SESSION['glpiactive_entity']
+        ]);
+        $this->string($ticket->fields['externalid'])->isEqualTo('ext1234');
+
+        $payload = <<<JSON
+            {
+                "event": "{{ event }}",
+                "external_id": "{{ parent_item.external_id }}",
+                "item": {
+                    "id": "{{ item.id }}",
+                    "itemtype": "{{ item.itemtype }}",
+                    "items_id": "{{ item.items_id }}",
+                    "content": "{{ item.content }}"
+                }
+            }
+JSON;
+
+        $webhook = $this->createItem('Webhook', [
+            'name' => 'Test webhook',
+            'entities_id' => $_SESSION['glpiactive_entity'],
+            'url' => 'http://localhost',
+            'itemtype' => 'ITILFollowup',
+            'event' => 'new',
+            'is_active' => 1,
+            'use_default_payload' => 0,
+            'payload' => $payload
+        ]);
+
+        $fup = $this->createItem('ITILFollowup', [
+            'items_id' => $ticket->getID(),
+            'itemtype' => 'Ticket',
+            'content' => 'Test followup'
+        ]);
+
+        $queued_webhooks = getAllDataFromTable(\QueuedWebhook::getTable(), ['webhooks_id' => $webhook->getID()]);
+        $queued_webhook = reset($queued_webhooks);
+
+        $this->array($queued_webhook)->size->isGreaterThan(0);
+
+        $body = json_decode($queued_webhook['body'], true);
+
+        $this->string($body['event'])->isEqualTo('new');
+        $this->string($body['external_id'])->isEqualTo('ext1234');
+        $this->string($body['item']['id'])->isEqualTo($fup->getID());
+        $this->string($body['item']['itemtype'])->isEqualTo('Ticket');
+        $this->string($body['item']['items_id'])->isEqualTo($ticket->getID());
+        $this->string($body['item']['content'])->isEqualTo('Test followup');
+    }
+
+    public function testWebhookURLTemplate()
+    {
+        $this->login();
+
+        $ticket = $this->createItem('Ticket', [
+            'name' => 'Test ticket',
+            'content' => 'Test ticket content',
+            'entities_id' => $_SESSION['glpiactive_entity'],
+            'externalid' => 'ext1234'
+        ]);
+
+        $payload = <<<JSON
+            {
+                "event": "{{ event }}"
+            }
+JSON;
+
+        $webhook = $this->createItem('Webhook', [
+            'name' => 'Test webhook',
+            'entities_id' => $_SESSION['glpiactive_entity'],
+            'url' => 'http://localhost/{{ parent_item.external_id }}/{{ event }}/{{ item.id }}',
+            'itemtype' => 'ITILFollowup',
+            'event' => 'new',
+            'is_active' => 1,
+            'use_default_payload' => 0,
+            'payload' => $payload
+        ]);
+
+        $fup = $this->createItem('ITILFollowup', [
+            'items_id' => $ticket->getID(),
+            'itemtype' => 'Ticket',
+            'content' => 'Test followup'
+        ]);
+
+        $queued_webhooks = getAllDataFromTable(\QueuedWebhook::getTable(), ['webhooks_id' => $webhook->getID()]);
+        $queued_webhook = reset($queued_webhooks);
+
+        $this->array($queued_webhook)->size->isGreaterThan(0);
+        $this->string($queued_webhook['url'])->isEqualTo('http://localhost/ext1234/new/' . $fup->getID());
+    }
+
+    public function testWebhookHeaderTemplate()
+    {
+        $this->login();
+
+        $ticket = $this->createItem('Ticket', [
+            'name' => 'Test ticket',
+            'content' => 'Test ticket content',
+            'entities_id' => $_SESSION['glpiactive_entity'],
+            'externalid' => 'ext1234'
+        ]);
+
+        $payload = <<<JSON
+            {
+                "event": "{{ event }}"
+            }
+JSON;
+        $custom_headers = <<<JSON
+            {
+                "X-Test-Event": "{{ event }}",
+                "X-Test-External-ID": "{{ parent_item.external_id }}",
+                "X-Test-Item-ID": "{{ item.id }}",
+                "X-Test-Mixed": "{{ event }}-{{ parent_item.external_id }}-{{ item.id }}"
+            }
+JSON;
+
+
+        $webhook = $this->createItem('Webhook', [
+            'name' => 'Test webhook',
+            'entities_id' => $_SESSION['glpiactive_entity'],
+            'url' => 'http://localhost',
+            'itemtype' => 'ITILFollowup',
+            'event' => 'new',
+            'is_active' => 1,
+            'use_default_payload' => 0,
+            'payload' => $payload,
+            'custom_headers' => $custom_headers
+        ], ['custom_headers']);
+
+        $fup = $this->createItem('ITILFollowup', [
+            'items_id' => $ticket->getID(),
+            'itemtype' => 'Ticket',
+            'content' => 'Test followup'
+        ]);
+
+        $queued_webhooks = getAllDataFromTable(\QueuedWebhook::getTable(), ['webhooks_id' => $webhook->getID()]);
+        $queued_webhook = reset($queued_webhooks);
+
+        $this->array($queued_webhook)->size->isGreaterThan(0);
+        $headers = json_decode($queued_webhook['headers'], true);
+
+        $this->string($headers['X-Test-Event'])->isEqualTo('new');
+        $this->string($headers['X-Test-External-ID'])->isEqualTo('ext1234');
+        $this->string($headers['X-Test-Item-ID'])->isEqualTo($fup->getID());
+        $this->string($headers['X-Test-Mixed'])->isEqualTo('new-ext1234-' . $fup->getID());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !31553

Information about parent items (The ticket for example when the webhook is for a followup) was only being retrieved when building the webhook body content, but not when the URL or header values were being processed by Twig.