### PR TITLE
Forms: hide long answer questions toolbar when inactive

### DIFF
--- a/css/includes/components/form/_form-editor.scss
+++ b/css/includes/components/form/_form-editor.scss
@@ -91,17 +91,25 @@
     }
 }
 
-// Hide secondary data on inactive questions
+// Show secondary data on active questions
 [data-glpi-form-editor-question].active [data-glpi-form-editor-question-extra-details] {
     opacity: 1;
     visibility: visible;
     transition: visibility 0s, opacity 0.20s linear;
 }
 
-[data-glpi-form-editor-question]:not(.active) [data-glpi-form-editor-question-extra-details] {
-    height: 0;
-    opacity: 0;
-    visibility: hidden;
+[data-glpi-form-editor-question]:not(.active) {
+    // Hide secondary data on inactive questions
+    [data-glpi-form-editor-question-extra-details] {
+        height: 0;
+        opacity: 0;
+        visibility: hidden;
+    }
+
+    // Hide tinymce toolbar on inactive questions
+    .tox-editor-header {
+        display: none !important;
+    }
 }
 
 .glpi-form-editor-drag-question-placeholder {


### PR DESCRIPTION
Suggested by @orthagh.

Tinymce's toolbar on "Long answer" questions is now hidden unless the question is active.

Inactive question:
![image](https://github.com/glpi-project/glpi/assets/42734840/0b3ce01a-d766-4efa-9686-5d7c8ad64214)


Active question:
![image](https://github.com/glpi-project/glpi/assets/42734840/c26f50e1-6404-4111-816c-2f484ba1ce96)


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
