### PR TITLE
Refresh menu when devices in menu changed

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -3710,6 +3710,12 @@ HTML;
             );
         }
 
+        // If the `devices_in_menu` option changed, we should regenerate the menu (unless we are in debug mode where it is always regenerated)
+        if ($this->fields['name'] === 'devices_in_menu' && $_SESSION['glpi_use_mode'] !== Session::DEBUG_MODE) {
+            $CFG_GLPI['devices_in_menu'] = json_decode($this->fields['value']) ?? [];
+            Html::generateMenuSession(true);
+        }
+
         if (array_key_exists('value', $this->oldvalues)) {
             $newvalue = (string)$this->fields['value'];
             $oldvalue = (string)$this->oldvalues['value'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://forum.glpi-project.org/viewtopic.php?id=289307

Force the menu to regenerate for the current session when the "Devices displayed in menu" option is changed. While this doesn't affect other users and they still have to log out and back in, it gives the person who made the change immediate feedback to know the effect of their change.