### PR TITLE
Do not refer to search options by ID literals

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -555,7 +555,7 @@ class Search
      **/
     public static function addDefaultToView($itemtype, $params)
     {
-        return SearchEngine::addDefaultToView($itemtype, $params);
+        return SearchOption::getDefaultToView($itemtype, $params);
     }
 
 

--- a/src/Search/SearchOption.php
+++ b/src/Search/SearchOption.php
@@ -690,15 +690,20 @@ final class SearchOption implements \ArrayAccess
             $entity_check = $item->isEntityAssign();
         }
 
-        // Add the related search option for the 'name' OR 'id' field. If none is found, add the search option 1 (how it was handled before).
-        // Since not all itemtypes have ID set to 1, it used to add other, heavier search options like content in the case of Followups.
-        $options = array_filter(self::getOptionsForItemtype($itemtype, false), static fn ($o) => is_numeric($o), ARRAY_FILTER_USE_KEY);
-        $id_field = array_filter($options, static function ($option) use ($itemtype) {
-            return $option['field'] === 'id' && $option['table'] === $itemtype::getTable();
-        });
-        $name_field = array_filter($options, static function ($option) use ($itemtype) {
-            return $option['field'] === 'name' && $option['table'] === $itemtype::getTable();
-        });
+        if ($itemtype !== \AllAssets::getType()) {
+            // Add the related search option for the 'name' OR 'id' field. If none is found, add the search option 1 (how it was handled before).
+            // Since not all itemtypes have ID set to 1, it used to add other, heavier search options like content in the case of Followups.
+            $options = array_filter(self::getOptionsForItemtype($itemtype, false), static fn($o) => is_numeric($o), ARRAY_FILTER_USE_KEY);
+            $id_field = array_filter($options, static function ($option) use ($itemtype) {
+                return $option['field'] === 'id' && $option['table'] === $itemtype::getTable();
+            });
+            $name_field = array_filter($options, static function ($option) use ($itemtype) {
+                return $option['field'] === 'name' && $option['table'] === $itemtype::getTable();
+            });
+        } else {
+            $id_field = [];
+            $name_field = [];
+        }
 
         if (count($name_field) > 0) {
             $toview[] = array_keys($name_field)[0];
@@ -709,26 +714,34 @@ final class SearchOption implements \ArrayAccess
             $toview[] = 1;
         }
 
-        if (isset($params['as_map']) && (int) $params['as_map'] === 1) {
-            // Add location name when map mode
-            $loc_opt = self::getOptionNumber($itemtype, 'locations_id');
-            if ($loc_opt > 0) {
-                $toview[] = $loc_opt;
+        if ($itemtype !== \AllAssets::getType()) {
+            if (isset($params['as_map']) && (int)$params['as_map'] === 1) {
+                // Add location name when map mode
+                $loc_opt = self::getOptionNumber($itemtype, 'locations_id');
+                if ($loc_opt > 0) {
+                    $toview[] = $loc_opt;
+                }
             }
+        } else {
+            $toview[] = 3;
         }
 
-        // Add entity view :
-        if (
-            \Session::isMultiEntitiesMode()
-            && $entity_check
-            && (isset($CFG_GLPI["union_search_type"][$itemtype])
-                || ($item && $item->maybeRecursive())
-                || isset($_SESSION['glpiactiveentities']) && (count($_SESSION["glpiactiveentities"]) > 1))
-        ) {
-            $entity_opt = self::getOptionNumber($itemtype, 'entities_id');
-            if ($entity_opt > 0) {
-                $toview[] = $entity_opt;
+        if ($itemtype !== \AllAssets::getType()) {
+            // Add entity view :
+            if (
+                \Session::isMultiEntitiesMode()
+                && $entity_check
+                && (isset($CFG_GLPI["union_search_type"][$itemtype])
+                    || ($item && $item->maybeRecursive())
+                    || isset($_SESSION['glpiactiveentities']) && (count($_SESSION["glpiactiveentities"]) > 1))
+            ) {
+                $entity_opt = self::getOptionNumber($itemtype, 'entities_id');
+                if ($entity_opt > 0) {
+                    $toview[] = $entity_opt;
+                }
             }
+        } else {
+            $toview[] = 80;
         }
         return $toview;
     }

--- a/src/Search/SearchOption.php
+++ b/src/Search/SearchOption.php
@@ -715,35 +715,36 @@ final class SearchOption implements \ArrayAccess
             $toview[] = 1;
         }
 
-        if ($itemtype !== \AllAssets::getType()) {
-            if (isset($params['as_map']) && (int)$params['as_map'] === 1) {
+        if (isset($params['as_map']) && (int)$params['as_map'] === 1) {
+            if ($itemtype !== \AllAssets::getType()) {
                 // Add location name when map mode
                 $loc_opt = self::getOptionNumber($itemtype, 'completename', 'Location');
                 if ($loc_opt > 0) {
                     $toview[] = $loc_opt;
                 }
+            } else {
+                $toview[] = 3;
             }
-        } else {
-            $toview[] = 3;
         }
 
-        if ($itemtype !== \AllAssets::getType()) {
-            // Add entity view :
-            if (
-                \Session::isMultiEntitiesMode()
-                && $entity_check
-                && (isset($CFG_GLPI["union_search_type"][$itemtype])
-                    || ($item && $item->maybeRecursive())
-                    || isset($_SESSION['glpiactiveentities']) && (count($_SESSION["glpiactiveentities"]) > 1))
-            ) {
+        // Add entity view :
+        if (
+            \Session::isMultiEntitiesMode()
+            && $entity_check
+            && (isset($CFG_GLPI["union_search_type"][$itemtype])
+                || ($item && $item->maybeRecursive())
+                || isset($_SESSION['glpiactiveentities']) && (count($_SESSION["glpiactiveentities"]) > 1))
+        ) {
+            if ($itemtype !== \AllAssets::getType()) {
                 $entity_opt = self::getOptionNumber($itemtype, 'completename', 'Entity');
                 if ($entity_opt > 0) {
                     $toview[] = $entity_opt;
                 }
+            } else {
+                $toview[] = 80;
             }
-        } else {
-            $toview[] = 80;
         }
+
         return $toview;
     }
 }

--- a/src/Search/SearchOption.php
+++ b/src/Search/SearchOption.php
@@ -576,22 +576,23 @@ final class SearchOption implements \ArrayAccess
      *
      * Get an option number in the SEARCH_OPTION array
      *
-     * @param class-string<\CommonDBTM> $itemtype  Item type
-     * @param string $field     Name
+     * @param class-string<\CommonDBTM> $itemtype  Item type the search option belongs to
+     * @param string $field     Name of the field
+     * @param class-string<\CommonDBTM>|null $meta_itemtype  If specified, the itemtype that provides the search option. This affects the table used to match the search option.
      *
      * @return integer
      **/
-    public static function getOptionNumber($itemtype, $field): int
+    public static function getOptionNumber($itemtype, $field, $meta_itemtype = null): int
     {
-
-        $table = $itemtype::getTable();
+        $meta_itemtype ??= $itemtype;
+        $table = $meta_itemtype::getTable();
         $opts  = self::getOptionsForItemtype($itemtype);
 
         foreach ($opts as $num => $opt) {
             if (
                 is_array($opt) && isset($opt['table'])
-                && ($opt['table'] == $table)
-                && ($opt['field'] == $field)
+                && ($opt['table'] === $table)
+                && ($opt['field'] === $field)
             ) {
                 return $num;
             }
@@ -717,7 +718,7 @@ final class SearchOption implements \ArrayAccess
         if ($itemtype !== \AllAssets::getType()) {
             if (isset($params['as_map']) && (int)$params['as_map'] === 1) {
                 // Add location name when map mode
-                $loc_opt = self::getOptionNumber($itemtype, 'locations_id');
+                $loc_opt = self::getOptionNumber($itemtype, 'completename', 'Location');
                 if ($loc_opt > 0) {
                     $toview[] = $loc_opt;
                 }
@@ -735,7 +736,7 @@ final class SearchOption implements \ArrayAccess
                     || ($item && $item->maybeRecursive())
                     || isset($_SESSION['glpiactiveentities']) && (count($_SESSION["glpiactiveentities"]) > 1))
             ) {
-                $entity_opt = self::getOptionNumber($itemtype, 'entities_id');
+                $entity_opt = self::getOptionNumber($itemtype, 'completename', 'Entity');
                 if ($entity_opt > 0) {
                     $toview[] = $entity_opt;
                 }

--- a/tests/functional/KnowbaseItem.php
+++ b/tests/functional/KnowbaseItem.php
@@ -1449,6 +1449,7 @@ HTML,
         $names = empty($names) ? [] : explode("\n", $names);
 
         // Check results
-        $this->array($names)->isEqualTo($articles);
+        $this->array($names)->size->isEqualTo(count($articles));
+        $this->array($names)->containsValues($articles);
     }
 }

--- a/tests/functional/Search.php
+++ b/tests/functional/Search.php
@@ -2287,7 +2287,8 @@ class Search extends DbTestCase
         $names = explode("\n", trim($names));
 
        // Check results
-        $this->array($names)->isEqualTo($expected);
+        $this->array($names)->size->isEqualTo(count($expected));
+        $this->array($names)->containsValues($expected);
     }
 
     protected function testMyselfSearchCriteriaProvider(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !31553

The search engine makes some assumptions about search option IDs that is correct in *most* cases, but not all (like Followups). Rather than mess with changing search option IDs, the better solution is to replace all cases where we use hard-coded search option IDs to refer to a specific option.

For example, it assumes that ID 1 is always present and always the name field. In followups, this is the content field. Having the content field shown by default is very resource intensive. Worse, the default sort is always ID 1 which means the search query suddenly becomes much less performant as it has to scan the entire table. When creating criteria filters for followups in the webhook feature on a database with 1.5 million followups, it was taking approximately 18 seconds to load the tab. With these changes, I expect it to be a few ms only.