### PR TITLE
Always store updated SMTP Oauth refresh token

### DIFF
--- a/src/Mail/SMTP/OAuthTokenProvider.php
+++ b/src/Mail/SMTP/OAuthTokenProvider.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Mail\SMTP;
+
+use PHPMailer\PHPMailer\OAuth;
+use League\OAuth2\Client\Token\AccessToken;
+
+final class OAuthTokenProvider extends OAuth
+{
+    /**
+     * Get the granted access token.
+     *
+     * @return AccessToken|null
+     */
+    public function getOauthToken(): ?AccessToken
+    {
+        return $this->oauthToken;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !31976

When connecting against the Microsoft SMTP server, the granted access token may (always?) contain a new refresh token. In this case, the refresh token has been itself refreshed. In this case, the previous token will expire 90 days later. To prevent this expiration to block the Oauth authentication, we have to replace the previously known refresh token by the new one.