### PR TITLE
Forms: configure destinations from the interface

### DIFF
--- a/ajax/form/answer.php
+++ b/ajax/form/answer.php
@@ -72,7 +72,7 @@ if (!$answers_set) {
 
 $links = [];
 foreach ($answers_set->getCreatedItems() as $item) {
-    if ($item::canView() && $item->canViewItem()) {
+    if ($item->can($item->getID(), READ)) {
         $links[] = $item->getLink();
     }
 }

--- a/ajax/form/answer.php
+++ b/ajax/form/answer.php
@@ -70,12 +70,24 @@ if (!$answers_set) {
     Response::sendError(500, __('Failed to save answers'));
 }
 
+$links = [];
+foreach ($answers_set->getCreatedItems() as $item) {
+    if ($item::canView() && $item->canViewItem()) {
+        $links[] = $item->getLink();
+    }
+}
+
+// If no items were created, display a link to the answers themselves instead
+if (empty($links)) {
+    $links[] = $answers_set->getLink();
+}
+
 // Success response
 $response = new Response(
     200,
     ['Content-Type' => 'application/json'],
     json_encode([
-        'link_to_created_item' => $answers_set->getLink(),
+        'links_to_created_items' => $links,
     ]),
 );
 $response->send();

--- a/front/form/destination/formdestination.form.php
+++ b/front/form/destination/formdestination.form.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+include('../../../inc/includes.php');
+
+use Glpi\Form\Destination\FormDestination;
+
+try {
+    $destination = new FormDestination();
+
+    if (isset($_POST["add"])) {
+        // Right check
+        $destination->check(-1, CREATE, $_POST);
+
+        // Create destination item
+        if (!$destination->add($_POST)) {
+            throw new RuntimeException("Failed to create destination item");
+        }
+    } elseif (isset($_POST["purge"])) {
+        // ID is mandatory
+        $id = $_POST['id'] ?? null;
+        if ($id === null) {
+            // Invalid request
+            throw new InvalidArgumentException("Missing id");
+        }
+
+        // Right check
+        $destination->check($id, PURGE, $_POST);
+
+        // Delete destination item
+        if (!$destination->delete($_POST, true)) {
+            throw new RuntimeException("Failed to create destination item");
+        }
+    } else {
+        // Unknown request
+        throw new InvalidArgumentException("Unknown action");
+    }
+} catch (\Throwable $e) {
+    // Log error
+    trigger_error(
+        // Insert POST data into logs to ease debugging
+        $e->getMessage() . ": " . json_encode($_POST),
+        E_USER_WARNING
+    );
+
+    Session::addMessageAfterRedirect(__('Unexpected error'), false, ERROR);
+} finally {
+    // Stop script and return to previous page
+    // Must always be run to prevent users being stuck on a blank page
+    Html::back();
+}

--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -584,6 +584,7 @@ $RELATION = [
         'glpi_fieldblacklists'             => 'entities_id',
         'glpi_fieldunicities'              => 'entities_id',
         'glpi_forms_forms'                 => 'entities_id',
+        'glpi_forms_answerssets'           => 'entities_id',
         'glpi_fqdns'                       => 'entities_id',
         'glpi_groups'                      => 'entities_id',
         'glpi_groups_knowbaseitems'        => 'entities_id',
@@ -694,7 +695,7 @@ $RELATION = [
     ],
 
     'glpi_forms_answerssets' => [
-        "glpi_forms_destinations_answerssets_formdestinationitems" => "forms_answerssets_id",
+        "_glpi_forms_destinations_answerssets_formdestinationitems" => "forms_answerssets_id",
     ],
 
     'glpi_forms_forms' => [

--- a/install/migrations/update_10.0.x_to_11.0.0/form.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/form.php
@@ -106,6 +106,7 @@ if (!$DB->tableExists('glpi_forms_answerssets')) {
         "CREATE TABLE `glpi_forms_answerssets` (
             `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
             `forms_forms_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+            `entities_id` int {$default_key_sign} NOT NULL DEFAULT '0',
             `users_id` int {$default_key_sign} NOT NULL DEFAULT '0',
             `name` varchar(255) NOT NULL DEFAULT '',
             `date_creation` timestamp NULL DEFAULT NULL,
@@ -117,7 +118,8 @@ if (!$DB->tableExists('glpi_forms_answerssets')) {
             KEY `date_creation` (`date_creation`),
             KEY `date_mod` (`date_mod`),
             KEY `forms_forms_id` (`forms_forms_id`),
-            KEY `users_id` (`users_id`)
+            KEY `users_id` (`users_id`),
+            KEY `entities_id` (`entities_id`)
         ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;"
     );
 }
@@ -158,7 +160,7 @@ $ADDTODISPLAYPREF['Glpi\Form\AnswersSet'] = [1, 3, 4];
 
 // Temporary migration code to cover dev migrations
 // TODO: Should be removed from the final release
-if (GLPI_VERSION == "10.1.0-dev") {
+if (GLPI_VERSION == "11.0.0-dev") {
     $migration->addField("glpi_forms_forms", "is_draft", "bool");
     $migration->addKey("glpi_forms_forms", "is_draft");
     $migration->changeField("glpi_forms_forms", "header", "header", "longtext");
@@ -193,4 +195,7 @@ if (GLPI_VERSION == "10.1.0-dev") {
             ));
         }
     }
+
+    $migration->addField("glpi_forms_answerssets", "entities_id", "fkey");
+    $migration->addKey("glpi_forms_answerssets", "entities_id");
 }

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9497,6 +9497,7 @@ DROP TABLE IF EXISTS `glpi_forms_answerssets`;
 CREATE TABLE `glpi_forms_answerssets` (
     `id` int unsigned NOT NULL AUTO_INCREMENT,
     `forms_forms_id` int unsigned NOT NULL DEFAULT '0',
+    `entities_id` int unsigned NOT NULL DEFAULT '0',
     `users_id` int unsigned NOT NULL DEFAULT '0',
     `name` varchar(255) NOT NULL DEFAULT '',
     `date_creation` timestamp NULL DEFAULT NULL,
@@ -9508,7 +9509,8 @@ CREATE TABLE `glpi_forms_answerssets` (
     KEY `date_creation` (`date_creation`),
     KEY `date_mod` (`date_mod`),
     KEY `forms_forms_id` (`forms_forms_id`),
-    KEY `users_id` (`users_id`)
+    KEY `users_id` (`users_id`),
+    KEY `entities_id` (`entities_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_forms_destinations_answerssets_formdestinationitems`;

--- a/js/form_renderer_controller.js
+++ b/js/form_renderer_controller.js
@@ -118,7 +118,7 @@ class GlpiFormRendererController
             glpi_toast_info(
                 __("Item successfully created: %s").replace(
                     "%s",
-                    response.link_to_created_item
+                    response.links_to_created_items.join(", ")
                 )
             );
 

--- a/src/Form/AnswersHandler/AnswersHandler.php
+++ b/src/Form/AnswersHandler/AnswersHandler.php
@@ -233,6 +233,7 @@ final class AnswersHandler
         $answers_set = new AnswersSet();
         $input = [
             'name'           => $form->getName() . " #$next_index",
+            'entities_id'    => $form->fields['entities_id'],
             'forms_forms_id' => $form->getID(),
             'answers'        => json_encode($formatted_answers),
             'users_id'       => $users_id,
@@ -285,7 +286,7 @@ final class AnswersHandler
 
                 $form_item = new AnswersSet_FormDestinationItem();
                 $input = [
-                    AnswersSet::getForeignKeyField() => $form->getID(),
+                    AnswersSet::getForeignKeyField() => $answers_set->getID(),
                     'itemtype'                       => $item::getType(),
                     'items_id'                       => $item->getID(),
                 ];

--- a/src/Form/Destination/AbstractFormDestinationType.php
+++ b/src/Form/Destination/AbstractFormDestinationType.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Destination;
+
+use CommonGLPI;
+use Glpi\Form\AnswersSet;
+use Override;
+use Search;
+
+abstract class AbstractFormDestinationType extends CommonGLPI implements FormDestinationInterface
+{
+    #[Override]
+    final public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
+    {
+        // Only for answers set
+        if (!($item instanceof AnswersSet)) {
+            return false;
+        }
+
+        $count = 0;
+        if ($_SESSION['glpishow_count_on_tabs']) {
+            $count = $this->countCreatedItemsForAnswersSet($item);
+        }
+
+        return self::createTabEntry(static::getTypeName(), $count);
+    }
+
+    #[Override]
+    final public static function displayTabContentForItem(
+        CommonGLPI $item,
+        $tabnum = 1,
+        $withtemplate = 0
+    ) {
+        // Only for answers set
+        if (!($item instanceof AnswersSet)) {
+            return false;
+        }
+
+        Search::showList(static::getTargetItemtype(), [
+            'criteria' => [
+                [
+                    'link'       => 'AND',
+                    'field'      => static::getFilterByAnswsersSetSearchOptionID(), // Parent answer
+                    'searchtype' => 'equals',
+                    'value'      => $item->getID()
+                ],
+            ],
+            'showmassiveactions' => false,
+            'hide_controls'      => true,
+            'order'              => 'DESC',
+            'as_map'             => false,
+        ]);
+        return true;
+    }
+
+    /**
+     * Count the number of created items for an answers set
+     *
+     * @param AnswersSet $answers
+     *
+     * @return int
+     */
+    final protected function countCreatedItemsForAnswersSet(AnswersSet $answers): int
+    {
+        return countElementsInTable(AnswersSet_FormDestinationItem::getTable(), [
+            'forms_answerssets_id' => $answers->getID(),
+            'itemtype'             => static::getTargetItemtype(),
+        ]);
+    }
+}

--- a/src/Form/Destination/AnswersSet_FormDestinationItem.php
+++ b/src/Form/Destination/AnswersSet_FormDestinationItem.php
@@ -44,7 +44,7 @@ final class AnswersSet_FormDestinationItem extends CommonDBRelation
      * Item 1 is an AnswersSet object
      */
     public static $itemtype_1 = AnswersSet::class;
-    public static $items_id_1 = 'forms_answserssets_id';
+    public static $items_id_1 = 'forms_answerssets_id';
 
     /**
      * Item 2 is any common DBTM item

--- a/src/Form/Destination/FormDestinationInterface.php
+++ b/src/Form/Destination/FormDestinationInterface.php
@@ -54,4 +54,18 @@ interface FormDestinationInterface
         Form $form,
         AnswersSet $answers_set
     ): array;
+
+    /**
+     * Get itemtype to create
+     *
+     * @return string (Must be a valid CommonDBTM class name)
+     */
+    public static function getTargetItemtype(): string;
+
+    /**
+     * Get the search option used to filter the target itemtype by answers set.
+     *
+     * @return int
+     */
+    public static function getFilterByAnswsersSetSearchOptionID(): int;
 }

--- a/src/Form/Destination/FormDestinationTicket.php
+++ b/src/Form/Destination/FormDestinationTicket.php
@@ -75,7 +75,7 @@ final class FormDestinationTicket extends AbstractFormDestinationType
         $item_ticket = new Item_Ticket();
         $input = [
             'tickets_id' => $ticket->getID(),
-            'itemtype'   => get_class($answers_set),
+            'itemtype'   => $answers_set::class,
             'items_id'   => $answers_set->getID(),
         ];
         if (!$item_ticket->add($input)) {

--- a/src/Form/Destination/FormDestinationTicket.php
+++ b/src/Form/Destination/FormDestinationTicket.php
@@ -35,16 +35,22 @@
 
 namespace Glpi\Form\Destination;
 
-use CommonDBTM;
 use Exception;
 use Glpi\Form\AnswersSet;
 use Glpi\Form\Form;
+use Item_Ticket;
 use Override;
 use Ticket;
 
 // TODO: we may need an abstract FormDestinationCommonITIL base class
-final class FormDestinationTicket extends CommonDBTM implements FormDestinationInterface
+final class FormDestinationTicket extends AbstractFormDestinationType
 {
+    #[Override]
+    public static function getTargetItemtype(): string
+    {
+        return Ticket::class;
+    }
+
     #[Override]
     public function createDestinationItems(
         Form $form,
@@ -63,6 +69,33 @@ final class FormDestinationTicket extends CommonDBTM implements FormDestinationI
             );
         }
 
+        // We will also link the answers directly to the ticket
+        // This allow users to see it an an associated item and known where the
+        // ticket come from
+        $item_ticket = new Item_Ticket();
+        $input = [
+            'tickets_id' => $ticket->getID(),
+            'itemtype'   => get_class($answers_set),
+            'items_id'   => $answers_set->getID(),
+        ];
+        if (!$item_ticket->add($input)) {
+            throw new Exception(
+                "Failed to create item ticket: " . json_encode($input)
+            );
+        }
+
         return [$ticket];
+    }
+
+    #[Override]
+    public static function getTypeName($nb = 0)
+    {
+        return Ticket::getTypeName($nb);
+    }
+
+    #[Override]
+    public static function getFilterByAnswsersSetSearchOptionID(): int
+    {
+        return 120;
     }
 }

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -83,6 +83,7 @@ final class Form extends CommonDBTM
     {
         $tabs = parent::defineTabs();
         $this->addStandardTab(AnswersSet::getType(), $tabs, $options);
+        $this->addStandardTab(FormDestination::getType(), $tabs, $options);
         $this->addStandardTab(Log::getType(), $tabs, $options);
         return $tabs;
     }

--- a/src/Html.php
+++ b/src/Html.php
@@ -437,9 +437,9 @@ class Html
     /**
      * Redirection to $_SERVER['HTTP_REFERER'] page
      *
-     * @return void
+     * @return never
      **/
-    public static function back()
+    public static function back(): never
     {
         self::redirect(self::getBackUrl());
     }
@@ -451,9 +451,9 @@ class Html
      * @param $dest string: Redirection destination
      * @param $http_response_code string: Forces the HTTP response code to the specified value
      *
-     * @return void
+     * @return never
      **/
-    public static function redirect($dest, $http_response_code = 302)
+    public static function redirect($dest, $http_response_code = 302): never
     {
 
         $toadd = '';

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -41,6 +41,8 @@ use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\Event;
+use Glpi\Form\AnswersSet;
+use Glpi\Form\Destination\AnswersSet_FormDestinationItem;
 use Glpi\RichText\RichText;
 
 /**
@@ -3159,6 +3161,35 @@ JAVASCRIPT;
                 ]
             ],
         ];
+
+        $tab[] = [
+            'id'   => 'forms',
+            'name' => __('Forms')
+        ];
+
+        // Search by form answer
+        $tab[] = [
+            'id'                 => '120',
+            'table'              => AnswersSet::getTable(),
+            'field'              => 'name',
+            'name'               => AnswersSet::getTypeName(1),
+            'massiveaction'      => false,
+            'searchtype'         => 'equals',
+            'datatype'           => 'itemlink',
+            'usehaving'          => true,
+            'joinparams'         => [
+                'beforejoin'         => [
+                    'table'              => AnswersSet_FormDestinationItem::getTable(),
+                    'joinparams'         => [
+                        'jointype'           => 'child',
+                        'linkfield'          => 'items_id',
+                        'condition'          => ['NEWTABLE.itemtype' => self::getType()]
+                    ]
+                ]
+            ],
+            'forcegroupby'       => true
+        ];
+
 
        // Filter search fields for helpdesk
         if (

--- a/templates/pages/admin/form/form_destination.html.twig
+++ b/templates/pages/admin/form/form_destination.html.twig
@@ -1,0 +1,119 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{# @var string                                        icon #}
+{# @var string                                        controller_url #}
+{# @var \Glpi\Form\Desination\AbstractFormDestination default_destination_object #}
+{# @var \Glpi\Form\Form                               form #}
+{# @var \Glpi\Form\Desination\FormDestination         destinations #}
+
+<div class="py-2 px-3">
+    <h2 class="d-flex">
+        <i class="{{ icon }} me-2"></i>
+        {{ __("Items to create") }}
+    </h2>
+
+    {% if destinations|length == 0 %}
+        <p class="empty-subtitle text-muted">
+            {{ __("No items will be created for this form.") }}
+        </p>
+    {% else %}
+        <div class="accordion mt-4">
+            {% for destination in destinations %}
+                {% set concrete_destination = destination.getConcreteDestinationItem() %}
+                <div
+                    id="glpi-destinations-accordion"
+                    class="accordion-item"
+                >
+                    <h3 class="accordion-header">
+                        <button
+                            class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#glpi-destinations-accordion-collapse-{{ loop.index }}"
+                            aria-expanded="false"
+                        >
+                            <i class="{{ concrete_destination.getTargetItemtype().getIcon() }} me-2"></i>
+                            {{ destination.getName() }}
+                        </button>
+                    </h3>
+                    <div
+                        id="glpi-destinations-accordion-collapse-{{ loop.index }}"
+                        class="accordion-collapse collapse"
+                        data-bs-parent="#glpi-destinations-accordion"
+                    >
+                        <div class="accordion-body pt-0">
+                            <form method="POST" action="{{ controller_url }}">
+                                <div>
+                                    {{ __("The created ticket's content is not yet customizable (WIP).") }}
+                                </div>
+
+                                {# Submit button to delete the destination #}
+                                <div class="d-flex">
+                                    <button class="btn btn-danger btn-sm mt-3" name="purge" type="submit">
+                                        <i class="ti ti-trash me-2"></i>
+                                        {{ __("Delete item") }}
+                                    </button>
+                                </div>
+
+                                {# Hidden values #}
+                                <input type="hidden" name="id" value="{{ destination.getID() }}"/>
+                                <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}"/>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    {% endif %}
+
+    <form method="POST" action="{{ controller_url }}">
+        {# Submit button to create a new destination #}
+        <button class="btn btn-primary btn-sm mt-4" name="add" type="submit">
+            <i class="ti ti-plus me-2"></i> {{ __("New item") }}
+        </button>
+
+        {# Hidden values #}
+        <input type="hidden" name="itemtype" value="{{ get_class(default_destination_object) }}"/>
+        <input type="hidden" name="name" value="{{ default_destination_object.getTypeName(1) }}"/>
+        <input type="hidden" name="{{ form.getForeignKeyField() }}" value="{{ form.getID() }}"/>
+        <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}"/>
+    <form>
+</div>
+
+<style>
+    /* Should be handled by tabler but it doesn't seem to be active */
+    .accordion-header {
+        color: var(--tblr-dark);
+    }
+</style>

--- a/tests/functional/Glpi/Form/Destination/FormDestination.php
+++ b/tests/functional/Glpi/Form/Destination/FormDestination.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\Destination;
+
+use CommonGLPI;
+use DbTestCase;
+use Glpi\Form\Destination\FormDestinationTicket;
+use Glpi\Form\QuestionType\QuestionTypeShortAnswerText;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+use Monitor;
+
+class FormDestination extends DbTestCase
+{
+    use FormTesterTrait;
+
+    /**
+     * Data provider for the "testGetTabNameForItem" method
+     *
+     * @return iterable
+     */
+    final protected function testGetTabNameForItemProvider(): iterable
+    {
+        $this->login();
+
+        // Invalid types
+        yield [new Monitor(), false];
+        yield [new CommonGLPI(), false];
+
+        // Answers set with no destinations
+        $form = $this->createForm(
+            (new FormBuilder())
+                ->addQuestion("Name", QuestionTypeShortAnswerText::class)
+        );
+        yield [$form, "Items to create"];
+
+        // Answers set with 4 destinations
+        $form = $this->createForm(
+            (new FormBuilder())
+                ->addQuestion("Name", QuestionTypeShortAnswerText::class)
+                ->addDestination(FormDestinationTicket::class, ['name' => 'destination 1'])
+                ->addDestination(FormDestinationTicket::class, ['name' => 'destination 2'])
+                ->addDestination(FormDestinationTicket::class, ['name' => 'destination 3'])
+                ->addDestination(FormDestinationTicket::class, ['name' => 'destination 4'])
+        );
+        yield [$form, "Items to create 4"];
+
+        // Disable tab count
+        $_SESSION['glpishow_count_on_tabs'] = false;
+        yield [$form, "Items to create"];
+    }
+
+    /**
+     * Test the getTabNameForItem method
+     *
+     * @dataProvider testGetTabNameForItemProvider
+     *
+     * @param CommonGLPI $item
+     * @param string|false $expected_tab_name
+     *
+     * @return void
+     */
+    final public function testGetTabNameForItem(
+        CommonGLPI $item,
+        string|false $expected_tab_name
+    ): void {
+        $link = new \Glpi\Form\Destination\FormDestination();
+        $tab_name = $link->getTabNameForItem($item);
+
+        if ($tab_name !== false) {
+            // Strip tags to keep only the relevant data
+            $tab_name = strip_tags($tab_name);
+        }
+        $this->variable($tab_name)->isEqualTo($expected_tab_name);
+    }
+
+    /**
+     * Data provider for the "testDisplayTabContentForItem" method
+     *
+     * @return iterable
+     */
+    final protected function testDisplayTabContentForItemProvider(): iterable
+    {
+        $this->login();
+
+        // Invalid types
+        yield [new Monitor(), false];
+        yield [new CommonGLPI(), false];
+
+        // Answers set with no destinations
+        $form = $this->createForm(
+            (new FormBuilder())
+                ->addQuestion("Name", QuestionTypeShortAnswerText::class)
+        );
+        yield [$form, true];
+
+        // Answers set with 4 destinations
+        $form = $this->createForm(
+            (new FormBuilder())
+                ->addQuestion("Name", QuestionTypeShortAnswerText::class)
+                ->addDestination(FormDestinationTicket::class, ['name' => 'destination 1'])
+                ->addDestination(FormDestinationTicket::class, ['name' => 'destination 2'])
+                ->addDestination(FormDestinationTicket::class, ['name' => 'destination 3'])
+                ->addDestination(FormDestinationTicket::class, ['name' => 'destination 4'])
+        );
+        yield [$form, true];
+    }
+
+    /**
+     * Test the displayTabContentForItem method
+     *
+     * The HTML content itselft is not tested, as it should be handled by an
+     * E2E test instead.
+     *
+     * @dataProvider testDisplayTabContentForItemProvider
+     *
+     * @param CommonGLPI $item
+     * @param bool $expected
+     *
+     * @return void
+     */
+    final public function testDisplayTabContentForItem(
+        CommonGLPI $item,
+        bool $expected
+    ): void {
+        $link = new \Glpi\Form\Destination\FormDestination();
+
+        // Render tab content
+        ob_start();
+        $this
+            ->boolean($link->displayTabContentForItem($item))
+            ->isEqualTo($expected);
+        ob_end_clean();
+    }
+}

--- a/tests/functional/Glpi/Form/Destination/FormDestinationTicket.php
+++ b/tests/functional/Glpi/Form/Destination/FormDestinationTicket.php
@@ -35,14 +35,15 @@
 
 namespace tests\units\Glpi\Form\Destination;
 
-use DbTestCase;
 use Glpi\Form\AnswersHandler\AnswersHandler;
 use Glpi\Form\QuestionType\QuestionTypeShortAnswerText;
+use Glpi\Tests\Form\Destination\AbstractFormDestinationType;
 use Glpi\Tests\FormBuilder;
 use Glpi\Tests\FormTesterTrait;
+use Override;
 use Ticket;
 
-class FormDestinationTicket extends DbTestCase
+class FormDestinationTicket extends AbstractFormDestinationType
 {
     use FormTesterTrait;
 
@@ -50,6 +51,13 @@ class FormDestinationTicket extends DbTestCase
      * Indirectly test the \Glpi\Form\AnswersHandler\AnswersHandler->createDestinations()
      * method using a FormDestinationTicket object
      */
+    #[Override]
+    protected function getTestedInstance(): \Glpi\Form\Destination\FormDestinationTicket
+    {
+        return new \Glpi\Form\Destination\FormDestinationTicket();
+    }
+
+    #[Override]
     public function testCreateDestinations(): void
     {
         $this->login();

--- a/tests/src/Form/Destination/AbstractFormDestinationType.php
+++ b/tests/src/Form/Destination/AbstractFormDestinationType.php
@@ -1,0 +1,245 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Tests\Form\Destination;
+
+use CommonDBTM;
+use CommonGLPI;
+use Computer;
+use DbTestCase;
+use Glpi\Form\AnswersHandler\AnswersHandler;
+use Glpi\Form\Form;
+use Glpi\Form\QuestionType\QuestionTypeShortAnswerText;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+use Impact;
+use ReflectionClass;
+
+abstract class AbstractFormDestinationType extends DbTestCase
+{
+    use FormTesterTrait;
+
+    /**
+     * Get the tested instance
+     *
+     * @return \Glpi\Form\Destination\AbstractFormDestinationType
+     */
+    abstract protected function getTestedInstance(): \Glpi\Form\Destination\AbstractFormDestinationType;
+
+    /**
+     * Tests for the "createDestinations" method of the FormDestinationInterface.
+     * Added here to ensure implementation by child classes.
+     *
+     * @return void
+     */
+    abstract public function testCreateDestinations(): void;
+
+    /**
+     * Test the getTargetItemtype method
+     *
+     * @return void
+     */
+    final public function testGetTargetItemtype(): void
+    {
+        // Ensure the type defined in the child class is a valid CommonDBTM class
+        $type = $this->getTestedInstance()::getTargetItemtype();
+        $is_valid_class = is_a($type, CommonDBTM::class, true)
+            && !(new ReflectionClass($type))->isAbstract();
+
+        $this->boolean($is_valid_class)->isTrue();
+    }
+
+    /**
+     * Test the getFilterByAnswsersSetSearchOptionID method
+     *
+     * @return void
+     */
+    final public function testGetFilterByAnswsersSetSearchOptionID(): void
+    {
+        $this->login();
+
+        // Get search option ID
+        $search_option_id = $this->getTestedInstance()::getFilterByAnswsersSetSearchOptionID();
+        $this->integer($search_option_id)->isGreaterThan(0);
+
+        // Compute all available search options for the target itemtype
+        $created_item = new ($this->getTestedInstance()::getTargetItemtype())();
+        $available_search_options = $created_item->searchOptions();
+
+        // Ensure the search option is available for the target itemtype
+        $this
+            ->boolean(isset($available_search_options[$search_option_id]))
+            ->isTrue()
+        ;
+    }
+
+    /**
+     * Data provider for the "testGetTabNameForItem" method
+     *
+     * @return iterable
+     */
+    final protected function testGetTabNameForItemProvider(): iterable
+    {
+        $this->login();
+
+        $destination = $this->getTestedInstance();
+        $answers_handler = AnswersHandler::getInstance();
+        $tab_name = $destination::getTargetItemtype()::getTypeName();
+
+        // Invalid types
+        yield [new Computer(), false];
+        yield [new Impact(), false];
+        yield [new Form(), false];
+
+        // Answers set with no destinations
+        $form = $this->createForm(
+            (new FormBuilder())
+                ->addQuestion("Name", QuestionTypeShortAnswerText::class)
+        );
+        $answers_set = $answers_handler->saveAnswers($form, [
+            $this->getQuestionId($form, "Name") => "Pierre Paul Jacques",
+        ], \Session::getLoginUserID());
+        yield [$answers_set, $tab_name];
+
+        // Answers set with 3 destinations
+        $form = $this->createForm(
+            (new FormBuilder())
+                ->addQuestion("Name", QuestionTypeShortAnswerText::class)
+                ->addDestination($destination::class, ['name' => 'destination 1'])
+                ->addDestination($destination::class, ['name' => 'destination 2'])
+                ->addDestination($destination::class, ['name' => 'destination 3'])
+        );
+        $answers_set = $answers_handler->saveAnswers($form, [
+            $this->getQuestionId($form, "Name") => "Pierre Paul Jacques",
+        ], \Session::getLoginUserID());
+        yield [$answers_set, $tab_name . " 3"];
+
+        // Disable tab count
+        $_SESSION['glpishow_count_on_tabs'] = false;
+        yield [$answers_set, $tab_name];
+    }
+
+    /**
+     * Test the getTabNameForItem method
+     *
+     * @dataProvider testGetTabNameForItemProvider
+     *
+     * @param CommonGLPI $item
+     * @param string|false $expected_tab_name
+     *
+     * @return void
+     */
+    final public function testGetTabNameForItem(
+        CommonGLPI $item,
+        string|false $expected_tab_name
+    ): void {
+        $destination = $this->getTestedInstance();
+        $tab_name = $destination->getTabNameForItem($item);
+
+        if ($tab_name !== false) {
+            // Strip tags to keep only the relevant data
+            $tab_name = strip_tags($tab_name);
+        }
+        $this->variable($tab_name)->isEqualTo($expected_tab_name);
+    }
+
+    /**
+     * Data provider for the "testDisplayTabContentForItem" method
+     *
+     * @return iterable
+     */
+    final protected function testDisplayTabContentForItemProvider(): iterable
+    {
+        $this->login();
+
+        $destination = $this->getTestedInstance();
+        $answers_handler = AnswersHandler::getInstance();
+
+        // Invalid types
+        yield [new Computer(), false];
+        yield [new Impact(), false];
+        yield [new Form(), false];
+
+        // Answers set with no destinations
+        $form = $this->createForm(
+            (new FormBuilder())
+                ->addQuestion("Name", QuestionTypeShortAnswerText::class)
+        );
+        $answers_set = $answers_handler->saveAnswers($form, [
+            $this->getQuestionId($form, "Name") => "Pierre Paul Jacques",
+        ], \Session::getLoginUserID());
+        yield [$answers_set, true];
+
+        // Answers set with 3 destinations
+        $form = $this->createForm(
+            (new FormBuilder())
+                ->addQuestion("Name", QuestionTypeShortAnswerText::class)
+                ->addDestination($destination::class, ['name' => 'destination 1'])
+                ->addDestination($destination::class, ['name' => 'destination 2'])
+                ->addDestination($destination::class, ['name' => 'destination 3'])
+        );
+        $answers_set = $answers_handler->saveAnswers($form, [
+            $this->getQuestionId($form, "Name") => "Pierre Paul Jacques",
+        ], \Session::getLoginUserID());
+        yield [$answers_set, true];
+    }
+
+    /**
+     * Test the displayTabContentForItem method
+     *
+     * The HTML content itselft is not tested, as it should be handled by an
+     * E2E test instead.
+     *
+     * @dataProvider testDisplayTabContentForItemProvider
+     *
+     * @param CommonGLPI $item
+     * @param bool $expected
+     *
+     * @return void
+     */
+    final public function testDisplayTabContentForItem(
+        CommonGLPI $item,
+        bool $expected
+    ): void {
+        $destination = $this->getTestedInstance();
+
+        // Render tab content
+        ob_start();
+        $this
+            ->boolean($destination->displayTabContentForItem($item))
+            ->isEqualTo($expected);
+        ob_end_clean();
+    }
+}

--- a/tests/src/FormBuilder.php
+++ b/tests/src/FormBuilder.php
@@ -326,7 +326,7 @@ class FormBuilder
             $this->destinations[$itemtype] = [];
         }
 
-        $this->destinations[$itemtype] = $values;
+        $this->destinations[$itemtype][] = $values;
         return $this;
     }
 }

--- a/tests/src/FormTesterTrait.php
+++ b/tests/src/FormTesterTrait.php
@@ -89,13 +89,15 @@ trait FormTesterTrait
         }
 
         // Create destinations
-        foreach ($builder->getDestinations() as $itemtype => $destination_data) {
-            $name = $destination_data['name'];
-            $this->createItem(FormDestination::class, [
-                'forms_forms_id' => $form->getID(),
-                'itemtype'       => $itemtype,
-                'name'           => $name,
-            ]);
+        foreach ($builder->getDestinations() as $itemtype => $destinations) {
+            foreach ($destinations as $destination_data) {
+                $name = $destination_data['name'];
+                $this->createItem(FormDestination::class, [
+                    'forms_forms_id' => $form->getID(),
+                    'itemtype'       => $itemtype,
+                    'name'           => $name,
+                ]);
+            }
         }
 
         // Reload form


### PR DESCRIPTION
Followup to #16613, allow forms destination to be configurated from the interface using a new "Items to create" tab.

![image](https://github.com/glpi-project/glpi/assets/42734840/de6f7d63-96bf-40f6-ac3b-13dbe7a4dbe9)

I don't think we need to discuss about the UI/UX of this tab yet as it does not have a lot of content.
It will be better to discuss it after more options are implemented.

The created tickets are listed on the answers page:

![image](https://github.com/glpi-project/glpi/assets/42734840/041b9020-397a-441b-b6b0-e9d9bea4973c)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
