### PR TITLE
fix(network port): error message

### DIFF
--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1284,11 +1284,11 @@ class NetworkPort extends CommonDBChild
                             }
                             break;
                         default:
-                            if ($option['table'] == $this->getTable()) {
+                            $netport_table = $this->getTable();
+                            if ($option['table'] == $netport_table) {
                                 $output .= $port[$option['field']];
                             } else {
                                 $already_link_tables = [];
-                                $netport_table = $netport->getTable();
                                 $join = Search::addLeftJoin(
                                     __CLASS__,
                                     $netport_table,

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -725,6 +725,9 @@ class NetworkPort extends CommonDBChild
         }
 
         $criteria = [
+            'SELECT' => [
+                $netport_table . '.*'
+            ],
             'FROM'   => $netport_table,
             'WHERE'  => [
                 "$netport_table.items_id"  => $item->getID(),
@@ -752,6 +755,7 @@ class NetworkPort extends CommonDBChild
                 $data["joinparams"],
                 $data["field"]
             );
+            $criteria['SELECT'][] = $data["table"] . '_' . $data["field"] . '.' . $data["field"];
             $criteria['JOIN'][] = new QueryExpression($join);
         }
 

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -755,7 +755,9 @@ class NetworkPort extends CommonDBChild
                 $data["joinparams"],
                 $data["field"]
             );
-            $criteria['SELECT'][] = $data["table"] . '_' . $data["field"] . '.' . $data["field"];
+            $pattern = "/AS `([^`]+)`/";
+            preg_match($pattern, $join, $matches);
+            $criteria['SELECT'][] = $matches[1] . '.' . $data["field"];
             $criteria['JOIN'][] = new QueryExpression($join);
         }
 

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -725,9 +725,6 @@ class NetworkPort extends CommonDBChild
         }
 
         $criteria = [
-            'SELECT' => [
-                $netport_table . '.*'
-            ],
             'FROM'   => $netport_table,
             'WHERE'  => [
                 "$netport_table.items_id"  => $item->getID(),
@@ -1284,10 +1281,11 @@ class NetworkPort extends CommonDBChild
                             }
                             break;
                         default:
-                            $netport_table = $this->getTable();
-                            if ($option['table'] == $netport_table) {
-                                $output .= $port[$option['field']];
-                            } else {
+                            if (
+                                isset($option["linkfield"])
+                                && isset($option['joinparams'])
+                            ) {
+                                $netport_table = $this->getTable();
                                 $already_link_tables = [];
                                 $join = Search::addLeftJoin(
                                     __CLASS__,
@@ -1310,6 +1308,8 @@ class NetworkPort extends CommonDBChild
                                 foreach ($iterator as $row) {
                                     $output .= $row[$option['field']];
                                 }
+                            } else {
+                                $output .= $port[$option['field']];
                             }
                             break;
                     }

--- a/tests/functional/NetworkPort.php
+++ b/tests/functional/NetworkPort.php
@@ -362,4 +362,55 @@ class NetworkPort extends DbTestCase
             $this->array($_SESSION['saveInput'])->notHasKey('NetworkPort');
         }
     }
+
+    public function testShowForItem()
+    {
+        $this->login();
+
+        $computer1 = getItemByTypeName('Computer', '_test_pc01');
+        $netport = new \NetworkPort();
+
+        // Add a network port
+        $np_id = $netport->add([
+            'items_id'           => $computer1->getID(),
+            'itemtype'           => 'Computer',
+            'entities_id'        => $computer1->fields['entities_id'],
+            'is_recursive'       => 0,
+            'logical_number'     => 6,
+            'mac'                => '00:24:81:eb:c6:d6',
+            'instantiation_type' => 'NetworkPortEthernet',
+            'name'               => 'eth1',
+        ]);
+        $this->integer((int)$np_id)->isGreaterThan(0);
+
+        // Display all columns
+        $so = $netport->rawSearchOptions();
+        $displaypref = new \DisplayPreference();
+        foreach ($so as $column) {
+            if (isset ($column['field'])) {
+                $input = [
+                    'itemtype' => 'NetworkPort',
+                    'users_id' => \Session::getLoginUserID(),
+                    'num' => $column['id'],
+                ];
+                $this->integer((int) $displaypref->add($input))->isGreaterThan(0);
+                $so_display[] = $column;
+            }
+        }
+
+        // Check that all columns are displayed and correct values
+        foreach (['showForItem', 'displayTabContentForItem'] as $method) {
+            $result = $this->output(
+                function () use ($method, $computer1) {
+                    \NetworkPort::$method($computer1);
+                }
+            );
+            foreach ($so_display as $column) {
+                $result->contains($column['name']);
+                if (isset($netport->fields[$column['field']])) {
+                    $result->contains($netport->fields[$column['field']]);
+                }
+            }
+        }
+    }
 }

--- a/tests/functional/NetworkPort.php
+++ b/tests/functional/NetworkPort.php
@@ -386,8 +386,9 @@ class NetworkPort extends DbTestCase
         // Display all columns
         $so = $netport->rawSearchOptions();
         $displaypref = new \DisplayPreference();
+        $so_display = [];
         foreach ($so as $column) {
-            if (isset ($column['field'])) {
+            if (isset($column['field'])) {
                 $input = [
                     'itemtype' => 'NetworkPort',
                     'users_id' => \Session::getLoginUserID(),


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !31937

Following https://github.com/glpi-project/glpi/pull/16738, we get an error on ports that have no correspondence in the Fields plugin tables, for example, when the port existed before the fields added by the plugin were created.

```
glpiphplog.NOTICE:   *** PHP Deprecated function (8192): htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/glpi/src/Html.php at line 2502
  Backtrace :
  src/Html.php:2502                                  htmlspecialchars()
  src/NetworkPort.php:1018                           Html::getMassiveActionCheckBox()
  src/NetworkPort.php:905                            NetworkPort->showPort()
  src/NetworkPort.php:1864                           NetworkPort::showForItem()
  src/CommonGLPI.php:694                             NetworkPort::displayTabContentForItem()
  ajax/common.tabs.php:120                           CommonGLPI::displayStandardTab()
  public/index.php:82                                require()
  
glpiphplog.NOTICE:   *** PHP Deprecated function (8192): round(): Passing null to parameter #1 ($num) of type int|float is deprecated in /var/www/glpi/src/NetworkPort.php at line 1054
  Backtrace :
  src/NetworkPort.php:1054                           round()
  src/NetworkPort.php:905                            NetworkPort->showPort()
  src/NetworkPort.php:1864                           NetworkPort::showForItem()
  src/CommonGLPI.php:694                             NetworkPort::displayTabContentForItem()
  ajax/common.tabs.php:120                           CommonGLPI::displayStandardTab()
  public/index.php:82                                require()
```


EDIT : 

Before the patch, the result of `$ports_iterator = $DB->request($criteria);` (L258) in SQL could give a result with 2 columns of the same name, notably ID. But in PHP, the data array has only one ID column (the first column being replaced by the last).