### PR TITLE
Support client credentials oauth for inventory

### DIFF
--- a/src/Glpi/Agent/Communication/AbstractRequest.php
+++ b/src/Glpi/Agent/Communication/AbstractRequest.php
@@ -215,7 +215,7 @@ abstract class AbstractRequest
             $request = new Request('POST', $_SERVER['REQUEST_URI'], $this->headers->getHeaders());
             try {
                 $client = Server::validateAccessToken($request);
-                if (!\User::isNewID($client['users_id']) || !in_array('inventory', $client['scopes'], true)) {
+                if (!\User::isNewID($client['user_id']) || !in_array('inventory', $client['scopes'], true)) {
                     $this->addError('Access denied. Agent must authenticate using client credentials and have the "inventory" OAuth scope', 401);
                     return false;
                 }

--- a/src/Glpi/Agent/Communication/AbstractRequest.php
+++ b/src/Glpi/Agent/Communication/AbstractRequest.php
@@ -215,6 +215,7 @@ abstract class AbstractRequest
             $request = new Request('POST', $_SERVER['REQUEST_URI'], $this->headers->getHeaders());
             try {
                 $client = Server::validateAccessToken($request);
+                // Agent must authenticate both using client credentials (and therefore no valid user ID associated) and have the "inventory" OAuth scope
                 if (!\User::isNewID($client['user_id']) || !in_array('inventory', $client['scopes'], true)) {
                     $this->addError('Access denied. Agent must authenticate using client credentials and have the "inventory" OAuth scope', 401);
                     return false;

--- a/src/Glpi/Agent/Communication/Headers/Common.php
+++ b/src/Glpi/Agent/Communication/Headers/Common.php
@@ -121,6 +121,12 @@ class Common
      */
     protected $glpi_proxy_id;
 
+    /**
+     * Authorization header
+     * @var string
+     */
+    protected $authorization;
+
     public function getRequireds(): array
     {
         return [

--- a/src/Glpi/Api/HL/Controller/CoreController.php
+++ b/src/Glpi/Api/HL/Controller/CoreController.php
@@ -462,6 +462,7 @@ HTML;
         } catch (OAuthServerException $exception) {
             return $exception->generateHttpResponse(new JSONResponse());
         } catch (\Throwable $exception) {
+            trigger_error($exception->getMessage(), E_USER_WARNING);
             return new JSONResponse(null, 500);
         }
     }

--- a/src/Glpi/Api/HL/Controller/CoreController.php
+++ b/src/Glpi/Api/HL/Controller/CoreController.php
@@ -40,6 +40,7 @@ use Glpi\Api\HL\OpenAPIGenerator;
 use Glpi\Api\HL\Route;
 use Glpi\Api\HL\Router;
 use Glpi\Api\HL\Doc as Doc;
+use Glpi\Application\ErrorHandler;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Http\JSONResponse;
 use Glpi\Http\Request;
@@ -462,7 +463,7 @@ HTML;
         } catch (OAuthServerException $exception) {
             return $exception->generateHttpResponse(new JSONResponse());
         } catch (\Throwable $exception) {
-            trigger_error($exception->getMessage(), E_USER_WARNING);
+            ErrorHandler::getInstance()->handleException($exception, true);
             return new JSONResponse(null, 500);
         }
     }

--- a/src/Glpi/Inventory/Conf.php
+++ b/src/Glpi/Inventory/Conf.php
@@ -96,6 +96,7 @@ use wapmorgan\UnifiedArchive\UnifiedArchive;
  * @property int $import_printer
  * @property int $import_peripheral
  * @property int $import_env
+ * @property string $auth_required
  *
  */
 class Conf extends CommonGLPI
@@ -383,6 +384,19 @@ class Conf extends CommonGLPI
             echo '</div>';
             echo "</td>";
             echo "</tr>";
+
+            echo "<tr class='tab_bg_1'>";
+            echo "<td>";
+            echo "<label for='auth'>" . __s('Authorization header') . "</label>";
+            echo "</td>";
+            echo "<td>";
+            Dropdown::showFromArray('auth_required', [
+                'none' => __('None'),
+                'client_credentials' => __('OAuth - Client credentials')
+            ], [
+                'value' => $config['auth_required'] ?? 'none'
+            ]);
+            echo "</td></tr>";
 
             echo "<tr>";
             echo "<th colspan='4'>";
@@ -1211,6 +1225,7 @@ class Conf extends CommonGLPI
             'stale_agents_status'            => 0,
             'stale_agents_status_condition'  => exportArrayToDB(['all']),
             'import_env'                     => 0,
+            'auth_required'                  => 'none',
         ];
     }
 

--- a/src/Glpi/OAuth/AccessTokenRepository.php
+++ b/src/Glpi/OAuth/AccessTokenRepository.php
@@ -85,13 +85,17 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
         global $DB;
 
         $iterator = $DB->request([
-            'SELECT' => 'identifier',
+            'SELECT' => ['identifier', 'date_expiration'],
             'FROM' => 'glpi_oauth_access_tokens',
             'WHERE' => [
                 'identifier' => $tokenId,
-                'date_expiration' => ['>', QueryFunction::now()],
             ]
         ]);
-        return $iterator->count() === 0;
+        if (count($iterator) === 0) {
+            return true;
+        }
+        // Check if the token is expired
+        $expiration = $iterator->current()['date_expiration'];
+        return (new \DateTime($expiration)) < new \DateTime();
     }
 }

--- a/src/Glpi/OAuth/AccessTokenRepository.php
+++ b/src/Glpi/OAuth/AccessTokenRepository.php
@@ -48,7 +48,9 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
     {
         $token = new AccessToken();
         $token->setClient($clientEntity);
-        $token->setUserIdentifier($userIdentifier);
+        if ($userIdentifier !== null) {
+            $token->setUserIdentifier($userIdentifier);
+        }
         foreach ($scopes as $scope) {
             $token->addScope($scope);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Adds ability to require OAuth Client Credentials authentication between agent and GLPI for inventory submission.
I guess there is already basic authentication support, but I can't see how that is possible (where is it handled?).

This was tested only so far as to check if I get an error regarding the missing token or an error regarding the XML.Needs changes on the agent side.
The agent will need to request a token through the new API using the client_credentials grant type while requesting the "inventory" scope (/api.php/token), and then send an Authorization Bearer header with the auth token when submitting inventory.