### PR TITLE
Remove buttons above user and group search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,7 @@ The present file will list all changes made to the project; according to the
 - `Glpi\System\Requirement\ProtectedWebAccess` class.
 - `Glpi\System\Requirement\SafeDocumentRoot` class.
 - `Glpi\System\Status\StatusChecker::getFullStatus()`
+- `Group::title()`
 - `Html::clean()`
 - `KnowbaseItem::addToFaq()`
 - `KnowbaseItem::addVisibilityJoins()`
@@ -271,6 +272,7 @@ The present file will list all changes made to the project; according to the
 - `Toolbox::sodiumDecrypt()`
 - `Toolbox::sodiumEncrypt()`
 - `Toolbox::unclean_cross_side_scripting_deep()`
+- `User::title()`
 - `XML` class.
 - Usage of `Search::addOrderBy` signature with ($itemtype, $ID, $order) parameters
 - Javascript file upload functions `dataURItoBlob`, `extractSrcFromImgTag`, `insertImgFromFile()`, `insertImageInTinyMCE`, `isImageBlobFromPaste`, `isImageFromPaste`.

--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -78,7 +78,7 @@
     --glpi-form-toolbar-bg: #f5f5f5;
     --glpi-topbar-height: 79px;
     --glpi-contextbar-height: 56px;
-    --glpi-content-margin: 20px;
+    --glpi-content-margin: 24px;
     --glpi-scrollbar-thumb-color: color-mix(in srgb, var(--tblr-secondary), transparent 20%);
     --glpi-scrollbar-track-color: transparent;
     --glpi-itil-secondary-bg: #f5f5f5;

--- a/front/group.php
+++ b/front/group.php
@@ -39,9 +39,6 @@ Session::checkRight("group", READ);
 
 Html::header(Group::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "admin", "group");
 
-$group = new Group();
-$group->title();
-
 Search::show('Group');
 
 Html::footer();

--- a/front/user.php
+++ b/front/user.php
@@ -39,9 +39,6 @@ Session::checkRight("user", READ);
 
 Html::header(User::getTypeName(Session::getPluralNumber()), '', "admin", "user");
 
-$user = new User();
-$user->title();
-
 Search::show('User');
 
 Html::footer();

--- a/src/Group.php
+++ b/src/Group.php
@@ -227,31 +227,17 @@ class Group extends CommonTreeDropdown
         ]);
     }
 
-    /**
-     * Print a good title for group pages
-     *
-     *@return void
-     **/
-    public function title()
+    public static function getAdditionalMenuLinks()
     {
-        $buttons = [];
+        $links = [];
         if (
-            Group::canUpdate()
-            && Session::haveRight("user", User::UPDATEAUTHENT)
-            && AuthLDAP::useAuthLdap()
+            AuthLDAP::useAuthLdap()
+            && Session::haveRight("user", User::IMPORTEXTAUTHUSERS)
+            && static::canUpdate()
         ) {
-            $buttons["ldap.group.php"] = "<i class='fas fa-users-cog fa-lg me-2'></i>" . __('LDAP directory link');
-            $title                     = "";
-        } else {
-            $title = "<i class='fas fa-users fa-lg me-2'></i>" . self::getTypeName(Session::getPluralNumber());
+            $links['<i class="ti ti-settings"></i><span>' . __s('LDAP directory link') . '</span>'] = "ldap.group.php";
         }
-
-        Html::displayTitle(
-            "",
-            self::getTypeName(Session::getPluralNumber()),
-            $title,
-            $buttons
-        );
+        return $links;
     }
 
     public function getSpecificMassiveActions($checkitem = null)

--- a/src/User.php
+++ b/src/User.php
@@ -130,6 +130,20 @@ class User extends CommonDBTM
         return false;
     }
 
+    public static function getAdditionalMenuLinks()
+    {
+        $links = [];
+        if (Auth::useAuthExt() && Session::haveRight('user', self::IMPORTEXTAUTHUSERS)) {
+            if (static::canCreate()) {
+                $ext_auth_label = __s('Add from an external source');
+                $links['<i class="ti ti-user-cog"></i>' . $ext_auth_label] = 'user.form.php?new=1&amp;ext_auth=1';
+            }
+            if (static::canCreate() || static::canUpdate()) {
+                $links['<i class="ti ti-settings"></i><span>' . __s('LDAP directory link') . '</span>'] = "ldap.php";
+            }
+        }
+        return $links;
+    }
 
     public function canViewItem()
     {
@@ -2489,49 +2503,6 @@ class User extends CommonDBTM
             );
         }
     }
-
-
-    /**
-     * Print a good title for user pages.
-     *
-     * @return void
-     */
-    public function title()
-    {
-        /** @var array $CFG_GLPI */
-        global $CFG_GLPI;
-
-        $buttons = [];
-        $title   = self::getTypeName(Session::getPluralNumber());
-
-        if (static::canCreate()) {
-            $buttons["user.form.php"] = "<i class='fas fa-user-plus fa-lg me-2'></i>" . __('Add user...');
-            $title = __("Actions");
-
-            if (
-                Auth::useAuthExt()
-                && Session::haveRight("user", self::IMPORTEXTAUTHUSERS)
-            ) {
-                // This requires write access because don't use entity config.
-                $buttons["user.form.php?new=1&amp;ext_auth=1"] = "<i class='fas fa-user-cog fa-lg me-2'></i>" . __('... From an external source');
-            }
-        }
-        if (
-            Session::haveRight("user", self::IMPORTEXTAUTHUSERS)
-            && (static::canCreate() || static::canUpdate())
-        ) {
-            if (AuthLDAP::useAuthLdap()) {
-                $buttons["ldap.php"] = "<i class='fas fa-cog fa-lg me-2'></i>" . __('LDAP directory link');
-            }
-        }
-        Html::displayTitle(
-            "",
-            self::getTypeName(Session::getPluralNumber()),
-            $title,
-            $buttons
-        );
-    }
-
 
     /**
      * Check if current user have more right than the specified one.

--- a/src/User.php
+++ b/src/User.php
@@ -136,7 +136,7 @@ class User extends CommonDBTM
         if (Auth::useAuthExt() && Session::haveRight('user', self::IMPORTEXTAUTHUSERS)) {
             if (static::canCreate()) {
                 $ext_auth_label = __s('Add from an external source');
-                $links['<i class="ti ti-user-cog"></i>' . $ext_auth_label] = 'user.form.php?new=1&amp;ext_auth=1';
+                $links['<i class="ti ti-user-cog"></i><span>' . $ext_auth_label . '</span>'] = 'user.form.php?new=1&amp;ext_auth=1';
             }
             if (static::canCreate() || static::canUpdate()) {
                 $links['<i class="ti ti-settings"></i><span>' . __s('LDAP directory link') . '</span>'] = "ldap.php";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

To avoid double scrollbar on these search pages, the buttons that were above the search have been moved to the top of the page. This also helps keep the UI consistent with other pages.
Even after moving the buttons, there was still a double scrollbar but without any clear reason so I made a small adjustment to the content-margin CSS variable to compensate.

There are two other pages with display alerts/messages above the search which also give the double scrollbar issue, but the fix is more complex so it will be done in another PR.