### PR TITLE
Add tech/group as default planning reminder notification target

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -4323,7 +4323,17 @@ $empty_data_builder = new class
                 'items_id'         => '21',
                 'type'             => '1',
                 'notifications_id' => '79',
-            ]
+            ], [
+                'id'               => '157',
+                'items_id'         => '16',
+                'type'             => '1',
+                'notifications_id' => '40',
+            ], [
+                'id'               => '158',
+                'items_id'         => '37',
+                'type'             => '1',
+                'notifications_id' => '40',
+            ],
         ];
 
         $tables['glpi_notificationtemplates'] = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | see #15930

By default, the planning recall notification is sent only to the requester. People complains that the notification is not sent to the tech/group in charge. I think we could add these target to the default targets.