### PR TITLE
[HLAPI] Fix some parameters incorrectly shown as required

### DIFF
--- a/src/Api/HL/OpenAPIGenerator.php
+++ b/src/Api/HL/OpenAPIGenerator.php
@@ -54,7 +54,7 @@ use Glpi\Api\HL\Doc\SchemaReference;
  *      name: string,
  *      in: string,
  *      description: string,
- *      required: 'true'|'false',
+ *      required: true|false,
  *      schema?: mixed
  * }
  * @phpstan-type PathSchema array{
@@ -528,7 +528,7 @@ EOT;
             'name' => $route_param->getName(),
             'description' => $route_param->getDescription(),
             'in' => $route_param->getLocation(),
-            'required' => $route_param->getRequired() ? 'true' : 'false',
+            'required' => $route_param->getRequired(),
             'schema' => $schema
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Some parameters had the 'required' property set to a string ('true' or 'false') in the OpenAPI doc which always evaluates as true because the OpenAPI spec expects this to be a boolean and Swagger evaluates the value as one. This made parameters like `filter'`, `start` and `limit` required in Swagger UI.