### PR TITLE
Replace usage of obsolete `docker-compose` method

### DIFF
--- a/.github/actions/init_containers-start.sh
+++ b/.github/actions/init_containers-start.sh
@@ -3,9 +3,9 @@ set -e -u -x -o pipefail
 
 mkdir -p $APP_CONTAINER_HOME
 
-docker-compose pull --quiet
-docker-compose up --no-start
-docker-compose start
+docker compose pull --quiet
+docker compose up --no-start
+docker compose start
 
 if [[ "$UPDATE_FILES_ACL" = true ]]; then
   # Change files rights to give write access to app container user
@@ -15,7 +15,7 @@ if [[ "$UPDATE_FILES_ACL" = true ]]; then
 fi
 
 # Check services health
-for CONTAINER_ID in `docker-compose ps -a -q`; do
+for CONTAINER_ID in `docker compose ps -a -q`; do
   CONTAINER_NAME=`/usr/bin/docker inspect --format='{{print .Name}}{{if .Config.Image}} ({{print .Config.Image}}){{end}}' $CONTAINER_ID`
   HEALTHY=false
   TOTAL_COUNT=0

--- a/.github/actions/init_initialize-0.80-db.sh
+++ b/.github/actions/init_initialize-0.80-db.sh
@@ -3,6 +3,6 @@ set -e -u -x -o pipefail
 
 ROOT_DIR=$(readlink -f "$(dirname $0)/../..")
 
-docker-compose exec -T db mysql --user=root --execute="DROP DATABASE IF EXISTS \`glpitest080\`;"
-docker-compose exec -T db mysql --user=root --execute="CREATE DATABASE \`glpitest080\`;"
-cat $ROOT_DIR/tests/glpi-0.80-empty.sql | docker-compose exec -T db mysql --user=root glpitest080
+docker compose exec -T db mysql --user=root --execute="DROP DATABASE IF EXISTS \`glpitest080\`;"
+docker compose exec -T db mysql --user=root --execute="CREATE DATABASE \`glpitest080\`;"
+cat $ROOT_DIR/tests/glpi-0.80-empty.sql | docker compose exec -T db mysql --user=root glpitest080

--- a/.github/actions/init_initialize-9.5-db.sh
+++ b/.github/actions/init_initialize-9.5-db.sh
@@ -3,7 +3,7 @@ set -e -u -x -o pipefail
 
 ROOT_DIR=$(readlink -f "$(dirname $0)/../..")
 
-docker-compose exec -T db mysql --user=root --execute="DROP DATABASE IF EXISTS \`glpitest-9.5\`;"
-docker-compose exec -T db mysql --user=root --execute="CREATE DATABASE \`glpitest-9.5\`;"
-cat $ROOT_DIR/install/mysql/glpi-9.5.13-empty.sql | docker-compose exec -T db mysql --user=root glpitest-9.5
-cat $ROOT_DIR/tests/glpi-9.5-data.sql | docker-compose exec -T db mysql --user=root glpitest-9.5
+docker compose exec -T db mysql --user=root --execute="DROP DATABASE IF EXISTS \`glpitest-9.5\`;"
+docker compose exec -T db mysql --user=root --execute="CREATE DATABASE \`glpitest-9.5\`;"
+cat $ROOT_DIR/install/mysql/glpi-9.5.13-empty.sql | docker compose exec -T db mysql --user=root glpitest-9.5
+cat $ROOT_DIR/tests/glpi-9.5-data.sql | docker compose exec -T db mysql --user=root glpitest-9.5

--- a/.github/actions/init_initialize-imap-fixtures.sh
+++ b/.github/actions/init_initialize-imap-fixtures.sh
@@ -3,8 +3,8 @@ set -e -u -x -o pipefail
 
 ROOT_DIR=$(readlink -f "$(dirname $0)/../..")
 
-docker-compose exec -T --user root dovecot doveadm expunge -u glpi mailbox 'INBOX' all
-docker-compose exec -T --user root dovecot doveadm purge -u glpi
+docker compose exec -T --user root dovecot doveadm expunge -u glpi mailbox 'INBOX' all
+docker compose exec -T --user root dovecot doveadm purge -u glpi
 for f in `ls $ROOT_DIR/tests/emails-tests/*.eml`; do
-  cat $f | docker-compose exec -T --user glpi dovecot getmail_maildir /home/glpi/Maildir/
+  cat $f | docker compose exec -T --user glpi dovecot getmail_maildir /home/glpi/Maildir/
 done

--- a/.github/actions/init_initialize-ldap-fixtures.sh
+++ b/.github/actions/init_initialize-ldap-fixtures.sh
@@ -4,8 +4,8 @@ set -e -u -x -o pipefail
 ROOT_DIR=$(readlink -f "$(dirname $0)/../..")
 
 # Recursively delete all LDAP entries
-docker-compose exec -T openldap ldapdelete -x -r -H ldap://127.0.0.1:3890/ -D "cn=Manager,dc=glpi,dc=org" -w insecure -c "dc=glpi,dc=org" || true
+docker compose exec -T openldap ldapdelete -x -r -H ldap://127.0.0.1:3890/ -D "cn=Manager,dc=glpi,dc=org" -w insecure -c "dc=glpi,dc=org" || true
 
 for f in `ls $ROOT_DIR/tests/LDAP/ldif/*.ldif`; do
-  cat $f | docker-compose exec -T openldap ldapadd -x -H ldap://127.0.0.1:3890/ -D "cn=Manager,dc=glpi,dc=org" -w insecure
+  cat $f | docker compose exec -T openldap ldapadd -x -H ldap://127.0.0.1:3890/ -D "cn=Manager,dc=glpi,dc=org" -w insecure
 done

--- a/.github/actions/init_show-versions.sh
+++ b/.github/actions/init_show-versions.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 set -e -u -o pipefail
 
-docker-compose exec -T app php --version
-docker-compose exec -T app php -r 'echo(sprintf("PHP extensions: %s\n", implode(", ", get_loaded_extensions())));'
-docker-compose exec -T app composer --version
-docker-compose exec -T app sh -c 'echo "node $(node --version)"'
-docker-compose exec -T app sh -c 'echo "npm $(npm --version)"'
+docker compose exec -T app php --version
+docker compose exec -T app php -r 'echo(sprintf("PHP extensions: %s\n", implode(", ", get_loaded_extensions())));'
+docker compose exec -T app composer --version
+docker compose exec -T app sh -c 'echo "node $(node --version)"'
+docker compose exec -T app sh -c 'echo "npm $(npm --version)"'
 
-if [[ -n $(docker-compose ps --all --services | grep "db") ]]; then
-  docker-compose exec -T db mysql --version;
+if [[ -n $(docker compose ps --all --services | grep "db") ]]; then
+  docker compose exec -T db mysql --version;
 fi
-if [[ -n $(docker-compose ps --all --services | grep "redis") ]]; then
-  docker-compose exec -T redis redis-server --version;
+if [[ -n $(docker compose ps --all --services | grep "redis") ]]; then
+  docker compose exec -T redis redis-server --version;
 fi
-if [[ -n $(docker-compose ps --all --services | grep "memcached") ]]; then
-  docker-compose exec -T memcached memcached --version;
+if [[ -n $(docker compose ps --all --services | grep "memcached") ]]; then
+  docker compose exec -T memcached memcached --version;
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,22 +74,22 @@ jobs:
           .github/actions/init_show-versions.sh
       - name: "Build dependencies / translations"
         run: |
-          docker-compose exec -T app .github/actions/init_build.sh
+          docker compose exec -T app .github/actions/init_build.sh
       - name: "PHP lint"
         run: |
-          docker-compose exec -T app .github/actions/lint_php-lint.sh
+          docker compose exec -T app .github/actions/lint_php-lint.sh
       - name: "Twig lint"
         run: |
-          docker-compose exec -T app .github/actions/lint_twig-lint.sh
+          docker compose exec -T app .github/actions/lint_twig-lint.sh
       - name: "JS lint"
         run: |
-          docker-compose exec -T app .github/actions/lint_js-lint.sh
+          docker compose exec -T app .github/actions/lint_js-lint.sh
       - name: "SCSS lint"
         run: |
-          docker-compose exec -T app .github/actions/lint_scss-lint.sh
+          docker compose exec -T app .github/actions/lint_scss-lint.sh
       - name: "Misc lint"
         run: |
-          docker-compose exec -T app .github/actions/lint_misc-lint.sh
+          docker compose exec -T app .github/actions/lint_misc-lint.sh
 
   tests:
     # Do not run scheduled tests on tier repositories
@@ -151,48 +151,48 @@ jobs:
       - name: "Build dependencies / translations"
         if: env.skip != 'true'
         run: |
-          docker-compose exec -T app .github/actions/init_build.sh
+          docker compose exec -T app .github/actions/init_build.sh
       - name: "Install DB tests"
         if: env.skip != 'true'
         run: |
-          docker-compose exec -T app .github/actions/test_install.sh
+          docker compose exec -T app .github/actions/test_install.sh
       - name: "Update DB tests (from 0.80, not using utf8mb4)"
         if: env.skip != 'true'
         run: |
           .github/actions/init_initialize-0.80-db.sh
-          docker-compose exec -T app .github/actions/test_update-from-older-version.sh
+          docker compose exec -T app .github/actions/test_update-from-older-version.sh
       - name: "Update DB tests (from 9.5, using utf8mb4)"
         if: env.skip != 'true'
         run: |
           .github/actions/init_initialize-9.5-db.sh
-          docker-compose exec -T app .github/actions/test_update-from-9.5.sh
+          docker compose exec -T app .github/actions/test_update-from-9.5.sh
       - name: "Unit tests"
         if: env.skip != 'true'
         run: |
-          docker-compose exec -T app .github/actions/test_tests-units.sh
+          docker compose exec -T app .github/actions/test_tests-units.sh
       - name: "Functional tests"
         if: env.skip != 'true'
         run: |
-          docker-compose exec -T app .github/actions/test_tests-functional.sh
+          docker compose exec -T app .github/actions/test_tests-functional.sh
       - name: "Cache tests"
         if: env.skip != 'true'
         run: |
-          docker-compose exec -T app .github/actions/test_tests-cache.sh
+          docker compose exec -T app .github/actions/test_tests-cache.sh
       - name: "LDAP tests"
         if: env.skip != 'true'
         run: |
           .github/actions/init_initialize-ldap-fixtures.sh
-          docker-compose exec -T app .github/actions/test_tests-ldap.sh
+          docker compose exec -T app .github/actions/test_tests-ldap.sh
       - name: "IMAP tests"
         if: env.skip != 'true'
         run: |
           .github/actions/init_initialize-imap-fixtures.sh
-          docker-compose exec -T app .github/actions/test_tests-imap.sh
+          docker compose exec -T app .github/actions/test_tests-imap.sh
       - name: "WEB tests"
         if: env.skip != 'true'
         run: |
-          docker-compose exec -T app .github/actions/test_tests-web.sh
+          docker compose exec -T app .github/actions/test_tests-web.sh
       - name: "Javascript tests"
         if: env.skip != 'true'
         run: |
-          docker-compose exec -T app .github/actions/test_javascript.sh
+          docker compose exec -T app .github/actions/test_javascript.sh

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -55,24 +55,24 @@ jobs:
           .github/actions/init_show-versions.sh
       - name: "Build dependencies / translations"
         run: |
-          docker-compose exec -T app .github/actions/init_build.sh
+          docker compose exec -T app .github/actions/init_build.sh
       - name: "Install database"
         run: |
-          docker-compose exec -T app .github/actions/test_install.sh
+          docker compose exec -T app .github/actions/test_install.sh
       - name: "Unit tests"
         run: |
-          docker-compose exec -T app .github/actions/test_tests-units.sh
+          docker compose exec -T app .github/actions/test_tests-units.sh
       - name: "Functional tests"
         run: |
-          docker-compose exec -T app .github/actions/test_tests-functional.sh
+          docker compose exec -T app .github/actions/test_tests-functional.sh
       - name: "LDAP tests"
         run: |
           .github/actions/init_initialize-ldap-fixtures.sh
-          docker-compose exec -T app .github/actions/test_tests-ldap.sh
+          docker compose exec -T app .github/actions/test_tests-ldap.sh
       - name: "IMAP tests"
         run: |
           .github/actions/init_initialize-imap-fixtures.sh
-          docker-compose exec -T app .github/actions/test_tests-imap.sh
+          docker compose exec -T app .github/actions/test_tests-imap.sh
       - name: "Codecov"
         uses: "codecov/codecov-action@v4"
         with:

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -201,7 +201,7 @@ $APPLICATION_ROOT/.github/actions/init_containers-start.sh
 $APPLICATION_ROOT/.github/actions/init_show-versions.sh
 
 # Install dependencies if required
-[[ "$BUILD" = false ]] || docker-compose exec -T app .github/actions/init_build.sh
+[[ "$BUILD" = false ]] || docker compose exec -T app .github/actions/init_build.sh
 
 INSTALL_TESTS_RUN=false
 
@@ -232,67 +232,67 @@ run_single_test () {
       # Misc lint (licence headers and locales) is not executed here as their output is not configurable yet
       # and it would be a pain to handle rolling back of their changes.
       # TODO Add ability to simulate locales extact without actually modifying locale files.
-         docker-compose exec -T app .github/actions/lint_php-lint.sh \
-      && docker-compose exec -T app .github/actions/lint_js-lint.sh \
-      && docker-compose exec -T app .github/actions/lint_scss-lint.sh \
-      && docker-compose exec -T app .github/actions/lint_twig-lint.sh \
+         docker compose exec -T app .github/actions/lint_php-lint.sh \
+      && docker compose exec -T app .github/actions/lint_js-lint.sh \
+      && docker compose exec -T app .github/actions/lint_scss-lint.sh \
+      && docker compose exec -T app .github/actions/lint_twig-lint.sh \
       || LAST_EXIT_CODE=$?
       ;;
     "lint_php")
-         docker-compose exec -T app .github/actions/lint_php-lint.sh \
+         docker compose exec -T app .github/actions/lint_php-lint.sh \
       || LAST_EXIT_CODE=$?
       ;;
     "lint_js")
-         docker-compose exec -T app .github/actions/lint_js-lint.sh \
+         docker compose exec -T app .github/actions/lint_js-lint.sh \
       || LAST_EXIT_CODE=$?
       ;;
     "lint_scss")
-         docker-compose exec -T app .github/actions/lint_scss-lint.sh \
+         docker compose exec -T app .github/actions/lint_scss-lint.sh \
       || LAST_EXIT_CODE=$?
       ;;
     "lint_twig")
-         docker-compose exec -T app .github/actions/lint_twig-lint.sh \
+         docker compose exec -T app .github/actions/lint_twig-lint.sh \
       || LAST_EXIT_CODE=$?
       ;;
     "install")
-         docker-compose exec -T app .github/actions/test_install.sh \
+         docker compose exec -T app .github/actions/test_install.sh \
       || LAST_EXIT_CODE=$?
       ;;
     "update")
          $APPLICATION_ROOT/.github/actions/init_initialize-0.80-db.sh \
       && $APPLICATION_ROOT/.github/actions/init_initialize-9.5-db.sh \
-      && docker-compose exec -T app .github/actions/test_update-from-older-version.sh \
-      && docker-compose exec -T app .github/actions/test_update-from-9.5.sh \
+      && docker compose exec -T app .github/actions/test_update-from-older-version.sh \
+      && docker compose exec -T app .github/actions/test_update-from-9.5.sh \
       || LAST_EXIT_CODE=$?
       ;;
     "units")
-         docker-compose exec -T app .github/actions/test_tests-units.sh $TEST_ARGS \
+         docker compose exec -T app .github/actions/test_tests-units.sh $TEST_ARGS \
       || LAST_EXIT_CODE=$?
       ;;
     "functional")
-         docker-compose exec -T app .github/actions/test_tests-functional.sh $TEST_ARGS \
+         docker compose exec -T app .github/actions/test_tests-functional.sh $TEST_ARGS \
       || LAST_EXIT_CODE=$?
       ;;
     "cache")
-         docker-compose exec -T app .github/actions/test_tests-cache.sh \
+         docker compose exec -T app .github/actions/test_tests-cache.sh \
       || LAST_EXIT_CODE=$?
       ;;
     "ldap")
          $APPLICATION_ROOT/.github/actions/init_initialize-ldap-fixtures.sh \
-      && docker-compose exec -T app .github/actions/test_tests-ldap.sh \
+      && docker compose exec -T app .github/actions/test_tests-ldap.sh \
       || LAST_EXIT_CODE=$?
       ;;
     "imap")
          $APPLICATION_ROOT/.github/actions/init_initialize-imap-fixtures.sh \
-      && docker-compose exec -T app .github/actions/test_tests-imap.sh \
+      && docker compose exec -T app .github/actions/test_tests-imap.sh \
       || LAST_EXIT_CODE=$?
       ;;
     "web")
-         docker-compose exec -T app .github/actions/test_tests-web.sh \
+         docker compose exec -T app .github/actions/test_tests-web.sh \
       || LAST_EXIT_CODE=$?
       ;;
     "javascript")
-         docker-compose exec -T app .github/actions/test_javascript.sh \
+         docker compose exec -T app .github/actions/test_javascript.sh \
       || LAST_EXIT_CODE=$?
       ;;
   esac
@@ -338,7 +338,7 @@ cleanup_and_exit () {
   find "$BACKUP_DIR" -mindepth 1 -exec mv -f {} $APPLICATION_ROOT/tests/config \;
 
   # Stop containers
-  docker-compose down --volumes
+  docker compose down --volumes
 
   exit $LAST_EXIT_CODE
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The `docker-compose` command is no more available on latest docker versions. It has been replaced by the `docker compose` command.