### PR TITLE
Groups UI Twig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,6 +290,7 @@ The present file will list all changes made to the project; according to the
 - `$DEBUG_SQL, `$SQL_TOTAL_REQUEST`, `$TIMER_DEBUG` and `$TIMER` global variables.
 - `$CFG_GLPI['debug_sql']` and `$CFG_GLPI['debug_vars']` configuration options.
 - `DropdownTranslation::getTranslationByName()`
+- `addgroup` and `deletegroup` actions in `front/user.form.php`.
 
 
 ## [10.0.14] unreleased

--- a/front/group_user.form.php
+++ b/front/group_user.form.php
@@ -47,7 +47,16 @@ $group_user = new Group_User();
 
 if (isset($_POST["add"])) {
     $group_user->check(-1, CREATE, $_POST);
-    $group_user->add($_POST);
+    if ($group_user->add($_POST)) {
+        Event::log(
+            $_POST["groups_id"],
+            "groups",
+            4,
+            "setup",
+            //TRANS: %s is the user login
+            sprintf(__('%s adds a user to a group'), $_SESSION["glpiname"])
+        );
+    }
     Html::back();
 }
 

--- a/front/group_user.form.php
+++ b/front/group_user.form.php
@@ -47,16 +47,7 @@ $group_user = new Group_User();
 
 if (isset($_POST["add"])) {
     $group_user->check(-1, CREATE, $_POST);
-    if ($group_user->add($_POST)) {
-        Event::log(
-            $_POST["groups_id"],
-            "groups",
-            4,
-            "setup",
-            //TRANS: %s is the user login
-            sprintf(__('%s adds a user to a group'), $_SESSION["glpiname"])
-        );
-    }
+    $group_user->add($_POST);
     Html::back();
 }
 

--- a/front/user.form.php
+++ b/front/user.form.php
@@ -151,36 +151,6 @@ if (isset($_GET['getvcard'])) {
         sprintf(__('%s updates an item'), $_SESSION["glpiname"])
     );
     Html::back();
-} else if (isset($_POST["addgroup"])) {
-    $groupuser->check(-1, CREATE, $_POST);
-    if ($groupuser->add($_POST)) {
-        Event::log(
-            $_POST["users_id"],
-            "users",
-            4,
-            "setup",
-            //TRANS: %s is the user login
-            sprintf(__('%s adds a user to a group'), $_SESSION["glpiname"])
-        );
-    }
-    Html::back();
-} else if (isset($_POST["deletegroup"])) {
-    if (count($_POST["item"])) {
-        foreach (array_keys($_POST["item"]) as $key) {
-            if ($groupuser->can($key, DELETE)) {
-                $groupuser->delete(['id' => $key]);
-            }
-        }
-    }
-    Event::log(
-        $_POST["users_id"],
-        "users",
-        4,
-        "setup",
-        //TRANS: %s is the user login
-        sprintf(__('%s deletes users from a group'), $_SESSION["glpiname"])
-    );
-    Html::back();
 } else if (isset($_POST["change_auth_method"])) {
     Session::checkRight('user', User::UPDATEAUTHENT);
 

--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -660,6 +660,9 @@ TWIG, $twig_params);
                 'is_raw' => true
             ],
             'columns' => $columns,
+            'formatters' => [
+                'name' => 'raw_html',
+            ],
             'entries' => $entries,
             'total_number' => count($entries),
             'filtered_number' => count($entries),

--- a/src/Group.php
+++ b/src/Group.php
@@ -784,7 +784,7 @@ class Group extends CommonTreeDropdown
             ]
         ];
         if ($tree || $user) {
-            $columns['field'] = sprintf(__('%1$s / %2$s'), self::getTypeName(1), User::getTypeName(1));
+            $columns['field'] = sprintf(__s('%1$s / %2$s'), self::getTypeName(1), User::getTypeName(1));
         }
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
@@ -805,7 +805,8 @@ class Group extends CommonTreeDropdown
                 'container'     => 'mass' . static::class . $rand,
                 'check_itemtype'   => 'Group',
                 'check_items_id'   => $ID,
-                'extraparams'      => ['is_tech' => $tech ? 1 : 0,
+                'extraparams'      => [
+                    'is_tech' => $tech ? 1 : 0,
                     'massive_action_fields' => ['field']
                 ],
                 'specific_actions' => [

--- a/src/Group.php
+++ b/src/Group.php
@@ -34,7 +34,9 @@
  */
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QuerySubQuery;
+use Glpi\Search\Provider\SQLProvider;
 
 /**
  * Group class
@@ -530,10 +532,11 @@ class Group extends CommonTreeDropdown
      * @param boolean $user  Include members (users)
      * @param integer $start First row to retrieve
      * @param array $res     Result filled on ouput
+     * @param array $extra_criteria
      *
      * @return integer total of items
      **/
-    public function getDataItems(array $types, $field, $tree, $user, $start, array &$res)
+    public function getDataItems(array $types, $field, $tree, $user, $start, array &$res, $extra_criteria = [])
     {
         /** @var \DBmysql $DB */
         global $DB;
@@ -634,19 +637,21 @@ class Group extends CommonTreeDropdown
                 $start -= $nb[$itemtype];
             } else {
                 $request = [
-                    'SELECT' => 'id',
+                    'SELECT' => [
+                        $itemtype === 'Consumable' ? 'glpi_consumableitems.id' : 'id',
+                        new QueryExpression($DB::quoteValue($itemtype), 'itemtype')
+                    ],
                     'FROM'   => $item::getTable(),
                     'WHERE'  => $restrict[$itemtype],
                     'LIMIT'  => $max,
                     'START'  => $start
-                ];
+                ] + $extra_criteria;
 
                 if ($item->isField('name')) {
                     $request['ORDER'] = 'name';
                 }
 
                 if ($itemtype === 'Consumable') {
-                    $request['SELECT'] = 'glpi_consumableitems.id';
                     $request['LEFT JOIN'] = [
                         'glpi_consumableitems' => [
                             'FKEY'   => [
@@ -690,172 +695,124 @@ class Group extends CommonTreeDropdown
         if ($tech) {
             $types = $CFG_GLPI['linkgroup_tech_types'];
             $field = 'groups_id_tech';
-            $title = __('Managed items');
         } else {
             $types = $CFG_GLPI['linkgroup_types'];
             $field = 'groups_id';
-            $title = __('Used items');
         }
 
-        $tree = Session::getSavedOption(__CLASS__, 'tree', 0);
-        $user = Session::getSavedOption(__CLASS__, 'user', 0);
-        $type = Session::getSavedOption(__CLASS__, 'onlytype', '');
-        if (!in_array($type, $types, true)) {
-            $type = '';
-        }
-        echo "<div class='spaced'>";
-       // Mini Search engine
-        echo "<table class='tab_cadre_fixe'>";
-        echo "<tr class='tab_bg_1'><th colspan='3'>$title</tr>";
-        echo "<tr class='tab_bg_1'><td class='center'>";
-        echo _n('Type', 'Types', 1) . "&nbsp;";
-        Dropdown::showItemType(
-            $types,
-            ['value'      => $type,
-                'name'       => 'onlytype',
-                'plural'     => true,
-                'on_change'  => 'reloadTab("start=0&onlytype="+this.value)',
-                'checkright' => true
-            ]
-        );
-        if ($this->haveChildren()) {
-            echo "</td><td class='center'>" . __('Child groups') . "&nbsp;";
-            Dropdown::showYesNo(
-                'tree',
-                $tree,
-                -1,
-                ['on_change' => 'reloadTab("start=0&tree="+this.value)']
-            );
-        } else {
-            $tree = 0;
-        }
-        if ($this->getField('is_usergroup')) {
-            echo "</td><td class='center'>" . User::getTypeName(Session::getPluralNumber()) . "&nbsp;";
-            Dropdown::showYesNo(
-                'user',
-                $user,
-                -1,
-                ['on_change' => 'reloadTab("start=0&user="+this.value)']
-            );
-        } else {
-            $user = 0;
-        }
-        echo "</td></tr></table>";
-
+        $tree = true;
+        $user = true;
         $datas = [];
-        if ($type) {
-            $types = [$type];
-        }
-        $start  = (isset($_GET['start']) ? intval($_GET['start']) : 0);
-        $nb     = $this->getDataItems($types, $field, $tree, $user, $start, $datas);
-        $nbcan  = 0;
-
-        if ($nb) {
-            Html::printAjaxPager('', $start, $nb);
-            $show_massive_actions = false;
-            if (self::canUpdate()) {
-                foreach ($datas as $data) {
-                    if (!($item = getItemForItemtype($data['itemtype']))) {
-                        continue;
-                    }
-                    if ($item->canUpdate($data['items_id']) || $item->canView($data['items_id'])) {
-                        // Show massive actions if there is at least one viewable/updatable item.
-                        $show_massive_actions = true;
-                        break;
-                    }
+        $start  = (isset($_GET['start']) ? (int)$_GET['start'] : 0);
+        $filters     = $_GET['filters'] ?? [];
+        $extra_criteria = [];
+        foreach ($filters as $f => $value) {
+            // This was the only filter before
+            //TODO More can be added later as time permits (requires SQL query changes and changes to datatables template)
+            if (!empty($value)) {
+                if ($f === 'type') {
+                    $extra_criteria['HAVING']['itemtype'] = ['LIKE', SQLProvider::makeTextSearchValue($value)];
                 }
             }
-            if ($show_massive_actions) {
-                Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
-                echo Html::hidden('field', ['value'                 => $field,
-                    'data-glpicore-ma-tags' => 'common'
-                ]);
+        }
+        $nb     = $this->getDataItems($types, $field, $tree, $user, $start, $datas, $extra_criteria);
 
-                $massiveactionparams = ['num_displayed'    => min($_SESSION['glpilist_limit'], $nb),
-                    'check_itemtype'   => 'Group',
-                    'check_items_id'   => $ID,
-                    'container'        => 'mass' . __CLASS__ . $rand,
-                    'extraparams'      => ['is_tech' => $tech ? 1 : 0,
-                        'massive_action_fields' => ['field']
-                    ],
-                    'specific_actions' => [__CLASS__ .
-                                                                    MassiveAction::CLASS_ACTION_SEPARATOR .
-                                                                    'changegroup' => __('Move')
-                    ]
-                ];
-                Html::showMassiveActions($massiveactionparams);
+        $show_massive_actions = false;
+
+        $tuser = new User();
+        $group = new Group();
+
+        // Some caches to avoid redundant DB requests
+        $itemtype_names = [];
+        $entity_names = [];
+        $group_links = [];
+        $user_links = [];
+
+        $entries = [];
+        foreach ($datas as $data) {
+            if (!($item = getItemForItemtype($data['itemtype']))) {
+                continue;
             }
-            echo "<table class='tab_cadre_fixehov'>";
-            $header_begin  = "<tr><th width='10'>";
-            if ($show_massive_actions) {
-                $header_top    = Html::getCheckAllAsCheckbox('mass' . __CLASS__ . $rand);
-                $header_bottom = Html::getCheckAllAsCheckbox('mass' . __CLASS__ . $rand);
+            $item->getFromDB($data['items_id']);
+            if (!isset($itemtype_names[$data['itemtype']])) {
+                $itemtype_names[$data['itemtype']] = $item::getTypeName(1);
+            }
+            if (!isset($entity_names[$item->getEntityID()])) {
+                $entity_names[$item->getEntityID()] = Dropdown::getDropdownName(table: "glpi_entities", id: $item->getEntityID(), default: '');
+            }
+
+            $entry = [
+                'itemtype' => self::class,
+                'id'       => $ID,
+                'type'     => $itemtype_names[$data['itemtype']],
+                'name'     => $item->getLink(['comments' => true]),
+                'entity'   => $entity_names[$item->getEntityID()],
+            ];
+            if ($item->canViewItem() || ($item->canViewItem() && self::canUpdate())) {
+                // Show massive actions if there is at least one viewable/updatable item.
+                $show_massive_actions = true;
             } else {
-                $header_top = $header_bottom = '';
+                // This row cannot have massive actions due to lack of rights.
+                $entry['skip_ma'] = true;
             }
-            $header_end    = '</th>';
 
-            $header_end .= "<th>" . _n('Type', 'Types', 1) . "</th><th>" . __('Name') . "</th><th>" . Entity::getTypeName(1) . "</th>";
             if ($tree || $user) {
-                $header_end .= "<th>" .
-                             sprintf(__('%1$s / %2$s'), self::getTypeName(1), User::getTypeName(1)) .
-                           "</th>";
-            }
-            $header_end .= "</tr>";
-            echo $header_begin . $header_top . $header_end;
-
-            $tuser = new User();
-            $group = new Group();
-
-            foreach ($datas as $data) {
-                if (!($item = getItemForItemtype($data['itemtype']))) {
-                    continue;
-                }
-                $item->getFromDB($data['items_id']);
-                echo "<tr class='tab_bg_1'><td>";
-                if (
-                    $item->canUpdate($data['items_id'])
-                    || ($item->canView($data['items_id'])
-                    && self::canUpdate())
-                ) {
-                    Html::showMassiveActionCheckBox($data['itemtype'], $data['items_id']);
-                }
-                echo "</td><td>" . $item->getTypeName(1);
-                echo "</td><td>" . $item->getLink(['comments' => true]);
-                echo "</td><td>" . Dropdown::getDropdownName("glpi_entities", $item->getEntityID());
-                if ($tree || $user) {
-                    echo "</td><td>";
-                    if ($grp = $item->getField($field)) {
-                        if ($group->getFromDB($grp)) {
-                             echo $group->getLink(['comments' => true]);
-                        }
-                    } else if ($usr = $item->getField(str_replace('groups', 'users', $field))) {
-                        if ($tuser->getFromDB($usr)) {
-                            echo $tuser->getLink(['comments' => true]);
-                        }
+                if ($grp = $item->getField($field)) {
+                    if (!isset($group_links[$grp]) && $group->getFromDB($grp)) {
+                        $group_links[$grp] = $group->getLink(['comments' => true]);
                     }
+                    $entry['field'] = $group_links[$grp] ?? '';
+                } else if ($usr = $item->getField(str_replace('groups', 'users', $field))) {
+                    if (!isset($user_links[$usr]) && $tuser->getFromDB($usr)) {
+                        $user_links[$usr] = $tuser->getLink(['comments' => true]);
+                    }
+                    $entry['field'] = $user_links[$usr] ?? '';
                 }
-                echo "</td></tr>";
             }
-            echo $header_begin . $header_bottom . $header_end;
-            echo "</table>";
-        } else {
-            echo "<p class='center b'>" . __('No item found') . "</p>";
+            $entries[] = $entry;
         }
 
-        if ($nb) {
-            if ($show_massive_actions) {
-                $massiveactionparams['ontop'] = false;
-                Html::showMassiveActions($massiveactionparams);
-            }
+        $columns = [
+            'type' => _n('Type', 'Types', 1),
+            'name' => [
+                'label' => __('Name'),
+                'no_filter' => true,
+            ],
+            'entity' => [
+                'label' => Entity::getTypeName(1),
+                'no_filter' => true,
+            ]
+        ];
+        if ($tree || $user) {
+            $columns['field'] = sprintf(__('%1$s / %2$s'), self::getTypeName(1), User::getTypeName(1));
         }
-        Html::closeForm();
-
-        if ($nb) {
-            Html::printAjaxPager('', $start, $nb);
-        }
-
-        echo "</div>";
+        TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
+            'is_tab' => true,
+            'start' => $start,
+            'limit' => $_SESSION['glpilist_limit'],
+            'filters' => $filters,
+            'columns' => $columns,
+            'formatters' => [
+                'name' => 'raw_html',
+                'field' => 'raw_html'
+            ],
+            'entries' => $entries,
+            'total_number' => $nb,
+            'filtered_number' => $nb,
+            'showmassiveactions' => self::canUpdate() && $show_massive_actions,
+            'massiveactionparams' => [
+                'num_displayed' => count($entries),
+                'container'     => 'mass' . static::class . $rand,
+                'check_itemtype'   => 'Group',
+                'check_items_id'   => $ID,
+                'extraparams'      => ['is_tech' => $tech ? 1 : 0,
+                    'massive_action_fields' => ['field']
+                ],
+                'specific_actions' => [
+                    self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'changegroup' => __('Move')
+                ]
+            ],
+        ]);
     }
 
     public function cleanRelationData()
@@ -985,7 +942,7 @@ class Group extends CommonTreeDropdown
 
     public function post_updateItem($history = 1)
     {
-        parent::post_updateItem();
+        parent::post_updateItem($history);
         // Changing a group's parent might invalidate the group cache if recursive
         // membership is enabled
         $parent_changed =

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -354,7 +354,7 @@ class Group_User extends CommonDBRelation
                 ]
             ],
             'WHERE' => [
-                    $group_users_table . '.groups_id'  => $restrict,
+                $group_users_table . '.groups_id'  => $restrict,
             ],
             'ORDERBY' => [
                 User::getTable() . '.realname',

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -796,13 +796,15 @@ class Group_User extends CommonDBRelation
 
         parent::post_purgeItem();
 
-        Event::log(
-            $this->fields['groups_id'],
-            "groups",
-            4,
-            "setup",
-            sprintf(__('%s deletes users from a group'), $_SESSION["glpiname"])
-        );
+        if (Session::getLoginUserID() !== false) {
+            Event::log(
+                $this->fields['groups_id'],
+                "groups",
+                4,
+                "setup",
+                sprintf(__('%s deletes users from a group'), $_SESSION["glpiname"])
+            );
+        }
 
         // remove user from plannings
         $groups_id  = $this->fields['groups_id'];

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -378,9 +378,6 @@ class Group_User extends CommonDBRelation
      */
     public static function showForGroup(Group $group)
     {
-        /** @var array $CFG_GLPI */
-        global $CFG_GLPI;
-
         $ID = $group->getID();
         if (
             !User::canView()
@@ -476,8 +473,8 @@ class Group_User extends CommonDBRelation
                 'active' => 'raw_html'
             ],
             'entries' => $entries,
-            'total_number' => count($entries),
-            'filtered_number' => count($entries),
+            'total_number' => $number,
+            'filtered_number' => $number,
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -33,7 +33,9 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryParam;
+use Glpi\Event;
 
 /**
  * Group_User Class
@@ -159,9 +161,6 @@ class Group_User extends CommonDBRelation
      **/
     public static function showForUser(User $user)
     {
-        /** @var array $CFG_GLPI */
-        global $CFG_GLPI;
-
         $ID = $user->fields['id'];
         if (
             !Group::canView()
@@ -176,7 +175,6 @@ class Group_User extends CommonDBRelation
 
         $iterator = self::getListForItem($user);
         $groups = [];
-       //$groups  = self::getUserGroups($ID);
         $used    = [];
         foreach ($iterator as $data) {
             $used[$data["id"]] = $data["id"];
@@ -184,170 +182,84 @@ class Group_User extends CommonDBRelation
         }
 
         if ($canedit) {
-            echo "<div class='firstbloc'>";
-            echo "<form name='groupuser_form$rand' id='groupuser_form$rand' method='post'";
-            echo " action='" . Toolbox::getItemTypeFormURL('User') . "'>";
-
-            echo "<table class='tab_cadre_fixe'>";
-            echo "<tr class='tab_bg_1'><th colspan='6'>" . __('Associate to a group') . "</th></tr>";
-            echo "<tr class='tab_bg_2'><td class='center'>";
-            echo "<input type='hidden' name='users_id' value='$ID'>";
-
-            $params = [
-                'used'      => $used,
-                'condition' => [
-                    'is_usergroup' => 1,
-                ] + getEntitiesRestrictCriteria(Group::getTable(), '', '', true)
-            ];
-            Group::dropdown($params);
-            echo "</td><td>" . _n('Manager', 'Managers', 1) . "</td><td>";
-            Dropdown::showYesNo('is_manager');
-
-            echo "</td><td>" . __('Delegatee') . "</td><td>";
-            Dropdown::showYesNo('is_userdelegate');
-
-            echo "</td><td class='tab_bg_2 center'>";
-            echo "<input type='submit' name='addgroup' value=\"" . _sx('button', 'Add') . "\"
-                class='btn btn-primary'>";
-
-            echo "</td></tr>";
-            echo "</table>";
-            Html::closeForm();
-            echo "</div>";
+            $group_user = new self();
+            $group_user->fields['users_id'] = $ID;
+            TemplateRenderer::getInstance()->display('pages/admin/group_user.html.twig', [
+                'source_itemtype' => User::class,
+                'item' => $group_user,
+                'no_header' => true,
+                'used' => $used,
+            ]);
         }
-
-        echo "<div class='spaced'>";
-        if ($canedit && count($used)) {
-            $rand = mt_rand();
-            Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
-            echo "<input type='hidden' name='users_id' value='" . $user->fields['id'] . "'>";
-            $massiveactionparams = ['num_displayed' => min($_SESSION['glpilist_limit'], count($used)),
-                'container'     => 'mass' . __CLASS__ . $rand
-            ];
-            Html::showMassiveActions($massiveactionparams);
-        }
-        echo "<table class='tab_cadre_fixehov'>";
-        $header_begin  = "<tr>";
-        $header_top    = '';
-        $header_bottom = '';
-        $header_end    = '';
-
-        if ($canedit && count($used)) {
-            $header_begin  .= "<th width='10'>";
-            $header_top    .= Html::getCheckAllAsCheckbox('mass' . __CLASS__ . $rand);
-            $header_bottom .= Html::getCheckAllAsCheckbox('mass' . __CLASS__ . $rand);
-            $header_end    .= "</th>";
-        }
-        $header_end .= "<th>" . Group::getTypeName(1) . "</th>";
-        $header_end .= "<th>" . __('Dynamic') . "</th>";
-        $header_end .= "<th>" . _n('Manager', 'Managers', 1) . "</th>";
-        $header_end .= "<th>" . __('Delegatee') . "</th></tr>";
-        echo $header_begin . $header_top . $header_end;
 
         $group = new Group();
-        if (!empty($groups)) {
-            Session::initNavigateListItems(
-                'Group',
-                //TRANS : %1$s is the itemtype name,
-                              //        %2$s is the name of the item (used for headings of a list)
-                                        sprintf(
-                                            __('%1$s = %2$s'),
-                                            User::getTypeName(1),
-                                            $user->getName()
-                                        )
-            );
-
-            foreach ($groups as $data) {
-                if (!$group->getFromDB($data["id"])) {
-                    continue;
-                }
-                Session::addToNavigateListItems('Group', $data["id"]);
-                echo "<tr class='tab_bg_1'>";
-
-                if ($canedit && count($used)) {
-                    echo "<td width='10'>";
-                    Html::showMassiveActionCheckBox(__CLASS__, $data["linkid"]);
-                    echo "</td>";
-                }
-                echo "<td>" . $group->getLink() . "</td>";
-                echo "<td class='center'>";
-                if ($data['is_dynamic']) {
-                    echo "<img src='" . $CFG_GLPI["root_doc"] . "/pics/ok.png' width='14' height='14' alt=\"" .
-                     __('Dynamic') . "\">";
-                }
-                echo "<td class='center'>";
-                if ($data['is_manager']) {
-                    echo "<img src='" . $CFG_GLPI["root_doc"] . "/pics/ok.png' width='14' height='14' alt=\"" .
-                    _n('Manager', 'Managers', 1) . "\">";
-                }
-                echo "</td><td class='center'>";
-                if ($data['is_userdelegate']) {
-                    echo "<img src='" . $CFG_GLPI["root_doc"] . "/pics/ok.png' width='14' height='14' alt=\"" .
-                     __('Delegatee') . "\">";
-                }
-                echo "</td></tr>";
+        $entries = [];
+        $yes_icon = "<i class='ti ti-circle-check text-success' title='" . __s('Yes') . "'></i>";
+        $no_icon  = "<i class='ti ti-circle-x text-danger' title='" . __s('No') . "'></i>";
+        foreach ($groups as $data) {
+            if (!$group->getFromDB($data["id"])) {
+                continue;
             }
-            echo $header_begin . $header_bottom . $header_end;
-        } else {
-            echo "<tr class='tab_bg_1'>";
-            echo "<td colspan='5' class='center'>" . __('None') . "</td></tr>";
+            $entries[] = [
+                'itemtype' => self::class,
+                'id'       => $data["linkid"],
+                'group'    => $group->getLink(),
+                'dynamic'  => $data['is_dynamic'] ? $yes_icon : $no_icon,
+                'manager'  => $data['is_manager'] ? $yes_icon : $no_icon,
+                'delegatee' => $data['is_userdelegate'] ? $yes_icon : $no_icon
+            ];
         }
-        echo "</table>";
 
-        if ($canedit && count($used)) {
-            $massiveactionparams['ontop'] = false;
-            Html::showMassiveActions($massiveactionparams);
-            Html::closeForm();
-        }
-        echo "</div>";
+        TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
+            'is_tab' => true,
+            'nopager' => true,
+            'nofilter' => true,
+            'columns' => [
+                'group' => Group::getTypeName(1),
+                'dynamic' => __('Dynamic'),
+                'manager' => _n('Manager', 'Managers', 1),
+                'delegatee' => __('Delegatee')
+            ],
+            'formatters' => [
+                'group' => 'raw_html',
+                'dynamic' => 'raw_html',
+                'manager' => 'raw_html',
+                'delegatee' => 'raw_html'
+            ],
+            'entries' => $entries,
+            'total_number' => count($entries),
+            'filtered_number' => count($entries),
+            'showmassiveactions' => $canedit,
+            'massiveactionparams' => [
+                'num_displayed' => count($entries),
+                'container'     => 'mass' . static::class . $rand
+            ]
+        ]);
     }
-
 
     /**
      * Show form to add a user in current group
      *
      * @since 0.83
      *
-     * @param $group                    Group object
-     * @param $used_ids        Array    of already add users
-     * @param $entityrestrict  Array    of entities
-     * @param $crit            String   for criteria (for default dropdown)
+     * @param Group $group
+     * @param array $used_ids Array of already added users
+     * @param array $entityrestrict Array of entities
      **/
-    private static function showAddUserForm(Group $group, $used_ids, $entityrestrict, $crit)
+    private static function showAddUserForm(Group $group, $used_ids, $entityrestrict)
     {
-        $rand = mt_rand();
         $res  = User::getSqlSearchResult(true, "all", $entityrestrict, 0, $used_ids, '', 0, -1, 0, 1);
-
         $nb = count($res);
-
         if ($nb) {
-            echo "<form name='groupuser_form$rand' id='groupuser_form$rand' method='post'
-                action='" . Toolbox::getItemTypeFormURL(__CLASS__) . "'>";
-            echo "<input type='hidden' name='groups_id' value='" . $group->fields['id'] . "'>";
-
-            echo "<div class='firstbloc'>";
-            echo "<table class='tab_cadre_fixe'>";
-            echo "<tr class='tab_bg_1'><th colspan='6'>" . __('Add a user') . "</th></tr>";
-            echo "<tr class='tab_bg_2'><td class='center'>";
-
-            User::dropdown(['right'  => "all",
-                'entity' => $entityrestrict,
-                'with_no_right' => true,
-                'used'   => $used_ids
+            $group_user = new self();
+            $group_user->fields['groups_id'] = $group->getID();
+            TemplateRenderer::getInstance()->display('pages/admin/group_user.html.twig', [
+                'source_itemtype' => Group::class,
+                'item' => $group_user,
+                'no_header' => true,
+                'used' => $used_ids,
+                'entityrestrict' => $entityrestrict
             ]);
-
-            echo "</td><td>" . _n('Manager', 'Managers', 1) . "</td><td>";
-            Dropdown::showYesNo('is_manager', (($crit == 'is_manager') ? 1 : 0));
-
-            echo "</td><td>" . __('Delegatee') . "</td><td>";
-            Dropdown::showYesNo('is_userdelegate', (($crit == 'is_userdelegate') ? 1 : 0));
-
-            echo "</td><td class='tab_bg_2 center'>";
-            echo "<input type='hidden' name'is_dynamic' value='0'>";
-            echo "<input type='submit' name='add' value=\"" . _sx('button', 'Add') . "\" class='btn btn-primary'>";
-            echo "</td></tr>";
-            echo "</table></div>";
-            Html::closeForm();
         }
     }
 
@@ -364,7 +276,7 @@ class Group_User extends CommonDBRelation
      * @param bool|int $tree             True to include member of sub-group (default 0)
      * @param bool     $check_entities   Apply entities restrictions ?
      *
-     * @return String tab of entity for restriction
+     * @return array|int Entities for restriction
      **/
     public static function getDataForGroup(
         Group $group,
@@ -461,10 +373,9 @@ class Group_User extends CommonDBRelation
     /**
      * Show users of a group
      *
+     * @param Group $group
      * @since 0.83
-     *
-     * @param $group  Group object: the group
-     **/
+     */
     public static function showForGroup(Group $group)
     {
         /** @var array $CFG_GLPI */
@@ -482,18 +393,16 @@ class Group_User extends CommonDBRelation
         $canedit = self::canUpdate();
         $rand    = mt_rand();
         $user    = new User();
-        $crit    = Session::getSavedOption(__CLASS__, 'criterion', '');
-        $tree    = Session::getSavedOption(__CLASS__, 'tree', 0);
         $used    = [];
         $ids     = [];
 
        // Retrieve member list
        // TODO: migrate to use CommonDBRelation::getListForItem()
-        $entityrestrict = self::getDataForGroup($group, $used, $ids, $crit, $tree, false);
+        $entityrestrict = self::getDataForGroup($group, $used, $ids, '', true, false);
 
         // We will load implicits members from parents groups and display
         // them after all the "direct" members
-        $parents_members = self::getParentsMembers($group, $crit);
+        $parents_members = self::getParentsMembers($group, '');
 
         foreach ($parents_members as $parent) {
             // Flag group as implicit, will be used to disallow massive
@@ -510,162 +419,71 @@ class Group_User extends CommonDBRelation
         $used = array_values(self::clearDuplicatedGroupData($used));
 
         if ($canedit) {
-            self::showAddUserForm($group, $ids, $entityrestrict, $crit);
+            self::showAddUserForm($group, $ids, $entityrestrict);
         }
 
-       // Mini Search engine
-        echo "<table class='tab_cadre_fixe'>";
-        echo "<tr class='tab_bg_1'><th colspan='2'>" . User::getTypeName(Session::getPluralNumber()) . "</th></tr>";
-        echo "<tr class='tab_bg_1'><td class='center'>";
-        echo _n('Criterion', 'Criteria', 1) . "&nbsp;";
-        $crits = ['is_manager'      => _n('Manager', 'Managers', 1),
-            'is_userdelegate' => __('Delegatee')
-        ];
-        Dropdown::showFromArray(
-            'crit',
-            $crits,
-            ['value'               => $crit,
-                'on_change'           => 'reloadTab("start=0&criterion="+this.value)',
-                'display_emptychoice' => true
-            ]
-        );
-        if ($group->haveChildren()) {
-            echo "</td><td class='center'>" . __('Child groups');
-            Dropdown::showYesNo(
-                'tree',
-                $tree,
-                -1,
-                ['on_change' => 'reloadTab("start=0&tree="+this.value)']
-            );
-        } else {
-            $tree = 0;
-        }
-        echo "</td></tr></table>";
         $number = count($used);
-        $start  = (isset($_GET['start']) ? intval($_GET['start']) : 0);
+        $start  = (isset($_GET['start']) ? (int) $_GET['start'] : 0);
         if ($start >= $number) {
             $start = 0;
         }
+        //TODO support filters
 
-       // Display results
-        if ($number) {
-            echo "<div class='spaced'>";
-            Html::printAjaxPager(
-                sprintf(
-                    __('%1$s (%2$s)'),
-                    User::getTypeName(Session::getPluralNumber()),
-                    __('D=Dynamic')
-                ),
-                $start,
-                $number
-            );
-
-            Session::initNavigateListItems(
-                'User',
-                //TRANS : %1$s is the itemtype name,
-                              //        %2$s is the name of the item (used for headings of a list)
-                                        sprintf(
-                                            __('%1$s = %2$s'),
-                                            Group::getTypeName(1),
-                                            $group->getName()
-                                        )
-            );
-
-            if ($canedit) {
-                Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
-                $massiveactionparams = ['num_displayed'    => min(
-                    $number - $start,
-                    $_SESSION['glpilist_limit']
-                ),
-                    'container'        => 'mass' . __CLASS__ . $rand
-                ];
-                Html::showMassiveActions($massiveactionparams);
+        $tmpgrp = new Group();
+        $entries = [];
+        $yes_icon = "<i class='ti ti-circle-check text-success' title='" . __s('Yes') . "'></i>";
+        $no_icon  = "<i class='ti ti-circle-x text-danger' title='" . __s('No') . "'></i>";
+        for ($i = $start, $j = 0; ($i < $number) && ($j < $_SESSION['glpilist_limit']); $i++, $j++) {
+            $data = $used[$i];
+            $user->getFromDB($data["id"]);
+            $group_link = '';
+            if ($tmpgrp->getFromDB($data['groups_id'])) {
+                $group_link = $tmpgrp->getLink(['comments' => true]);
             }
-
-            echo "<table class='tab_cadre_fixehov'>";
-
-            $header_begin  = "<tr>";
-            $header_top    = '';
-            $header_bottom = '';
-            $header_end    = '';
-
-            if ($canedit) {
-                $header_begin  .= "<th width='10'>";
-                $header_top    .= Html::getCheckAllAsCheckbox('mass' . __CLASS__ . $rand);
-                $header_bottom .= Html::getCheckAllAsCheckbox('mass' . __CLASS__ . $rand);
-                $header_end    .= "</th>";
-            }
-            $header_end .= "<th>" . User::getTypeName(1) . "</th>";
-            $header_end .= "<th>" . Group::getTypeName(1) . "</th>";
-            $header_end .= "<th>" . __('Dynamic') . "</th>";
-            $header_end .= "<th>" . _n('Manager', 'Managers', 1) . "</th>";
-            $header_end .= "<th>" . __('Delegatee') . "</th>";
-            $header_end .= "<th>" . __('Active') . "</th></tr>";
-            echo $header_begin . $header_top . $header_end;
-
-            $tmpgrp = new Group();
-
-            for ($i = $start, $j = 0; ($i < $number) && ($j < $_SESSION['glpilist_limit']); $i++, $j++) {
-                $data = $used[$i];
-                $user->getFromDB($data["id"]);
-                Session::addToNavigateListItems('User', $data["id"]);
-
-                echo "\n<tr class='tab_bg_" . ($user->isDeleted() ? '1_2' : '1') . "'>";
-                if ($canedit) {
-                    echo "<td width='10'>";
-                    if (!($data['implicit'] ?? false)) {
-                        Html::showMassiveActionCheckBox(__CLASS__, $data["linkid"]);
-                    }
-                    echo "</td>";
-                }
-                echo "<td>" . $user->getLink();
-                echo "</td><td>";
-                if ($tmpgrp->getFromDB($data['groups_id'])) {
-                    echo $tmpgrp->getLink(['comments' => true]);
-                }
-                echo "</td><td class='center'>";
-                if ($data['is_dynamic']) {
-                    echo "<img src='" . $CFG_GLPI["root_doc"] . "/pics/ok.png' width='14' height='14' alt=\"" .
-                      __('Dynamic') . "\">";
-                }
-                echo "</td><td class='center'>";
-                if ($data['is_manager']) {
-                    echo "<img src='" . $CFG_GLPI["root_doc"] . "/pics/ok.png' width='14' height='14' alt=\"" .
-                    _n('Manager', 'Managers', 1) . "\">";
-                }
-                echo "</td><td class='center'>";
-                if ($data['is_userdelegate']) {
-                    echo "<img src='" . $CFG_GLPI["root_doc"] . "/pics/ok.png' width='14' height='14' alt=\"" .
-                      __('Delegatee') . "\">";
-                }
-                echo "</td><td class='center'>";
-                if ($user->fields['is_active']) {
-                    echo "<img src='" . $CFG_GLPI["root_doc"] . "/pics/ok.png' width='14' height='14' alt=\"" .
-                    __('Active') . "\">";
-                }
-                echo "</tr>";
-            }
-            echo $header_begin . $header_bottom . $header_end;
-            echo "</table>";
-            if ($canedit) {
-                $massiveactionparams['ontop'] = false;
-                Html::showMassiveActions($massiveactionparams);
-                Html::closeForm();
-            }
-            Html::printAjaxPager(
-                sprintf(
-                    __('%1$s (%2$s)'),
-                    User::getTypeName(Session::getPluralNumber()),
-                    __('D=Dynamic')
-                ),
-                $start,
-                $number
-            );
-
-            echo "</div>";
-        } else {
-            echo "<p class='center b'>" . __('No item found') . "</p>";
+            $entries[] = [
+                'itemtype'  => self::class,
+                'id'        => $data["linkid"],
+                'row_class' => $user->isDeleted() ? 'table-danger' : '',
+                'user'      => $user->getLink(),
+                'group'     => $group_link,
+                'dynamic'   => $data['is_dynamic'] ? $yes_icon : $no_icon,
+                'manager'   => $data['is_manager'] ? $yes_icon : $no_icon,
+                'delegatee' => $data['is_userdelegate'] ? $yes_icon : $no_icon,
+                'active'    => $user->fields['is_active'] ? $yes_icon : $no_icon
+            ];
         }
+
+        TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
+            'start' => $start,
+            'limit' => $_SESSION['glpilist_limit'],
+            'is_tab' => true,
+            'nopager' => false,
+            'nofilter' => true,
+            'columns' => [
+                'user' => User::getTypeName(1),
+                'group' => Group::getTypeName(1),
+                'dynamic' => __('Dynamic'),
+                'manager' => _n('Manager', 'Managers', 1),
+                'delegatee' => __('Delegatee'),
+                'active' => __('Active')
+            ],
+            'formatters' => [
+                'user' => 'raw_html',
+                'group' => 'raw_html',
+                'dynamic' => 'raw_html',
+                'manager' => 'raw_html',
+                'delegatee' => 'raw_html',
+                'active' => 'raw_html'
+            ],
+            'entries' => $entries,
+            'total_number' => count($entries),
+            'filtered_number' => count($entries),
+            'showmassiveactions' => $canedit,
+            'massiveactionparams' => [
+                'num_displayed' => count($entries),
+                'container'     => 'mass' . static::class . $rand
+            ]
+        ]);
     }
 
     public static function getRelationMassiveActionsSpecificities()
@@ -879,7 +697,15 @@ class Group_User extends CommonDBRelation
 
         parent::post_addItem();
 
-       // add new user to plannings
+        Event::log(
+            $this->fields['groups_id'],
+            "groups",
+            4,
+            "setup",
+            sprintf(__('%s adds a user to a group'), $_SESSION["glpiname"])
+        );
+
+        // add new user to plannings
         $groups_id  = $this->fields['groups_id'];
         $planning_k = 'group_' . $groups_id . '_users';
 
@@ -942,6 +768,14 @@ class Group_User extends CommonDBRelation
         global $DB;
 
         parent::post_purgeItem();
+
+        Event::log(
+            $this->fields['groups_id'],
+            "groups",
+            4,
+            "setup",
+            sprintf(__('%s deletes users from a group'), $_SESSION["glpiname"])
+        );
 
         // remove user from plannings
         $groups_id  = $this->fields['groups_id'];

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -311,19 +311,6 @@ class Group_User extends CommonDBRelation
         }
 
         $group_users_table = self::getTable();
-        $filter_map = [
-            'dynamic' => "$group_users_table.is_dynamic",
-            'manager' => "$group_users_table.is_manager",
-            'delegatee' => "$group_users_table.is_userdelegate",
-            'is_active' => 'glpi_users.is_active',
-        ];
-        if (is_array($crit)) {
-            foreach ($crit as $key => $value) {
-                if (!empty($value) && isset($filter_map[$key])) {
-                    $where_filters[$filter_map[$key]] = $value;
-                }
-            }
-        }
 
         // All group members
         $pu_table = Profile_User::getTable();

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -194,8 +194,8 @@ class Group_User extends CommonDBRelation
 
         $group = new Group();
         $entries = [];
-        $yes_icon = "<i class='ti ti-check' title='" . __s('Yes') . "'></i>";
-        $no_icon  = "<span class='visually-hidden' aria-label='" . __s('No') . "'></span>";
+        $yes_icon = '<i class="ti ti-check" title="' . __s('Yes') . '"></i>';
+        $no_icon  = '<span class="visually-hidden" aria-label="' . __s('No') . '"></span>';
         foreach ($groups as $data) {
             if (!$group->getFromDB($data["id"])) {
                 continue;
@@ -459,8 +459,8 @@ class Group_User extends CommonDBRelation
 
         $tmpgrp = new Group();
         $entries = [];
-        $yes_icon = "<i class='ti ti-check' title='" . __s('Yes') . "'></i>";
-        $no_icon  = "<span class='visually-hidden' aria-label='" . __s('No') . "'></span>";
+        $yes_icon = '<i class="ti ti-check" title="' . __s('Yes') . '"></i>';
+        $no_icon  = '<span class="visually-hidden" aria-label="' . __s('No') . '"></span>';
         for ($i = $start, $j = 0; ($i < $number) && ($j < $_SESSION['glpilist_limit']); $i++, $j++) {
             $data = $used[$i];
             $user->getFromDB($data["id"]);

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -194,7 +194,7 @@ class Group_User extends CommonDBRelation
 
         $group = new Group();
         $entries = [];
-        $yes_icon = "<i class='ti ti-circle-check text-success' title='" . __s('Yes') . "'></i>";
+        $yes_icon = "<i class='ti ti-check' title='" . __s('Yes') . "'></i>";
         $no_icon  = "<span class='visually-hidden' aria-label='" . __s('No') . "'></span>";
         foreach ($groups as $data) {
             if (!$group->getFromDB($data["id"])) {
@@ -428,7 +428,7 @@ class Group_User extends CommonDBRelation
 
         $tmpgrp = new Group();
         $entries = [];
-        $yes_icon = "<i class='ti ti-circle-check text-success' title='" . __s('Yes') . "'></i>";
+        $yes_icon = "<i class='ti ti-check' title='" . __s('Yes') . "'></i>";
         $no_icon  = "<span class='visually-hidden' aria-label='" . __s('No') . "'></span>";
         for ($i = $start, $j = 0; ($i < $number) && ($j < $_SESSION['glpilist_limit']); $i++, $j++) {
             $data = $used[$i];

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -195,7 +195,7 @@ class Group_User extends CommonDBRelation
         $group = new Group();
         $entries = [];
         $yes_icon = "<i class='ti ti-circle-check text-success' title='" . __s('Yes') . "'></i>";
-        $no_icon  = "<i class='ti ti-circle-x text-danger' title='" . __s('No') . "'></i>";
+        $no_icon  = "<span class='visually-hidden' aria-label='" . __s('No') . "'></span>";
         foreach ($groups as $data) {
             if (!$group->getFromDB($data["id"])) {
                 continue;
@@ -432,7 +432,7 @@ class Group_User extends CommonDBRelation
         $tmpgrp = new Group();
         $entries = [];
         $yes_icon = "<i class='ti ti-circle-check text-success' title='" . __s('Yes') . "'></i>";
-        $no_icon  = "<i class='ti ti-circle-x text-danger' title='" . __s('No') . "'></i>";
+        $no_icon  = "<span class='visually-hidden' aria-label='" . __s('No') . "'></span>";
         for ($i = $start, $j = 0; ($i < $number) && ($j < $_SESSION['glpilist_limit']); $i++, $j++) {
             $data = $used[$i];
             $user->getFromDB($data["id"]);

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -745,14 +745,6 @@ class Group_User extends CommonDBRelation
 
         parent::post_addItem();
 
-        Event::log(
-            $this->fields['groups_id'],
-            "groups",
-            4,
-            "setup",
-            sprintf(__('%s adds a user to a group'), $_SESSION["glpiname"])
-        );
-
         // add new user to plannings
         $groups_id  = $this->fields['groups_id'];
         $planning_k = 'group_' . $groups_id . '_users';

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -176,9 +176,11 @@
                         <tr class="{{ row_class|default('') }} {{ entry['row_class']|default('') }}" data-itemtype="{{ entry['itemtype'] }}" data-id="{{ entry['id'] }}">
                             {% if showmassiveactions %}
                                 <td style="width: 10px">
-                                    <input class="form-check-input massive_action_checkbox" type="checkbox" data-glpicore-ma-tags="common"
-                                        value="1" aria-label=""
-                                        name="item[{{ entry['itemtype'] }}][{{ entry['id'] }}]" />
+                                    {% if entry['skip_ma'] is not defined or entry['skip_ma'] == false %}
+                                        <input class="form-check-input massive_action_checkbox" type="checkbox" data-glpicore-ma-tags="common"
+                                               value="1" aria-label=""
+                                               name="item[{{ entry['itemtype'] }}][{{ entry['id'] }}]" />
+                                    {% endif %}
                                 </td>
                             {% endif %}
                             {% for colkey, colum in columns %}

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -159,6 +159,16 @@
                                             min="0" max="100" step="1">
                                     {% elseif formatter == 'avatar' %}
                                         {# Cannot be filtered #}
+                                    {% elseif formatter == 'yesno' %}
+                                        <select name="filters[{{ colkey }}]" class="form-select">
+                                            <option value="">{{ __('All') }}</option>
+                                            <option value="1" {{ filters[colkey] == '1' ? 'selected' : '' }}>
+                                                {{ __('Yes') }}
+                                            </option>
+                                            <option value="0" {{ filters[colkey] == '0' ? 'selected' : '' }}>
+                                                {{ __('No') }}
+                                            </option>
+                                        </select>
                                     {% else %}
                                         <input type="text" class="form-control"
                                             name="filters[{{ colkey }}]"

--- a/templates/pages/admin/group_user.html.twig
+++ b/templates/pages/admin/group_user.html.twig
@@ -71,3 +71,4 @@
         </div>
     </form>
 </div>
+<hr class="my-2">

--- a/templates/pages/admin/group_user.html.twig
+++ b/templates/pages/admin/group_user.html.twig
@@ -23,7 +23,7 @@
  # This program is distributed in the hope that it will be useful,
  # but WITHOUT ANY WARRANTY; without even the implied warranty of
  # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- # GNU General Public License for more details.A
+ # GNU General Public License for more details.
  #
  # You should have received a copy of the GNU General Public License
  # along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/templates/pages/admin/group_user.html.twig
+++ b/templates/pages/admin/group_user.html.twig
@@ -1,0 +1,73 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.A
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
+
+{#  not extending generic form due to the canEdit check required to add the form and the odd (broken?) checks done for CommonDBRelation items #}
+<div class="asset">
+    <form name="asset_form" method="post" action="{{ 'Group_User'|itemtype_form_path }}" enctype="multipart/form-data" data-submit-once>
+        <div class="d-flex flex-row flex-wrap">
+            {% set field_options = {
+                field_class: 'col-4',
+            } %}
+            {{ inputs.hidden('_glpi_csrf_token', csrf_token()) }}
+            {% if source_itemtype is not defined or source_itemtype == 'User' %}
+                {{ inputs.hidden('users_id', item.fields['users_id']) }}
+                {{ fields.dropdownField('Group', 'groups_id', item.fields['groups_id']|default(0), 'Group'|itemtype_name, {
+                    used: used,
+                    condition: {
+                        is_usergroup: 1
+                    },
+                    entity: session('glpiactive_entity'),
+                    entity_sons: true
+                } + field_options) }}
+            {% endif %}
+            {% if source_itemtype is not defined or source_itemtype == 'Group' %}
+                {{ inputs.hidden('groups_id', item.fields['groups_id']) }}
+                {{ fields.dropdownField('User', 'users_id', item.fields['users_id']|default(0), 'User'|itemtype_name, {
+                    used: used,
+                    entity: entityrestrict|default(session('glpiactive_entity')),
+                    right: 'all',
+                    with_no_right: true
+                } + field_options) }}
+            {% endif %}
+
+            {{ fields.dropdownYesNo('is_manager', item.fields['is_manager'], _n('Manager', 'Managers', 1), field_options) }}
+            {{ fields.dropdownYesNo('is_userdelegate', item.fields['is_userdelegate'], __('Delegatee'), field_options) }}
+        </div>
+        <div class="d-flex flex-row-reverse pe-2">
+            {{ inputs.submit('add', _x('button', 'Add'), 1, field_options) }}
+        </div>
+    </form>
+</div>

--- a/tests/functional/Group_User.php
+++ b/tests/functional/Group_User.php
@@ -41,6 +41,7 @@ class Group_User extends \DbTestCase
 {
     public function testGetGroupUsers()
     {
+        $this->login();
         $group = new \Group();
         $gid = (int)$group->add([
             'name' => 'Test group'
@@ -82,6 +83,7 @@ class Group_User extends \DbTestCase
 
     public function testGetUserGroups()
     {
+        $this->login();
         $uid = (int)getItemByTypeName('User', 'normal', true);
 
         $group = new \Group();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Move UI relating to items belonging to/managed by groups, users in a group, and groups assigned to a user to twig.

Still need to re-add filter support to the lists. Will require some changes to how filters are handled in the datatables template.

List of users in a group (Before):
![Selection_268](https://github.com/glpi-project/glpi/assets/17678637/3f5a6a78-e9a7-4757-9612-30ca16be2639)

List of users in a group (After):
![Selection_269](https://github.com/glpi-project/glpi/assets/17678637/26d86a0f-cb74-4b92-acc3-21f4bba1656f)

List of groups for a user (Before):
![Selection_266](https://github.com/glpi-project/glpi/assets/17678637/50eaa4c8-0b8c-463c-b98d-5909345c831e)

List of groups for a user (After):
![Selection_267](https://github.com/glpi-project/glpi/assets/17678637/6cc98529-42de-49ed-a844-803f140e729c)
