### PR TITLE
Forms: make sure tests fails if new categories content is not tested

### DIFF
--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypesManager.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypesManager.php
@@ -136,4 +136,25 @@ class QuestionTypesManager extends DbTestCase
 
         $this->array($types)->isEqualTo($expected_types);
     }
+
+    /**
+     * This test case ensure all categories are defined by the
+     * testGetTypesForCategoryProvider provider.
+     *
+     * This prevent us from forgetting to update this provider when adding new
+     * questions types
+     *
+     * @return void
+     */
+    public function testEnsureAllCategoriesAreTested(): void
+    {
+        $manager = \Glpi\Form\QuestionType\QuestionTypesManager::getInstance();
+        $provider_data = iterator_to_array($this->testGetTypesForCategoryProvider());
+
+        $this
+            ->array($provider_data)
+            ->hasSize(
+                count($manager->getCategories())
+            );
+    }
 }

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypesManager.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypesManager.php
@@ -154,7 +154,8 @@ class QuestionTypesManager extends DbTestCase
         $this
             ->array($provider_data)
             ->hasSize(
-                count($manager->getCategories())
+                count($manager->getCategories()),
+                "All categories must be added to the `testGetTypesForCategoryProvider` provider"
             );
     }
 }


### PR DESCRIPTION
Force `testGetTypesForCategoryProvider` to use all available categories.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
