### PR TITLE
Review and clean some notification code

### DIFF
--- a/src/NotificationAjaxSetting.php
+++ b/src/NotificationAjaxSetting.php
@@ -43,18 +43,15 @@ class NotificationAjaxSetting extends NotificationSetting
         return __('Browser followups configuration');
     }
 
-
     public function getEnableLabel()
     {
         return __('Enable followups from browser');
     }
 
-
     public static function getMode()
     {
         return Notification_NotificationTemplate::MODE_AJAX;
     }
-
 
     public function showFormConfig()
     {

--- a/src/NotificationEventAbstract.php
+++ b/src/NotificationEventAbstract.php
@@ -115,8 +115,8 @@ abstract class NotificationEventAbstract implements NotificationEventInterface
                                 )
                             ) {
                                 //Send notification to the user
-                                if ($label == '') {
-                                    $itemtype = $item->getType();
+                                if ($label === '') {
+                                    $itemtype = $item::class;
                                     $items_id = method_exists($item, "getID") ? max($item->getID(), 0) : 0;
 
                                     $send_data = $template->getDataToSend(
@@ -132,14 +132,15 @@ abstract class NotificationEventAbstract implements NotificationEventInterface
                                     $send_data['_entities_id']              = $entity;
                                     $send_data['mode']                      = $data['mode'];
                                     $send_data['event']                     = $event;
-                                    $send_data['attach_documents']          = $data['attach_documents'] == NotificationSetting::ATTACH_INHERIT
+                                    $send_data['attach_documents']          = $data['attach_documents'] === NotificationSetting::ATTACH_INHERIT
                                         ? $CFG_GLPI['attach_ticket_documents_to_mail']
                                         : $data['attach_documents'];
-                                    $send_data['itemtype_trigger']          = $trigger !== null ? $trigger->getType() : $itemtype;
+                                    $send_data['itemtype_trigger']          = $trigger !== null ? $trigger::class : $itemtype;
                                     $send_data['items_id_trigger']          = $trigger !== null ? $trigger->getID() : $items_id;
 
                                     Notification::send($send_data);
                                 } else {
+                                    // This is only used in the debug tab of some forms
                                     $notificationtarget->getFromDB($target['id']);
                                     echo "<tr class='tab_bg_2'><td>" . $label . "</td>";
                                     echo "<td>" . $notificationtarget->getNameID() . "</td>";

--- a/src/NotificationEventInterface.php
+++ b/src/NotificationEventInterface.php
@@ -110,7 +110,6 @@ interface NotificationEventInterface
      */
     public static function getEntityAdminsData($entity);
 
-
     /**
      * Send notification
      *

--- a/src/NotificationTemplateTranslation.php
+++ b/src/NotificationTemplateTranslation.php
@@ -63,36 +63,26 @@ class NotificationTemplateTranslation extends CommonDBChild
         return 'id';
     }
 
-    /**
-     * @since 0.84
-     **/
     public function getForbiddenStandardMassiveAction()
     {
-
         $forbidden   = parent::getForbiddenStandardMassiveAction();
         $forbidden[] = 'update';
         return $forbidden;
     }
-
 
     protected function computeFriendlyName()
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        if ($this->getField('language') != '') {
+        if ($this->getField('language') !== '') {
             return $CFG_GLPI['languages'][$this->getField('language')][0];
-        } else {
-            return __('Default translation');
         }
-
-        return '';
+        return __('Default translation');
     }
-
 
     public function defineTabs($options = [])
     {
-
         $ong = [];
         $this->addDefaultFormTab($ong);
         $this->addStandardTab('Log', $ong, $options);
@@ -100,16 +90,12 @@ class NotificationTemplateTranslation extends CommonDBChild
         return $ong;
     }
 
-
     public function showForm($ID, array $options = [])
     {
         if (!Config::canUpdate()) {
             return false;
         }
-        $notificationtemplates_id = -1;
-        if (isset($options['notificationtemplates_id'])) {
-            $notificationtemplates_id = $options['notificationtemplates_id'];
-        }
+        $notificationtemplates_id = $options['notificationtemplates_id'] ?? -1;
 
         if ($this->getFromDB($ID)) {
             $notificationtemplates_id = $this->getField('notificationtemplates_id');
@@ -119,15 +105,15 @@ class NotificationTemplateTranslation extends CommonDBChild
 
         TemplateRenderer::getInstance()->display('pages/setup/notification/translation.html.twig', [
             'item' => $this,
-            'template' => $template
+            'template' => $template,
+            'used_languages' => self::getAllUsedLanguages($notificationtemplates_id),
         ]);
         return true;
     }
 
-
     /**
-     * @param $template        NotificationTemplate object
-     * @param $options   array
+     * @param NotificationTemplate $template object
+     * @param array $options
      **/
     public function showSummary(NotificationTemplate $template, $options = [])
     {
@@ -192,7 +178,7 @@ class NotificationTemplateTranslation extends CommonDBChild
                 echo "<a href='" . Toolbox::getItemTypeFormURL('NotificationTemplateTranslation') .
                   "?id=" . $data['id'] . "&amp;notificationtemplates_id=" . $nID . "'>";
 
-                if ($data['language'] != '') {
+                if ($data['language'] !== '') {
                     echo $CFG_GLPI['languages'][$data['language']][0];
                 } else {
                     echo __('Default translation');
@@ -211,37 +197,34 @@ class NotificationTemplateTranslation extends CommonDBChild
         echo "</div>";
     }
 
-
     /**
-     * @param $input  array
+     * @param array $input
+     * @return array
      */
     public static function cleanContentHtml(array $input)
     {
-       // Get as text plain text
+        // Get as text plain text
         $txt = RichText::getTextFromHtml($input['content_html'], true, false, false, true);
 
         if (!$txt) {
-           // No HTML (nothing to display)
+            // No HTML (nothing to display)
             $input['content_html'] = '';
         } else if (!$input['content_text']) {
-           // Use cleaned HTML
+            // Use cleaned HTML
             $input['content_text'] = $txt;
         }
         return $input;
     }
-
 
     public function prepareInputForAdd($input)
     {
         return parent::prepareInputForAdd(self::cleanContentHtml($input));
     }
 
-
     public function prepareInputForUpdate($input)
     {
         return parent::prepareInputForUpdate(self::cleanContentHtml($input));
     }
-
 
     public function post_addItem()
     {
@@ -256,7 +239,6 @@ class NotificationTemplateTranslation extends CommonDBChild
         parent::post_addItem();
     }
 
-
     public function post_updateItem($history = true)
     {
         // Handle rich-text images and uploaded documents
@@ -270,7 +252,6 @@ class NotificationTemplateTranslation extends CommonDBChild
         parent::post_updateItem($history);
     }
 
-
     public function rawSearchOptions()
     {
         $tab = [];
@@ -282,7 +263,7 @@ class NotificationTemplateTranslation extends CommonDBChild
 
         $tab[] = [
             'id'                 => '1',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'language',
             'name'               => __('Language'),
             'datatype'           => 'language',
@@ -291,7 +272,7 @@ class NotificationTemplateTranslation extends CommonDBChild
 
         $tab[] = [
             'id'                 => '2',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'subject',
             'name'               => __('Subject'),
             'massiveaction'      => false,
@@ -300,7 +281,7 @@ class NotificationTemplateTranslation extends CommonDBChild
 
         $tab[] = [
             'id'                 => '3',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'content_html',
             'name'               => __('Email HTML body'),
             'datatype'           => 'text',
@@ -310,7 +291,7 @@ class NotificationTemplateTranslation extends CommonDBChild
 
         $tab[] = [
             'id'                 => '4',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'content_text',
             'name'               => __('Email text body'),
             'datatype'           => 'text',
@@ -320,21 +301,26 @@ class NotificationTemplateTranslation extends CommonDBChild
         return $tab;
     }
 
-
     /**
      * @param $language_id
-     **/
+     * @return array
+     */
     public static function getAllUsedLanguages($language_id)
     {
+        /**
+         * @var \DBmysql $DB
+         */
+        global $DB;
 
-        $used_languages = getAllDataFromTable(
-            'glpi_notificationtemplatetranslations',
-            [
+        $used_languages = $DB->request([
+            'SELECT' => ['language'],
+            'FROM' => 'glpi_notificationtemplatetranslations',
+            'WHERE' => [
                 'notificationtemplates_id' => $language_id
             ]
-        );
-        $used           = [];
+        ]);
 
+        $used           = [];
         foreach ($used_languages as $used_language) {
             $used[$used_language['language']] = $used_language['language'];
         }
@@ -342,9 +328,9 @@ class NotificationTemplateTranslation extends CommonDBChild
         return $used;
     }
 
-
     /**
      * @param $itemtype
+     * @return void
      **/
     public static function showAvailableTags($itemtype)
     {
@@ -362,7 +348,7 @@ class NotificationTemplateTranslation extends CommonDBChild
 
         $rows = [];
         foreach ($tags as $tag => $values) {
-            if ($values['events'] == NotificationTarget::TAG_FOR_ALL_EVENTS) {
+            if ($values['events'] === NotificationTarget::TAG_FOR_ALL_EVENTS) {
                 $event = __('All');
             } else {
                 $event = implode(', ', $values['events']);
@@ -380,18 +366,18 @@ class NotificationTemplateTranslation extends CommonDBChild
                 $allowed_values = '';
             }
 
-            if ($values['type'] == NotificationTarget::TAG_LANGUAGE) {
+            if ($values['type'] === NotificationTarget::TAG_LANGUAGE) {
                 $label = sprintf(__('%1$s: %2$s'), __('Label'), $values['label']);
             } else {
                 $label = $values['label'];
             }
             $rows[] = [
                 'values' => [
-                    ['content' => $tag],
-                    ['content' => $label],
-                    ['content' => $event],
-                    ['content' => $action],
-                    ['content' => $allowed_values],
+                    ['content' => htmlspecialchars($tag)],
+                    ['content' => htmlspecialchars($label)],
+                    ['content' => htmlspecialchars($event)],
+                    ['content' => htmlspecialchars($action)],
+                    ['content' => htmlspecialchars($allowed_values)],
                 ]
             ];
         }
@@ -411,37 +397,33 @@ class NotificationTemplateTranslation extends CommonDBChild
         ]);
     }
 
-
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
 
         if (!$withtemplate) {
             $nb = 0;
-            switch ($item->getType()) {
+            switch ($item::class) {
                 case 'NotificationTemplate':
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = countElementsInTable(
-                            $this->getTable(),
+                            static::getTable(),
                             ['notificationtemplates_id' => $item->getID()]
                         );
                     }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
             }
         }
         return '';
     }
 
-
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
     {
-
-        if ($item->getType() == 'NotificationTemplate') {
+        if ($item::class === NotificationTemplate::class) {
             $temp = new self();
             $temp->showSummary($item);
         }
         return true;
     }
-
 
     /**
      * Display debug information for current object
@@ -465,29 +447,30 @@ class NotificationTemplateTranslation extends CommonDBChild
             'Problem', 'Project', 'Ticket', 'User'
         ];
 
-        if (!in_array($itemtype, $oktypes)) {
+        if (!in_array($itemtype, $oktypes, true)) {
             // this itemtype doesn't work, need to be fixed
             return;
         }
 
         // Criteria Form
-        $key   = getForeignKeyFieldForItemType($item->getType());
+        $key   = getForeignKeyFieldForItemType($item::class);
         $id    = Session::getSavedOption(__CLASS__, $key, 0);
         $event = Session::getSavedOption(__CLASS__, $key . '_event', '');
 
 
         $data = null;
 
-       // Preview
+        // Preview
         if ($event && $item->getFromDB($id)) {
             $options = ['_debug' => true];
 
             // TODO Awfull Hack waiting for https://forge.indepnet.net/issues/3439
+            //TODO Is this supposed to refer to notifications that are grouped together? For example, one notification about all certificates expiring? This may not be up to date.
             $multi   = ['alert', 'alertnotclosed', 'end', 'notice',
                 'periodicity', 'periodicitynotice'
             ];
-            if (in_array($event, $multi)) {
-             // Won't work for Cardridge and Consumable
+            if (in_array($event, $multi, true)) {
+                // Won't work for Cardridge and Consumable
                 $options['entities_id'] = $item->getEntityID();
                 $options['items']       = [$item->getID() => $item->fields];
             }
@@ -502,7 +485,6 @@ class NotificationTemplateTranslation extends CommonDBChild
                 $data = $template->templates_by_languages[$tid];
             }
         }
-        echo "</table></div>";
         TemplateRenderer::getInstance()->display('pages/setup/notification/translation_debug.html.twig', [
             'template' => $template,
             'data' => $data

--- a/src/Notification_NotificationTemplate.php
+++ b/src/Notification_NotificationTemplate.php
@@ -132,7 +132,7 @@ class Notification_NotificationTemplate extends CommonDBRelation
 
         if (
             $canedit
-            && !(!empty($withtemplate) && ($withtemplate === 2))
+            && !(!empty($withtemplate) && ((int)$withtemplate === 2))
         ) {
             echo "<div class='center firstbloc'>" .
                "<a class='btn btn-primary' href='" . self::getFormURL() . "?notifications_id=$ID&amp;withtemplate=" .

--- a/src/Notification_NotificationTemplate.php
+++ b/src/Notification_NotificationTemplate.php
@@ -69,24 +69,24 @@ class Notification_NotificationTemplate extends CommonDBRelation
 
         if (!$withtemplate && Notification::canView()) {
             $nb = 0;
-            switch ($item->getType()) {
+            switch ($item::class) {
                 case Notification::class:
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = countElementsInTable(
-                            $this->getTable(),
+                            static::getTable(),
                             ['notifications_id' => $item->getID()]
                         );
                     }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
                 break;
                 case NotificationTemplate::class:
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = countElementsInTable(
-                            $this->getTable(),
+                            static::getTable(),
                             ['notificationtemplates_id' => $item->getID()]
                         );
                     }
-                    return self::createTabEntry(Notification::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                    return self::createTabEntry(Notification::getTypeName(Session::getPluralNumber()), $nb, $item::class);
                 break;
             }
         }
@@ -106,7 +106,6 @@ class Notification_NotificationTemplate extends CommonDBRelation
 
         return true;
     }
-
 
     /**
      * Print the notification templates
@@ -133,7 +132,7 @@ class Notification_NotificationTemplate extends CommonDBRelation
 
         if (
             $canedit
-            && !(!empty($withtemplate) && ($withtemplate == 2))
+            && !(!empty($withtemplate) && ($withtemplate === 2))
         ) {
             echo "<div class='center firstbloc'>" .
                "<a class='btn btn-primary' href='" . self::getFormURL() . "?notifications_id=$ID&amp;withtemplate=" .
@@ -207,7 +206,6 @@ class Notification_NotificationTemplate extends CommonDBRelation
         echo "</div>";
     }
 
-
     /**
      * Print associated notifications
      *
@@ -264,14 +262,12 @@ class Notification_NotificationTemplate extends CommonDBRelation
         ]);
     }
 
-
     /**
      * Form for Notification on Massive action
      **/
     public static function showFormMassiveAction()
     {
-
-        echo __('Mode') . "<br>";
+        echo __s('Mode') . "<br>";
         self::dropdownMode(['name' => 'mode']);
         echo "<br><br>";
 
@@ -286,12 +282,10 @@ class Notification_NotificationTemplate extends CommonDBRelation
         echo Html::submit(_x('button', 'Add'), ['name' => 'massiveaction']);
     }
 
-
     public function getName($options = [])
     {
         return $this->getID();
     }
-
 
     /**
      * Print the form
@@ -327,21 +321,17 @@ class Notification_NotificationTemplate extends CommonDBRelation
         return true;
     }
 
-
     /**
      * Get notification method label
      *
      * @param string $mode the mode to use
      *
-     * @return array
+     * @return array|string The mode data if found, otherwise {@link NOT_AVAILABLE}.
      **/
     public static function getMode($mode)
     {
         $tab = self::getModes();
-        if (isset($tab[$mode])) {
-            return $tab[$mode];
-        }
-        return NOT_AVAILABLE;
+        return $tab[$mode] ?? NOT_AVAILABLE;
     }
 
     /**
@@ -397,7 +387,7 @@ class Notification_NotificationTemplate extends CommonDBRelation
         if (!isset($CFG_GLPI['notifications_modes']) || !is_array($CFG_GLPI['notifications_modes'])) {
             $CFG_GLPI['notifications_modes'] = $core_modes;
         } else {
-           //check that core modes are part of the config
+            // check that core modes are part of the config
             foreach ($core_modes as $mode => $conf) {
                 if (!isset($CFG_GLPI['notifications_modes'][$mode])) {
                     $CFG_GLPI['notifications_modes'][$mode] = $conf;
@@ -407,7 +397,6 @@ class Notification_NotificationTemplate extends CommonDBRelation
 
         return $CFG_GLPI['notifications_modes'];
     }
-
 
     public static function getSpecificValueToDisplay($field, $values, array $options = [])
     {
@@ -427,10 +416,8 @@ class Notification_NotificationTemplate extends CommonDBRelation
         return parent::getSpecificValueToDisplay($field, $values, $options);
     }
 
-
     public static function getSpecificValueToSelect($field, $name = '', $values = '', array $options = [])
     {
-
         if (!is_array($values)) {
             $values = [$field => $values];
         }
@@ -444,7 +431,6 @@ class Notification_NotificationTemplate extends CommonDBRelation
         }
         return parent::getSpecificValueToSelect($field, $name, $values, $options);
     }
-
 
     /**
      * Display a dropdown with all the available notification modes
@@ -479,24 +465,25 @@ class Notification_NotificationTemplate extends CommonDBRelation
      * Get class name for specified mode
      *
      * @param string $mode      Requested mode
-     * @param string $extratype Extra type (either 'event' or 'setting')
+     * @param 'event'|'setting' $extratype Extra type (either 'event' or 'setting')
      *
      * @return string
+     * @phpstan-return $extratype === 'event' ? class-string<NotificationEventInterface> : class-string<NotificationSetting>
      */
     public static function getModeClass($mode, $extratype = '')
     {
-        if ($extratype == 'event') {
+        if ($extratype === 'event') {
             $classname = 'NotificationEvent' . ucfirst($mode);
-        } else if ($extratype == 'setting') {
+        } else if ($extratype === 'setting') {
             $classname = 'Notification' . ucfirst($mode) . 'Setting';
         } else {
-            if ($extratype != '') {
+            if ($extratype !== '') {
                 throw new \LogicException(sprintf('Unknown type `%s`.', $extratype));
             }
             $classname = 'Notification' . ucfirst($mode);
         }
         $conf = self::getMode($mode);
-        if ($conf['from'] != 'core') {
+        if ($conf['from'] !== 'core') {
             $classname = 'Plugin' . ucfirst($conf['from']) . $classname;
         }
         return $classname;

--- a/src/QueuedNotification.php
+++ b/src/QueuedNotification.php
@@ -50,19 +50,16 @@ class QueuedNotification extends CommonDBTM
         return __('Notification queue');
     }
 
-
     public static function canCreate()
     {
-       // Everybody can create : human and cron
+        // Everybody can create : human and cron
         return Session::getLoginUserID(false);
     }
-
 
     public static function getForbiddenActionsForMenu()
     {
         return ['add'];
     }
-
 
     public function getForbiddenStandardMassiveAction()
     {
@@ -83,12 +80,8 @@ class QueuedNotification extends CommonDBTM
         return $forbidden;
     }
 
-    /**
-     * @see CommonDBTM::getSpecificMassiveActions()
-     **/
     public function getSpecificMassiveActions($checkitem = null, $is_deleted = false)
     {
-
         $isadmin = static::canUpdate();
         $actions = parent::getSpecificMassiveActions($checkitem);
 
@@ -99,10 +92,6 @@ class QueuedNotification extends CommonDBTM
         return $actions;
     }
 
-
-    /**
-     * @see CommonDBTM::processMassiveActionsForOneItemtype()
-     **/
     public static function processMassiveActionsForOneItemtype(
         MassiveAction $ma,
         CommonDBTM $item,
@@ -128,13 +117,12 @@ class QueuedNotification extends CommonDBTM
         parent::processMassiveActionsForOneItemtype($ma, $item, $ids);
     }
 
-
     public function prepareInputForAdd($input)
     {
-        if (!isset($input['create_time']) || empty($input['create_time'])) {
+        if (empty($input['create_time'])) {
             $input['create_time'] = $_SESSION["glpi_currenttime"];
         }
-        if (!isset($input['send_time']) || empty($input['send_time'])) {
+        if (empty($input['send_time'])) {
             $toadd = 0;
             if (isset($input['entities_id'])) {
                 $toadd = Entity::getUsedConfig('delay_send_emails', $input['entities_id']);
@@ -163,13 +151,12 @@ class QueuedNotification extends CommonDBTM
         }
 
        // Force items_id to integer
-        if (!isset($input['items_id']) || empty($input['items_id'])) {
+        if (empty($input['items_id'])) {
             $input['items_id'] = 0;
         }
 
         return $input;
     }
-
 
     public function rawSearchOptions()
     {
@@ -182,7 +169,7 @@ class QueuedNotification extends CommonDBTM
 
         $tab[] = [
             'id'                 => '1',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'name',
             'name'               => __('Subject'),
             'datatype'           => 'itemlink',
@@ -191,7 +178,7 @@ class QueuedNotification extends CommonDBTM
 
         $tab[] = [
             'id'                 => '2',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'id',
             'name'               => __('ID'),
             'massiveaction'      => false,
@@ -200,7 +187,7 @@ class QueuedNotification extends CommonDBTM
 
         $tab[] = [
             'id'                 => '16',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'create_time',
             'name'               => __('Creation date'),
             'datatype'           => 'datetime',
@@ -209,7 +196,7 @@ class QueuedNotification extends CommonDBTM
 
         $tab[] = [
             'id'                 => '3',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'send_time',
             'name'               => __('Expected send date'),
             'datatype'           => 'datetime',
@@ -218,7 +205,7 @@ class QueuedNotification extends CommonDBTM
 
         $tab[] = [
             'id'                 => '4',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'sent_time',
             'name'               => __('Send date'),
             'datatype'           => 'datetime',
@@ -227,7 +214,7 @@ class QueuedNotification extends CommonDBTM
 
         $tab[] = [
             'id'                 => '5',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'sender',
             'name'               => __('Sender email'),
             'datatype'           => 'text',
@@ -236,7 +223,7 @@ class QueuedNotification extends CommonDBTM
 
         $tab[] = [
             'id'                 => '6',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'sendername',
             'name'               => __('Sender name'),
             'datatype'           => 'string',
@@ -245,7 +232,7 @@ class QueuedNotification extends CommonDBTM
 
         $tab[] = [
             'id'                 => '7',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'recipient',
             'name'               => __('Recipient email'),
             'datatype'           => 'string',
@@ -254,7 +241,7 @@ class QueuedNotification extends CommonDBTM
 
         $tab[] = [
             'id'                 => '8',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'recipientname',
             'name'               => __('Recipient name'),
             'datatype'           => 'string',
@@ -263,7 +250,7 @@ class QueuedNotification extends CommonDBTM
 
         $tab[] = [
             'id'                 => '9',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'replyto',
             'name'               => __('Reply-To email'),
             'datatype'           => 'string',
@@ -272,7 +259,7 @@ class QueuedNotification extends CommonDBTM
 
         $tab[] = [
             'id'                 => '10',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'replytoname',
             'name'               => __('Reply-To name'),
             'datatype'           => 'string',
@@ -281,7 +268,7 @@ class QueuedNotification extends CommonDBTM
 
         $tab[] = [
             'id'                 => '11',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'headers',
             'name'               => __('Additional headers'),
             'datatype'           => 'specific',
@@ -290,7 +277,7 @@ class QueuedNotification extends CommonDBTM
 
         $tab[] = [
             'id'                 => '12',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'body_html',
             'name'               => __('Email HTML body'),
             'datatype'           => 'text',
@@ -300,7 +287,7 @@ class QueuedNotification extends CommonDBTM
 
         $tab[] = [
             'id'                 => '13',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'body_text',
             'name'               => __('Email text body'),
             'datatype'           => 'text',
@@ -309,7 +296,7 @@ class QueuedNotification extends CommonDBTM
 
         $tab[] = [
             'id'                 => '14',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'messageid',
             'name'               => __('Message ID'),
             'datatype'           => 'string',
@@ -318,7 +305,7 @@ class QueuedNotification extends CommonDBTM
 
         $tab[] = [
             'id'                 => '15',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'sent_try',
             'name'               => __('Number of tries of sent'),
             'datatype'           => 'integer',
@@ -327,7 +314,7 @@ class QueuedNotification extends CommonDBTM
 
         $tab[] = [
             'id'                 => '20',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'itemtype',
             'name'               => _n('Type', 'Types', 1),
             'datatype'           => 'itemtypename',
@@ -336,7 +323,7 @@ class QueuedNotification extends CommonDBTM
 
         $tab[] = [
             'id'                 => '21',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'items_id',
             'name'               => __('Associated item ID'),
             'massiveaction'      => false,
@@ -377,15 +364,8 @@ class QueuedNotification extends CommonDBTM
         return $tab;
     }
 
-
-    /**
-     * @param $field
-     * @param $values
-     * @param $options   array
-     **/
     public static function getSpecificValueToDisplay($field, $values, array $options = [])
     {
-
         if (!is_array($values)) {
             $values = [$field => $values];
         }
@@ -399,15 +379,11 @@ class QueuedNotification extends CommonDBTM
                     }
                 }
                 return $out;
-            break;
             case 'mode':
-                $out = Notification_NotificationTemplate::getMode($values[$field])['label'];
-                return $out;
-            break;
+                return Notification_NotificationTemplate::getMode($values[$field])['label'];
         }
         return parent::getSpecificValueToDisplay($field, $values, $options);
     }
-
 
     public static function getSpecificValueToSelect($field, $name = '', $values = '', array $options = [])
     {
@@ -425,7 +401,6 @@ class QueuedNotification extends CommonDBTM
         return parent::getSpecificValueToSelect($field, $name, $values, $options);
     }
 
-
     /**
      * Send notification in queue
      *
@@ -439,16 +414,15 @@ class QueuedNotification extends CommonDBTM
             $mode = $this->getField('mode');
             $eventclass = 'NotificationEvent' . ucfirst($mode);
             $conf = Notification_NotificationTemplate::getMode($mode);
-            if ($conf['from'] != 'core') {
+            if ($conf['from'] !== 'core') {
                 $eventclass = 'Plugin' . ucfirst($conf['from']) . $eventclass;
             }
 
             return $eventclass::send([$this->fields]);
-        } else {
-            return false;
         }
-    }
 
+        return false;
+    }
 
     /**
      * Give cron information
@@ -459,24 +433,21 @@ class QueuedNotification extends CommonDBTM
      **/
     public static function cronInfo($name)
     {
-
-        switch ($name) {
-            case 'queuednotification':
-                return ['description' => __('Send mails in queue'),
-                    'parameter'   => __('Maximum emails to send at once')
-                ];
-
-            case 'queuednotificationclean':
-                return ['description' => __('Clean notification queue'),
-                    'parameter'   => __('Days to keep sent emails')
-                ];
-
-            case 'queuednotificationcleanstaleajax':
-                return ['description' => __('Clean stale queued browser notifications')];
-        }
-        return [];
+        return match ($name) {
+            'queuednotification' => [
+                'description' => __('Send mails in queue'),
+                'parameter' => __('Maximum emails to send at once')
+            ],
+            'queuednotificationclean' => [
+                'description' => __('Clean notification queue'),
+                'parameter' => __('Days to keep sent emails')
+            ],
+            'queuednotificationcleanstaleajax' => [
+                'description' => __('Clean stale queued browser notifications')
+            ],
+            default => [],
+        };
     }
-
 
     /**
      * Get pending notifications in queue
@@ -516,12 +487,12 @@ class QueuedNotification extends CommonDBTM
         $modes = Notification_NotificationTemplate::getModes();
         foreach ($modes as $mode => $conf) {
             $eventclass = 'NotificationEvent' . ucfirst($mode);
-            if ($conf['from'] != 'core') {
+            if ($conf['from'] !== 'core') {
                 $eventclass = 'Plugin' . ucfirst($conf['from']) . $eventclass;
             }
 
             if (
-                $limit_modes !== null && !in_array($mode, $limit_modes)
+                ($limit_modes !== null && !in_array($mode, $limit_modes, true))
                 || !$CFG_GLPI['notifications_' . $mode]
                 || !$eventclass::canCron()
             ) {
@@ -544,13 +515,13 @@ class QueuedNotification extends CommonDBTM
         return $pendings;
     }
 
-
     /**
      * Cron action on notification queue: send notifications in queue
      *
      * @param CommonDBTM $task for log (default NULL)
      *
      * @return integer either 0 or 1
+     * @used-by CronTask
      **/
     public static function cronQueuedNotification($task = null)
     {
@@ -570,7 +541,7 @@ class QueuedNotification extends CommonDBTM
         foreach ($pendings as $mode => $data) {
             $eventclass = 'NotificationEvent' . ucfirst($mode);
             $conf = Notification_NotificationTemplate::getMode($mode);
-            if ($conf['from'] != 'core') {
+            if ($conf['from'] !== 'core') {
                 $eventclass = 'Plugin' . ucfirst($conf['from']) . $eventclass;
             }
 
@@ -586,13 +557,13 @@ class QueuedNotification extends CommonDBTM
         return $cron_status;
     }
 
-
     /**
      * Cron action on queued notification: clean notification queue
      *
      * @param CommonDBTM $task for log (default NULL)
      *
      * @return integer either 0 or 1
+     * @used-by CronTask
      **/
     public static function cronQueuedNotificationClean($task = null)
     {
@@ -601,7 +572,7 @@ class QueuedNotification extends CommonDBTM
 
         $vol = 0;
 
-       // Expire mails in queue
+        // Expire mails in queue
         if ($task->fields['param'] > 0) {
             $secs      = $task->fields['param'] * DAY_TIMESTAMP;
             $send_time = date("U") - $secs;
@@ -609,7 +580,7 @@ class QueuedNotification extends CommonDBTM
                 self::getTable(),
                 [
                     'is_deleted'   => 1,
-                    new QueryExpression('(UNIX_TIMESTAMP(' . $DB->quoteName('send_time') . ') < ' . $DB->quoteValue($send_time) . ')')
+                    new QueryExpression(QueryFunction::unixTimestamp('send_time') . ' < ' . $DB::quoteValue($send_time)),
                 ]
             );
             $vol = $DB->affectedRows();
@@ -619,13 +590,13 @@ class QueuedNotification extends CommonDBTM
         return ($vol > 0 ? 1 : 0);
     }
 
-
     /**
      * Cron action on queued notification: clean stale ajax notification queue
      *
      * @param CommonDBTM $task for log (default NULL)
      *
      * @return integer either 0 or 1
+     * @used-by CronTask
      **/
     public static function cronQueuedNotificationCleanStaleAjax($task = null)
     {
@@ -661,7 +632,6 @@ class QueuedNotification extends CommonDBTM
         return ($vol > 0 ? 1 : 0);
     }
 
-
     /**
      * Force sending all mails in queue for a specific item
      *
@@ -672,15 +642,10 @@ class QueuedNotification extends CommonDBTM
      **/
     public static function forceSendFor($itemtype, $items_id)
     {
-        if (
-            !empty($itemtype)
-            && !empty($items_id)
-        ) {
+        if (!empty($itemtype) && !empty($items_id)) {
             $pendings = self::getPendings(
-                null,
-                1,
-                null,
-                [
+                limit: 1,
+                extra_where: [
                     'itemtype'  => $itemtype,
                     'items_id'  => $items_id
                 ]
@@ -692,7 +657,6 @@ class QueuedNotification extends CommonDBTM
             }
         }
     }
-
 
     /**
      * Print the queued mail form
@@ -812,15 +776,13 @@ class QueuedNotification extends CommonDBTM
         return true;
     }
 
-
     /**
-     * @since 0.85
-     *
      * @param $string
-     **/
+     * @return string
+     * @since 0.85
+     */
     public static function cleanHtml($string)
     {
-
         $begin_strip     = -1;
         $end_strip       = -1;
         $begin_match     = "/<body>/";
@@ -828,7 +790,7 @@ class QueuedNotification extends CommonDBTM
         $content         = explode("\n", $string);
         $newstring       = '';
         foreach ($content as $ID => $val) {
-           // Get last tag for end
+            // Get last tag for end
             if ($begin_strip >= 0) {
                 if (preg_match($end_match, $val)) {
                     $end_strip = $ID;
@@ -838,7 +800,7 @@ class QueuedNotification extends CommonDBTM
             if (($begin_strip >= 0) && ($end_strip < 0)) {
                 $newstring .= $val;
             }
-           // Get first tag for begin
+            // Get first tag for begin
             if ($begin_strip < 0) {
                 if (preg_match($begin_match, $val)) {
                     $begin_strip = $ID;
@@ -847,7 +809,6 @@ class QueuedNotification extends CommonDBTM
         }
         return $newstring;
     }
-
 
     public static function getIcon()
     {

--- a/templates/pages/setup/notification/translation.html.twig
+++ b/templates/pages/setup/notification/translation.html.twig
@@ -55,6 +55,7 @@
 
    {{ fields.htmlField('', call('Dropdown::showLanguages', ['language', {
       value: item.fields['language'],
+      used: used_languages,
       display_emptychoice: true,
       emptylabel: __('Default translation'),
       display: false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

UI migrations to twig to come in another PR.
- Cleanup/modernization of some notification code
- Some sanitization done in places that won't be migrated to Twig/used in Twig now but are output as raw values
- Fix for already used template translation languages showing up in the language dropdown for a new translation (missing since 9.5.6)