### PR TITLE
Fix existing actors loading

### DIFF
--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -34,7 +34,7 @@
 {% set rand = random() %}
 
 {% set load_actors = params['load_actors'] ?? true %}
-{% set actors = load_selected_actors ? item.getActorsForType(actortypeint, params) : [] %}
+{% set actors = load_actors ? item.getActorsForType(actortypeint, params) : [] %}
 
 {% set required = false %}
 {% if itiltemplate.isMandatoryField('_users_id_' ~ actortype) or itiltemplate.isMandatoryField('_groups_id_' ~ actortype) or (actortype == 'assign' and itiltemplate.isMandatoryField('_suppliers_id_' ~ actortype)) %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fix a typo in a variable name introduced in #16064. It prevented existing actors to be loaded in ticket form.