### PR TITLE
Fix default view of planning list

### DIFF
--- a/js/planning.js
+++ b/js/planning.js
@@ -91,6 +91,7 @@ var GLPIPlanning  = {
             timeZone:    'UTC',
             theme:       true,
             weekNumbers: options.full_view ? true : false,
+            defaultView: options.default_view,
             timeFormat:  'H:mm',
             eventLimit:  true, // show 'more' button when too mmany events
             minTime:     CFG_GLPI.planning_begin,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !32081

Corrected the appearance of tasks each time the page is loaded. It is no longer necessary to refresh manually with the button. 

**Before**
![image](https://github.com/glpi-project/glpi/assets/107540223/d2d7a7f2-c770-46ae-8a6b-9ea3a4cd3931)

**After**
![Screencast-from-15-03-2024-11_58_50](https://github.com/glpi-project/glpi/assets/107540223/731948ed-c281-48c5-87af-ebe9ad641679)




