### PR TITLE
Fix singleton property visibility

### DIFF
--- a/src/Form/AnswersHandler/AnswersHandler.php
+++ b/src/Form/AnswersHandler/AnswersHandler.php
@@ -48,7 +48,7 @@ class AnswersHandler
      * Singleton instance
      * @var AnswersHandler|null
      */
-    public static ?AnswersHandler $instance = null;
+    protected static ?AnswersHandler $instance = null;
 
     /**
      * Private constructor to prevent instantiation (singleton)

--- a/src/Form/QuestionType/QuestionTypesManager.php
+++ b/src/Form/QuestionType/QuestionTypesManager.php
@@ -47,7 +47,7 @@ final class QuestionTypesManager
      * Singleton instance
      * @var QuestionTypesManager|null
      */
-    public static ?QuestionTypesManager $instance = null;
+    protected static ?QuestionTypesManager $instance = null;
 
     /**
      * Available question types


### PR DESCRIPTION
These variables should have been protected as the instance is accessed using the dedicated `getInstance()` method.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
