### PR TITLE
Fix(Inventory): allow to download inventory file only if is_dynamic

### DIFF
--- a/src/Features/Inventoriable.php
+++ b/src/Features/Inventoriable.php
@@ -73,18 +73,8 @@ trait Inventoriable
      */
     public function getInventoryFileName(bool $prepend_dir_path = true): ?string
     {
-
-        if ($this->isField('autoupdatesystems_id')) {
-            $source = new \AutoUpdateSystem();
-            $source->getFromDBByCrit(['name' => AutoUpdateSystem::NATIVE_INVENTORY]);
-
-            if (
-                !$this->isDynamic()
-                || !isset($source->fields['id'])
-                || $this->fields['autoupdatesystems_id'] != $source->fields['id']
-            ) {
-                return null;
-            }
+        if (!$this->isDynamic()) {
+            return null;
         }
 
         $inventory_dir_path = GLPI_INVENTORY_DIR . '/';


### PR DESCRIPTION
Allow the inventory file to be downloaded only if the item is dynamic.

The condition concerning the update source makes no sense

A plugin could inject its json / xml and decide on the update source (```!= Glpi Native Inventory```)

Internal need with (cloud inventory plugin)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
