### PR TITLE
Remove duplicated imports of jQuery UI

### DIFF
--- a/.webpack.config.js
+++ b/.webpack.config.js
@@ -51,6 +51,12 @@ let config = {
                 use: ['script-loader', 'strip-sourcemap-loader'],
             },
             {
+                // Test for a polyfill (or any file) and it won't be included in your
+                // bundle
+                test: path.resolve(__dirname, 'node_modules/jquery.fancytree/dist/modules/jquery.fancytree.ui-deps.js'),
+                use: 'null-loader',
+            },
+            {
             // Build styles
                 test: /\.css$/,
                 use: [MiniCssExtractPlugin.loader, 'css-loader'],

--- a/lib/bundles/base.js
+++ b/lib/bundles/base.js
@@ -48,6 +48,16 @@ window.$.migrateTrace = false;
 // jQuery plugins
 require('fittext.js');
 
+// jQuery UI widgets required by
+// - jquery-file-upload (widget)
+// - jquery.fancytree (widget, position, jquery-patch, keycode, scroll-parent, unique-id)
+require('jquery-ui/ui/widget');
+require('jquery-ui/ui/position');
+require('jquery-ui/ui/jquery-patch');
+require('jquery-ui/ui/keycode');
+require('jquery-ui/ui/scroll-parent');
+require('jquery-ui/ui/unique-id');
+
 // jQuery fancttree
 require('jquery.fancytree');
 require('jquery.fancytree/dist/modules/jquery.fancytree.grid');
@@ -58,11 +68,6 @@ import 'jquery.fancytree/dist/skin-awesome/ui.fancytree.css';
 import PlainScrollbar from 'exports-loader?exports=default|PlainScrollbar!plain-scrollbar';
 import 'plain-scrollbar/plain-scrollbar.css';
 window.PlainScrollbar = PlainScrollbar;
-
-
-// jQuery UI widgets required by
-// - jquery-file-upload (widget)
-require('jquery-ui/ui/widget');
 
 // Tabler
 import '@tabler/core';

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,7 @@
                 "jest-environment-jsdom": "^29.7.0",
                 "jest-extended": "^4.0.2",
                 "mini-css-extract-plugin": "^2.7.7",
+                "null-loader": "^4.0.1",
                 "script-loader": "^0.7.2",
                 "strip-sourcemap-loader": "^0.0.1",
                 "stylelint": "^16.2.0",
@@ -2895,6 +2896,15 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
+        "node_modules/big.js": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+            "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -3909,6 +3919,15 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true
+        },
+        "node_modules/emojis-list": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+            "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+            "dev": true,
+            "engines": {
+                "node": ">= 4"
+            }
         },
         "node_modules/encoding": {
             "version": "0.1.13",
@@ -7550,6 +7569,20 @@
                 "node": ">=6.11.5"
             }
         },
+        "node_modules/loader-utils": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+            "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+            "dev": true,
+            "dependencies": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^3.0.0",
+                "json5": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=8.9.0"
+            }
+        },
         "node_modules/locate-path": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -7850,6 +7883,44 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/null-loader": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/null-loader/-/null-loader-4.0.1.tgz",
+            "integrity": "sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==",
+            "dev": true,
+            "dependencies": {
+                "loader-utils": "^2.0.0",
+                "schema-utils": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^4.0.0 || ^5.0.0"
+            }
+        },
+        "node_modules/null-loader/node_modules/schema-utils": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+            "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+            "dev": true,
+            "dependencies": {
+                "@types/json-schema": "^7.0.8",
+                "ajv": "^6.12.5",
+                "ajv-keywords": "^3.5.2"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/nwsapi": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
         "jest-environment-jsdom": "^29.7.0",
         "jest-extended": "^4.0.2",
         "mini-css-extract-plugin": "^2.7.7",
+        "null-loader": "^4.0.1",
         "script-loader": "^0.7.2",
         "strip-sourcemap-loader": "^0.0.1",
         "stylelint": "^16.2.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

`jquery-ui-widget` was loaded twice because it is unexpectedly loaded by the `jquery.fancytree` package. I disabled the `jquery.fancytree/dist/modules/jquery.fancytree.ui-deps.js` file inclusion using the `WebPack` `null-loader`, and added required widgets in our bundle file.