### PR TITLE
fix: resolve issue with auto-setting real start and end dates in ProjectTask

### DIFF
--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -581,11 +581,11 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
             return $input;
         } else {
             // Set automatically the real start date if not set
-            if ($real_start_date === null && $percent_done > 0) {
+            if (empty($real_start_date) && $percent_done > 0) {
                 $input['real_start_date'] = Session::getCurrentTime();
             }
             // Set automatically the real end date if not set
-            if ($real_end_date === null && $percent_done === 100) {
+            if (empty($real_end_date) && $percent_done === 100) {
                 $input['real_end_date'] = Session::getCurrentTime();
             }
             // Set automatically the effective duration if not set


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

Corrects a problem initiated by PR #16718, the purpose of which was to automatically set the actual date of a project task. However, when the `real_start_date` field was set to an empty string (when saving the form with an empty date, for example), the automatic date setting no longer worked, since the field was not `null`.