### PR TITLE
OAuth Client IP Restrictions

### DIFF
--- a/install/migrations/update_10.0.x_to_11.0.0/oauth.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/oauth.php
@@ -91,6 +91,7 @@ if (!$DB->tableExists('glpi_oauthclients')) {
         `scopes` text NOT NULL,
         `is_active` tinyint NOT NULL DEFAULT '1',
         `is_confidential` tinyint NOT NULL DEFAULT '1',
+        `allowed_ips` text DEFAULT NULL,
         PRIMARY KEY (`identifier`),
         KEY `id` (`id`),
         KEY `name` (`name`),
@@ -100,6 +101,10 @@ if (!$DB->tableExists('glpi_oauthclients')) {
 } else {
     // Dev migration for `redirect_uri` column from varchar(255) to TEXT
     $migration->changeField('glpi_oauthclients', 'redirect_uri', 'redirect_uri', 'TEXT NOT NULL');
+
+    $migration->addField('glpi_oauthclients', 'allowed_ips', 'TEXT DEFAULT NULL', [
+        'after' => 'is_confidential'
+    ]);
 }
 
 $migration->addRight('oauth_client', ALLSTANDARDRIGHT, ['config' => UPDATE]);

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9672,6 +9672,7 @@ CREATE TABLE `glpi_oauthclients` (
    `scopes` text NOT NULL,
    `is_active` tinyint NOT NULL DEFAULT '1',
    `is_confidential` tinyint NOT NULL DEFAULT '1',
+   `allowed_ips` text DEFAULT NULL,
    PRIMARY KEY (`identifier`),
    KEY `id` (`id`),
    KEY `name` (`name`),

--- a/src/Api/HL/Middleware/IPRestrictionRequestMiddleware.php
+++ b/src/Api/HL/Middleware/IPRestrictionRequestMiddleware.php
@@ -43,7 +43,7 @@ class IPRestrictionRequestMiddleware extends AbstractMiddleware implements Reque
     public function process(MiddlewareInput $input, callable $next): void
     {
         $client = Router::getInstance()->getCurrentClient();
-        if (!$client) {
+        if (!$client || isCommandLine()) {
             $next($input);
             return;
         }

--- a/src/Api/HL/Middleware/IPRestrictionRequestMiddleware.php
+++ b/src/Api/HL/Middleware/IPRestrictionRequestMiddleware.php
@@ -77,7 +77,7 @@ class IPRestrictionRequestMiddleware extends AbstractMiddleware implements Reque
         $next($input);
     }
 
-    public function isIPAllowed(string $ip, string $allowed_ips): bool
+    private function isIPAllowed(string $ip, string $allowed_ips): bool
     {
         $allowed_ip_array = array_map('trim', explode(',', $allowed_ips));
         foreach ($allowed_ip_array as $allowed_ip) {
@@ -98,7 +98,7 @@ class IPRestrictionRequestMiddleware extends AbstractMiddleware implements Reque
      * @param string $range The CIDR notation range
      * @return bool
      */
-    public function isCidrMatch(string $ip, string $range): bool
+    private function isCidrMatch(string $ip, string $range): bool
     {
         $ipv6 = str_contains($ip, ':');
         $max_mask = $ipv6 ? 128 : 32;

--- a/src/OAuthClient.php
+++ b/src/OAuthClient.php
@@ -109,6 +109,10 @@ final class OAuthClient extends CommonDBTM
 
     public function prepareInputForAdd($input)
     {
+        if (!$this->validateAllowedIPs($input['allowed_ips'])) {
+            Session::addMessageAfterRedirect(__('Invalid IP address or CIDR range'), false);
+            return false;
+        }
         $key = new GLPIKey();
         $input['identifier'] = self::getNewIDOrSecret();
         $input['secret'] = $key->encrypt(self::getNewIDOrSecret());
@@ -126,6 +130,10 @@ final class OAuthClient extends CommonDBTM
 
     public function prepareInputForUpdate($input)
     {
+        if (!$this->validateAllowedIPs($input['allowed_ips'])) {
+            Session::addMessageAfterRedirect(__('Invalid IP address or CIDR range'), false);
+            return false;
+        }
         $key = new GLPIKey();
         if (isset($input['secret'])) {
             $input['secret'] = $key->encrypt($input['secret']);
@@ -139,6 +147,33 @@ final class OAuthClient extends CommonDBTM
         $input['redirect_uri'] = json_encode($input['redirect_uri'] ?? []);
 
         return $input;
+    }
+
+    /**
+     * Ensure the allowed IPs input is a comma-separated list of valid IP addresses or CIDR ranges.
+     * @param string $allowed_ips
+     * @return bool
+     */
+    private function validateAllowedIPs(string $allowed_ips)
+    {
+        if (empty($allowed_ips)) {
+            return true;
+        }
+        $allowed_ip_array = array_map('trim', explode(',', $allowed_ips));
+        foreach ($allowed_ip_array as $allowed_ip) {
+            if (str_contains($allowed_ip, '/')) {
+                [$ip, $mask] = explode('/', $allowed_ip);
+                if (filter_var($mask, FILTER_VALIDATE_INT, ['options' => ['min_range' => 0, 'max_range' => 32]]) === false) {
+                    return false;
+                }
+            } else {
+                $ip = $allowed_ip;
+            }
+            if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6) === false) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public function post_getFromDB()

--- a/templates/pages/setup/oauthclient.html.twig
+++ b/templates/pages/setup/oauthclient.html.twig
@@ -108,7 +108,7 @@
                                 no_label: true,
                                 field_class: 'col-12 d-flex',
                             }) }}
-                            <div class="authorized-uri-fields">
+                            <div class="authorized-uri-fields mb-3">
                                 <button type="button" class="btn btn-secondary mt-3" name="add_uri">
                                     <i class="ti ti-plus"></i>
                                     {{ __('Add URI') }}
@@ -135,6 +135,12 @@
                                     $('.authorized-uri-field input').last().val(uri);
                                 });
                             </script>
+
+                            {{ fields.smallTitle(__('IP Restrictions'), 'ti ti-network', __('Comma separated list of individual IPv4/IPv6 addresses or ranges in CIDR notation. An empty list indicates there are no restrictions.')) }}
+                            {{ fields.textField('allowed_ips', item.fields['allowed_ips'], null, {
+                                no_label: true,
+                                field_class: 'col-12 d-flex',
+                            }) }}
                         {% endblock %}
                     </div> {# .row #}
                 </div> {# .row #}

--- a/tests/functional/Glpi/Api/HL/Middleware/IPRestrictionRequestMiddleware.php
+++ b/tests/functional/Glpi/Api/HL/Middleware/IPRestrictionRequestMiddleware.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Api\HL\Middleware;
+
+class IPRestrictionRequestMiddleware extends \GLPITestCase
+{
+    protected function isIPAllowedProvider()
+    {
+        return [
+            ['ip' => '127.0.0.1', 'allowed_ips' => '127.0.0.1', 'expected' => true],
+            ['ip' => '127.0.0.1', 'allowed_ips' => '::1', 'expected' => false],
+            ['ip' => '127.0.0.1', 'allowed_ips' => '::1,127.0.0.1', 'expected' => true],
+            ['ip' => '10.10.13.5', 'allowed_ips' => '10.10.13.0/24', 'expected' => true],
+            ['ip' => '10.10.13.5', 'allowed_ips' => '10.10.13.0/16', 'expected' => true],
+            ['ip' => '10.10.13.5', 'allowed_ips' => '10.10.13.0/32', 'expected' => false],
+            ['ip' => '10.10.13.5', 'allowed_ips' => '10.10.13.5/32', 'expected' => true],
+            ['ip' => '2001:4860:4860::8888', 'allowed_ips' => '2001:4860:4860::8888/32', 'expected' => true],
+            ['ip' => '2001:4860:4860::8888', 'allowed_ips' => '2001:4860:4860::8888/64', 'expected' => true],
+            ['ip' => '2001:4860:4860::8888', 'allowed_ips' => '2001:4860:4860::8888/128', 'expected' => true],
+            ['ip' => '2001:4861:4860::8888', 'allowed_ips' => '2001:4860:4860::8888/32', 'expected' => false],
+            ['ip' => '::1', 'allowed_ips' => '2001:4860:4860::8888/64,::1', 'expected' => true],
+        ];
+    }
+
+    /**
+     * @dataProvider isIPAllowedProvider
+     */
+    public function testIsIPAllowed($ip, $allowed_ips, $expected)
+    {
+        $middleware = new \Glpi\Api\HL\Middleware\IPRestrictionRequestMiddleware();
+        $this->variable($middleware->isIPAllowed($ip, $allowed_ips))->isEqualTo($expected);
+    }
+
+    protected function isCidrMatchProvider()
+    {
+        return [
+            ['ip' => '10.10.13.5', 'range' => '10.10.13.0/24', 'expected' => true],
+            ['ip' => '10.10.13.5', 'range' => '10.10.13.0/16', 'expected' => true],
+            ['ip' => '10.10.13.5', 'range' => '10.10.13.0/32', 'expected' => false],
+            ['ip' => '10.10.13.5', 'range' => '10.10.13.5/32', 'expected' => true],
+            ['ip' => '2001:4860:4860::8888', 'range' => '2001:4860:4860::8888/32', 'expected' => true],
+            ['ip' => '2001:4860:4860::8888', 'range' => '2001:4860:4860::8888/64', 'expected' => true],
+            ['ip' => '2001:4861:4860::8888', 'range' => '2001:4860:4860::8888/32', 'expected' => false],
+        ];
+    }
+
+    /**
+     * @dataProvider isCidrMatchProvider
+     */
+    public function testIsCidrMatch($ip, $range, $expected)
+    {
+        $middleware = new \Glpi\Api\HL\Middleware\IPRestrictionRequestMiddleware();
+        $this->variable($middleware->isCidrMatch($ip, $range))->isEqualTo($expected);
+    }
+}

--- a/tests/functional/Glpi/Api/HL/Middleware/IPRestrictionRequestMiddleware.php
+++ b/tests/functional/Glpi/Api/HL/Middleware/IPRestrictionRequestMiddleware.php
@@ -61,7 +61,8 @@ class IPRestrictionRequestMiddleware extends \GLPITestCase
     public function testIsIPAllowed($ip, $allowed_ips, $expected)
     {
         $middleware = new \Glpi\Api\HL\Middleware\IPRestrictionRequestMiddleware();
-        $this->variable($middleware->isIPAllowed($ip, $allowed_ips))->isEqualTo($expected);
+        $this->variable($this->callPrivateMethod($middleware, 'isIPAllowed', $ip, $allowed_ips))
+            ->isEqualTo($expected);
     }
 
     protected function isCidrMatchProvider()
@@ -83,6 +84,7 @@ class IPRestrictionRequestMiddleware extends \GLPITestCase
     public function testIsCidrMatch($ip, $range, $expected)
     {
         $middleware = new \Glpi\Api\HL\Middleware\IPRestrictionRequestMiddleware();
-        $this->variable($middleware->isCidrMatch($ip, $range))->isEqualTo($expected);
+        $this->variable($this->callPrivateMethod($middleware, 'isCidrMatch', $ip, $range))
+            ->isEqualTo($expected);
     }
 }

--- a/tests/functional/OAuthClient.php
+++ b/tests/functional/OAuthClient.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+class OAuthClient extends \DbTestCase
+{
+    protected function validateAllowedIPsProvider()
+    {
+        return [
+            [null, true],
+            ['', true],
+            ['::1', true],
+            ['127.0.0.1,::1', true],
+            ['127.0.0.1, ::1', true],
+            ['127.0.0.1, 10.10.13.0/24', true],
+            ['10.10.13.0/0', false],
+            ['10.10.13.0/1', true],
+            ['10.10.13.0/128', false],
+            ['::1/0', false],
+            ['::1/1', true],
+            ['::1/129', false],
+            ['::1/128', true],
+            ['2001:4860:4860::8888/32', true]
+        ];
+    }
+
+    /**
+     * @dataProvider validateAllowedIPsProvider
+     */
+    public function testValidateAllowedIPs($allowed_ips, $is_valid)
+    {
+        $client = new \OAuthClient();
+        $add_result = $client->prepareInputForAdd([
+            'allowed_ips' => $allowed_ips
+        ]);
+        if (!$is_valid) {
+            $this->variable($add_result)->isEqualTo(false);
+            $this->hasSessionMessages(ERROR, ['Invalid IP address or CIDR range']);
+        } else {
+            $this->variable($add_result['allowed_ips'])->isIdenticalTo($allowed_ips);
+        }
+
+        $update_result = $client->prepareInputForUpdate([
+            'allowed_ips' => $allowed_ips
+        ]);
+        if (!$is_valid) {
+            $this->variable($update_result)->isEqualTo(false);
+            $this->hasSessionMessages(ERROR, ['Invalid IP address or CIDR range']);
+        } else {
+            $this->variable($update_result['allowed_ips'])->isIdenticalTo($allowed_ips);
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This was possible with the legacy API Clients, but wasn't added during the initial implementation of OAuth or the new API.
While API Clients have three fields `Pv4 address range start`, `IPv4 address range end` and `IPv6 address`, OAuth clients have a single `Allowed IPs` field which accepts a comma-separated list of individual IPv4/IPv6 addresses or ranges in CIDR notation. If the allowed IPs field is left blank, it is treated as there being no IP restrictions for the client.