### PR TITLE
Forms: focus input

### DIFF
--- a/js/form_editor_controller.js
+++ b/js/form_editor_controller.js
@@ -102,6 +102,13 @@ class GlpiFormEditorController
         this.#enableSortable(
             $(this.#target).find("[data-glpi-form-editor-sections]")
         );
+
+        // Focus the form's name input if there are no questions
+        if (this.#getQuestionsCount() === 0) {
+            $(this.#target)
+                .find("[data-glpi-form-editor-form-details-name]")[0]
+                .focus();
+        }
     }
 
     /**
@@ -594,6 +601,11 @@ class GlpiFormEditorController
         // Update UX
         this.#setActiveItem(new_question);
         this.#updateAddSectionActionVisiblity();
+
+        // Focus question's name
+        new_question
+            .find("[data-glpi-form-editor-question-details-name]")[0]
+            .focus();
     }
 
     /**
@@ -907,6 +919,11 @@ class GlpiFormEditorController
         this.#setActiveItem(
             section.find("[data-glpi-form-editor-section-details]")
         );
+
+        // Focus section's name
+        section
+            .find("[data-glpi-form-editor-section-details-name]")[0]
+            .focus();
     }
 
     /**
@@ -967,6 +984,16 @@ class GlpiFormEditorController
     #getSectionCount() {
         return $(this.#target)
             .find("[data-glpi-form-editor-section]")
+            .length;
+    }
+
+    /**
+     * Count the number of questions in the form.
+     * @returns {number}
+     */
+    #getQuestionsCount() {
+        return $(this.#target)
+            .find("[data-glpi-form-editor-question]")
             .length;
     }
 

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -96,6 +96,7 @@
                                         class="form-control content-editable-h1"
                                         name="name"
                                         value="{{ item.fields.name|e('html_attr') }}"
+                                        data-glpi-form-editor-form-details-name
                                     >
 
                                     {# Form's status #}

--- a/templates/pages/admin/form/form_question.html.twig
+++ b/templates/pages/admin/form/form_question.html.twig
@@ -77,6 +77,7 @@
                     placeholder="{{ __("New question") }}"
                     data-glpi-form-editor-dynamic-input
                     data-glpi-form-editor-on-input="compute-dynamic-input"
+                    data-glpi-form-editor-question-details-name
                 />
                 <span data-glpi-form-editor-required-mark class="text-danger d-none">*</span>
             </div>

--- a/templates/pages/admin/form/form_section.html.twig
+++ b/templates/pages/admin/form/form_section.html.twig
@@ -82,6 +82,7 @@
                         name="name"
                         value="{{ section is not null ? section.fields.name|e('html_attr') : '' }}"
                         placeholder="{{ __("New section") }}"
+                        data-glpi-form-editor-section-details-name
                     >
 
                     {# Extra actions #}


### PR DESCRIPTION
Suggested by @orthagh:
* When opening a form, focus its name if it has no question
* When adding a question or section, focus its name

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
