### PR TITLE
Fix tinymce config conflicts in the form editor

### DIFF
--- a/js/form_editor_controller.js
+++ b/js/form_editor_controller.js
@@ -741,7 +741,10 @@ class GlpiFormEditorController
         copy.find("textarea").each(function() {
             // Get editor config for this field
             let id = $(this).attr("id");
-            const config = window.tinymce_editor_configs[id];
+
+            // JS object are passed by reference, we need to clone the config
+            // to avoid breaking previous instances
+            const config = { ...window.tinymce_editor_configs[id]};
 
             // Rename id to ensure it is unique
             const uid = getUUID();

--- a/js/form_editor_controller.js
+++ b/js/form_editor_controller.js
@@ -744,7 +744,7 @@ class GlpiFormEditorController
 
             // JS object are passed by reference, we need to clone the config
             // to avoid breaking previous instances
-            const config = { ...window.tinymce_editor_configs[id]};
+            const config = _.cloneDeep(window.tinymce_editor_configs[id]);
 
             // Rename id to ensure it is unique
             const uid = getUUID();


### PR DESCRIPTION
When a question/section is moved, we need to reinitialize its tinymce instance.
It was however failing in some cases and I didn't know why.

It turns out it was just some config conflitcs, I forgot that javascript use references for object by default.
| Q             | A

| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
