### PR TITLE
Basic OAuth scopes implementation

### DIFF
--- a/src/Api/HL/Controller/AdministrationController.php
+++ b/src/Api/HL/Controller/AdministrationController.php
@@ -415,7 +415,7 @@ final class AdministrationController extends AbstractController
         return $emails;
     }
 
-    #[Route(path: '/User/me', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[Route(path: '/User/Me', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get the current user',
         responses: [
@@ -428,7 +428,7 @@ final class AdministrationController extends AbstractController
         return Search::getOneBySchema($this->getKnownSchema('User'), ['id' => $my_user_id], $request->getParameters());
     }
 
-    #[Route(path: '/User/me/emails', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[Route(path: '/User/Me/Email', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get the current user\'s email addresses',
         responses: [
@@ -440,7 +440,7 @@ final class AdministrationController extends AbstractController
         return new JSONResponse($this->getEmailDataForUser($this->getMyUserID()));
     }
 
-    #[Route(path: '/User/me/emails', methods: ['POST'])]
+    #[Route(path: '/User/Me/Email', methods: ['POST'])]
     #[Doc\Route(
         description: 'Create a new email address for the current user',
         parameters: [
@@ -499,7 +499,7 @@ final class AdministrationController extends AbstractController
         return self::getCRUDCreateResponse($emails_id, self::getAPIPathForRouteFunction(self::class, 'getMyEmail', ['id' => $emails_id]));
     }
 
-    #[Route(path: '/User/me/emails/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
+    #[Route(path: '/User/Me/Email/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
         description: 'Get a specific email address for the current user',
         responses: [
@@ -511,6 +511,24 @@ final class AdministrationController extends AbstractController
         $emails = $this->getEmailDataForUser($this->getMyUserID());
         foreach ($emails as $email) {
             if ($email['id'] == $request->getAttribute('id')) {
+                return new JSONResponse($email);
+            }
+        }
+        return self::getNotFoundErrorResponse();
+    }
+
+    #[Route(path: '/User/Me/Emails/Default', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[Doc\Route(
+        description: 'Get a specific email address for the current user',
+        responses: [
+            ['schema' => 'EmailAddress']
+        ]
+    )]
+    public function getMyDefaultEmail(Request $request): Response
+    {
+        $emails = $this->getEmailDataForUser($this->getMyUserID());
+        foreach ($emails as $email) {
+            if ($email['is_default']) {
                 return new JSONResponse($email);
             }
         }
@@ -533,7 +551,7 @@ final class AdministrationController extends AbstractController
         return \Toolbox::sendFile($picture_path, $username, null, false, true);
     }
 
-    #[Route(path: '/User/me/Picture', methods: ['GET'])]
+    #[Route(path: '/User/Me/Picture', methods: ['GET'])]
     #[Doc\Route(
         description: 'Get the picture for the current user'
     )]

--- a/src/Api/HL/Controller/AdministrationController.php
+++ b/src/Api/HL/Controller/AdministrationController.php
@@ -519,7 +519,7 @@ final class AdministrationController extends AbstractController
 
     #[Route(path: '/User/Me/Emails/Default', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
     #[Doc\Route(
-        description: 'Get a specific email address for the current user',
+        description: 'Get the default email address for the current user',
         responses: [
             ['schema' => 'EmailAddress']
         ]

--- a/src/Api/HL/Middleware/OAuthRequestMiddleware.php
+++ b/src/Api/HL/Middleware/OAuthRequestMiddleware.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Api\HL\Middleware;
+
+use CommonDBTM;
+use Glpi\Api\HL\Controller\AbstractController;
+use Glpi\Api\HL\Doc\Route;
+use Glpi\Api\HL\RoutePath;
+use Glpi\Api\HL\Router;
+use Glpi\Http\Request;
+use Glpi\Http\Response;
+
+/**
+ * Handles OAuth scopes
+ */
+class OAuthRequestMiddleware extends AbstractMiddleware implements RequestMiddlewareInterface
+{
+    public function process(MiddlewareInput $input, callable $next): void
+    {
+        $route_path = $input->route_path->getRoutePath();
+        if (isCommandLine() || $input->route_path->getRouteSecurityLevel() === \Glpi\Api\HL\Route::SECURITY_NONE) {
+            $next($input);
+            return;
+        }
+        // If OAuth scopes are expanded to be more endpoint-specific, the Route attributes should be updated with the ability to specify the scopes,
+        // and the middleware should check the scopes against the scopes allowed/requested for the client.
+        //TODO Handle 'inventory' scope. I guess the agent communication needs redirected through the API.
+
+        if (strcasecmp($route_path, '/Administration/User/Me/Email/Default') === 0) {
+            $scopes_required = ['OR' => ['email', 'user']];
+        } else if (
+            strcasecmp($route_path, '/Administration/User/Me') === 0
+            || str_starts_with(strtolower($route_path), '/administration/user/me/')
+        ) {
+            $scopes_required = ['OR' => ['user']];
+        } else if (str_starts_with(strtolower($route_path), '/status')) {
+            $scopes_required = ['OR' => ['status']];
+        } else {
+            $scopes_required = ['OR' => ['api']];
+        }
+
+        $client = Router::getInstance()->getCurrentClient();
+        if ($client === null) {
+            $input->response = AbstractController::getAccessDeniedErrorResponse();
+            return;
+        }
+        foreach ($scopes_required['OR'] as $scope) {
+            if (in_array($scope, $client['scopes'], true)) {
+                $next($input);
+                return;
+            }
+        }
+
+        $input->response = AbstractController::getAccessDeniedErrorResponse();
+    }
+}

--- a/src/Api/HL/OpenAPIGenerator.php
+++ b/src/Api/HL/OpenAPIGenerator.php
@@ -39,6 +39,7 @@ use Glpi\Api\HL\Controller\ProjectController;
 use Glpi\Api\HL\Doc\Response;
 use Glpi\Api\HL\Doc\Schema;
 use Glpi\Api\HL\Doc\SchemaReference;
+use Glpi\OAuth\Server;
 
 /**
  * @phpstan-type OpenAPIInfo array{title: string, version: string, license: array{name: string, url: string}}
@@ -434,6 +435,10 @@ EOT;
      */
     private function getSecuritySchemeComponents(): array
     {
+        $scopes = Server::getAllowedScopes();
+        $scope_descriptions = Server::getScopeDescriptions();
+        $scopes = array_combine(array_keys($scopes), $scope_descriptions);
+
         return [
             'oauth' => [
                 'type' => 'oauth2',
@@ -442,9 +447,11 @@ EOT;
                         'authorizationUrl' => '/api.php/authorize',
                         'tokenUrl' => '/api.php/token',
                         'refreshUrl' => '/api.php/token',
+                        'scopes' => $scopes
                     ],
                     'password' => [
                         'tokenUrl' => '/api.php/token',
+                        'scopes' => $scopes
                     ]
                 ]
             ],

--- a/src/Api/HL/Router.php
+++ b/src/Api/HL/Router.php
@@ -57,6 +57,7 @@ use Glpi\Api\HL\Middleware\DebugRequestMiddleware;
 use Glpi\Api\HL\Middleware\DebugResponseMiddleware;
 use Glpi\Api\HL\Middleware\IPRestrictionRequestMiddleware;
 use Glpi\Api\HL\Middleware\MiddlewareInput;
+use Glpi\Api\HL\Middleware\OAuthRequestMiddleware;
 use Glpi\Api\HL\Middleware\RequestMiddlewareInterface;
 use Glpi\Api\HL\Middleware\ResponseMiddlewareInterface;
 use Glpi\Api\HL\Middleware\ResultFormatterMiddleware;
@@ -198,6 +199,7 @@ EOT;
             $instance->registerAuthMiddleware(new CookieAuthMiddleware(), 0, static fn(RoutePath $route_path) => false);
 
             $instance->registerRequestMiddleware(new IPRestrictionRequestMiddleware());
+            $instance->registerRequestMiddleware(new OAuthRequestMiddleware());
             $instance->registerRequestMiddleware(new CRUDRequestMiddleware(), 0, static function (RoutePath $route_path) {
                 return \Toolbox::hasTrait($route_path->getControllerInstance(), CRUDControllerTrait::class);
             });

--- a/src/OAuth/Server.php
+++ b/src/OAuth/Server.php
@@ -155,8 +155,24 @@ final class Server
      */
     public static function getAllowedScopes(): array
     {
-        // Not yet supported
-        return [];
+        return [
+            'email' => 'email',
+            'user' => 'user',
+            'api' => 'api',
+            'inventory' => 'inventory',
+            'status' => 'status',
+        ];
+    }
+
+    public static function getScopeDescriptions(): array
+    {
+        return [
+            'email' => __('Access to the user\'s email address'),
+            'user' => __('Access to the user\'s information'),
+            'api' => __('Access to the API'),
+            'inventory' => __('Access to submit inventory from an agent'),
+            'status' => __('Access to the status endpoint'),
+        ];
     }
 
     public static function generateKeys(): void

--- a/src/OAuthClient.php
+++ b/src/OAuthClient.php
@@ -202,5 +202,6 @@ final class OAuthClient extends CommonDBTM
     public function post_getEmpty()
     {
         $this->fields['grants'] = [];
+        $this->fields['scopes'] = [];
     }
 }

--- a/templates/pages/oauth/authorize.html.twig
+++ b/templates/pages/oauth/authorize.html.twig
@@ -36,29 +36,38 @@
 {% extends 'layout/page_card_notlogged.html.twig' %}
 
 {% block content_block %}
-   <form method="post">
-      <div class="card">
-         <div class="card-header">
-            <h3 class="card-title">{{ __('%s wants to access your GLPI account')|format(client.name) }}</h3>
-            <h4 class="card-subtitle">
-               {{ include('components/user/picture.html.twig', {
-                  'users_id': user.fields['id'],
-                  'with_link': false,
-                  'avatar_size': '',
-               }) }}
-               <span class="ms-2">{{ get_item_name(user) }}</span>
-            </h4>
-         </div>
-         <div class="card-body">
-            {# TODO Implement scopes #}
-            <p>{{ __('This application will be able to access your account and perform actions on your behalf') }}</p>
-         </div>
-         <div class="card-footer">
-            <div class="d-flex justify-content-end">
-               <button type="submit" name="accept" class="btn btn-primary">{{ __('Accept') }}</button>
-               <button type="submit" name="deny" class="btn btn-secondary ms-2">{{ __('Deny') }}</button>
+    <form method="post">
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title">{{ __('%s wants to access your GLPI account')|format(client.name) }}</h3>
+                <h4 class="card-subtitle">
+                    {{ include('components/user/picture.html.twig', {
+                        'users_id': user.fields['id'],
+                        'with_link': false,
+                        'avatar_size': '',
+                    }) }}
+                    <span class="ms-2">{{ get_item_name(user) }}</span>
+                </h4>
             </div>
-         </div>
-      </div>
-   </form>
+            <div class="card-body">
+                {% set scope_descriptions = call('Glpi\\OAuth\\Server::getScopeDescriptions') %}
+                <p>{{ __('This application will be able to access your account and perform the following actions on your behalf:') }}</p>
+                <ul>
+                    {% if scopes|length > 0 %}
+                        {% for scope in scopes %}
+                            <li>{{ scope_descriptions[scope.identifier] }}</li>
+                        {% endfor %}
+                    {% else %}
+                        <li>{{ __('No specific permissions requested') }}</li>
+                    {% endif %}
+                </ul>
+            </div>
+            <div class="card-footer">
+                <div class="d-flex justify-content-end">
+                    <button type="submit" name="accept" class="btn btn-primary">{{ __('Accept') }}</button>
+                    <button type="submit" name="deny" class="btn btn-secondary ms-2">{{ __('Deny') }}</button>
+                </div>
+            </div>
+        </div>
+    </form>
 {% endblock %}

--- a/templates/pages/setup/oauthclient.html.twig
+++ b/templates/pages/setup/oauthclient.html.twig
@@ -76,13 +76,6 @@
                                 }) }}
                             {% endif %}
 
-                            {% if allowed_scopes is defined and allowed_scopes is not empty %}
-                                {{ fields.dropdownArrayField('scopes', null, allowed_scopes, __('Scopes'), {
-                                    multiple: true,
-                                    values: item.fields['scopes'],
-                                }) }}
-                            {% endif %}
-
                             {{ fields.textareaField(
                                 'comment',
                                 item.fields['comment'],

--- a/tests/functional/Glpi/Api/HL/Controller/AdministrationController.php
+++ b/tests/functional/Glpi/Api/HL/Controller/AdministrationController.php
@@ -236,7 +236,7 @@ class AdministrationController extends \HLAPITestCase
     public function testGetMyEmails()
     {
         $this->login();
-        $this->api->call(new Request('GET', '/Administration/User/me/emails'), function ($call) {
+        $this->api->call(new Request('GET', '/Administration/User/me/email'), function ($call) {
             /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()

--- a/tests/functional/Glpi/Api/HL/Controller/AdministrationController.php
+++ b/tests/functional/Glpi/Api/HL/Controller/AdministrationController.php
@@ -270,7 +270,7 @@ class AdministrationController extends \HLAPITestCase
             ]
         ])->current()['id'];
 
-        $this->api->call(new Request('GET', "/Administration/User/me/emails/$email_id"), function ($call) {
+        $this->api->call(new Request('GET', "/Administration/User/me/email/$email_id"), function ($call) {
             /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
@@ -281,14 +281,14 @@ class AdministrationController extends \HLAPITestCase
         });
 
         // Try getting an email that doesn't exist
-        $this->api->call(new Request('GET', "/Administration/User/me/emails/999999999"), function ($call) {
+        $this->api->call(new Request('GET', "/Administration/User/me/email/999999999"), function ($call) {
             /** @var \HLAPICallAsserter $call */
             $call->response->isNotFoundError();
         });
 
         // Log in as another user and try to get the email of the first user (should fail)
         $this->login('tech', 'tech');
-        $this->api->call(new Request('GET', "/Administration/User/me/emails/$email_id"), function ($call) {
+        $this->api->call(new Request('GET', "/Administration/User/me/email/$email_id"), function ($call) {
             /** @var \HLAPICallAsserter $call */
             $call->response->isNotFoundError();
         });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Adds very basic OAuth scopes support:
- `email`: Access to the user's own default email address
- `user`: Access to the user's information
- `status`: Access to the status endpoints (Does not apply when accessed via the CLI commands)
- `inventory`: Access to submit inventory from an agent (Not implemented yet). Will eventually be used for authentication between the GLPI Agent and GLPI.
- `api`: Access to the API (All other endpoints not handled by their own scope)

The scopes are added into the OpenAPI documentation so the Swagger authentication UI has new options:
![Selection_246](https://github.com/glpi-project/glpi/assets/17678637/6aef49f9-fd63-4c35-882f-9a14aa109382)

The authorization page in GLPI has been updated to show what information the external application is requesting:
![Selection_245](https://github.com/glpi-project/glpi/assets/17678637/f141f580-da90-450e-8a30-10a4802798b9)

The allowed scopes can be configured in the form for each OAuth Client. If you try to authenticate while specifying a scope that wasn't added in the OAuth Client you are using, it will be discarded/ignored.

OAuth scopes do NOT change the actual permissions in GLPI. So, these scopes only restrict the usual permissions for the user rather than replace or add to them.