### PR TITLE
Fix forms tooltips on cloned nodes

### DIFF
--- a/js/form_editor_controller.js
+++ b/js/form_editor_controller.js
@@ -772,6 +772,12 @@ class GlpiFormEditorController
         // Init the editors
         tiny_mce_to_init.forEach((config) => tinyMCE.init(config));
 
+        // Init tooltips
+        const tooltip_trigger_list = copy.find('[data-bs-toggle="tooltip"]');
+        [...tooltip_trigger_list].map(
+            tooltip_trigger_el => new bootstrap.Tooltip(tooltip_trigger_el)
+        );
+
         return copy;
     }
 


### PR DESCRIPTION
Bootstrap tooltips were not working on new questions and sections.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
