### PR TITLE
Enable sortable on new form sections

### DIFF
--- a/js/form_editor_controller.js
+++ b/js/form_editor_controller.js
@@ -972,9 +972,13 @@ class GlpiFormEditorController
         this.#updateSectionsDetailsVisiblity();
         this.#updateMergeSectionActionVisibility();
 
+        // Mark new serction as active
         this.#setActiveItem(
             section.find("[data-glpi-form-editor-section-details]")
         );
+
+        // Enable sortable
+        this.#enableSortable(section);
 
         // Focus section's name
         section


### PR DESCRIPTION
Not sure why this is missing, I remember adding it a while ago.
Maybe delete by mistake at some point.

This enable the question drag and drop features on newly created form sections.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
