### PR TITLE
Fix(ReservationItem): Fix SQL error when 'is_recursive' column not exist

### DIFF
--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -1112,7 +1112,7 @@ class ReservationItem extends CommonDBChild
         ];
 
         if ($item->isEntityAssign()) {
-            $criteria['WHERE'] += getEntitiesRestrictCriteria($item_table, '', '', true);
+            $criteria['WHERE'] += getEntitiesRestrictCriteria($item_table, '', '', $item->maybeRecursive());
         }
 
         if ($item->maybeTemplate()) {


### PR DESCRIPTION
Fix SQL error when ```is_recursive``` column not exist

```sql
SQL: SELECT COUNT(*) AS total FROM `glpi_plugin_genericobject_scannerportables` INNER JOIN `glpi_reservationitems` ON (`glpi_reservationitems`.`items_id` = `glpi_plugin_genericobject_scannerportables`.`id` AND `glpi_reservationitems`.`itemtype` = 'PluginGenericobjectScannerportable') WHERE `glpi_reservationitems`.`is_active` = '1' AND `glpi_plugin_genericobject_scannerportables`.`is_deleted` = '0' AND ((`glpi_plugin_genericobject_scannerportables`.`entities_id` IN ('1') OR (`glpi_plugin_genericobject_scannerportables`.`is_recursive` = '1' AND `glpi_plugin_genericobject_scannerportables`.`entities_id` IN ('0'))))
  Error: Unknown column 'glpi_plugin_genericobject_scannerportables.is_recursive' in 'where clause'
```


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !31866
