### PR TITLE
Add missing UUID search options

### DIFF
--- a/src/Phone.php
+++ b/src/Phone.php
@@ -455,6 +455,14 @@ class Phone extends CommonDBTM
             'massiveaction'      => false
         ];
 
+        $tab[] = [
+            'id'                 => '47',
+            'table'              => static::getTable(),
+            'field'              => 'uuid',
+            'name'               => __('UUID'),
+            'datatype'           => 'string',
+        ];
+
         $tab = array_merge($tab, Notepad::rawSearchOptionsToAdd());
 
         $tab = array_merge($tab, Socket::rawSearchOptionsToAdd());

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -655,6 +655,14 @@ class Printer extends CommonDBTM
             'massiveaction'      => false
         ];
 
+        $tab[] = [
+            'id'                 => '47',
+            'table'              => static::getTable(),
+            'field'              => 'uuid',
+            'name'               => __('UUID'),
+            'datatype'           => 'string',
+        ];
+
         $tab = array_merge($tab, Notepad::rawSearchOptionsToAdd());
 
         $tab = array_merge($tab, Item_Devices::rawSearchOptionsToAdd(get_class($this)));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Phone and Printer have a UUID field, but there was no search option for it. Noticed while looking at global inventory locks as the label was showing as the internal field name "uuid" instead of the label "UUID".