### PR TITLE
Monaco show basic suggestions for Twig env

### DIFF
--- a/js/modules/Monaco/MonacoEditor.js
+++ b/js/modules/Monaco/MonacoEditor.js
@@ -77,7 +77,7 @@ export default class MonacoEditor {
 
         window.monaco.languages.registerCompletionItemProvider(new_lang_id, {
             triggerCharacters: trigger_characters[language] ?? [],
-            provideCompletionItems: function (model, position) {
+            provideCompletionItems: (model, position) => {
                 const word = model.getWordUntilPosition(position);
                 const range = {
                     startLineNumber: position.lineNumber,
@@ -124,6 +124,9 @@ export default class MonacoEditor {
                 return {
                     suggestions: ((range) => {
                         const suggestions = [];
+                        if (language === 'twig') {
+                            suggestions.push(...this.getTwigCompletions());
+                        }
                         // expand completions to monaco format
                         for (const completion of completions) {
                             suggestions.push({
@@ -165,6 +168,64 @@ export default class MonacoEditor {
                 }
             });
         }
+    }
+
+    getTwigCompletions() {
+        const keywords = [
+            // (opening) tags
+            'apply', 'autoescape', 'block', 'deprecated', 'do', 'embed', 'extends', 'flush', 'for', 'from', 'if',
+            'import', 'include', 'macro', 'sandbox', 'set', 'use', 'verbatim', 'with',
+            // closing tags
+            'endapply', 'endautoescape', 'endblock', 'endembed', 'endfor', 'endif', 'endmacro', 'endsandbox',
+            'endset', 'endwith',
+            // literals
+            'true', 'false', 'null'
+        ];
+        const operators = [
+            'in', 'is', 'and', 'or', 'not', 'b-and', 'b-xor', 'b-or', 'matches', 'starts with', 'ends with', 'has some', 'has every',
+        ];
+        const functions = ['min', 'max', 'random', 'range'];
+        // Like functions but occur after '|'
+        const filters = [
+            'abs', 'batch', 'capitalize', 'column', 'default', 'escape', 'filter', 'first', 'format', 'join',
+            'json_encode', 'keys', 'last', 'length', 'lower', 'map', 'merge', 'nl2br', 'raw', 'reduce', 'replace',
+            'reverse', 'round', 'slice', 'sort', 'split', 'striptags', 'title', 'trim', 'upper', 'url_encode'
+        ];
+        function getKeyword(name) {
+            return {
+                label: name,
+                kind: window.monaco.languages.CompletionItemKind['Keyword'],
+                insertText: name,
+            };
+        }
+        function getOperator(name) {
+            return {
+                label: name,
+                kind: window.monaco.languages.CompletionItemKind['Operator'],
+                insertText: name,
+            };
+        }
+        function getFunction(name) {
+            return {
+                label: name,
+                kind: window.monaco.languages.CompletionItemKind['Function'],
+                insertText: name,
+            };
+        }
+        const suggestions = [];
+        for (const keyword of keywords) {
+            suggestions.push(getKeyword(keyword));
+        }
+        for (const operator of operators) {
+            suggestions.push(getOperator(operator));
+        }
+        for (const func of functions) {
+            suggestions.push(getFunction(func));
+        }
+        for (const filter of filters) {
+            suggestions.push(getFunction(filter));
+        }
+        return suggestions;
     }
 }
 

--- a/js/modules/Monaco/MonacoEditor.js
+++ b/js/modules/Monaco/MonacoEditor.js
@@ -173,7 +173,7 @@ export default class MonacoEditor {
     getTwigCompletions() {
         const keywords = [
             // (opening) tags
-            'apply', 'autoescape', 'block', 'for', 'if', 'macro', 'set',
+            'apply', 'autoescape', 'block', 'for', 'if', 'elseif', 'macro', 'set',
             // closing tags
             'endapply', 'endautoescape', 'endblock', 'endfor', 'endif', 'endmacro', 'endset',
             // literals
@@ -182,10 +182,10 @@ export default class MonacoEditor {
         const operators = [
             'in', 'is', 'and', 'or', 'not', 'b-and', 'b-xor', 'b-or', 'matches', 'starts with', 'ends with', 'has some', 'has every',
         ];
-        const functions = ['min', 'max', 'random', 'range'];
+        const functions = ['date', 'min', 'max', 'random', 'range'];
         // Like functions but occur after '|'
         const filters = [
-            'abs', 'batch', 'capitalize', 'column', 'default', 'escape', 'filter', 'first', 'format', 'join',
+            'abs', 'batch', 'capitalize', 'column', 'date', 'default', 'escape', 'filter', 'first', 'format', 'join',
             'json_encode', 'keys', 'last', 'length', 'lower', 'map', 'merge', 'nl2br', 'raw', 'reduce', 'replace',
             'reverse', 'round', 'slice', 'sort', 'split', 'striptags', 'title', 'trim', 'upper', 'url_encode'
         ];

--- a/js/modules/Monaco/MonacoEditor.js
+++ b/js/modules/Monaco/MonacoEditor.js
@@ -173,11 +173,9 @@ export default class MonacoEditor {
     getTwigCompletions() {
         const keywords = [
             // (opening) tags
-            'apply', 'autoescape', 'block', 'deprecated', 'do', 'embed', 'extends', 'flush', 'for', 'from', 'if',
-            'import', 'include', 'macro', 'sandbox', 'set', 'use', 'verbatim', 'with',
+            'apply', 'autoescape', 'block', 'for', 'if', 'macro', 'set',
             // closing tags
-            'endapply', 'endautoescape', 'endblock', 'endembed', 'endfor', 'endif', 'endmacro', 'endsandbox',
-            'endset', 'endwith',
+            'endapply', 'endautoescape', 'endblock', 'endfor', 'endif', 'endmacro', 'endset',
             // literals
             'true', 'false', 'null'
         ];

--- a/src/ContentTemplates/TemplateManager.php
+++ b/src/ContentTemplates/TemplateManager.php
@@ -160,8 +160,12 @@ class TemplateManager
      */
     public static function getSecurityPolicy(): SecurityPolicy
     {
-        $tags = ['if', 'for'];
-        $filters = ['escape', 'upper', 'date', 'length', 'round', 'lower', 'trim', 'raw'];
+        $tags = ['apply', 'autoescape', 'block', 'if', 'for', 'macro', 'set'];
+        $filters = [
+            'abs', 'batch', 'capitalize', 'column', 'date', 'default', 'escape', 'filter', 'first', 'format', 'join',
+            'json_encode', 'keys', 'last', 'length', 'lower', 'map', 'merge', 'nl2br', 'raw', 'reduce', 'replace',
+            'reverse', 'round', 'slice', 'sort', 'split', 'striptags', 'title', 'trim', 'upper', 'url_encode'
+        ];
         $methods = [];
         $properties = [];
         $functions = ['date', 'max', 'min','random', 'range'];

--- a/src/ContentTemplates/TemplateManager.php
+++ b/src/ContentTemplates/TemplateManager.php
@@ -65,7 +65,8 @@ class TemplateManager
     public static function render(
         string $content,
         array $params,
-        bool $expect_html = true
+        bool $expect_html = true,
+        array $extra_extensions = []
     ): string {
         // Init twig
         $loader = new ArrayLoader(['template' => $content]);
@@ -73,6 +74,11 @@ class TemplateManager
 
         // Use sandbox extension to restrict code execution
         $twig->addExtension(new SandboxExtension(self::getSecurityPolicy(), true));
+
+        // Add extra extensions
+        foreach ($extra_extensions as $extension) {
+            $twig->addExtension($extension);
+        }
 
         // Render the template
         $result = $twig->render('template', $params);

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -39,6 +39,7 @@ use Glpi\Api\HL\Controller\ITILController;
 use Glpi\Api\HL\Controller\ManagementController;
 use Glpi\Api\HL\Doc\Schema;
 use Glpi\Api\HL\Router;
+use Glpi\ContentTemplates\TemplateManager;
 use Glpi\Http\Request;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Search\FilterableInterface;
@@ -510,13 +511,7 @@ class Webhook extends CommonDBTM implements FilterableInterface
                     };
                     $data = $fn_desanitize($data);
                     try {
-                        $env = new \Twig\Environment(
-                            new \Twig\Loader\ArrayLoader([
-                                'payload' => $payload_template
-                            ])
-                        );
-                        $env->addExtension(new \Twig\Extra\Markdown\MarkdownExtension());
-                        return $env->render('payload', $data);
+                        return TemplateManager::render($payload_template, $data, false, [new \Twig\Extra\Markdown\MarkdownExtension()]);
                     } catch (Throwable $e) {
                         return null;
                     }
@@ -1152,25 +1147,15 @@ class Webhook extends CommonDBTM implements FilterableInterface
 
             $custom_headers = $webhook->fields['custom_headers'];
             foreach ($custom_headers as $key => $value) {
-                $env = new \Twig\Environment(
-                    new \Twig\Loader\ArrayLoader([
-                        'payload' => $value
-                    ])
-                );
                 try {
-                    $custom_headers[$key] = $env->render('payload', $api_data);
+                    $custom_headers[$key] = TemplateManager::render($value, $api_data, false);
                 } catch (\Exception $e) {
                     // Header will not be sent
                 }
             }
             $headers = array_merge($headers, $custom_headers);
 
-            $env = new \Twig\Environment(
-                new \Twig\Loader\ArrayLoader([
-                    'payload' => $webhook->fields['url']
-                ])
-            );
-            $webhook->fields['url'] = $env->render('payload', $api_data);
+            $webhook->fields['url'] = TemplateManager::render($webhook->fields['url'], $api_data, false);
 
             $data = $webhook->fields;
             $data['items_id'] = $item->getID();

--- a/tests/abstracts/AbstractITILChildTemplate.php
+++ b/tests/abstracts/AbstractITILChildTemplate.php
@@ -102,9 +102,9 @@ HTML
         ];
 
         yield [
-            'content'  => 'Unauthorized tag {% set var = 15 %}',
+            'content'  => 'Unauthorized tag {% do 1 + 2 %}',
             'is_valid' => false,
-            'error'    => 'Content: Invalid twig template (Tag "set" is not allowed in "template" at line 1.)',
+            'error'    => 'Content: Invalid twig template (Tag "do" is not allowed in "template" at line 1.)',
         ];
     }
 

--- a/tests/units/Glpi/ContentTemplates/TemplateManager.php
+++ b/tests/units/Glpi/ContentTemplates/TemplateManager.php
@@ -74,10 +74,10 @@ class TemplateManager extends GLPITestCase
                 'expected'  => "<p>Test for: no items</p>",
             ],
             [
-                'content'   => "Test forbidden tag: {% set var = 'value' %}",
+                'content'   => "Test forbidden tag: {% do 1 + 2 %}",
                 'params'    => [],
                 'expected'  => "",
-                'error'     => 'Invalid twig template (Tag "set" is not allowed in "template" at line 1.)',
+                'error'     => 'Invalid twig template (Tag "do" is not allowed in "template" at line 1.)',
             ],
             [
                 'content'   => "Test syntax error {{",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Monaco's support for Twig doesn't include any information about the default environment, possibly because it can change (although it doesn't explain why keywords are missing). This PR at least adds some of the more common, available by default, keywords, functions, filters, etc to the list.
Obviously, this is still no replacement for user's reading the Twig documentation, but may give some hints to them that they do indeed have access to a default Twig environment and have some idea of what is available to them.