### PR TITLE
Remove self hosted Github Action runner support

### DIFF
--- a/.github/actions/teardown_containers-cleanup.sh
+++ b/.github/actions/teardown_containers-cleanup.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e -u -x -o pipefail
-
-docker-compose down --volumes

--- a/.github/workflows/audit_dependencies.yml
+++ b/.github/workflows/audit_dependencies.yml
@@ -22,11 +22,13 @@ jobs:
           - {branch: "10.0/bugfixes", php-version: "7.4"}
     env:
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml"
-      APP_CONTAINER_HOME: "${{ runner.temp }}/app_home"
       APPLICATION_ROOT: "${{ github.workspace }}"
       PHP_IMAGE: "githubactions-php:${{ matrix.php-version }}"
       UPDATE_FILES_ACL: true
     steps:
+      - name: "Set env"
+        run: |
+          echo "APP_CONTAINER_HOME=${{ runner.temp }}/app_home" >> $GITHUB_ENV
       - name: "Checkout"
         uses: "actions/checkout@v4"
         with:

--- a/.github/workflows/audit_dependencies.yml
+++ b/.github/workflows/audit_dependencies.yml
@@ -22,15 +22,11 @@ jobs:
           - {branch: "10.0/bugfixes", php-version: "7.4"}
     env:
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml"
+      APP_CONTAINER_HOME: "${{ runner.temp }}/app_home"
       APPLICATION_ROOT: "${{ github.workspace }}"
       PHP_IMAGE: "githubactions-php:${{ matrix.php-version }}"
       UPDATE_FILES_ACL: true
     steps:
-      - name: "Clean workspace"
-        run: |
-          echo "APP_CONTAINER_HOME=${{ runner.temp }}/app_home" >> $GITHUB_ENV
-          rm -rf "${{ env.APPLICATION_ROOT }}/*"
-          rm -rf "${{ env.APP_CONTAINER_HOME }}/*"
       - name: "Checkout"
         uses: "actions/checkout@v4"
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     # Do not run scheduled lint on tier repositories
     if: github.repository == 'glpi-project/glpi' || github.event_name != 'schedule'
     name: "Lint on PHP ${{ matrix.php-version }}"
-    runs-on: "${{ github.repository == 'glpi-network/glpi' && 'self-hosted' || 'ubuntu-latest' }}"
+    runs-on: "ubuntu-latest"
     strategy:
       fail-fast: false
       matrix:
@@ -38,15 +38,11 @@ jobs:
           - {php-version: "8.3"} # Lint on higher PHP version to detected deprecated elements usage
     env:
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml"
+      APP_CONTAINER_HOME: "${{ runner.temp }}/app_home"
       APPLICATION_ROOT: "${{ github.workspace }}"
       PHP_IMAGE: "githubactions-php:${{ matrix.php-version }}"
       UPDATE_FILES_ACL: true
     steps:
-      - name: "Clean workspace"
-        run: |
-          echo "APP_CONTAINER_HOME=${{ runner.temp }}/app_home" >> $GITHUB_ENV
-          rm -rf "${{ env.APPLICATION_ROOT }}/*"
-          rm -rf "${{ env.APP_CONTAINER_HOME }}/*"
       - name: "Checkout"
         uses: "actions/checkout@v4"
       - name: "Restore dependencies cache"
@@ -92,16 +88,12 @@ jobs:
       - name: "Misc lint"
         run: |
           docker-compose exec -T app .github/actions/lint_misc-lint.sh
-      - name: "Cleanup containers"
-        if: always()
-        run: |
-          .github/actions/teardown_containers-cleanup.sh
 
   tests:
     # Do not run scheduled tests on tier repositories
     if: github.repository == 'glpi-project/glpi' || github.event_name != 'schedule'
     name: "Test on PHP ${{ matrix.php-version }} using ${{ matrix.db-image }}"
-    runs-on: "${{ github.repository == 'glpi-network/glpi' && 'self-hosted' || 'ubuntu-latest' }}"
+    runs-on: "ubuntu-latest"
     strategy:
       fail-fast: false
       matrix:
@@ -124,17 +116,12 @@ jobs:
       # No jobs will be skipped on nightly build, manual dispatch or push on main branches (main and */bugfixes) or tags.
       skip: ${{ matrix.always == false && (github.event_name == 'pull_request' || github.repository != 'glpi-project/glpi' || !(github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || endsWith(github.ref, '/bugfixes') || startsWith(github.ref, 'refs/tags'))) }}
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml:.github/actions/docker-compose-services.yml"
+      APP_CONTAINER_HOME: "${{ runner.temp }}/app_home"
       APPLICATION_ROOT: "${{ github.workspace }}"
       DB_IMAGE: "githubactions-${{ matrix.db-image }}"
       PHP_IMAGE: "githubactions-php:${{ matrix.php-version }}"
       UPDATE_FILES_ACL: true
     steps:
-      - name: "Clean workspace"
-        if: env.skip != 'true'
-        run: |
-          echo "APP_CONTAINER_HOME=${{ runner.temp }}/app_home" >> $GITHUB_ENV
-          rm -rf "${{ env.APPLICATION_ROOT }}/*"
-          rm -rf "${{ env.APP_CONTAINER_HOME }}/*"
       - name: "Checkout"
         if: env.skip != 'true'
         uses: "actions/checkout@v4"
@@ -205,7 +192,3 @@ jobs:
         if: env.skip != 'true'
         run: |
           docker-compose exec -T app .github/actions/test_javascript.sh
-      - name: "Cleanup containers"
-        if: env.skip != 'true' && always()
-        run: |
-          .github/actions/teardown_containers-cleanup.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,13 @@ jobs:
           - {php-version: "8.3"} # Lint on higher PHP version to detected deprecated elements usage
     env:
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml"
-      APP_CONTAINER_HOME: "${{ runner.temp }}/app_home"
       APPLICATION_ROOT: "${{ github.workspace }}"
       PHP_IMAGE: "githubactions-php:${{ matrix.php-version }}"
       UPDATE_FILES_ACL: true
     steps:
+      - name: "Set env"
+        run: |
+          echo "APP_CONTAINER_HOME=${{ runner.temp }}/app_home" >> $GITHUB_ENV
       - name: "Checkout"
         uses: "actions/checkout@v4"
       - name: "Restore dependencies cache"
@@ -116,12 +118,14 @@ jobs:
       # No jobs will be skipped on nightly build, manual dispatch or push on main branches (main and */bugfixes) or tags.
       skip: ${{ matrix.always == false && (github.event_name == 'pull_request' || github.repository != 'glpi-project/glpi' || !(github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || endsWith(github.ref, '/bugfixes') || startsWith(github.ref, 'refs/tags'))) }}
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml:.github/actions/docker-compose-services.yml"
-      APP_CONTAINER_HOME: "${{ runner.temp }}/app_home"
       APPLICATION_ROOT: "${{ github.workspace }}"
       DB_IMAGE: "githubactions-${{ matrix.db-image }}"
       PHP_IMAGE: "githubactions-php:${{ matrix.php-version }}"
       UPDATE_FILES_ACL: true
     steps:
+      - name: "Set env"
+        run: |
+          echo "APP_CONTAINER_HOME=${{ runner.temp }}/app_home" >> $GITHUB_ENV
       - name: "Checkout"
         if: env.skip != 'true'
         uses: "actions/checkout@v4"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,18 +24,13 @@ jobs:
           - {branch: "main", php-version: "8.2", db-image: "mariadb:11.0"}
     env:
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml:.github/actions/docker-compose-services.yml"
+      APP_CONTAINER_HOME: "${{ runner.temp }}/app_home"
       APPLICATION_ROOT: "${{ github.workspace }}"
       DB_IMAGE: "githubactions-${{ matrix.db-image }}"
       PHP_IMAGE: "githubactions-php-coverage:${{ matrix.php-version }}"
       UPDATE_FILES_ACL: true
       CODE_COVERAGE: true
     steps:
-      - name: "Clean workspace"
-        if: env.skip != 'true'
-        run: |
-          echo "APP_CONTAINER_HOME=${{ runner.temp }}/app_home" >> $GITHUB_ENV
-          rm -rf "${{ env.APPLICATION_ROOT }}/*"
-          rm -rf "${{ env.APP_CONTAINER_HOME }}/*"
       - name: "Checkout"
         uses: "actions/checkout@v4"
         with:
@@ -81,7 +76,3 @@ jobs:
         with:
           files: ./tests/coverage-unit/clover.xml,./tests/coverage-functional/clover.xml,./tests/coverage-ldap/clover.xml,./tests/coverage-imap/clover.xml
           override_branch: ${{ matrix.branch }}
-      - name: "Cleanup containers"
-        if: always()
-        run: |
-          .github/actions/teardown_containers-cleanup.sh

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,13 +24,15 @@ jobs:
           - {branch: "main", php-version: "8.2", db-image: "mariadb:11.0"}
     env:
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml:.github/actions/docker-compose-services.yml"
-      APP_CONTAINER_HOME: "${{ runner.temp }}/app_home"
       APPLICATION_ROOT: "${{ github.workspace }}"
       DB_IMAGE: "githubactions-${{ matrix.db-image }}"
       PHP_IMAGE: "githubactions-php-coverage:${{ matrix.php-version }}"
       UPDATE_FILES_ACL: true
       CODE_COVERAGE: true
     steps:
+      - name: "Set env"
+        run: |
+          echo "APP_CONTAINER_HOME=${{ runner.temp }}/app_home" >> $GITHUB_ENV
       - name: "Checkout"
         uses: "actions/checkout@v4"
         with:

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -338,7 +338,7 @@ cleanup_and_exit () {
   find "$BACKUP_DIR" -mindepth 1 -exec mv -f {} $APPLICATION_ROOT/tests/config \;
 
   # Stop containers
-  $APPLICATION_ROOT/.github/actions/teardown_containers-cleanup.sh
+  docker-compose down --volumes
 
   exit $LAST_EXIT_CODE
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The self hosted Github Action runner is not used anymore as it is far from being reliable (not enough system resources to be able to run GLPI test suite completely and in an acceptable delay). As we do not use it anymore, we can remove corresponding scripts.