### PR TITLE
Fix SQL timings in debug bar

### DIFF
--- a/js/src/vue/Debug/Toolbar.vue
+++ b/js/src/vue/Debug/Toolbar.vue
@@ -274,7 +274,7 @@
             // update the total counters
             data.forEach((query) => {
                 sql_data.total_requests += 1;
-                sql_data.total_duration += parseInt(query['time']);
+                sql_data.total_duration += query['time'];
             });
         });
 

--- a/js/src/vue/Debug/Widget/RequestSummary.vue
+++ b/js/src/vue/Debug/Widget/RequestSummary.vue
@@ -16,7 +16,7 @@
     let total_sql_queries = 0;
     $.each(props.current_profile.sql['queries'], (i, query) => {
         total_sql_queries++;
-        total_sql_duration += parseFloat(query['time']);
+        total_sql_duration += query['time'];
     });
 </script>
 
@@ -39,7 +39,7 @@
                     <td>
                         SQL Requests: {{ total_sql_queries }}
                         <br>
-                        SQL Duration: {{ total_sql_duration }} ms
+                        SQL Duration: {{ total_sql_duration.toFixed(1) }} ms
                     </td>
                 </tr>
             </tbody>

--- a/js/src/vue/Debug/Widget/SQLRequests.vue
+++ b/js/src/vue/Debug/Widget/SQLRequests.vue
@@ -41,7 +41,7 @@
             // update the total counters
             data.forEach((query) => {
                 sql_data.total_requests += 1;
-                sql_data.total_duration += parseInt(query['time']);
+                sql_data.total_duration += query['time'];
             });
         });
 
@@ -150,7 +150,7 @@
                             </button>
                         </div>
                     </td>
-                    <td>{{ query.time }} ms</td>
+                    <td>{{ query.time.toFixed(1) }}&nbsp;ms</td>
                     <td>{{ query.rows }}</td>
                     <td>{{ query.warnings }}</td>
                     <td>{{ query.errors }}</td>

--- a/src/Debug/Profile.php
+++ b/src/Debug/Profile.php
@@ -140,7 +140,7 @@ final class Profile
         $this->additional_info[$widget][] = $data;
     }
 
-    public function addSQLQueryData(string $query, int $time, int $rows = 0, string $errors = '', string $warnings = '')
+    public function addSQLQueryData(string $query, float $time, int $rows = 0, string $errors = '', string $warnings = '')
     {
         if ($this->disabled) {
             return;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Fixes the following error:
```
glpiphplog.NOTICE:   *** PHP Deprecated function (8192): Implicit conversion from float 0.762939453125 to int loses precision in /var/www/glpi/src/Debug/Profile.php at line 143
  Backtrace :
  src/DBmysql.php:438                                Glpi\Debug\Profile->addSQLQueryData()
  src/DBmysqlIterator.php:119                        DBmysql->doQuery()
  src/DBmysql.php:1091                               DBmysqlIterator->execute()
  src/Session.php:999                                DBmysql->request()
  src/Session.php:1107                               Session::checkValidSessionId()
  ajax/common.tabs.php:52                            Session::checkLoginUser()
  public/index.php:82                                require()
```

2. Display only 1 decimal in SQL timings (1 decimal because without any, many timings would be `0 ms`).
![image](https://github.com/glpi-project/glpi/assets/33253653/19d0c894-5a68-44f0-a74c-ab5ea53a521e)

3. In the SQL table view, I change space to an insecble space to ensure that `ms` unit is not displayed in a second line on small screens.