### PR TITLE
Correction of label size when entity name is too long

### DIFF
--- a/templates/components/form/header_content.html.twig
+++ b/templates/components/form/header_content.html.twig
@@ -128,9 +128,13 @@
    {% if item.isEntityAssign() and is_multi_entities_mode() and item is not instanceof('Entity') %}
       {% set single_actions_ms_auto = false %}
       <span class="badge entity-name mx-1 px-2 ms-auto align-items-center" title="{{ entity_name }}">
-                  <i class="ti ti-stack me-2"></i>
-                  {{ entity_name }}
-               </span>
+        <i class="ti ti-stack me-2"></i>
+           <div style="width: 200px; direction: ltr;">
+              <div class="text-truncate" style="direction: rtl;">
+                 {{ entity_name }}
+              </div>
+           </div>
+      </span>
 
       {% if item.maybeRecursive() %}
          <span class="badge is_recursive-toggle mx-1 px-2 align-items-center">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14165

When the entity name is too long, the action button moves behind the object tab, and it's not possible to read the label.

I've set the maximum width of this label, and when the text is too long, only the end of the entity name is modified, because for a sub-entity of a sub-entity, it's the end of the entity that's interesting to know.

However, it is possible to view the entire name by hovering the mouse over it.

**Before**
![image](https://github.com/glpi-project/glpi/assets/107540223/0fd5e7f9-bd27-415a-8ad2-7fef552c6a73)

**After**
![image](https://github.com/glpi-project/glpi/assets/107540223/6aaf45d7-9314-4805-b51e-4785e57eb112)

