### PR TITLE
Form destinations: basic configuration

### DIFF
--- a/front/form/destination/formdestination.form.php
+++ b/front/form/destination/formdestination.form.php
@@ -45,9 +45,13 @@ try {
         $destination->check(-1, CREATE, $_POST);
 
         // Create destination item
-        if (!$destination->add($_POST)) {
+        $id = $destination->add($_POST);
+        if (!$id) {
             throw new RuntimeException("Failed to create destination item");
         }
+
+        // Save the ID to reopen the correct accordion item
+        $_SESSION['active_destination'] = $id;
     } elseif (isset($_POST["update"])) {
         // ID is mandatory
         $id = $_POST['id'] ?? null;

--- a/front/form/destination/formdestination.form.php
+++ b/front/form/destination/formdestination.form.php
@@ -48,6 +48,24 @@ try {
         if (!$destination->add($_POST)) {
             throw new RuntimeException("Failed to create destination item");
         }
+    } elseif (isset($_POST["update"])) {
+        // ID is mandatory
+        $id = $_POST['id'] ?? null;
+        if ($id === null) {
+            // Invalid request
+            throw new InvalidArgumentException("Missing id");
+        }
+
+        // Right check
+        $destination->check($id, UPDATE, $_POST);
+
+        // Update destination item
+        if (!$destination->update($_POST)) {
+            throw new RuntimeException("Failed to update destination item");
+        }
+
+        // Save the ID to reopen the correct accordion item
+        $_SESSION['active_destination'] = $id;
     } elseif (isset($_POST["purge"])) {
         // ID is mandatory
         $id = $_POST['id'] ?? null;

--- a/install/migrations/update_10.0.x_to_11.0.0/form.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/form.php
@@ -143,6 +143,7 @@ if (!$DB->tableExists('glpi_forms_destinations_formdestinations')) {
             `forms_forms_id` int {$default_key_sign} NOT NULL DEFAULT '0',
             `itemtype` varchar(255) NOT NULL,
             `name` varchar(255) NOT NULL,
+            `config` longtext COMMENT 'JSON - Extra configuration field(s) depending on the destination type',
             PRIMARY KEY (`id`),
             KEY `name` (`name`),
             KEY `itemtype` (`itemtype`),
@@ -198,4 +199,5 @@ if (GLPI_VERSION == "11.0.0-dev") {
 
     $migration->addField("glpi_forms_answerssets", "entities_id", "fkey");
     $migration->addKey("glpi_forms_answerssets", "entities_id");
+    $migration->addField("glpi_forms_destinations_formdestinations", "config", "longtext COMMENT 'JSON - Extra configuration field(s) depending on the destination type'");
 }

--- a/install/migrations/update_10.0.x_to_11.0.0/form.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/form.php
@@ -143,7 +143,7 @@ if (!$DB->tableExists('glpi_forms_destinations_formdestinations')) {
             `forms_forms_id` int {$default_key_sign} NOT NULL DEFAULT '0',
             `itemtype` varchar(255) NOT NULL,
             `name` varchar(255) NOT NULL,
-            `config` longtext COMMENT 'JSON - Extra configuration field(s) depending on the destination type',
+            `config` JSON NOT NULL COMMENT 'Extra configuration field(s) depending on the destination type',
             PRIMARY KEY (`id`),
             KEY `name` (`name`),
             KEY `itemtype` (`itemtype`),
@@ -199,5 +199,5 @@ if (GLPI_VERSION == "11.0.0-dev") {
 
     $migration->addField("glpi_forms_answerssets", "entities_id", "fkey");
     $migration->addKey("glpi_forms_answerssets", "entities_id");
-    $migration->addField("glpi_forms_destinations_formdestinations", "config", "longtext COMMENT 'JSON - Extra configuration field(s) depending on the destination type'");
+    $migration->addField("glpi_forms_destinations_formdestinations", "config", "JSON NOT NULL COMMENT 'Extra configuration field(s) depending on the destination type'");
 }

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9531,7 +9531,7 @@ CREATE TABLE `glpi_forms_destinations_formdestinations` (
     `forms_forms_id` int unsigned NOT NULL DEFAULT '0',
     `itemtype` varchar(255) NOT NULL,
     `name` varchar(255) NOT NULL,
-    `config` longtext COMMENT 'JSON - Extra configuration field(s) depending on the destination type',
+    `config` JSON NOT NULL COMMENT 'Extra configuration field(s) depending on the destination type',
     PRIMARY KEY (`id`),
     KEY `name` (`name`),
     KEY `itemtype` (`itemtype`),

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9531,6 +9531,7 @@ CREATE TABLE `glpi_forms_destinations_formdestinations` (
     `forms_forms_id` int unsigned NOT NULL DEFAULT '0',
     `itemtype` varchar(255) NOT NULL,
     `name` varchar(255) NOT NULL,
+    `config` longtext COMMENT 'JSON - Extra configuration field(s) depending on the destination type',
     PRIMARY KEY (`id`),
     KEY `name` (`name`),
     KEY `itemtype` (`itemtype`),

--- a/src/Form/AnswersHandler/AnswersHandler.php
+++ b/src/Form/AnswersHandler/AnswersHandler.php
@@ -285,7 +285,11 @@ final class AnswersHandler
             }
 
             // Create destination item
-            $items = $concrete_destination->createDestinationItems($form, $answers_set);
+            $items = $concrete_destination->createDestinationItems(
+                $form,
+                $answers_set,
+                $destination->getConfig()
+            );
 
             // Link items to answers by creating a AnswersSet_FormDestinationItem object
             foreach ($items as $item) {

--- a/src/Form/Destination/AbstractCommonITILFormDestination.php
+++ b/src/Form/Destination/AbstractCommonITILFormDestination.php
@@ -129,7 +129,7 @@ abstract class AbstractCommonITILFormDestination extends AbstractFormDestination
     /**
      * List the configurable fields for this destination type.
      *
-     * @return \Glpi\Form\Destination\CommonITILField\CommonITILFieldInterface[]
+     * @return \Glpi\Form\Destination\ConfigFieldInterface[]
      */
     public function getConfigurableFields(): array
     {

--- a/src/Form/Destination/CommonITILField/CommonITILFieldInterface.php
+++ b/src/Form/Destination/CommonITILField/CommonITILFieldInterface.php
@@ -33,49 +33,42 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Form\Destination;
+namespace Glpi\Form\Destination\CommonITILField;
 
-use Glpi\Form\AnswersSet;
-use Glpi\Form\Form;
-
-interface FormDestinationInterface
+interface CommonITILFieldInterface
 {
     /**
-     * Create one or multiple items for a given form and its answers
+     * Get the unique key used to set/get this field configuration in the
+     * destination JSON configuration.
      *
-     * @param Form       $form
-     * @param AnswersSet $answers_set
-     * @param array      $config
-     *
-     * @return \CommonDBTM[]
-     *
-     * @throws \Exception Must be thrown if the item can't be created
+     * @return string
      */
-    public function createDestinationItems(
-        Form $form,
-        AnswersSet $answers_set,
-        array $config
-    ): array;
-
+    public function getKey(): string;
 
     /**
-     * Render the configuration form for this destination type.
+     * Label to be displayed when configuring this field.
      *
-     * @return string The rendered HTML content
+     * @return string
      */
-    public function renderConfigForm(array $config): string;
+    public function getLabel(): string;
 
     /**
-     * Get itemtype to create
+     * Render the input field for this configuration.
      *
-     * @return string (Must be a valid CommonDBTM class name)
+     * @param array|null $config
+     *
+     * @return string
      */
-    public static function getTargetItemtype(): string;
+    public function renderConfigForm(?array $config): string;
 
     /**
-     * Get the search option used to filter the target itemtype by answers set.
+     * Apply configurated value to the given input.
      *
-     * @return int
+     * @param array      $input
+     * @param array|null $config May be null if there is no configuration for
+     *                           this field.
+     *
+     * @return array
      */
-    public static function getFilterByAnswsersSetSearchOptionID(): int;
+    public function applyConfiguratedValue(array $input, ?array $config): array;
 }

--- a/src/Form/Destination/CommonITILField/ContentField.php
+++ b/src/Form/Destination/CommonITILField/ContentField.php
@@ -36,9 +36,10 @@
 namespace Glpi\Form\Destination\CommonITILField;
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Form\Destination\ConfigFieldInterface;
 use Override;
 
-class ContentField implements CommonITILFieldInterface
+class ContentField implements ConfigFieldInterface
 {
     #[Override]
     public function getKey(): string

--- a/src/Form/Destination/CommonITILField/ContentField.php
+++ b/src/Form/Destination/CommonITILField/ContentField.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Destination\CommonITILField;
+
+use Glpi\Application\View\TemplateRenderer;
+use Override;
+
+class ContentField implements CommonITILFieldInterface
+{
+    #[Override]
+    public function getKey(): string
+    {
+        return 'content';
+    }
+
+    #[Override]
+    public function getLabel(): string
+    {
+        return __("Content");
+    }
+
+    #[Override]
+    public function renderConfigForm(?array $config): string
+    {
+        $template = <<<TWIG
+            {% import 'components/form/basic_inputs_macros.html.twig' as fields %}
+
+            {{ fields.textarea(
+                "config[" ~ key ~ "][value]",
+                value,
+                {
+                    'enable_richtext': true,
+                }
+            ) }}
+TWIG;
+
+        $twig = TemplateRenderer::getInstance();
+        return $twig->renderFromStringTemplate($template, [
+            'key' => $this->getKey(),
+            'value' => $config['value'] ?? '',
+        ]);
+    }
+
+    #[Override]
+    public function applyConfiguratedValue(array $input, ?array $config): array
+    {
+        if (is_null($config)) {
+            return $input;
+        }
+
+        $input['content'] = $config['value'];
+
+        return $input;
+    }
+}

--- a/src/Form/Destination/CommonITILField/ContentField.php
+++ b/src/Form/Destination/CommonITILField/ContentField.php
@@ -63,6 +63,7 @@ class ContentField implements CommonITILFieldInterface
                 value,
                 {
                     'enable_richtext': true,
+                    'enable_images': false,
                 }
             ) }}
 TWIG;

--- a/src/Form/Destination/CommonITILField/TitleField.php
+++ b/src/Form/Destination/CommonITILField/TitleField.php
@@ -33,49 +33,54 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Form\Destination;
+namespace Glpi\Form\Destination\CommonITILField;
 
-use Glpi\Form\AnswersSet;
-use Glpi\Form\Form;
+use Glpi\Application\View\TemplateRenderer;
+use Override;
 
-interface FormDestinationInterface
+class TitleField implements CommonITILFieldInterface
 {
-    /**
-     * Create one or multiple items for a given form and its answers
-     *
-     * @param Form       $form
-     * @param AnswersSet $answers_set
-     * @param array      $config
-     *
-     * @return \CommonDBTM[]
-     *
-     * @throws \Exception Must be thrown if the item can't be created
-     */
-    public function createDestinationItems(
-        Form $form,
-        AnswersSet $answers_set,
-        array $config
-    ): array;
+    #[Override]
+    public function getKey(): string
+    {
+        return 'title';
+    }
 
+    #[Override]
+    public function getLabel(): string
+    {
+        return __("Title");
+    }
 
-    /**
-     * Render the configuration form for this destination type.
-     *
-     * @return string The rendered HTML content
-     */
-    public function renderConfigForm(array $config): string;
+    #[Override]
+    public function renderConfigForm(?array $config): string
+    {
+        $template = <<<TWIG
+            {% import 'components/form/basic_inputs_macros.html.twig' as fields %}
 
-    /**
-     * Get itemtype to create
-     *
-     * @return string (Must be a valid CommonDBTM class name)
-     */
-    public static function getTargetItemtype(): string;
+            {{ fields.input(
+                "config[" ~ key ~ "][value]",
+                value,
+                {}
+            ) }}
+TWIG;
 
-    /**
-     * Get the search option used to filter the target itemtype by answers set.
-     *
-     * @return int
-     */
-    public static function getFilterByAnswsersSetSearchOptionID(): int;
+        $twig = TemplateRenderer::getInstance();
+        return $twig->renderFromStringTemplate($template, [
+            'key' => $this->getKey(),
+            'value' => $config['value'] ?? '',
+        ]);
+    }
+
+    #[Override]
+    public function applyConfiguratedValue(array $input, ?array $config): array
+    {
+        if (is_null($config)) {
+            return $input;
+        }
+
+        $input['name'] = $config['value'];
+
+        return $input;
+    }
 }

--- a/src/Form/Destination/CommonITILField/TitleField.php
+++ b/src/Form/Destination/CommonITILField/TitleField.php
@@ -36,9 +36,10 @@
 namespace Glpi\Form\Destination\CommonITILField;
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Form\Destination\ConfigFieldInterface;
 use Override;
 
-class TitleField implements CommonITILFieldInterface
+class TitleField implements ConfigFieldInterface
 {
     #[Override]
     public function getKey(): string

--- a/src/Form/Destination/ConfigFieldInterface.php
+++ b/src/Form/Destination/ConfigFieldInterface.php
@@ -33,9 +33,9 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Form\Destination\CommonITILField;
+namespace Glpi\Form\Destination;
 
-interface CommonITILFieldInterface
+interface ConfigFieldInterface
 {
     /**
      * Get the unique key used to set/get this field configuration in the

--- a/src/Form/Destination/FormDestinationTypeManager.php
+++ b/src/Form/Destination/FormDestinationTypeManager.php
@@ -88,7 +88,7 @@ final class FormDestinationTypeManager
     {
         $values = [];
         foreach ($this->getDestinationTypes() as $type) {
-            $values[get_class($type)] = $type->getTypeName();
+            $values[get_class($type)] = $type->getTypeName(1);
         }
 
         return $values;

--- a/templates/pages/admin/form/form_destination.html.twig
+++ b/templates/pages/admin/form/form_destination.html.twig
@@ -114,7 +114,7 @@
                 <input type="hidden" name="itemtype" value="{{ get_class(default_destination_object) }}"/>
                 <input type="hidden" name="{{ form.getForeignKeyField() }}" value="{{ form.getID() }}"/>
                 <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}"/>
-            <form>
+            </form>
         {% endfor %}
     </div>
 </div>

--- a/templates/pages/admin/form/form_destination.html.twig
+++ b/templates/pages/admin/form/form_destination.html.twig
@@ -80,8 +80,8 @@
                                 </div>
 
                                 {# Submit button to delete the destination #}
-                                <div class="d-flex mt-3">
-                                    <button class="btn btn-primary me-2" name="update" type="submit">
+                                <div class="d-flex flex-row-reverse mt-3">
+                                    <button class="btn btn-primary ms-2" name="update" type="submit">
                                         <i class="ti ti-device-floppy me-2"></i>
                                         {{ __("Update item") }}
                                     </button>
@@ -102,27 +102,21 @@
         </div>
     {% endif %}
 
-    <form method="POST" action="{{ controller_url }}">
+    <div class="d-flex mt-4">
+        {% for type, label in available_destinations_types %}
+            <form method="POST" action="{{ controller_url }}">
+                {# Submit button to create a new destination #}
+                <button class="btn btn-ligh-secondary ms-2" name="add" type="submit">
+                    <i class="ti ti-plus me-2"></i> {{ __("Add %s"|format(label|lower)) }}
+                </button>
 
-        <div class="d-flex mt-4">
-            {% do call('Dropdown::showFromArray', [
-                "itemtype",
-                available_destinations_types,
-                {
-                    'value': get_class(default_destination_object),
-                }
-            ]) %}
-
-            {# Submit button to create a new destination #}
-            <button class="btn btn-primary ms-2" name="add" type="submit">
-                <i class="ti ti-plus me-2"></i> {{ __("New item") }}
-            </button>
-        </div>
-
-        {# Hidden values #}
-        <input type="hidden" name="{{ form.getForeignKeyField() }}" value="{{ form.getID() }}"/>
-        <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}"/>
-    <form>
+                {# Hidden values #}
+                <input type="hidden" name="itemtype" value="{{ get_class(default_destination_object) }}"/>
+                <input type="hidden" name="{{ form.getForeignKeyField() }}" value="{{ form.getID() }}"/>
+                <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}"/>
+            <form>
+        {% endfor %}
+    </div>
 </div>
 
 <style>

--- a/templates/pages/admin/form/form_destination.html.twig
+++ b/templates/pages/admin/form/form_destination.html.twig
@@ -111,7 +111,7 @@
                 </button>
 
                 {# Hidden values #}
-                <input type="hidden" name="itemtype" value="{{ get_class(default_destination_object) }}"/>
+                <input type="hidden" name="itemtype" value="{{ type }}"/>
                 <input type="hidden" name="{{ form.getForeignKeyField() }}" value="{{ form.getID() }}"/>
                 <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}"/>
             </form>

--- a/templates/pages/admin/form/form_destination.html.twig
+++ b/templates/pages/admin/form/form_destination.html.twig
@@ -36,6 +36,7 @@
 {# @var \Glpi\Form\Desination\AbstractFormDestination default_destination_object #}
 {# @var \Glpi\Form\Form                               form #}
 {# @var \Glpi\Form\Desination\FormDestination         destinations #}
+{# @var int|null                                      active_destination #}
 
 <div class="py-2 px-3">
     <h2 class="d-flex">
@@ -57,11 +58,11 @@
                 >
                     <h3 class="accordion-header">
                         <button
-                            class="accordion-button collapsed"
+                            class="accordion-button {{ active_destination == destination.getID() ? '' : 'collapsed' }}"
                             type="button"
                             data-bs-toggle="collapse"
                             data-bs-target="#glpi-destinations-accordion-collapse-{{ loop.index }}"
-                            aria-expanded="false"
+                            aria-expanded="{{ active_destination == destination.getID() ? 'true' : 'false' }}"
                         >
                             <i class="{{ concrete_destination.getTargetItemtype()|itemtype_icon }} me-2"></i>
                             {{ destination.getName() }}
@@ -69,20 +70,24 @@
                     </h3>
                     <div
                         id="glpi-destinations-accordion-collapse-{{ loop.index }}"
-                        class="accordion-collapse collapse"
+                        class="accordion-collapse collapse {{ active_destination == destination.getID() ? 'show' : '' }}"
                         data-bs-parent="#glpi-destinations-accordion"
                     >
                         <div class="accordion-body pt-0">
                             <form method="POST" action="{{ controller_url }}">
                                 <div>
-                                    {{ concrete_destination.renderConfigForm()|raw }}
+                                    {{ concrete_destination.renderConfigForm(destination.getConfig())|raw }}
                                 </div>
 
                                 {# Submit button to delete the destination #}
-                                <div class="d-flex">
-                                    <button class="btn btn-danger btn-sm mt-3" name="purge" type="submit">
+                                <div class="d-flex mt-3">
+                                    <button class="btn btn-primary me-2" name="update" type="submit">
+                                        <i class="ti ti-device-floppy me-2"></i>
+                                        {{ __("Update item") }}
+                                    </button>
+                                    <button class="btn btn-ghost-danger" name="purge" type="submit">
                                         <i class="ti ti-trash me-2"></i>
-                                        {{ __("Delete item") }}
+                                        {{ __("Delete") }}
                                     </button>
                                 </div>
 
@@ -123,6 +128,9 @@
 <style>
     /* Should be handled by tabler but it doesn't seem to be active */
     .accordion-header {
+        color: var(--tblr-dark);
+    }
+    .accordion-item {
         color: var(--tblr-dark);
     }
 </style>

--- a/templates/pages/admin/form/form_destination_commonitil_config.html.twig
+++ b/templates/pages/admin/form/form_destination_commonitil_config.html.twig
@@ -37,7 +37,7 @@
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
 <div>
-    {# @var Glpi\Form\Destination\CommonITILField\CommonITILFieldInterface field #}
+    {# @var Glpi\Form\Destination\ConfigFieldInterface field #}
     {% for field in item.getConfigurableFields() %}
         {% set input_field %}
             {{ field.renderConfigForm(

--- a/templates/pages/admin/form/form_destination_commonitil_config.html.twig
+++ b/templates/pages/admin/form/form_destination_commonitil_config.html.twig
@@ -32,7 +32,21 @@
  #}
 
 {# @var Glpi\Form\Destination\AbstractCommonITILFormDestination item #}
+{# @var array                                                   config #}
+
+{% import 'components/form/fields_macros.html.twig' as fields %}
 
 <div>
-    {{ __("The created " ~ item.getTargetItemtype()|itemtype_name ~ " content is not yet customizable (WIP).") }}
+    {# @var Glpi\Form\Destination\CommonITILField\CommonITILFieldInterface field #}
+    {% for field in item.getConfigurableFields() %}
+        {% set input_field %}
+            {{ field.renderConfigForm(
+                config[field.getKey()]
+            )|raw }}
+        {% endset %}
+
+        {{ fields.field(field.getKey(), input_field, field.getLabel(), {
+            'is_horizontal': false,
+        }) }}
+    {% endfor %}
 </div>

--- a/tests/functional/Glpi/Form/AnswersSet.php
+++ b/tests/functional/Glpi/Form/AnswersSet.php
@@ -302,8 +302,8 @@ class AnswersSet extends DbTestCase
         $form = $this->createForm(
             (new FormBuilder())
                 ->addQuestion("Name", QuestionTypeShortText::class)
-                ->addDestination(FormDestinationTicket::class, ['name' => 'Ticket 1'])
-                ->addDestination(FormDestinationTicket::class, ['name' => 'Ticket 2'])
+                ->addDestination(FormDestinationTicket::class, 'Ticket 1')
+                ->addDestination(FormDestinationTicket::class, 'Ticket 2')
         );
 
         // Submit form

--- a/tests/functional/Glpi/Form/Destination/FormDestination.php
+++ b/tests/functional/Glpi/Form/Destination/FormDestination.php
@@ -71,10 +71,10 @@ class FormDestination extends DbTestCase
         $form = $this->createForm(
             (new FormBuilder())
                 ->addQuestion("Name", QuestionTypeShortText::class)
-                ->addDestination(FormDestinationTicket::class, ['name' => 'destination 1'])
-                ->addDestination(FormDestinationTicket::class, ['name' => 'destination 2'])
-                ->addDestination(FormDestinationTicket::class, ['name' => 'destination 3'])
-                ->addDestination(FormDestinationTicket::class, ['name' => 'destination 4'])
+                ->addDestination(FormDestinationTicket::class, 'destination 1')
+                ->addDestination(FormDestinationTicket::class, 'destination 2')
+                ->addDestination(FormDestinationTicket::class, 'destination 3')
+                ->addDestination(FormDestinationTicket::class, 'destination 4')
         );
         yield [$form, "Items to create 4"];
 
@@ -131,10 +131,10 @@ class FormDestination extends DbTestCase
         $form = $this->createForm(
             (new FormBuilder())
                 ->addQuestion("Name", QuestionTypeShortText::class)
-                ->addDestination(FormDestinationTicket::class, ['name' => 'destination 1'])
-                ->addDestination(FormDestinationTicket::class, ['name' => 'destination 2'])
-                ->addDestination(FormDestinationTicket::class, ['name' => 'destination 3'])
-                ->addDestination(FormDestinationTicket::class, ['name' => 'destination 4'])
+                ->addDestination(FormDestinationTicket::class, 'destination 1')
+                ->addDestination(FormDestinationTicket::class, 'destination 2')
+                ->addDestination(FormDestinationTicket::class, 'destination 3')
+                ->addDestination(FormDestinationTicket::class, 'destination 4')
         );
         yield [$form, true];
     }

--- a/tests/functional/Glpi/Form/Destination/FormDestinationChange.php
+++ b/tests/functional/Glpi/Form/Destination/FormDestinationChange.php
@@ -64,19 +64,30 @@ class FormDestinationChange extends AbstractFormDestinationType
         $form = $this->createForm(
             (new FormBuilder("Test form 1"))
                 ->addQuestion("Name", QuestionTypeShortText::class)
-                ->addDestination(\Glpi\Form\Destination\FormDestinationChange::class, ['name' => 'test'])
+                ->addDestination(
+                    \Glpi\Form\Destination\FormDestinationChange::class,
+                    'test',
+                    [
+                        'title'   => ['value' => 'Change title'],
+                        'content' => ['value' => 'Change content'],
+                    ]
+                )
         );
 
         // There are no change in the database named after this form
-        $changes = (new Change())->find(['name' => 'Change from form: Test form 1']);
+        $changes = (new Change())->find(['name' => 'Change title']);
         $this->array($changes)->hasSize(0);
 
         // Submit form, a single change should be created
         $answers = $answers_handler->saveAnswers($form, [
             $this->getQuestionId($form, "Name") => "My name",
         ], \Session::getLoginUserID());
-        $changes = (new Change())->find(['name' => 'Change from form: Test form 1']);
+        $changes = (new Change())->find(['name' => 'Change title']);
         $this->array($changes)->hasSize(1);
+
+        // Check fields
+        $change = current($changes);
+        $this->string($change['content'])->isEqualTo('Change content');
 
         // Make sure link with the form answers was created too
         $change = array_pop($changes);

--- a/tests/functional/Glpi/Form/Destination/FormDestinationProblem.php
+++ b/tests/functional/Glpi/Form/Destination/FormDestinationProblem.php
@@ -64,19 +64,30 @@ class FormDestinationProblem extends AbstractFormDestinationType
         $form = $this->createForm(
             (new FormBuilder("Test form 1"))
                 ->addQuestion("Name", QuestionTypeShortText::class)
-                ->addDestination(\Glpi\Form\Destination\FormDestinationProblem::class, ['name' => 'test'])
+                ->addDestination(
+                    \Glpi\Form\Destination\FormDestinationProblem::class,
+                    'test',
+                    [
+                        'title'   => ['value' => 'Problem title'],
+                        'content' => ['value' => 'Problem content'],
+                    ]
+                )
         );
 
         // There are no problems in the database named after this form
-        $problems = (new Problem())->find(['name' => 'Problem from form: Test form 1']);
+        $problems = (new Problem())->find(['name' => 'Problem title']);
         $this->array($problems)->hasSize(0);
 
         // Submit form, a single problem should be created
         $answers = $answers_handler->saveAnswers($form, [
             $this->getQuestionId($form, "Name") => "My name",
         ], \Session::getLoginUserID());
-        $problems = (new Problem())->find(['name' => 'Problem from form: Test form 1']);
+        $problems = (new Problem())->find(['name' => 'Problem title']);
         $this->array($problems)->hasSize(1);
+
+        // Check fields
+        $problem = current($problems);
+        $this->string($problem['content'])->isEqualTo('Problem content');
 
         // Make sure link with the form answers was created too
         $problem = array_pop($problems);

--- a/tests/functional/Glpi/Form/Destination/FormDestinationTicket.php
+++ b/tests/functional/Glpi/Form/Destination/FormDestinationTicket.php
@@ -64,19 +64,30 @@ class FormDestinationTicket extends AbstractFormDestinationType
         $form = $this->createForm(
             (new FormBuilder("Test form 1"))
                 ->addQuestion("Name", QuestionTypeShortText::class)
-                ->addDestination(\Glpi\Form\Destination\FormDestinationTicket::class, ['name' => 'test'])
+                ->addDestination(
+                    \Glpi\Form\Destination\FormDestinationTicket::class,
+                    'test',
+                    [
+                        'title'   => ['value' => 'Ticket title'],
+                        'content' => ['value' => 'Ticket content'],
+                    ]
+                )
         );
 
         // There are no tickets in the database named after this form
-        $tickets = (new Ticket())->find(['name' => 'Ticket from form: Test form 1']);
+        $tickets = (new Ticket())->find(['name' => 'Ticket title']);
         $this->array($tickets)->hasSize(0);
 
         // Submit form, a single ticket should be created
         $answers = $answers_handler->saveAnswers($form, [
             $this->getQuestionId($form, "Name") => "My name",
         ], \Session::getLoginUserID());
-        $tickets = (new Ticket())->find(['name' => 'Ticket from form: Test form 1']);
+        $tickets = (new Ticket())->find(['name' => 'Ticket title']);
         $this->array($tickets)->hasSize(1);
+
+        // Check fields
+        $ticket = current($tickets);
+        $this->string($ticket['content'])->isEqualTo('Ticket content');
 
         // Make sure link with the form answers was created too
         $ticket = array_pop($tickets);

--- a/tests/functional/Glpi/Form/Form.php
+++ b/tests/functional/Glpi/Form/Form.php
@@ -902,7 +902,7 @@ class Form extends DbTestCase
                 ->addQuestion('Question 1', QuestionTypeShortText::class)
                 ->addQuestion('Question 2', QuestionTypeShortText::class)
                 ->addQuestion('Question 3', QuestionTypeShortText::class)
-                ->addDestination(FormDestinationTicket::class, ['name' => 'Destination 1'])
+                ->addDestination(FormDestinationTicket::class, 'Destination 1')
         );
 
         // Control subject that we are going to keep, its data shouldn't be deleted
@@ -910,7 +910,7 @@ class Form extends DbTestCase
             (new FormBuilder())
                 ->addSection('Section 1')
                 ->addQuestion('Question 1', QuestionTypeShortText::class)
-                ->addDestination(FormDestinationTicket::class, ['name' => 'Destination 1'])
+                ->addDestination(FormDestinationTicket::class, 'Destination 1')
         );
 
         // Count items before deletion

--- a/tests/src/Form/Destination/AbstractFormDestinationType.php
+++ b/tests/src/Form/Destination/AbstractFormDestinationType.php
@@ -137,9 +137,9 @@ abstract class AbstractFormDestinationType extends DbTestCase
         $form = $this->createForm(
             (new FormBuilder())
                 ->addQuestion("Name", QuestionTypeShortText::class)
-                ->addDestination($destination::class, ['name' => 'destination 1'])
-                ->addDestination($destination::class, ['name' => 'destination 2'])
-                ->addDestination($destination::class, ['name' => 'destination 3'])
+                ->addDestination($destination::class, 'destination 1')
+                ->addDestination($destination::class, 'destination 2')
+                ->addDestination($destination::class, 'destination 3')
         );
         $answers_set = $answers_handler->saveAnswers($form, [
             $this->getQuestionId($form, "Name") => "Pierre Paul Jacques",
@@ -206,9 +206,9 @@ abstract class AbstractFormDestinationType extends DbTestCase
         $form = $this->createForm(
             (new FormBuilder())
                 ->addQuestion("Name", QuestionTypeShortText::class)
-                ->addDestination($destination::class, ['name' => 'destination 1'])
-                ->addDestination($destination::class, ['name' => 'destination 2'])
-                ->addDestination($destination::class, ['name' => 'destination 3'])
+                ->addDestination($destination::class, 'destination 1')
+                ->addDestination($destination::class, 'destination 2')
+                ->addDestination($destination::class, 'destination 3')
         );
         $answers_set = $answers_handler->saveAnswers($form, [
             $this->getQuestionId($form, "Name") => "Pierre Paul Jacques",
@@ -252,7 +252,7 @@ abstract class AbstractFormDestinationType extends DbTestCase
     final public function testRenderConfigForm(): void
     {
         $destination = $this->getTestedInstance();
-        $html = $destination->renderConfigForm();
+        $html = $destination->renderConfigForm([]);
         $this->string($html)->isNotEmpty();
     }
 }

--- a/tests/src/FormBuilder.php
+++ b/tests/src/FormBuilder.php
@@ -315,18 +315,25 @@ class FormBuilder
      * Add a destination to the form
      *
      * @param string $itemtype Destination itemtype
-     * @param array  $values   Input values
+     * @param array  $name     Destination name
+     * @param array  $config   Config values
      *
      * @return self To allow chain calls
      */
-    public function addDestination(string $itemtype, array $values): self
-    {
+    public function addDestination(
+        string $itemtype,
+        string $name,
+        array $config = []
+    ): self {
         // If first destination of the given itemtype, init its key
         if (!isset($this->destinations[$itemtype])) {
             $this->destinations[$itemtype] = [];
         }
 
-        $this->destinations[$itemtype][] = $values;
+        $this->destinations[$itemtype][] = [
+            'name'   => $name,
+            'config' => $config,
+        ];
         return $this;
     }
 }

--- a/tests/src/FormTesterTrait.php
+++ b/tests/src/FormTesterTrait.php
@@ -91,12 +91,12 @@ trait FormTesterTrait
         // Create destinations
         foreach ($builder->getDestinations() as $itemtype => $destinations) {
             foreach ($destinations as $destination_data) {
-                $name = $destination_data['name'];
                 $this->createItem(FormDestination::class, [
                     'forms_forms_id' => $form->getID(),
                     'itemtype'       => $itemtype,
-                    'name'           => $name,
-                ]);
+                    'name'           => $destination_data['name'],
+                    'config'         => $destination_data['config'],
+                ], ['config']);
             }
         }
 


### PR DESCRIPTION
Add basic configuration for forms destination:

![image](https://github.com/glpi-project/glpi/assets/42734840/e99a1ed4-5bd5-4c44-8d59-90170bad3afb)

Once merged, the next steps are:
- Enable dynamic values based on the users answers.
- Add some kind of "auto" mode that auto compute these dynamic values (e.g. the ticket content will list all available questions/answers when in auto mode). The goal is that 99% of the users can just let "auto" everywhere and get a perfectly working form, leaving manual configuration for the 1% power users.
- Support all fields (will need the relevant question types to be added first, e.g. it is not possible to properly add the ticket type (request/incident) field config before the "request type" question type is added to forms).

The UI is not final but you can start making UI/UX suggestion if you want.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
