### PR TITLE
Make `CommonDBTM::getFromDBByCrit()` return positive result on multiple matches

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -362,7 +362,7 @@ class CommonDBTM extends CommonGLPI
      *
      * @param array $crit search criteria
      *
-     * @return boolean|array
+     * @return boolean
      */
     public function getFromDBByCrit(array $crit)
     {
@@ -375,10 +375,12 @@ class CommonDBTM extends CommonGLPI
         ];
 
         $iter = $DB->request($crit);
-        if (count($iter) == 1) {
-            $row = $iter->current();
-            return $this->getFromDB($row['id']);
-        } else if (count($iter) > 1) {
+
+        if (count($iter) === 0) {
+            return false;
+        }
+
+        if (count($iter) > 1) {
             trigger_error(
                 sprintf(
                     'getFromDBByCrit expects to get one result, %1$s found in query "%2$s".',
@@ -388,7 +390,9 @@ class CommonDBTM extends CommonGLPI
                 E_USER_WARNING
             );
         }
-        return false;
+
+        $row = $iter->current();
+        return $this->getFromDB($row['id']);
     }
 
 

--- a/tests/functional/CommonDBTM.php
+++ b/tests/functional/CommonDBTM.php
@@ -161,6 +161,26 @@ class CommonDBTM extends DbTestCase
         $this->boolean($instance->isNewItem())->isTrue();
     }
 
+    public function testGetFromDBByCrit()
+    {
+        $entity = new \Entity();
+        $this->boolean($entity->getFromDBByCrit(['name' => '_test_root_entity']))->isTrue();
+        $this->string($entity->fields['name'])->isEqualTo('_test_root_entity');
+
+        $this->when(
+            function () {
+                $entity = new \Entity();
+                $this->boolean($entity->getFromDBByCrit(['level' => ['>', 0]]))->isTrue();
+                $this->string($entity->fields['name'])->isEqualTo('Root entity');
+            }
+        )->error
+            ->withType(E_USER_WARNING)
+            ->withMessage('getFromDBByCrit expects to get one result, 4 found in query "SELECT `id` FROM `glpi_entities` WHERE `level` > \'0\'".')
+            ->exists();
+
+
+    }
+
     public function testGetFromResultSet()
     {
         global $DB;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Many usages of `CommonDBTM::getFromDBByCrit()` are used in a logic that will create a new item if no item is found using given criteria. The problem is that, when there is already an unexpected duplication, the falsy result of `getFromDBByCrit()` will lead to create another duplicated entry, making the initial issue worse.

IMHO, getting randomly the first result found will almost in all cases be a better solution than returning a falsy result. The warning will anyway be triggered, so people will still be able to warn about a potential issue.

Another solution could be, in contrary, to make this error a blocker, by throwing an exception. This alternative solution is probably safer, but may also be a bit rude.

Anyway, I think the current behaviour is not satisfying.