### PR TITLE
Fix Chartist Pie unfilled colors

### DIFF
--- a/css/standalone/chartist.scss
+++ b/css/standalone/chartist.scss
@@ -32,6 +32,7 @@
  */
 
 .ct-series.ct-series-p {
+    fill: #c2f040;
     stroke: #c2f040;
 }
 
@@ -41,6 +42,7 @@
 }
 
 .ct-series.ct-series-q {
+    fill: #ca12d3;
     stroke: #ca12d3;
 }
 
@@ -50,6 +52,7 @@
 }
 
 .ct-series.ct-series-r {
+    fill: #f75037;
     stroke: #f75037;
 }
 
@@ -59,6 +62,7 @@
 }
 
 .ct-series.ct-series-s {
+    fill: #6224af;
     stroke: #6224af;
 }
 
@@ -68,6 +72,7 @@
 }
 
 .ct-series.ct-series-t {
+    fill: #854f95;
     stroke: #854f95;
 }
 
@@ -77,6 +82,7 @@
 }
 
 .ct-series.ct-series-u {
+    fill: #fcfefd;
     stroke: #fcfefd;
 }
 
@@ -86,6 +92,7 @@
 }
 
 .ct-series.ct-series-v {
+    fill: #1739c0;
     stroke: #1739c0;
 }
 
@@ -95,6 +102,7 @@
 }
 
 .ct-series.ct-series-w {
+    fill: #f83db1;
     stroke: #f83db1;
 }
 
@@ -104,6 +112,7 @@
 }
 
 .ct-series.ct-series-x {
+    fill: #a52ab5;
     stroke: #a52ab5;
 }
 
@@ -113,6 +122,7 @@
 }
 
 .ct-series.ct-series-y {
+    fill: #1f8870;
     stroke: #1f8870;
 }
 
@@ -122,6 +132,7 @@
 }
 
 .ct-series.ct-series-z {
+    fill: #d7192e;
     stroke: #d7192e;
 }
 


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !32051

Resolved a display bug on pie and donut diagrams in the dashboard.

Before:
![image](https://github.com/glpi-project/glpi/assets/102067890/923eb060-5866-48a5-934f-e38e89544899)

After: 
![image](https://github.com/glpi-project/glpi/assets/102067890/b429385a-034e-4666-b187-ca6ccb0378ce)

