### PR TITLE
drop DropdownTranslation::getTranslationByName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,6 +281,7 @@ The present file will list all changes made to the project; according to the
 - `DisplayPreference::showFormPerso` `target_id` parameter.
 - `$DEBUG_SQL, `$SQL_TOTAL_REQUEST`, `$TIMER_DEBUG` and `$TIMER` global variables.
 - `$CFG_GLPI['debug_sql']` and `$CFG_GLPI['debug_vars']` configuration options.
+- `DropdownTranslation::getTranslationByName()`
 
 
 ## [10.0.13] unreleased

--- a/src/DropdownTranslation.php
+++ b/src/DropdownTranslation.php
@@ -762,41 +762,6 @@ JAVASCRIPT
     }
 
     /**
-     * Get a translation for a value
-     *
-     * @param string $itemtype  itemtype
-     * @param string $field     field to query
-     * @param string $value     value to translate
-     *
-     * @return string the value translated if a translation is available, or the same value if not
-     **/
-    public static function getTranslationByName($itemtype, $field, $value)
-    {
-        //TODO Check which version used this last
-        /** @var \DBmysql $DB */
-        global $DB;
-
-        $iterator = $DB->request([
-            'SELECT' => ['id'],
-            'FROM'   => getTableForItemType($itemtype),
-            'WHERE'  => [
-                $field   => $value
-            ]
-        ]);
-        if (count($iterator) > 0) {
-            $current = $iterator->current();
-            return self::getTranslatedValue(
-                $current['id'],
-                $itemtype,
-                $field,
-                $_SESSION['glpilanguage'],
-                $value
-            );
-        }
-        return $value;
-    }
-
-    /**
      * Get translations for an item
      *
      * @param string  $itemtype  itemtype


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Followup to the previous cleanup PR. After searching every tagged version of GLPI from 0.20 until now, this method is only ever declared and not used. I don't see any plugins using it either (although I don't have all of them downloaded locally).