### PR TITLE
Support planned deprecations

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -575,8 +575,7 @@ class Document extends CommonDBTM
         $link_params = '';
         if (is_string($linked_item)) {
             // Old behaviour.
-            // TODO: Deprecate it in GLPI 10.1.
-            // Toolbox::deprecated('Passing additionnal URL parameters in Document::getDownloadLink() is deprecated.');
+            Toolbox::deprecated('Passing additionnal URL parameters in Document::getDownloadLink() is deprecated.', true, '11.0');
             $linked_item = null;
             $link_params = $linked_item;
         } elseif ($linked_item !== null && !($linked_item instanceof CommonDBTM)) {

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -572,12 +572,11 @@ class Toolbox
      * Send a deprecated message in log (with backtrace)
      * @param  string $message the message to send
      * @param  boolean $strict
-     * @param  string $version The version to start the deprecation alert. If null, it is considered deprecated in the current version.
+     * @param  string|null $version The version to start the deprecation alert. If null, it is considered deprecated in the current version.
      * @return void
      */
-    public static function deprecated($message = "Called method is deprecated", $strict = true, $version = null)
+    public static function deprecated($message = "Called method is deprecated", $strict = true, ?string $version = null)
     {
-        $version ??= GLPI_VERSION;
         if (
             $version !== null
             && version_compare(

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -571,10 +571,23 @@ class Toolbox
     /**
      * Send a deprecated message in log (with backtrace)
      * @param  string $message the message to send
+     * @param  boolean $strict
+     * @param  string $version The version to start the deprecation alert. If null, it is considered deprecated in the current version.
      * @return void
      */
-    public static function deprecated($message = "Called method is deprecated", $strict = true)
+    public static function deprecated($message = "Called method is deprecated", $strict = true, $version = null)
     {
+        $version ??= GLPI_VERSION;
+        if (
+            $version !== null
+            && version_compare(
+                VersionParser::getNormalizedVersion($version, false),
+                VersionParser::getNormalizedVersion(GLPI_VERSION, false),
+                '>'
+            )
+        ) {
+            return;
+        }
         if (
             $strict === true ||
             (defined('GLPI_STRICT_DEPRECATED') && GLPI_STRICT_DEPRECATED === true)

--- a/tests/functional/Toolbox.php
+++ b/tests/functional/Toolbox.php
@@ -43,6 +43,7 @@ use Glpi\Features\DCBreadcrumb;
 use Glpi\Features\Kanban;
 use Glpi\Features\PlanningEvent;
 use Glpi\Toolbox\Sanitizer;
+use Glpi\Toolbox\VersionParser;
 use ITILFollowup;
 use stdClass;
 use Ticket;
@@ -1069,6 +1070,36 @@ class Toolbox extends DbTestCase
          ->withType(E_USER_DEPRECATED)
          ->withMessage('Calling this function is deprecated')
          ->exists();
+
+        // Test planned deprecation in the past
+        $this->when(
+            function () {
+                \Toolbox::deprecated('Calling this function is deprecated', true, '10.0');
+            }
+        )->error()
+            ->withType(E_USER_DEPRECATED)
+            ->withMessage('Calling this function is deprecated')
+            ->exists();
+
+        // Test planned deprecation in current version
+        $this->when(
+            function () {
+                \Toolbox::deprecated('Calling this function is deprecated', true, GLPI_VERSION);
+            }
+        )->error()
+            ->withType(E_USER_DEPRECATED)
+            ->withMessage('Calling this function is deprecated')
+            ->exists();
+
+        // Test planned deprecation in the future
+        $this->when(
+            function () {
+                \Toolbox::deprecated('Calling this function is deprecated', true, '99.0');
+            }
+        )->error()
+            ->withType(E_USER_DEPRECATED)
+            ->withMessage('Calling this function is deprecated')
+            ->notExists();
     }
 
     public function hasTraitProvider()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Currently, there are some TODO comments saying that certain functions or code blocks should be deprecated in a future version. Sometimes, these are missed before that version is released. So, we should allow adding `Toolbox::deprecated` immediately while targeting that future version for when the messages should start being logged.