### PR TITLE
Use HL API to handle status.php calls and drop plain-text output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ The present file will list all changes made to the project; according to the
 - The database "master" property in the status checker (/status.php and glpi:system:status), replaced by "main".
 - The database "slaves" property in the status checker (/status.php and glpi:system:status), replaced by "replicas".
 - API URL is no longer customizable within GLPI. Use alias/rewrite rules in your web server configuration instead if needed.
+- `status.php` and `bin/console system:status` no longer supports plain-text output.
+- `Glpi\System\Status\StatusChecker::getServiceStatus()` `as_array` parameter.
 
 ### API changes
 

--- a/src/Api/HL/Controller/CoreController.php
+++ b/src/Api/HL/Controller/CoreController.php
@@ -493,7 +493,7 @@ HTML;
         return new JSONResponse($data);
     }
 
-    #[Route(path: '/status/all', methods: ['GET'], tags: ['Status'])]
+    #[Route(path: '/status/all', methods: ['GET'], security_level: Route::SECURITY_NONE, tags: ['Status'])]
     #[Doc\Route(
         description: 'Get the the status of all GLPI system status checker services',
         responses: [

--- a/src/Api/HL/Router.php
+++ b/src/Api/HL/Router.php
@@ -118,7 +118,7 @@ class Router
 
     /**
      * Get information about all API versions available.
-     * @return array
+     * @return array{api_version: string, version: string, description?: string, endpoint: string}[]
      */
     public static function getAPIVersions(): array
     {

--- a/src/Console/System/CheckStatusCommand.php
+++ b/src/Console/System/CheckStatusCommand.php
@@ -40,7 +40,6 @@ use Glpi\System\Status\StatusChecker;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Toolbox;
 
 class CheckStatusCommand extends AbstractCommand
 {
@@ -52,13 +51,6 @@ class CheckStatusCommand extends AbstractCommand
 
         $this->setName('system:status');
         $this->setDescription(__('Check system status'));
-        $this->addOption(
-            'format',
-            'f',
-            InputOption::VALUE_OPTIONAL,
-            'Output format [plain or json]',
-            'plain'
-        );
         $this->addOption(
             'private',
             'p',
@@ -76,16 +68,8 @@ class CheckStatusCommand extends AbstractCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-
-        $format = strtolower($input->getOption('format'));
-        $status = StatusChecker::getServiceStatus($input->getOption('service'), !$input->getOption('private'), $format === 'json');
-
-        if ($format === 'json') {
-            $output->writeln(json_encode($status, JSON_PRETTY_PRINT));
-        } else {
-            Toolbox::deprecated('Plain-text status output is deprecated please use the JSON format instead by specifically using the "--format json" parameter. In the future, JSON output will be the default.');
-            $output->writeln($status);
-        }
+        $status = StatusChecker::getServiceStatus($input->getOption('service'), !$input->getOption('private'));
+        $output->writeln(json_encode($status, JSON_PRETTY_PRINT));
 
         return 0; // Success
     }

--- a/src/System/Status/StatusChecker.php
+++ b/src/System/Status/StatusChecker.php
@@ -127,7 +127,7 @@ final class StatusChecker
                 ]
             ];
             foreach ($services as $name => $service_check_method) {
-                $service_status = self::getServiceStatus($name, $public_only, true);
+                $service_status = self::getServiceStatus($name, $public_only);
                 $status[$name] = $service_status;
             }
 

--- a/src/System/Status/StatusChecker.php
+++ b/src/System/Status/StatusChecker.php
@@ -38,9 +38,6 @@ namespace Glpi\System\Status;
 use AuthLDAP;
 use CronTask;
 use DBConnection;
-use DBmysql;
-use Glpi\DBAL\QueryExpression;
-use Glpi\DBAL\QueryFunction;
 use MailCollector;
 use Plugin;
 use Toolbox;
@@ -117,13 +114,10 @@ final class StatusChecker
      * @param string|null $service The name of the service or if null/'all' all services will be checked
      * @param bool $public_only True if only public information should be available in the status check.
      *    If true, assume the data is being viewed by an anonymous user.
-     * @param bool $as_array True if the service check result should be returned as an array instead of a plain-text string.
-     * @return array|string An array or string with the result based on the $as_array parameter value.
-     * @phpstan-return ($as_array is true ? array : string)
+     * @return array An array with the status information
      * @since 10.0.0
-     * @FIXME Remove deprecated plain text output in GLPI 11.0.
      */
-    public static function getServiceStatus(?string $service, $public_only = true, $as_array = true)
+    public static function getServiceStatus(?string $service, $public_only = true)
     {
         $services = self::getServices();
         if ($service === 'all' || $service === null) {
@@ -139,25 +133,17 @@ final class StatusChecker
 
             $status['glpi']['status'] = self::calculateGlobalStatus($status);
 
-            if ($as_array) {
-                return $status;
-            } else {
-                return self::getPlaintextOutput($status);
-            }
+            return $status;
         }
 
         if (!array_key_exists($service, $services)) {
-            return $as_array ? [] : '';
+            return [];
         }
         $service_check_method = $services[$service];
         if (method_exists($service_check_method[0], $service_check_method[1])) {
-            $service_status = $service_check_method($public_only);
-            if ($as_array) {
-                return $service_status;
-            }
-            return strtoupper($service) . '_' . $service_status['status'];
+            return $service_check_method($public_only);
         }
-        return $as_array ? [] : '';
+        return [];
     }
 
     /**
@@ -591,67 +577,5 @@ final class StatusChecker
         }
 
         return $status;
-    }
-
-    /**
-     * Format the given full service status result as a plain-text output compatible with previous versions of GLPI.
-     * @param array $status
-     * @return string
-     */
-    private static function getPlaintextOutput(array $status): string
-    {
-       // Deprecated notices are done on the /status.php endpoint and CLI commands to give better migration hints
-        $output = '';
-       // Plain-text output
-        if (count($status['db']['replicas'])) {
-            foreach ($status['db']['replicas']['servers'] as $num => $slave_info) {
-                $output .= "GLPI_DBSLAVE_{$num}_{$slave_info['status']}\n";
-            }
-        } else {
-            $output .= "No slave DB\n"; // Leave as "slave" since plain text is already deprecated
-        }
-        $output .= "GLPI_DB_{$status['db']['main']['status']}\n";
-        $output .= "GLPI_SESSION_DIR_{$status['filesystem']['session_dir']['status']}\n";
-        if (count($status['ldap']['servers'])) {
-            $output .= 'Check LDAP servers:';
-            foreach ($status['ldap']['servers'] as $name => $ldap_info) {
-                $output .= " {$name}_{$ldap_info['status']}\n";
-            }
-        } else {
-            $output .= "No LDAP server\n";
-        }
-        if (count($status['imap']['servers'])) {
-            $output .= 'Check IMAP servers:';
-            foreach ($status['imap']['servers'] as $name => $imap_info) {
-                $output .= " {$name}_{$imap_info['status']}\n";
-            }
-        } else {
-            $output .= "No IMAP server\n";
-        }
-        if (isset($status['cas']['status']) && $status['cas']['status'] !== self::STATUS_NO_DATA) {
-            $output .= "CAS_SERVER_{$status['cas']['status']}\n";
-        } else {
-            $output .= "No CAS server\n";
-        }
-        if (count($status['mail_collectors']['servers'])) {
-            $output .= 'Check mail collectors:';
-            foreach ($status['mail_collectors']['servers'] as $name => $collector_info) {
-                $output .= " {$name}_{$collector_info['status']}\n";
-            }
-        } else {
-            $output .= "No mail collector\n";
-        }
-        if (count($status['crontasks']['stuck'])) {
-            $output .= 'Check crontasks:';
-            foreach ($status['crontasks']['stuck'] as $name) {
-                $output .= " {$name}_PROBLEM\n";
-            }
-        } else {
-            $output .= "Crontasks_OK\n";
-        }
-
-       // Overall Status
-        $output .= "\nGLPI_{$status['glpi']['status']}\n";
-        return $output;
     }
 }

--- a/status.php
+++ b/status.php
@@ -33,42 +33,27 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\System\Status\StatusChecker;
+use Glpi\Api\HL\Router;
+use Glpi\Application\ErrorHandler;
+use Glpi\Http\Request;
+use Glpi\Http\Response;
 
 include('./inc/includes.php');
 
 // Force in normal mode
 $_SESSION['glpi_use_mode'] = Session::NORMAL_MODE;
 
-// Need to be used using :
+// Example usage with Nagios check_http plugin:
 // check_http -H servername -u /glpi/status.php -s GLPI_OK
 
-$valid_response_types = ['text/plain', 'application/json'];
-$fallback_response_type = 'text/plain';
+// Redirect handling to the High-Level API (we may eventually remove this script)
 
-if (!isset($_SERVER['HTTP_ACCEPT']) || !in_array($_SERVER['HTTP_ACCEPT'], $valid_response_types, true)) {
-    $_SERVER['HTTP_ACCEPT'] = $fallback_response_type;
-}
-
-$format = $_SERVER['HTTP_ACCEPT'];
-if (isset($_REQUEST['format'])) {
-    switch ($_REQUEST['format']) {
-        case 'json':
-            $format = 'application/json';
-            break;
-        case 'plain':
-            $format = 'text/plain';
-            break;
-    }
-}
-
-if ($format === 'text/plain') {
-    Toolbox::deprecated('Plain-text status output is deprecated please use the JSON format instead by specifically setting the Accept header to "application/json". In the future, JSON output will be the default.');
-}
-header('Content-type: ' . $format);
-
-if ($format === 'application/json') {
-    echo json_encode(StatusChecker::getServiceStatus($_REQUEST['service'] ?? null, true, true));
-} else {
-    echo StatusChecker::getServiceStatus($_REQUEST['service'] ?? null, true, false);
+$request = new Request('GET', '/Status/All', getallheaders() ?? []);
+try {
+    $response = Router::getInstance()->handleRequest($request);
+    $response->send();
+} catch (\Throwable $e) {
+    ErrorHandler::getInstance()->handleException($e);
+    $response = new Response(500);
+    $response->send();
 }

--- a/status.php
+++ b/status.php
@@ -42,12 +42,7 @@ include('./inc/includes.php');
 
 // Force in normal mode
 $_SESSION['glpi_use_mode'] = Session::NORMAL_MODE;
-
-// Example usage with Nagios check_http plugin:
-// check_http -H servername -u /glpi/status.php -s GLPI_OK
-
 // Redirect handling to the High-Level API (we may eventually remove this script)
-
 $request = new Request('GET', '/Status/All', getallheaders() ?? []);
 try {
     $response = Router::getInstance()->handleRequest($request);

--- a/tests/functional/Glpi/System/Status/StatusChecker.php
+++ b/tests/functional/Glpi/System/Status/StatusChecker.php
@@ -43,13 +43,10 @@ use Glpi\System\Status\StatusChecker as GlpiStatusChecker;
 
 class StatusChecker extends DbTestCase
 {
-    public function testStatusFormats()
+    public function testStatusFormat()
     {
         $status = GlpiStatusChecker::getServiceStatus(null, true);
         $this->boolean(is_array($status))->isTrue();
-
-        $status = GlpiStatusChecker::getServiceStatus(null, true, false);
-        $this->boolean(is_string($status))->isTrue();
     }
 
     public function testDefaultStatus()
@@ -150,7 +147,7 @@ class StatusChecker extends DbTestCase
             'state'        => \CronTask::STATE_RUNNING,
         ]);
 
-        $status = GlpiStatusChecker::getServiceStatus(null, true, true);
+        $status = GlpiStatusChecker::getServiceStatus(null, true);
 
        // Test overall status is PROBLEM
         $this->string($status['glpi']['status'])->isEqualTo(GlpiStatusChecker::STATUS_PROBLEM);
@@ -246,14 +243,6 @@ class StatusChecker extends DbTestCase
             $status = GlpiStatusChecker::getServiceStatus($name, false);
             $this->boolean(is_array($status))->isTrue();
             $this->array($status)->hasKey('status');
-
-            $status = GlpiStatusChecker::getServiceStatus($name, true, false);
-            $this->boolean(is_string($status))->isTrue();
-            $this->string($status)->isNotEmpty();
-
-            $status = GlpiStatusChecker::getServiceStatus($name, false, false);
-            $this->boolean(is_string($status))->isTrue();
-            $this->string($status)->isNotEmpty();
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

- Forces requests to `status.php` to be directed through the new API
- Drops old pain-text output format

By having all HTTP access to the status checker going through the new API we can have it use any potential new restrictions we may add to the new API like rate limiting, IP restrictions, OAuth scopes, etc.