### PR TITLE
[HLAPI] Remove expanded path parameters from OpenAPI doc

### DIFF
--- a/src/Api/HL/Controller/ITILController.php
+++ b/src/Api/HL/Controller/ITILController.php
@@ -600,7 +600,7 @@ final class ITILController extends AbstractController
         return $subitem_schema;
     }
 
-    #[Route(path: '/{itemtype}/', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[Route(path: '/{itemtype}', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'List or search Tickets, Changes or Problems',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT],
@@ -635,7 +635,7 @@ final class ITILController extends AbstractController
         return Search::getOneBySchema($this->getKnownSchema($itemtype), $request->getAttributes(), $request->getParameters());
     }
 
-    #[Route(path: '/{itemtype}/', methods: ['POST'])]
+    #[Route(path: '/{itemtype}', methods: ['POST'])]
     #[Doc\Route(
         description: 'Create a new Ticket, Change or Problem',
         parameters: [

--- a/src/Api/HL/OpenAPIGenerator.php
+++ b/src/Api/HL/OpenAPIGenerator.php
@@ -64,7 +64,7 @@ use Glpi\Api\HL\Doc\SchemaReference;
  *      parameters: PathParameterSchema[],
  *      requestBody?: RequestBodySchema,
  * }
- * @phpstan-type RequestBodySchema array{content: array{'application/json': array{schema: SchemaArray}}}
+ * @phpstan-type RequestBodySchema array{content: array{"application/json": array{schema: SchemaArray}}}
  */
 final class OpenAPIGenerator
 {
@@ -403,7 +403,12 @@ EOT;
                             );
                         }
                         // Remove the itemtype path parameter now that it is a static value
-                        unset($temp_expanded['parameters'][$placeholder]);
+                        foreach ($temp_expanded['parameters'] as $param_key => $param) {
+                            if ($param['name'] === $placeholder) {
+                                unset($temp_expanded['parameters'][$param_key]);
+                                break;
+                            }
+                        }
                     }
                     if (!isset($paths[$new_url][$method])) {
                         $expanded[$new_url][$method] = $temp_expanded;

--- a/src/Api/HL/RoutePath.php
+++ b/src/Api/HL/RoutePath.php
@@ -351,14 +351,14 @@ final class RoutePath
 
             // Merge requirements and tags
             $this->route->requirements = array_merge($controller_route->requirements, $this->route->requirements);
-            $this->route->tags = array_merge($controller_route->tags, $this->route->tags);
+            $this->route->tags = array_unique(array_merge($controller_route->tags, $this->route->tags));
 
             if ($controller_route->priority !== Route::DEFAULT_PRIORITY && $this->route->priority === Route::DEFAULT_PRIORITY) {
                 $this->setPriority($controller_route->priority);
             }
 
             // Merge middlewares
-            $this->route->middlewares = array_merge($controller_route->middlewares, $this->route->middlewares);
+            $this->route->middlewares = array_unique(array_merge($controller_route->middlewares, $this->route->middlewares));
 
             // None of the other properties have meaning when on a class
         }

--- a/tests/functional/Glpi/Api/HL/OpenAPIGenerator.php
+++ b/tests/functional/Glpi/Api/HL/OpenAPIGenerator.php
@@ -39,6 +39,37 @@ use HLAPITestCase;
 
 class OpenAPIGenerator extends HLAPITestCase
 {
+    public function testExpandedEndpoints()
+    {
+        $this->login();
+        // Some expanded paths to spot-check
+        $to_check = [
+            '/Assistance/Ticket',
+            '/Assistance/Change',
+            '/Assistance/Problem',
+            '/Assistance/Ticket/{id}',
+            '/Assets/Computer',
+            '/Assets/Computer/{id}',
+            '/Assets/Monitor/{id}',
+        ];
+        $generator = new \Glpi\Api\HL\OpenAPIGenerator(\Glpi\Api\HL\Router::getInstance());
+        $openapi = $generator->getSchema();
+
+        foreach ($to_check as $path) {
+            $this->array($openapi['paths'])->hasKey($path);
+        }
+
+        // Check that the pre-expanded paths are not present
+        $to_check = [
+            '/Assistance/{itemtype}',
+            '/Assistance/{itemtype}/{id}',
+            '/Assets/{itemtype}',
+        ];
+        foreach ($to_check as $path) {
+            $this->array($openapi['paths'])->notHasKey($path);
+        }
+    }
+
     /**
      * Endpoints that get expanded (for example /Assistance/{itemtype} where 'itemtype' is known to be Ticket, Change or Problem)
      * should not list the 'itemtype' parameter in the documentation.

--- a/tests/functional/Glpi/Api/HL/OpenAPIGenerator.php
+++ b/tests/functional/Glpi/Api/HL/OpenAPIGenerator.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Api\HL;
+
+use HLAPITestCase;
+
+class OpenAPIGenerator extends HLAPITestCase
+{
+    /**
+     * Endpoints that get expanded (for example /Assistance/{itemtype} where 'itemtype' is known to be Ticket, Change or Problem)
+     * should not list the 'itemtype' parameter in the documentation.
+     */
+    public function testExpandedAttributesNoParameter()
+    {
+        $this->login();
+        // Some expanded paths to spot-check
+        $to_check = [
+            ['path' => '/Assistance/Ticket', 'placeholder' => 'itemtype'],
+            ['path' => '/Assistance/Change', 'placeholder' => 'itemtype'],
+            ['path' => '/Assistance/Problem', 'placeholder' => 'itemtype'],
+            ['path' => '/Assistance/Ticket/{id}', 'placeholder' => 'itemtype'],
+            ['path' => '/Assistance/Change/{id}', 'placeholder' => 'itemtype'],
+            ['path' => '/Assistance/Problem/{id}', 'placeholder' => 'itemtype'],
+        ];
+
+        $generator = new \Glpi\Api\HL\OpenAPIGenerator(\Glpi\Api\HL\Router::getInstance());
+        $openapi = $generator->getSchema();
+
+        foreach ($to_check as $endpoint) {
+            $this->array(array_filter($openapi['paths'][$endpoint['path']]['get']['parameters'], static fn ($v) => $v['name'] === $endpoint['placeholder']))->size->isEqualTo(0);
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When path parameters like `{itemtype}` were expanded (for example to Ticket, Change and Problem), the parameters were still incorrectly shown.