### PR TITLE
Ensure `_networkports` result in API to be consistent with expected schema

### DIFF
--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -2893,6 +2893,8 @@ abstract class API
         } else {
             $networkport_types = NetworkPort::getNetworkPortInstantiations();
             foreach ($networkport_types as $networkport_type) {
+                $_networkports[$networkport_type] = [];
+
                 $netport_table = $networkport_type::getTable();
                 $netp_iterator = $DB->request([
                     'SELECT'    => [

--- a/tests/APIBaseClass.php
+++ b/tests/APIBaseClass.php
@@ -784,10 +784,6 @@ abstract class APIBaseClass extends atoum
     {
         $computer = $this->createComputer();
         $computers_id = $computer->getID();
-
-       // create a network port for the previous computer
-        $this->createNetworkPort($computers_id);
-
        // Get the User TU_USER
         $uid = getItemByTypeName('User', TU_USER, true);
         $data = $this->query(
@@ -847,8 +843,30 @@ abstract class APIBaseClass extends atoum
          ->hasKey('name')
          ->hasKey('_networkports');
 
-        $this->array($data['_networkports'])
-         ->hasKey('NetworkPortEthernet');
+        $this->array($data['_networkports'])->hasKey('NetworkPortEthernet');
+        $this->array($data['_networkports']['NetworkPortEthernet'])->isEmpty();
+
+       // create a network port for the computer
+        $this->createNetworkPort($computers_id);
+
+        $data = $this->query(
+            'getItem',
+            ['itemtype' => 'Computer',
+                'id'       => $computers_id,
+                'headers'  => ['Session-Token' => $this->session_token],
+                'query'    => ['with_networkports' => true]
+            ]
+        );
+
+        $this->variable($data)->isNotFalse();
+
+        $this->array($data)
+         ->hasKey('id')
+         ->hasKey('name')
+         ->hasKey('_networkports');
+
+        $this->array($data['_networkports'])->hasKey('NetworkPortEthernet');
+        $this->array($data['_networkports']['NetworkPortEthernet'])->isNotEmpty();
 
         $this->array($data['_networkports']['NetworkPortEthernet'][0])->hasKey('NetworkName');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #16259

Many libraries used to produce object oriented API connectors does not like to have a different behaviours for the same endpoint.

With the proposed modification, `_networkports` will always have the same behaviour whether there are existing ports or not.

Without existing ports:
```json
"_networkports": {
    "NetworkPortEthernet": [],
    "NetworkPortWifi": [],
    "NetworkPortAggregate": [],
    "NetworkPortAlias": [],
    "NetworkPortDialup": [],
    "NetworkPortLocal": [],
    "NetworkPortFiberchannel": []
}
```

With existing ports:
```json
"_networkports": {
    "NetworkPortEthernet": [
        {
            "netport_id": 15,
            ...
        }
    ],
    "NetworkPortWifi": [],
    "NetworkPortAggregate": [],
    "NetworkPortAlias": [],
    "NetworkPortDialup": [],
    "NetworkPortLocal": [],
    "NetworkPortFiberchannel": []
}
```
