### PR TITLE
Forms: duplicate questions

### DIFF
--- a/js/form_editor_controller.js
+++ b/js/form_editor_controller.js
@@ -327,6 +327,13 @@ class GlpiFormEditorController
                 );
                 break;
 
+            // Duplicate target question
+            case "duplicate-question":
+                this.#duplicateQuestion(
+                    target.closest("[data-glpi-form-editor-question]")
+                );
+                break;
+
             // No specific instructions for these events.
             // They must still be kept here as they benefits from the common code
             // like refreshUX() and glpiUnsavedFormChanges.
@@ -476,6 +483,7 @@ class GlpiFormEditorController
         if (id == 0) {
             // Replace by UUID
             this.#setItemInput(item, "id", getUUID());
+            this.#setItemInput(item, "_use_uuid", 1);
         }
     }
 
@@ -1377,13 +1385,27 @@ class GlpiFormEditorController
      * @param {jQuery} section
      */
     #duplicateSection(section) {
-        // TinyMCE must be disabled before we can duplicate the section
+        // TinyMCE must be disabled before we can duplicate the section DOM
         const ids = this.#disableTinyMce(section);
         const new_section = this.#copy_template(section, section, "after");
         this.#enableTinyMce(ids);
 
         this.#setActiveItem(new_section);
         this.#enableSortable(new_section);
+    }
+
+    /**
+     * Duplicate the given question
+     * @param {jQuery} section
+     */
+    #duplicateQuestion(question) {
+        // TinyMCE must be disabled before we can duplicate the question DOM
+        const ids = this.#disableTinyMce(question);
+        const new_question = this.#copy_template(question, question, "after");
+        this.#enableTinyMce(ids);
+
+        this.#setItemInput(new_question, "id", 0);
+        this.#setActiveItem(new_question);
     }
 
     /**

--- a/js/form_editor_controller.js
+++ b/js/form_editor_controller.js
@@ -1390,6 +1390,14 @@ class GlpiFormEditorController
         const new_section = this.#copy_template(section, section, "after");
         this.#enableTinyMce(ids);
 
+        this.#setItemInput(new_section, "id", 0);
+        new_section
+            .find("[data-glpi-form-editor-question]")
+            .each((index, question) => {
+                this.#setItemInput($(question), "id", 0);
+            })
+        ;
+
         this.#setActiveItem(new_section);
         this.#enableSortable(new_section);
     }

--- a/templates/pages/admin/form/form_question.html.twig
+++ b/templates/pages/admin/form/form_question.html.twig
@@ -68,7 +68,7 @@
                 ></i>
             </div>
             {# Display question's title #}
-            <div class="d-flex mt-n1">
+            <div class="d-flex mt-n1 align-items-center">
                 <input
                     class="form-control content-editable-h2 mb-0"
                     type="text"
@@ -80,6 +80,14 @@
                     data-glpi-form-editor-question-details-name
                 />
                 <span data-glpi-form-editor-required-mark class="text-danger d-none">*</span>
+                {# Duplicate question #}
+                <i
+                    class="ti ti-copy ms-auto cursor-pointer"
+                    data-bs-toggle="tooltip"
+                    data-bs-placement="top"
+                    title="{{ __("Duplicate question") }}"
+                    data-glpi-form-editor-on-click="duplicate-question"
+                ></i>
             </div>
 
             {# Render the specific question type #}


### PR DESCRIPTION
Add the ability to duplicate questions and fixes the section duplication action that was not working properly in some cases.

![dup_q](https://github.com/glpi-project/glpi/assets/42734840/f823f985-6bbe-44ca-a282-02eaee15e27a)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
