### PR TITLE
Fix item_item search options

### DIFF
--- a/src/Search/Provider/SQLProvider.php
+++ b/src/Search/Provider/SQLProvider.php
@@ -2532,11 +2532,11 @@ final class SQLProvider implements SearchProviderInterface
                             'LEFT JOIN' => [
                                 "$new_table$AS" => [
                                     'ON' => [
-                                        $nt => 'id',
-                                        $rt => getForeignKeyFieldForTable($cleanrt) . '_1',
+                                        $rt => 'id',
+                                        $nt => getForeignKeyFieldForTable($cleanrt) . '_1',
                                         [
                                             'OR' => [
-                                                "$nt.id" => $rt . '.' . getForeignKeyFieldForTable($cleanrt) . '_2'
+                                                "$rt.id" => $nt . '.' . getForeignKeyFieldForTable($cleanrt) . '_2'
                                             ]
                                         ]
                                     ]

--- a/src/Search/Provider/SQLProvider.php
+++ b/src/Search/Provider/SQLProvider.php
@@ -2290,7 +2290,8 @@ final class SQLProvider implements SearchProviderInterface
         array $joinparams = [],
         string $field = ''
     ): array {
-
+        /** @var \DBmysql $DB */
+        global $DB;
         // Rename table for meta left join
         $AS = "";
         $nt = $new_table;
@@ -2536,7 +2537,7 @@ final class SQLProvider implements SearchProviderInterface
                                         $nt => getForeignKeyFieldForTable($cleanrt) . '_1',
                                         [
                                             'OR' => [
-                                                "$rt.id" => $nt . '.' . getForeignKeyFieldForTable($cleanrt) . '_2'
+                                                new QueryExpression($DB::quoteName("$rt.id") . ' = ' . $DB::quoteName("$nt." . getForeignKeyFieldForTable($cleanrt) . '_2'))
                                             ]
                                         ]
                                     ]
@@ -2557,7 +2558,7 @@ final class SQLProvider implements SearchProviderInterface
                                         $rt => getForeignKeyFieldForTable($cleannt) . '_1',
                                         [
                                             'OR' => [
-                                                "$nt.id" => $rt . '.' . getForeignKeyFieldForTable($cleannt) . '_2'
+                                                new QueryExpression($DB::quoteName("$nt.id") . ' = ' . $DB::quoteName("$rt." . getForeignKeyFieldForTable($cleannt) . '_2'))
                                             ]
                                         ]
                                     ]

--- a/tests/functional/Glpi/Search/Provider/SQLProvider.php
+++ b/tests/functional/Glpi/Search/Provider/SQLProvider.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Search\Provider;
+
+use DbTestCase;
+
+class SQLProvider extends DbTestCase
+{
+    public function testGetLeftJoinCriteria()
+    {
+        global $DB;
+
+        $already_linked = [];
+        $item_item_join = \Glpi\Search\Provider\SQLProvider::getLeftJoinCriteria(
+            'Ticket',
+            'glpi_tickets',
+            $already_linked,
+            'glpi_tickets_tickets',
+            'tickets_tickets_id',
+            false,
+            0,
+            ['jointype' => 'item_item'],
+            'tickets_id_1'
+        );
+        $it = new \DBmysqlIterator($DB);
+        $this->string($it->analyseJoins($item_item_join))->isEqualTo(' LEFT JOIN `glpi_tickets_tickets` ON (`glpi_tickets`.`id` = `glpi_tickets_tickets`.`tickets_id_1` OR `glpi_tickets`.`id` = `glpi_tickets_tickets`.`tickets_id_2`)');
+
+        $item_item_revert_join = \Glpi\Search\Provider\SQLProvider::getLeftJoinCriteria(
+            'Ticket_Ticket',
+            'glpi_tickets_tickets',
+            $already_linked,
+            'glpi_tickets',
+            'tickets_id',
+            false,
+            0,
+            ['jointype' => 'item_item_revert'],
+            'tickets_id'
+        );
+        $this->string($it->analyseJoins($item_item_revert_join))->isEqualTo(' LEFT JOIN `glpi_tickets` ON (`glpi_tickets`.`id` = `glpi_tickets_tickets`.`tickets_id_1` OR `glpi_tickets`.`id` = `glpi_tickets_tickets`.`tickets_id_2`)');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Only affects `main` as bug was introduced while the search code was being refactored. The handling of `item_item` type search options was the same as `item_item_revert`.

10.0 handling can be found here for reference:
https://github.com/glpi-project/glpi/blob/a040236888d5e0eeb0707058be3bcbfe6953346c/src/Search.php#L6082-L6100