### PR TITLE
Fix OAuth authcode flow

### DIFF
--- a/src/Api/HL/Controller/CoreController.php
+++ b/src/Api/HL/Controller/CoreController.php
@@ -401,7 +401,7 @@ HTML;
         return new JSONResponse($session);
     }
 
-    #[Route(path: '/authorize', methods: ['GET', 'POST'], security_level: Route::SECURITY_NONE, tags: ['Session'])]
+    #[Route(path: '/authorize', methods: ['GET', 'POST'], security_level: Route::SECURITY_NONE, tags: ['Session'], middlewares: [CookieAuthMiddleware::class])]
     #[Doc\Route(
         description: 'Authorize the API client using the authorization code grant type.',
     )]
@@ -411,11 +411,6 @@ HTML;
         global $CFG_GLPI;
         try {
             $auth_request = Server::getAuthorizationServer()->validateAuthorizationRequest($request);
-            // Try loading session from Cookie
-            session_destroy();
-            ini_set('session.use_cookies', 1);
-            session_name("glpi_" . md5(realpath(GLPI_ROOT)));
-            @session_start();
 
             $user_id = Session::getLoginUserID();
             if ($user_id === false) {

--- a/src/Api/HL/RoutePath.php
+++ b/src/Api/HL/RoutePath.php
@@ -414,11 +414,13 @@ final class RoutePath
         $matched_doc = array_filter($docs, static function (Doc\Route $doc) use ($request) {
             return !count($doc->getMethods()) || in_array($request->getMethod(), $doc->getMethods(), true);
         });
-        $route_params = $matched_doc[0]->getParameters();
-        /** @var Parameter $param */
-        foreach ($route_params as $param) {
-            if (!isset($params[$param->getName()]) && $param->getDefaultValue() !== null) {
-                $request->setParameter($param->getName(), $param->getDefaultValue());
+        if (count($matched_doc)) {
+            $route_params = $matched_doc[0]->getParameters();
+            /** @var Parameter $param */
+            foreach ($route_params as $param) {
+                if (!isset($params[$param->getName()]) && $param->getDefaultValue() !== null) {
+                    $request->setParameter($param->getName(), $param->getDefaultValue());
+                }
             }
         }
         $response = $this->getMethod()->invoke($this->getControllerInstance(), $request);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Two bugs found when testing Authorization Code authentication within Swagger UI:
- Infinite redirect loop on /authorize endpoint caused by bad handling of cookie authentication. Custom logic was removed and replaced with the newer CookieAuthMiddleware.
- Swagger's redirect URI was resulting in a server error because it does not have any documentation attribute and it was trying to use the documentation to fill in any missing parameters with the default values (if they existed).