### PR TITLE
Fix(Inventory) add history on Item_Devices add / update / delete when Mainasset already exist

### DIFF
--- a/src/Inventory/Asset/Device.php
+++ b/src/Inventory/Asset/Device.php
@@ -175,7 +175,7 @@ abstract class Device extends InventoryAsset
                         'items_id' => $this->item->fields['id'],
                         'is_dynamic' => 1
                     ] + $this->handleInput($val, $itemdevice);
-                    $itemdevice->add(Sanitizer::sanitize($itemdevice_data), [], false);
+                    $itemdevice->add(Sanitizer::sanitize($itemdevice_data), [], !$this->item->isNewItem()); //log only if mainitem is not new
                     $this->itemdeviceAdded($itemdevice, $val);
                 }
 
@@ -188,12 +188,7 @@ abstract class Device extends InventoryAsset
             foreach ($existing as $data) {
                 foreach ($data as $itemdevice_data) {
                     if ($itemdevice_data['is_dynamic'] == 1) {
-                        $DB->delete(
-                            $itemdevice->getTable(),
-                            [
-                                'id' => $itemdevice_data['id']
-                            ]
-                        );
+                        $itemdevice->delete(['id' => $itemdevice_data['id']], true, !$this->item->isNewItem()); //log only if mainitem is not new
                     }
                 }
             }

--- a/tests/functional/Glpi/Inventory/Inventory.php
+++ b/tests/functional/Glpi/Inventory/Inventory.php
@@ -1788,6 +1788,7 @@ class Inventory extends InventoryTestCase
         $expected_types_count = [
             0 => 3, //Agent version, disks usage
             \Log::HISTORY_ADD_DEVICE => 2, //new item_device...
+            \Log::HISTORY_DELETE_DEVICE => 2, //delete item_device...
             \Log::HISTORY_ADD_RELATION => 1, //new IPNetwork/IPAddress
             \Log::HISTORY_DEL_RELATION => 2,//monitor-computer relation
             \Log::HISTORY_ADD_SUBITEM => 3247,//network port/name, ip address, VMs, Software

--- a/tests/functional/Glpi/Inventory/Inventory.php
+++ b/tests/functional/Glpi/Inventory/Inventory.php
@@ -1783,16 +1783,17 @@ class Inventory extends InventoryTestCase
             'OFFSET' => $nblogsnow,
         ]);
 
-        $this->integer(count($logs))->isIdenticalTo(4412);
+        $this->integer(count($logs))->isIdenticalTo(4418);
 
         $expected_types_count = [
             0 => 3, //Agent version, disks usage
+            \Log::HISTORY_ADD_DEVICE => 2, //new item_device...
             \Log::HISTORY_ADD_RELATION => 1, //new IPNetwork/IPAddress
             \Log::HISTORY_DEL_RELATION => 2,//monitor-computer relation
             \Log::HISTORY_ADD_SUBITEM => 3247,//network port/name, ip address, VMs, Software
             \Log::HISTORY_UPDATE_SUBITEM => 828,//disks usage, software updates
             \Log::HISTORY_DELETE_SUBITEM => 99,//networkport and networkname, Software?
-            \Log::HISTORY_CREATE_ITEM => 230, //virtual machines, os, manufacturer, net ports, net names, software category ...
+            \Log::HISTORY_CREATE_ITEM => 232, //virtual machines, os, manufacturer, net ports, net names, software category / item_device...
             \Log::HISTORY_UPDATE_RELATION => 2,//kernel version
         ];
 


### PR DESCRIPTION
Same as https://github.com/glpi-project/glpi/pull/16222 but for ```Item_Device``` 

![image](https://github.com/glpi-project/glpi/assets/7335054/f73ebe64-4642-43fb-8746-230159f4970b)

I'm leaving it in draft form until I can see what impact it will have on the TUs for logs.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !31950
