### PR TITLE
Fix `PLUGINS_DIRECTORIES` default value

### DIFF
--- a/inc/based_config.php
+++ b/inc/based_config.php
@@ -212,7 +212,13 @@ if (!isCommandLine()) {
     foreach ($constants_names as $name) {
         $value = $constants[GLPI_ENVIRONMENT_TYPE][$name] ?? $constants['default'][$name];
         if (!defined($name) && (!is_string($value) || !preg_match($inherit_pattern, $value))) {
-            define($name, $value);
+            if (
+                (!is_string($value) && !is_array($value))
+                || (is_string($value) && !preg_match($inherit_pattern, $value))
+                || (is_array($value) && count(preg_grep($inherit_pattern, $value)) === 0)
+            ) {
+                define($name, $value);
+            }
         }
     }
     foreach ($constants_names as $name) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Since #16763, the default value was `['{GLPI_MARKETPLACE_DIR}', '/var/www/glpi/plugins']` due to bad handling of inheritence defaults for array values.