### PR TITLE
Add a search option for every state/itemtype visibility

### DIFF
--- a/install/migrations/update_10.0.x_to_11.0.0/states.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/states.php
@@ -111,3 +111,24 @@ $migration->addKey('glpi_items_devicecameras', 'states_id');
 // Drop unexpected fields
 $migration->dropField('glpi_devicegenerics', 'states_id');
 $migration->dropField('glpi_devicesensors', 'states_id');
+
+// Migrate search options related to visibility
+$migration->changeSearchOption('State', 21, 99999); // Computer
+$migration->changeSearchOption('State', 22, 99999); // SoftwareVersion
+$migration->changeSearchOption('State', 23, 99999); // Monitor
+$migration->changeSearchOption('State', 24, 99999); // Printer
+$migration->changeSearchOption('State', 25, 99999); // Peripheral
+$migration->changeSearchOption('State', 26, 99999); // Phone
+$migration->changeSearchOption('State', 27, 99999); // NetworkEquipment
+$migration->changeSearchOption('State', 28, 99999); // SoftwareLicense
+$migration->changeSearchOption('State', 29, 99999); // Certificate
+$migration->changeSearchOption('State', 30, 99999); // Rack
+$migration->changeSearchOption('State', 31, 99999); // Line
+$migration->changeSearchOption('State', 32, 99999); // Enclosure
+$migration->changeSearchOption('State', 33, 99999); // PDU
+$migration->changeSearchOption('State', 34, 99999); // Cluster
+$migration->changeSearchOption('State', 35, 99999); // PassiveDCEquipment
+$migration->changeSearchOption('State', 36, 99999); // Contract
+$migration->changeSearchOption('State', 37, 99999); // Appliance
+$migration->changeSearchOption('State', 38, 99999); // Cable
+$migration->changeSearchOption('State', 39, 99999); // DatabaseInstance

--- a/src/Search/SearchOption.php
+++ b/src/Search/SearchOption.php
@@ -760,12 +760,12 @@ final class SearchOption implements \ArrayAccess
     public static function generateAProbablyUniqueId(string $string_identifier, ?string $plugin = null): int
     {
         // Generates an ID that can be assigned anywhere in the 10000-19999 range
-        $generated_id = (int)abs((int)hexdec(hash('xxh3', $string_identifier))) % 10000 + 10000;
+        $generated_id = (int)abs((int)hexdec(hash('xxh32', $string_identifier))) % 10000 + 10000;
 
         if ($plugin !== null && $plugin !== '') {
             // For plugins, increment the generated ID from a value between 10000 to 79999,
             // to get a final ID anywhere in the 20000-99999 range.
-            $plugin_increment = (int)abs((int)hexdec(hash('xxh3', $plugin))) % 80000 + 10000;
+            $plugin_increment = (int)abs((int)hexdec(hash('xxh32', $plugin))) % 80000 + 10000;
             $generated_id += $plugin_increment;
         }
 

--- a/src/State.php
+++ b/src/State.php
@@ -36,6 +36,7 @@
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\Features\Clonable;
+use Glpi\Search\SearchOption;
 
 /**
  * State Class
@@ -373,369 +374,38 @@ class State extends CommonTreeDropdown
 
     public function rawSearchOptions()
     {
-        $tab = parent::rawSearchOptions();
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
 
-        $tab[] = [
-            'id'                 => '21',
-            'table'              => DropdownVisibility::getTable(),
-            'field'              => 'is_visible',
-            'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'), Computer::getTypeName(Session::getPluralNumber())),
-            'datatype'           => 'bool',
-            'joinparams'         => [
-                'jointype' => 'itemtypeonly',
-                'table'      => $this->getTable(),
-                'condition' => [
-                    'NEWTABLE.visible_itemtype' => 'Computer',
-                    'NEWTABLE.items_id' => new QueryExpression('REFTABLE.id')
+        $search_options = parent::rawSearchOptions();
+
+        foreach ($CFG_GLPI['state_types'] as $itemtype) {
+            if (!is_a($itemtype, CommonDBTM::class, true)) {
+                continue;
+            }
+
+            $plugin = null;
+            if ($itemtype_parts = isPluginItemType($itemtype)) {
+                $plugin = $itemtype_parts['plugin'];
+            }
+            $search_options[] = [
+                'id'                 => SearchOption::generateAProbablyUniqueId($itemtype, $plugin),
+                'table'              => DropdownVisibility::getTable(),
+                'field'              => 'is_visible',
+                'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'), $itemtype::getTypeName(Session::getPluralNumber())),
+                'datatype'           => 'bool',
+                'joinparams'         => [
+                    'jointype' => 'itemtypeonly',
+                    'table'      => $this->getTable(),
+                    'condition' => [
+                        'NEWTABLE.visible_itemtype' => $itemtype,
+                        'NEWTABLE.items_id' => new QueryExpression('REFTABLE.id')
+                    ]
                 ]
-            ]
-        ];
+            ];
+        }
 
-        $tab[] = [
-            'id'                 => '22',
-            'table'              => DropdownVisibility::getTable(),
-            'field'              => 'is_visible',
-            'name'               => sprintf(
-                __('%1$s - %2$s'),
-                __('Visibility'),
-                SoftwareVersion::getTypeName(Session::getPluralNumber())
-            ),
-            'datatype'           => 'bool',
-            'joinparams'         => [
-                'jointype' => 'itemtypeonly',
-                'table'      => $this->getTable(),
-                'condition' => [
-                    'NEWTABLE.visible_itemtype' => 'SoftwareVersion',
-                    'NEWTABLE.items_id' => new QueryExpression('REFTABLE.id')
-                ]
-            ]
-        ];
-
-        $tab[] = [
-            'id'                 => '23',
-            'table'              => DropdownVisibility::getTable(),
-            'field'              => 'is_visible',
-            'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'), Monitor::getTypeName(Session::getPluralNumber())),
-            'datatype'           => 'bool',
-            'joinparams'         => [
-                'jointype' => 'itemtypeonly',
-                'table'      => $this->getTable(),
-                'condition' => [
-                    'NEWTABLE.visible_itemtype' => 'Monitor',
-                    'NEWTABLE.items_id' => new QueryExpression('REFTABLE.id')
-                ]
-            ]
-        ];
-
-        $tab[] = [
-            'id'                 => '24',
-            'table'              => DropdownVisibility::getTable(),
-            'field'              => 'is_visible',
-            'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'), Printer::getTypeName(Session::getPluralNumber())),
-            'datatype'           => 'bool',
-            'joinparams'         => [
-                'jointype' => 'itemtypeonly',
-                'table'      => $this->getTable(),
-                'condition' => [
-                    'NEWTABLE.visible_itemtype' => 'Printer',
-                    'NEWTABLE.items_id' => new QueryExpression('REFTABLE.id')
-                ]
-            ]
-        ];
-
-        $tab[] = [
-            'id'                 => '25',
-            'table'              => DropdownVisibility::getTable(),
-            'field'              => 'is_visible',
-            'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'), Peripheral::getTypeName(Session::getPluralNumber())),
-            'datatype'           => 'bool',
-            'joinparams'         => [
-                'jointype' => 'itemtypeonly',
-                'table'      => $this->getTable(),
-                'condition' => [
-                    'NEWTABLE.visible_itemtype' => 'Peripheral',
-                    'NEWTABLE.items_id' => new QueryExpression('REFTABLE.id')
-                ]
-            ]
-        ];
-
-        $tab[] = [
-            'id'                 => '26',
-            'table'              => DropdownVisibility::getTable(),
-            'field'              => 'is_visible',
-            'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'), Phone::getTypeName(Session::getPluralNumber())),
-            'datatype'           => 'bool',
-            'joinparams'         => [
-                'jointype' => 'itemtypeonly',
-                'table'      => $this->getTable(),
-                'condition' => [
-                    'NEWTABLE.visible_itemtype' => 'Phone',
-                    'NEWTABLE.items_id' => new QueryExpression('REFTABLE.id')
-                ]
-            ]
-        ];
-
-        $tab[] = [
-            'id'                 => '27',
-            'table'              => DropdownVisibility::getTable(),
-            'field'              => 'is_visible',
-            'name'               => sprintf(
-                __('%1$s - %2$s'),
-                __('Visibility'),
-                NetworkEquipment::getTypeName(Session::getPluralNumber())
-            ),
-            'datatype'           => 'bool',
-            'joinparams'         => [
-                'jointype' => 'itemtypeonly',
-                'table'      => $this->getTable(),
-                'condition' => [
-                    'NEWTABLE.visible_itemtype' => 'NetworkEquipment',
-                    'NEWTABLE.items_id' => new QueryExpression('REFTABLE.id')
-                ]
-            ]
-        ];
-
-        $tab[] = [
-            'id'                 => '28',
-            'table'              => DropdownVisibility::getTable(),
-            'field'              => 'is_visible',
-            'name'               => sprintf(
-                __('%1$s - %2$s'),
-                __('Visibility'),
-                SoftwareLicense::getTypeName(Session::getPluralNumber())
-            ),
-            'datatype'           => 'bool',
-            'joinparams'         => [
-                'jointype' => 'itemtypeonly',
-                'table'      => $this->getTable(),
-                'condition' => [
-                    'NEWTABLE.visible_itemtype' => 'SoftwareLicense',
-                    'NEWTABLE.items_id' => new QueryExpression('REFTABLE.id')
-                ]
-            ]
-        ];
-
-        $tab[] = [
-            'id'                 => '29',
-            'table'              => DropdownVisibility::getTable(),
-            'field'              => 'is_visible',
-            'name'               => sprintf(
-                __('%1$s - %2$s'),
-                __('Visibility'),
-                Certificate::getTypeName(Session::getPluralNumber())
-            ),
-            'datatype'           => 'bool',
-            'joinparams'         => [
-                'jointype' => 'itemtypeonly',
-                'table'      => $this->getTable(),
-                'condition' => [
-                    'NEWTABLE.visible_itemtype' => 'Certificate',
-                    'NEWTABLE.items_id' => new QueryExpression('REFTABLE.id')
-                ]
-            ]
-        ];
-
-        $tab[] = [
-            'id'                 => '30',
-            'table'              => DropdownVisibility::getTable(),
-            'field'              => 'is_visible',
-            'name'               => sprintf(
-                __('%1$s - %2$s'),
-                __('Visibility'),
-                Rack::getTypeName(Session::getPluralNumber())
-            ),
-            'datatype'           => 'bool',
-            'joinparams'         => [
-                'jointype' => 'itemtypeonly',
-                'table'      => $this->getTable(),
-                'condition' => [
-                    'NEWTABLE.visible_itemtype' => 'Rack',
-                    'NEWTABLE.items_id' => new QueryExpression('REFTABLE.id')
-                ]
-            ]
-        ];
-
-        $tab[] = [
-            'id'                 => '31',
-            'table'              => DropdownVisibility::getTable(),
-            'field'              => 'is_visible',
-            'name'               => sprintf(
-                __('%1$s - %2$s'),
-                __('Visibility'),
-                Line::getTypeName(Session::getPluralNumber())
-            ),
-            'datatype'           => 'bool',
-            'joinparams'         => [
-                'jointype' => 'itemtypeonly',
-                'table'      => $this->getTable(),
-                'condition' => [
-                    'NEWTABLE.visible_itemtype' => 'Line',
-                    'NEWTABLE.items_id' => new QueryExpression('REFTABLE.id')
-                ]
-            ]
-        ];
-
-        $tab[] = [
-            'id'                 => '32',
-            'table'              => DropdownVisibility::getTable(),
-            'field'              => 'is_visible',
-            'name'               => sprintf(
-                __('%1$s - %2$s'),
-                __('Visibility'),
-                Enclosure::getTypeName(Session::getPluralNumber())
-            ),
-            'datatype'           => 'bool',
-            'joinparams'         => [
-                'jointype' => 'itemtypeonly',
-                'table'      => $this->getTable(),
-                'condition' => [
-                    'NEWTABLE.visible_itemtype' => 'Enclosure',
-                    'NEWTABLE.items_id' => new QueryExpression('REFTABLE.id')
-                ]
-            ]
-        ];
-
-        $tab[] = [
-            'id'                 => '33',
-            'table'              => DropdownVisibility::getTable(),
-            'field'              => 'is_visible',
-            'name'               => sprintf(
-                __('%1$s - %2$s'),
-                __('Visibility'),
-                PDU::getTypeName(Session::getPluralNumber())
-            ),
-            'datatype'           => 'bool',
-            'joinparams'         => [
-                'jointype' => 'itemtypeonly',
-                'table'      => $this->getTable(),
-                'condition' => [
-                    'NEWTABLE.visible_itemtype' => 'PDU',
-                    'NEWTABLE.items_id' => new QueryExpression('REFTABLE.id')
-                ]
-            ]
-        ];
-
-        $tab[] = [
-            'id'                 => '34',
-            'table'              => DropdownVisibility::getTable(),
-            'field'              => 'is_visible',
-            'name'               => sprintf(
-                __('%1$s - %2$s'),
-                __('Visibility'),
-                Cluster::getTypeName(Session::getPluralNumber())
-            ),
-            'datatype'           => 'bool',
-            'joinparams'         => [
-                'jointype' => 'itemtypeonly',
-                'table'      => $this->getTable(),
-                'condition' => [
-                    'NEWTABLE.visible_itemtype' => 'Cluster',
-                    'NEWTABLE.items_id' => new QueryExpression('REFTABLE.id')
-                ]
-            ]
-        ];
-
-        $tab[] = [
-            'id'                 => '35',
-            'table'              => DropdownVisibility::getTable(),
-            'field'              => 'is_visible',
-            'name'               => sprintf(
-                __('%1$s - %2$s'),
-                __('Visibility'),
-                PassiveDCEquipment::getTypeName(Session::getPluralNumber())
-            ),
-            'datatype'           => 'bool',
-            'joinparams'         => [
-                'jointype' => 'itemtypeonly',
-                'table'      => $this->getTable(),
-                'condition' => [
-                    'NEWTABLE.visible_itemtype' => 'PassiveDCEquipment',
-                    'NEWTABLE.items_id' => new QueryExpression('REFTABLE.id')
-                ]
-            ]
-        ];
-
-        $tab[] = [
-            'id'                 => '36',
-            'table'              => DropdownVisibility::getTable(),
-            'field'              => 'is_visible',
-            'name'               => sprintf(
-                __('%1$s - %2$s'),
-                __('Visibility'),
-                Contract::getTypeName(Session::getPluralNumber())
-            ),
-            'datatype'           => 'bool',
-            'joinparams'         => [
-                'jointype' => 'itemtypeonly',
-                'table'      => $this->getTable(),
-                'condition' => [
-                    'NEWTABLE.visible_itemtype' => 'Contract',
-                    'NEWTABLE.items_id' => new QueryExpression('REFTABLE.id')
-                ]
-            ]
-        ];
-
-        $tab[] = [
-            'id'                 => '37',
-            'table'              => DropdownVisibility::getTable(),
-            'field'              => 'is_visible',
-            'name'               => sprintf(
-                __('%1$s - %2$s'),
-                __('Visibility'),
-                Appliance::getTypeName(Session::getPluralNumber())
-            ),
-            'datatype'           => 'bool',
-            'joinparams'         => [
-                'jointype' => 'itemtypeonly',
-                'table'      => $this->getTable(),
-                'condition' => [
-                    'NEWTABLE.visible_itemtype' => 'Appliance',
-                    'NEWTABLE.items_id' => new QueryExpression('REFTABLE.id')
-                ]
-            ]
-        ];
-
-        $tab[] = [
-            'id'                 => '38',
-            'table'              => DropdownVisibility::getTable(),
-            'field'              => 'is_visible',
-            'name'               => sprintf(
-                __('%1$s - %2$s'),
-                __('Visibility'),
-                Cable::getTypeName(Session::getPluralNumber())
-            ),
-            'datatype'           => 'bool',
-            'joinparams'         => [
-                'jointype' => 'itemtypeonly',
-                'table'      => $this->getTable(),
-                'condition' => [
-                    'NEWTABLE.visible_itemtype' => 'Cable',
-                    'NEWTABLE.items_id' => new QueryExpression('REFTABLE.id')
-                ]
-            ]
-        ];
-
-        $tab[] = [
-            'id'                 => '39',
-            'table'              => DropdownVisibility::getTable(),
-            'field'              => 'is_visible',
-            'name'               => sprintf(
-                __('%1$s - %2$s'),
-                __('Visibility'),
-                DatabaseInstance::getTypeName(Session::getPluralNumber())
-            ),
-            'datatype'           => 'bool',
-            'joinparams'         => [
-                'jointype' => 'itemtypeonly',
-                'table'      => $this->getTable(),
-                'condition' => [
-                    'NEWTABLE.visible_itemtype' => 'DatabaseInstance',
-                    'NEWTABLE.items_id' => new QueryExpression('REFTABLE.id')
-                ]
-            ]
-        ];
-
-        $tab[] = [
+        $search_options[] = [
             'id'                 => '40',
             'table'              => $this->getTable(),
             'field'              => 'is_helpdesk_visible',
@@ -743,7 +413,7 @@ class State extends CommonTreeDropdown
             'datatype'           => 'bool'
         ];
 
-        return $tab;
+        return $search_options;
     }
 
     public function prepareInputForUpdate($input)

--- a/tests/units/Glpi/Search/SearchOption.php
+++ b/tests/units/Glpi/Search/SearchOption.php
@@ -42,17 +42,17 @@ class SearchOption extends \GLPITestCase
         yield [
             'string_identifier' => 'any string can be used',
             'plugin'            => null,
-            'generated_id'      => 12835,
+            'generated_id'      => 10013,
         ];
         yield [
             'string_identifier' => 'any string can be used',
             'plugin'            => 'MyPlugin',
-            'generated_id'      => 80255,
+            'generated_id'      => 37205,
         ];
         yield [
             'string_identifier' => 'any string can be used',
             'plugin'            => 'AnotherPlugin',
-            'generated_id'      => 30995,
+            'generated_id'      => 59584,
         ];
     }
 
@@ -70,14 +70,17 @@ class SearchOption extends \GLPITestCase
 
     public function testGenerateAPropbablyUniqueIdRange()
     {
-        for ($i = 'a'; $i < 'aaa'; $i = str_increment($i)) {
-            $core_result = \Glpi\Search\SearchOption::generateAProbablyUniqueId($i, null);
+        $str = 'a';
+        for ($i = 0; $i < 10000; $i++) {
+            $core_result = \Glpi\Search\SearchOption::generateAProbablyUniqueId($str, null);
             $this->integer($core_result)->isGreaterThanOrEqualTo(10000);
             $this->integer($core_result)->isLessThanOrEqualTo(19999);
 
-            $plugin_result = \Glpi\Search\SearchOption::generateAProbablyUniqueId($i, 'MyPlugin');
+            $plugin_result = \Glpi\Search\SearchOption::generateAProbablyUniqueId($str, 'MyPlugin');
             $this->integer($plugin_result)->isGreaterThanOrEqualTo(20000);
             $this->integer($plugin_result)->isLessThanOrEqualTo(99999);
+
+            $str = str_increment($str);
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Generate a `Visibility` search option for every itemtype that is declared in `$CFG_GLPI['state_types']`.

I had to change the algorithm used to generate the ID has I had a duplicated ID generated. I keep it as draft until we decide of the best solution to decrease the probability of ID conflicts.
A solution could be to increment the range (for instance `10000-99999` -> `1000000-9999999`). I do not know if there are limitations related to search option IDs somewhere.
