### PR TITLE
Fix date install item software version

### DIFF
--- a/src/Inventory/Asset/Software.php
+++ b/src/Inventory/Asset/Software.php
@@ -41,6 +41,7 @@ use Dropdown;
 use Entity;
 use Glpi\Inventory\Conf;
 use Glpi\Toolbox\Sanitizer;
+use Item_SoftwareVersion;
 use QueryParam;
 use RuleDictionnarySoftwareCollection;
 use Software as GSoftware;
@@ -308,6 +309,7 @@ class Software extends InventoryAsset
         $iterator = $DB->request([
             'SELECT' => [
                 'glpi_items_softwareversions.id as item_soft_version_id',
+                'glpi_items_softwareversions.date_install as item_soft_version_date_install',
                 'glpi_softwares.id as softid',
                 'glpi_softwares.name',
                 'glpi_softwareversions.id AS versionid',
@@ -355,13 +357,17 @@ class Software extends InventoryAsset
 
         foreach ($iterator as $data) {
             $item_soft_v_id = $data['item_soft_version_id'];
+            $item_soft_v_date_install = $data['item_soft_version_date_install'];
             unset($data['item_soft_version_id']);
             if ($data['manufacturers_id'] == null) {
                 $data['manufacturers_id'] = 0;
             }
             $key_w_version = $this->getFullCompareKey((object)$data);
             $key_wo_version = $this->getFullCompareKey((object)$data, false);
-            $db_software[$key_w_version] = $item_soft_v_id;
+            $db_software[$key_w_version] = [
+                'id' => $item_soft_v_id,
+                'date_install' => $item_soft_v_date_install,
+            ];
             $db_software_wo_version[$key_wo_version] = [
                 'versionid' => $data['versionid'],
                 'softid'    => $data['softid'],
@@ -407,6 +413,20 @@ class Software extends InventoryAsset
                 ], 0);
             }
 
+            //update date_install if needed
+            //reconciles the software with the version (needed here)
+            if (
+                property_exists($val, 'date_install')
+                && isset($db_software[$key_w_version])
+                && $db_software[$key_w_version]['date_install'] != $val->date_install
+            ) {
+                $software_version = new Item_SoftwareVersion();
+                $software_version->update([
+                    "id" => $db_software[$key_w_version]['id'],
+                    "date_install" => $val->date_install
+                ], 0);
+            }
+
             if (isset($db_software[$key_w_version])) {
                 // software exist with the same version
                 unset($this->data[$k]);
@@ -445,7 +465,7 @@ class Software extends InventoryAsset
             $DB->delete(
                 'glpi_items_softwareversions',
                 [
-                    'id' => $db_software
+                    'id' => array_column($db_software, 'id')
                 ]
             );
         }

--- a/tests/functional/Glpi/Inventory/Assets/Software.php
+++ b/tests/functional/Glpi/Inventory/Assets/Software.php
@@ -1519,4 +1519,112 @@ class Software extends AbstractInventoryAsset
         ]))->isTrue();
         $this->integer($item_versions_id)->isIdenticalTo($item_version->fields['id']);
     }
+
+    public function testDateInstallUpdate()
+    {
+        $computer = new \Computer();
+        $soft = new \Software();
+        $version = new \SoftwareVersion();
+        $item_version = new \Item_SoftwareVersion();
+
+        $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<REQUEST>
+  <CONTENT>
+      <SOFTWARES>
+      <NAME>A great software</NAME>
+      <VERSION>2.0.0</VERSION>
+      <INSTALL_DATE>2014-03-04 16:12:35</INSTALL_DATE>
+      <PUBLISHER>Manufacture</PUBLISHER>
+    </SOFTWARES>
+    <HARDWARE>
+      <NAME>pc002</NAME>
+    </HARDWARE>
+    <BIOS>
+      <SSN>sdfgdfg8dfg</SSN>
+    </BIOS>
+    <VERSIONCLIENT>FusionInventory-Agent_v2.3.19</VERSIONCLIENT>
+  </CONTENT>
+  <DEVICEID>test-pc002</DEVICEID>
+  <QUERY>INVENTORY</QUERY>
+</REQUEST>";
+
+        //create manually a computer
+        $computers_id = $computer->add([
+            'name'   => 'pc003',
+            'serial' => 'sdfgdfg8dfg',
+            'entities_id' => 0
+        ]);
+        $this->integer($computers_id)->isGreaterThan(0);
+
+        $this->doInventory($xml_source, true);
+
+        //check software has been created
+        $this->boolean(
+            $soft->getFromDBByCrit(['name' => 'A great software'])
+        )->isTrue();
+        $softwares_id = $soft->fields['id'];
+
+        //check version has been created
+        $this->boolean(
+            $version->getFromDBByCrit(['name' => '2.0.0'])
+        )->isTrue();
+        $this->integer($version->fields['softwares_id'])->isIdenticalTo($softwares_id);
+        $versions_id = $version->fields['id'];
+
+        //check computer-softwareverison relation has been created
+        $this->boolean($item_version->getFromDBByCrit([
+            "itemtype" => "Computer",
+            "items_id" => $computers_id,
+            "softwareversions_id" => $versions_id,
+            "date_install" => "2014-03-04"
+        ]))->isTrue();
+        $item_versions_id = $item_version->fields['id'];
+
+        $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<REQUEST>
+  <CONTENT>
+      <SOFTWARES>
+      <NAME>A great software</NAME>
+      <VERSION>2.0.0</VERSION>
+      <INSTALL_DATE>2024-03-04 16:12:35</INSTALL_DATE>
+      <PUBLISHER>Manufacture</PUBLISHER>
+    </SOFTWARES>
+    <HARDWARE>
+      <NAME>pc002</NAME>
+    </HARDWARE>
+    <BIOS>
+      <SSN>sdfgdfg8dfg</SSN>
+    </BIOS>
+    <VERSIONCLIENT>FusionInventory-Agent_v2.3.19</VERSIONCLIENT>
+  </CONTENT>
+  <DEVICEID>test-pc002</DEVICEID>
+  <QUERY>INVENTORY</QUERY>
+</REQUEST>";
+
+        //import again
+        $this->doInventory($xml_source, true);
+
+        //check software is the same
+        $this->boolean(
+            $soft->getFromDBByCrit(['name' => 'A great software'])
+        )->isTrue();
+        $this->integer($softwares_id)->isIdenticalTo($soft->fields['id']);
+
+        //check version is the same
+        $this->boolean(
+            $version->getFromDBByCrit(['name' => '2.0.0'])
+        )->isTrue();
+        $this->integer($versions_id)->isIdenticalTo($version->fields['id']);
+
+        //check computer-softwareverison relation has been updated (date_install)
+        $this->boolean($item_version->getFromDBByCrit([
+            "itemtype" => "Computer",
+            "items_id" => $computers_id,
+            "softwareversions_id" => $versions_id,
+            "date_install" => "2024-03-04"
+        ]))->isTrue();
+
+        //check computer-softwareverison relation is the same (ID)
+        $this->integer($item_versions_id)->isIdenticalTo($item_version->fields['id']);
+    }
 }


### PR DESCRIPTION
Like https://github.com/glpi-project/glpi/pull/12634

But for ```Item_SoftwareVersion``` ```date_install```

Add capability of inventory to update ```date_install``` of ```Item_SoftwareVersion``` if needed


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !31593
