### PR TITLE
Fix cookie and internal auth for API

### DIFF
--- a/src/Api/HL/Middleware/CookieAuthMiddleware.php
+++ b/src/Api/HL/Middleware/CookieAuthMiddleware.php
@@ -51,6 +51,11 @@ class CookieAuthMiddleware extends AbstractMiddleware implements AuthMiddlewareI
             Session::start();
             // unset the response to indicate a successful auth
             $input->response = null;
+            $input->client = [
+                'client_id' => 'internal', // Internal just means the user was authenticated internally either by cookie or an already existing session.
+                'users_id'  => Session::getLoginUserID(),
+                'scopes' => []
+            ];
         } else {
             $next($input);
         }

--- a/src/Api/HL/Middleware/InternalAuthMiddleware.php
+++ b/src/Api/HL/Middleware/InternalAuthMiddleware.php
@@ -45,6 +45,11 @@ class InternalAuthMiddleware extends AbstractMiddleware implements AuthMiddlewar
     public function process(MiddlewareInput $input, callable $next): void
     {
         if (\Session::getLoginUserID()) {
+            $input->client = [
+                'client_id' => 'internal', // Internal just means the user was authenticated internally either by cookie or an already existing session.
+                'users_id'  => \Session::getLoginUserID(),
+                'scopes' => []
+            ];
             $input->response = null;
         } else {
             $next($input);

--- a/src/Api/HL/Middleware/MiddlewareInput.php
+++ b/src/Api/HL/Middleware/MiddlewareInput.php
@@ -44,7 +44,8 @@ final class MiddlewareInput
     public function __construct(
         public Request $request,
         public RoutePath $route_path,
-        public ?Response $response
+        public ?Response $response,
+        public ?array $client = null,
     ) {
     }
 }

--- a/src/Api/HL/Middleware/OAuthRequestMiddleware.php
+++ b/src/Api/HL/Middleware/OAuthRequestMiddleware.php
@@ -76,6 +76,10 @@ class OAuthRequestMiddleware extends AbstractMiddleware implements RequestMiddle
         if ($client === null) {
             $input->response = AbstractController::getAccessDeniedErrorResponse();
             return;
+        } else if ($client['client_id'] === 'internal') {
+            // No scope restrictions for internal clients
+            $next($input);
+            return;
         }
         foreach ($scopes_required['OR'] as $scope) {
             if (in_array($scope, $client['scopes'], true)) {

--- a/src/Api/HL/Router.php
+++ b/src/Api/HL/Router.php
@@ -612,6 +612,7 @@ EOT;
             // Do auth middlewares now even if auth isn't required so session data *could* be used like the theme for doc endpoints.
             $this->doAuthMiddleware($middleware_input);
             $auth_from_middleware = $middleware_input->response === null;
+            $this->current_client = $this->current_client ?? $middleware_input->client;
 
             if ($requires_auth && !$auth_from_middleware) {
                 if (!($request->hasHeader('Authorization') && Session::getLoginUserID() !== false)) {

--- a/tests/functional/Webhook.php
+++ b/tests/functional/Webhook.php
@@ -225,4 +225,23 @@ JSON;
         $this->string($headers['X-Test-Item-ID'])->isEqualTo($fup->getID());
         $this->string($headers['X-Test-Mixed'])->isEqualTo('new-ext1234-' . $fup->getID());
     }
+
+    public function testGetResultForPath()
+    {
+        $this->login();
+        /** @var \Webhook $webhook */
+        $webhook = $this->createItem('Webhook', [
+            'name' => 'Test webhook',
+            'entities_id' => $_SESSION['glpiactive_entity'],
+            'url' => 'http://localhost',
+            'itemtype' => 'User',
+            'event' => 'new',
+            'is_active' => 1,
+            'use_default_payload' => 1,
+        ]);
+        $users_id = \Session::getLoginUserID();
+        // Make sure we get at least something as a response.
+        // The main purpose is to test the internal authentication middleware.
+        $this->variable($webhook->getResultForPath('/Administration/User/' . $users_id, 'new', 'User', $users_id))->isNotNull();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Internal and cookie authentication to the API was not setting the client information. So, when the new OAuth scope restriction middleware was run, it looked like no user was authenticated.