### PR TITLE
Crontask datatable twig migration

### DIFF
--- a/src/Application/View/Extension/DataHelpersExtension.php
+++ b/src/Application/View/Extension/DataHelpersExtension.php
@@ -52,6 +52,7 @@ class DataHelpersExtension extends AbstractExtension
         return [
             new TwigFilter('formatted_datetime', [$this, 'getFormattedDatetime']),
             new TwigFilter('formatted_duration', [$this, 'getFormattedDuration']),
+            new TwigFilter('formatted_integer', [$this, 'getFormattedInteger']),
             new TwigFilter('formatted_number', [$this, 'getFormattedNumber']),
             new TwigFilter('formatted_size', [$this, 'getFormattedSize']),
             new TwigFilter('html_to_text', [$this, 'getTextFromHtml']),
@@ -116,17 +117,27 @@ class DataHelpersExtension extends AbstractExtension
     }
 
     /**
-     * Return number formatted to user preferred format.
+     * Return integer formatted to user preferred format.
      *
      * @param mixed $number Number to display
-     * @param boolean $edit display number for edition ? (id edit use . in all case)
-     * @param integer $forcedecimal Force decimal number (do not use default value) (default -1)
      *
      * @return string
      */
-    public function getFormattedNumber($number, $edit = false, $forcedecimal = -1): string
+    public function getFormattedInteger($number): string
     {
-        return Html::formatNumber($number, $edit, $forcedecimal);
+        return Html::formatNumber($number, forcedecimal: 0);
+    }
+
+    /**
+     * Return number formatted to user preferred format.
+     *
+     * @param mixed $number Number to display
+     *
+     * @return string
+     */
+    public function getFormattedNumber($number): string
+    {
+        return Html::formatNumber($number);
     }
 
     /**

--- a/src/Application/View/Extension/DataHelpersExtension.php
+++ b/src/Application/View/Extension/DataHelpersExtension.php
@@ -118,13 +118,15 @@ class DataHelpersExtension extends AbstractExtension
     /**
      * Return number formatted to user preferred format.
      *
-     * @param mixed $number
+     * @param mixed $number Number to display
+     * @param boolean $edit display number for edition ? (id edit use . in all case)
+     * @param integer $forcedecimal Force decimal number (do not use default value) (default -1)
      *
      * @return string
      */
-    public function getFormattedNumber($number): string
+    public function getFormattedNumber($number, $edit = false, $forcedecimal = -1): string
     {
-        return Html::formatNumber($number);
+        return Html::formatNumber($number, $edit, $forcedecimal);
     }
 
     /**

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -33,7 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
-// Needed for signal handler
+// Needed for signal handler to handle SIGTERM in CLI mode
 declare(ticks=1);
 
 use Glpi\DBAL\QueryExpression;
@@ -56,24 +56,25 @@ class CronTask extends CommonDBTM
     private $volume          = 0;
     public static $rightname        = 'config';
 
-   // Class constant
+    /** The automatic action is disabled */
     const STATE_DISABLE = 0;
+    /** The automatic action is enabled and waiting to be run */
     const STATE_WAITING = 1;
+    /** The automatic action was started and hasn't returned to the waiting state yet */
     const STATE_RUNNING = 2;
 
+    /** The automatic action is run internally (run by GLPI via a hidden image src) */
     const MODE_INTERNAL = 1;
+    /** The automatic action is run with an external scheduler like cron or Task Scheduler */
     const MODE_EXTERNAL = 2;
-
 
     public static function getForbiddenActionsForMenu()
     {
         return ['add'];
     }
 
-
     public function getForbiddenStandardMassiveAction()
     {
-
         $forbidden   = parent::getForbiddenStandardMassiveAction();
         $forbidden[] = 'delete';
         $forbidden[] = 'purge';
@@ -81,16 +82,13 @@ class CronTask extends CommonDBTM
         return $forbidden;
     }
 
-
     public static function getTypeName($nb = 0)
     {
         return _n('Automatic action', 'Automatic actions', $nb);
     }
 
-
     public function defineTabs($options = [])
     {
-
         $ong = [];
         $this->addDefaultFormTab($ong);
         $this->addImpactTab($ong, $options);
@@ -100,21 +98,17 @@ class CronTask extends CommonDBTM
         return $ong;
     }
 
-
     public static function canDelete()
     {
         return false;
     }
 
-
     public function cleanDBonPurge()
     {
-
-       // CronTaskLog does not extends CommonDBConnexity
+        // CronTaskLog does not extend CommonDBConnexity
         $ctl = new CronTaskLog();
         $ctl->deleteByCriteria(['crontasks_id' => $this->fields['id']]);
     }
-
 
     /**
      * Read a CronTask by its name
@@ -128,23 +122,26 @@ class CronTask extends CommonDBTM
      **/
     public function getFromDBbyName($itemtype, $name)
     {
-
+        $table = self::getTable();
         return $this->getFromDBByCrit([
-            $this->getTable() . '.name'      => (string)$name,
-            $this->getTable() . '.itemtype'  => (string)$itemtype
+            $table . '.name'      => (string)$name,
+            $table . '.itemtype'  => (string)$itemtype
         ]);
     }
 
-
     /**
-     * Give a task state
+     * Check if the task is disabled and the reason if so.
      *
-     * @return integer 0 : task is enabled
-     *    if disable : 1: by config, 2: by system lock, 3: by plugin
+     * @return integer
+     * <ul>
+     *    <li>0: Enabled</li>
+     *    <li>1: Disabled by task configuration</li>
+     *    <li>2: Disabled by system lock</li>
+     *    <li>3: Task belongs to a disabled plugin</li>
+     * </ul>
      **/
     public function isDisabled()
     {
-
         if ($this->fields['state'] == self::STATE_DISABLE) {
             return 1;
         }
@@ -153,7 +150,7 @@ class CronTask extends CommonDBTM
             is_file(GLPI_CRON_DIR . '/all.lock')
             || is_file(GLPI_CRON_DIR . '/' . $this->fields['name'] . '.lock')
         ) {
-           // Global lock
+            // Global lock
             return 2;
         }
 
@@ -161,7 +158,7 @@ class CronTask extends CommonDBTM
             return 0;
         }
 
-       // Plugin case
+        // Plugin case
         $plug = new Plugin();
         if (!$plug->isActivated($tab["plugin"])) {
             return 3;
@@ -196,16 +193,17 @@ class CronTask extends CommonDBTM
      *
      * @param integer $signo Signal number
      * @since 9.1
+     * @todo Is there an alternative way to handle this? ext-pcntl is not enabled by default in PHP and isn't available on Windows.
      */
     public function signal($signo)
     {
         if ($signo == SIGTERM) {
             pcntl_signal(SIGTERM, SIG_DFL);
 
-           // End of this task
+            // End of this task
             $this->end(null);
 
-           // End of this cron
+            // End of this cron
             $_SESSION["glpicronuserrunning"] = '';
             self::release_lock();
             Toolbox::logInFile('cron', __('Action aborted') . "\n");
@@ -232,7 +230,7 @@ class CronTask extends CommonDBTM
         }
 
         $result = $DB->update(
-            $this->getTable(),
+            self::getTable(),
             [
                 'state'  => self::STATE_RUNNING,
                 'lastrun'   => QueryFunction::dateFormat(
@@ -254,11 +252,12 @@ class CronTask extends CommonDBTM
             $txt = sprintf(
                 '%1$s: %2$s',
                 'Run mode',
-                $this->getModeName(isCommandLine() ? self::MODE_EXTERNAL
+                self::getModeName(isCommandLine() ? self::MODE_EXTERNAL
                 : self::MODE_INTERNAL)
             );
 
-            $this->startlog = $log->add(['crontasks_id'    => $this->fields['id'],
+            $this->startlog = $log->add([
+                'crontasks_id'    => $this->fields['id'],
                 'date'            => $_SESSION['glpi_currenttime'],
                 'content'         => $txt,
                 'crontasklogs_id' => 0,
@@ -271,7 +270,6 @@ class CronTask extends CommonDBTM
         return false;
     }
 
-
     /**
      * Set the currently proccessed volume of a running task
      *
@@ -281,7 +279,6 @@ class CronTask extends CommonDBTM
     {
         $this->volume = $volume;
     }
-
 
     /**
      * Increase the currently proccessed volume of a running task
@@ -293,14 +290,15 @@ class CronTask extends CommonDBTM
         $this->volume += $volume;
     }
 
-
     /**
      * End a task, timer, stat, log, ...
      *
      * @param int|null $retcode
-     *    <0: need to run again
-     *    0 : nothing to do
-     *    >0: ok
+     * <ul>
+     *    <li>&lt; 0: Need to run again</li>
+     *    <li>0: Nothing to do</li>
+     *   <li>&gt; 0: Ok</li>
+     * </ul>
      * @param int $log_state
      *
      * @return bool : true if ok (not start by another)
@@ -328,8 +326,8 @@ class CronTask extends CommonDBTM
         );
 
         if ($DB->affectedRows() > 0) {
-           // No gettext for log but add gettext line to be parsed for pot generation
-           // order is important for insertion in english in the database
+            // No gettext for log but add gettext line to be parsed for pot generation
+            // order is important for insertion in english in the database
             if ($log_state === CronTaskLog::STATE_ERROR) {
                 $content = __('Execution error');
                 $content = 'Execution error';
@@ -361,7 +359,6 @@ class CronTask extends CommonDBTM
         return false;
     }
 
-
     /**
      * Add a log message for a running task
      *
@@ -369,7 +366,6 @@ class CronTask extends CommonDBTM
      **/
     public function log($content)
     {
-
         if (!isset($this->fields['id'])) {
             return false;
         }
@@ -384,7 +380,6 @@ class CronTask extends CommonDBTM
             'elapsed'         => (microtime(true) - $this->timer)
         ]);
     }
-
 
     /**
      * read the first task which need to be run by cron
@@ -403,7 +398,7 @@ class CronTask extends CommonDBTM
         $hour_criteria = new QueryExpression('hour(curtime())');
 
         $itemtype_orwhere = [
-         // Core crontasks
+            // Core crontasks
             [
                 ['NOT' => ['itemtype' => ['LIKE', 'Plugin%']]],
                 ['NOT' => ['itemtype' => ['LIKE', 'GlpiPlugin\\\\' . '%']]]
@@ -437,7 +432,7 @@ class CronTask extends CommonDBTM
                 $WHERE['mode'] = $mode;
             }
 
-           // Get system lock
+            // Get system lock
             if (is_file(GLPI_CRON_DIR . '/all.lock')) {
                // Global lock
                 return false;
@@ -529,16 +524,16 @@ class CronTask extends CommonDBTM
             ]
         );
         if ($alert_iterator->count() > 0) {
-           // An alert has been sent within last day, so do not send a new one to not bother administrator
+            // An alert has been sent within last day, so do not send a new one to not bother administrator
             return;
         }
 
-       // Check if errors threshold is exceeded, and send a notification in this case.
-       //
-       // We check on last "$threshold * 2" runs as a task that works only half of the time
-       // is not a normal behaviour.
-       // For instance, if threshold is 5, then a task that fails 5 times on last 10 executions
-       // will trigger a notification.
+        // Check if errors threshold is exceeded, and send a notification in this case.
+        //
+        // We check on last "$threshold * 2" runs as a task that works only half of the time
+        // is not a normal behaviour.
+        // For instance, if threshold is 5, then a task that fails 5 times on last 10 executions
+        // will trigger a notification.
         $threshold = 5;
 
         $iterator = $DB->request(
@@ -561,15 +556,15 @@ class CronTask extends CommonDBTM
         }
 
         if ($error_count >= $threshold) {
-           // No alert has been sent within last day, so we can send one without bothering administrator
+            // No alert has been sent within last day, so we can send one without bothering administrator
             NotificationEvent::raiseEvent('alert', $this, ['items' => [$this->fields['id'] => $this->fields]]);
-            QueuedNotification::forceSendFor($this->getType(), $this->fields['id']);
+            QueuedNotification::forceSendFor(self::class, $this->fields['id']);
 
-           // Delete existing outdated alerts
+            // Delete existing outdated alerts
             $alert = new Alert();
             $alert->deleteByCriteria(['itemtype' => 'CronTask', 'items_id' => $this->fields['id']], 1);
 
-           // Create a new alert
+            // Create a new alert
             $alert->add(
                 [
                     'type'     => Alert::THRESHOLD,
@@ -579,7 +574,6 @@ class CronTask extends CommonDBTM
             );
         }
     }
-
 
     /**
      * Print the contact form
@@ -652,65 +646,56 @@ class CronTask extends CommonDBTM
         return true;
     }
 
-
     /**
      * reset the next launch date => for a launch as soon as possible
      **/
     public function resetDate()
     {
-
         if (!isset($this->fields['id'])) {
             return false;
         }
-        return $this->update(['id'      => $this->fields['id'],
+        return $this->update([
+            'id'      => $this->fields['id'],
             'lastrun' => 'NULL'
         ]);
     }
-
 
     /**
      * reset the current state
      **/
     public function resetState()
     {
-
         if (!isset($this->fields['id'])) {
             return false;
         }
-        return $this->update(['id'    => $this->fields['id'],
+        return $this->update([
+            'id'    => $this->fields['id'],
             'state' => self::STATE_WAITING
         ]);
     }
 
-
     /**
      * Translate task description
      *
-     * @param $id integer ID of the crontask
+     * @param integer $id ID of the crontask
      *
      * @return string
      **/
     public function getDescription($id)
     {
-
         if (!isset($this->fields['id']) || ($this->fields['id'] != $id)) {
             $this->getFromDB($id);
         }
 
         $hook = [$this->fields['itemtype'], 'cronInfo'];
         if (is_callable($hook)) {
-            $info = call_user_func($hook, $this->fields['name']);
+            $info = $hook($this->fields['name']);
         } else {
             $info = false;
         }
 
-        if (isset($info['description'])) {
-            return $info['description'];
-        }
-
-        return $this->fields['name'];
+        return $info['description'] ?? $this->fields['name'];
     }
-
 
     /**
      * Translate task parameter description
@@ -719,47 +704,34 @@ class CronTask extends CommonDBTM
      **/
     public function getParameterDescription()
     {
-
         $hook = [$this->fields['itemtype'], 'cronInfo'];
 
         if (is_callable($hook)) {
-            $info = call_user_func($hook, $this->fields['name']);
+            $info = $hook($this->fields['name']);
         } else {
             $info = false;
         }
 
-        if (isset($info['parameter'])) {
-            return $info['parameter'];
-        }
-
-        return '';
+        return $info['parameter'] ?? '';
     }
-
 
     /**
      * Translate state to string
      *
-     * @param $state integer
+     * @param integer $state
+     * @phpstan-param self::STATE_* $state
      *
      * @return string
      **/
     public static function getStateName($state)
     {
-
-        switch ($state) {
-            case self::STATE_RUNNING:
-                return __('Running');
-
-            case self::STATE_WAITING:
-                return __('Scheduled');
-
-            case self::STATE_DISABLE:
-                return __('Disabled');
-        }
-
-        return '???';
+        return match ($state) {
+            self::STATE_RUNNING => __('Running'),
+            self::STATE_WAITING => __('Scheduled'),
+            self::STATE_DISABLE => __('Disabled'),
+            default => '???',
+        };
     }
-
 
     /**
      * Dropdown of state
@@ -772,7 +744,6 @@ class CronTask extends CommonDBTM
      **/
     public static function dropdownState($name, $value = 0, $display = true)
     {
-
         return Dropdown::showFromArray(
             $name,
             [self::STATE_DISABLE => __('Disabled'),
@@ -784,50 +755,43 @@ class CronTask extends CommonDBTM
         );
     }
 
-
     /**
      * Translate Mode to string
      *
-     * @param $mode integer
+     * @param integer $mode
+     * @phpstan-param self::MODE_* $mode
      *
      * @return string
      **/
     public static function getModeName($mode)
     {
-
-        switch ($mode) {
-            case self::MODE_INTERNAL:
-                return __('GLPI');
-
-            case self::MODE_EXTERNAL:
-                return __('CLI');
-        }
-
-        return '???';
+        return match ($mode) {
+            self::MODE_INTERNAL => __('GLPI'),
+            self::MODE_EXTERNAL => __('CLI'),
+            default => '???',
+        };
     }
-
 
     /**
      * Get a global database lock for cron
      *
-     * @return Boolean
+     * @return boolean
      **/
     private static function get_lock()
     {
         /** @var \DBmysql $DB */
         global $DB;
 
-       // Changer de nom toutes les heures en cas de blocage MySQL (ca arrive)
-        $nom = "glpicron." . intval(time() / HOUR_TIMESTAMP - 340000);
+        // Change name every hour in case of MySQL blocking (it happens)
+        $name = "glpicron." . (int) (time() / HOUR_TIMESTAMP - 340000);
 
-        if ($DB->getLock($nom)) {
-            self::$lockname = $nom;
+        if ($DB->getLock($name)) {
+            self::$lockname = $name;
             return true;
         }
 
         return false;
     }
-
 
     /**
      * Release the global database lock
@@ -843,7 +807,6 @@ class CronTask extends CommonDBTM
         }
     }
 
-
     /**
      * Launch the need cron tasks
      *
@@ -858,7 +821,7 @@ class CronTask extends CommonDBTM
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-       // No cron in maintenance mode
+        // No cron in maintenance mode
         if (isset($CFG_GLPI['maintenance_mode']) && $CFG_GLPI['maintenance_mode']) {
             Toolbox::logInFile('cron', __('Maintenance mode enabled, running tasks is disabled') . "\n");
             return false;
@@ -866,14 +829,14 @@ class CronTask extends CommonDBTM
 
         $crontask = new self();
         $taskname = '';
-        if (abs($mode) == self::MODE_EXTERNAL) {
-           // If cron is launched in command line, and if memory is insufficient,
-           // display a warning in the logs
-            if (Toolbox::checkMemoryLimit() == 2) {
+        if (abs($mode) === self::MODE_EXTERNAL) {
+            // If cron is launched in command line, and if memory is insufficient,
+            // display a warning in the logs
+            if (Toolbox::checkMemoryLimit() === 2) {
                 Toolbox::logInFile('cron', __('A minimum of 64 Mio is commonly required for GLPI.') . "\n");
             }
-           // If no task in CLI mode, call cron.php from command line is not really usefull ;)
-            if (!countElementsInTable($crontask->getTable(), ['mode' => abs($mode)])) {
+            // If no task in CLI mode, call cron.php from command line is not really usefull ;)
+            if (!countElementsInTable(self::getTable(), ['mode' => abs($mode)])) {
                 Toolbox::logInFile(
                     'cron',
                     __('No task with Run mode = CLI, fix your tasks configuration') . "\n"
@@ -886,7 +849,7 @@ class CronTask extends CommonDBTM
                 $msgprefix = sprintf(
                 //TRANS: %1$s is mode (external or internal), %2$s is an order number,
                     __('%1$s #%2$s'),
-                    abs($mode) == self::MODE_EXTERNAL ? __('External') : __('Internal'),
+                    abs($mode) === self::MODE_EXTERNAL ? __('External') : __('Internal'),
                     $i
                 );
                 if ($crontask->getNeedToRun($mode, $name)) {
@@ -907,7 +870,7 @@ class CronTask extends CommonDBTM
                                 )
                             );
                             try {
-                                  $retcode = call_user_func($function, $crontask);
+                                  $retcode = $function($crontask);
                             } catch (\Throwable $e) {
                                 /** @var \GLPI $GLPI */
                                 global $GLPI;
@@ -952,7 +915,7 @@ class CronTask extends CommonDBTM
                             ) . "\n" . $undefined_msg
                         );
                     }
-                } else if ($i == 1) {
+                } else if ($i === 1) {
                     $msgcron = sprintf(__('%1$s: %2$s'), $msgprefix, __('Nothing to launch'));
                     Toolbox::logInFile('cron', $msgcron . "\n");
                 }
@@ -965,7 +928,6 @@ class CronTask extends CommonDBTM
 
         return $taskname;
     }
-
 
     /**
      * Register new task for plugin (called by plugin during install)
@@ -981,7 +943,6 @@ class CronTask extends CommonDBTM
      **/
     public static function register($itemtype, $name, $frequency, $options = [])
     {
-
         // Check that hook exists
         if (!isPluginItemType($itemtype) && !class_exists($itemtype)) {
             return false;
@@ -999,11 +960,8 @@ class CronTask extends CommonDBTM
             'frequency' => $frequency
         ];
 
-        foreach (
-            ['allowmode', 'comment', 'hourmax', 'hourmin', 'logs_lifetime', 'mode',
-                'param', 'state'
-            ] as $key
-        ) {
+        $fields = ['allowmode', 'comment', 'hourmax', 'hourmin', 'logs_lifetime', 'mode', 'param', 'state'];
+        foreach ($fields as $key) {
             if (isset($options[$key])) {
                 $input[$key] = $options[$key];
             }
@@ -1019,11 +977,10 @@ class CronTask extends CommonDBTM
         return $temp->add($input);
     }
 
-
     /**
      * Unregister tasks for a plugin (call by glpi after uninstall)
      *
-     * @param $plugin : name of the plugin
+     * @param string $plugin Name of the plugin
      *
      * @return bool for success
      **/
@@ -1056,7 +1013,6 @@ class CronTask extends CommonDBTM
 
         return $ret;
     }
-
 
     /**
      * Display statistics of a task
@@ -1151,7 +1107,6 @@ class CronTask extends CommonDBTM
         ]);
     }
 
-
     /**
      * Display list of a runned tasks
      *
@@ -1167,13 +1122,9 @@ class CronTask extends CommonDBTM
             return;
         }
 
-        if (isset($_GET["start"])) {
-            $start = $_GET["start"];
-        } else {
-            $start = 0;
-        }
+        $start = (int) ($_GET["start"] ?? 0);
 
-       // Total Number of events
+        // Total Number of events
         $number = countElementsInTable(
             'glpi_crontasklogs',
             [
@@ -1182,68 +1133,54 @@ class CronTask extends CommonDBTM
             ]
         );
 
-        echo "<br><div class='center'>";
-        if ($number < 1) {
-            echo "<table class='tab_cadre_fixe'>";
-            echo "<tr><th>" . __('No item found') . "</th></tr>";
-            echo "</table>";
-            echo "</div>";
-            return;
-        }
-
-       // Display the pager
-        Html::printAjaxPager(__('Last run list'), $start, $number);
-
-        $iterator = $DB->request([
+        $criteria = [
             'FROM'   => 'glpi_crontasklogs',
             'WHERE'  => [
                 'crontasks_id' => $this->fields['id'],
                 'state'        => [CronTaskLog::STATE_STOP, CronTaskLog::STATE_ERROR],
             ],
             'ORDER'  => 'id DESC',
-            'START'  => (int)$start,
-            'LIMIT'  => (int)$_SESSION['glpilist_limit']
-        ]);
+            'START'  => $start,
+            'LIMIT'  => (int) $_SESSION['glpilist_limit']
+        ];
+        $iterator = $DB->request($criteria);
+        $count_criteria = $criteria;
+        unset($count_criteria['START'], $count_criteria['LIMIT']);
+        $count_criteria['COUNT'] = 'cpt';
+        $total_count = $DB->request($count_criteria)->current()['cpt'];
 
-        if (count($iterator)) {
-            echo "<table class='tab_cadrehov'>";
-            $header = "<tr>";
-            $header .= "<th>" . _n('Date', 'Dates', 1) . "</th>";
-            $header .= "<th>" . __('Total duration') . "</th>";
-            $header .= "<th>" . _x('quantity', 'Number') . "</th>";
-            $header .= "<th>" . __('Description') . "</th>";
-            $header .= "</tr>\n";
-            echo $header;
-
-            foreach ($iterator as $data) {
-                echo "<tr class='tab_bg_2'>";
-                echo "<td><a href='javascript:reloadTab(\"crontasklogs_id=" .
-                        $data['crontasklogs_id'] . "\");'>" . Html::convDateTime($data['date']) .
-                  "</a></td>";
-                echo "<td class='right'>" . sprintf(
-                    _n(
-                        '%s second',
-                        '%s seconds',
-                        intval($data['elapsed'])
-                    ),
-                    number_format($data['elapsed'], 3)
-                ) .
-                    "&nbsp;&nbsp;&nbsp;</td>";
-                echo "<td class='numeric'>" . $data['volume'] . "</td>";
-               // Use gettext to display
-                echo "<td>" . __($data['content']) . "</td>";
-                echo "</tr>\n";
-            }
-            echo $header;
-            echo "</table>";
-        } else { // Not found
-            echo __('No item found');
+        $entries = [];
+        foreach ($iterator as $data) {
+            $entries[] = [
+                'itemtype' => CronTaskLog::class,
+                'id'       => $data['id'],
+                'date'     => "<a href='javascript:reloadTab(\"crontasklogs_id={$data['id']}\");'>" . Html::convDateTime($data['date']) . "</a>",
+                'elapsed'  => $data['elapsed'],
+                'volume'   => $data['volume'],
+                'content'  => $data['content']
+            ];
         }
-        Html::printAjaxPager(__('Last run list'), $start, $number);
 
-        echo "</div>";
+        TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
+            'is_tab' => true,
+            'nofilter' => true,
+            'columns' => [
+                'date' => _n('Date', 'Dates', 1),
+                'elapsed' => __('Total duration'),
+                'volume' => _x('quantity', 'Number'),
+                'content' => __('Description')
+            ],
+            'formatters' => [
+                'date' => 'raw_html',
+                'elapsed' => 'duration',
+                'volume' => 'integer',
+            ],
+            'entries' => $entries,
+            'total_number' => $total_count,
+            'filtered_number' => $total_count,
+            'showmassiveactions' => false
+        ]);
     }
-
 
     /**
      * Display detail of a runned task
@@ -1257,9 +1194,14 @@ class CronTask extends CommonDBTM
         /** @var \DBmysql $DB */
         global $DB;
 
-        echo "<br><div class='center'>";
-        echo "<p><a href='javascript:reloadTab(\"crontasklogs_id=0\");'>" . __('Last run list') . "</a>" .
-           "</p>";
+        echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
+            <div class="mt-2 text-center">
+                <button class="btn btn-outline-secondary" onclick="reloadTab('crontasklogs_id=0')">
+                    {{ msg }}
+                </button>
+            </div>
+TWIG, ['msg' => __('Last run list')]);
+
 
         $iterator = $DB->request([
             'FROM'   => 'glpi_crontasklogs',
@@ -1272,86 +1214,73 @@ class CronTask extends CommonDBTM
             'ORDER'  => 'id ASC'
         ]);
 
-        if (count($iterator)) {
-            echo "<table class='tab_cadrehov'><tr>";
-            echo "<th>" . _n('Date', 'Dates', 1) . "</th>";
-            echo "<th>" . __('Status') . "</th>";
-            echo "<th>" . __('Duration') . "</th>";
-            echo "<th>" . _x('quantity', 'Number') . "</th>";
-            echo "<th>" . __('Description') . "</th>";
-            echo "</tr>\n";
+        $first = true;
+        $entries = [];
+        foreach ($iterator as $data) {
+            $content = $data['content'];
+            switch ($data['state']) {
+                case CronTaskLog::STATE_START:
+                    $state = __('Start');
+                    // Pass content to gettext
+                    // implode (Run mode: XXX)
+                    $list = explode(':', $data['content']);
+                    if (count($list) === 2) {
+                           $content = sprintf('%1$s: %2$s', __($list[0]), $list[1]);
+                    }
+                    break;
+                case CronTaskLog::STATE_STOP:
+                    $state = __('End');
+                    // Pass content to gettext
+                    $content = __($data['content']);
+                    break;
+                case CronTaskLog::STATE_ERROR:
+                    $state = _n('Error', 'Errors', 1);
+                    // Pass content to gettext
+                    $content = __($data['content']);
+                    break;
+                default:
+                    $state = __('Running');
+                    // Pass content to gettext
+                    $content = __($data['content']);
+            }
 
-            $first = true;
-            foreach ($iterator as $data) {
-                echo "<tr class='tab_bg_2'>";
-                echo "<td class='center'>" . ($first ? Html::convDateTime($data['date'])
-                                                : "&nbsp;") . "</a></td>";
-                $content = $data['content'];
-                switch ($data['state']) {
-                    case CronTaskLog::STATE_START:
-                        echo "<td>" . __('Start') . "</td>";
-                     // Pass content to gettext
-                     // implode (Run mode: XXX)
-                        $list = explode(':', $data['content']);
-                        if (count($list) == 2) {
-                               $content = sprintf('%1$s: %2$s', __($list[0]), $list[1]);
-                        }
-                        break;
-
-                    case CronTaskLog::STATE_STOP:
-                        echo "<td>" . __('End') . "</td>";
-                   // Pass content to gettext
-                        $content = __($data['content']);
-                        break;
-
-                    case CronTaskLog::STATE_ERROR:
-                        echo "<td>" . _n('Error', 'Errors', 1) . "</td>";
-                        // Pass content to gettext
-                        $content = __($data['content']);
-                        break;
-
-                    default:
-                         echo "<td>" . __('Running') . "</td>";
-                         // Pass content to gettext
-                         $content = __($data['content']);
-                }
-
-                echo "<td class='right'>" . sprintf(
-                    _n(
-                        '%s second',
-                        '%s seconds',
-                        intval($data['elapsed'])
-                    ),
-                    number_format($data['elapsed'], 3)
-                ) .
-                    "&nbsp;&nbsp;</td>";
-                echo "<td class='numeric'>" . $data['volume'] . "</td>";
-
-                echo "<td>" . $content . "</td>";
-                echo "</tr>\n";
-                $first = false;
-            };
-
-            echo "</table>";
-        } else { // Not found
-            echo __('No item found');
+            $entries[] = [
+                'itemtype' => CronTaskLog::class,
+                'id'       => $data['id'],
+                'date'     => $first ? $data['date'] : '',
+                'state'   => $state,
+                'elapsed'  => $data['elapsed'],
+                'volume'   => $data['volume'],
+                'content'  => $content
+            ];
+            $first = false;
         }
 
-        echo "</div>";
+        TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
+            'is_tab' => true,
+            'nofilter' => true,
+            'nopager' => true,
+            'columns' => [
+                'date' => _n('Date', 'Dates', 1),
+                'state' => __('Status'),
+                'elapsed' => __('Duration'),
+                'volume' => _x('quantity', 'Number'),
+                'content' => __('Description')
+            ],
+            'formatters' => [
+                'date' => 'datetime',
+                'elapsed' => 'duration',
+                'volume' => 'integer',
+            ],
+            'entries' => $entries,
+            'total_number' => count($entries),
+            'filtered_number' => count($entries),
+            'showmassiveactions' => false
+        ]);
     }
 
-
-    /**
-     * @since 0.84
-     *
-     * @param $field
-     * @param $name               (default '')
-     * @param $values             (default '')
-     * @param $options      array
-     **/
     public static function getSpecificValueToSelect($field, $name = '', $values = '', array $options = [])
     {
-
         if (!is_array($values)) {
             $values = [$field => $values];
         }
@@ -1366,33 +1295,26 @@ class CronTask extends CommonDBTM
                 return Dropdown::showFromArray($name, $tab, $options);
 
             case 'state':
-                return CronTask::dropdownState($name, $values[$field], false);
+                return self::dropdownState($name, $values[$field], false);
         }
 
         return parent::getSpecificValueToSelect($field, $name, $values, $options);
     }
 
-
     public static function getSpecificValueToDisplay($field, $values, array $options = [])
     {
-
         if (!is_array($values)) {
             $values = [$field => $values];
         }
-        switch ($field) {
-            case 'mode':
-                return self::getModeName($values[$field]);
-
-            case 'state':
-                return self::getStateName($values[$field]);
-        }
-        return parent::getSpecificValueToDisplay($field, $values, $options);
+        return match ($field) {
+            'mode' => self::getModeName($values[$field]),
+            'state' => self::getStateName($values[$field]),
+            default => parent::getSpecificValueToDisplay($field, $values, $options),
+        };
     }
-
 
     public function getSpecificMassiveActions($checkitem = null)
     {
-
         $isadmin = static::canUpdate();
         $actions = parent::getSpecificMassiveActions($checkitem);
 
@@ -1401,7 +1323,6 @@ class CronTask extends CommonDBTM
         }
         return $actions;
     }
-
 
     public static function processMassiveActionsForOneItemtype(
         MassiveAction $ma,
@@ -1434,7 +1355,6 @@ class CronTask extends CommonDBTM
         parent::processMassiveActionsForOneItemtype($ma, $item, $ids);
     }
 
-
     public function rawSearchOptions()
     {
         /** @var \DBmysql $DB */
@@ -1449,7 +1369,7 @@ class CronTask extends CommonDBTM
 
         $tab[] = [
             'id'                 => '1',
-            'table'              => $this->getTable(),
+            'table'              => self::getTable(),
             'field'              => 'name',
             'name'               => __('Name'),
             'datatype'           => 'itemlink',
@@ -1458,7 +1378,7 @@ class CronTask extends CommonDBTM
 
         $tab[] = [
             'id'                 => '2',
-            'table'              => $this->getTable(),
+            'table'              => self::getTable(),
             'field'              => 'id',
             'name'               => __('ID'),
             'massiveaction'      => false,
@@ -1467,19 +1387,19 @@ class CronTask extends CommonDBTM
 
         $tab[] = [
             'id'                 => '3',
-            'table'              => $this->getTable(),
+            'table'              => self::getTable(),
             'field'              => 'description',
             'name'               => __('Description'),
             'nosearch'           => true,
             'nosort'             => true,
             'massiveaction'      => false,
             'datatype'           => 'text',
-            'computation'        => $DB->quoteName('TABLE.id') // Virtual data
+            'computation'        => $DB::quoteName('TABLE.id') // Virtual data
         ];
 
         $tab[] = [
             'id'                 => '4',
-            'table'              => $this->getTable(),
+            'table'              => self::getTable(),
             'field'              => 'state',
             'name'               => __('Status'),
             'searchtype'         => ['equals', 'notequals'],
@@ -1488,7 +1408,7 @@ class CronTask extends CommonDBTM
 
         $tab[] = [
             'id'                 => '5',
-            'table'              => $this->getTable(),
+            'table'              => self::getTable(),
             'field'              => 'mode',
             'name'               => __('Run mode'),
             'datatype'           => 'specific',
@@ -1497,7 +1417,7 @@ class CronTask extends CommonDBTM
 
         $tab[] = [
             'id'                 => '6',
-            'table'              => $this->getTable(),
+            'table'              => self::getTable(),
             'field'              => 'frequency',
             'name'               => __('Run frequency'),
             'datatype'           => 'timestamp',
@@ -1506,7 +1426,7 @@ class CronTask extends CommonDBTM
 
         $tab[] = [
             'id'                 => '7',
-            'table'              => $this->getTable(),
+            'table'              => self::getTable(),
             'field'              => 'lastrun',
             'name'               => __('Last run'),
             'datatype'           => 'datetime',
@@ -1515,7 +1435,7 @@ class CronTask extends CommonDBTM
 
         $tab[] = [
             'id'                 => '8',
-            'table'              => $this->getTable(),
+            'table'              => self::getTable(),
             'field'              => 'itemtype',
             'name'               => __('Item type'),
             'massiveaction'      => false,
@@ -1525,7 +1445,7 @@ class CronTask extends CommonDBTM
 
         $tab[] = [
             'id'                 => '16',
-            'table'              => $this->getTable(),
+            'table'              => self::getTable(),
             'field'              => 'comment',
             'name'               => __('Comments'),
             'datatype'           => 'text'
@@ -1533,7 +1453,7 @@ class CronTask extends CommonDBTM
 
         $tab[] = [
             'id'                 => '17',
-            'table'              => $this->getTable(),
+            'table'              => self::getTable(),
             'field'              => 'hourmin',
             'name'               => __('Begin hour of run period'),
             'datatype'           => 'integer',
@@ -1543,7 +1463,7 @@ class CronTask extends CommonDBTM
 
         $tab[] = [
             'id'                 => '18',
-            'table'              => $this->getTable(),
+            'table'              => self::getTable(),
             'field'              => 'hourmax',
             'name'               => __('End hour of run period'),
             'datatype'           => 'integer',
@@ -1553,7 +1473,7 @@ class CronTask extends CommonDBTM
 
         $tab[] = [
             'id'                 => '19',
-            'table'              => $this->getTable(),
+            'table'              => self::getTable(),
             'field'              => 'logs_lifetime',
             'name'               => __('Number of days this action logs are stored'),
             'datatype'           => 'integer',
@@ -1567,7 +1487,7 @@ class CronTask extends CommonDBTM
 
         $tab[] = [
             'id'                 => '20',
-            'table'              => $this->getTable(),
+            'table'              => self::getTable(),
             'field'              => 'date_mod',
             'name'               => __('Last update'),
             'datatype'           => 'datetime',
@@ -1576,7 +1496,7 @@ class CronTask extends CommonDBTM
 
         $tab[] = [
             'id'                 => '121',
-            'table'              => $this->getTable(),
+            'table'              => self::getTable(),
             'field'              => 'date_creation',
             'name'               => __('Creation date'),
             'datatype'           => 'datetime',
@@ -1586,18 +1506,17 @@ class CronTask extends CommonDBTM
         return $tab;
     }
 
-
     /**
      * Garbage collector for expired file session
      *
      * @param CronTask $task for log
      *
      * @return integer
+     * @used-by self
      **/
     public static function cronSession(CronTask $task)
     {
-
-       // max time to keep the file session
+        // max time to keep the file session
         $maxlifetime = ini_get('session.gc_maxlifetime');
         if ($maxlifetime == 0) {
             $maxlifetime = WEEK_TIMESTAMP;
@@ -1605,7 +1524,7 @@ class CronTask extends CommonDBTM
         $nb = 0;
         foreach (glob(GLPI_SESSION_DIR . "/sess_*") as $filename) {
             if ((filemtime($filename) + $maxlifetime) < time()) {
-               // Delete session file if not delete before
+                // Delete session file if not delete before
                 if (@unlink($filename)) {
                     $nb++;
                 }
@@ -1630,7 +1549,6 @@ class CronTask extends CommonDBTM
         return 0;
     }
 
-
     /**
      * Circular logs
      *
@@ -1639,23 +1557,23 @@ class CronTask extends CommonDBTM
      * @param CronTask $task for log
      *
      * @return integer
+     * @used-by self
      **/
     public static function cronCircularlogs(CronTask $task)
     {
-
         $actionCode = 0; // by default
         $error      = false;
         $task->setVolume(0); // start with zero
 
-       // compute date in the past for the archived log to be deleted
+        // compute date in the past for the archived log to be deleted
         $firstdate = date("Ymd", time() - ($task->fields['param'] * DAY_TIMESTAMP)); // compute current date - param as days and format it like YYYYMMDD
 
-       // first look for bak to delete
+        // first look for bak to delete
         $dir       = GLPI_LOG_DIR . "/*.bak";
         $findfiles = glob($dir);
         foreach ($findfiles as $file) {
             $shortfile = str_replace(GLPI_LOG_DIR . '/', '', $file);
-           // now depending on the format of the name we delete the file (for aging archives) or rename it (will add Ymd.log to the end of the file)
+            // now depending on the format of the name we delete the file (for aging archives) or rename it (will add Ymd.log to the end of the file)
             $match = null;
             if (preg_match('/.+[.]log[.](\\d{8})[.]bak$/', $file, $match) > 0) {
                 if ($match[1] < $firstdate) {
@@ -1671,12 +1589,12 @@ class CronTask extends CommonDBTM
             }
         }
 
-       // second look for log to archive
+        // second look for log to archive
         $dir       = GLPI_LOG_DIR . "/*.log";
         $findfiles = glob($dir);
         foreach ($findfiles as $file) {
             $shortfile    = str_replace(GLPI_LOG_DIR . '/', '', $file);
-           // rename the file
+            // rename the file
             $newfilename  = $file . "." . date("Ymd", time()) . ".bak"; // will add to filename a string with format YYYYMMDD (= current date)
             $shortnewfile = str_replace(GLPI_LOG_DIR . '/', '', $newfilename);
 
@@ -1700,22 +1618,21 @@ class CronTask extends CommonDBTM
         return $actionCode;
     }
 
-
     /**
      * Garbage collector for cleaning graph files
      *
      * @param CronTask $task for log
      *
      * @return integer
+     * @used-by self
      **/
     public static function cronGraph(CronTask $task)
     {
-
-       // max time to keep the file session
+        // max time to keep the file session
         $maxlifetime = HOUR_TIMESTAMP;
         $nb          = 0;
         foreach (glob(GLPI_GRAPH_DIR . "/*") as $filename) {
-            if (basename($filename) == "remove.txt" && is_dir(GLPI_ROOT . '/.git')) {
+            if (basename($filename) === "remove.txt" && is_dir(GLPI_ROOT . '/.git')) {
                 continue;
             }
             if ((filemtime($filename) + $maxlifetime) < time()) {
@@ -1748,11 +1665,11 @@ class CronTask extends CommonDBTM
      * @param CronTask $task for log
      *
      * @return integer
+     * @used-by self
      **/
     public static function cronTemp(CronTask $task)
     {
-
-       // max time to keep the file session
+        // max time to keep the file session
         $maxlifetime = HOUR_TIMESTAMP;
         $nb          = 0;
 
@@ -1762,9 +1679,9 @@ class CronTask extends CommonDBTM
             RecursiveIteratorIterator::CHILD_FIRST
         );
 
-       //first step unlike only file if needed
+        // first step unlink only file if needed
         foreach ($files as $filename) {
-            if (basename($filename) == ".gitkeep") {
+            if (basename($filename) === ".gitkeep") {
                 continue;
             }
 
@@ -1779,8 +1696,8 @@ class CronTask extends CommonDBTM
 
             if (
                 is_dir($filename) && is_readable($filename)
-                //be sure that the directory is empty
-                && count(scandir($filename)) == 2
+                // be sure that the directory is empty
+                && count(scandir($filename)) === 2
             ) {
                 if (@rmdir($filename)) {
                     $nb++;
@@ -1811,6 +1728,7 @@ class CronTask extends CommonDBTM
      * @param CronTask $task
      *
      * @return integer
+     * @used-by self
      **/
     public static function cronLogs($task)
     {
@@ -1819,7 +1737,7 @@ class CronTask extends CommonDBTM
 
         $vol = 0;
 
-       // Expire Event Log
+        // Expire Event Log
         if ($task->fields['param'] > 0) {
             $vol += Event::cleanOld($task->fields['param']);
         }
@@ -1833,17 +1751,16 @@ class CronTask extends CommonDBTM
         return ($vol > 0 ? 1 : 0);
     }
 
-
     /**
      * Cron job to check if a new version is available
      *
      * @param CronTask $task for log
      *
      * @return integer
+     * @used-by self
      **/
     public static function cronCheckUpdate($task)
     {
-
         $result = Toolbox::checkNewVersionAvailable();
         $task->log($result);
 
@@ -1879,12 +1796,10 @@ class CronTask extends CommonDBTM
      * @param CronTask $task for log
      *
      * @return integer
+     * @used-by self
      **/
     public static function cronWatcher($task)
     {
-        /** @var \DBmysql $DB */
-        global $DB;
-
         // CronTasks running for more than 1 hour or 2 frequency
         $iterator = self::getZombieCrontasks();
         $crontasks = [];
@@ -1898,54 +1813,48 @@ class CronTask extends CommonDBTM
             if (NotificationEvent::raiseEvent("alert", $task, ['items' => $crontasks])) {
                 $task->addVolume(1);
             }
-            QueuedNotification::forceSendFor($task->getType(), $task->fields['id']);
+            QueuedNotification::forceSendFor(self::class, $task->fields['id']);
         }
 
         return 1;
     }
 
-
     /**
      * get Cron description parameter for this class
      *
-     * @param $name string name of the task
+     * @param string $name name of the task
      *
      * @return array of string
      **/
     public static function cronInfo($name)
     {
-
-        switch ($name) {
-            case 'checkupdate':
-                return ['description' => __('Check for new updates')];
-
-            case 'logs':
-                return ['description' => __('Clean old logs'),
-                    'parameter'
-                           => __('System logs retention period (in days, 0 for infinite)')
-                ];
-
-            case 'session':
-                return ['description' => __('Clean expired sessions')];
-
-            case 'graph':
-                return ['description' => __('Clean generated graphics')];
-
-            case 'temp':
-                return ['description' => __('Clean temporary files')];
-
-            case 'watcher':
-                return ['description' => __('Monitoring of automatic actions')];
-
-            case 'circularlogs':
-                return ['description' => __("Archives log files and deletes aging ones"),
-                    'parameter'   => __("Number of days to keep archived logs")
-                ];
-        }
-
-        return [];
+        return match ($name) {
+            'checkupdate' => [
+                'description' => __('Check for new updates')
+            ],
+            'logs'        => [
+                'description' => __('Clean old logs'),
+                'parameter'   => __('System logs retention period (in days, 0 for infinite)')
+            ],
+            'session'     => [
+                'description' => __('Clean expired sessions')
+            ],
+            'graph'       => [
+                'description' => __('Clean generated graphics')
+            ],
+            'temp'        => [
+                'description' => __('Clean temporary files')
+            ],
+            'watcher'     => [
+                'description' => __('Monitoring of automatic actions')
+            ],
+            'circularlogs' => [
+                'description' => __("Archives log files and deletes aging ones"),
+                'parameter'   => __("Number of days to keep archived logs")
+            ],
+            default       => []
+        };
     }
-
 
     /**
      * Call cron without time check
@@ -1965,7 +1874,6 @@ class CronTask extends CommonDBTM
         return true;
     }
 
-
     /**
      * Check if any web cron task exist and is enabled
      *
@@ -1981,7 +1889,6 @@ class CronTask extends CommonDBTM
         return $web_tasks_count > 0;
     }
 
-
     /**
      * Call cron if time since last launch elapsed
      *
@@ -1989,21 +1896,19 @@ class CronTask extends CommonDBTM
      **/
     public static function callCron()
     {
-
         if (isset($_SESSION["glpicrontimer"])) {
-           // call static function callcron() every 5min
+            // call static function callcron() every 5min
             if ((time() - $_SESSION["glpicrontimer"]) > 300) {
                 if (self::callCronForce()) {
-                   // Restart timer
+                    // Restart timer
                     $_SESSION["glpicrontimer"] = time();
                 }
             }
         } else {
-           // Start timer
+            // Start timer
             $_SESSION["glpicrontimer"] = time();
         }
     }
-
 
     public static function getIcon()
     {

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -628,7 +628,7 @@ class CronTask extends CommonDBTM
             }
 
             if ($next < time()) {
-                $next_run_display = __('As soon as possible') . '<br>(' . Html::convDateTime($next_run_display) . ') ';
+                $next_run_display = __('As soon as possible') . ' (' . Html::convDateTime($next_run_display) . ') ';
             } else {
                 $next_run_display = Html::convDateTime($next_run_display);
             }
@@ -1154,7 +1154,11 @@ class CronTask extends CommonDBTM
             $entries[] = [
                 'itemtype' => CronTaskLog::class,
                 'id'       => $data['id'],
-                'date'     => "<a href='javascript:reloadTab(\"crontasklogs_id={$data['id']}\");'>" . Html::convDateTime($data['date']) . "</a>",
+                'date'     => sprintf(
+                    '<a href="javascript:reloadTab(\'crontasklogs_id=%s\');">%s</a>',
+                    $data['id'],
+                    htmlspecialchars(Html::convDateTime($data['date']))
+                ),
                 'elapsed'  => $data['elapsed'],
                 'volume'   => $data['volume'],
                 'content'  => $data['content']
@@ -1195,7 +1199,7 @@ class CronTask extends CommonDBTM
         global $DB;
 
         echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
-            <div class="mt-2 text-center">
+            <div class="my-2 text-center">
                 <button class="btn btn-outline-secondary" onclick="reloadTab('crontasklogs_id=0')">
                     {{ msg }}
                 </button>

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -203,7 +203,7 @@
                                         {% elseif formatter == 'number' %}
                                             {{ entry[colkey]|formatted_number }}
                                         {% elseif formatter == 'integer' %}
-                                            {{ entry[colkey]|formatted_number(false, 0) }}
+                                            {{ entry[colkey]|formatted_integer }}
                                         {% elseif formatter == "raw_html" %}
                                             {{ entry[colkey]|raw }}
                                         {% elseif formatter == 'avatar' %}

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -196,10 +196,14 @@
                                             {{ call("Html::convDate", [entry[colkey]])|raw }}
                                         {% elseif formatter == "datetime" %}
                                             {{ call("Html::convDateTime", [entry[colkey]])|raw }}
+                                        {% elseif formatter == "duration" %}
+                                            {{ entry[colkey]|formatted_duration }}
                                         {% elseif formatter == "bytesize" %}
                                             {{ call("Toolbox::getSize", [entry[colkey]])|raw }}
                                         {% elseif formatter == 'number' %}
                                             {{ entry[colkey]|formatted_number }}
+                                        {% elseif formatter == 'integer' %}
+                                            {{ entry[colkey]|formatted_number(false, 0) }}
                                         {% elseif formatter == "raw_html" %}
                                             {{ entry[colkey]|raw }}
                                         {% elseif formatter == 'avatar' %}

--- a/templates/pages/setup/crontask/crontask.html.twig
+++ b/templates/pages/setup/crontask/crontask.html.twig
@@ -143,7 +143,7 @@
                            {% if item.fields['state'] != constant('CronTask::STATE_WAITING') %}
                               {{ item.getStateName(item.fields['state']) }}
                            {% else %}
-                              {{ item_meta.next_run_display|raw }}
+                              {{ item_meta.next_run_display }}
                            {% endif %}
                            {% if config('maintenance_mode') %}
                               <div class="alert alert-warning">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

- Twig migration for crontask logs list.
- Minor code cleanup.

CronTasks use the ext-pcntl extension to handle when the CLI script is terminated early (not a regular script exit). However, it isn't enabled in PHP by default and it also isn't available in Windows. So, I think the majority of GLPI installations are not using this functionality.
Is there an alternative way to handle this?