### PR TITLE
Fix merging of join conditions in search engine

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -4574,6 +4574,16 @@ abstract class CommonITILObject extends CommonDBTM
             ]
         ];
 
+        $last_solution_condition = new QuerySubQuery([
+            'SELECT' => 'id',
+            'FROM'   => ITILSolution::getTable(),
+            'WHERE'  => [
+                ITILSolution::getTable() . '.items_id' => new QueryExpression($DB::quoteName('REFTABLE.id')),
+                ITILSolution::getTable() . '.itemtype' => static::getType()
+            ],
+            'ORDER'  => ITILSolution::getTable() . '.id DESC',
+            'LIMIT'  => 1
+        ]);
         $tab[] = [
             'id'                  => '39',
             'table'               => ITILSolution::getTable(),
@@ -4588,17 +4598,7 @@ abstract class CommonITILObject extends CommonDBTM
                 'jointype'  => 'itemtype_item',
             // Get only last created solution
                 'condition' => [
-                    'NEWTABLE.id'  => ['=', new QuerySubQuery([
-                        'SELECT' => 'id',
-                        'FROM'   => ITILSolution::getTable(),
-                        'WHERE'  => [
-                            ITILSolution::getTable() . '.items_id' => new QueryExpression($DB->quoteName('REFTABLE.id')),
-                            ITILSolution::getTable() . '.itemtype' => static::getType()
-                        ],
-                        'ORDER'  => ITILSolution::getTable() . '.id DESC',
-                        'LIMIT'  => 1
-                    ])
-                    ]
+                    'NEWTABLE.id'  => new QueryExpression($last_solution_condition->getQuery())
                 ]
             ]
         ];

--- a/src/Search/Provider/SQLProvider.php
+++ b/src/Search/Provider/SQLProvider.php
@@ -2481,7 +2481,7 @@ final class SQLProvider implements SearchProviderInterface
                     $last_key = array_keys($join_fkey);
                     $last_key = array_pop($last_key);
                     // Append new criteria to the last key
-                    $join_fkey[$last_key][] = [$add_link => $additional_criteria];
+                    $join_fkey[$last_key]['AND'][] = [$add_link => $additional_criteria];
                 }
             };
             $placeholders = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The conversion of request criteria arrays to SQL can only handle a single extra element in the join array for additional criteria. Any extra conditions have to be inside that third element or else they are ignored.