### PR TITLE
Forms: floating toolbar

### DIFF
--- a/css/includes/components/form/_form-editor.scss
+++ b/css/includes/components/form/_form-editor.scss
@@ -92,17 +92,19 @@
 // Show secondary data on active items
 [data-glpi-form-editor-form-details][data-glpi-form-editor-active] [data-glpi-form-editor-form-extra-details],
 [data-glpi-form-editor-section-details][data-glpi-form-editor-active] [data-glpi-form-editor-section-extra-details],
-[data-glpi-form-editor-question][data-glpi-form-editor-active] [data-glpi-form-editor-question-extra-details] {
+[data-glpi-form-editor-question-details][data-glpi-form-editor-active] [data-glpi-form-editor-question-extra-details] {
     opacity: 1;
     visibility: visible;
     transition: visibility 0s, opacity 0.20s linear;
 }
 
-[data-glpi-form-editor-form-details]:not([data-glpi-form-editor-active]) [data-glpi-form-editor-form-extra-details],
-[data-glpi-form-editor-section-details]:not([data-glpi-form-editor-active]) [data-glpi-form-editor-section-extra-details],
-[data-glpi-form-editor-question]:not([data-glpi-form-editor-active]) [data-glpi-form-editor-question-extra-details] {
+[data-glpi-form-editor-form-details]:not([data-glpi-form-editor-active]),
+[data-glpi-form-editor-section-details]:not([data-glpi-form-editor-active]),
+[data-glpi-form-editor-question]:not([data-glpi-form-editor-active]) {
     // Hide secondary data on inactive questions
-    [data-glpi-form-editor-question-extra-details] {
+    [data-glpi-form-editor-question-extra-details],
+    [data-glpi-form-editor-section-extra-details],
+    [data-glpi-form-editor-form-extra-details] {
         height: 0;
         opacity: 0;
         visibility: hidden;

--- a/css/includes/components/form/_form-editor.scss
+++ b/css/includes/components/form/_form-editor.scss
@@ -76,43 +76,83 @@
     }
 }
 
-// Hide active status by default
-[data-glpi-form-editor-active-status-indicator] {
-    display: none;
-}
+[data-glpi-form-editor-form] {
+    &[data-glpi-form-editor-active-form] {
+        // Show secondary data on active form
+        [data-glpi-form-editor-form-extra-details] {
+            opacity: 1;
+            visibility: visible;
+            transition: visibility 0s, opacity 0.20s linear;
+        }
+    }
 
-// Higlight active item
-[data-glpi-form-editor-active]
-{
-    [data-glpi-form-editor-active-status-indicator] {
-        display: inline-block;
+    &:not([data-glpi-form-editor-active-form]) {
+        // Do not highlight inactive forms
+        [data-glpi-form-editor-active-form-status-indicator] {
+            display: none;
+        }
+
+        // Do not show secondary data on inactive form
+        [data-glpi-form-editor-form-extra-details] {
+            height: 0;
+            opacity: 0;
+            visibility: hidden;
+        }
     }
 }
 
-// Show secondary data on active items
-[data-glpi-form-editor-form-details][data-glpi-form-editor-active] [data-glpi-form-editor-form-extra-details],
-[data-glpi-form-editor-section-details][data-glpi-form-editor-active] [data-glpi-form-editor-section-extra-details],
-[data-glpi-form-editor-question-details][data-glpi-form-editor-active] [data-glpi-form-editor-question-extra-details] {
-    opacity: 1;
-    visibility: visible;
-    transition: visibility 0s, opacity 0.20s linear;
-}
-
-[data-glpi-form-editor-form-details]:not([data-glpi-form-editor-active]),
-[data-glpi-form-editor-section-details]:not([data-glpi-form-editor-active]),
-[data-glpi-form-editor-question]:not([data-glpi-form-editor-active]) {
-    // Hide secondary data on inactive questions
-    [data-glpi-form-editor-question-extra-details],
-    [data-glpi-form-editor-section-extra-details],
-    [data-glpi-form-editor-form-extra-details] {
-        height: 0;
-        opacity: 0;
-        visibility: hidden;
+[data-glpi-form-editor-section] {
+    &[data-glpi-form-editor-active-section] {
+        // Show secondary data on active form
+        [data-glpi-form-editor-section-extra-details] {
+            opacity: 1;
+            visibility: visible;
+            transition: visibility 0s, opacity 0.20s linear;
+        }
     }
 
-    // Hide tinymce toolbar on inactive questions
-    .tox-editor-header {
-        display: none !important;
+    &:not([data-glpi-form-editor-active-section]) {
+        // Do not highlight inactive forms
+        [data-glpi-form-editor-active-section-status-indicator] {
+            display: none;
+        }
+
+        // Do not show secondary data on inactive form
+        [data-glpi-form-editor-section-extra-details] {
+            height: 0;
+            opacity: 0;
+            visibility: hidden;
+        }
+    }
+}
+
+[data-glpi-form-editor-question] {
+    &[data-glpi-form-editor-active-question] {
+        // Show secondary data on active form
+        [data-glpi-form-editor-question-extra-details] {
+            opacity: 1;
+            visibility: visible;
+            transition: visibility 0s, opacity 0.20s linear;
+        }
+    }
+
+    &:not([data-glpi-form-editor-active-question]) {
+        // Do not highlight inactive forms
+        [data-glpi-form-editor-active-question-status-indicator] {
+            display: none;
+        }
+
+        // Do not show secondary data on inactive form
+        [data-glpi-form-editor-question-extra-details] {
+            height: 0;
+            opacity: 0;
+            visibility: hidden;
+        }
+
+        // Hide tinymce toolbar on inactive questions
+        .tox-editor-header {
+            display: none !important;
+        }
     }
 }
 

--- a/css/includes/components/form/_form-editor.scss
+++ b/css/includes/components/form/_form-editor.scss
@@ -77,28 +77,30 @@
 }
 
 // Hide active status by default
-[data-active-status] {
+[data-glpi-form-editor-active-status-indicator] {
     display: none;
 }
 
 // Higlight active item
-[data-glpi-form-editor-form-details].active,
-[data-glpi-form-editor-question].active,
-[data-glpi-form-editor-section-form-container].active
+[data-glpi-form-editor-active]
 {
-    [data-active-status] {
+    [data-glpi-form-editor-active-status-indicator] {
         display: inline-block;
     }
 }
 
-// Show secondary data on active questions
-[data-glpi-form-editor-question].active [data-glpi-form-editor-question-extra-details] {
+// Show secondary data on active items
+[data-glpi-form-editor-form-details][data-glpi-form-editor-active] [data-glpi-form-editor-form-extra-details],
+[data-glpi-form-editor-section-details][data-glpi-form-editor-active] [data-glpi-form-editor-section-extra-details],
+[data-glpi-form-editor-question][data-glpi-form-editor-active] [data-glpi-form-editor-question-extra-details] {
     opacity: 1;
     visibility: visible;
     transition: visibility 0s, opacity 0.20s linear;
 }
 
-[data-glpi-form-editor-question]:not(.active) {
+[data-glpi-form-editor-form-details]:not([data-glpi-form-editor-active]) [data-glpi-form-editor-form-extra-details],
+[data-glpi-form-editor-section-details]:not([data-glpi-form-editor-active]) [data-glpi-form-editor-section-extra-details],
+[data-glpi-form-editor-question]:not([data-glpi-form-editor-active]) [data-glpi-form-editor-question-extra-details] {
     // Hide secondary data on inactive questions
     [data-glpi-form-editor-question-extra-details] {
         height: 0;
@@ -131,7 +133,7 @@
     opacity: 0;
 }
 
-[data-glpi-form-editor-question] {
+[data-glpi-form-editor-question-details] {
     &:hover {
         .glpi-form-editor-question-handle {
             opacity: 0.7;

--- a/js/form_editor_controller.js
+++ b/js/form_editor_controller.js
@@ -152,7 +152,7 @@ class GlpiFormEditorController
                     const target = $(e.currentTarget);
                     const action = target.attr(attribute);
 
-                    this.#handleEditorAction(action, target);
+                    this.#handleEditorAction(action, target, e);
                 });
         });
     }
@@ -172,23 +172,26 @@ class GlpiFormEditorController
      *
      * @param {string} action Action to perform
      * @param {jQuery} target Element that triggered the action
+     * @param {Event}  event  Event
      */
-    #handleEditorAction(action, target) {
+    #handleEditorAction(action, target, event) {
         switch (action) {
             // Mark the target item as active
             case "set-active":
                 this.#setActiveItem(target);
                 break;
 
-            // Add a new question at the end of the current section
+            // Add a new question
             case "add-question":
+                event.stopPropagation(); // We don't want to trigger the "set-active" action for this item
                 this.#addQuestion(
-                    target.closest("[data-glpi-form-editor-section]")
+                    target.closest('[data-glpi-form-editor-active]'),
                 );
                 break;
 
             // Delete the target question
             case "delete-question":
+                event.stopPropagation(); // We don't want to trigger the "set-active" action for this item
                 this.#deleteQuestion(
                     target.closest("[data-glpi-form-editor-question]")
                 );
@@ -225,7 +228,10 @@ class GlpiFormEditorController
 
             // Add a new section at the end of the form
             case "add-section":
-                this.#addSection();
+                event.stopPropagation(); // We don't want to trigger the "set-active" action for this item
+                this.#addSection(
+                    target.closest('[data-glpi-form-editor-active]')
+                );
                 break;
 
             // Delete the target section
@@ -263,7 +269,7 @@ class GlpiFormEditorController
         sections.each((s_index, section) => {
             // Compute state for each sections
             this.#formatInputsNames(
-                $(section).find("[data-glpi-form-editor-section-form-container]"),
+                $(section).find("[data-glpi-form-editor-section-details]"),
                 'section',
                 s_index
             );
@@ -504,24 +510,45 @@ class GlpiFormEditorController
     #setActiveItem(item_container) {
         // Remove current active item
         $(this.#target)
-            .find("\
-                [data-glpi-form-editor-form-details], \
-                [data-glpi-form-editor-question], \
-                [data-glpi-form-editor-section-form-container] \
-            ")
-            .removeClass("active");
+            .find("[data-glpi-form-editor-active]")
+            .removeAttr("data-glpi-form-editor-active");
 
         // Set new active item if specified
         if (item_container !== null) {
-            item_container.addClass("active");
+            item_container.attr("data-glpi-form-editor-active", "");
         }
     }
 
     /**
      * Add a new question at the end of the form
-     * @param {jQuery} section
+     * @param {jQuery} target   Current position in the form
      */
-    #addQuestion(section) {
+    #addQuestion(target) {
+        let destination;
+        let action;
+
+        // Find the context using the target
+        if (target.data('glpi-form-editor-question') !== undefined) {
+            // Adding a new question after an existing question
+            destination = target;
+            action = "after";
+        } else if (target.data('glpi-form-editor-section-details') !== undefined) {
+            // Adding a question at the start of a section
+            destination = target
+                .closest("[data-glpi-form-editor-section]")
+                .find("[data-glpi-form-editor-section-questions]");
+            action = "prepend";
+        } else if (target.data('glpi-form-editor-form-details') !== undefined) {
+            // Adding a question at the start of the form
+            destination = target
+                .closest("[data-glpi-form-editor-form]")
+                .find("[data-glpi-form-editor-section]:first-child")
+                .find("[data-glpi-form-editor-section-questions]");
+            action = "prepend";
+        } else {
+            throw new Error('Unexpected target');
+        }
+
         // Get template content
         const template_content = this.#getQuestionTemplate(
             this.#defaultQuestionType
@@ -530,7 +557,8 @@ class GlpiFormEditorController
         // Insert the new template into the questions area of the current section
         const new_question = this.#copy_template(
             template_content,
-            section.find("[data-glpi-form-editor-section-questions]"),
+            destination,
+            action
         );
 
         // Update UX
@@ -546,6 +574,14 @@ class GlpiFormEditorController
         // Remove question and update UX
         question.remove();
         this.#updateAddSectionActionVisiblity();
+
+        // If the last questions was deleted, most active item to the form itself
+        // to show its toolbar
+        if ($(this.#target).find("[data-glpi-form-editor-question]").length == 0) {
+            this.#setActiveItem(
+                $(this.#target).find("[data-glpi-form-editor-form-details]")
+            );
+        }
     }
 
     /**
@@ -578,9 +614,10 @@ class GlpiFormEditorController
      *
      * @param {jQuery} target         Template to copy
      * @param {jQuery} destination    Destination to copy the template into
+     * @param {string} action         How to insert the template (append, prepend, after)
      * @returns {jQuery} Copy of the template
      */
-    #copy_template(target, destination) {
+    #copy_template(target, destination, action = "append") {
         const copy = target.clone();
 
         // Keep track of rich text editors that will need to be initialized
@@ -608,8 +645,25 @@ class GlpiFormEditorController
             window.tinymce_editor_configs[id] = config;
         });
 
-        // Insert the new question and init the editors
-        copy.appendTo(destination);
+        // Insert the new question
+        switch (action) {
+            case "append":
+                copy.appendTo(destination);
+                break;
+            case "prepend":
+                copy.prependTo(destination);
+                break;
+            case "before":
+                copy.insertBefore(destination);
+                break;
+            case "after":
+                copy.insertAfter(destination);
+                break;
+            default:
+                throw new Error(`Unknown action: ${action}`);
+        }
+
+        // Init the editors
         tiny_mce_to_init.forEach((config) => tinyMCE.init(config));
 
         return copy;
@@ -735,8 +789,44 @@ class GlpiFormEditorController
 
     /**
      * Add a new section at the end of the form.
+     * @param {jQuery} target Current position in the form
      */
-    #addSection() {
+    #addSection(target) {
+        let destination;
+        let action;
+        let to_move;
+
+        // Find the context using the target
+        if (target.data('glpi-form-editor-question') !== undefined) {
+            // Adding a new section after an existing question
+            // For the existing sections, any questions AFTER the target will
+            // be moved into the new section
+            destination = target
+                .closest("[data-glpi-form-editor-section]");
+            action = "after";
+            to_move = $(target).nextAll();
+        } else if (target.data('glpi-form-editor-section-details') !== undefined) {
+            // Adding a new section at the start of an existing section
+            // All questions of the existing section will be moved into the new
+            // section, leaving it empty
+            destination = target
+                .closest("[data-glpi-form-editor-section]");
+            action = "after";
+            to_move = $(target)
+                .closest("[data-glpi-form-editor-section]")
+                .find("[data-glpi-form-editor-question]");
+        } else if (target.data('glpi-form-editor-form-details') !== undefined) {
+            // Adding a section at the start of the form
+            // The new section will be empty
+            destination = target
+                .closest("[data-glpi-form-editor-form]")
+                .find("[data-glpi-form-editor-section]:first-child");
+            action = "before";
+            to_move = null;
+        } else {
+            throw new Error('Unexpected target');
+        }
+
         // Find the section template
         const template = $(this.#templates)
             .find("[data-glpi-form-editor-section-template]")
@@ -745,14 +835,25 @@ class GlpiFormEditorController
         // Copy the new section template into the sections area
         const section = this.#copy_template(
             template,
-            $(this.#target).find("[data-glpi-form-editor-sections]"),
+            destination,
+            action
         );
+
+        // Move questions into their new sections if needed
+        if (to_move !== null && to_move.length > 0) {
+            to_move.detach().appendTo(
+                section.find("[data-glpi-form-editor-section-questions]")
+            );
+            to_move.each((index, question) => {
+                this.#handleItemMove(question);
+            });
+        }
 
         // Update UX
         this.#updateSectionCountLabels();
         this.#updateSectionsDetailsVisiblity();
         this.#setActiveItem(
-            section.find("[data-glpi-form-editor-section-form-container]")
+            section.find("[data-glpi-form-editor-section-details]")
         );
     }
 
@@ -798,7 +899,7 @@ class GlpiFormEditorController
         if (sections_count <= 1) {
             // Only one section, do not display its details
             $(this.#target)
-                .find("[data-glpi-form-editor-section-form-container]")
+                .find("[data-glpi-form-editor-section-details]")
                 .addClass("d-none");
             $(this.#target)
                 .find("[data-glpi-form-editor-section-number-display]")
@@ -806,7 +907,7 @@ class GlpiFormEditorController
         } else {
             // Mutliple sections, display all details
             $(this.#target)
-                .find("[data-glpi-form-editor-section-form-container]")
+                .find("[data-glpi-form-editor-section-details]")
                 .removeClass("d-none");
             $(this.#target)
                 .find("[data-glpi-form-editor-section-number-display]")
@@ -859,15 +960,7 @@ class GlpiFormEditorController
         sections
             .find("[data-glpi-form-editor-section-questions]")
             .on('sortupdate', (e) => {
-                // TinyMCE does no like being moved around and must be
-                // reinitialized by destroying the editor instance and
-                // recreating it
-                $(e.detail.item).find("textarea").each((index, textarea) => {
-                    const id = $(textarea).prop("id");
-                    const editor = tinymce.get(id);
-                    editor.destroy();
-                    tinymce.init(window.tinymce_editor_configs[id]);
-                });
+                this.#handleItemMove($(e.detail.item));
             });
     }
 
@@ -924,6 +1017,13 @@ class GlpiFormEditorController
      * Reorder the sections based on the "move section modal" content.
      */
     #reorderSections() {
+        // Temporary bugfix: state must be manually computed before we can reorder
+        // the sections as we use the data-glpi-form-editor-key parameter to
+        // select the correct section
+        this.#computeState();
+        // TODO: #computeState should not generate keys, it should be handled
+        // somewhere else
+
         // Close modal
         $(this.#target)
             .find("[data-glpi-form-editor-move-section-modal]")
@@ -954,6 +1054,7 @@ class GlpiFormEditorController
             });
 
         // Reinit tiynmce for all richtext inputs
+        // TODO: use #handleItemMove and only reinit the moved sections, not everything
         $(this.#target)
             .find("textarea")
             .each((index, textarea) => {
@@ -968,5 +1069,24 @@ class GlpiFormEditorController
 
         // Relabel sections
         this.#updateSectionCountLabels();
+    }
+
+    /**
+     * Some libraries like TinyMCE does not like being moved around and need
+     * to be reinitialized after being moved.
+     */
+    #handleItemMove(item) {
+        // Reinit tiynmce for all richtext inputs
+        item
+            .find("textarea")
+            .each((index, textarea) => {
+                const id = $(textarea).prop("id");
+                const editor = tinymce.get(id);
+
+                if (editor) {
+                    editor.destroy();
+                    tinymce.init(window.tinymce_editor_configs[id]);
+                }
+            });
     }
 }

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -95,7 +95,7 @@
                                         type="text"
                                         class="form-control content-editable-h1"
                                         name="name"
-                                        value="{{ item.fields.name }}"
+                                        value="{{ item.fields.name|e('html_attr') }}"
                                     >
 
                                     {# Form's status #}

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -71,60 +71,68 @@
             <div class="row">
 
                 {# We expect to use the right side to display some extra info later so keep some available space for now #}
-                <div class="col-7">
+                <div class="col-7" data-glpi-form-editor-form>
 
-                    {# Card containing the main form data: title, header and status #}
                     <div
-                        class="card form-details mb-3 active"
-                        data-glpi-form-editor-on-click="set-active"
                         data-glpi-form-editor-form-details
+                        data-glpi-form-editor-active
+                        data-glpi-form-editor-on-click="set-active"
                     >
+                        {# Card containing the main form data: title, header and status #}
+                        <div class="card form-details mb-3">
+                            <div
+                                class="card-status-start bg-primary"
+                                data-glpi-form-editor-active-status-indicator
+                            ></div>
+                            <div class="card-body">
 
-                        <div
-                            class="card-status-start bg-primary"
-                            data-active-status
-                        ></div>
-                        <div class="card-body">
-
-                            {# Header #}
-                            <div class="d-flex">
-                                {# Form's name #}
-                                <input
-                                    type="text"
-                                    class="form-control content-editable-h1"
-                                    name="name"
-                                    value="{{ item.fields.name }}"
-                                >
-
-                                {# Form's status #}
-                                <label class="form-check form-switch ms-3" style="margin-top: 2px">
-                                    <input type="hidden" value="0" name="is_active">
+                                {# Header #}
+                                <div class="d-flex">
+                                    {# Form's name #}
                                     <input
-                                        class="form-check-input"
-                                        name="is_active"
-                                        type="checkbox"
-                                        value="1"
-                                        {% if item.fields.is_active %} checked {% endif %}
+                                        type="text"
+                                        class="form-control content-editable-h1"
+                                        name="name"
+                                        value="{{ item.fields.name }}"
                                     >
-                                    <span class="form-check-label">{{ __("Active") }}</span>
-                                </label>
-                            </div>
 
-                            {# Form's hader #}
-                            <div class="content-editable-tinymce">
-                                {{ fields.textareaField(
-                                    'header',
-                                    item.fields.header,
-                                    __('Header'),
-                                    base_field_options|merge({
-                                        'enable_richtext': true,
-                                        'add_body_classes': ['content-editable-tinymce-editor', 'text-muted'],
-                                        'editor_height': "0",
-                                        'rows' : 1,
-                                        'toolbar_location': 'bottom',
-                                    })
-                                ) }}
+                                    {# Form's status #}
+                                    <label class="form-check form-switch ms-3" style="margin-top: 2px">
+                                        <input type="hidden" value="0" name="is_active">
+                                        <input
+                                            class="form-check-input"
+                                            name="is_active"
+                                            type="checkbox"
+                                            value="1"
+                                            {% if item.fields.is_active %} checked {% endif %}
+                                        >
+                                        <span class="form-check-label">{{ __("Active") }}</span>
+                                    </label>
+                                </div>
+
+                                {# Form's hader #}
+                                <div class="content-editable-tinymce">
+                                    {{ fields.textareaField(
+                                        'header',
+                                        item.fields.header,
+                                        __('Header'),
+                                        base_field_options|merge({
+                                            'enable_richtext': true,
+                                            'add_body_classes': ['content-editable-tinymce-editor', 'text-muted'],
+                                            'editor_height': "0",
+                                            'rows' : 1,
+                                            'toolbar_location': 'bottom',
+                                        })
+                                    ) }}
+                                </div>
                             </div>
+                        </div>
+
+                        <div data-glpi-form-editor-form-extra-details>
+                            {{ include('pages/admin/form/form_toolbar.html.twig', {
+                                'can_update': item.canUpdate(),
+                                'form'      : item,
+                            }, with_context = false) }}
                         </div>
                     </div>
 
@@ -143,20 +151,6 @@
                             }, with_context = false) }}
                         {% endfor %}
                     </div>
-
-                    {# Single add section action at the end of the form#}
-                    {# TODO: UI/UX #}
-                    {% if item.canUpdate() %}
-                        {% set add_section_action_visible = number_of_sections > 1 or (item.getSections()|first).getQuestions()|length > 0 %}
-                        <div
-                            class="card cursor-pointer align-items-center {{ add_section_action_visible ? "" : "d-none" }}"
-                            data-glpi-form-editor-on-click="add-section"
-                        >
-                            <div class="card-body">
-                                <h3 class="d-flex align-items-center"><i class="ti ti-circle-plus me-2"></i> {{ __("Add section") }}</h3>
-                            </div>
-                        </div>
-                    {% endif %}
                 </div>
             </div>
         </div>
@@ -297,10 +291,12 @@
             <div data-glpi-form-editor-question-template="{{ key }}">
                 {# Render admin template for the given question type #}
                 {{ include('pages/admin/form/form_question.html.twig', {
+                    'form'                   : item,
                     'question_types_manager' : question_types_manager,
                     'question_type'          : question_type,
                     'question'               : null,
                     'section'                : null,
+                    'can_update'             : true,
                 }, with_context = false) }}
             </div>
         {% endfor %}

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -71,18 +71,20 @@
             <div class="row">
 
                 {# We expect to use the right side to display some extra info later so keep some available space for now #}
-                <div class="col-7" data-glpi-form-editor-form>
-
+                <div
+                    class="col-7"
+                    data-glpi-form-editor-form
+                    data-glpi-form-editor-active-form
+                >
                     <div
                         data-glpi-form-editor-form-details
-                        data-glpi-form-editor-active
                         data-glpi-form-editor-on-click="set-active"
                     >
                         {# Card containing the main form data: title, header and status #}
                         <div class="card form-details mb-3">
                             <div
                                 class="card-status-start bg-primary"
-                                data-glpi-form-editor-active-status-indicator
+                                data-glpi-form-editor-active-form-status-indicator
                             ></div>
                             <div class="card-body">
 
@@ -127,13 +129,6 @@
                                 </div>
                             </div>
                         </div>
-
-                        <div data-glpi-form-editor-form-extra-details>
-                            {{ include('pages/admin/form/form_toolbar.html.twig', {
-                                'can_update': item.canUpdate(),
-                                'form'      : item,
-                            }, with_context = false) }}
-                        </div>
                     </div>
 
                     {# Display all questions here #}
@@ -150,6 +145,13 @@
                                 'number_of_sections'    : number_of_sections,
                             }, with_context = false) }}
                         {% endfor %}
+                    </div>
+
+                    <div data-glpi-form-editor-form-extra-details>
+                        {{ include('pages/admin/form/form_toolbar.html.twig', {
+                            'can_update': item.canUpdate(),
+                            'form'      : item,
+                        }, with_context = false) }}
                     </div>
                 </div>
             </div>

--- a/templates/pages/admin/form/form_question.html.twig
+++ b/templates/pages/admin/form/form_question.html.twig
@@ -31,11 +31,12 @@
  # ---------------------------------------------------------------------
  #}
 
+{# @var form                   Glpi\Form #}
 {# @var question_types_manager Glpi\Form\QuestionType\QuestionTypesManager #}
 {# @var question_type          Glpi\Form\QuestionType\QuestionTypeInterface #}
 {# @var question               Glpi\Form\Question|null #}
 {# @var section                Glpi\Form\Section|null #}
-
+{# @var can_update             bool #}
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
@@ -46,156 +47,167 @@
 } %}
 
 <div
-    class="card mb-3 {{ question is not null and question.fields.is_mandatory ? 'mandatory-question' : '' }}"
+    class="mb-3"
     data-glpi-form-editor-question
     data-glpi-form-editor-on-click="set-active"
 >
     <div
-        class="card-status-start bg-primary"
-        data-active-status
-    ></div>
-    <div class="card-body">
-        <div class="d-flex">
-            <i
-                class="glpi-form-editor-question-handle ti ti-grip-horizontal cursor-grab ms-auto me-auto mt-n3 mb-n2"
-                data-glpi-form-editor-question-handle
-                draggable="true"
-            ></i>
-        </div>
-        {# Display question's title #}
-        <div class="d-flex mt-n1">
-            <input
-                class="form-control content-editable-h2"
-                type="text"
-                name="name"
-                value="{{ question is not null ? question.fields.name : '' }}"
-                placeholder="{{ __("New question") }}"
-                data-glpi-form-editor-dynamic-input
-                data-glpi-form-editor-on-input="compute-dynamic-input"
-            />
-            <span data-glpi-form-editor-required-mark class="text-danger d-none">*</span>
-        </div>
-
-        {# Render the specific question type #}
-        <div data-glpi-form-editor-question-type-specific>
-            {{ question_type.renderAdminstrationTemplate(question)|raw }}
-        </div>
-
-        {# Display common fields #}
+        data-glpi-form-editor-question-details
+        class="card {{ question is not null and question.fields.is_mandatory ? 'mandatory-question' : '' }}"
+    >
         <div
-            class="content-editable-tinymce"
-            data-glpi-form-editor-question-description
-            {# Mark as secondary if empty #}
-            {{ question is null or question.fields.description|length == 0 ? "data-glpi-form-editor-question-extra-details" : "" }}
-        >
-            {{ fields.textareaField(
-                'description',
-                question is not null ? question.fields.description : '',
-                __('Description'),
-                base_field_options|merge({
-                    'placeholder': __('Add a description...'),
-                    'enable_richtext': true,
-                    'add_body_classes': ['content-editable-tinymce-editor', 'text-muted'],
-                    'editor_height': "0",
-                    'rows' : 1,
-                    'toolbar_location': 'bottom',
-                    'init': question is not null ? true : false,
-                })
-            ) }}
-        </div>
-
-        <div
-            class="d-flex align-items-center"
-            data-glpi-form-editor-question-extra-details
-        >
-            <select
-                {# Note: _type_category is not saved by the backend as we can guess it from the type itself #}
-                name="_type_category"
-                class="form-select form-select-sm me-2"
-                aria-label="{{ __('Question type') }}"
-                style="width: auto;"
-                data-glpi-form-editor-on-change="change-question-type-category"
-            >
-
-                {% for category in question_types_manager.getCategories() %}
-                    {# TODO: add icon, use select2 ? #}
-                     <option
-                        value="{{ category.value }}"
-                        {{ category.value == question_type.getCategory().value ? 'selected' : '' }}
-                    >
-                        {{ category.getLabel() }}
-                    </option>
-                {% endfor %}
-            </select>
-
-            {% set types = question_types_manager.getTypesForCategory(question_type.getCategory()) %}
-            <select
-                name="type"
-                class="form-select form-select-sm {{ types|length == 1 ? 'd-none' : '' }}"
-                aria-label="{{ __('Question sub type') }}"
-                style="width: auto;"
-                data-glpi-form-editor-on-change="change-question-type"
-                data-glpi-form-editor-question-type-selector
-            >
-                {% for possible_question_type in types %}
-                    {# TODO: add icon, use select2 ? #}
-                    <option
-                        value="{{ get_class(possible_question_type) }}"
-                        {{ get_class(possible_question_type) == get_class(question_type) ? 'selected' : '' }}
-                    >
-                        {{ possible_question_type.getName() }}
-                    </option>
-                {% endfor %}
-            </select>
-
-            <label class="form-check form-switch ms-auto mb-0 me-2 cursor-pointer">
-                <input type="hidden" value="0" name="is_mandatory">
+            class="card-status-start bg-primary"
+            data-glpi-form-editor-active-status-indicator
+        ></div>
+        <div class="card-body">
+            <div class="d-flex">
+                <i
+                    class="glpi-form-editor-question-handle ti ti-grip-horizontal cursor-grab ms-auto me-auto mt-n3 mb-n2"
+                    data-glpi-form-editor-question-handle
+                    draggable="true"
+                ></i>
+            </div>
+            {# Display question's title #}
+            <div class="d-flex mt-n1">
                 <input
-                    class="form-check-input"
-                    name="is_mandatory"
-                    type="checkbox"
-                    value="1"
-                    {{ question is not null and question.fields.is_mandatory ? 'checked' : '' }}
-                    data-glpi-form-editor-on-change="toggle-mandatory-question"
-                >
-                <span class="form-check-label">{{ __("Mandatory") }}</span>
-            </label>
+                    class="form-control content-editable-h2"
+                    type="text"
+                    name="name"
+                    value="{{ question is not null ? question.fields.name : '' }}"
+                    placeholder="{{ __("New question") }}"
+                    data-glpi-form-editor-dynamic-input
+                    data-glpi-form-editor-on-input="compute-dynamic-input"
+                />
+                <span data-glpi-form-editor-required-mark class="text-danger d-none">*</span>
+            </div>
 
-            <button
-                class="btn btn-ghost-danger px-2"
-                type="button"
-                data-glpi-form-editor-on-click="delete-question"
+            {# Render the specific question type #}
+            <div data-glpi-form-editor-question-type-specific>
+                {{ question_type.renderAdminstrationTemplate(question)|raw }}
+            </div>
+
+            {# Display common fields #}
+            <div
+                class="content-editable-tinymce"
+                data-glpi-form-editor-question-description
+                {# Mark as secondary if empty #}
+                {{ question is null or question.fields.description|length == 0 ? "data-glpi-form-editor-question-extra-details" : "" }}
             >
-                <i class="ti ti-trash me-2"></i>
-                {{ __("Delete") }}
-            </button>
-        </div>
-    </div>
+                {{ fields.textareaField(
+                    'description',
+                    question is not null ? question.fields.description : '',
+                    __('Description'),
+                    base_field_options|merge({
+                        'placeholder': __('Add a description...'),
+                        'enable_richtext': true,
+                        'add_body_classes': ['content-editable-tinymce-editor', 'text-muted'],
+                        'editor_height': "0",
+                        'rows' : 1,
+                        'toolbar_location': 'bottom',
+                        'init': question is not null ? true : false,
+                    })
+                ) }}
+            </div>
 
-    {# Common hidden data #}
-    <input
-        type="hidden"
-        name="_use_uuid"
-        value="{{ question is not null ? 0 : 1 }}"
-    />
-    <input
-        type="hidden"
-        name="id"
-        value="{{ question is not null ? question.fields.id : 0 }}"
-    />
-    <input
-        type="hidden"
-        name="_use_uuid_for_sections_id"
-        value="{{ section is not null ? 0 : 1 }}"
-    />
-    <input
-        type="hidden"
-        name="forms_sections_id"
-        value="{{ section is not null ? section.fields.id : 0 }}"
-    />
-    <input
-        type="hidden"
-        name="rank"
-        value="{{ question is not null ? question.fields.rank : 0 }}"
-    />
+            <div
+                class="d-flex align-items-center"
+                data-glpi-form-editor-question-extra-details
+            >
+                <select
+                    {# Note: _type_category is not saved by the backend as we can guess it from the type itself #}
+                    name="_type_category"
+                    class="form-select form-select-sm me-2"
+                    aria-label="{{ __('Question type') }}"
+                    style="width: auto;"
+                    data-glpi-form-editor-on-change="change-question-type-category"
+                >
+
+                    {% for category in question_types_manager.getCategories() %}
+                        {# TODO: add icon, use select2 ? #}
+                        <option
+                            value="{{ category.value }}"
+                            {{ category.value == question_type.getCategory().value ? 'selected' : '' }}
+                        >
+                            {{ category.getLabel() }}
+                        </option>
+                    {% endfor %}
+                </select>
+
+                {% set types = question_types_manager.getTypesForCategory(question_type.getCategory()) %}
+                <select
+                    name="type"
+                    class="form-select form-select-sm {{ types|length == 1 ? 'd-none' : '' }}"
+                    aria-label="{{ __('Question sub type') }}"
+                    style="width: auto;"
+                    data-glpi-form-editor-on-change="change-question-type"
+                    data-glpi-form-editor-question-type-selector
+                >
+                    {% for possible_question_type in types %}
+                        {# TODO: add icon, use select2 ? #}
+                        <option
+                            value="{{ get_class(possible_question_type) }}"
+                            {{ get_class(possible_question_type) == get_class(question_type) ? 'selected' : '' }}
+                        >
+                            {{ possible_question_type.getName() }}
+                        </option>
+                    {% endfor %}
+                </select>
+
+                <label class="form-check form-switch ms-auto mb-0 me-2 cursor-pointer">
+                    <input type="hidden" value="0" name="is_mandatory">
+                    <input
+                        class="form-check-input"
+                        name="is_mandatory"
+                        type="checkbox"
+                        value="1"
+                        {{ question is not null and question.fields.is_mandatory ? 'checked' : '' }}
+                        data-glpi-form-editor-on-change="toggle-mandatory-question"
+                    >
+                    <span class="form-check-label">{{ __("Mandatory") }}</span>
+                </label>
+
+                <button
+                    class="btn btn-ghost-danger px-2"
+                    type="button"
+                    data-glpi-form-editor-on-click="delete-question"
+                >
+                    <i class="ti ti-trash me-2"></i>
+                    {{ __("Delete") }}
+                </button>
+            </div>
+        </div>
+
+        {# Common hidden data #}
+        <input
+            type="hidden"
+            name="_use_uuid"
+            value="{{ question is not null ? 0 : 1 }}"
+        />
+        <input
+            type="hidden"
+            name="id"
+            value="{{ question is not null ? question.fields.id : 0 }}"
+        />
+        <input
+            type="hidden"
+            name="_use_uuid_for_sections_id"
+            value="{{ section is not null ? 0 : 1 }}"
+        />
+        <input
+            type="hidden"
+            name="forms_sections_id"
+            value="{{ section is not null ? section.fields.id : 0 }}"
+        />
+        <input
+            type="hidden"
+            name="rank"
+            value="{{ question is not null ? question.fields.rank : 0 }}"
+        />
+    </div>
+    <div data-glpi-form-editor-question-extra-details>
+        {{ include('pages/admin/form/form_toolbar.html.twig', {
+            'can_update': can_update,
+            'form': form,
+        }, with_context = false) }}
+    </div>
 </div>

--- a/templates/pages/admin/form/form_question.html.twig
+++ b/templates/pages/admin/form/form_question.html.twig
@@ -49,15 +49,15 @@
 <div
     class="mb-3"
     data-glpi-form-editor-question
-    data-glpi-form-editor-on-click="set-active"
 >
     <div
+        data-glpi-form-editor-on-click="set-active"
         data-glpi-form-editor-question-details
         class="card {{ question is not null and question.fields.is_mandatory ? 'mandatory-question' : '' }}"
     >
         <div
             class="card-status-start bg-primary"
-            data-glpi-form-editor-active-status-indicator
+            data-glpi-form-editor-active-question-status-indicator
         ></div>
         <div class="card-body">
             <div class="d-flex">

--- a/templates/pages/admin/form/form_question.html.twig
+++ b/templates/pages/admin/form/form_question.html.twig
@@ -73,7 +73,7 @@
                     class="form-control content-editable-h2"
                     type="text"
                     name="name"
-                    value="{{ question is not null ? question.fields.name : '' }}"
+                    value="{{ question is not null ? question.fields.name|e('html_attr') : '' }}"
                     placeholder="{{ __("New question") }}"
                     data-glpi-form-editor-dynamic-input
                     data-glpi-form-editor-on-input="compute-dynamic-input"

--- a/templates/pages/admin/form/form_section.html.twig
+++ b/templates/pages/admin/form/form_section.html.twig
@@ -70,7 +70,7 @@
         >
             <div
                 class="card-status-start bg-primary"
-                data-glpi-form-editor-active-status-indicator
+                data-glpi-form-editor-active-section-status-indicator
             ></div>
             <div class="card-body">
                 {# Header #}

--- a/templates/pages/admin/form/form_section.html.twig
+++ b/templates/pages/admin/form/form_section.html.twig
@@ -62,9 +62,10 @@
     <div
         data-glpi-form-editor-section-details
         data-glpi-form-editor-on-click="set-active"
+        class="{{ show_section_form ? "" : "d-none" }}"
     >
         <div
-            class="card {{ show_section_form ? "" : "d-none" }}"
+            class="card"
             style="border-top-left-radius:0;"
         >
             <div

--- a/templates/pages/admin/form/form_section.html.twig
+++ b/templates/pages/admin/form/form_section.html.twig
@@ -58,130 +58,129 @@
     >
         {{ __("Section %d of %d")|format(section_index, number_of_sections) }}
     </div>
+
     <div
-        class="card mb-3 {{ show_section_form ? "" : "d-none" }}"
-        style="border-top-left-radius:0;"
-        data-glpi-form-editor-section-form-container
+        data-glpi-form-editor-section-details
         data-glpi-form-editor-on-click="set-active"
     >
         <div
-            class="card-status-start bg-primary"
-            data-active-status
-        ></div>
-        <div class="card-body">
-            {# Header #}
-            <div class="d-flex">
-                {# Section's name #}
-                <input
-                    type="text"
-                    class="form-control content-editable-h2"
-                    name="name"
-                    value="{{ section is not null ? section.fields.name|e('html_attr') : '' }}"
-                    placeholder="{{ __("New section") }}"
-                >
+            class="card {{ show_section_form ? "" : "d-none" }}"
+            style="border-top-left-radius:0;"
+        >
+            <div
+                class="card-status-start bg-primary"
+                data-glpi-form-editor-active-status-indicator
+            ></div>
+            <div class="card-body">
+                {# Header #}
+                <div class="d-flex">
+                    {# Section's name #}
+                    <input
+                        type="text"
+                        class="form-control content-editable-h2"
+                        name="name"
+                        value="{{ section is not null ? section.fields.name|e('html_attr') : '' }}"
+                        placeholder="{{ __("New section") }}"
+                    >
 
-                {# Extra actions #}
-                <div class="dropdown ms-auto cursor-pointer">
-                    <i
-                        class="ti ti-dots-vertical show"
-                        data-bs-toggle="dropdown"
-                        aria-expanded="false"
-                    ></i>
-                    <ul class="dropdown-menu" data-bs-popper="none">
-                        <li>
-                            <a
-                                href="#"
-                                class="dropdown-item"
-                                data-bs-toggle="modal"
-                                data-bs-target="[data-glpi-form-editor-move-section-modal]"
-                                data-glpi-form-editor-on-click="build-move-section-modal-content"
-                            >
-                                <i class="ti ti-arrows-move-vertical me-2"></i>
-                                <span>{{ __("Move section") }}</span>
-                            </a>
-                        </li>
+                    {# Extra actions #}
+                    <div class="dropdown ms-auto cursor-pointer">
+                        <i
+                            class="ti ti-dots-vertical show"
+                            data-bs-toggle="dropdown"
+                            aria-expanded="false"
+                        ></i>
+                        <ul class="dropdown-menu" data-bs-popper="none">
+                            <li>
+                                <a
+                                    href="#"
+                                    class="dropdown-item"
+                                    data-bs-toggle="modal"
+                                    data-bs-target="[data-glpi-form-editor-move-section-modal]"
+                                    data-glpi-form-editor-on-click="build-move-section-modal-content"
+                                >
+                                    <i class="ti ti-arrows-move-vertical me-2"></i>
+                                    <span>{{ __("Move section") }}</span>
+                                </a>
+                            </li>
 
-                        <li>
-                            <a
-                                href="#"
-                                class="dropdown-item"
-                                data-glpi-form-editor-on-click="delete-section"
-                            >
-                                <i class="ti ti-trash me-2"></i>
-                                <span>{{ __("Delete section") }}</span>
-                            </a>
-                        </li>
-                    </ul>
+                            <li>
+                                <a
+                                    href="#"
+                                    class="dropdown-item"
+                                    data-glpi-form-editor-on-click="delete-section"
+                                >
+                                    <i class="ti ti-trash me-2"></i>
+                                    <span>{{ __("Delete section") }}</span>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
                 </div>
-            </div>
 
-            {# Section's description #}
-            <div class="content-editable-tinymce">
-                {{ fields.textareaField(
-                    "description",
-                    section is not null ? section.fields.description : '',
-                    __('Header'),
-                    base_field_options|merge({
-                        'enable_richtext': true,
-                        'placeholder': __('Add a description to this section...'),
-                        'add_body_classes': ['content-editable-tinymce-editor', 'text-muted'],
-                        'editor_height': "0",
-                        'rows' : 1,
-                        'toolbar_location': 'bottom',
-                        'init': section is not null ? true : false,
-                    })
-                ) }}
-            </div>
+                {# Section's description #}
+                <div class="content-editable-tinymce">
+                    {{ fields.textareaField(
+                        "description",
+                        section is not null ? section.fields.description : '',
+                        __('Header'),
+                        base_field_options|merge({
+                            'enable_richtext': true,
+                            'placeholder': __('Add a description to this section...'),
+                            'add_body_classes': ['content-editable-tinymce-editor', 'text-muted'],
+                            'editor_height': "0",
+                            'rows' : 1,
+                            'toolbar_location': 'bottom',
+                            'init': section is not null ? true : false,
+                        })
+                    ) }}
+                </div>
 
-            <input
-                type="hidden"
-                name="_use_uuid"
-                value="{{ section is not null ? 0 : 1 }}"
-            />
-            <input
-                type="hidden"
-                name="id"
-                value="{{ section is not null ? section.fields.id : 0 }}"
-            />
-            <input
-                type="hidden"
-                name="forms_forms_id"
-                value="{{ form.fields.id }}"
-            />
-            <input
-                type="hidden"
-                name="rank"
-                value="{{ section is not null ? section.fields.rank : 0 }}"
-            />
+                <input
+                    type="hidden"
+                    name="_use_uuid"
+                    value="{{ section is not null ? 0 : 1 }}"
+                />
+                <input
+                    type="hidden"
+                    name="id"
+                    value="{{ section is not null ? section.fields.id : 0 }}"
+                />
+                <input
+                    type="hidden"
+                    name="forms_forms_id"
+                    value="{{ form.fields.id }}"
+                />
+                <input
+                    type="hidden"
+                    name="rank"
+                    value="{{ section is not null ? section.fields.rank : 0 }}"
+                />
+            </div>
         </div>
+
+        <div data-glpi-form-editor-section-extra-details>
+            {{ include('pages/admin/form/form_toolbar.html.twig', {
+                'can_update': can_update,
+                'form'      : form,
+            }, with_context = false) }}
+        </div>
+
     </div>
 
-     <div data-glpi-form-editor-section-questions>
+    <div data-glpi-form-editor-section-questions class="mt-3">
         {% for question in section.getQuestions() %}
             {# Render admin template for the given question type #}
             {{ include('pages/admin/form/form_question.html.twig', {
+                'form'                  : form,
                 'question_types_manager': question_types_manager,
                 'question_type'         : question.getQuestionType(),
                 'question'              : question,
                 'section'               : section,
+                'can_update'            : can_update,
             }, with_context = false) }}
         {% endfor %}
     </div>
 
-    {# Add question action at the end of each sections #}
-    {# TODO: UI/UX #}
-    {% if can_update %}
-        <div
-            class="card cursor-pointer align-items-center mb-4"
-            data-glpi-form-editor-on-click="add-question"
-        >
-            <div class="card-body">
-                <h3 class="d-flex align-items-center">
-                    <i class="ti ti-circle-plus me-2"></i>
-                    {{ __("Add question") }}
-                </h3>
-            </div>
-        </div>
-    {% endif %}
 </div>
 

--- a/templates/pages/admin/form/form_toolbar.html.twig
+++ b/templates/pages/admin/form/form_toolbar.html.twig
@@ -1,0 +1,68 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{# @var form       Glpi\Form\Form #}
+{# @var can_update bool #}
+
+{% if can_update %}
+    <div
+        class="btn-group mt-2 d-flex justify-content-center"
+        style="box-shadow:none;"
+        role="group"
+    >
+        {# Add question action #}
+        <label
+            for="btn-radio-toolbar-1"
+            class="btn btn-icon flex-grow-0"
+            data-glpi-form-editor-on-click="add-question"
+        >
+            {# This is the main action, we highlight it by adding a description #}
+            <span class="px-2 d-flex align-items-center">
+                <i class="ti ti-circle-plus me-2"></i> {{ __("Add a new question") }}
+            </span>
+        </label>
+
+        {# Add section action #}
+        {% set add_section_action_visible = form.getSections()|length > 1 or (form.getSections()|first).getQuestions()|length > 0 %}
+        <label
+            for="btn-radio-toolbar-1"
+            class="btn btn-icon flex-grow-0 {{ add_section_action_visible ? '' : 'd-none' }}"
+            data-bs-toggle="tooltip"
+            data-bs-placement="bottom"
+            title="{{ __("Add a new section") }}" {# Secondary action, use a tooltip #}
+            data-glpi-form-editor-on-click="add-section"
+        >
+            <i class="ti ti-box-align-top"></i>
+        </label>
+    </div>
+{% endif %}

--- a/templates/pages/admin/form/form_toolbar.html.twig
+++ b/templates/pages/admin/form/form_toolbar.html.twig
@@ -44,11 +44,13 @@
         <label
             for="btn-radio-toolbar-1"
             class="btn btn-icon flex-grow-0"
+            data-bs-toggle="tooltip"
+            data-bs-placement="bottom"
+            title="{{ __("Add a new question") }}"
             data-glpi-form-editor-on-click="add-question"
         >
-            {# This is the main action, we highlight it by adding a description #}
             <span class="px-2 d-flex align-items-center">
-                <i class="ti ti-circle-plus me-2"></i> {{ __("Add a new question") }}
+                <i class="ti ti-circle-plus"></i>
             </span>
         </label>
 
@@ -59,7 +61,7 @@
             class="btn btn-icon flex-grow-0 {{ add_section_action_visible ? '' : 'd-none' }}"
             data-bs-toggle="tooltip"
             data-bs-placement="bottom"
-            title="{{ __("Add a new section") }}" {# Secondary action, use a tooltip #}
+            title="{{ __("Add a new section") }}"
             data-glpi-form-editor-on-click="add-section"
         >
             <i class="ti ti-box-align-top"></i>


### PR DESCRIPTION
Add a "floating toolbar" to the form editor.

![image](https://github.com/glpi-project/glpi/assets/42734840/7525ae9a-893a-42f4-b9e1-be72a88b2fc4)

This toolbar is shown for the active item and allow to insert a new question or section.
Its design and position might change in futures PR as we discuss UX later on.

Others changes:
* Renamed the `data-active-status` attribute to `[data-glpi-form-editor-active-status-indicator]` (to keep things consistant)
* Replaced the `.active` class by a `[data-glpi-form-editor-active]` data attribute (to prevent conflicts as others components may use the same `.active` class, which may impact our selectors)
* Question drag and drop handle is only shown when hovering the question itself (new `[data-glpi-form-editor-question-details]` attribute instead of `[data-glpi-form-editor-question]` which now also contain the toolbar).
* `#handleEditorAction` now received the original event objet to allow specific actions to prevent event propagation.
* The `#addQuestion` and `#addSection` methods now require the current active form element as a parameter, which may be a question, a section or the form itself.
This is needed because these methods behave differently based on the active item (while previously questions and section would always be added at the end of the form, they can now be added anywhere)
* When the last question is deleted, we set the form as active.
This allow the form toolbar to be shown as it will be used to recreate questions if needed.
* Renamed `[data-glpi-form-editor-section-form-container]` to `[data-glpi-form-editor-section-details]` to be consistant with similar selectors for questions and the form itself.
* `#copy_template` accept a new parameter to specify how the data should be copied relative to the destination (after, before, prepend or append).
* Added `#handleItemMove` to centralize tinymce re-initialization process as it can now be triggered from two separate actions (creating a section in the middle of an existing one or moving a question with its handle). The reorder section actions should probably use it too but I didn't want to change it here as it a bit more complicated to handle (TODO later).
* Small bugfix to `#reorderSections` + added a TODO that explain it should no rely on the computeState() data for its behavior.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
