### PR TITLE
ObjectLock feature/UI review

### DIFF
--- a/js/modules/ObjectLock.js
+++ b/js/modules/ObjectLock.js
@@ -98,6 +98,11 @@ class ObjectLock {
                             title: __('Unlock request sent!'),
                             message: escapeMarkupText(__('Request sent to %s').replace('%s', this.user_data['name'])),
                         });
+                    }, () => {
+                        glpi_alert({
+                            title: __('Error'),
+                            message: __('An error occurred while sending the unlock request'),
+                        });
                     });
                 }
             });

--- a/js/modules/ObjectLock.js
+++ b/js/modules/ObjectLock.js
@@ -108,6 +108,38 @@ class ObjectLock {
             });
         });
 
+        $('button.force-unlock-item').on('click', () => {
+            glpi_confirm({
+                title: `${this.lock.itemtype_name} #${this.lock.items_id}`,
+                message: __('Force unlock this item?'),
+                confirm_callback: () => {
+                    $.post({
+                        url: `${CFG_GLPI.root_doc}/ajax/unlockobject.php`,
+                        cache: false,
+                        data: {
+                            unlock: 1,
+                            force: 1,
+                            id: this.lock.id,
+                        },
+                        dataType: 'json'
+                    }).then(() => {
+                        glpi_confirm({
+                            title: __('Item unlocked!'),
+                            message: __('Reload page?'),
+                            confirm_callback: () => {
+                                window.location.reload();
+                            }
+                        });
+                    }, () => {
+                        glpi_alert({
+                            title: __('Item NOT unlocked!'),
+                            message: __('Contact your GLPI admin!'),
+                        });
+                    });
+                }
+            });
+        });
+
         if (this.new_lock) {
             $(window).on('beforeunload', () => {
                 const fallback_request = () => {

--- a/js/modules/ObjectLock.js
+++ b/js/modules/ObjectLock.js
@@ -164,7 +164,7 @@ class ObjectLock {
                             'Content-Type': 'application/x-www-form-urlencoded;',
                             'X-Glpi-Csrf-Token': getAjaxCsrfToken()
                         },
-                        body: 'unlock=1&id={$id}'
+                        body: `unlock=1&id=${this.lock.id}`
                     }).catch(() => {
                         //fallback if fetch fails
                         fallback_request();

--- a/js/modules/ObjectLock.js
+++ b/js/modules/ObjectLock.js
@@ -1,0 +1,145 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/* global glpi_confirm, glpi_alert, escapeMarkupText, getAjaxCsrfToken */
+
+/**
+ * @todo Candidate for a websocket-based feature (or a mix of Ajax + Server-Sent Events)
+ */
+class ObjectLock {
+    /**
+     * @param {{id: number, itemtype: string, itemtype_name: string, items_id: number}} lock
+     * @param {{name: string}} user_data
+     * @param {boolean} new_lock Was the item locked by the current user during this page request?
+     */
+    constructor(lock, user_data, new_lock = false) {
+        this.lock = lock;
+        this.user_data = user_data;
+        this.new_lock = new_lock;
+        this.lockStatusTimer = undefined;
+        $(() => {
+            this.#registerListeners();
+        });
+    }
+
+    #registerListeners() {
+        $('#alertMe').on('change', (e) => {
+            const checked = e.target.checked;
+            if (checked) {
+                this.lockStatusTimer = setInterval(() => {
+                    $.get({
+                        url: `${CFG_GLPI.root_doc}/ajax/unlockobject.php`,
+                        cache: false,
+                        data: `lockstatus=1&id=${this.lock.id}`,
+                    }).then((data) => {
+                        if (data === 0) {
+                            clearInterval(this.lockStatusTimer);
+                            glpi_confirm({
+                                title: __('Item unlocked!'),
+                                message: __('Reload page?'),
+                                confirm_callback: () => {
+                                    window.location.reload();
+                                }
+                            });
+                        }
+                    });
+                }, 15000);
+            } else {
+                clearInterval(this.lockStatusTimer);
+            }
+        });
+
+        $('button.ask-unlock-item').on('click', () => {
+            glpi_confirm({
+                title: `${this.lock.itemtype_name} #${this.lock.items_id}`,
+                message: __('Ask for unlock this item?'),
+                confirm_callback: () => {
+                    $.post({
+                        url: `${CFG_GLPI.root_doc}/ajax/unlockobject.php`,
+                        cache: false,
+                        data: {
+                            requestunlock: 1,
+                            id: this.lock.id
+                        },
+                        dataType: 'json'
+                    }).then(() => {
+                        glpi_alert({
+                            title: __('Unlock request sent!'),
+                            message: escapeMarkupText(__('Request sent to %s').replace('%s', this.user_data['name'])),
+                        });
+                    });
+                }
+            });
+        });
+
+        if (this.new_lock) {
+            $(window).on('beforeunload', () => {
+                const fallback_request = () => {
+                    $.post({
+                        url: `${CFG_GLPI.root_doc}/ajax/unlockobject.php`,
+                        async: false,
+                        cache: false,
+                        data: {
+                            unlock: 1,
+                            id: this.lock.id
+                        },
+                        dataType: 'json'
+                    });
+                };
+
+                if (typeof window.fetch !== 'undefined') {
+                    fetch(`${CFG_GLPI.root_doc}/ajax/unlockobject.php`, {
+                        method: 'POST',
+                        cache: 'no-cache',
+                        headers: {
+                            'Accept': 'application/json',
+                            'Content-Type': 'application/x-www-form-urlencoded;',
+                            'X-Glpi-Csrf-Token': getAjaxCsrfToken()
+                        },
+                        body: 'unlock=1&id={$id}'
+                    }).catch(() => {
+                        //fallback if fetch fails
+                        fallback_request();
+                    });
+                } else {
+                    //fallback for browsers with no fetch support
+                    fallback_request();
+                }
+            });
+        }
+    }
+}
+
+export function initObjectLock(lock, user_data, new_lock = false) {
+    new ObjectLock(lock, user_data, new_lock);
+}

--- a/js/modules/ObjectLock.js
+++ b/js/modules/ObjectLock.js
@@ -100,7 +100,7 @@ class ObjectLock {
                         });
                     }, () => {
                         glpi_alert({
-                            title: __('Error'),
+                            title: _n('Error', 'Errors', 1),
                             message: __('An error occurred while sending the unlock request'),
                         });
                     });

--- a/js/modules/ObjectLock.js
+++ b/js/modules/ObjectLock.js
@@ -47,9 +47,7 @@ class ObjectLock {
         this.user_data = user_data;
         this.new_lock = new_lock;
         this.lockStatusTimer = undefined;
-        $(() => {
-            this.#registerListeners();
-        });
+        this.#registerListeners();
     }
 
     #registerListeners() {
@@ -60,7 +58,10 @@ class ObjectLock {
                     $.get({
                         url: `${CFG_GLPI.root_doc}/ajax/unlockobject.php`,
                         cache: false,
-                        data: `lockstatus=1&id=${this.lock.id}`,
+                        data: {
+                            lockstatus: 1,
+                            id: this.lock.id
+                        },
                     }).then((data) => {
                         if (data === 0) {
                             clearInterval(this.lockStatusTimer);

--- a/src/ObjectLock.php
+++ b/src/ObjectLock.php
@@ -120,9 +120,9 @@ class ObjectLock extends CommonDBTM
             // should get locking user info
             $useremail = new UserEmail();
             $showAskUnlock = $useremail->getFromDBByCrit([
-                    'users_id' => $this->fields['users_id'],
-                    'is_default' => 1
-                ]) && ($CFG_GLPI['notifications_mailing'] == 1);
+                'users_id' => $this->fields['users_id'],
+                'is_default' => 1
+            ]) && ($CFG_GLPI['notifications_mailing'] == 1);
         }
 
         if (!$autolock) {

--- a/templates/layout/parts/objectlock_message.html.twig
+++ b/templates/layout/parts/objectlock_message.html.twig
@@ -41,39 +41,6 @@
             <i class="ti ti-lock-open"></i>
             <span>{{ __('Force unlock %1s #%2s')|format(item.fields['itemtype']|itemtype_name, item.fields['items_id']) }}</span>
         </button>
-        <script>
-            $('button.force-unlock-item').on('click', () => {
-                glpi_confirm({
-                    title: '{{ item.fields['itemtype']|itemtype_name|e('js') }} #{{ item.fields['items_id'] }}',
-                    message: __('Force unlock this item?'),
-                    confirm_callback: () => {
-                        $.post({
-                            url: '{{ config('root_doc') }}/ajax/unlockobject.php',
-                            cache: false,
-                            data: {
-                                unlock: 1,
-                                force: 1,
-                                id: {{ item.getID() }},
-                            },
-                            dataType: 'json'
-                        }).then(() => {
-                            glpi_confirm({
-                                title: __('Item unlocked!'),
-                                message: __('Reload page?'),
-                                confirm_callback: () => {
-                                    window.location.reload();
-                                }
-                            });
-                        }, () => {
-                            glpi_alert({
-                                title: __('Item NOT unlocked!'),
-                                message: __('Contact your GLPI admin!'),
-                            });
-                        });
-                    }
-                });
-            });
-        </script>
     {% endif %}
 {% endmacro %}
 

--- a/templates/layout/parts/objectlock_message.html.twig
+++ b/templates/layout/parts/objectlock_message.html.twig
@@ -44,7 +44,7 @@
         <script>
             $('button.force-unlock-item').on('click', () => {
                 glpi_confirm({
-                    title: '{{ item.fields['itemtype']|itemtype_name }} #{{ item.fields['items_id'] }}',
+                    title: '{{ item.fields['itemtype']|itemtype_name|e('js') }} #{{ item.fields['items_id'] }}',
                     message: __('Force unlock this item?'),
                     confirm_callback: () => {
                         $.post({
@@ -53,7 +53,7 @@
                             data: {
                                 unlock: 1,
                                 force: 1,
-                                id: {{ item.getID }},
+                                id: {{ item.getID() }},
                             },
                             dataType: 'json'
                         }).then(() => {
@@ -141,11 +141,11 @@
                 $('#message_after_lock').insertAfter('.navigationheader');
             }
             new m.initObjectLock({
-                id: {{ item.getID }},
-                itemtype: '{{ item.fields['itemtype'] }}',
-                itemtype_name: '{{ item.fields['itemtype']|itemtype_name }}',
-                items_id: {{ item.fields['items_id'] }},
-            }, {{ user_data|json_encode|raw }}, {{ new_lock }});
+                id: {{ item.getID() }},
+                itemtype: '{{ item.fields['itemtype']|e('js') }}',
+                itemtype_name: '{{ item.fields['itemtype']|itemtype_name|e('js') }}',
+                items_id: {{ item.fields['items_id']|e('js') }},
+            }, {{ user_data|json_encode|raw }}, {{ new_lock ? true : false }});
         });
     });
 </script>

--- a/templates/layout/parts/objectlock_message.html.twig
+++ b/templates/layout/parts/objectlock_message.html.twig
@@ -1,0 +1,128 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+#}
+
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
+{% macro forceUnlockButton(check_unlock_right) %}
+    {% set real_profile = session('glpilocksavedprofile')|default(null) %}
+    {% if not check_unlock_right or (real_profile != null and real_profile[item.itemtype] b-and constant('UNLOCK')) %}
+        <button type="button" class="btn btn-sm btn-primary ms-2 force-unlock-item">
+            <i class="ti ti-lock-open"></i>
+            <span>{{ __('Force unlock %1s #%2s')|format(item.itemtypename, item.itemid) }}</span>
+        </button>
+        <script>
+            $('button.force-unlock-item').on('click', () => {
+                glpi_confirm({
+                    title: '{{ item.itemtypename }} #{{ item.itemid }}',
+                    message: __('Force unlock this item?'),
+                    confirm_callback: () => {
+                        $.post({
+                            url: '{{ config('root_doc') }}/ajax/unlockobject.php',
+                            cache: false,
+                            data: {
+                                unlock: 1,
+                                force: 1,
+                                id: {{ lock_id }}
+                            },
+                            dataType: 'json'
+                        }).then(() => {
+                            glpi_confirm({
+                                title: __('Item unlocked!'),
+                                message: __('Reload page?'),
+                                confirm_callback: () => {
+                                    window.location.reload();
+                                }
+                            });
+                        }, () => {
+                            glpi_alert({
+                                title: __('Item NOT unlocked!'),
+                                message: __('Contact your GLPI admin!'),
+                            });
+                        });
+                    }
+                });
+            });
+        </script>
+    {% endif %}
+{% endmacro %}
+
+{% if autolock %}
+
+{% else %}
+    {% if not new_lock %}
+        <div id="message_after_lock" class="objectlockmessage d-inline-block w-100">
+            {% if item.fields['users_id'] != session('glpiID') %}
+                <strong class="nowrap">
+                    {% set locked_by_msg %}
+                        {% set locked_by_link %}
+                            <a href="{{ 'User'|itemtype_form_path(item.fields['users_id']) }}">{{ user_data['name'] }}</a>
+                        {% endset %}
+                        {{ __('Locked by %1s')|format(locked_by_link)|raw }}
+                    {% endset %}
+                    {{ fields.htmlField('', locked_by_msg, '', {
+                        no_label: true,
+                        helper: user_data['comment'],
+                        field_class: 'd-inline-block',
+                        mb: '',
+                    }) }}
+                    <span class="mx-2">-></span>
+                    <span>{{ item.fields['date']|formatted_datetime }}</span>
+                </strong>
+                {% if show_ask_unlock %}
+                    <button type="button" class="btn btn-sm btn-primary ms-2 ask-unlock-item">
+                        <i class="ti ti-lock-open"></i>
+                        <span>{{ __('Ask for unlock') }}</span>
+                    </button>
+                    {{ fields.checkboxField('alertMe', 0, __('Alert me when unlocked')) }}
+                    {{ _self.forceUnlockButton(true) }}
+                {% endif %}
+            {% else %}
+                <strong class="nowrap">
+                    {{ __('Locked by you!') }}
+                    {{ _self.forceUnlockButton(false) }}
+                </strong>
+            {% endif %}
+        </div>
+    {% endif %}
+{% endif %}
+
+<script>
+    import({{ js_path('modules/ObjectLock.js') }}).then((m) => {
+        new m.initObjectLock({
+            id: {{ item.getID }},
+            itemtype: {{ item.itemtype }},
+            itemtype_name: '{{ item.itemtypename }}',
+            items_id: {{ item.itemid }},
+        }, {{ user_data }}, {{ new_lock }});
+    });
+</script>

--- a/templates/layout/parts/objectlock_message.html.twig
+++ b/templates/layout/parts/objectlock_message.html.twig
@@ -135,14 +135,17 @@
 {% endif %}
 
 <script>
-    import({{ js_path('modules/ObjectLock.js') }}).then((m) => {
+    import('{{ js_path('js/modules/ObjectLock.js') }}').then((m) => {
         $(() => {
+            if ($('.navigationheader').length > 0) {
+                $('#message_after_lock').insertAfter('.navigationheader');
+            }
             new m.initObjectLock({
                 id: {{ item.getID }},
-                itemtype: {{ item.fields['itemtype'] }},
+                itemtype: '{{ item.fields['itemtype'] }}',
                 itemtype_name: '{{ item.fields['itemtype']|itemtype_name }}',
                 items_id: {{ item.fields['items_id'] }},
-            }, {{ user_data }}, {{ new_lock }});
+            }, {{ user_data|json_encode|raw }}, {{ new_lock }});
         });
     });
 </script>

--- a/templates/layout/parts/objectlock_message.html.twig
+++ b/templates/layout/parts/objectlock_message.html.twig
@@ -136,11 +136,13 @@
 
 <script>
     import({{ js_path('modules/ObjectLock.js') }}).then((m) => {
-        new m.initObjectLock({
-            id: {{ item.getID }},
-            itemtype: {{ item.fields['itemtype'] }},
-            itemtype_name: '{{ item.fields['itemtype']|itemtype_name }}',
-            items_id: {{ item.fields['items_id'] }},
-        }, {{ user_data }}, {{ new_lock }});
+        $(() => {
+            new m.initObjectLock({
+                id: {{ item.getID }},
+                itemtype: {{ item.fields['itemtype'] }},
+                itemtype_name: '{{ item.fields['itemtype']|itemtype_name }}',
+                items_id: {{ item.fields['items_id'] }},
+            }, {{ user_data }}, {{ new_lock }});
+        });
     });
 </script>

--- a/templates/layout/parts/objectlock_message.html.twig
+++ b/templates/layout/parts/objectlock_message.html.twig
@@ -32,18 +32,19 @@
 #}
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
 
-{% macro forceUnlockButton(check_unlock_right) %}
+{% macro forceUnlockButton(item, check_unlock_right) %}
     {% set real_profile = session('glpilocksavedprofile')|default(null) %}
-    {% if not check_unlock_right or (real_profile != null and real_profile[item.itemtype] b-and constant('UNLOCK')) %}
+    {% if not check_unlock_right or (real_profile != null and real_profile[item.fields['itemtype']] b-and constant('UNLOCK')) %}
         <button type="button" class="btn btn-sm btn-primary ms-2 force-unlock-item">
             <i class="ti ti-lock-open"></i>
-            <span>{{ __('Force unlock %1s #%2s')|format(item.itemtypename, item.itemid) }}</span>
+            <span>{{ __('Force unlock %1s #%2s')|format(item.fields['itemtype']|itemtype_name, item.fields['items_id']) }}</span>
         </button>
         <script>
             $('button.force-unlock-item').on('click', () => {
                 glpi_confirm({
-                    title: '{{ item.itemtypename }} #{{ item.itemid }}',
+                    title: '{{ item.fields['itemtype']|itemtype_name }} #{{ item.fields['items_id'] }}',
                     message: __('Force unlock this item?'),
                     confirm_callback: () => {
                         $.post({
@@ -52,7 +53,7 @@
                             data: {
                                 unlock: 1,
                                 force: 1,
-                                id: {{ lock_id }}
+                                id: {{ item.getID }},
                             },
                             dataType: 'json'
                         }).then(() => {
@@ -76,40 +77,57 @@
     {% endif %}
 {% endmacro %}
 
-{% if autolock %}
-
+{% if autolock_readmode %}
+    <div id="message_after_lock" class="d-inline-block w-100 alert alert-warning">
+        <span class="me-3">
+            <i class="ti ti-eye"></i>
+            {{ __('Read-only mode') }}
+        </span>
+        <form method="post" class="d-inline">
+            {{ inputs.hidden('_glpi_csrf_token', csrf_token()) }}
+            {{ inputs.submit('lockwrite', __('Edit'), 1, {
+                class: 'btn btn-sm btn-primary ms-2',
+                icon: 'ti ti-pencil',
+            }) }}
+        </form>
+    </div>
 {% else %}
     {% if not new_lock %}
-        <div id="message_after_lock" class="objectlockmessage d-inline-block w-100">
+        <div id="message_after_lock" class="d-inline-block w-100 alert alert-warning">
             {% if item.fields['users_id'] != session('glpiID') %}
                 <strong class="nowrap">
                     {% set locked_by_msg %}
                         {% set locked_by_link %}
                             <a href="{{ 'User'|itemtype_form_path(item.fields['users_id']) }}">{{ user_data['name'] }}</a>
                         {% endset %}
-                        {{ __('Locked by %1s')|format(locked_by_link)|raw }}
+                        {{ __('Locked: %1$s by %2$s')|e|format(item.fields['date']|relative_datetime, locked_by_link)|raw }}
                     {% endset %}
                     {{ fields.htmlField('', locked_by_msg, '', {
                         no_label: true,
                         helper: user_data['comment'],
                         field_class: 'd-inline-block',
+                        wrapper_class: 'd-block',
                         mb: '',
                     }) }}
-                    <span class="mx-2">-></span>
-                    <span>{{ item.fields['date']|formatted_datetime }}</span>
                 </strong>
                 {% if show_ask_unlock %}
-                    <button type="button" class="btn btn-sm btn-primary ms-2 ask-unlock-item">
+                    <br>
+                    <button type="button" class="btn btn-sm btn-primary ask-unlock-item mt-2 me-2">
                         <i class="ti ti-lock-open"></i>
                         <span>{{ __('Ask for unlock') }}</span>
                     </button>
-                    {{ fields.checkboxField('alertMe', 0, __('Alert me when unlocked')) }}
-                    {{ _self.forceUnlockButton(true) }}
+                    <div class="d-inline-flex" style="vertical-align: sub">
+                        {{ inputs.label(__('Alert me when unlocked'), 'alertMe', {}, 'form-label mb-0 me-2') }}
+                        {{ inputs.checkbox('alertMe', 0, {
+                            id: 'alertMe'
+                        }) }}
+                    </div>
+                    {{ _self.forceUnlockButton(item, true) }}
                 {% endif %}
             {% else %}
                 <strong class="nowrap">
                     {{ __('Locked by you!') }}
-                    {{ _self.forceUnlockButton(false) }}
+                    {{ _self.forceUnlockButton(item, false) }}
                 </strong>
             {% endif %}
         </div>
@@ -120,9 +138,9 @@
     import({{ js_path('modules/ObjectLock.js') }}).then((m) => {
         new m.initObjectLock({
             id: {{ item.getID }},
-            itemtype: {{ item.itemtype }},
-            itemtype_name: '{{ item.itemtypename }}',
-            items_id: {{ item.itemid }},
+            itemtype: {{ item.fields['itemtype'] }},
+            itemtype_name: '{{ item.fields['itemtype']|itemtype_name }}',
+            items_id: {{ item.fields['items_id'] }},
         }, {{ user_data }}, {{ new_lock }});
     });
 </script>

--- a/tests/js/modules/ObjectLock.test.js
+++ b/tests/js/modules/ObjectLock.test.js
@@ -1,0 +1,231 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { initObjectLock } from '../../../js/modules/ObjectLock.js';
+import {jest} from '@jest/globals';
+
+describe('Object Lock', () => {
+    let window_reload_spy;
+    let glpi_confirm_spy;
+    let glpi_alert_spy;
+
+    beforeEach(() => {
+        // Mock reload function
+        delete window.location;
+        Object.defineProperty(window, 'location', {
+            value: {
+                href: '',
+                reload: jest.fn().mockImplementation(() => {})
+            },
+            writable: true,
+            configurable: true,
+        });
+        window_reload_spy = jest.spyOn(window.location, 'reload');
+
+        window.glpi_confirm = jest.fn((opts) => {
+            if (opts.confirm_callback) {
+                opts.confirm_callback();
+            }
+        });
+        window.glpi_alert = jest.fn((opts) => {
+            if (opts.ok_callback) {
+                opts.ok_callback();
+            }
+        });
+        glpi_confirm_spy = jest.spyOn(window, 'glpi_confirm');
+        glpi_alert_spy = jest.spyOn(window, 'glpi_alert');
+
+        $('body').empty();
+    });
+    afterEach(() => {
+        jest.clearAllMocks();
+        // clear timer mock
+        jest.useRealTimers();
+        window.AjaxMock.end();
+        $(window).off('beforeunload');
+    });
+
+    test('Exports', () => {
+        expect(initObjectLock).toBeFunction();
+    });
+    test('Alert me', async () => {
+        $('body').append('<input type="checkbox" id="alertMe" />');
+        // Legacy fake timers needed to support setInterval
+        jest.useFakeTimers({
+            doNotFake: ['nextTick'],
+        });
+
+        window.AjaxMock.start();
+        window.AjaxMock.addMockResponse(new window.AjaxMockResponse('//ajax/unlockobject.php', 'GET', {
+            lockstatus: 1,
+            id: 3450
+        }, () => {
+            return 1; // Not unlocked yet
+        }));
+        window.AjaxMock.addMockResponse(new window.AjaxMockResponse('//ajax/unlockobject.php', 'GET', {
+            lockstatus: 1,
+            id: 3450
+        }, () => {
+            return 0; // Unlocked
+        }));
+
+        window.escapeMarkupText = jest.fn((text) => {
+            return text;
+        });
+
+        initObjectLock({
+            id: 3450,
+            itemtype: 'Ticket',
+            itemtype_name: 'Ticket',
+            items_id: 24
+        }, {
+            name: 'John Doe'
+        }, false);
+
+        // Checkbox not checked, so no timer and no AJAX
+        jest.advanceTimersByTime(30000);
+        expect(window.AjaxMock.response_stack).toHaveLength(2);
+
+        $('#alertMe').prop('checked', true).trigger('change');
+        await new Promise(process.nextTick);
+        jest.advanceTimersByTime(15000);
+        expect(window.AjaxMock.response_stack).toHaveLength(1);
+        jest.advanceTimersByTime(15000);
+        expect(window.AjaxMock.response_stack).toHaveLength(0);
+        await new Promise(process.nextTick);
+        expect(glpi_confirm_spy).toHaveBeenCalled();
+        expect(glpi_confirm_spy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                title: 'Item unlocked!',
+                message: 'Reload page?',
+                confirm_callback: expect.toBeFunction()
+            })
+        );
+        expect(window_reload_spy).toHaveBeenCalled();
+        jest.advanceTimersByTime(15000);
+        // AjaxMock should not throw an error here. If it does, it means the timer is still running
+    });
+    test('Ask unlock item', async () => {
+        $('body').append('<button class="ask-unlock-item"></button>');
+        window.AjaxMock.start();
+        window.AjaxMock.addMockResponse(new window.AjaxMockResponse('//ajax/unlockobject.php', 'POST', {
+            requestunlock: 1,
+            id: 3450
+        }, () => {
+            return Promise.resolve();
+        }));
+
+        initObjectLock({
+            id: 3450,
+            itemtype: 'Ticket',
+            itemtype_name: 'Ticket',
+            items_id: 24
+        }, {
+            name: 'John Doe'
+        }, false);
+
+        $('.ask-unlock-item').trigger('click');
+        await new Promise(process.nextTick);
+        expect(glpi_confirm_spy).toHaveBeenCalled();
+        expect(glpi_confirm_spy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                title: 'Ticket #24',
+                message: 'Ask for unlock this item?',
+                confirm_callback: expect.toBeFunction()
+            })
+        );
+        await new Promise(process.nextTick);
+        expect(glpi_alert_spy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                title: 'Unlock request sent!',
+                message: 'Request sent to John Doe',
+            })
+        );
+        expect(window.AjaxMock.response_stack).toHaveLength(0);
+    });
+    test('Unlock on beforeunload - fetch', async () => {
+        window.fetch = jest.fn(() => {
+            return {
+                catch: () => {}
+            };
+        });
+        const fetch_spy = jest.spyOn(window, 'fetch');
+        window.getAjaxCsrfToken = jest.fn(() => {
+            return 'token';
+        });
+
+        initObjectLock({
+            id: 3450,
+            itemtype: 'Ticket',
+            itemtype_name: 'Ticket',
+            items_id: 24
+        }, {
+            name: 'John Doe'
+        }, true);
+
+        window.dispatchEvent(new Event('beforeunload'));
+        await new Promise(process.nextTick);
+        expect(fetch_spy).toHaveBeenCalledWith('//ajax/unlockobject.php', expect.objectContaining({
+            method: 'POST',
+            cache: 'no-cache',
+            headers: expect.objectContaining({
+                'Accept': 'application/json',
+                'Content-Type': 'application/x-www-form-urlencoded;',
+                'X-Glpi-Csrf-Token': 'token'
+            })
+        }));
+    });
+    test('Unlock on beforeunload - ajax fallback', async () => {
+        window.fetch = undefined;
+        window.AjaxMock.start();
+        window.AjaxMock.addMockResponse(new window.AjaxMockResponse('//ajax/unlockobject.php', 'POST', {
+            unlock: 1,
+            id: 3450
+        }, () => {
+            return true;
+        }));
+
+        initObjectLock({
+            id: 3450,
+            itemtype: 'Ticket',
+            itemtype_name: 'Ticket',
+            items_id: 24
+        }, {
+            name: 'John Doe'
+        }, true);
+
+        window.dispatchEvent(new Event('beforeunload'));
+        await new Promise(process.nextTick);
+        expect(window.AjaxMock.response_stack).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

For ObjectLock:
- Migrate UI to Twig and cleanup
- Migrate inline scripts to dedicated ESM module
- PHPDoc cleanup
- Jest tests

Some behavior changes:
- When auto-lock disabled and another user had the item locked, it was simply showing it was "Read-only" with a button to request it to be unlocked. Now, it clearly shows the Locked by someone else message.
- When auto-lock disabled and the item is not locked, it now shows the user is currently in Read-only mode and gives them a button to "Edit" the item.

Screenshots Before -> After (Note that the message still shows under the navigation header. This was fixed after the screenshots were taken):
Auto-lock mode off and item not locked yet:
![Selection_234](https://github.com/glpi-project/glpi/assets/17678637/1159ec2d-e15b-4984-b3e7-f8ff3cde8d06)
![Selection_232](https://github.com/glpi-project/glpi/assets/17678637/8d9ac76a-2e8f-42d9-8f75-372ff22b45c4)

Locked by you:
![Selection_235](https://github.com/glpi-project/glpi/assets/17678637/5126e471-1d2e-4563-bc99-6100da1e2669)
![Selection_231](https://github.com/glpi-project/glpi/assets/17678637/7a325292-8844-49df-acdb-d852f26225d4)

Locked by someone else:
![Selection_236](https://github.com/glpi-project/glpi/assets/17678637/cef12a77-5086-408f-80a0-7d888ffbce24)
![Selection_233](https://github.com/glpi-project/glpi/assets/17678637/031d2a05-a400-4267-b664-d83af263154f)
