### PR TITLE
Fix double escape on checkboxes with IDs

### DIFF
--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -367,7 +367,7 @@
     <input type="hidden"   name="{{ name }}" value="0" />
     <input type="checkbox" name="{{ name }}" value="1"
            class="form-check-input {{ options.input_addclass }}"
-           {{ options.id != null ? 'id="' ~ options.id ~ '"' : '' }}
+           {{ (options.id != null ? 'id="' ~ options.id|e('html_attr') ~ '"' : '')|raw }}
            {{ value == 1 ? 'checked' : '' }}
            {{ options.readonly ? 'readonly' : '' }}
            {{ options.required ? 'required' : '' }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Checkbox IDs attributes are double escaped due to how they are added. We only add the ID attribute if one was specified.
`{{ options.id != null ? 'id="' ~ options.id ~ '"' : '' }}`
This escapes "options.id" and then escapes the entire attribute again which results in something like `id=""agree_unstable""`.