### PR TITLE
Allow TinyMCE to convert safe embed/objects to audio/img/video

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
                 "select2": "^4.0.13",
                 "spectrum-colorpicker2": "^2.0.9",
                 "spin.js": "^4.1.0",
-                "tinymce": "^6.7.3",
+                "tinymce": "^6.8.3",
                 "tinymce-i18n": "^23.6.19"
             },
             "devDependencies": {
@@ -9694,9 +9694,9 @@
             "dev": true
         },
         "node_modules/tinymce": {
-            "version": "6.7.3",
-            "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.7.3.tgz",
-            "integrity": "sha512-J7WmYIi/gt1RvZ6Ap2oQiUjzAoiS9pfV+d4GnKuZuPu8agmlAEAInNmMvMjfCNBzHv4JnZXY7qlHUAI0IuYQVA=="
+            "version": "6.8.3",
+            "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.8.3.tgz",
+            "integrity": "sha512-3fCHKAeqT+xNwBVESf6iDbDV0VNwZNmfrkx9c/6Gz5iB8piMfaO6s7FvoiTrj1hf1gVbfyLTnz1DooI6DhgINQ=="
         },
         "node_modules/tinymce-i18n": {
             "version": "23.6.19",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "select2": "^4.0.13",
         "spectrum-colorpicker2": "^2.0.9",
         "spin.js": "^4.1.0",
-        "tinymce": "^6.7.3",
+        "tinymce": "^6.8.3",
         "tinymce-i18n": "^23.6.19"
     },
     "scripts": {

--- a/src/Html.php
+++ b/src/Html.php
@@ -3851,7 +3851,7 @@ JS;
         $cache_suffix = '?v=' . FrontEnd::getVersionCacheKey(GLPI_VERSION);
         $readonlyjs   = $readonly ? 'true' : 'false';
 
-        $invalid_elements = 'applet,canvas,embed,form,object';
+        $invalid_elements = 'applet,canvas,form';
         if (!$enable_images) {
             $invalid_elements .= ',img';
         }
@@ -3934,10 +3934,13 @@ JS;
 
                // Content settings
                entity_encoding: 'raw',
-               invalid_elements: '{$invalid_elements}',
                readonly: {$readonlyjs},
                relative_urls: false,
                remove_script_host: false,
+
+               // Security settings
+               convert_unsafe_embeds: true,
+               invalid_elements: '{$invalid_elements}',
 
                // Misc options
                browser_spellcheck: true,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

TinyMCE recently published 2 security advisories:
 - https://github.com/advisories/GHSA-5359-pvf2-pw78
 - https://github.com/advisories/GHSA-438c-3975-5x3f

By default, we are not impacted by these security issues, but it is still preferable to upgrade to a version that is not marked as vulnerable. For the moment, the 6.8.1+ versions are still considered as vulnerable, but they should probably not, see https://github.com/tinymce/tinymce/issues/9513.

For the vulnerability related to usage of `iframe`, we already block them unless people set the `GLPI_ALLOW_IFRAME_IN_RICH_TEXT` to `true`. In this case, I think we should not set the `sandbox_iframes` option to true (see https://www.tiny.cloud/docs/tinymce/6/security/#sandbox-iframes-option) as I guess people may sometimes use forms or scripts in their own iframes, and that is probably the reason they are enable them.

For the vulnerability related to usage of `object` and `embed` elements, we do not allow them for the moment. I propose to allow them now, as they will be converted to `audio`/`img`/`video` tags when possible, or into `iframe` tags otherwise thanks to `convert_unsafe_embeds`. If `GLPI_ALLOW_IFRAME_IN_RICH_TEXT` is not set to `true`, the resulting `iframe` tags will be discarded automatically (once https://github.com/tinymce/tinymce/issues/9516 will be fixed).

I keep this PR as a draft, waiting for https://github.com/tinymce/tinymce/issues/9513 and https://github.com/tinymce/tinymce/issues/9516 to be fixed.