### PR TITLE
Drop focus when the user click outside the form

### DIFF
--- a/js/form_editor_controller.js
+++ b/js/form_editor_controller.js
@@ -131,6 +131,13 @@ class GlpiFormEditorController
             () => this.#handleBackendUpdateResponse()
         );
 
+        // Handle global click event, remove the active item
+        $(document)
+            .on(
+                'click',
+                () => this.#setActiveItem(null)
+            );
+
         // Handle tinymce change event
         $(document)
             .on(
@@ -204,6 +211,9 @@ class GlpiFormEditorController
          */
         let unsaved_changes = true;
 
+        // Events should only be handled here once.
+        event.stopPropagation();
+
         switch (action) {
             // Mark the target item as active
             case "set-active":
@@ -213,7 +223,6 @@ class GlpiFormEditorController
 
             // Add a new question
             case "add-question":
-                event.stopPropagation(); // We don't want to trigger the "set-active" action for this item
                 this.#addQuestion(
                     target.closest(`
                         [data-glpi-form-editor-active-form],
@@ -225,7 +234,6 @@ class GlpiFormEditorController
 
             // Delete the target question
             case "delete-question":
-                event.stopPropagation(); // We don't want to trigger the "set-active" action for this item
                 this.#deleteQuestion(
                     target.closest("[data-glpi-form-editor-question]")
                 );
@@ -262,7 +270,6 @@ class GlpiFormEditorController
 
             // Add a new section at the end of the form
             case "add-section":
-                event.stopPropagation(); // We don't want to trigger the "set-active" action for this item
                 this.#addSection(
                     target.closest(`
                         [data-glpi-form-editor-active-form],
@@ -274,7 +281,6 @@ class GlpiFormEditorController
 
             // Delete the target section
             case "delete-section":
-                event.stopPropagation(); // We don't want to trigger the "set-active" action for this item
                 this.#deleteSection(
                     target.closest("[data-glpi-form-editor-section]")
                 );


### PR DESCRIPTION
Previously, the "active" form item was highlighted until the user clicked on another form item.
Clicking outside the form did nothing, which is unexpected as most UX items are usually no longer "active" when you click outside of them.


![drop-focus](https://github.com/glpi-project/glpi/assets/42734840/c9d068b7-189a-4afc-ae3e-26603832df6e)


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
