### PR TITLE
Project UI Migration (Part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,7 +148,9 @@ The present file will list all changes made to the project; according to the
 - Usage of `verbatim_value` Twig filter.
 - `AuthLDAP::dropdownUserDeletedActions()`
 - `AuthLDAP::getOptions()`
+- `CommonITILObject::commonListHeader()`
 - `CommonITILObject::isValidator()`
+- `CommonITILObject::showShort()`
 - `CommonITILValidation::alreadyExists()`
 - `CommonITILValidation::getTicketStatusNumber()`
 - `ComputerAntivirus` has been deprecated and replaced by `ItemAntivirus`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,9 +148,7 @@ The present file will list all changes made to the project; according to the
 - Usage of `verbatim_value` Twig filter.
 - `AuthLDAP::dropdownUserDeletedActions()`
 - `AuthLDAP::getOptions()`
-- `CommonITILObject::commonListHeader()`
 - `CommonITILObject::isValidator()`
-- `CommonITILObject::showShort()`
 - `CommonITILValidation::alreadyExists()`
 - `CommonITILValidation::getTicketStatusNumber()`
 - `ComputerAntivirus` has been deprecated and replaced by `ItemAntivirus`

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7242,7 +7242,6 @@ abstract class CommonITILObject extends CommonDBTM
                         $user_cache[$d['users_id']] = getUserName($d['users_id'], 2);
                     }
                     $entry['assigned'] .= $user_cache[$d['users_id']]['name'] . '<br>';
-
                 }
             }
             foreach ($item->getGroups(CommonITILActor::ASSIGN) as $d) {

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7203,7 +7203,7 @@ abstract class CommonITILObject extends CommonDBTM
 
             $priority_name = static::getPriorityName($item->fields["priority"]);
             $priority_color = $_SESSION["glpipriority_" . $item->fields["priority"]];
-            $entry['priority'] = '<span class="fw-bold badge text-body" style="background-color: ' . $priority_color . '">' . $priority_name . '</span>';
+            $entry['priority'] = '<span class="fw-bold badge text-body" style="background-color: ' . htmlspecialchars($priority_color) . '">' . htmlspecialchars($priority_name) . '</span>';
 
             $entry['requester'] = '';
             foreach ($item->getUsers(CommonITILActor::REQUESTER) as $d) {
@@ -7228,35 +7228,35 @@ abstract class CommonITILObject extends CommonDBTM
                 if (!isset($group_cache[$d['groups_id']])) {
                     $group_cache[$d['groups_id']] = Dropdown::getDropdownName(table: 'glpi_groups', id: $d['groups_id'], default: '');
                 }
-                $entry['requester'] .= $group_cache[$d['groups_id']] . '<br>';
+                $entry['requester'] .= htmlspecialchars($group_cache[$d['groups_id']]) . '<br>';
             }
 
             $entry['assigned'] = '';
             foreach ($item->getUsers(CommonITILActor::ASSIGN) as $d) {
                 if (Session::getCurrentInterface() === 'helpdesk' && !empty($anon_name = User::getAnonymizedNameForUser($d['users_id'], $item->getEntityID()))) {
-                    $entry['assigned'] .= $anon_name . '<br>';
+                    $entry['assigned'] .= htmlspecialchars($anon_name) . '<br>';
                 } else {
                     if (!isset($user_cache[$d['users_id']])) {
                         $user_cache[$d['users_id']] = getUserName($d['users_id'], 2);
                     }
-                    $entry['assigned'] .= $user_cache[$d['users_id']]['name'] . '<br>';
+                    $entry['assigned'] .= htmlspecialchars($user_cache[$d['users_id']]['name']) . '<br>';
                 }
             }
             foreach ($item->getGroups(CommonITILActor::ASSIGN) as $d) {
                 if (Session::getCurrentInterface() === 'helpdesk' && !empty($anon_name = Group::getAnonymizedName($item->getEntityID()))) {
-                    $entry['assigned'] .= $anon_name . '<br>';
+                    $entry['assigned'] .= htmlspecialchars($anon_name) . '<br>';
                 } else {
                     if (!isset($group_cache[$d['groups_id']])) {
                         $group_cache[$d['groups_id']] = Dropdown::getDropdownName(table: 'glpi_groups', id: $d['groups_id'], default: '');
                     }
-                    $entry['assigned'] .= $group_cache[$d['groups_id']] . '<br>';
+                    $entry['assigned'] .= htmlspecialchars($group_cache[$d['groups_id']]) . '<br>';
                 }
             }
             foreach ($item->getSuppliers(CommonITILActor::ASSIGN) as $d) {
                 if (!isset($supplier_cache[$d['suppliers_id']])) {
                     $supplier_cache[$d['suppliers_id']] = Dropdown::getDropdownName(table: 'glpi_suppliers', id: $d['suppliers_id'], default: '');
                 }
-                $entry['assigned'] .= $supplier_cache[$d['suppliers_id']] . '<br>';
+                $entry['assigned'] .= htmlspecialchars($supplier_cache[$d['suppliers_id']]) . '<br>';
             }
 
             if (!$params['ticket_stats']) {
@@ -7269,7 +7269,7 @@ abstract class CommonITILObject extends CommonDBTM
                     if (!isset($asset_cache[$val['itemtype']][$val['items_id']])) {
                         $object = getItemForItemtype($val["itemtype"]);
                         if ($object && $object->getFromDB($val["items_id"])) {
-                            $asset_cache[$val['itemtype']][$val['items_id']] = $object::canView() ? $object->getLink() : $object->getNameID();
+                            $asset_cache[$val['itemtype']][$val['items_id']] = $object::canView() ? $object->getLink() : htmlspecialchars($object->getNameID());
                         }
                     }
                     if (isset($asset_cache[$val['itemtype']][$val['items_id']])) {
@@ -7305,13 +7305,13 @@ abstract class CommonITILObject extends CommonDBTM
                 foreach ($result as $plan) {
                     if (isset($plan['begin']) && $plan['begin']) {
                         $items[$plan['id']] = $plan['id'];
-                        $planned_infos .= sprintf(__s('From %s'), Html::convDateTime($plan['begin']));
-                        $planned_infos .= sprintf(__s('To %s'), Html::convDateTime($plan['end']));
+                        $planned_infos .= htmlspecialchars(sprintf(__('From %s'), Html::convDateTime($plan['begin'])));
+                        $planned_infos .= htmlspecialchars(sprintf(__('To %s'), Html::convDateTime($plan['end'])));
                         if ($plan['users_id_tech']) {
                             if (!isset($user_cache[$plan['users_id_tech']])) {
                                 $user_cache[$plan['users_id_tech']] = getUserName($plan['users_id_tech'], 2);
                             }
-                            $planned_infos .= sprintf(__s('By %s'), $user_cache[$plan['users_id_tech']]['name']);
+                            $planned_infos .= htmlspecialchars(sprintf(__('By %s'), $user_cache[$plan['users_id_tech']]['name']));
                         }
                         $planned_infos .= "<br>";
                     }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -6621,7 +6621,6 @@ abstract class CommonITILObject extends CommonDBTM
      *      id_for_massaction      : default 0 means no massive action
      *
      * @since 10.0.0 "followups" option has been dropped
-     * @deprecated 11.0 Use {@link self::getDatatableEntries()} instead
      */
     public static function showShort($id, $options = [])
     {
@@ -6990,7 +6989,6 @@ abstract class CommonITILObject extends CommonDBTM
     /**
      * @param integer $output_type Output type
      * @param string  $mass_id     id of the form to check all
-     * @deprecated 11.0 Use {@link self::getCommonDatatableColumns()}
      */
     public static function commonListHeader(
         $output_type = Search::HTML_OUTPUT,

--- a/src/Itil_Project.php
+++ b/src/Itil_Project.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\View\TemplateRenderer;
+
 /**
  * Relation between Itil items and Projects
  *
@@ -120,8 +122,11 @@ class Itil_Project extends CommonDBRelation
      **/
     public static function showForProject(Project $project)
     {
-        /** @var \DBmysql $DB */
-        global $DB;
+        /**
+         * @var \DBmysql $DB
+         * @var array $CFG_GLPI
+         */
+        global $DB, $CFG_GLPI;
 
         $ID = $project->getField('id');
         if (!$project->can($ID, READ)) {
@@ -130,130 +135,113 @@ class Itil_Project extends CommonDBRelation
 
         $canedit = $project->canEdit($ID);
 
-        /** @var CommonITILObject $itemtype */
-        foreach ([Change::class, Problem::class, Ticket::class] as $itemtype) {
-            $rand    = mt_rand();
-
-            $selfTable = self::getTable();
-            $itemTable = $itemtype::getTable();
-
-            $iterator = $DB->request([
+        $queries = [];
+        foreach ($CFG_GLPI['itil_types'] as $itemtype) {
+            $link_table = self::getTable();
+            $itil_table = $itemtype::getTable();
+            $queries[] = [
                 'SELECT'          => [
-                    "$selfTable.id AS linkid",
-                    "$itemTable.*"
+                    "$link_table.id AS linkid",
+                    "$link_table.items_id AS id",
+                    new \Glpi\DBAL\QueryExpression($DB::quoteValue($itemtype), 'itemtype'),
+                    new \Glpi\DBAL\QueryExpression($DB::quoteValue($itemtype::getTypeName(1)), 'itemtype_label'),
                 ],
                 'DISTINCT'        => true,
-                'FROM'            => $selfTable,
+                'FROM'            => $link_table,
                 'LEFT JOIN'       => [
-                    $itemTable => [
+                    $itil_table => [
                         'FKEY' => [
-                            $selfTable => 'items_id',
-                            $itemTable => 'id',
+                            $link_table => 'items_id',
+                            $itil_table => 'id',
                         ],
                     ],
                 ],
                 'WHERE'           => [
-                    "{$selfTable}.itemtype"    => $itemtype,
-                    "{$selfTable}.projects_id" => $ID,
-                    'NOT'                      => ["{$itemTable}.id" => null],
+                    "{$link_table}.projects_id" => $ID,
+                    "{$link_table}.itemtype"    => $itemtype,
+                    'NOT'                      => ["{$itil_table}.id" => null],
                 ],
-                'ORDER'  => "{$itemTable}.name",
-            ]);
-
-            $numrows = $iterator->count();
-
-            $items = [];
-            $used  = [];
-            foreach ($iterator as $data) {
-                $items[$data['id']] = $data;
-                $used[$data['id']]  = $data['id'];
-            }
-            if ($canedit) {
-                echo '<div class="firstbloc">';
-                $formId = 'itilproject_' . strtolower($itemtype) . '_form' . $rand;
-                echo '<form name="' . $formId . '"
-                        id="' . $formId . '"
-                        method="post"
-                        action="' . Toolbox::getItemTypeFormURL(__CLASS__) . '">';
-                echo '<table class="tab_cadre_fixe">';
-
-                $label = match ($itemtype) {
-                    Change::class => __('Add a change'),
-                    Problem::class => __('Add a problem'),
-                    Ticket::class => __('Add a ticket'),
-                    default => null
-                };
-                echo '<tr class="tab_bg_2"><th colspan="2">' . $label . '</th></tr>';
-                echo '<tr class="tab_bg_2">';
-                echo '<td>';
-                echo '<input type="hidden" name="projects_id" value="' . $ID . '" />';
-                echo '<input type="hidden" name="itemtype" value="' . $itemtype . '" />';
-                $itemtype::dropdown(
-                    [
-                        'entity'      => $project->getEntityID(),
-                        'entity_sons' => $project->isRecursive(),
-                        'name'        => 'items_id',
-                        'used'        => $used,
-                    ]
-                );
-                echo '</td>';
-                echo '<td class="center">';
-                echo '<input type="submit" name="add" value="' . _sx('button', 'Add') . '" class="btn btn-primary" />';
-                echo '</td>';
-                echo '</tr>';
-                echo '</table>';
-                Html::closeForm();
-                echo '</div>';
-            }
-
-            echo '<div class="spaced">';
-            $massContainerId = 'mass' . __CLASS__ . $rand;
-            if ($canedit && $numrows) {
-                Html::openMassiveActionsForm($massContainerId);
-                $massiveactionparams = [
-                    'num_displayed' => min($_SESSION['glpilist_limit'], $numrows),
-                    'container'     => $massContainerId,
-                ];
-                Html::showMassiveActions($massiveactionparams);
-            }
-
-            echo '<table class="tab_cadre_fixehov">';
-            echo '<tr class="noHover">';
-            echo '<th colspan="12">' . $itemtype::getTypeName($numrows) . '</th>';
-            echo '</tr>';
-            if ($numrows) {
-                $itemtype::commonListHeader(Search::HTML_OUTPUT, $massContainerId);
-                Session::initNavigateListItems(
-                    $itemtype,
-                    //TRANS : %1$s is the itemtype name,
-                    //        %2$s is the name of the item (used for headings of a list)
-                    sprintf(__('%1$s = %2$s'), Project::getTypeName(1), $project->fields['name'])
-                );
-
-                $i = 0;
-                foreach ($items as $data) {
-                     Session::addToNavigateListItems($itemtype, $data['id']);
-                     $itemtype::showShort(
-                         $data['id'],
-                         [
-                             'row_num'                => $i,
-                             'type_for_massiveaction' => __CLASS__,
-                             'id_for_massiveaction'   => $data['linkid']
-                         ]
-                     );
-                     $i++;
-                }
-                $itemtype::commonListHeader(Search::HTML_OUTPUT, $massContainerId);
-            }
-            echo '</table>';
-
-            if ($canedit && $numrows) {
-                $massiveactionparams['ontop'] = false;
-                Html::showMassiveActions($massiveactionparams);
-                Html::closeForm();
-            }
-            echo '</div>';
+            ];
         }
+
+        $it = $DB->request([
+            'FROM' => new \Glpi\DBAL\QueryUnion($queries),
+        ]);
+        $entries_by_itemtype = [];
+        $used  = [];
+        foreach ($it as $data) {
+            $used[$data['itemtype']][$data['id']]  = $data['id'];
+            $entries_by_itemtype[$data['itemtype']][] = [
+                'id'             => $data['linkid'],
+                'itemtype'       => $data['itemtype'],
+                'item_id'        => $data['id'],
+                'itemtype_label' => $data['itemtype_label'],
+            ];
+        }
+
+        if ($canedit) {
+            $twig_params = [
+                'btn_msg' => _x('button', 'Add'),
+                'used'    => $used,
+                'ID'      => $ID,
+            ];
+            // language=Twig
+            echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
+                    {% import 'components/form/fields_macros.html.twig' as fields %}
+                    <div class="text-center mb-3">
+                        <form method="post" action="{{ 'Itil_Project'|itemtype_form_path }}">
+                            <input type="hidden" name="projects_id" value="{{ ID }}"/>
+                            <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}"/>
+                            <div>
+                                {{ fields.dropdownItemsFromItemtypes('items_id', null, {
+                                    no_label: true,
+                                    full_width: true,
+                                    itemtypes: config('itil_types'),
+                                    used: used,
+                                    add_field_class: 'd-flex'
+                                }) }}
+                            </div>
+                            <div class="card-body mx-n2 border-top d-flex flex-row-reverse align-items-start flex-wrap py-2">
+                                <button class="btn btn-primary" type="submit" name="add" value="">{{ btn_msg }}</button>
+                            </div>
+                        </form>
+                    </div>
+TWIG, $twig_params);
+        }
+
+        $cols = CommonITILObject::getCommonDatatableColumns();
+        // insert 'itemtype_label' column after 'item_id' column
+        $cols['columns'] = array_merge(
+            ['item_id' => $cols['columns']['item_id']],
+            ['itemtype_label' => __('Type')],
+            array_slice($cols['columns'], 1)
+        );
+        $entries = [];
+        /** @var class-string<CommonITILObject> $itemtype */
+        foreach ($entries_by_itemtype as $itemtype => $v) {
+            $entries = [...$entries, ...$itemtype::getDatatableEntries($v)];
+        }
+        // add itemtype for MA
+        foreach ($entries as &$entry) {
+            $entry['itemtype'] = self::class;
+        }
+        TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
+            'is_tab' => true,
+            'nopager' => true,
+            'nofilter' => true,
+            'nosort' => true,
+            'columns' => $cols['columns'],
+            'formatters' => $cols['formatters'],
+            'entries' => $entries,
+            'total_number' => count($entries),
+            'filtered_number' => count($entries),
+            'showmassiveactions' => $canedit,
+            'massiveactionparams' => [
+                'num_displayed' => count($entries),
+                'container'     => 'mass' . self::class . mt_rand(),
+                'specific_actions' => ['purge' => _x('button', 'Delete permanently')]
+            ]
+        ]);
     }
 
     /**

--- a/src/Itil_Project.php
+++ b/src/Itil_Project.php
@@ -144,7 +144,6 @@ class Itil_Project extends CommonDBRelation
                     "$link_table.id AS linkid",
                     "$link_table.items_id AS id",
                     new \Glpi\DBAL\QueryExpression($DB::quoteValue($itemtype), 'itemtype'),
-                    new \Glpi\DBAL\QueryExpression($DB::quoteValue($itemtype::getTypeName(1)), 'itemtype_label'),
                 ],
                 'DISTINCT'        => true,
                 'FROM'            => $link_table,
@@ -175,7 +174,7 @@ class Itil_Project extends CommonDBRelation
                 'id'             => $data['linkid'],
                 'itemtype'       => $data['itemtype'],
                 'item_id'        => $data['id'],
-                'itemtype_label' => $data['itemtype_label'],
+                'itemtype_label' => $data['itemtype']::getTypeName(1),
             ];
         }
 

--- a/src/Project.php
+++ b/src/Project.php
@@ -2249,7 +2249,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
                 $done = count(array_filter($item['_steps'], static fn ($step) => (int) $step['percent_done'] === 100));
                 $total = count($item['_steps']);
                 $content .= "<div class='flex-break'></div>";
-                $content .= sprintf(__('%s / %s tasks complete'), $done, $total);
+                $content .= sprintf(__s('%s / %s tasks complete'), $done, $total);
             }
            // Percent Done
             $content .= "<div class='flex-break'></div>";

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -1700,6 +1700,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
      *
      * @param string $itemtype The itemtype (User or Group)
      * @return void
+     * @used-by Central
      */
     public static function showListForCentral(string $itemtype): void
     {

--- a/tests/functional/Entity.php
+++ b/tests/functional/Entity.php
@@ -891,18 +891,26 @@ class Entity extends DbTestCase
        // Case 1: removed (test values recovered from CommonITILObject::showUsersAssociated())
 
        // Case 2: test values recovered from CommonITILObject:::showShort()
-        ob_start();
-        Ticket::showShort($tickets_id);
-        $html = ob_get_clean();
+        $entries = Ticket::getDatatableEntries([
+            [
+                'item_id' => $tickets_id,
+                'id' => $tickets_id,
+                'itemtype' => 'Ticket',
+            ]
+        ]);
+        $entry = $entries[0];
 
+        $entry_contents = array_reduce(array_keys($entry), static function ($carry, $key) use ($entry) {
+            return $carry . $entry[$key];
+        }, '');
         foreach ($possible_values as $value) {
-            if ($value == $expected) {
-                $this->string($html)->contains(
+            if ($value === $expected) {
+                $this->string($entry_contents)->contains(
                     $value,
-                    "Ticket showShort must contains '$value' in interface '$interface' with settings '$setting'"
+                    "Ticket getDatatableEntries must contains '$value' in interface '$interface' with settings '$setting'"
                 );
             } else {
-                $this->string($html)->notContains(
+                $this->string($entry_contents)->notContains(
                     $value,
                     "Ticket form must not contains '$value' (expected '$expected') in interface '$interface' with settings '$setting'"
                 );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Migrations for the project-related UI are proving to be more work than originally intended so I am splitting the work over multiple PRs. The "Itil items" tab for projects relied on `CommonITILObject::commonListHeader` and `CommonITILObject::showShort` to display the lists. Both methods echo raw HTML. To allow these lists to be shown with the datatable template like almost every other list, two replacement methods were added. The original methods are now deprecated. There are other places that use the old methods in the core and they will be migrated in future PRs. The old methods are used in at least one plugin (Releases).

- Dropdowns to add new Ticket/Change/Problem were collapsed to a single itemtype/item dropdown field.
- Dropdown is based on the itil_types config array (new for GLPI 11) instead of just Tickets, Changes and Problems.
- Individual lists of connected ITIL items was collapsed to a single list.
- Associated elements show for all itemtypes, not just Tickets.
- ITIL items with no associated elements now show nothing instead of "General" (Not sure if there was a legitimate use, but it seems confusing to say a ticket is linked to "General" when it isn't linked to any asset).
- The replacement for `showShort` works on multiple entries at a time. This allows the use of some caches to avoid duplicate DB queries for things like user, entity, and category data.
- The background for the priority column is now just a badge instead of changing the cell color. This was done because the datatable template doesn't have a way to change the color of the cell, and there probably isn't a good way to do that.

 
![Selection_287](https://github.com/glpi-project/glpi/assets/17678637/f60ccd46-7327-46a1-9143-d827544ab7b3)

![Selection_289](https://github.com/glpi-project/glpi/assets/17678637/324b85f9-1268-4e1e-b9f3-81aee11cb875)