### PR TITLE
Fix project search criteria and state handling in personnal and group dashboard

### DIFF
--- a/src/Project.php
+++ b/src/Project.php
@@ -2838,18 +2838,37 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
             'criteria' => [
                 [
                     'link' => 'AND',
-                    'field' => 87,
-                    'searchtype' => 'equals',
-                    'value' => 'myself'
-                ],
-                [
-                    'link' => 'OR',
-                    'field' => 24,
-                    'searchtype' => 'equals',
-                    'value' => 'myself'
+                    'criteria' => [
+                        [
+                            'link' => 'AND',
+                            'field' => ($itemtype === 'User') ? 87 : 88, // 87 = Project teams - Users, 88 = Project teams - Groups
+                            'searchtype' => 'equals',
+                            'value' => ($itemtype === 'User') ? 'myself' : 'mygroups'
+                        ],
+                        [
+                            'link' => 'OR',
+                            'field' => ($itemtype === 'User') ? 24 : 49, // 24 = Project Manager, 49 = Project Manager group
+                            'searchtype' => 'equals',
+                            'value' => ($itemtype === 'User') ? 'myself' : 'mygroups'
+                        ]
+                    ]
                 ]
             ]
         ];
+
+        // Retrieve finished project states to exclude them from the search
+        $project_states = (new ProjectState())->find([
+            'is_finished' => 1
+        ]);
+
+        foreach ($project_states as $state) {
+            $options['criteria'][] = [
+                'link' => 'AND',
+                'field' => 12,
+                'searchtype' => 'notequals',
+                'value' => $state['id']
+            ];
+        }
 
         $displayed_row_count = min(count($projects_id), (int)$_SESSION['glpidisplay_count_on_home']);
 

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -1764,7 +1764,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
         $projecttasks_id = [];
         switch ($itemtype) {
             case 'User':
-                $projecttasks_id = self::getActiveProjectTaskIDsForUser([Session::getLoginUserID()]);
+                $projecttasks_id = self::getActiveProjectTaskIDsForUser([Session::getLoginUserID()], false);
                 break;
             case 'Group':
                 $projecttasks_id = self::getActiveProjectTaskIDsForGroup($_SESSION['glpigroups']);


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

This pull request addresses issues with the search criteria and state handling in the Project class, which were introduced in the initial implementation of feature #16709.

- The search criteria now correctly differentiates between User and Group item types
- The search criteria now also takes into account the state of the project. Previously, finished projects were included in the search results.
- Add search options on users/groups/suppliers/contact for project tasks

