### PR TITLE
Fix group cache invalidation

### DIFF
--- a/src/Group.php
+++ b/src/Group.php
@@ -989,6 +989,7 @@ class Group extends CommonTreeDropdown
 
     public function post_addItem()
     {
+        parent::post_addItem();
         // Adding a new group might invalidate the group cache if it's a new child
         // group and recursive membership is enabled
         if ($this->fields['groups_id']) {
@@ -998,6 +999,7 @@ class Group extends CommonTreeDropdown
 
     public function post_updateItem($history = 1)
     {
+        parent::post_updateItem();
         // Changing a group's parent might invalidate the group cache if recursive
         // membership is enabled
         $parent_changed =


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

New recursive feature for groups added overrides for `post_addItem` and `post_updateItem` but calls the the parent methods were missing which meant the caches were not being managed at all. Adding a new child group would not invalidate the relevant caches.