### PR TITLE
fix legacy display for search form (missing border and spacing)

### DIFF
--- a/templates/components/search/query_builder/main.html.twig
+++ b/templates/components/search/query_builder/main.html.twig
@@ -35,7 +35,7 @@
 {% set rand = random() %}
 {% set mainform = mainform is not defined ? true : mainform %}
 {% set main_block_class = mainform ? '' : 'sub_criteria' %}
-{% set card_class = mainform ? 'search-form card card-sm' : 'border d-inline-block ms-1' %}
+{% set card_class = mainform ? 'search-form card card-sm border mb-3' : 'border d-inline-block ms-1' %}
 {% set hide_criteria = not(p.hide_criteria is defined and not p.hide_criteria) %}
 {% set extra_actions_templates = p.extra_actions_templates|default([]) %}
 {% set hide_controls = p.hide_controls is defined and p.hide_controls %}


### PR DESCRIPTION
Missing border and bottom spacing

before: 
![image](https://github.com/glpi-project/glpi/assets/418844/dd8cc624-879c-4152-865e-d92344977356)


after:
![image](https://github.com/glpi-project/glpi/assets/418844/709b8a4b-8106-452b-8aaf-38588f37234e)

