### PR TITLE
fix(dropdown): prevent warning on add form

### DIFF
--- a/ajax/common.tabs.php
+++ b/ajax/common.tabs.php
@@ -53,8 +53,6 @@ if (isset($_GET['full_page_tab'])) {
     Html::header_nocache();
 }
 
-$_GET['_target'] = Toolbox::cleanTarget($_GET['_target'] ?? $_SERVER['REQUEST_URI']);
-
 if (!($CFG_GLPI["use_public_faq"] && str_ends_with($_GET["_target"], '/front/helpdesk.faq.php'))) {
     Session::checkLoginUser();
 }
@@ -99,6 +97,10 @@ if ($item = getItemForItemtype($_UGET['_itemtype'])) {
             exit();
         }
     }
+}
+
+if (isset($_GET['_target'])) {
+    $_GET['_target'] = Toolbox::cleanTarget($_GET['_target']);
 }
 
 Session::setActiveTab($_GET['_itemtype'], $_GET['_glpi_tab']);

--- a/ajax/common.tabs.php
+++ b/ajax/common.tabs.php
@@ -53,7 +53,9 @@ if (isset($_GET['full_page_tab'])) {
     Html::header_nocache();
 }
 
-if (!($CFG_GLPI["use_public_faq"] && str_ends_with($_GET["_target"] ?? $_SERVER['REQUEST_URI'], '/front/helpdesk.faq.php'))) {
+$_GET['_target'] = Toolbox::cleanTarget($_GET['_target'] ?? $_SERVER['REQUEST_URI']);
+
+if (!($CFG_GLPI["use_public_faq"] && str_ends_with($_GET["_target"], '/front/helpdesk.faq.php'))) {
     Session::checkLoginUser();
 }
 
@@ -97,10 +99,6 @@ if ($item = getItemForItemtype($_UGET['_itemtype'])) {
             exit();
         }
     }
-}
-
-if (isset($_GET['_target'])) {
-    $_GET['_target'] = Toolbox::cleanTarget($_GET['_target']);
 }
 
 Session::setActiveTab($_GET['_itemtype'], $_GET['_glpi_tab']);

--- a/ajax/common.tabs.php
+++ b/ajax/common.tabs.php
@@ -53,7 +53,7 @@ if (isset($_GET['full_page_tab'])) {
     Html::header_nocache();
 }
 
-if (!($CFG_GLPI["use_public_faq"] && str_ends_with($_GET["_target"], '/front/helpdesk.faq.php'))) {
+if (!($CFG_GLPI["use_public_faq"] && str_ends_with($_GET["_target"] ?? $_SERVER['REQUEST_URI'], '/front/helpdesk.faq.php'))) {
     Session::checkLoginUser();
 }
 

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -898,17 +898,18 @@ class CommonGLPI implements CommonGLPIInterface
         }
 
         if (count($onglets)) {
-            $tab_path = $this->getTabsURL();
-            $parse_url = parse_url($tab_path);
-            if (isset($parse_url['query'])) {
-                parse_str($parse_url['query'], $url_params);
-                $tab_path = Html::cleanParametersURL($tab_path);
-                $cleaned_options = array_merge($cleaned_options, $url_params);
+            $tabs_url   = $this->getTabsURL();
+            $parsed_url = parse_url($tabs_url);
+            $tab_path   = $parsed_url['path'];
+            $tab_params = [];
+            if (array_key_exists('query', $parsed_url)) {
+                parse_str($parsed_url['query'], $tab_params);
             }
-            $tabs    = [];
+
+            $tab_params = array_merge($cleaned_options, $tab_params);
 
             $tab_params = array_merge(
-                $cleaned_options,
+                $tab_params,
                 [
                     '_target' => $target,
                     '_itemtype' => $this->getType(),
@@ -916,6 +917,7 @@ class CommonGLPI implements CommonGLPIInterface
                 ]
             );
 
+            $tabs = [];
             foreach ($onglets as $key => $val) {
                 $tabs[$key] = ['title'  => $val,
                     'url'    => $tab_path,

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -862,13 +862,6 @@ class CommonGLPI implements CommonGLPIInterface
         }
 
         $cleaned_options = $options;
-        $tab_path = $this->getTabsURL();
-        $parse_url = parse_url($tab_path);
-        if (isset($parse_url['query'])) {
-            parse_str($parse_url['query'], $url_params);
-            $tab_path = Html::cleanParametersURL($tab_path);
-            $cleaned_options = array_merge($options, $url_params);
-        }
         unset($cleaned_options['id'], $cleaned_options['stock_image']);
 
         $target         = $_SERVER['PHP_SELF'];
@@ -905,6 +898,13 @@ class CommonGLPI implements CommonGLPIInterface
         }
 
         if (count($onglets)) {
+            $tab_path = $this->getTabsURL();
+            $parse_url = parse_url($tab_path);
+            if (isset($parse_url['query'])) {
+                parse_str($parse_url['query'], $url_params);
+                $tab_path = Html::cleanParametersURL($tab_path);
+                $cleaned_options = array_merge($cleaned_options, $url_params);
+            }
             $tabs    = [];
 
             $tab_params = array_merge(

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -902,6 +902,7 @@ class CommonGLPI implements CommonGLPIInterface
 
         if (count($onglets)) {
             $tabpage = $this->getTabsURL();
+            $tabpage = Html::cleanParametersURL($tabpage);
             $tabs    = [];
 
             foreach ($onglets as $key => $val) {


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When you add a value to a dropdown, it raises a warning:
_In this example, it's a dropdown of the Fields plugin_

![image](https://github.com/glpi-project/glpi/assets/8530352/ab807d31-54c1-47c0-8847-d5f737826383)

```
glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "_target" in .../ajax/common.tabs.php at line 56
  Backtrace :
  public/index.php:82                                require()
  
glpiphplog.NOTICE:   *** PHP Deprecated function (8192): str_ends_with(): Passing null to parameter #1 ($haystack) of type string is deprecated in .../ajax/common.tabs.php at line 56
  Backtrace :
  ajax/common.tabs.php:56                            str_ends_with()
  public/index.php:82                                require()
```
  