### PR TITLE
fix(ticket): deleted budget

### DIFF
--- a/src/CommonITILCost.php
+++ b/src/CommonITILCost.php
@@ -340,7 +340,11 @@ abstract class CommonITILCost extends CommonDBChild
             $this->fields['cost_fixed'] = $lastdata['cost_fixed'];
         }
         if (isset($lastdata['budgets_id'])) {
-            $this->fields['budgets_id'] = $lastdata['budgets_id'];
+            $budget_id = $lastdata['budgets_id'];
+            $budget    = new Budget();
+            if ($budget->getFromDB($budget_id) && $budget->fields['is_deleted'] == 0) {
+                $this->fields['budgets_id'] = $budget_id;
+            }
         }
         if (isset($lastdata['name'])) {
             $this->fields['name'] = $lastdata['name'];


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !31520

If a cost has already been charged to a budget for a ticket, the next time the ticket is added, the previously used budget is filled in by default in the addition form, without checking whether this budget has been deleted. _This allowed a deleted budget to continue to be charged. When the dropdown was unfolded, the deleted value was not listed._

![image](https://github.com/glpi-project/glpi/assets/8530352/714f6af4-da93-439d-8638-403866743785)

