### PR TITLE
Fix deprecation on dropdown fields with a `null` entity restrict

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -202,7 +202,9 @@ class Dropdown
                 $params['entity'] = getSonsOf('glpi_entities', $params['entity']);
             }
         }
-        $params['entity'] = Session::getMatchingActiveEntities($params['entity']);
+        if ($params['entity'] !== null) {
+            $params['entity'] = Session::getMatchingActiveEntities($params['entity']);
+        }
 
         $field_id = Html::cleanId("dropdown_" . $params['name'] . $params['rand']);
 

--- a/src/Session.php
+++ b/src/Session.php
@@ -1978,18 +1978,25 @@ class Session
             return $entities_ids;
         }
 
-        if (!is_array($entities_ids) && !is_int($entities_ids) && !ctype_digit($entities_ids)) {
+        if (
+            !is_array($entities_ids)
+            && !is_int($entities_ids)
+            && (!is_string($entities_ids) || !ctype_digit($entities_ids))
+        ) {
             // Unexpected value type.
             return [];
         }
 
         $active_entities_ids = [];
         foreach ($_SESSION['glpiactiveentities'] ?? [] as $active_entity_id) {
-            if (!is_int($active_entity_id) && !ctype_digit($active_entity_id)) {
+            if (
+                !is_int($active_entity_id)
+                && (!is_string($active_entity_id) || !ctype_digit($active_entity_id))
+            ) {
                 // Ensure no unexpected value converted to int
                 // as it would be converted to `0` and would permit access to root entity
                 trigger_error(
-                    sprintf('Unexpected value `%s` found in `$_SESSION[\'glpiactiveentities\']`.', $active_entity_id),
+                    sprintf('Unexpected value `%s` found in `$_SESSION[\'glpiactiveentities\']`.', $active_entity_id ?? 'null'),
                     E_USER_WARNING
                 );
                 continue;
@@ -2004,7 +2011,7 @@ class Session
         $filtered = [];
         foreach ((array)$entities_ids as $entity_id) {
             if (
-                (is_int($entity_id) || ctype_digit($entity_id))
+                (is_int($entity_id) || (is_string($entity_id) && ctype_digit($entity_id)))
                 && in_array((int)$entity_id, $active_entities_ids, true)
             ) {
                 $filtered[] = (int)$entity_id;

--- a/tests/functional/Session.php
+++ b/tests/functional/Session.php
@@ -722,12 +722,24 @@ class Session extends \DbTestCase
                 'result'          => is_array($entity_restrict) ? [2] : 2,
             ];
         }
+
+        // Invalid null values in input
+        yield [
+            'entity_restrict' => null,
+            'active_entities' => [0, 1, '2', 3],
+            'result'          => [],
+        ];
+        yield [
+            'entity_restrict' => [1, null, 3],
+            'active_entities' => [0, 1, '2', 3],
+            'result'          => [1, 3],
+        ];
     }
 
     /**
      * @dataProvider entitiesRestrictProvider
      */
-    public function testGetMatchingActiveEntities(/*int|array*/ $entity_restrict, ?array $active_entities, /*int|array*/ $result): void
+    public function testGetMatchingActiveEntities(/*mixed*/ $entity_restrict, ?array $active_entities, /*int|array*/ $result): void
     {
         $_SESSION['glpiactiveentities'] = $active_entities;
         $this->variable(\Session::getMatchingActiveEntities($entity_restrict))->isIdenticalTo($result);
@@ -735,7 +747,7 @@ class Session extends \DbTestCase
 
     public function testGetMatchingActiveEntitiesWithUnexpectedValue(): void
     {
-        $_SESSION['glpiactiveentities'] = [0, 1, 2, 'foo', 3];
+        $_SESSION['glpiactiveentities'] = [0, 1, 2, 'foo', null, 3];
 
         $this->when(
             function () {
@@ -744,6 +756,10 @@ class Session extends \DbTestCase
         )->error
          ->withType(E_USER_WARNING)
          ->withMessage('Unexpected value `foo` found in `$_SESSION[\'glpiactiveentities\']`.')
+         ->exists()
+         ->error
+         ->withType(E_USER_WARNING)
+         ->withMessage('Unexpected value `null` found in `$_SESSION[\'glpiactiveentities\']`.')
          ->exists();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The dropdown fields displayed by the `generic_show_form` template are always passing `item.fields['entities_id']` to restrict dropdown entities, even for items that does not have this field (e.g. `Socket`). See https://github.com/glpi-project/glpi/blob/eb40b431374bde303d958f7af4cfa8724d17de85/templates/generic_show_form.html.twig#L156-L166

It triggers a deprecation log on PHP >= 8.1.
