### PR TITLE
Forms: history

### DIFF
--- a/js/form_editor_controller.js
+++ b/js/form_editor_controller.js
@@ -815,7 +815,7 @@ class GlpiFormEditorController
     }
 
     /**
-     * Update "Section X of Y" labels
+     * Update "Step X of Y" labels
      */
     #updateSectionCountLabels() {
         const sections = $(this.#target).find("[data-glpi-form-editor-section]");
@@ -824,7 +824,7 @@ class GlpiFormEditorController
                 .find("[data-glpi-form-editor-section-number-display]");
 
             display.html(
-                __("Section %1$d of %2$d")
+                __("Step %1$d of %2$d")
                     .replace("%1$d", s_index + 1)
                     .replace("%2$d", sections.length)
             );

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -54,6 +54,12 @@ final class Form extends CommonDBTM
 {
     public static $rightname = 'form';
 
+    public $dohistory = true;
+
+    public $history_blacklist = [
+        'date_mod',
+    ];
+
     /**
      * Lazy loaded array of sections
      * Should always be accessed through getSections()

--- a/src/Form/Question.php
+++ b/src/Form/Question.php
@@ -37,6 +37,8 @@ namespace Glpi\Form;
 
 use CommonDBChild;
 use Glpi\Form\QuestionType\QuestionTypeInterface;
+use Log;
+use Override;
 use ReflectionClass;
 
 /**
@@ -46,6 +48,35 @@ final class Question extends CommonDBChild
 {
     public static $itemtype = Section::class;
     public static $items_id = 'forms_sections_id';
+
+    public $dohistory = true;
+
+    #[Override]
+    public static function getTypeName($nb = 0)
+    {
+        return _n('Question', 'Questions', $nb);
+    }
+
+    #[Override]
+    public function post_addItem()
+    {
+        // Report logs to the parent form
+        $this->logCreationInParentForm();
+    }
+
+    #[Override]
+    public function post_updateItem($history = true)
+    {
+        // Report logs to the parent form
+        $this->logUpdateInParentForm($history);
+    }
+
+    #[Override]
+    public function post_deleteFromDB()
+    {
+        // Report logs to the parent form
+        $this->logDeleteInParentForm();
+    }
 
     /**
      * Get type object for the current object.
@@ -64,5 +95,114 @@ final class Question extends CommonDBChild
         }
 
         return new $type();
+    }
+
+    /**
+     * Get the parent form of this question
+     *
+     * @return Form
+     */
+    protected function getForm(): Form
+    {
+        return $this->getItem()->getItem();
+    }
+
+    /**
+     * Manually update logs of the parent form item
+     *
+     * @return void
+     */
+    protected function logCreationInParentForm(): void
+    {
+        if ($this->input['_no_history'] ?? false) {
+            return;
+        }
+
+        $form = $this->getForm();
+        $changes = [
+            '0',
+            '',
+            $this->getHistoryNameForItem($form, 'add'),
+        ];
+
+        // Report logs to the parent form
+        Log::history(
+            $form->getID(),
+            $form->getType(),
+            $changes,
+            $this->getType(),
+            static::$log_history_add
+        );
+
+        parent::post_addItem();
+    }
+
+    /**
+     * Manually update logs of the parent form item
+     *
+     * @param bool $history
+     *
+     * @return void
+     */
+    protected function logUpdateInParentForm($history = true): void
+    {
+        if ($this->input['_no_history'] ?? false) {
+            return;
+        }
+
+        $form = $this->getForm();
+
+        $oldvalues = $this->oldvalues;
+        unset($oldvalues[static::$itemtype]);
+        unset($oldvalues[static::$items_id]);
+
+        foreach (array_keys($oldvalues) as $field) {
+            if (in_array($field, $this->getNonLoggedFields())) {
+                continue;
+            }
+            $changes = $this->getHistoryChangeWhenUpdateField($field);
+            if ((!is_array($changes)) || (count($changes) != 3)) {
+                continue;
+            }
+
+            Log::history(
+                $form->getID(),
+                $form->getType(),
+                $changes,
+                $this->getType(),
+                static::$log_history_update
+            );
+        }
+
+        parent::post_updateItem($history);
+    }
+
+    /**
+     * Manually update logs of the parent form item
+     *
+     * @return void
+     */
+    protected function logDeleteInParentForm(): void
+    {
+        if ($this->input['_no_history'] ?? false) {
+            return;
+        }
+
+        $form = $this->getForm();
+        $changes = [
+            '0',
+            '',
+            $this->getHistoryNameForItem($form, 'delete'),
+        ];
+
+        Log::history(
+            $form->getID(),
+            $form->getType(),
+            $changes,
+            $this->getType(),
+            static::$log_history_delete
+        );
+
+        parent::post_deleteFromDB();
     }
 }

--- a/src/Form/Section.php
+++ b/src/Form/Section.php
@@ -54,6 +54,12 @@ final class Section extends CommonDBChild
     protected ?array $questions = null;
 
     #[Override]
+    public static function getTypeName($nb = 0)
+    {
+        return _n('Step', 'Steps', $nb);
+    }
+
+    #[Override]
     public function post_getFromDB()
     {
         // Clear any lazy loaded data

--- a/templates/pages/admin/form/form_section.html.twig
+++ b/templates/pages/admin/form/form_section.html.twig
@@ -56,7 +56,7 @@
         style="width: fit-content;"
         data-glpi-form-editor-section-number-display
     >
-        {{ __("Section %d of %d")|format(section_index, number_of_sections) }}
+        {{ __("Step %d of %d")|format(section_index, number_of_sections) }}
     </div>
     <div
         class="card mb-3 {{ show_section_form ? "" : "d-none" }}"


### PR DESCRIPTION
Enable history for forms.

Needed some specific code to take questions update into account as they are an indirect relation (Form -> Section -> Question) and our framework only manage related logs for direct relation.

![image](https://github.com/glpi-project/glpi/assets/42734840/f0341e7d-88ac-4b63-a8fc-f33e425b30f5)


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

