### PR TITLE
Add missing JS var declaration in profile selector

### DIFF
--- a/templates/layout/parts/profile_selector.html.twig
+++ b/templates/layout/parts/profile_selector.html.twig
@@ -132,6 +132,7 @@
 
     <script type="text/javascript">
     $(function() {
+        let block_fake_scrollbar_event = false;
         var initTree{{ rand }} = function() {
             if ($.ui.fancytree.getTree("#tree_entity{{ rand }}") !== null) {
                 return;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Follows #16520. While reviewing #16373, I saw that this variable declaration was missing.