### PR TITLE
Fixed display of html signature tags in e-mails

### DIFF
--- a/src/NotificationMailing.php
+++ b/src/NotificationMailing.php
@@ -105,17 +105,18 @@ class NotificationMailing implements NotificationInterface
         $mmail->AddCustomHeader("X-Auto-Response-Suppress: OOF, DR, NDR, RN, NRN");
         $mmail->SetFrom($sender['email'], Sanitizer::decodeHtmlSpecialChars($sender['name'] ?? ''), false);
 
-        $text = __('This is a test email.') . "\n-- \n" . Sanitizer::decodeHtmlSpecialChars($CFG_GLPI["mailing_signature"]);
+        $text = __('This is a test email.') . "<br>-- <br>" . Sanitizer::decodeHtmlSpecialChars($CFG_GLPI["mailing_signature"]);
         $recipient = $CFG_GLPI['admin_email'];
         if (defined('GLPI_FORCE_MAIL')) {
            //force recipient to configured email address
             $recipient = GLPI_FORCE_MAIL;
            //add original email addess to message body
-            $text .= "\n" . sprintf(__('Original email address was %1$s'), $CFG_GLPI['admin_email']);
+            $text .= "<br>" . sprintf(__('Original email address was %1$s'), $CFG_GLPI['admin_email']);
         }
 
         $mmail->AddAddress($recipient, Sanitizer::decodeHtmlSpecialChars($CFG_GLPI["admin_email_name"]));
         $mmail->Subject = "[GLPI] " . __('Mail test');
+        $mmail->isHTML(true);
         $mmail->Body    = $text;
 
         if (!$mmail->Send()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14500

When signing an email is configured with HTML text.
I changed the signature to HTML text, with bold characters for example.
The test email received still has the HTML tags:
`<b>My name</b><i>My business</i>`

**Before**
![image](https://github.com/glpi-project/glpi/assets/107540223/3d794d09-9d89-46e8-a832-ed6fc36ffb00)

**After**
![image](https://github.com/glpi-project/glpi/assets/107540223/ef51a258-1a49-494d-aaee-8332db599636)

