### PR TITLE
fix(project): warning on null content

### DIFF
--- a/src/RichText/RichText.php
+++ b/src/RichText/RichText.php
@@ -295,7 +295,7 @@ final class RichText
         ];
         $p = array_replace($p, $params);
 
-        $content_size = strlen($content);
+        $content_size = strlen($content ?? '');
 
        // Sanitize content first (security and to decode HTML entities)
         $content = self::getSafeHtml($content);


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Prevent warning message:

![image](https://github.com/glpi-project/glpi/assets/8530352/e16da5b8-2054-4398-a32b-b4bf4633ca5a)

```
glpiphplog.NOTICE:   *** PHP Deprecated function (8192): strlen(): Passing null to parameter #1 ($string) of type string is deprecated in .../src/RichText/RichText.php at line 298
  Backtrace :
  src/RichText/RichText.php:298                      strlen()
  src/ProjectTask.php:1158                           Glpi\RichText\RichText::getEnhancedHtml()
  src/ProjectTask.php:1234                           ProjectTask::showFor()
  src/CommonGLPI.php:694                             ProjectTask::displayTabContentForItem()
  ajax/common.tabs.php:120                           CommonGLPI::displayStandardTab()
  public/index.php:82                                require()
```
