### PR TITLE
Prevent invalid lock config

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -298,6 +298,23 @@ class Config extends CommonDBTM
             $input['glpinetwork_registration_key'] = trim($input['glpinetwork_registration_key']);
         }
 
+        // Prevent invalid profile to be set as the lock profile.
+        // User updating the config from GLPI's UI should not be able to send
+        // invalid values but API or manual HTTP requests might be invalid.
+        if (isset($input['lock_lockprofile_id'])) {
+            $profile = Profile::getById($input['lock_lockprofile_id']);
+
+            if (!$profile || $profile->fields['interface'] !== 'central') {
+                // Invalid profile
+                Session::addMessageAfterRedirect(
+                    __("The specified profile doesn't exist or is not allowed to access the central interface."),
+                    false,
+                    ERROR
+                );
+                unset($input['lock_lockprofile_id']);
+            }
+        }
+
         $this->setConfigurationValues('core', $input);
 
         return false;

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -312,6 +312,8 @@ class Profile extends CommonDBTM
 
     public function prepareInputForUpdate($input)
     {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
 
         if (isset($input["_helpdesk_item_types"])) {
             if ((!isset($input["helpdesk_item_type"])) || (!is_array($input["helpdesk_item_type"]))) {
@@ -424,6 +426,21 @@ class Profile extends CommonDBTM
         if (isset($input['interface']) && $input['interface'] == 'helpdesk' && $this->isLastSuperAdminProfile()) {
             Session::addMessageAfterRedirect(
                 __("Can't change the interface on this profile as it is the only remaining profile with rights to modify profiles with this interface."),
+                false,
+                ERROR
+            );
+            unset($input['interface']);
+        }
+
+        // If the profile is used as the "Profile to be used when locking items",
+        // it can't be set to the "helpdesk" interface.
+        if (
+            isset($input['interface'])
+            && $input['interface'] === "helpdesk"
+            && $this->fields['id'] === (int) $CFG_GLPI['lock_lockprofile_id']
+        ) {
+            Session::addMessageAfterRedirect(
+                __("This profile can't be moved to the simplified interface as it is used for locking items."),
                 false,
                 ERROR
             );

--- a/templates/pages/setup/general/general_setup.html.twig
+++ b/templates/pages/setup/general/general_setup.html.twig
@@ -276,6 +276,9 @@
         inline_field_options|merge(lock_options)|merge({
             'width': 'auto',
             'rand': locks_rand,
+            'condition': {
+                'interface': 'central',
+            }
         })
     ) }}
 

--- a/tests/DbTestCase.php
+++ b/tests/DbTestCase.php
@@ -229,8 +229,9 @@ class DbTestCase extends \GLPITestCase
      *
      * @param string $itemtype
      * @param array $input
+     * @param array $skip_fields Fields that wont be checked after update
      */
-    protected function updateItem($itemtype, $id, $input)
+    protected function updateItem($itemtype, $id, $input, $skip_fields = [])
     {
         $item = new $itemtype();
         $input['id'] = $id;
@@ -238,9 +239,9 @@ class DbTestCase extends \GLPITestCase
         $success = $item->update($input);
         $this->boolean($success)->isTrue();
 
-       // Remove special fields
-        $input = array_filter($input, function ($key) {
-            return strpos($key, '_') !== 0;
+        // Remove special fields
+        $input = array_filter($input, function ($key) use ($skip_fields) {
+            return !in_array($key, $skip_fields) && strpos($key, '_') !== 0;
         }, ARRAY_FILTER_USE_KEY);
 
         $this->checkInput($item, $id, $input);

--- a/tests/functional/Profile.php
+++ b/tests/functional/Profile.php
@@ -249,6 +249,17 @@ class Profile extends DbTestCase
         $this->hasSessionMessages(ERROR, [
             "Can't remove update right on this profile as it is the only remaining profile with this right."
         ]);
+
+        // Try to change the interface of the lock profile
+        $readonly = getItemByTypeName('Profile', 'Read-Only');
+        $this->updateItem("Profile", $readonly->getID(), [
+            'interface' => 'helpdesk'
+        ], ['interface']); // Skip interface check as it should not be updated.
+        $readonly->getFromDB($readonly->fields['id']); // Reload data
+        $this->string($readonly->fields['interface'])->isEqualTo('central');
+        $this->hasSessionMessages(ERROR, [
+            "This profile can't be moved to the simplified interface as it is used for locking items."
+        ]);
     }
 
     /**


### PR DESCRIPTION
Some users ran into trouble when they modified the `Read-Only` profile to be restricted to the simplified interface.

This create major issues with the locking mechanism (as this profile is the default `Profile to be used when locking items` on a fresh install).

Trying to open a locked item will then log out the user because GLPI try to load a self-service profile while being on a central restricted page (e.g. a computer):

![image](https://github.com/glpi-project/glpi/assets/42734840/7965f7e6-13a0-4d28-afdc-749726754bbb)

---

To prevent this, I've added two restrictions:
* The current "Profile to be used when locking items" can't be set to use the simplified interface.
* In the general configuration, simplified interface profiles can't be set as the "Profile to be used when locking items".


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !32346
