### PR TITLE
Fixed ticket creation with closed status to exclude technician

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -9797,7 +9797,7 @@ abstract class CommonITILObject extends CommonDBTM
         ) {
             foreach (['requester', 'observer', 'assign'] as $actor_type) {
                 $actor_type_value = constant(CommonITILActor::class . '::' . strtoupper($actor_type));
-                if ($actor_type_value === CommonITILActor::ASSIGN && !$this->canAssign()) {
+                if ($actor_type_value === CommonITILActor::ASSIGN && !$this->canAssign() && !$this->isNewItem()) {
                     continue;
                 }
                 if ($actor_type_value !== CommonITILActor::ASSIGN && !$this->isNewItem() && !$this->canUpdateItem()) {

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -909,6 +909,7 @@ abstract class CommonITILObject extends CommonDBTM
         if (
             isset($this->fields['is_deleted']) && ($this->fields['is_deleted'] == 1)
             || isset($this->fields['status']) && in_array($this->fields['status'], $this->getClosedStatusArray())
+            || isset($this->input['status']) && in_array($this->input['status'], $this->getClosedStatusArray())
         ) {
             return false;
         }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -185,10 +185,7 @@ class Ticket extends CommonITILObject
 
     public function canAssign()
     {
-        if (
-            isset($this->fields['is_deleted']) && ($this->fields['is_deleted'] == 1)
-            || isset($this->fields['status']) && in_array($this->fields['status'], $this->getClosedStatusArray())
-        ) {
+        if (!parent::canAssign()) {
             return false;
         }
         return Session::haveRight(static::$rightname, self::ASSIGN);

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -185,7 +185,11 @@ class Ticket extends CommonITILObject
 
     public function canAssign()
     {
-        if (!parent::canAssign()) {
+        if (
+            isset($this->fields['is_deleted']) && ($this->fields['is_deleted'] == 1)
+            || isset($this->fields['status']) && in_array($this->fields['status'], $this->getClosedStatusArray())
+            || isset($this->input['status']) && in_array($this->input['status'], $this->getClosedStatusArray())
+        ) {
             return false;
         }
         return Session::haveRight(static::$rightname, self::ASSIGN);

--- a/tests/functional/Ticket.php
+++ b/tests/functional/Ticket.php
@@ -5062,35 +5062,17 @@ HTML
         }
     }
 
-    public function testAddAssignWithoutUpdateRight()
+    public function testAddAssignWhenTicketClosed()
     {
         $this->login();
 
         $ticket = new \Ticket();
         $tickets_id = $ticket->add([
-            'name' => 'testAddAssignWithoutUpdateRight',
-            'content' => 'testAddAssignWithoutUpdateRight',
-            '_skip_auto_assign' => true,
-        ]);
-        $this->integer($tickets_id)->isGreaterThan(0);
-
-        $ticket->loadActors();
-        $this->integer($ticket->countUsers(\CommonITILActor::ASSIGN))->isEqualTo(0);
-        $this->integer($ticket->countUsers(\CommonITILActor::REQUESTER))->isEqualTo(0);
-
-        $this->changeTechRight(\Ticket::ASSIGN | \Ticket::READALL);
-        $this->boolean($ticket->canUpdateItem())->isFalse();
-        $this->boolean((bool) $ticket->canAssign())->isTrue();
-        $this->boolean($ticket->update([
-            'id' => $tickets_id,
+            'name' => 'testAddAssignWhenTicketClosed',
+            'content' => 'testAddAssignWhenTicketClosed',
+            'status' => \CommonITILObject::CLOSED,
             '_actors' => [
                 'requester' => [
-                    [
-                        'itemtype'  => 'User',
-                        'items_id'  => getItemByTypeName('User', 'post-only', true),
-                        'use_notification' => 0,
-                        'alternative_email' => '',
-                    ],
                     [
                         'itemtype'  => 'User',
                         'items_id'  => getItemByTypeName('User', 'tech', true),
@@ -5107,12 +5089,14 @@ HTML
                     ]
                 ],
             ],
-        ]))->isTrue();
+        ]);
+        $this->integer($tickets_id)->isGreaterThan(0);
+
+        $closedticket = $ticket->getFromDB($tickets_id);
+        $this->boolean($closedticket)->isTrue();
         $ticket->loadActors();
-        // Verify new assignee was added
         $this->integer($ticket->countUsers(\CommonITILActor::ASSIGN))->isEqualTo(1);
-        // Verify new requester wasn't added
-        $this->integer($ticket->countUsers(\CommonITILActor::REQUESTER))->isEqualTo(0);
+        $this->integer($ticket->countUsers(\CommonITILActor::REQUESTER))->isEqualTo(1);
     }
 
     public function testAddAssignWithoutAssignRight()
@@ -6885,5 +6869,58 @@ HTML
         $values = \Dropdown::getDropdownValue($dropdown_params + ['_idor_token' => $idor], false);
         $this->array($values['results'])->size->isGreaterThan(1);
         $this->boolean($fn_dropdown_has_id($values['results'], $not_my_tickets_id))->isTrue();
+    }
+
+    public function testAddAssignWithoutUpdateRight()
+    {
+        $this->login();
+
+        $ticket = new \Ticket();
+        $tickets_id = $ticket->add([
+            'name' => 'testAddAssignWithoutUpdateRight',
+            'content' => 'testAddAssignWithoutUpdateRight',
+            '_skip_auto_assign' => true,
+        ]);
+        $this->integer($tickets_id)->isGreaterThan(0);
+
+        $ticket->loadActors();
+        $this->integer($ticket->countUsers(\CommonITILActor::ASSIGN))->isEqualTo(0);
+        $this->integer($ticket->countUsers(\CommonITILActor::REQUESTER))->isEqualTo(0);
+
+        $this->changeTechRight(\Ticket::ASSIGN | \Ticket::READALL);
+        $this->boolean($ticket->canUpdateItem())->isFalse();
+        $this->boolean((bool) $ticket->canAssign())->isTrue();
+        $this->boolean($ticket->update([
+            'id' => $tickets_id,
+            '_actors' => [
+                'requester' => [
+                    [
+                        'itemtype'  => 'User',
+                        'items_id'  => getItemByTypeName('User', 'post-only', true),
+                        'use_notification' => 0,
+                        'alternative_email' => '',
+                    ],
+                    [
+                        'itemtype'  => 'User',
+                        'items_id'  => getItemByTypeName('User', 'tech', true),
+                        'use_notification' => 0,
+                        'alternative_email' => '',
+                    ]
+                ],
+                'assign' => [
+                    [
+                        'itemtype'  => 'User',
+                        'items_id'  => getItemByTypeName('User', 'tech', true),
+                        'use_notification' => 0,
+                        'alternative_email' => '',
+                    ]
+                ],
+            ],
+        ]))->isTrue();
+        $ticket->loadActors();
+        // Verify new assignee was added
+        $this->integer($ticket->countUsers(\CommonITILActor::ASSIGN))->isEqualTo(1);
+        // Verify new requester wasn't added
+        $this->integer($ticket->countUsers(\CommonITILActor::REQUESTER))->isEqualTo(0);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #16381

When the ticket was created with a closed status and a technician, the technician was not inserted into the database.
`line 9800 in CommonITILObject::transformActorsInput`
![image](https://github.com/glpi-project/glpi/assets/107540223/76fa8180-4ba4-4773-b4fe-bfc9fe943725)

So I added a simple check to see if the item is a new item, otherwise the behavior remains the same as before.
![image](https://github.com/glpi-project/glpi/assets/107540223/b098ecbf-58c8-49f3-8c78-2273648f4be8)
