### PR TITLE
Make `mbstring` extension mandatory

### DIFF
--- a/src/System/RequirementsManager.php
+++ b/src/System/RequirementsManager.php
@@ -110,6 +110,11 @@ class RequirementsManager
             __('Required for internationalization.')
         );
         $requirements[] = new Extension(
+            'mbstring',
+            false,
+            __('Required for multibyte chars support and charset conversion.')
+        );
+        $requirements[] = new Extension(
             'zlib',
             false,
             __('Required for handling of compressed communication with inventory agents, installation of gzip packages from marketplace and PDF generation.')
@@ -181,7 +186,7 @@ class RequirementsManager
         );
         $requirements[] = new ExtensionGroup(
             __('PHP emulated extensions'),
-            ['ctype', 'iconv', 'mbstring', 'sodium'],
+            ['ctype', 'iconv', 'sodium'],
             true,
             __('Slightly enhance performances.')
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | see #16694

The `symfony/polyfill-mbstring` components only provides a partial implementation of the native `mbstring` extension. It will permit, for instance, to be able to correctly display the GLPI console (see #8331), but it will not be able to convert chars to the `UTF7-IMAP` encoding required by the mail collector. I propose to make this extension mandatory in future GLPI versions.

Related error:
```
glpiphplog.WARNING:   *** PHP Warning (2): iconv(): Wrong encoding, conversion from "UTF-8" to "UTF7-IMAP//IGNORE" is not allowed in /var/www/html/glpi/vendor/symfony/polyfill-mbstring/Mbstring.php at line 116
  Backtrace :
  vendor/symfony/polyfill-mbstring/Mbstring.php:116  iconv()
  ...or/symfony/polyfill-mbstring/bootstrap80.php:15 Symfony\Polyfill\Mbstring\Mbstring::mb_convert_encoding()
  src/MailCollector.php:1419                         mb_convert_encoding()
  src/MailCollector.php:707                          MailCollector->connect()
  src/MailCollector.php:1913                         MailCollector->collect()
  src/CronTask.php:1018                              MailCollector::cronMailgate()
  front/cron.php:84                                  CronTask::launch()
```