### PR TITLE
Ignore invalid questions types in the form editor

### DIFF
--- a/src/Form/AnswersHandler/AnswersHandler.php
+++ b/src/Form/AnswersHandler/AnswersHandler.php
@@ -218,6 +218,15 @@ final class AnswersHandler
 
         $formatted_answers = [];
         foreach ($answers as $question_id => $answer) {
+            if (!isset($questions[$question_id])) {
+                // Ignore unknown question
+                trigger_error(
+                    "Unknown question: $question_id",
+                    E_USER_WARNING
+                );
+                continue;
+            }
+
             // We need to keep track of some extra data like label and type because
             // the linked question might be deleted one day but the answer must still
             // be readable.

--- a/src/Form/Section.php
+++ b/src/Form/Section.php
@@ -96,6 +96,12 @@ final class Section extends CommonDBChild
                 $question = new Question();
                 $question->getFromResultSet($row);
                 $question->post_getFromDB();
+
+                if ($question->getQuestionType() === null) {
+                    // The question might belong to a disabled plugin
+                    continue;
+                }
+
                 $this->questions[$row['id']] = $question;
             }
         }

--- a/tests/functional/Glpi/Form/Section.php
+++ b/tests/functional/Glpi/Form/Section.php
@@ -125,6 +125,20 @@ class Section extends DbTestCase
             $section,
             ['Question 1', 'Question 2']
         ];
+
+        // Ensure that invalid questions types are dropped
+        $form_3 = $this->createForm(
+            (new FormBuilder())
+                ->addSection('Section 1')
+                ->addQuestion('Valid question type', QuestionTypeShortAnswerText::class)
+                ->addQuestion('Invalid question type', "Not a type")
+        );
+
+        $section = \Glpi\Form\Section::getById($this->getSectionId($form_3, 'Section 1'));
+        yield [
+            $section,
+            ['Valid question type']
+        ];
     }
 
     /**


### PR DESCRIPTION
The form editor currently "crashes" when an invalid question type is supplied.

This is not good because it might be a valid scenario (e.g. a type is defined by a plugin which was later disabled).
Thus it is better to simply ignore the question in this case.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
