### PR TITLE
Improve HL API test failure messages

### DIFF
--- a/tests/HLAPITestCase.php
+++ b/tests/HLAPITestCase.php
@@ -442,12 +442,15 @@ class HLAPITestScore extends atoum\atoum\score {
             $frame = array_shift($trace);
         }
 
-        $real_line = $frame['line'];
-        $real_class = $frame['class'];
-        $real_method = $frame['function'];
+        $new_asserter = $asserter;
+        if ($frame !== null && isset($frame['line'], $frame['class'], $frame['function'])) {
+            $real_line = $frame['line'];
+            $real_class = $frame['class'];
+            $real_method = $frame['function'];
 
-        // Replace the $asserter string to display the desired info
-        $new_asserter = $real_class . '::' . $real_method . ' (line ' . $real_line . ')';
+            // Replace the $asserter string to display the desired info
+            $new_asserter = $real_class . '::' . $real_method . ' (line ' . $real_line . ')';
+        }
         return $this->real_score->addFail($file, $class, $method, $line, $new_asserter, $reason, $case, $dataSetKey, $dataSetProvider);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The default failure information atoum shows is not always useful or accurate in certain cases.
If you have a test class with an abstract parent which has a test method in it and that test fails, it reports the test failed in the child class on line 0.
If you call a method outside the test class which then in turn performs the assertions, the file/class/line reported is the last line in the backtrace from the test class rather than where the assertion was called.
I don't have confidence in a global fix for this but since the HL API tests have helper classes than act like pseudo-assertions, it makes sense to intercept the assertion failures and change the information to provide more details.

Example where the isOK status code check was purposefully changed to cause a failure (not count 200 as success):
```php
/** Test function in CoreController test class */
public function testOptionsRoute()
{
    $this->login();
}

/** Overridden function in parent HLAPITestCase class */
protected function login(...)
{
    // Calls /token endpoint with Password OAuth grant
    $this->api->call($request, function ($call) {
        /** @var \HLAPICallAsserter $call */
        $call->response
            ->isOK()
            [...]
    });
}

/** Function in the Response "asserter" class */
public function isOK(): HLAPIResponseAsserter
{
    $this->call_asserter->test->integer($this->response->getStatusCode())->isGreaterThanOrEqualTo(201);
    $this->call_asserter->test->integer($this->response->getStatusCode())->isLessThan(300);
    return $this;
}
```

Before:
```
=> tests\units\Glpi\Api\HL\Controller\CoreController::testOptionsRoute():
In file /var/glpi/tests/functional/Glpi/Api/HL/Controller/CoreController.php on line 64, integer() failed: integer(200) is not greater than or equal to integer(201)
```

After:
```
=> tests\units\Glpi\Api\HL\Controller\CoreController::testOptionsRoute():
In file /var/glpi/tests/functional/Glpi/Api/HL/Controller/CoreController.php on line 64, HLAPIResponseAsserter::isOK (line 96) failed: integer(200) is not greater than or equal to integer(201)
```

This PR also adds custom failure messages for some of the assertions.