### PR TITLE
Prevent DB check to fail on unexpected 250 index length

### DIFF
--- a/src/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
+++ b/src/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
@@ -531,6 +531,9 @@ class DatabaseSchemaIntegrityChecker
             '/(UNIQUE|FULLTEXT)\s*(`|\()/' => '$1 KEY $2',
             // Always have a key identifier (except on PRIMARY key)
             '/(?<!PRIMARY )KEY\s*\((`\w+`)\)/' => 'KEY $1 ($1)',
+            // Ignore length on indexes when value is `250`
+            // MariaDB in some recent version (at least 10.11.7) seems to mention it on some indexes, but we do not know why.
+            '/(`\w+`)\(250\)/' => '$1',
         ];
         $indexes = preg_replace(array_keys($indexes_replacements), array_values($indexes_replacements), $indexes);
         if (!$this->strict) {

--- a/tests/units/Glpi/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
+++ b/tests/units/Glpi/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
@@ -1280,6 +1280,76 @@ DIFF,
                 'ignore_unsigned_keys_migration' => true
             ]
         );
+
+        // Always ignore key length when value is `250`,
+        // but detect differences when value is not `250`.
+        yield $convert_to_provider_entry(
+            [
+                [
+                    'name' => sprintf('table_%s', ++$table_increment),
+                    'raw_sql' => <<<SQL
+CREATE TABLE `table_{$table_increment}` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `key` varchar(255) NOT NULL,
+  `uid` varchar(255) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `name` (`name`),
+  KEY `key` (`key`),
+  KEY `uid` (`uid`)
+) ENGINE=InnoDB
+SQL,
+                    'normalized_sql' => <<<SQL
+CREATE TABLE `table_{$table_increment}` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `key` varchar(255) NOT NULL,
+  `uid` varchar(255) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `name` (`name`),
+  KEY `key` (`key`),
+  KEY `uid` (`uid`)
+) ENGINE=InnoDB
+SQL,
+                    'effective_sql'  => <<<SQL
+CREATE TABLE `table_{$table_increment}` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `key` varchar(255) NOT NULL,
+  `uid` varchar(255) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `name` (`name`(250)),
+  KEY `key` (`key`),
+  KEY `uid` (`uid`(100))
+) ENGINE=InnoDB
+SQL,
+                    'differences'    => [
+                        'type' => 'altered_table',
+                        'diff' => <<<DIFF
+--- Expected database schema
++++ Current database schema
+@@ @@
+   PRIMARY KEY (`id`),
+   KEY `name` (`name`),
+   KEY `key` (`key`),
+-  KEY `uid` (`uid`)
++  KEY `uid` (`uid`(100))
+ ) ENGINE=InnoDB
+
+DIFF,
+                    ],
+                ],
+            ],
+            [
+                'strict' => true,
+                'allow_signed_keys' => false,
+                'ignore_innodb_migration' => false,
+                'ignore_timestamps_migration' => false,
+                'ignore_utf8mb4_migration' => false,
+                'ignore_dynamic_row_format_migration' => false,
+                'ignore_unsigned_keys_migration' => false,
+            ]
+        );
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

We do not know really what it happens, but on one of our GLPI cloud instance, some tables return an unexpected length of `250` on some indexes on their `SHOW CREATE TABLE` command. Removing an recreating the index without specifying any length does not change anything.

It blocks the update script as the `db:check` commands considers that the DB schema is not correct.

```
Le schéma diffère pour la table "glpi_authldaps".
--- Schéma de base de données attendu
+++ Schéma de base de données actuel
@@ @@
   KEY `is_active` (`is_active`),
   KEY `is_default` (`is_default`),
   KEY `name` (`name`),
-  KEY `sync_field` (`sync_field`)
+  KEY `sync_field` (`sync_field`(250))
 )
Le schéma diffère pour la table "glpi_computermodels".
--- Schéma de base de données attendu
+++ Schéma de base de données actuel
@@ @@
   KEY `date_creation` (`date_creation`),
   KEY `date_mod` (`date_mod`),
   KEY `name` (`name`),
-  KEY `product_number` (`product_number`)
+  KEY `product_number` (`product_number`(250))
 )
Le schéma diffère pour la table "glpi_monitormodels".
--- Schéma de base de données attendu
+++ Schéma de base de données actuel
@@ @@
   KEY `date_creation` (`date_creation`),
   KEY `date_mod` (`date_mod`),
   KEY `name` (`name`),
-  KEY `product_number` (`product_number`)
+  KEY `product_number` (`product_number`(250))
 )
Le schéma diffère pour la table "glpi_monitors".
--- Schéma de base de données attendu
+++ Schéma de base de données actuel
@@ @@
   KEY `states_id` (`states_id`),
   KEY `users_id_tech` (`users_id_tech`),
   KEY `users_id` (`users_id`),
-  KEY `uuid` (`uuid`)
+  KEY `uuid` (`uuid`(250))
 )
Le schéma diffère pour la table "glpi_networkequipmentmodels".
--- Schéma de base de données attendu
+++ Schéma de base de données actuel
@@ @@
   KEY `date_creation` (`date_creation`),
   KEY `date_mod` (`date_mod`),
   KEY `name` (`name`),
-  KEY `product_number` (`product_number`)
+  KEY `product_number` (`product_number`(250))
 )
Le schéma diffère pour la table "glpi_networkequipments".
--- Schéma de base de données attendu
+++ Schéma de base de données actuel
@@ @@
   KEY `states_id` (`states_id`),
   KEY `users_id_tech` (`users_id_tech`),
   KEY `users_id` (`users_id`),
-  KEY `uuid` (`uuid`)
+  KEY `uuid` (`uuid`(250))
 )
Le schéma diffère pour la table "glpi_peripheralmodels".
--- Schéma de base de données attendu
+++ Schéma de base de données actuel
@@ @@
   KEY `date_creation` (`date_creation`),
   KEY `date_mod` (`date_mod`),
   KEY `name` (`name`),
-  KEY `product_number` (`product_number`)
+  KEY `product_number` (`product_number`(250))
 )
Le schéma diffère pour la table "glpi_peripherals".
--- Schéma de base de données attendu
+++ Schéma de base de données actuel
@@ @@
   KEY `states_id` (`states_id`),
   KEY `users_id_tech` (`users_id_tech`),
   KEY `users_id` (`users_id`),
-  KEY `uuid` (`uuid`)
+  KEY `uuid` (`uuid`(250))
 )
Le schéma diffère pour la table "glpi_phonemodels".
--- Schéma de base de données attendu
+++ Schéma de base de données actuel
@@ @@
   KEY `date_creation` (`date_creation`),
   KEY `date_mod` (`date_mod`),
   KEY `name` (`name`),
-  KEY `product_number` (`product_number`)
+  KEY `product_number` (`product_number`(250))
 )
Le schéma diffère pour la table "glpi_phones".
--- Schéma de base de données attendu
+++ Schéma de base de données actuel
@@ @@
   KEY `states_id` (`states_id`),
   KEY `users_id_tech` (`users_id_tech`),
   KEY `users_id` (`users_id`),
-  KEY `uuid` (`uuid`)
+  KEY `uuid` (`uuid`(250))
 )
Le schéma diffère pour la table "glpi_printermodels".
--- Schéma de base de données attendu
+++ Schéma de base de données actuel
@@ @@
   KEY `date_creation` (`date_creation`),
   KEY `date_mod` (`date_mod`),
   KEY `name` (`name`),
-  KEY `product_number` (`product_number`)
+  KEY `product_number` (`product_number`(250))
 )
Le schéma diffère pour la table "glpi_printers".
--- Schéma de base de données attendu
+++ Schéma de base de données actuel
@@ @@
   KEY `states_id` (`states_id`),
   KEY `users_id_tech` (`users_id_tech`),
   KEY `users_id` (`users_id`),
-  KEY `uuid` (`uuid`)
+  KEY `uuid` (`uuid`(250))
 )
```