### PR TITLE
fix(document): icon in timeline

### DIFF
--- a/src/Application/View/Extension/DocumentExtension.php
+++ b/src/Application/View/Extension/DocumentExtension.php
@@ -83,11 +83,14 @@ class DocumentExtension extends AbstractExtension
             }
         }
 
+        $defaultIcon = '/pics/timeline/file.png';
+        $icon = $defaultIcon;
+
         if (isset($CFG_GLPI['extension_icon'][$extension])) {
             $icon = '/pics/icones/' . $CFG_GLPI['extension_icon'][$extension];
         }
 
-        return $CFG_GLPI['root_doc'] . (file_exists(GLPI_ROOT . $icon) ? $icon : '/pics/timeline/file.png');
+        return $CFG_GLPI['root_doc'] . (file_exists(GLPI_ROOT . $icon) ? $icon : $defaultIcon);
     }
 
     /**

--- a/src/Application/View/Extension/DocumentExtension.php
+++ b/src/Application/View/Extension/DocumentExtension.php
@@ -44,7 +44,10 @@ use Twig\TwigFilter;
  */
 class DocumentExtension extends AbstractExtension
 {
-    private static $extensionIcon = null;
+    /**
+     * Static cache for user defined files extensions icons.
+     */
+    private static array $extensionIcon = null;
 
     public function getFilters(): array
     {

--- a/src/Application/View/Extension/DocumentExtension.php
+++ b/src/Application/View/Extension/DocumentExtension.php
@@ -44,6 +44,8 @@ use Twig\TwigFilter;
  */
 class DocumentExtension extends AbstractExtension
 {
+    static $extensionIcon = null;
+
     public function getFilters(): array
     {
         return [
@@ -67,7 +69,7 @@ class DocumentExtension extends AbstractExtension
 
         $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
 
-        if (!isset($CFG_GLPI['extension_icon'])) {
+        if (static::$extensionIcon === null) {
             $iterator = $DB->request([
                 'SELECT' => [
                     'ext',
@@ -79,15 +81,15 @@ class DocumentExtension extends AbstractExtension
                 ]
             ]);
             foreach ($iterator as $result) {
-                $CFG_GLPI['extension_icon'][$result['ext']] = $result['icon'];
+                static::$extensionIcon[$result['ext']] = $result['icon'];
             }
         }
 
         $defaultIcon = '/pics/timeline/file.png';
         $icon = $defaultIcon;
 
-        if (isset($CFG_GLPI['extension_icon'][$extension])) {
-            $icon = '/pics/icones/' . $CFG_GLPI['extension_icon'][$extension];
+        if (isset(static::$extensionIcon[$extension])) {
+            $icon = '/pics/icones/' . static::$extensionIcon[$extension];
         }
 
         return $CFG_GLPI['root_doc'] . (file_exists(GLPI_ROOT . $icon) ? $icon : $defaultIcon);

--- a/src/Application/View/Extension/DocumentExtension.php
+++ b/src/Application/View/Extension/DocumentExtension.php
@@ -65,14 +65,22 @@ class DocumentExtension extends AbstractExtension
         /** @var \DBmysql $DB */
         global $CFG_GLPI, $DB;
 
-        $icon = sprintf('/pics/icones/%s-dist.png', strtolower(pathinfo($filename, PATHINFO_EXTENSION)));
+        $extention = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+        $icon = sprintf('/pics/icones/%s-dist.png', $extention);
 
         if (file_exists(GLPI_ROOT . $icon)) {
             return $CFG_GLPI['root_doc'] . $icon;
         }
 
-        $extention = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+        // If the file extension ends with 'x' (e.g. 'docx'), try to find an icon for the base extension (e.g. 'doc')
+        if (substr($extention, -1) === 'x') {
+            $icon = sprintf('/pics/icones/%s-dist.png', substr($extention, 0, -1));
+            if (file_exists(GLPI_ROOT . $icon)) {
+                return $CFG_GLPI['root_doc'] . $icon;
+            }
+        }
 
+        // Database search if icon not found by direct name
         $iterator = $DB->request([
             'SELECT' => 'icon',
             'FROM'   => 'glpi_documenttypes',

--- a/src/Application/View/Extension/DocumentExtension.php
+++ b/src/Application/View/Extension/DocumentExtension.php
@@ -44,7 +44,7 @@ use Twig\TwigFilter;
  */
 class DocumentExtension extends AbstractExtension
 {
-    static $extensionIcon = null;
+    private static $extensionIcon = null;
 
     public function getFilters(): array
     {

--- a/src/Application/View/Extension/DocumentExtension.php
+++ b/src/Application/View/Extension/DocumentExtension.php
@@ -47,7 +47,7 @@ class DocumentExtension extends AbstractExtension
     /**
      * Static cache for user defined files extensions icons.
      */
-    private static array $extensionIcon = null;
+    private static $extensionIcon = null;
 
     public function getFilters(): array
     {

--- a/src/Application/View/Extension/DocumentExtension.php
+++ b/src/Application/View/Extension/DocumentExtension.php
@@ -62,11 +62,30 @@ class DocumentExtension extends AbstractExtension
     public function getDocumentIcon(string $filename): string
     {
         /** @var array $CFG_GLPI */
-        global $CFG_GLPI;
+        /** @var \DBmysql $DB */
+        global $CFG_GLPI, $DB;
 
-        $icon = sprintf('/pics/icones/%s-dist.png', strtolower(pathinfo($filename, PATHINFO_EXTENSION)));
+        $extention = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
 
-        return $CFG_GLPI['root_doc'] . (file_exists(GLPI_ROOT . $icon) ? $icon : '/pics/timeline/file.png');
+        $iterator = $DB->request([
+            'SELECT' => 'icon',
+            'FROM'   => 'glpi_documenttypes',
+            'WHERE'  => [
+                'ext'    => $extention,
+                'icon'   => ['<>', '']
+            ]
+        ]);
+
+        $icon = '/pics/timeline/file.png';
+
+        foreach ($iterator as $result) {
+            if (file_exists(GLPI_ROOT . '/pics/icones/' . $result['icon'])) {
+                $icon = '/pics/icones/' . $result['icon'];
+                break;
+            }
+        }
+
+        return $CFG_GLPI['root_doc'] . $icon;
     }
 
     /**

--- a/src/Application/View/Extension/DocumentExtension.php
+++ b/src/Application/View/Extension/DocumentExtension.php
@@ -65,6 +65,12 @@ class DocumentExtension extends AbstractExtension
         /** @var \DBmysql $DB */
         global $CFG_GLPI, $DB;
 
+        $icon = sprintf('/pics/icones/%s-dist.png', strtolower(pathinfo($filename, PATHINFO_EXTENSION)));
+
+        if (file_exists(GLPI_ROOT . $icon)) {
+            return $CFG_GLPI['root_doc'] . $icon;
+        }
+
         $extention = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
 
         $iterator = $DB->request([

--- a/src/Application/View/Extension/DocumentExtension.php
+++ b/src/Application/View/Extension/DocumentExtension.php
@@ -65,19 +65,23 @@ class DocumentExtension extends AbstractExtension
         /** @var \DBmysql $DB */
         global $CFG_GLPI, $DB;
 
-        $extention = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
-        $icon = sprintf('/pics/icones/%s-dist.png', $extention);
+        $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+        $icon = sprintf('/pics/icones/%s-dist.png', $extension);
 
         if (file_exists(GLPI_ROOT . $icon)) {
             return $CFG_GLPI['root_doc'] . $icon;
         }
 
-        // If the file extension ends with 'x' (e.g. 'docx'), try to find an icon for the base extension (e.g. 'doc')
-        if (substr($extention, -1) === 'x') {
-            $icon = sprintf('/pics/icones/%s-dist.png', substr($extention, 0, -1));
-            if (file_exists(GLPI_ROOT . $icon)) {
-                return $CFG_GLPI['root_doc'] . $icon;
-            }
+        // substitute for some common file types
+        $extensionIcons = [
+            'xlsx' => '/pics/icones/xls-dist.png',
+            'docx' => '/pics/icones/doc-dist.png',
+            'pptx' => '/pics/icones/ppt-dist.png',
+            'jpeg' => '/pics/icones/jpg-dist.png',
+        ];
+
+        if (file_exists(GLPI_ROOT . $extensionIcons[$extension] ?? '')) {
+            return $CFG_GLPI['root_doc'] . $extensionIcons[$extension];
         }
 
         // Database search if icon not found by direct name
@@ -85,7 +89,7 @@ class DocumentExtension extends AbstractExtension
             'SELECT' => 'icon',
             'FROM'   => 'glpi_documenttypes',
             'WHERE'  => [
-                'ext'    => $extention,
+                'ext'    => $extension,
                 'icon'   => ['<>', '']
             ]
         ]);


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !31632

The icon of a document in the timeline is not always identical to the icon of the same document in the documents menu. Especially with docx or xlsx.

Documents menu:
![image](https://github.com/glpi-project/glpi/assets/8530352/4c0fe8b5-58c3-4e0e-a95d-fad33b9d8c8c)

Timeline Before:
![image](https://github.com/glpi-project/glpi/assets/8530352/ce4474d7-2147-49c1-b830-013b6f6a3667)

Timeline After:
![image](https://github.com/glpi-project/glpi/assets/8530352/65794ad2-9dfa-4d63-acd8-9beabd04c0ff)
