### PR TITLE
Fixed display of group name in simplified interface

### DIFF
--- a/src/Group.php
+++ b/src/Group.php
@@ -1035,7 +1035,7 @@ class Group extends CommonTreeDropdown
     {
         if (
             Session::getCurrentInterface() == 'helpdesk'
-            && ($anon = self::getAnonymizedName()) !== ""
+            && ($anon = self::getAnonymizedName()) !== null
         ) {
             return $anon;
         }
@@ -1048,7 +1048,7 @@ class Group extends CommonTreeDropdown
     {
         if (
             Session::getCurrentInterface() == 'helpdesk'
-            && ($anon = $this->getAnonymizedName()) !== ""
+            && ($anon = $this->getAnonymizedName()) !== null
         ) {
             return $anon;
         }
@@ -1057,12 +1057,12 @@ class Group extends CommonTreeDropdown
     }
 
 
-    public static function getAnonymizedName(?int $entities_id = null): string
+    public static function getAnonymizedName(?int $entities_id = null): ?string
     {
         switch (Entity::getAnonymizeConfig($entities_id)) {
             default:
             case Entity::ANONYMIZE_DISABLED:
-                return "";
+                return null;
 
             case Entity::ANONYMIZE_USE_GENERIC:
             case Entity::ANONYMIZE_USE_NICKNAME:
@@ -1083,12 +1083,12 @@ class Group extends CommonTreeDropdown
      *
      * @return string
      */
-    public function getGroupLink(bool $enable_anonymization = false): string
+    public function getGroupLink(bool $enable_anonymization = false): ?string
     {
 
         if ($enable_anonymization && Session::getCurrentInterface() == 'helpdesk' && ($anon = $this->getAnonymizedName()) !== null) {
            // if anonymized name active, return only the anonymized name
-            return $anon;
+            return "test";
         }
 
         return $this->getLink();

--- a/src/Group.php
+++ b/src/Group.php
@@ -1083,7 +1083,7 @@ class Group extends CommonTreeDropdown
      *
      * @return string
      */
-    public function getGroupLink(bool $enable_anonymization = false): ?string
+    public function getGroupLink(bool $enable_anonymization = false): string
     {
 
         if ($enable_anonymization && Session::getCurrentInterface() == 'helpdesk' && ($anon = $this->getAnonymizedName()) !== null) {

--- a/src/Group.php
+++ b/src/Group.php
@@ -1088,7 +1088,7 @@ class Group extends CommonTreeDropdown
 
         if ($enable_anonymization && Session::getCurrentInterface() == 'helpdesk' && ($anon = $this->getAnonymizedName()) !== null) {
            // if anonymized name active, return only the anonymized name
-            return "test";
+            return $anon;
         }
 
         return $this->getLink();

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -69,7 +69,11 @@
             {% if entry_i['groups_id_tech'] %}
                <span class="badge bg-orange-lt">
                   <i class="fas fa-users me-1"></i>
-                  {{ get_item_link('Group', entry_i['groups_id_tech'], {'enable_anonymization': true}) }}
+                  {% if get_current_interface() == 'helpdesk' %}
+                     {{ get_item_name('Group', entry_i['groups_id_tech'], {'enable_anonymization': true}) }}
+                  {% else %}
+                     {{ get_item_link('Group', entry_i['groups_id_tech'], {'enable_anonymization': true}) }}
+                  {% endif %}
                </span>
             {% endif %}
 

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -69,11 +69,7 @@
             {% if entry_i['groups_id_tech'] %}
                <span class="badge bg-orange-lt">
                   <i class="fas fa-users me-1"></i>
-                  {% if get_current_interface() == 'helpdesk' %}
-                     {{ get_item_name('Group', entry_i['groups_id_tech'], {'enable_anonymization': true}) }}
-                  {% else %}
                      {{ get_item_link('Group', entry_i['groups_id_tech'], {'enable_anonymization': true}) }}
-                  {% endif %}
                </span>
             {% endif %}
 

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -69,7 +69,7 @@
             {% if entry_i['groups_id_tech'] %}
                <span class="badge bg-orange-lt">
                   <i class="fas fa-users me-1"></i>
-                     {{ get_item_link('Group', entry_i['groups_id_tech'], {'enable_anonymization': true}) }}
+                  {{ get_item_link('Group', entry_i['groups_id_tech'], {'enable_anonymization': true}) }}
                </span>
             {% endif %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #16560

When using the simplified interface, task groups are not visible.
Now the name is visible.

**Basic interface :** 
_Group name and link_
![image](https://github.com/glpi-project/glpi/assets/107540223/ee4ae372-6f68-400c-a5ea-c1dab9ceb488)

**Simplified interface :** 
_Just group name_
![image](https://github.com/glpi-project/glpi/assets/107540223/5168c9e3-8b38-490d-95a0-9b76898b2317)
