### PR TITLE
Select form name instead of focusing it

### DIFF
--- a/js/form_editor_controller.js
+++ b/js/form_editor_controller.js
@@ -107,7 +107,7 @@ class GlpiFormEditorController
         if (this.#getQuestionsCount() === 0) {
             $(this.#target)
                 .find("[data-glpi-form-editor-form-details-name]")[0]
-                .focus();
+                .select();
         }
     }
 


### PR DESCRIPTION
Very small improvement on #16715.

Since the form name is already initialized with the "Untitled form" value on creation, we should select the input's value instead of simply focusing it.
This allow the user to start typing a new name directly without having to delete the default one.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
