### PR TITLE
Forms: fix minor drag and drop issues

### DIFF
--- a/css/includes/components/_content-editable-inputs.scss
+++ b/css/includes/components/_content-editable-inputs.scss
@@ -128,21 +128,23 @@ $inline-input-padding: 2px 4px;
 
 // Simulate focus like a bootstrap input, needed for tinymce with some javascript
 // help to trigger and remove the class as needed
-.simulate-focus {
-    box-shadow: 0 0 0 0.25rem rgba(var(--tblr-primary-rgb), 0.20);
+form:not(.disable-focus) {
+    .simulate-focus {
+        box-shadow: 0 0 0 0.25rem rgba(var(--tblr-primary-rgb), 0.20);
 
-    // Show richtext toolbar only when focused
-    .tox-editor-header {
-        opacity: unset;
-        height: 48px !important; // Need to set a fixed height for transition
-        transition: height 0.25s ease !important;
-        margin-top: 1rem !important;
-    }
+        // Show richtext toolbar only when focused
+        .tox-editor-header {
+            opacity: unset;
+            height: 48px !important; // Need to set a fixed height for transition
+            transition: height 0.25s ease !important;
+            margin-top: 1rem !important;
+        }
 
-    // Partial revert of margin change in this case as we want to keep the
-    // natural margin while the toolbar is visible
-    .tox-sidebar-wrap {
-        margin-bottom: -5px;
+        // Partial revert of margin change in this case as we want to keep the
+        // natural margin while the toolbar is visible
+        .tox-sidebar-wrap {
+            margin-bottom: -5px;
+        }
     }
 }
 

--- a/js/form_editor_controller.js
+++ b/js/form_editor_controller.js
@@ -485,9 +485,13 @@ class GlpiFormEditorController
      * @param {Object} e Event data
      */
     #handleTinyMCEClick(e) {
+        // The event target expose its relevant textarea in a `data-id` property
+        const id = $(e.target).closest("#tinymce").data("id");
+        const textarea = $(`#${id}`);
+
         // Handle 'set-active' action for clicks inside tinymce
         this.#setActiveItem(
-            $(e.target.container)
+            textarea
                 .closest('[data-glpi-form-editor-on-click="set-active"]')
         );
     }
@@ -1128,12 +1132,19 @@ class GlpiFormEditorController
         // Keep track on unsaved changes if the sort order was updated
         sections
             .find("[data-glpi-form-editor-section-questions]")
-            .on('sortupdate', (e) => {
+            .on('sortupdate', () => {
                 // Would be nice to not have a specific case here where we need
                 // to manually call this
                 // TODO: this event handler should use the main handleEditorAction
                 // method rather than defining its code directly
                 window.glpiUnsavedFormChanges = true;
+            });
+
+        // Add a special class while a drag and drop is happening
+        sections
+            .find("[data-glpi-form-editor-section-questions]")
+            .on('sortstart', () => {
+                $(this.#target).addClass("disable-focus");
             });
 
         // Run the post move process if any item was dragged, even if it was not
@@ -1150,6 +1161,14 @@ class GlpiFormEditorController
                 }
 
                 this.#handleItemMove($(e.detail.item));
+
+                // Prevent tinymce from stealing focus when dragging someting
+                // over it.
+                // It seems to be caused by the fact that tinymce expect files
+                // to be dragged into it, thus we have to manually disable focus
+                // until our drag operation is over.
+                $(this.#target).removeClass("disable-focus");
+                $('.content-editable-tinymce').removeClass('simulate-focus');
             });
     }
 

--- a/js/form_editor_controller.js
+++ b/js/form_editor_controller.js
@@ -1125,17 +1125,31 @@ class GlpiFormEditorController
                 });
             });
 
-
+        // Keep track on unsaved changes if the sort order was updated
         sections
             .find("[data-glpi-form-editor-section-questions]")
             .on('sortupdate', (e) => {
-                this.#handleItemMove($(e.detail.item));
-
                 // Would be nice to not have a specific case here where we need
                 // to manually call this
                 // TODO: this event handler should use the main handleEditorAction
                 // method rather than defining its code directly
                 window.glpiUnsavedFormChanges = true;
+            });
+
+        // Run the post move process if any item was dragged, even if it was not
+        // moved in the end (= dragged on itself)
+        sections
+            .find("[data-glpi-form-editor-section-questions]")
+            .on('sortstop', (e) => {
+                // The 'sortstop' event trigger twice for a single drag and drop
+                // action.
+                // The first iteration will have the 'sortable-dragging' class,
+                // which we can check to filter it out.
+                if ($(e.detail.item).hasClass("sortable-dragging")) {
+                    return;
+                }
+
+                this.#handleItemMove($(e.detail.item));
             });
     }
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -4030,6 +4030,11 @@ JS;
                         $(editor.container).removeClass('required');
                      });
                    }
+                        // Propagate click event to allow other components to
+                        // listen to it
+                        editor.on('click', function (e) {
+                            $(document).trigger('tinyMCEClick', [e]);
+                        });
 
                         // Simulate focus on content-editable tinymce
                         editor.on('click focus', function (e) {
@@ -4045,9 +4050,6 @@ JS;
                             $(e.target.editorContainer)
                                 .closest('.content-editable-tinymce')
                                 .addClass('simulate-focus');
-
-                            // Propagate event to the document to allow other components to listen to it
-                            $(document).trigger('tinyMCEClick', [e]);
                         });
 
                         editor.on('Change', function (e) {


### PR DESCRIPTION
Fix two drag and drop issues

1\) [Fix question drag on itself](https://github.com/glpi-project/glpi/commit/94e001933af86feb09b28407c2f0cff0f7c72800)

Starting a drag and drop action and dropping the item on its own position (= no change) would break tinymce.
This kind of issue is already known and handled by the `handleItemMove` function but it wasn't triggered in this case.
Fixed by listening to the `sortstop` event, which is always triggered even if the item final position is unchanged.

Before:
![after_drag_itself](https://github.com/glpi-project/glpi/assets/42734840/3008799c-6c41-4c57-8ae9-4812bc305cfc)

After:
![before_drag_itself](https://github.com/glpi-project/glpi/assets/42734840/041877af-50e5-41ca-8bfe-14b92dbfab59)

2\) [Fix drag and drop focus issue](https://github.com/glpi-project/glpi/commit/ad82daef2f)

Fix some focus conflicts with tinymce.

Some were caused by a bad implementation of the tinymceOnClick event, others by the fact that tinymce will trigger the "focus" event when you drag over it (which is probably for attachment feature).

I've fixed our bad event and added a bypass to the focus problem by adding a special class when we are reorder questions.

Before:
![before_drag_over](https://github.com/glpi-project/glpi/assets/42734840/4035dfc9-f159-48c9-afce-9d861a48708a)


After:
![drag_over_after](https://github.com/glpi-project/glpi/assets/42734840/ab668fc2-3ad8-4a80-8df0-6c9a9927f878)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
