### PR TITLE
fix missing tinymce in general setup

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -593,7 +593,7 @@ $CFG_GLPI['javascript'] = [
         'plugin' => [
             'marketplace' => ['marketplace']
         ],
-        'config' => ['clipboard']
+        'config' => ['clipboard', 'tinymce']
     ],
     'admin'        => ['clipboard', 'sortable'],
     'preference'   => ['clipboard'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Opening Setup > General > General tab displays a warning and an error in the console saying that tinyMCE is not defined and the login text option is shown as a regular textarea instead of a richtext editor.