### PR TITLE
Prevent admin to use some reserved words as asset system name

### DIFF
--- a/src/Asset/AssetDefinitionManager.php
+++ b/src/Asset/AssetDefinitionManager.php
@@ -100,6 +100,35 @@ final class AssetDefinitionManager
     }
 
     /**
+     * Returns the list of reserved system names
+     * @return array
+     */
+    public function getReservedAssetsSystemNames(): array
+    {
+        $names = [
+            'Computer',
+            'Monitor',
+            'Software',
+            'NetworkEquipment',
+            'Peripheral',
+            'Printer',
+            'Cartridge',
+            'Consumable',
+            'Phone',
+            'Rack',
+            'Enclosure',
+            'PDU',
+            'PassiveDCEquipment',
+            'Unmanaged',
+            'Cable',
+        ];
+
+        sort($names);
+
+        return $names;
+    }
+
+    /**
      * Register assets concrete classes autoload.
      *
      * @return void

--- a/templates/pages/admin/assetdefinition/main.html.twig
+++ b/templates/pages/admin/assetdefinition/main.html.twig
@@ -44,14 +44,19 @@
     {% endif %}
 
     {% if item.isNewItem() %}
+        {% set helper %}
+            {{ __('The system name corresponds to the customizable part of the asset class which will correspond to the current definition. For example, assets linked to the system name "%s" will have the class "%s".')|format('Laptop', 'Glpi\\CustomAsset\\Laptop') }}
+            {{ __('The value must contains only letters and must not end by "Model" or "Type".') }}
+            {{ __('Also, the value must not be one of the following reserved names: %s.')|format('"' ~ reserved_system_names|join('", "') ~ '"') }}
+        {% endset %}
         {{ fields.textField(
             'system_name',
             item.fields['system_name'],
             __('System name'),
             {
                 'required': true,
-                'pattern': '^[A-Za-z]+(?<!Model|Type)$',
-                'helper': __('The system name corresponds to the customizable part of the asset class which will correspond to the current definition. For example, assets linked to the system name "%s" will have the class "%s".')|format('Laptop', 'Glpi\\CustomAsset\\Laptop') ~ ' ' ~ __('The value must contains only letters and must not end by "Model" or "Type".')
+                'pattern': '^(?!(' ~ reserved_system_names|join('|') ~ ')$)[A-Za-z]+(?<!Model|Type)$',
+                'helper': helper
             }
         ) }}
     {% else %}

--- a/tests/functional/Glpi/Asset/AssetDefinition.php
+++ b/tests/functional/Glpi/Asset/AssetDefinition.php
@@ -37,6 +37,7 @@ namespace tests\units\Glpi\Asset;
 
 use Computer;
 use DbTestCase;
+use Glpi\Asset\AssetDefinitionManager;
 use Glpi\Asset\Capacity\HasDocumentsCapacity;
 use Glpi\Asset\Capacity\HasInfocomCapacity;
 use Profile;
@@ -234,6 +235,45 @@ class AssetDefinition extends DbTestCase
             }
         }
 
+        foreach (AssetDefinitionManager::getInstance()->getReservedAssetsSystemNames() as $system_name) {
+            // System name must not be a reserved name
+            yield [
+                'input'    => [
+                    'system_name' => $system_name,
+                ],
+                'output'   => false,
+                'messages' => [
+                    ERROR => [
+                        sprintf('The system name must not be the reserved word "%s".', $system_name),
+                    ],
+                ],
+            ];
+            // but can start with it
+            yield [
+                'input'    => [
+                    'system_name' => 'My' . $system_name,
+                ],
+                'output'   => [
+                    'system_name' => 'My' . $system_name,
+                    'capacities'  => '[]',
+                    'profiles'    => '[]',
+                ],
+                'messages' => [],
+            ];
+            // or end with it
+            yield [
+                'input'    => [
+                    'system_name' => $system_name . 'NG',
+                ],
+                'output'   => [
+                    'system_name' => $system_name . 'NG',
+                    'capacities'  => '[]',
+                    'profiles'    => '[]',
+                ],
+                'messages' => [],
+            ];
+        }
+
         // System name must not end with `Model` suffix
         yield [
             'input'    => [
@@ -242,7 +282,7 @@ class AssetDefinition extends DbTestCase
             'output'   => false,
             'messages' => [
                 ERROR => [
-                    'The following field has an incorrect value: "System name".',
+                    'The system name must not end with the word "Model" or the word "Type".',
                 ],
             ],
         ];
@@ -267,7 +307,7 @@ class AssetDefinition extends DbTestCase
             'output'   => false,
             'messages' => [
                 ERROR => [
-                    'The following field has an incorrect value: "System name".',
+                    'The system name must not end with the word "Model" or the word "Type".',
                 ],
             ],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

With this proposal, we will prevent administrator to use the system names that we would probably use when the assets from the corresponding classes will be transfered in the generic asset system.

Some of them will likely not be transfered, like `Unmanaged`, but I guess it is still preferable to prevent this system name to be used, at least to prevent any ambiguity with the GLPI native itemtype.