### PR TITLE
Review and clean Lock class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@ The present file will list all changes made to the project; according to the
 - `CommonITILTask::getItilObjectItemType` is now static.
 - The `Item_Ticket$1` tab should be used in replacement of the `Ticket$1` tab to display tickets associated with an item.
 - Specifying the `ranking` of a rule during add/update now triggers `RuleCollection::moveRule` to manage the rankings of other rules to try to keep them valid and in order.
+- `Lock::getLocksQueryInfosByItemType()` has been made private.
 
 #### Deprecated
 - Usage of `MAIL_SMTPSSL` and `MAIL_SMTPTLS` constants.

--- a/inc/db.function.php
+++ b/inc/db.function.php
@@ -112,7 +112,7 @@ function getItemTypeForTable($table)
  *
  * @param string $fkname
  *
- * @return string ItemType name for the fkname parameter
+ * @return class-string<CommonDBTM> Itemtype class for the fkname parameter
  */
 function getItemtypeForForeignKeyField($fkname)
 {

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -2330,7 +2330,7 @@ final class DbUtils
      *
      * @param string $fkname Foreign key
      *
-     * @return string ItemType name for the fkname parameter
+     * @return class-string<CommonDBTM> Itemtype class for the fkname parameter
      */
     public function getItemtypeForForeignKeyField($fkname)
     {

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -44,12 +44,14 @@ use Glpi\Search\SearchOption;
  * Lock management is available for objects and link between objects. It relies on the use of
  * a is_dynamic field, to incidate if item supports lock, and is_deleted field to incidate if the
  * item or link is locked
- * By setting is_deleted to 0 again, the item is unlock
+ * By setting is_deleted to 0 again, the item is unlocked.
  *
  * Note : GLPI's core supports locks for objects. It's up to the external inventory tool to manage
  * locks for fields
  *
  * @since 0.84
+ * @see ObjectLock - Object-level locks
+ * @see Lockedfield - Field-level locks
  **/
 class Lock extends CommonGLPI
 {
@@ -95,48 +97,50 @@ class Lock extends CommonGLPI
         echo "</div>";
 
         $lockedfield = new Lockedfield();
+        $lockedfield_table = $lockedfield::getTable();
         if ($lockedfield->isHandled($item)) {
             $subquery = [];
 
-            //get locked field for current itemtype
+            // get locked field for current itemtype
             $subquery[] = new QuerySubQuery([
-                'SELECT' => $lockedfield->getTable() . ".*",
-                'FROM'   => $lockedfield->getTable(),
+                'SELECT' => $lockedfield_table . ".*",
+                'FROM'   => $lockedfield_table,
                 'WHERE'  => [
                     'OR' => [
                         [
-                            $lockedfield->getTable() . '.itemtype'  => $itemtype,
-                            $lockedfield->getTable() . '.items_id'  => $ID
+                            $lockedfield_table . '.itemtype'  => $itemtype,
+                            $lockedfield_table . '.items_id'  => $ID
                         ], [
-                            $lockedfield->getTable() . '.itemtype'  => $itemtype,
-                            $lockedfield->getTable() . '.is_global' => 1
+                            $lockedfield_table . '.itemtype'  => $itemtype,
+                            $lockedfield_table . '.is_global' => 1
                         ]
                     ]
                 ]
             ]);
 
-            //get locked field for other lockable object
+            // get locked field for other lockable object
             foreach ($CFG_GLPI['inventory_lockable_objects'] as $lockable_itemtype) {
+                $lockable_itemtype_table = getTableForItemType($lockable_itemtype);
                 $lockable_object = new $lockable_itemtype();
                 $query  = [
-                    'SELECT' => $lockedfield->getTable() . ".*",
-                    'FROM'   => $lockedfield->getTable(),
+                    'SELECT' => $lockedfield_table . ".*",
+                    'FROM'   => $lockedfield_table,
                     'LEFT JOIN' => [
-                        getTableForItemType($lockable_itemtype)   => [
+                        $lockable_itemtype_table   => [
                             'FKEY'   => [
-                                $lockedfield->getTable()  => 'items_id',
-                                getTableForItemType($lockable_itemtype)   => 'id'
+                                $lockedfield_table  => 'items_id',
+                                $lockable_itemtype_table   => 'id'
                             ]
                         ]
                     ],
                     'WHERE'  => [
                         'OR' => [
                             [
-                                $lockedfield->getTable() . '.itemtype'  => $lockable_itemtype,
-                                $lockedfield->getTable() . '.items_id'  => new QueryExpression(getTableForItemType($lockable_itemtype) . '.id')
+                                $lockedfield_table . '.itemtype'  => $lockable_itemtype,
+                                $lockedfield_table . '.items_id'  => new QueryExpression($DB::quoteName($lockable_itemtype_table . '.id'))
                             ], [
-                                $lockedfield->getTable() . '.itemtype'  => $lockable_itemtype,
-                                $lockedfield->getTable() . '.is_global' => 1
+                                $lockedfield_table . '.itemtype'  => $lockable_itemtype,
+                                $lockedfield_table . '.is_global' => 1
                             ]
                         ]
                     ]
@@ -153,8 +157,8 @@ class Lock extends CommonGLPI
                             $lockable_object::getTableField('is_deleted') => 0
                         ];
                     }
-                } elseif (in_array($lockable_itemtype, $CFG_GLPI['directconnect_types'])) {
-                    //we need to restrict scope with Computer_Item to prevent loading of all lockedfield
+                } elseif (in_array($lockable_itemtype, $CFG_GLPI['directconnect_types'], true)) {
+                    // we need to restrict scope with Computer_Item to prevent loading of all lockedfield
                     $query['LEFT JOIN'][Computer_Item::getTable()] =
                     [
                         'FKEY'   => [
@@ -211,7 +215,7 @@ class Lock extends CommonGLPI
                 foreach ($search_options as $search_option) {
                     //exclude SO added by dropdown part (to get real name)
                     //ex : Manufacturer != Firmware : Manufacturer
-                    if (isset($search_option['table']) && $search_option['table'] == getTableForItemType($itemtype)) {
+                    if (isset($search_option['table']) && $search_option['table'] === getTableForItemType($itemtype)) {
                         if (isset($search_option['linkfield'])) {
                             $so_fields[$search_option['linkfield']] = $search_option['name'];
                         } else if (isset($search_option['field'])) {
@@ -223,7 +227,7 @@ class Lock extends CommonGLPI
                 foreach ($locked_iterator as $row) {
                     echo "<tr class='tab_bg_1'>";
                     echo "<td class='center' width='10'>";
-                    if ($row['is_global'] == 0 && ($lockedfield->can($row['id'], UPDATE) || $lockedfield->can($row['id'], PURGE))) {
+                    if ($row['is_global'] === 0 && ($lockedfield->can($row['id'], UPDATE) || $lockedfield->can($row['id'], PURGE))) {
                         $header = true;
                         echo Html::getMassiveActionCheckBox(Lockedfield::class, $row['id'], ['massive_tags' => 'select_' . $lockedfield::getType()]);
                     }
@@ -234,7 +238,7 @@ class Lock extends CommonGLPI
                     } else if (isForeignKeyField($row['field'])) {
                     //on fkey, we can try to retrieve the object
                         $object = getItemtypeForForeignKeyField($row['field']);
-                        if ($object != 'UNKNOWN') {
+                        if ($object !== 'UNKNOWN') {
                             $field_label = $object::getTypeName(1);
                         }
                     }
@@ -253,29 +257,29 @@ class Lock extends CommonGLPI
                     $default_itemtype       = $row['itemtype'];
                     $default_items_id       = null;
 
-                    //get real type name from Item_Devices
+                    // get real type name from Item_Devices
                     // ex: get 'Hard drives' instead of 'Hard drive items'
-                    if (get_parent_class($row['itemtype']) == Item_Devices::class) {
+                    if (get_parent_class($row['itemtype']) === Item_Devices::class) {
                         $default_itemtype =  $row['itemtype']::$itemtype_2;
                         $default_items_id =  $row['itemtype']::$items_id_2;
                         $default_itemtype_label = $row['itemtype']::$itemtype_2::getTypeName();
-                    //get real type name from CommonDBRelation
+                    // get real type name from CommonDBRelation
                     // ex: get 'Operating System' instead of 'Item operating systems'
-                    } elseif (get_parent_class($row['itemtype']) == CommonDBRelation::class) {
-                        //For CommonDBRelation
+                    } elseif (get_parent_class($row['itemtype']) === CommonDBRelation::class) {
+                        // For CommonDBRelation
                         // $itemtype_1 / $items_id_1 and $itemtype_2 / $items_id_2 can be inverted
 
-                        //ex: Item_Software have
+                        // ex: Item_Software have
                         // $itemtype_1 = 'itemtype';
                         // $items_id_1 = 'items_id';
                         // $itemtype_2 = 'SoftwareVersion';
                         // $items_id_2 = 'softwareversions_id';
-                        if (preg_match('/^itemtype/', $row['itemtype']::$itemtype_1)) {
+                        if (str_starts_with($row['itemtype']::$itemtype_1, 'itemtype')) {
                             $default_itemtype =  $row['itemtype']::$itemtype_2;
                             $default_items_id =  $row['itemtype']::$items_id_2;
                             $default_itemtype_label = $row['itemtype']::$itemtype_2::getTypeName();
                         } else {
-                            //ex: Item_OperatingSystem have
+                            // ex: Item_OperatingSystem have
                             // $itemtype_1 = 'OperatingSystem';
                             // $items_id_1 = 'operatingsystems_id';
                             // $itemtype_2 = 'itemtype';
@@ -338,8 +342,10 @@ class Lock extends CommonGLPI
         echo "</span>";
         echo "</div>";
 
+        //TODO We already get a lot of data from the DB so we may as well display links to the different items rather than just the names.
+        //TODO Since a lot of data is loaded from the DB, try to cache as much as possible to avoid multiple queries
         //Special locks for computers only
-        if ($itemtype == 'Computer') {
+        if ($itemtype === Computer::class) {
             //computer_item
             $computer_item = new Computer_Item();
             $types = $CFG_GLPI['directconnect_types'];
@@ -384,19 +390,21 @@ class Lock extends CommonGLPI
 
             //items disks
             $item_disk = new Item_Disk();
-            $params = [
-                'is_dynamic'   => 1,
-                'is_deleted'   => 1,
-                'items_id'     => $ID,
-                'itemtype'     => $itemtype
-            ];
-            $params['FIELDS'] = ['id', 'name'];
+            $item_disks = $DB->request([
+                'FROM'  => $item_disk::getTable(),
+                'WHERE' => [
+                    'is_dynamic'   => 1,
+                    'is_deleted'   => 1,
+                    'items_id'     => $ID,
+                    'itemtype'     => $itemtype
+                ]
+            ]);
             $first  = true;
-            foreach ($DB->request($item_disk->getTable(), $params) as $line) {
+            foreach ($item_disks as $line) {
                 if ($first) {
                     echo "<tr>";
                     echo "<th width='10'></th>";
-                    echo "<th>" . $item_disk->getTypeName(Session::getPluralNumber()) . "</th>";
+                    echo "<th>" . $item_disk::getTypeName(Session::getPluralNumber()) . "</th>";
                     echo "<th>" . __('Partition') . "</th>";
                     echo "<th>" . __('Mount point') . "</th>";
                     echo "<th>" . __('Automatic inventory') . "</th>";
@@ -404,12 +412,12 @@ class Lock extends CommonGLPI
                     $first = false;
                 }
 
-                $item_disk->getFromDB($line['id']);
+                $item_disk->getFromResultSet($line);
                 echo "<tr class='tab_bg_1'>";
                 echo "<td class='center' width='10'>";
-                if ($item_disk->can($line['id'], UPDATE) || $item_disk->can($line['id'], PURGE)) {
+                if ($item_disk->can($line['id'], UPDATE) || $item_disk->can($item_disk->getID(), PURGE)) {
                     $header = true;
-                    echo "<input type='checkbox' name='Item_Disk[" . $line['id'] . "]'>";
+                    echo "<input type='checkbox' name='Item_Disk[" . $item_disk->getID() . "]'>";
                 }
                 echo "</td>";
                 echo "<td class='left'>" . $item_disk->getLink() . "</td>";
@@ -421,18 +429,21 @@ class Lock extends CommonGLPI
         }
 
         $item_vm = new ItemVirtualMachine();
-        $params = ['is_dynamic'    => 1,
-            'is_deleted'    => 1,
-            'itemtype' => $itemtype,
-            'items_id'  => $ID
-        ];
-        $params['FIELDS'] = ['id', 'name'];
+        $item_vms = $DB->request([
+            'FROM'  => $item_vm::getTable(),
+            'WHERE' => [
+                'is_dynamic'   => 1,
+                'is_deleted'   => 1,
+                'itemtype'     => $itemtype,
+                'items_id'     => $ID
+            ]
+        ]);
         $first  = true;
-        foreach ($DB->request($item_vm->getTable(), $params) as $line) {
+        foreach ($item_vms as $line) {
             if ($first) {
                 echo "<tr>";
                 echo "<th width='10'></th>";
-                echo "<th>" . $item_vm->getTypeName(Session::getPluralNumber()) . "</th>";
+                echo "<th>" . $item_vm::getTypeName(Session::getPluralNumber()) . "</th>";
                 echo "<th>" . __('UUID') . "</th>";
                 echo "<th>" . __('Machine') . "</th>";
                 echo "<th>" . __('Automatic inventory') . "</th>";
@@ -440,12 +451,12 @@ class Lock extends CommonGLPI
                 $first = false;
             }
 
-            $item_vm->getFromDB($line['id']);
+            $item_vm->getFromResultSet($line);
             echo "<tr class='tab_bg_1'>";
             echo "<td class='center' width='10'>";
-            if ($item_vm->can($line['id'], UPDATE) || $item_vm->can($line['id'], PURGE)) {
+            if ($item_vm->can($line['id'], UPDATE) || $item_vm->can($item_vm->getID(), PURGE)) {
                 $header = true;
-                echo "<input type='checkbox' name='ItemVirtualMachine[" . $line['id'] . "]'>";
+                echo "<input type='checkbox' name='ItemVirtualMachine[" . $item_vm->getID() . "]'>";
             }
             echo "</td>";
             echo "<td class='left'>" . $item_vm->getLink() . "</td>";
@@ -479,7 +490,7 @@ class Lock extends CommonGLPI
             echo "</tr>\n";
         }
 
-        //Software versions
+        // Software versions
         $item_sv = new Item_SoftwareVersion();
         $item_sv_table = Item_SoftwareVersion::getTable();
 
@@ -527,20 +538,14 @@ class Lock extends CommonGLPI
             $item_sv->getFromDB($data['id']);
             echo "<tr class='tab_bg_1'>";
             echo "<td class='center' width='10'>";
-            if ($item_sv->can($data['id'], UPDATE) || $item_sv->can($data['id'], PURGE)) {
+            if ($item_sv->can($item_sv->getID(), UPDATE) || $item_sv->can($item_sv->getID(), PURGE)) {
                 $header = true;
-                echo "<input type='checkbox' name='Item_SoftwareVersion[" . $data['id'] . "]'>";
+                echo "<input type='checkbox' name='Item_SoftwareVersion[" . $item_sv->getID() . "]'>";
             }
 
-            $sversion = new SoftwareVersion();
-            $sversion->getFromDB($item_sv->fields['softwareversions_id']);
-
-            $software = new Software();
-            $software->getFromDB($sversion->fields['softwares_id']);
-
             echo "</td>";
-            echo "<td class='left'>" . $software->fields['name'] . "</td>"; //no form for item software version
-            echo "<td class='left'>" . $sversion->fields['name'] . "</td>";
+            echo "<td class='left'>" . $data['software'] . "</td>"; //no form for item software version
+            echo "<td class='left'>" . $data['version'] . "</td>";
             echo "<td class='left'>" . Html::convDateTime($item_sv->fields['date_install']) . "</td>";
             echo "<td class='left'>" . Dropdown::getYesNo($item_sv->fields['is_dynamic']) . "</td>";
             echo "</tr>";
@@ -553,7 +558,7 @@ class Lock extends CommonGLPI
         $iterator = $DB->request([
             'SELECT'    => [
                 'isl.id AS id',
-                'sl.name AS version',
+                'sl.name AS license',
                 's.name AS software'
             ],
             'FROM'      => "{$item_sl_table} AS isl",
@@ -625,14 +630,17 @@ class Lock extends CommonGLPI
 
         $first  = true;
         $networkport = new NetworkPort();
-        $params = ['is_dynamic' => 1,
-            'is_deleted' => 1,
-            'items_id'   => $ID,
-            'itemtype'   => $itemtype
-        ];
-        $params['FIELDS'] = ['id'];
-        foreach ($DB->request($networkport->getTable(), $params) as $line) {
-            $networkport->getFromDB($line['id']);
+        $networkports = $DB->request([
+            'FROM'  => $networkport::getTable(),
+            'WHERE' => [
+                'is_dynamic' => 1,
+                'is_deleted' => 1,
+                'items_id'   => $ID,
+                'itemtype'   => $itemtype
+            ]
+        ]);
+        foreach ($networkports as $line) {
+            $networkport->getFromResultSet($line);
             if ($first) {
                 echo "<tr>";
                 echo "<th width='10'></th>";
@@ -646,9 +654,9 @@ class Lock extends CommonGLPI
 
             echo "<tr class='tab_bg_1'>";
             echo "<td class='center' width='10'>";
-            if ($networkport->can($line['id'], UPDATE) || $networkport->can($line['id'], PURGE)) {
+            if ($networkport->can($networkport->getID(), UPDATE) || $networkport->can($networkport->getID(), PURGE)) {
                 $header = true;
-                echo "<input type='checkbox' name='NetworkPort[" . $line['id'] . "]'>";
+                echo "<input type='checkbox' name='NetworkPort[" . $networkport->getID() . "]'>";
             }
             echo "</td>";
             echo "<td class='left'>" . $networkport->getLink() . "</td>";
@@ -660,21 +668,34 @@ class Lock extends CommonGLPI
 
         $first = true;
         $networkname = new NetworkName();
-        $params = [
-            'glpi_networknames.is_dynamic' => 1,
-            'glpi_networknames.is_deleted' => 1,
-            'glpi_networknames.itemtype'   => 'NetworkPort',
-            'glpi_networknames.items_id'   => new QueryExpression($DB->quoteName('glpi_networkports.id')),
-            'glpi_networkports.items_id'   => $ID,
-            'glpi_networkports.itemtype'   => $itemtype
-        ];
-        $params['FIELDS'] = ['glpi_networknames' => 'id'];
-        foreach ($DB->request(['glpi_networknames', 'glpi_networkports'], $params) as $line) {
-            $networkname->getFromDB($line['id']);
+        $networknames = $DB->request([
+            'SELECT' => ['glpi_networknames.*'],
+            'FROM'  => $networkname::getTable(),
+            'LEFT JOIN' => [ // These joins are used to filter the network names that are linked to the current item's network ports
+                'glpi_networkports' => [
+                    'ON' => [
+                        'glpi_networknames' => 'items_id',
+                        'glpi_networkports' => 'id', [
+                            'AND' => [
+                                'glpi_networkports.itemtype'  => $itemtype,
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            'WHERE' => [
+                'glpi_networkports.items_id'   => $ID,
+                'glpi_networknames.is_dynamic' => 1,
+                'glpi_networknames.is_deleted' => 1,
+                'glpi_networknames.itemtype'   => 'NetworkPort',
+            ]
+        ]);
+        foreach ($networknames as $line) {
+            $networkname->getFromResultSet($line);
             if ($first) {
                 echo "<tr>";
                 echo "<th width='10'></th>";
-                echo "<th>" . $networkname->getTypeName(Session::getPluralNumber()) . "</th>";
+                echo "<th>" . $networkname::getTypeName(Session::getPluralNumber()) . "</th>";
                 echo "<th>" . __('FQDN') . "</th>";
                 echo "<th></th>";
                 echo "<th>" . __('Automatic inventory') . "</th>";
@@ -684,9 +705,9 @@ class Lock extends CommonGLPI
 
             echo "<tr class='tab_bg_1'>";
             echo "<td class='center' width='10'>";
-            if ($networkname->can($line['id'], UPDATE) || $networkname->can($line['id'], PURGE)) {
+            if ($networkname->can($networkname->getID(), UPDATE) || $networkname->can($networkname->getID(), PURGE)) {
                 $header = true;
-                echo "<input type='checkbox' name='NetworkName[" . $line['id'] . "]'>";
+                echo "<input type='checkbox' name='NetworkName[" . $networkname->getID() . "]'>";
             }
             echo "</td>";
             echo "<td class='left'>" . $networkname->getLink() . "</td>";
@@ -704,29 +725,45 @@ class Lock extends CommonGLPI
 
         $first  = true;
         $ipaddress = new IPAddress();
-        $params = [
-            'glpi_ipaddresses.is_dynamic' => 1,
-            'glpi_ipaddresses.is_deleted' => 1,
-            'glpi_ipaddresses.itemtype'   => 'NetworkName',
-            'glpi_ipaddresses.items_id'   => new QueryExpression($DB->quoteName('glpi_networknames.id')),
-            'glpi_networknames.itemtype'  => 'NetworkPort',
-            'glpi_networknames.items_id'  => new QueryExpression($DB->quoteName('glpi_networkports.id')),
-            'glpi_networkports.items_id'  => $ID,
-            'glpi_networkports.itemtype'  => $itemtype
-        ];
-        $params['FIELDS'] = ['glpi_ipaddresses' => 'id'];
-        foreach (
-            $DB->request(['glpi_ipaddresses',
-                'glpi_networknames',
-                'glpi_networkports'
-            ], $params) as $line
-        ) {
-            $ipaddress->getFromDB($line['id']);
+        $ipaddresses = $DB->request([
+            'SELECT' => ['glpi_ipaddresses.*'],
+            'FROM'  => $ipaddress::getTable(),
+            'LEFT JOIN' => [ // These joins are used to filter the IP addresses that are linked to the current item's network ports
+                'glpi_networknames' => [
+                    'ON' => [
+                        'glpi_ipaddresses' => 'items_id',
+                        'glpi_networknames' => 'id', [
+                            'AND' => [
+                                'glpi_networknames.itemtype'  => 'NetworkPort',
+                            ]
+                        ]
+                    ]
+                ],
+                'glpi_networkports' => [
+                    'ON' => [
+                        'glpi_networknames' => 'items_id',
+                        'glpi_networkports' => 'id', [
+                            'AND' => [
+                                'glpi_networkports.itemtype'  => $itemtype,
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            'WHERE' => [
+                'glpi_networkports.items_id'  => $ID,
+                'glpi_ipaddresses.is_dynamic' => 1,
+                'glpi_ipaddresses.is_deleted' => 1,
+                'glpi_ipaddresses.itemtype'   => 'NetworkName',
+            ]
+        ]);
+        foreach ($ipaddresses as $line) {
+            $ipaddress->getFromResultSet($line);
             if ($first) {
                 echo "<tr>";
                 echo "<th width='10'></th>";
-                echo "<th>" . $ipaddress->getTypeName(Session::getPluralNumber()) . "</th>";
-                echo "<th>" . SoftwareVersion::getTypeName(Session::getPluralNumber()) . "</th>";
+                echo "<th>" . $ipaddress::getTypeName(1) . "</th>";
+                echo "<th>" . _n('Version', 'Versions', 1) . "</th>";
                 echo "<th></th>";
                 echo "<th>" . __('Automatic inventory') . "</th>";
                 echo "</tr>";
@@ -735,9 +772,9 @@ class Lock extends CommonGLPI
 
             echo "<tr class='tab_bg_1'>";
             echo "<td class='center' width='10'>";
-            if ($ipaddress->can($line['id'], UPDATE) || $ipaddress->can($line['id'], PURGE)) {
+            if ($ipaddress->can($ipaddress->getID(), UPDATE) || $ipaddress->can($ipaddress->getID(), PURGE)) {
                 $header = true;
-                echo "<input type='checkbox' name='IPAddress[" . $line['id'] . "]'>";
+                echo "<input type='checkbox' name='IPAddress[" . $ipaddress->getID() . "]'>";
             }
             echo "</td>";
             echo "<td class='left'>" . $ipaddress->fields['name'] . "</td>"; //no form for IP address
@@ -844,11 +881,14 @@ class Lock extends CommonGLPI
 
         foreach ($data as $row) {
             $database_instance = DatabaseInstance::getById($row['id']);
+            if ($database_instance === false) {
+                continue;
+            }
             echo "<tr class='tab_bg_1'>";
             echo "<td class='center' width='10'>";
-            if ($database_instance->can($row['id'], UPDATE) || $database_instance->can($row['id'], PURGE)) {
+            if ($database_instance->can($database_instance->getID(), UPDATE) || $database_instance->can($database_instance->getID(), PURGE)) {
                 $header = true;
-                echo "<input type='checkbox' name='DatabaseInstance[" . $row['id'] . "]'>";
+                echo "<input type='checkbox' name='DatabaseInstance[" . $database_instance->getID() . "]'>";
             }
             echo "</td>";
             echo "<td class='left'>" . $database_instance->getLink() . "</td>";
@@ -943,53 +983,39 @@ class Lock extends CommonGLPI
         echo "</div>\n";
     }
 
-
-    /**
-     * @see CommonGLPI::getTabNameForItem()
-     *
-     * @param $item               CommonGLPI object
-     * @param $withtemplate       (default 0)
-     **/
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-
         if ($item->isDynamic() && $item->can($item->fields['id'], UPDATE)) {
-            return self::createTabEntry(Lock::getTypeName(Session::getPluralNumber()), 0, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), 0, $item::getType());
         }
         return '';
     }
 
-
-    /**
-     * @param $item            CommonGLPI object
-     * @param $tabnum          (default 1)
-     * @param $withtemplate    (default 0)
-     **/
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
     {
-
         if ($item->isDynamic() && $item->can($item->fields['id'], UPDATE)) {
             self::showForItem($item);
         }
         return true;
     }
 
-
     /**
-     * Get infos to build an SQL query to get locks fields in a table
+     * Get infos to build an SQL query to get locks fields in a table.
+     * The criteria returned will only retrieve the 'id' column of the main table by default.
      *
-     * @param string $itemtype      itemtype of the item to look for locked fields
-     * @param string $baseitemtype  itemtype of the based item
+     * @param class-string<CommonDBTM> $itemtype      itemtype of the item to look for locked fields
+     * @param class-string<CommonDBTM> $baseitemtype  itemtype of the based item
      *
-     * @return array  which contains necessary information to build the SQL query
+     * @return array{criteria: array, field: string, type: class-string<CommonDBTM>} Necessary information to build the SQL query.
+     * <ul>
+     *     <li>'criteria' array contains the joins and where criteria to apply to the SQL query (DBmysqlIterator format).</li>
+     *     <li>'field' refers to the criteria condition key where the item ID should be inserted. This key is not already present in the criteria array.</li>
+     *     <li>'type' refers to the class of the item to look for locked fields.</li>
+     * </ul>
      **/
-    public static function getLocksQueryInfosByItemType($itemtype, $baseitemtype)
+    private static function getLocksQueryInfosByItemType($itemtype, $baseitemtype)
     {
-        /** @var \DBmysql $DB */
-        global $DB;
-
-        $condition = [];
-        $table     = false;
+        $criteria = [];
         $field     = '';
         $type      = $itemtype;
 
@@ -998,110 +1024,157 @@ class Lock extends CommonGLPI
             case 'Monitor':
             case 'Printer':
             case 'Phone':
-                $condition = ['itemtype'   => $itemtype,
-                    'is_dynamic' => 1,
-                    'is_deleted' => 1
+                $criteria = [
+                    'SELECT' => ['glpi_computers_items.id'],
+                    'FROM' => 'glpi_computers_items',
+                    'WHERE' => [
+                        'itemtype'   => $itemtype,
+                        'is_dynamic' => 1,
+                        'is_deleted' => 1
+                    ]
                 ];
-                $table     = 'glpi_computers_items';
                 $field     = 'computers_id';
                 $type      = 'Computer_Item';
                 break;
 
             case 'NetworkPort':
-                $condition = ['itemtype'   => $baseitemtype,
-                    'is_dynamic' => 1,
-                    'is_deleted' => 1
+                $criteria = [
+                    'SELECT' => ['glpi_networkports.id'],
+                    'FROM' => 'glpi_networkports',
+                    'WHERE' => [
+                        'itemtype'   => $baseitemtype,
+                        'is_dynamic' => 1,
+                        'is_deleted' => 1
+                    ]
                 ];
-                $table     = 'glpi_networkports';
                 $field     = 'items_id';
                 break;
 
             case 'NetworkName':
-                $condition = [
-                    'glpi_networknames.is_dynamic' => 1,
-                    'glpi_networknames.is_deleted' => 1,
-                    'glpi_networknames.itemtype'   => 'NetworkPort',
-                    'glpi_networknames.items_id'   => new QueryExpression($DB->quoteName('glpi_networkports.id')),
-                    'glpi_networkports.itemtype'   => $baseitemtype
+                $criteria = [
+                    'SELECT' => ['glpi_networknames.id'],
+                    'FROM' => 'glpi_networknames',
+                    'LEFT JOIN' => [
+                        'glpi_networkports' => [
+                            'ON' => [
+                                'glpi_networknames' => 'items_id',
+                                'glpi_networkports' => 'id', [
+                                    'AND' => [
+                                        'glpi_networkports.itemtype'  => $baseitemtype,
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ],
+                    'WHERE' => [
+                        'glpi_networknames.is_dynamic' => 1,
+                        'glpi_networknames.is_deleted' => 1,
+                        'glpi_networknames.itemtype'   => 'NetworkPort',
+                    ]
                 ];
-                $condition['FIELDS']
-                       = ['glpi_networknames' => 'id'];
-                $table     = ['glpi_networknames', 'glpi_networkports'];
                 $field     = 'glpi_networkports.items_id';
                 break;
 
             case 'IPAddress':
-                $condition = [
-                    'glpi_ipaddresses.is_dynamic'   => 1,
-                    'glpi_ipaddresses.is_deleted'   => 1,
-                    'glpi_ipaddresses.itemtype'     => 'NetworkName',
-                    'glpi_ipaddresses.items_id'     => 'glpi_networknames.id',
-                    'glpi_networknames.itemtype'    => 'NetworkPort',
-                    'glpi_networknames.items_id'    => 'glpi_networkports.id',
-                    'glpi_networkports.itemtype'    => $baseitemtype
+                $criteria = [
+                    'SELECT' => ['glpi_ipaddresses.id'],
+                    'FROM' => 'glpi_ipaddresses',
+                    'LEFT JOIN' => [
+                        'glpi_networknames' => [
+                            'ON' => [
+                                'glpi_ipaddresses' => 'items_id',
+                                'glpi_networknames' => 'id', [
+                                    'AND' => [
+                                        'glpi_networknames.itemtype'  => 'NetworkPort',
+                                    ]
+                                ]
+                            ]
+                        ],
+                        'glpi_networkports' => [
+                            'ON' => [
+                                'glpi_networknames' => 'items_id',
+                                'glpi_networkports' => 'id', [
+                                    'AND' => [
+                                        'glpi_networkports.itemtype'  => $baseitemtype,
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ],
+                    'WHERE' => [
+                        'glpi_ipaddresses.is_dynamic' => 1,
+                        'glpi_ipaddresses.is_deleted' => 1,
+                        'glpi_ipaddresses.itemtype'   => 'NetworkName',
+                    ]
                 ];
-                $condition['FIELDS']
-                       = ['glpi_ipaddresses' => 'id'];
-                $table     = ['glpi_ipaddresses', 'glpi_networknames', 'glpi_networkports'];
                 $field     = 'glpi_networkports.items_id';
                 break;
 
             case 'Item_Disk':
-                $condition = [
-                    'is_dynamic' => 1,
-                    'is_deleted' => 1,
-                    'itemtype'   => $itemtype
+                $criteria = [
+                    'SELECT' => ['glpi_items_disks.id'],
+                    'FROM' => 'glpi_items_disks',
+                    'WHERE' => [
+                        'is_dynamic' => 1,
+                        'is_deleted' => 1,
+                        'itemtype'   => $itemtype
+                    ]
                 ];
-                $table     = Item_Disk::getTable();
                 $field     = 'items_id';
                 break;
 
             case 'ItemVirtualMachine':
-                $condition = [
-                    'is_dynamic' => 1,
-                    'is_deleted' => 1,
-                    'itemtype'   => $itemtype
+                $table = $itemtype::getTable();
+                $criteria = [
+                    'SELECT' => ["$table.id"],
+                    'FROM' => $table,
+                    'WHERE' => [
+                        'is_dynamic' => 1,
+                        'is_deleted' => 1,
+                        'itemtype'   => $itemtype
+                    ]
                 ];
-                $table     = $itemtype::getTable();
                 $field     = 'items_id';
                 break;
 
             case 'SoftwareVersion':
-                $condition = [
-                    'is_dynamic' => 1,
-                    'is_deleted' => 1,
-                    'itemtype'   => $itemtype
+                $criteria = [
+                    'SELECT' => ['glpi_items_softwareversions.id'],
+                    'FROM' => 'glpi_items_softwareversions',
+                    'WHERE' => [
+                        'is_dynamic' => 1,
+                        'is_deleted' => 1,
+                        'itemtype'   => $itemtype
+                    ]
                 ];
-                $table     = 'glpi_items_softwareversions';
                 $field     = 'items_id';
                 $type      = 'Item_SoftwareVersion';
                 break;
 
             default:
-               // Devices
-                if (preg_match('/^Item\_Device/', $itemtype)) {
-                    $condition = ['itemtype'   => $baseitemtype,
-                        'is_dynamic' => 1,
-                        'is_deleted' => 1
+                // Devices
+                if (str_starts_with($itemtype, "Item_Device")) {
+                    $table = getTableForItemType($itemtype);
+                    $criteria = [
+                        'SELECT' => ["$table.id"],
+                        'FROM' => $table,
+                        'WHERE' => [
+                            'itemtype'   => $itemtype,
+                            'is_dynamic' => 1,
+                            'is_deleted' => 1
+                        ]
                     ];
-                    $table     = getTableForItemType($itemtype);
                     $field     = 'items_id';
                 }
         }
 
-        return ['condition' => $condition,
-            'table'     => $table,
-            'field'     => $field,
-            'type'      => $type
+        return [
+            'criteria' => $criteria,
+            'field' => $field,
+            'type' => $type
         ];
     }
 
-
-    /**
-     * @since 0.85
-     *
-     * @see CommonDBTM::getMassiveActionsForItemtype()
-     **/
     public static function getMassiveActionsForItemtype(
         array &$actions,
         $itemtype,
@@ -1116,24 +1189,19 @@ class Lock extends CommonGLPI
 
         if (
             Session::haveRight(strtolower($itemtype), UPDATE)
-            && in_array($itemtype, $CFG_GLPI['inventory_types'] + $CFG_GLPI['inventory_lockable_objects'])
+            && in_array($itemtype, $CFG_GLPI['inventory_types'] + $CFG_GLPI['inventory_lockable_objects'], true)
         ) {
             $actions[$action_unlock_component] = __('Unlock components');
             $actions[$action_unlock_fields] = __('Unlock fields');
         }
     }
 
-
-    /**
-     * @since 0.85
-     *
-     * @see CommonDBTM::showMassiveActionsSubForm()
-     **/
     public static function showMassiveActionsSubForm(MassiveAction $ma)
     {
         switch ($ma->getAction()) {
             case 'unlock_component':
-                $types = ['Monitor'                => _n('Monitor', 'Monitors', Session::getPluralNumber()),
+                $types = [
+                    'Monitor'                => _n('Monitor', 'Monitors', Session::getPluralNumber()),
                     'Peripheral'             => Peripheral::getTypeName(Session::getPluralNumber()),
                     'Printer'                => Printer::getTypeName(Session::getPluralNumber()),
                     'SoftwareVersion'        => SoftwareVersion::getTypeName(Session::getPluralNumber()),
@@ -1182,12 +1250,6 @@ class Lock extends CommonGLPI
         return false;
     }
 
-
-    /**
-     * @since 0.85
-     *
-     * @see CommonDBTM::processMassiveActionsForOneItemtype()
-     **/
     public static function processMassiveActionsForOneItemtype(
         MassiveAction $ma,
         CommonDBTM $baseitem,
@@ -1204,7 +1266,7 @@ class Lock extends CommonGLPI
                     foreach ($ids as $id) {
                         $lock_fields_name = [];
                         foreach ($input['attached_fields'] as $fields) {
-                            list($itemtype, $field) = explode(' - ', $fields);
+                            [, $field] = explode(' - ', $fields);
                             $lock_fields_name[] = $field;
                         }
                         $lockfield = new Lockedfield();
@@ -1226,7 +1288,7 @@ class Lock extends CommonGLPI
                 $input = $ma->getInput();
                 if (isset($input['attached_item'])) {
                     $attached_items = $input['attached_item'];
-                    if (($device_key = array_search('Device', $attached_items)) !== false) {
+                    if (($device_key = array_search('Device', $attached_items, true)) !== false) {
                         unset($attached_items[$device_key]);
                         $attached_items = array_merge($attached_items, Item_Devices::getDeviceTypes());
                     }
@@ -1241,15 +1303,15 @@ class Lock extends CommonGLPI
                     foreach ($ids as $id) {
                         $action_valid = false;
                         foreach ($links as $infos) {
-                            $infos['condition'][$infos['field']] = $id;
-                            $locked_items = $DB->request($infos['table'], $infos['condition']);
+                            $infos['criteria']['WHERE'][$infos['field']] = $id;
+                            $locked_items = $DB->request($infos['criteria']);
 
                             if ($locked_items->count() === 0) {
                                 $action_valid = true;
                                 continue;
                             }
                             foreach ($locked_items as $data) {
-                             // Restore without history
+                                // Restore without history
                                 $action_valid = $infos['item']->restore(['id' => $data['id']]);
                             }
                         }

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -671,7 +671,7 @@ class Lock extends CommonGLPI
         $networknames = $DB->request([
             'SELECT' => ['glpi_networknames.*'],
             'FROM'  => $networkname::getTable(),
-            'LEFT JOIN' => [ // These joins are used to filter the network names that are linked to the current item's network ports
+            'INNER JOIN' => [ // These joins are used to filter the network names that are linked to the current item's network ports
                 'glpi_networkports' => [
                     'ON' => [
                         'glpi_networknames' => 'items_id',
@@ -728,7 +728,7 @@ class Lock extends CommonGLPI
         $ipaddresses = $DB->request([
             'SELECT' => ['glpi_ipaddresses.*'],
             'FROM'  => $ipaddress::getTable(),
-            'LEFT JOIN' => [ // These joins are used to filter the IP addresses that are linked to the current item's network ports
+            'INNER JOIN' => [ // These joins are used to filter the IP addresses that are linked to the current item's network ports
                 'glpi_networknames' => [
                     'ON' => [
                         'glpi_ipaddresses' => 'items_id',
@@ -1054,7 +1054,7 @@ class Lock extends CommonGLPI
                 $criteria = [
                     'SELECT' => ['glpi_networknames.id'],
                     'FROM' => 'glpi_networknames',
-                    'LEFT JOIN' => [
+                    'INNER JOIN' => [
                         'glpi_networkports' => [
                             'ON' => [
                                 'glpi_networknames' => 'items_id',
@@ -1079,7 +1079,7 @@ class Lock extends CommonGLPI
                 $criteria = [
                     'SELECT' => ['glpi_ipaddresses.id'],
                     'FROM' => 'glpi_ipaddresses',
-                    'LEFT JOIN' => [
+                    'INNER JOIN' => [
                         'glpi_networknames' => [
                             'ON' => [
                                 'glpi_ipaddresses' => 'items_id',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

- `Lock::getLocksQueryInfosByItemType()` is only used in the Lock class. It was made private.
- Fix static method calls.
- Increase strictness of datatype comparisons.
- Replacement of implicit joins (multiple tables in FROM) with explicit joins. Not likely to affect performance, but implicit joins aren't supported by some DBMS and may be more confusing for some people to read.
- PHPDoc improvements/fixes
- Performance improvements:
  - De-duplicate getting some table names.
  - Replacing preg_match with str_starts_with when only checking if a string starts with another.
  - Reduce number of queries in case where a first query is used to get a list of IDs and then `getFromDB` is called for each ID which in turns retrieves every column. Getting all columns in the first query, followed by using `getFromResultSet` to simply assign the data to `fields` should be much faster.
  - Only request the required column in `getLocksQueryInfosByItemType` (method only used by massive actions and only needs the ID).