### PR TITLE
Add agent inventory action hooks

### DIFF
--- a/src/Inventory/Request.php
+++ b/src/Inventory/Request.php
@@ -349,9 +349,14 @@ class Request extends AbstractRequest
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $data = Plugin::doHook(Hooks::PRE_INVENTORY, $data);
-        if ($data === null) {
-            $this->addError('Rejected by a plugin', 400);
+        try {
+            $data = Plugin::doHook(Hooks::PRE_INVENTORY, $data);
+            if ($data === null) {
+                $this->addError('Rejected by a plugin: No reason specified', 400);
+                return;
+            }
+        } catch (\Exception $e) {
+            $this->addError('Rejected by a plugin: ' . $e->getMessage(), 400);
             return;
         }
 

--- a/src/Plugin/Hooks.php
+++ b/src/Plugin/Hooks.php
@@ -126,7 +126,9 @@ class Hooks
     const INVENTORY_GET_PARAMS = 'inventory_get_params';
     /** @var string Hook called before the inventory submission is handled.
      *              You may modify the inventory data which is passed as a parameter (stdClass) and return the modified data.
-     *              Returning null will cancel the inventory submission.
+     *              Returning null will cancel the inventory submission with no specific reason.
+     *              Throwing an Exception will cancel the inventory submission with the exception message as the reason.
+     *              To avoid unrelated exception messages from being sent to the agent, you must handle all exceptions (except the one you would throw to cancel the inventory) within the hook function.
      */
     const PRE_INVENTORY = 'pre_inventory';
     /** @var string Hook called after the inventory submission is handled.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Adds 2 new hooks:
- `pre_inventory`: Called before the inventory is processed. Plugins may use this to modify the data or reject it completely.
- `post_inventory`: Called after the inventory is processed and only when it was successful.