### PR TITLE
fix(search): contains &

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -4748,6 +4748,13 @@ JAVASCRIPT;
                     }
                 }
 
+                // To search for '&' in rich text
+                if (
+                    (($searchopt[$ID]['datatype'] ?? null) === 'text')
+                    && (($searchopt[$ID]['htmltext'] ?? null) === true)
+                ) {
+                    $val = str_replace('&#38;', '38;amp;', $val);
+                }
                 if ($should_use_subquery) {
                     // Subquery will be needed to get accurate results
                     $use_subquery_on_text_search = true;
@@ -4757,13 +4764,6 @@ JAVASCRIPT;
                     $subquery_operator = $nott ? "NOT IN" : "IN";
                 } else {
                     $SEARCH = self::makeTextSearch($val, $nott);
-                }
-                // To search for '&' in rich text
-                if (
-                    (($searchopt[$ID]['datatype'] ?? null) === 'text')
-                    && (($searchopt[$ID]['htmltext'] ?? null) === true)
-                ) {
-                    $val = str_replace('&#38;', '38;amp;', $val);
                 }
                 break;
 

--- a/src/Search.php
+++ b/src/Search.php
@@ -4758,6 +4758,13 @@ JAVASCRIPT;
                 } else {
                     $SEARCH = self::makeTextSearch($val, $nott);
                 }
+                // To search for '&' in rich text
+                if (
+                    (($searchopt[$ID]['datatype'] ?? null) === 'text')
+                    && (($searchopt[$ID]['htmltext'] ?? null) === true)
+                ) {
+                    $val = str_replace('&#38;', '38;amp;', $val);
+                }
                 break;
 
             case "equals":
@@ -5180,14 +5187,6 @@ JAVASCRIPT;
                     list($itemtype_val, $event_val) = explode(self::SHORTSEP, $val);
                     return " $link $not(`$table`.`event` = '$event_val'
                                AND `$table`.`itemtype` = '$itemtype_val')";
-                }
-                break;
-
-            case "glpi_changes.content":
-            case "glpi_problems.content":
-            case "glpi_tickets.content":
-                if (in_array($searchtype, ['contains', 'notcontains'])) {
-                    $val = str_replace('&#38;', '38;amp;', $val);
                 }
                 break;
         }

--- a/src/Search.php
+++ b/src/Search.php
@@ -5182,6 +5182,14 @@ JAVASCRIPT;
                                AND `$table`.`itemtype` = '$itemtype_val')";
                 }
                 break;
+
+            case "glpi_changes.content":
+            case "glpi_problems.content":
+            case "glpi_tickets.content":
+                if (in_array($searchtype, ['contains', 'notcontains'])) {
+                    $val = str_replace('&#38;', '38;amp;', $val);
+                }
+                break;
         }
 
        //// Default cases

--- a/tests/functional/Search.php
+++ b/tests/functional/Search.php
@@ -4721,38 +4721,48 @@ class Search extends DbTestCase
         $this->createItems('Ticket', [
             [
                 'name' => 'Ticket 1',
-                'content' => 'This is a test ticket'
+                'content' => '<p>This is a test ticket</p>'
             ],
             [
                 'name' => 'Ticket 2',
-                'content' => 'This is a test ticket with & in description'
+                'content' => '<p>This is a test ticket with &amp; in description</p>'
             ],
             [
                 'name' => 'Ticket 3',
-                'content' => 'This is a test ticket with followup'
+                'content' => '<p>This is a test ticket with matching followup</p>'
             ],
             [
                 'name' => 'Ticket 4',
-                'content' => 'This is a test ticket with task'
+                'content' => '<p>This is a test ticket with task</p>'
             ],
             [
                 'name' => 'Ticket & 5',
-                'content' => 'This is a test ticket'
+                'content' => '<p>This is a test ticket</p>'
             ],
         ]);
 
-        // Add a followup to ticket 3
+        $this->createItem('ITILFollowup', [
+            'itemtype' => 'Ticket',
+            'items_id' => getItemByTypeName('Ticket', 'Ticket 1')->getID(),
+            'content' => '<p>This is a followup</p>'
+        ]);
         $this->createItem('ITILFollowup', [
             'itemtype' => 'Ticket',
             'items_id' => getItemByTypeName('Ticket', 'Ticket 3')->getID(),
-            'content' => 'This is a followup with & in description'
+            'content' => '<p>This is a followup with &amp; in description</p>'
         ]);
 
-        // Add a task to ticket 4
+        $this->createItem('TicketTask', [
+            'tickets_id' => getItemByTypeName('Ticket', 'Ticket 1')->getID(),
+            'content' => '<p>This is a task</p>'
+        ]);
         $this->createItem('TicketTask', [
             'tickets_id' => getItemByTypeName('Ticket', 'Ticket 4')->getID(),
-            'content' => 'This is a task with & in description'
+            'content' => '<p>This is a task with &amp; in description</p>'
         ]);
+
+        // When user searches for a `&`, the criteria is sanitized and its value is therefore `&#38;`
+        $sanitized_ampersand_criteria = '&#38;';
 
         yield [
             'search_params' => [
@@ -4763,7 +4773,7 @@ class Search extends DbTestCase
                         'link'       => 'AND',
                         'field'      => 1, // title
                         'searchtype' => 'contains',
-                        'value'      => '&'
+                        'value'      => $sanitized_ampersand_criteria
                     ]
                 ],
             ],
@@ -4781,7 +4791,7 @@ class Search extends DbTestCase
                         'link'       => 'AND',
                         'field'      => 21, // ticket content
                         'searchtype' => 'contains',
-                        'value'      => '&'
+                        'value'      => $sanitized_ampersand_criteria
                     ]
                 ],
             ],
@@ -4799,7 +4809,7 @@ class Search extends DbTestCase
                         'link'       => 'AND',
                         'field'      => 25, // followup content
                         'searchtype' => 'contains',
-                        'value'      => '&'
+                        'value'      => $sanitized_ampersand_criteria
                     ]
                 ],
             ],
@@ -4817,7 +4827,7 @@ class Search extends DbTestCase
                         'link'       => 'AND',
                         'field'      => 26, // task content
                         'searchtype' => 'contains',
-                        'value'      => '&'
+                        'value'      => $sanitized_ampersand_criteria
                     ]
                 ],
             ],
@@ -4835,7 +4845,7 @@ class Search extends DbTestCase
                         'link' => 'AND',
                         'field' => 'view', // items seen
                         'searchtype' => 'contains',
-                        'value' => '&'
+                        'value' => $sanitized_ampersand_criteria
                     ],
                     1 => [
                         'link' => 'AND',

--- a/tests/functional/Search.php
+++ b/tests/functional/Search.php
@@ -4735,7 +4735,6 @@ class Search extends DbTestCase
                 'name' => 'Ticket 4',
                 'content' => 'This is a test ticket with task'
             ],
-            
             [
                 'name' => 'Ticket & 5',
                 'content' => 'This is a test ticket'


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !31814

When we search for `&` in the contents of a ticket, the result returns all HTML entities, so more than expected.
