### PR TITLE
Fix(RuleRight): Take db groups into account for rights rules on LDAusers

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -578,6 +578,27 @@ class User extends CommonDBTM
     }
 
     /**
+     * Retrieve a user from the database using it's dn and auths_id.
+     *
+     * @param string $user_dn
+     * @param int $auths_id
+     *
+     * @return bool
+     */
+    public function getFromDBbyDnAndAuth(string $user_dn, int $auths_id): bool
+    {
+        /**
+         * We use the 'user_dn_hash' field instead of 'user_dn' for performance reasons.
+         * The 'user_dn_hash' field is a hashed version of the 'user_dn' field
+         * and is indexed in the database, making it faster to search.
+         */
+        return $this->getFromDBByCrit([
+            'user_dn_hash' => md5($user_dn),
+            'auths_id'     => $auths_id
+        ]);
+    }
+
+    /**
      * Get users ids matching the given email
      *
      * @param string $email     Email to search for
@@ -2095,6 +2116,17 @@ class User extends CommonDBTM
                 } else {
                     $groups = [];
                 }
+
+                // Take database groups into acount for user
+                $searched_user = new User();
+                if ($searched_user->getFromDBbyDnAndAuth($userdn, $ldap_method["id"])) {
+                    $groups = array_merge($groups, array_column(Group_User::getUserGroups($searched_user->getID()), 'id'));
+                }
+
+                if ($this->fields['name'] == "brazil7") {
+                    var_dump($groups);
+                }
+
 
                 $this->fields = $rule->processAllRules($groups, $this->fields, [
                     'type'        => Auth::LDAP,

--- a/src/User.php
+++ b/src/User.php
@@ -2123,11 +2123,6 @@ class User extends CommonDBTM
                     $groups = array_merge($groups, array_column(Group_User::getUserGroups($searched_user->getID()), 'id'));
                 }
 
-                if ($this->fields['name'] == "brazil7") {
-                    var_dump($groups);
-                }
-
-
                 $this->fields = $rule->processAllRules($groups, $this->fields, [
                     'type'        => Auth::LDAP,
                     'ldap_server' => $ldap_method["id"],

--- a/tests/DbTestCase.php
+++ b/tests/DbTestCase.php
@@ -273,11 +273,11 @@ class DbTestCase extends \GLPITestCase
      *
      * @return Rule Created rule
      */
-    protected function createRule(RuleBuilder $builder, string $ruleclass): Rule
+    protected function createRule(RuleBuilder $builder): Rule
     {
         $rule = $this->createItem(Rule::class, [
             'is_active'    => 1,
-            'sub_type'     => $ruleclass,
+            'sub_type'     => $builder->getRuleType(),
             'name'         => $builder->getName(),
             'match'        => $builder->getOperator(),
             'condition'    => $builder->getCondition(),

--- a/tests/LDAP/AuthLdap.php
+++ b/tests/LDAP/AuthLdap.php
@@ -40,6 +40,8 @@ use GLPIKey;
 use Group;
 use Group_User;
 use Profile_User;
+use RuleBuilder;
+use RuleRight;
 use UserTitle;
 
 /* Test for inc/authldap.class.php */
@@ -2367,6 +2369,57 @@ class AuthLDAP extends DbTestCase
         $this->array($gus)->hasSize(1);
     }
 
+
+    /**
+     * Test if ruleright '_groups_id' criteria is working
+     *
+     * @return void
+     */
+    public function testRuleRightGroupCriteria()
+    {
+
+        // create manual group
+        $group = $this->createItem(Group::class, [
+            'name'         => "test",
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+        ]);
+        $group_id = $group->getID();
+
+        // create RuleRight
+        $builder = new RuleBuilder('Test _groups_id criteria', RuleRight::class);
+        $builder->addCriteria('_groups_id', \Rule::PATTERN_IS, $group_id);
+        $builder->addAction('assign', 'profiles_id', 4); // Super admin
+        $builder->addAction('assign', 'entities_id', 1);
+        $builder->setEntity(0);
+        $this->createRule($builder);
+
+        // login the user to force a real synchronisation (and creation into DB)
+        $this->login('brazil7', 'password', false);
+        $users_id = \User::getIdByName('brazil7');
+
+        // Add group to user
+        $this->createItem(Group_User::class, [
+            'groups_id' => $group_id,
+            'users_id'  => $users_id,
+        ]);
+        $groups = (new Group_User())->find([
+            'groups_id' => $group_id,
+            'users_id'  => $users_id,
+        ]);
+        $this->array($groups)->hasSize(1);
+
+        // Log in again to trigger rule
+        $this->login('brazil7', 'password', false);
+
+        // Check that the correct profile was set
+        $rights = (new Profile_User())->find([
+            'users_id' => $users_id,
+            'profiles_id' => 4,
+        ]);
+
+        $this->array($rights)->hasSize(1);
+    }
     /**
      * @extensions ldap
      */

--- a/tests/LDAP/AuthLdap.php
+++ b/tests/LDAP/AuthLdap.php
@@ -2403,11 +2403,13 @@ class AuthLDAP extends DbTestCase
             'groups_id' => $group_id,
             'users_id'  => $users_id,
         ]);
-        $groups = (new Group_User())->find([
-            'groups_id' => $group_id,
-            'users_id'  => $users_id,
+
+        // Check that the user is not attached to the profile at creation
+        $rights = (new Profile_User())->find([
+            'users_id' => $users_id,
+            'profiles_id' => 4,
         ]);
-        $this->array($groups)->hasSize(1);
+        $this->array($rights)->hasSize(0);
 
         // Log in again to trigger rule
         $this->login('brazil7', 'password', false);

--- a/tests/RuleBuilder.php
+++ b/tests/RuleBuilder.php
@@ -93,7 +93,7 @@ class RuleBuilder
         $this->criteria     = [];
         $this->actions      = [];
 
-        if ($this->rule_type === RuleTicket::class) {
+        if (is_a($this->rule_type, RuleCommonITILObject::class, true)) {
             $this->condition = RuleTicket::ONADD | RuleTicket::ONUPDATE;
         } else {
             $this->condition = 0;

--- a/tests/RuleBuilder.php
+++ b/tests/RuleBuilder.php
@@ -74,19 +74,30 @@ class RuleBuilder
     protected array $actions;
 
     /**
+     * @property string $name Rule name
+     */
+    protected string $rule_type;
+
+    /**
      * @param string $name Rule name
      */
-    public function __construct(string $name)
+    public function __construct(string $name, ?string $rule_type = null)
     {
         $this->name = $name;
 
         // Default values
         $this->operator     = "AND";
-        $this->condition    = RuleTicket::ONADD | RuleTicket::ONUPDATE;
+        $this->rule_type    = $rule_type ?? RuleTicket::class;
         $this->is_recursive = true;
         $this->entities_id  = getItemByTypeName(Entity::class, '_test_root_entity', true);
         $this->criteria     = [];
         $this->actions      = [];
+
+        if ($this->rule_type === RuleTicket::class) {
+            $this->condition = RuleTicket::ONADD | RuleTicket::ONUPDATE;
+        } else {
+            $this->condition = 0;
+        }
     }
 
     /**
@@ -185,6 +196,15 @@ class RuleBuilder
         return $this;
     }
 
+    /**
+     * Get rule name
+     *
+     * @return string Rule name
+     */
+    public function getRuleType(): string
+    {
+        return $this->rule_type;
+    }
 
     /**
      * Get rule name

--- a/tests/functional/RuleCommonITILObject.php
+++ b/tests/functional/RuleCommonITILObject.php
@@ -2617,12 +2617,12 @@ abstract class RuleCommonITILObject extends DbTestCase
             'is_recursive' => true,
         ]);
 
-        $builder = new RuleBuilder('Test global_validation criteria rule');
+        $builder = new RuleBuilder('Test global_validation criteria rule', $this->getTestedClass());
         $builder
             ->addCriteria('global_validation', Rule::PATTERN_IS, CommonITILValidation::WAITING)
             ->addCriteria('itilcategories_id', Rule::PATTERN_IS, $category1->getID())
             ->addAction('assign', 'urgency', $urgency_if_rule_triggered);
-        $this->createRule($builder, $this->getTestedClass());
+        $this->createRule($builder);
 
         // Create ITIL object with validation request
         $itil_object = $this->createItem($this->getITILObjectClass(), [
@@ -2681,16 +2681,16 @@ abstract class RuleCommonITILObject extends DbTestCase
         ]);
 
         // Create two rules
-        $builder = new RuleBuilder('Test category code criterion rule');
+        $builder = new RuleBuilder('Test category code criterion rule', $this->getTestedClass());
         $builder
             ->addCriteria('urgency', Rule::PATTERN_IS, 5)
             ->addAction('assign', 'itilcategories_id', $category->getID());
-        $this->createRule($builder, $this->getTestedClass());
+        $this->createRule($builder);
 
         $builder
             ->addCriteria('itilcategories_id_code', Rule::PATTERN_IS, $category->fields['code'])
             ->addAction('assign', 'locations_id', $location->getID());
-        $this->createRule($builder, $this->getTestedClass());
+        $this->createRule($builder);
 
         // Create a itil object with "Very high" urgency
         $itil_object = $this->createItem($this->getITILObjectClass(), [
@@ -2730,19 +2730,19 @@ abstract class RuleCommonITILObject extends DbTestCase
         ]);
 
         // Create two rules
-        $builder = new RuleBuilder('Test default profile criterion rule');
+        $builder = new RuleBuilder('Test default profile criterion rule', $this->getTestedClass());
         $builder
             ->addCriteria('profiles_id', Rule::PATTERN_IS, 4)
             ->addAction('assign', 'locations_id', $location->getID());
-        $this->createRule($builder, $this->getTestedClass());
+        $this->createRule($builder);
 
 
         // Create two rules
-        $builder = new RuleBuilder('Test default profile criterion rule on update');
+        $builder = new RuleBuilder('Test default profile criterion rule on update', $this->getTestedClass());
         $builder
             ->addCriteria('profiles_id', Rule::PATTERN_IS, 0)
             ->addAction('assign', 'locations_id', $location2->getID());
-        $this->createRule($builder, $this->getTestedClass());
+        $this->createRule($builder);
 
         //Load user jsmith123
         $user = new \User();

--- a/tests/functional/SLM.php
+++ b/tests/functional/SLM.php
@@ -1411,22 +1411,22 @@ class SLM extends DbTestCase
                 }
 
                 // First OLA is added on creation
-                $builder = new RuleBuilder('Add first LA on creation');
+                $builder = new RuleBuilder('Add first LA on creation', RuleTicket::class);
                 $builder->setEntity($entity)
                     ->setCondtion(RuleTicket::ONADD)
                     ->addCriteria('name', Rule::PATTERN_IS, $test_ticket_name)
                     ->addCriteria('entities_id', Rule::PATTERN_IS, $entity)
                     ->addAction('assign', $la_fk_field, $la1->getID());
-                $this->createRule($builder, RuleTicket::class);
+                $this->createRule($builder);
 
                 // First OLA is added on update
-                $builder = new RuleBuilder('Add second LA on update');
+                $builder = new RuleBuilder('Add second LA on update', RuleTicket::class);
                 $builder->setEntity($entity)
                     ->setCondtion(RuleTicket::ONUPDATE)
                     ->addCriteria('name', Rule::PATTERN_IS, $test_ticket_name)
                     ->addCriteria('urgency', Rule::PATTERN_IS, 5)
                     ->addAction('assign', $la_fk_field, $la2->getID());
-                $this->createRule($builder, RuleTicket::class);
+                $this->createRule($builder);
             }
         }
 
@@ -1625,13 +1625,13 @@ class SLM extends DbTestCase
             ]);
 
             // First OLA is added on creation
-            $builder = new RuleBuilder('Add first LA on creation');
+            $builder = new RuleBuilder('Add first LA on creation', RuleTicket::class);
             $builder->setEntity($entity)
                 ->setCondtion(RuleTicket::ONADD)
                 ->addCriteria('name', Rule::PATTERN_IS, $test_ticket_name)
                 ->addCriteria('entities_id', Rule::PATTERN_IS, $entity)
                 ->addAction('assign', $la_fk_field, $la->getID());
-            $this->createRule($builder, RuleTicket::class);
+            $this->createRule($builder);
         }
 
         // Create a ticket
@@ -1766,13 +1766,13 @@ class SLM extends DbTestCase
             ]);
 
             // OLA is added on update
-            $builder = new RuleBuilder('Add second LA on update');
+            $builder = new RuleBuilder('Add second LA on update', RuleTicket::class);
             $builder->setEntity($entity)
                 ->setCondtion(RuleTicket::ONUPDATE)
                 ->addCriteria('name', Rule::PATTERN_IS, $test_ticket_name)
                 ->addCriteria('urgency', Rule::PATTERN_IS, 5)
                 ->addAction('assign', $la_fk_field, $la->getID());
-            $this->createRule($builder, RuleTicket::class);
+            $this->createRule($builder);
         }
 
         // Update ticket, triggering an LA change


### PR DESCRIPTION
same as https://github.com/glpi-project/glpi/pull/16548 but for main

The "groups" criteria for authorizations rules is not processed correctly for LDAP users.

Small improvement added to the unit test ```RuleBuilder``` to manages the ```subtype```, rather than the ```CreateRule``` function.


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !31311
