### PR TITLE
Change notifications task labels

### DIFF
--- a/src/NotificationTargetProjectTask.php
+++ b/src/NotificationTargetProjectTask.php
@@ -60,8 +60,8 @@ class NotificationTargetProjectTask extends NotificationTarget
     public function addAdditionalTargets($event = '')
     {
 
-        $this->addTarget(Notification::TEAM_USER, __('Project team user'));
-        $this->addTarget(Notification::TEAM_GROUP, __('Project team group'));
+        $this->addTarget(Notification::TEAM_USER, __('Project task team user'));
+        $this->addTarget(Notification::TEAM_GROUP, __('Project task team group'));
         $this->addTarget(Notification::TEAM_GROUP_SUPERVISOR, __('Manager of group of project team'));
         $this->addTarget(
             Notification::TEAM_GROUP_WITHOUT_SUPERVISOR,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !32275

The old labeling suggested that users and groups linked to the project would be notified when a task was created or updated. In the new code, users or groups linked to the task are notified, which is more logical.

**Before**
![image](https://github.com/glpi-project/glpi/assets/107540223/a62d8f50-26cd-4855-aa5b-046b5802dbc6)

**After**
![image](https://github.com/glpi-project/glpi/assets/107540223/df96ca74-24b6-4966-95e9-af2048c82ba6)

