### PR TITLE
Dynamic asset capacity search option ids

### DIFF
--- a/src/Asset/AssetDefinition.php
+++ b/src/Asset/AssetDefinition.php
@@ -41,7 +41,7 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\Asset\Capacity\CapacityInterface;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
-use Glpi\Search\Input\QueryBuilder;
+use Glpi\Search\SearchOption;
 use Profile;
 use ProfileRight;
 use Session;
@@ -629,10 +629,6 @@ final class AssetDefinition extends CommonDBTM
             'datatype'      => 'text'
         ];
 
-        // Capacity search option IDs can be assigned anywhere in the 1000-11000 range based on the capacity class name
-        $fn_get_id_for_capacity = static function (string $capacity) {
-            return (int) abs((int) hexdec(hash('xxh3', $capacity)) % 10000) + 1000;
-        };
         $search_options[] = [
             'id'   => 'capacities',
             'name' => __('Capacities')
@@ -647,7 +643,7 @@ final class AssetDefinition extends CommonDBTM
             $search_string = str_replace('\\', '\\\\', $search_string);
 
             $search_options[] = [
-                'id'            => $fn_get_id_for_capacity($capacity::class),
+                'id'            => SearchOption::generateAPropbablyUniqueId($capacity::class),
                 'table'         => self::getTable(),
                 'field'         => sprintf('_capacities_%s', $capacity::class),
                 'name'          => $capacity->getLabel(),

--- a/src/Asset/AssetDefinition.php
+++ b/src/Asset/AssetDefinition.php
@@ -629,14 +629,15 @@ final class AssetDefinition extends CommonDBTM
             'datatype'      => 'text'
         ];
 
-        $i = 1000;
+        // Capacity search option IDs can be assigned anywhere in the 1000-11000 range based on the capacity class name
+        $fn_get_id_for_capacity = static function (string $capacity) {
+            return (int) abs((int) hexdec(hash('xxh3', $capacity)) % 10000) + 1000;
+        };
         $search_options[] = [
             'id'   => 'capacities',
             'name' => __('Capacities')
         ];
         foreach (AssetDefinitionManager::getInstance()->getAvailableCapacities() as $capacity) {
-            $i++;
-
             // capacity is stored in a JSON array, so entry is surrounded by double quotes
             $search_string = json_encode($capacity::class);
             // Backslashes must be doubled in LIKE clause, according to MySQL documentation:
@@ -646,7 +647,7 @@ final class AssetDefinition extends CommonDBTM
             $search_string = str_replace('\\', '\\\\', $search_string);
 
             $search_options[] = [
-                'id'            => $i,
+                'id'            => $fn_get_id_for_capacity($capacity::class),
                 'table'         => self::getTable(),
                 'field'         => sprintf('_capacities_%s', $capacity::class),
                 'name'          => $capacity->getLabel(),

--- a/src/Asset/AssetDefinition.php
+++ b/src/Asset/AssetDefinition.php
@@ -643,7 +643,7 @@ final class AssetDefinition extends CommonDBTM
             $search_string = str_replace('\\', '\\\\', $search_string);
 
             $search_options[] = [
-                'id'            => SearchOption::generateAPropbablyUniqueId($capacity::class),
+                'id'            => SearchOption::generateAProbablyUniqueId($capacity::class),
                 'table'         => self::getTable(),
                 'field'         => sprintf('_capacities_%s', $capacity::class),
                 'name'          => $capacity->getLabel(),

--- a/src/Search/SearchOption.php
+++ b/src/Search/SearchOption.php
@@ -757,7 +757,7 @@ final class SearchOption implements \ArrayAccess
      * @param string $plugin
      * @return int
      */
-    public static function generateAPropbablyUniqueId(string $string_identifier, ?string $plugin = null): int
+    public static function generateAProbablyUniqueId(string $string_identifier, ?string $plugin = null): int
     {
         // Generates an ID that can be assigned anywhere in the 10000-19999 range
         $generated_id = (int)abs((int)hexdec(hash('xxh3', $string_identifier))) % 10000 + 10000;

--- a/src/Search/SearchOption.php
+++ b/src/Search/SearchOption.php
@@ -747,4 +747,28 @@ final class SearchOption implements \ArrayAccess
 
         return $toview;
     }
+
+    /**
+     * Generates a search option ID that will probably be unique.
+     * This automatically generated ID will be in the 10000-19999 range for GLPI core and in the 20000-99999 range if a
+     * plugin name is provided.
+     *
+     * @param string $string_identifier
+     * @param string $plugin
+     * @return int
+     */
+    public static function generateAPropbablyUniqueId(string $string_identifier, ?string $plugin = null): int
+    {
+        // Generates an ID that can be assigned anywhere in the 10000-19999 range
+        $generated_id = (int)abs((int)hexdec(hash('xxh3', $string_identifier))) % 10000 + 10000;
+
+        if ($plugin !== null && $plugin !== '') {
+            // For plugins, increment the generated ID from a value between 10000 to 79999,
+            // to get a final ID anywhere in the 20000-99999 range.
+            $plugin_increment = (int)abs((int)hexdec(hash('xxh3', $plugin))) % 80000 + 10000;
+            $generated_id += $plugin_increment;
+        }
+
+        return $generated_id;
+    }
 }

--- a/tests/units/Glpi/Search/SearchOption.php
+++ b/tests/units/Glpi/Search/SearchOption.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Search;
+
+class SearchOption extends \GLPITestCase
+{
+    protected function searchOptionIdGeneratorProvider(): iterable
+    {
+        yield [
+            'string_identifier' => 'any string can be used',
+            'plugin'            => null,
+            'generated_id'      => 12835,
+        ];
+        yield [
+            'string_identifier' => 'any string can be used',
+            'plugin'            => 'MyPlugin',
+            'generated_id'      => 80255,
+        ];
+        yield [
+            'string_identifier' => 'any string can be used',
+            'plugin'            => 'AnotherPlugin',
+            'generated_id'      => 30995,
+        ];
+    }
+
+    /**
+     * @dataProvider searchOptionIdGeneratorProvider
+     */
+    public function testGenerateAPropbablyUniqueId(
+        string $string_identifier,
+        ?string $plugin,
+        int $generated_id
+    ) {
+        $result = \Glpi\Search\SearchOption::generateAPropbablyUniqueId($string_identifier, $plugin);
+        $this->integer($result)->isEqualTo($generated_id);
+    }
+
+    public function testGenerateAPropbablyUniqueIdRange()
+    {
+        for ($i = 'a'; $i < 'aaa'; $i = str_increment($i)) {
+            $core_result = \Glpi\Search\SearchOption::generateAPropbablyUniqueId($i, null);
+            $this->integer($core_result)->isGreaterThanOrEqualTo(10000);
+            $this->integer($core_result)->isLessThanOrEqualTo(19999);
+
+            $plugin_result = \Glpi\Search\SearchOption::generateAPropbablyUniqueId($i, 'MyPlugin');
+            $this->integer($plugin_result)->isGreaterThanOrEqualTo(20000);
+            $this->integer($plugin_result)->isLessThanOrEqualTo(99999);
+        }
+    }
+}

--- a/tests/units/Glpi/Search/SearchOption.php
+++ b/tests/units/Glpi/Search/SearchOption.php
@@ -64,18 +64,18 @@ class SearchOption extends \GLPITestCase
         ?string $plugin,
         int $generated_id
     ) {
-        $result = \Glpi\Search\SearchOption::generateAPropbablyUniqueId($string_identifier, $plugin);
+        $result = \Glpi\Search\SearchOption::generateAProbablyUniqueId($string_identifier, $plugin);
         $this->integer($result)->isEqualTo($generated_id);
     }
 
     public function testGenerateAPropbablyUniqueIdRange()
     {
         for ($i = 'a'; $i < 'aaa'; $i = str_increment($i)) {
-            $core_result = \Glpi\Search\SearchOption::generateAPropbablyUniqueId($i, null);
+            $core_result = \Glpi\Search\SearchOption::generateAProbablyUniqueId($i, null);
             $this->integer($core_result)->isGreaterThanOrEqualTo(10000);
             $this->integer($core_result)->isLessThanOrEqualTo(19999);
 
-            $plugin_result = \Glpi\Search\SearchOption::generateAPropbablyUniqueId($i, 'MyPlugin');
+            $plugin_result = \Glpi\Search\SearchOption::generateAProbablyUniqueId($i, 'MyPlugin');
             $this->integer($plugin_result)->isGreaterThanOrEqualTo(20000);
             $this->integer($plugin_result)->isLessThanOrEqualTo(99999);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Assign search option IDs for capacities based on the capacity class name to ensure each capacity keeps the same ID regardless of the order they are defined.