### PR TITLE
Fix tab changes not persisting

### DIFF
--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -360,7 +360,7 @@ JAVASCRIPT;
             $js = "
          var url_hash = window.location.hash;
          var loadTabContents = function (tablink, force_reload = false, update_session_tab = true) {
-            const href_url_params = new URLSearchParams($(tablink).prop('href'));
+            const href_url_params = new URL(url, CFG_GLPI.url_base).searchParams;
             var url = tablink.attr('href');
             var target = tablink.attr('data-bs-target');
 

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -360,8 +360,8 @@ JAVASCRIPT;
             $js = "
          var url_hash = window.location.hash;
          var loadTabContents = function (tablink, force_reload = false, update_session_tab = true) {
-            const href_url_params = new URL(url, CFG_GLPI.url_base).searchParams;
             var url = tablink.attr('href');
+            const href_url_params = new URL(url, CFG_GLPI.url_base).searchParams;
             var target = tablink.attr('data-bs-target');
 
             const updateCurrentTab = () => {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Seems like a recent break (something to E2E test once that is ready I guess) as I only noticed it now, but I don't know which change could have broken it. The previous code only recognized some of the parameters in the URL and seemed to be an encoding issue. The options in the encoded `formoptions` parameter were recognized, which the non-encoded ones were not. This was the only solution I found that worked properly.