### PR TITLE
Improve form editors margins

### DIFF
--- a/css/includes/components/_content-editable-inputs.scss
+++ b/css/includes/components/_content-editable-inputs.scss
@@ -65,28 +65,7 @@ $inline-input-padding: 2px 4px;
     box-shadow: none;
 }
 
-// Fix some weird margin issue due to the fact that part of a question form
-// is hidden using visibility: hidden and opacity: 0, which cause internal
-// negative margin to have unwanted effect on the parent container
-// TODO: need some E2E tests to make sure these margins are not broken
-[data-glpi-form-editor-question-description][data-glpi-form-editor-question-extra-details].content-editable-tinymce {
-    margin-bottom: 0 !important;
-}
-
-[data-glpi-form-editor-question].active {
-    .content-editable-tinymce.simulate-focus {
-        margin-bottom: 8px !important;
-    }
-}
-
-[data-glpi-form-editor-question].active [data-glpi-form-editor-question-description][data-glpi-form-editor-question-extra-details].content-editable-tinymce:not(.simulate-focus) {
-    margin-bottom: -1rem !important;
-}
-
 .content-editable-tinymce {
-    // Override some hard-set tinymce margins
-    margin-bottom: -1rem !important;
-
     // Remove default border and padding, add similar hover style used on our inputs
     .tox-tinymce {
         border-color: transparent !important;
@@ -113,6 +92,7 @@ $inline-input-padding: 2px 4px;
         opacity: 0;
         height: 0 !important;
         transition: height 0.25s ease !important;
+        padding: 0 !important;
     }
 
     // Override some hard-set tinymce margins
@@ -138,6 +118,7 @@ form:not(.disable-focus) {
             height: 48px !important; // Need to set a fixed height for transition
             transition: height 0.25s ease !important;
             margin-top: 1rem !important;
+            padding: 4px !important;
         }
 
         // Partial revert of margin change in this case as we want to keep the

--- a/js/form_editor_controller.js
+++ b/js/form_editor_controller.js
@@ -136,7 +136,10 @@ class GlpiFormEditorController
         $(document)
             .on(
                 'click',
-                () => this.#setActiveItem(null)
+                () => {
+                    this.#setActiveItem(null);
+                    $('.simulate-focus').removeClass('simulate-focus');
+                }
             );
 
         // Handle tinymce change event

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -66,7 +66,7 @@
     {# Form editor page #}
     {# UX and items placement are a work in progress #}
     {# Need more elements (questions, sections) before finalizing the design #}
-    <div class="form-editor row">
+    <div class="form-editor row flex-reverse">
 
         <div class="designer col-12 px-4 py-3">
             <div class="row">
@@ -126,6 +126,7 @@
                                             'editor_height': "0",
                                             'rows' : 1,
                                             'toolbar_location': 'bottom',
+                                            'mb': 'mb-0',
                                         })
                                     ) }}
                                 </div>
@@ -336,3 +337,11 @@
         "[data-glpi-form-editor-templates]"
     );
 </script>
+
+<style>
+    /* Fix a weird scrolling issue, can't find a better solution at this time */
+    /* Must be inline style to make sure it is only applied to this page */
+    html {
+        overflow: hidden;
+    }
+</style>

--- a/templates/pages/admin/form/form_question.html.twig
+++ b/templates/pages/admin/form/form_question.html.twig
@@ -115,7 +115,7 @@
             </div>
 
             <div
-                class="d-flex align-items-center mt-3"
+                class="d-flex align-items-center mt-2"
                 data-glpi-form-editor-question-extra-details
             >
                 <select

--- a/templates/pages/admin/form/form_section.html.twig
+++ b/templates/pages/admin/form/form_section.html.twig
@@ -50,6 +50,7 @@
 
 <div
     data-glpi-form-editor-section
+    class="mt-4"
 >
     <div
         class="bg-primary px-2 py-1 rounded-top {{ show_section_form ? "" : "d-none" }}"
@@ -156,6 +157,7 @@
                             'rows' : 1,
                             'toolbar_location': 'bottom',
                             'init': section is not null ? true : false,
+                            'mb': 'mb-0',
                         })
                     ) }}
                 </div>


### PR DESCRIPTION
Some margins where not ideal after recent changes.
\+ fixed an annoying scrolling issue.

Before:

![image](https://github.com/glpi-project/glpi/assets/42734840/943fbf4c-e529-420b-8f08-53ea78d2acee)


After:

![image](https://github.com/glpi-project/glpi/assets/42734840/c40f8909-0b88-4e4c-900b-a4d8075f742d)


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 