### PR TITLE
Fix(User): fix default group / profile / entity security

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -1083,16 +1083,16 @@ class User extends CommonDBTM
             $_SESSION["glpidefault_entity"] = $input["entities_id"];
         }
 
-        // Security on default profile update
-        if (!isset($input['_ruleright_process'])) {
-            if (isset($input['profiles_id'])) {
+        // Security on default values (manually update)
+        if (!isset($input['_ruleright_process'])) { // if no rule right process
+            if (isset($input['profiles_id'])) { //check if desired profile can be set (depending on user's profiles)
                 if (!in_array($input['profiles_id'], Profile_User::getUserProfiles($input['id']))) {
                     unset($input['profiles_id']);
                 }
             }
 
             // Security on default entity  update
-            if (isset($input['entities_id'])) {
+            if (isset($input['entities_id'])) { //check if desired entity can be set (depending on user's entities)
                 if (!in_array($input['entities_id'], Profile_User::getUserEntities($input['id']))) {
                     unset($input['entities_id']);
                 }
@@ -1100,7 +1100,7 @@ class User extends CommonDBTM
 
             // Security on default group  update
             if (
-                isset($input['groups_id'])
+                isset($input['groups_id']) //check if desired group can be set (depending on user's groups)
                 && !Group_User::isUserInGroup($input['id'], $input['groups_id'])
             ) {
                 unset($input['groups_id']);
@@ -1366,15 +1366,19 @@ class User extends CommonDBTM
             }
 
             $default_option = [];
-            // Security on default entity update
+            // Security on default entity update by rule
+            // if input contain default entity and if it not user's entity
             if (isset($this->input['entities_id']) && $this->input['entities_id'] != $this->fields['entities_id']) {
+                // Check if the entity is in the user's entities
                 if (in_array($this->input['entities_id'], Profile_User::getUserEntities($this->input['id']))) {
                     $default_option['entities_id'] = $this->input['entities_id'];
                 }
             }
 
-            // Security on default profile update
+            // Security on default profile update by rule
+             // if input contain default profile and if it not user's profile
             if (isset($this->input['profiles_id']) && $this->input['profiles_id'] != $this->fields['profiles_id']) {
+                // Check if the profile is in the user's profiles
                 if (in_array($this->input['profiles_id'], Profile_User::getUserProfiles($this->input['id']))) {
                     $default_option['profiles_id'] = $this->input['profiles_id'];
                 }

--- a/src/User.php
+++ b/src/User.php
@@ -1083,6 +1083,30 @@ class User extends CommonDBTM
             $_SESSION["glpidefault_entity"] = $input["entities_id"];
         }
 
+        // Security on default profile update
+        if (!isset($input['_ruleright_process'])) {
+            if (isset($input['profiles_id'])) {
+                if (!in_array($input['profiles_id'], Profile_User::getUserProfiles($input['id']))) {
+                    unset($input['profiles_id']);
+                }
+            }
+
+            // Security on default entity  update
+            if (isset($input['entities_id'])) {
+                if (!in_array($input['entities_id'], Profile_User::getUserEntities($input['id']))) {
+                    unset($input['entities_id']);
+                }
+            }
+
+            // Security on default group  update
+            if (
+                isset($input['groups_id'])
+                && !Group_User::isUserInGroup($input['id'], $input['groups_id'])
+            ) {
+                unset($input['groups_id']);
+            }
+        }
+
         if (
             isset($input['_reset_personal_token'])
             && $input['_reset_personal_token']

--- a/tests/units/RuleRight.php
+++ b/tests/units/RuleRight.php
@@ -364,6 +364,5 @@ class RuleRight extends DbTestCase
         $this->integer($users->fields['entities_id'])->isEqualTo(0);
         $this->integer($users->fields['profiles_id'])->isEqualTo(4);
         $this->integer($users->fields['groups_id'])->isEqualTo($new_groups_id);
-
     }
 }


### PR DESCRIPTION
The check on the default```entity``` / ```profile``` and ```group``` does not take account of data after the rules (```LDAP``` / ```Right```)

This PR fix this


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !32328
