### PR TITLE
Forms: collaspe sections

### DIFF
--- a/css/includes/components/form/_form-editor.scss
+++ b/css/includes/components/form/_form-editor.scss
@@ -186,8 +186,7 @@
 // Hide content of collapsed sections
 [data-glpi-form-editor-section].section-collapsed {
     [data-glpi-form-editor-section-description],
-    [data-glpi-form-editor-question-description],
-    [data-glpi-form-editor-question-type-specific] {
+    [data-glpi-form-editor-section-questions] {
         display: none;
     }
 }

--- a/css/includes/components/form/_form-editor.scss
+++ b/css/includes/components/form/_form-editor.scss
@@ -186,8 +186,11 @@
 // Hide content of collapsed sections
 [data-glpi-form-editor-section].section-collapsed {
     [data-glpi-form-editor-section-description],
-    [data-glpi-form-editor-section-questions] {
+    [data-glpi-form-editor-section-questions],
+    [data-glpi-form-editor-section-extra-details] {
         display: none;
     }
+
+    margin-bottom: 1rem !important;
 }
 

--- a/css/includes/components/form/_form-editor.scss
+++ b/css/includes/components/form/_form-editor.scss
@@ -183,4 +183,12 @@
     }
 }
 
+// Hide content of collapsed sections
+[data-glpi-form-editor-section].section-collapsed {
+    [data-glpi-form-editor-section-description],
+    [data-glpi-form-editor-question-description],
+    [data-glpi-form-editor-question-type-specific] {
+        display: none;
+    }
+}
 

--- a/js/form_editor_controller.js
+++ b/js/form_editor_controller.js
@@ -282,6 +282,13 @@ class GlpiFormEditorController
                 );
                 break;
 
+            // Collapse/uncollapse target section
+            case "collapse-section":
+                this.#collaspeSection(
+                    target.closest("[data-glpi-form-editor-section]")
+                );
+                break;
+
             // Unknown action
             default:
                 throw new Error(`Unknown action: ${action}`);
@@ -548,6 +555,7 @@ class GlpiFormEditorController
                 .removeAttr(`data-glpi-form-editor-active-${type}`);
         });
 
+
         // Set new active item if specified
         if (item_container !== null) {
             possible_active_items.forEach((type) => {
@@ -561,6 +569,14 @@ class GlpiFormEditorController
                         .attr(`data-glpi-form-editor-active-${type}`, "");
                 }
             });
+
+            // An item can't be active if its parent section is collapsed
+            const section = item_container.closest("[data-glpi-form-editor-section]");
+            if (section.hasClass("section-collapsed")) {
+                return;
+            }
+
+            item_container.addClass("active");
         }
     }
 
@@ -1254,5 +1270,14 @@ class GlpiFormEditorController
         this.#updateSectionCountLabels();
         this.#updateSectionsDetailsVisiblity();
         this.#updateMergeSectionActionVisibility();
+    }
+
+    /**
+     * Collaspe target section
+     * @param {jQuery} section
+     */
+    #collaspeSection(section) {
+        // Simple class toggle, hiding the correct parts is handled by CSS rules
+        section.toggleClass("section-collapsed");
     }
 }

--- a/templates/pages/admin/form/form_question.html.twig
+++ b/templates/pages/admin/form/form_question.html.twig
@@ -70,7 +70,7 @@
             {# Display question's title #}
             <div class="d-flex mt-n1">
                 <input
-                    class="form-control content-editable-h2"
+                    class="form-control content-editable-h2 mb-0"
                     type="text"
                     name="name"
                     value="{{ question is not null ? question.fields.name|e('html_attr') : '' }}"
@@ -83,7 +83,10 @@
             </div>
 
             {# Render the specific question type #}
-            <div data-glpi-form-editor-question-type-specific>
+            <div
+                class="mt-3"
+                data-glpi-form-editor-question-type-specific
+            >
                 {{ question_type.renderAdminstrationTemplate(question)|raw }}
             </div>
 

--- a/templates/pages/admin/form/form_section.html.twig
+++ b/templates/pages/admin/form/form_section.html.twig
@@ -78,12 +78,21 @@
                     {# Section's name #}
                     <input
                         type="text"
-                        class="form-control content-editable-h2"
+                        class="form-control content-editable-h2 mb-0"
                         name="name"
                         value="{{ section is not null ? section.fields.name|e('html_attr') : '' }}"
                         placeholder="{{ __("New section") }}"
                         data-glpi-form-editor-section-details-name
                     >
+
+                    {# Collapse section #}
+                    <i
+                        class="ti ti-selector ms-3 me-3 cursor-pointer"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="{{ __("Collapse section") }}"
+                        data-glpi-form-editor-on-click="collapse-section"
+                    ></i>
 
                     {# Extra actions #}
                     <div class="dropdown ms-auto cursor-pointer">
@@ -131,7 +140,10 @@
                 </div>
 
                 {# Section's description #}
-                <div class="content-editable-tinymce">
+                <div
+                    class="content-editable-tinymce mt-3"
+                    data-glpi-form-editor-section-description
+                >
                     {{ fields.textareaField(
                         "description",
                         section is not null ? section.fields.description : '',


### PR DESCRIPTION
Allow sections to be collapsed.

![image](https://github.com/glpi-project/glpi/assets/42734840/eec82fc2-8466-42e3-a9bb-d94d03a1cf51)

Collapsed:
![image](https://github.com/glpi-project/glpi/assets/42734840/de264edf-266a-4d88-bb36-32f2f7c9b146)


Non-collapsed:
![image](https://github.com/glpi-project/glpi/assets/42734840/1fe53e6f-39d4-42e7-9a0e-327bab2a0889)



| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
