### PR TITLE
Handle search button with JS only

### DIFF
--- a/templates/components/search/query_builder/main.html.twig
+++ b/templates/components/search/query_builder/main.html.twig
@@ -108,7 +108,7 @@
             <span class="ms-auto btn-group">
                 {% if (showaction) %}
                 {# Display submit button #}
-                <button class="btn btn-sm btn-primary" type="submit" name="{{ p['actionname'] }}">
+                <button class="btn btn-sm btn-primary" type="button" name="{{ p['actionname'] }}">
                     <i class="ti ti-search"></i>
                     <span class="d-none d-sm-block">{{ p['actionvalue'] }}</span>
                 </button>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

While working on troubleshooting a performance issue related to Criteria Filters and followups in the Webhook feature, I found that in some cases clicking the Preview or Search buttons would redirect to the search URL for followups (which doesn't exist and wouldn't be desired behavior anyways in this case). When the Fluid Search feature was added, the old button types and click handlers were left in place. While this was great as a fallback option when the fluid search's JS failed for some reason, it is now causing issues on its own. I believe the handling defined by the JS to use the AJAX script to reload results with a simple page refresh as a fallback is sufficient now and provides the desired behavior in both regular searches and within the Criteria Filter feature.