### PR TITLE
Fix(NotificationTargetTicket): add missing ##ticket.externalid## TAG

### DIFF
--- a/src/NotificationTargetTicket.php
+++ b/src/NotificationTargetTicket.php
@@ -547,6 +547,9 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
                 $data['validations'][] = $tmp;
             }
         }
+
+        $data['##ticket.externalid##'] = $item->fields['externalid'];
+
         return $data;
     }
 
@@ -579,6 +582,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
                 __('OLA'),
                 __('Internal time to resolve')
             ),
+            'ticket.externalid'            => __('External ID'),
             'ticket.requesttype'           => RequestType::getTypeName(1),
             'ticket.itemtype'              => __('Item type'),
             'ticket.item.name'             => _n('Associated item', 'Associated items', 1),

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -125,7 +125,7 @@ function loadDataset()
    // Unit test data definition
     $data = [
       // bump this version to force reload of the full dataset, when content change
-        '_version' => '4.11',
+        '_version' => '4.12',
 
       // Type => array of entries
         'Entity' => [
@@ -451,6 +451,7 @@ function loadDataset()
             [
                 'name'           => '_ticket01',
                 'content'        => 'Content for ticket _ticket01',
+                'externalid'     => 'external_id',
                 'users_id_recipient' => TU_USER,
                 'entities_id'    => '_test_root_entity'
             ],

--- a/tests/functional/NotificationTargetTicket.php
+++ b/tests/functional/NotificationTargetTicket.php
@@ -50,6 +50,19 @@ class NotificationTargetTicket extends DbTestCase
         $notiftargetticket = new \NotificationTargetTicket(getItemByTypeName('Entity', '_test_root_entity', true), 'new', $tkt);
         $notiftargetticket->getTags();
 
+        // basic test for ##ticket.externalid## tag
+        $expected = [
+            'tag'             => 'ticket.externalid',
+            'value'           => true,
+            'label'           => 'External ID',
+            'events'          => 0,
+            'foreach'         => false,
+            'lang'            => true,
+            'allowed_values'  => [],
+        ];
+        $this->array($notiftargetticket->tag_descriptions['lang']['##lang.ticket.externalid##'])
+         ->isIdenticalTo($expected);
+
        // basic test for ##task.categorycomment## tag
         $expected = [
             'tag'             => 'task.categorycomment',
@@ -81,6 +94,15 @@ class NotificationTargetTicket extends DbTestCase
         $this->array($notiftargetticket->tag_descriptions['tag']['##task.categoryid##'])
          ->isIdenticalTo($expected);
 
+        // advanced test for ##ticket.externalid## tag
+        $basic_options = [
+            'additionnaloption' => [
+                'usertype' => \NotificationTarget::GLPI_USER,
+            ]
+        ];
+        $ret = $notiftargetticket->getDataForObject($tkt, $basic_options);
+        $this->string($ret['##ticket.externalid##'])->isIdenticalTo("external_id");
+
        // advanced test for ##task.categorycomment## and ##task.categoryid## tags
        // test of the getDataForObject for default language en_GB
         $taskcat = getItemByTypeName('TaskCategory', '_subcat_1');
@@ -103,11 +125,6 @@ class NotificationTargetTicket extends DbTestCase
             ]
         ];
 
-        $basic_options = [
-            'additionnaloption' => [
-                'usertype' => \NotificationTarget::GLPI_USER,
-            ]
-        ];
         $ret = $notiftargetticket->getDataForObject($tkt, $basic_options);
 
         $this->array($ret['tasks'])->isIdenticalTo($expected);


### PR DESCRIPTION
add missing ```##ticket.externalid##``` TAG


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !31246
