### PR TITLE
Fix update ticket status when ticket task is de-scheduled

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -3743,7 +3743,7 @@ abstract class CommonITILObject extends CommonDBTM
         if (
             array_key_exists(
                 static::STATUS_MATRIX_FIELD,
-                $_SESSION['glpiactiveprofile']
+                $_SESSION['glpiactiveprofile'] ?? []
             )
             && static::isStatusExists($new)
         ) { // maybe not set for post-only

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -499,6 +499,16 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
                         '_disablenotif' => true,
                     ];
                     $item->update($input2);
+                } elseif (
+                    $item->isStatusExists(CommonITILObject::ASSIGNED)
+                    && ($item->fields["status"] == CommonITILObject::PLANNED)
+                ) {
+                    $input2 = [
+                        'id'            => $item->getID(),
+                        'status'        => CommonITILObject::ASSIGNED,
+                        '_disablenotif' => false,
+                    ];
+                    $item->update($input2);
                 }
 
                 if (!isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"]) {

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -475,58 +475,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
                 if (!$this->input['_job']->getFromDB($this->fields[$this->input['_job']->getForeignKeyField()])) {
                     return false;
                 }
-                if (
-                    isset($this->input['_status'])
-                    && ($this->input['_status'] != $this->input['_job']->fields['status'])
-                ) {
-                    $update = [
-                        'status'        => $this->input['_status'],
-                        'id'            => $this->input['_job']->fields['id'],
-                        '_disablenotif' => true,
-                    ];
-                    $this->input['_job']->update($update);
-                }
-
-                if (
-                    !empty($this->fields['begin'])
-                    && $item->isStatusExists(CommonITILObject::PLANNED)
-                    && (($item->fields["status"] == CommonITILObject::INCOMING)
-                     || ($item->fields["status"] == CommonITILObject::ASSIGNED))
-                ) {
-                    $input2 = [
-                        'id'            => $item->getID(),
-                        'status'        => CommonITILObject::PLANNED,
-                        '_disablenotif' => true,
-                    ];
-                    $item->update($input2);
-                } elseif (
-                    $item->fields["status"] == CommonITILObject::PLANNED
-                ) {
-                    if (
-                        $item->isAllowedStatus($item->fields["status"], CommonITILObject::ASSIGNED)
-                        && (
-                            ($item->countUsers(CommonITILActor::ASSIGN) > 0)
-                            || ($item->countGroups(CommonITILActor::ASSIGN) > 0)
-                            || ($item->countSuppliers(CommonITILActor::ASSIGN) > 0)
-                        )
-                    ) {
-                        $input2 = [
-                            'id'            => $item->getID(),
-                            'status'        => CommonITILObject::ASSIGNED,
-                            '_disablenotif' => false,
-                        ];
-                        $item->update($input2);
-                    } elseif (
-                        $item->isAllowedStatus($item->fields["status"], CommonITILObject::INCOMING)
-                    ) {
-                        $input2 = [
-                            'id'            => $item->getID(),
-                            'status'        => CommonITILObject::INCOMING,
-                            '_disablenotif' => false,
-                        ];
-                        $item->update($input2);
-                    }
-                }
+                $this->updateParentStatus($this->input['_job'], $this->input);
 
                 if (!isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"]) {
                     $options = ['task_id'    => $this->fields["id"],

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -500,15 +500,32 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
                     ];
                     $item->update($input2);
                 } elseif (
-                    $item->isStatusExists(CommonITILObject::ASSIGNED)
-                    && ($item->fields["status"] == CommonITILObject::PLANNED)
+                    $item->fields["status"] == CommonITILObject::PLANNED
                 ) {
-                    $input2 = [
-                        'id'            => $item->getID(),
-                        'status'        => CommonITILObject::ASSIGNED,
-                        '_disablenotif' => false,
-                    ];
-                    $item->update($input2);
+                    if (
+                        $item->isAllowedStatus($item->fields["status"], CommonITILObject::ASSIGNED)
+                        && (
+                            ($item->countUsers(CommonITILActor::ASSIGN) > 0)
+                            || ($item->countGroups(CommonITILActor::ASSIGN) > 0)
+                            || ($item->countSuppliers(CommonITILActor::ASSIGN) > 0)
+                        )
+                    ) {
+                        $input2 = [
+                            'id'            => $item->getID(),
+                            'status'        => CommonITILObject::ASSIGNED,
+                            '_disablenotif' => false,
+                        ];
+                        $item->update($input2);
+                    } elseif (
+                        $item->isAllowedStatus($item->fields["status"], CommonITILObject::INCOMING)
+                    ) {
+                        $input2 = [
+                            'id'            => $item->getID(),
+                            'status'        => CommonITILObject::INCOMING,
+                            '_disablenotif' => false,
+                        ];
+                        $item->update($input2);
+                    }
                 }
 
                 if (!isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"]) {

--- a/src/Glpi/Features/ParentStatus.php
+++ b/src/Glpi/Features/ParentStatus.php
@@ -173,7 +173,11 @@ trait ParentStatus
                     || $needupdateparent)
             ) {
                 $input['_status'] = CommonITILObject::PLANNED;
-            } elseif ($parentitem->fields["status"] == CommonITILObject::PLANNED) {
+            } elseif (
+                $parentitem->fields["status"] == CommonITILObject::PLANNED
+                && in_array('begin', $this->updates)
+                && $this->isField('begin')
+            ) {
                 /** @var \DBmysql $DB */
                 global $DB;
                 $criteria = [

--- a/src/Glpi/Features/ParentStatus.php
+++ b/src/Glpi/Features/ParentStatus.php
@@ -133,7 +133,7 @@ trait ParentStatus
                 if (
                     Session::isCron()
                     || Session::getCurrentInterface() == "helpdesk"
-                    || $parentitem::isAllowedStatus($parentitem->fields["status"], CommonITILObject::ASSIGNED)
+                    || $parentitem->isStatusExists(CommonITILObject::ASSIGNED)
                 ) {
                     $needupdateparent = true;
                     // If begin date is defined, the status must be planned if it exists, rather than assigned.
@@ -148,7 +148,7 @@ trait ParentStatus
                 if (
                     Session::isCron()
                     || Session::getCurrentInterface() == "helpdesk"
-                    || $parentitem::isAllowedStatus($parentitem->fields["status"], CommonITILObject::INCOMING)
+                    || $parentitem->isStatusExists(CommonITILObject::INCOMING)
                 ) {
                     $needupdateparent = true;
                     $update['status'] = CommonITILObject::INCOMING;
@@ -192,7 +192,7 @@ trait ParentStatus
                 if ($iterator->numrows() > 0) {
                     $input['_status'] = CommonITILObject::PLANNED;
                 } elseif (
-                    $parentitem::isAllowedStatus($parentitem->fields["status"], CommonITILObject::ASSIGNED)
+                    $parentitem->isStatusExists(CommonITILObject::ASSIGNED)
                     && (
                         ($parentitem->countUsers(CommonITILActor::ASSIGN) > 0)
                         || ($parentitem->countGroups(CommonITILActor::ASSIGN) > 0)
@@ -201,7 +201,7 @@ trait ParentStatus
                 ) {
                     $input['_status'] = CommonITILObject::ASSIGNED;
                 } elseif (
-                    $parentitem::isAllowedStatus($parentitem->fields["status"], CommonITILObject::INCOMING)
+                    $parentitem->isStatusExists(CommonITILObject::INCOMING)
                 ) {
                     $input['_status'] = CommonITILObject::INCOMING;
                 }

--- a/tests/functional/TicketTask.php
+++ b/tests/functional/TicketTask.php
@@ -452,7 +452,54 @@ class TicketTask extends DbTestCase
             'end'                => $date_end_string,
         ]))->isTrue();
 
+
+
         $this->integer(\Ticket::getById($ticket_id)->fields['status'])->isEqualTo(\Ticket::PLANNED);
+
+        $ticket = new \Ticket();
+        $ticket_users = new \Ticket_User();
+
+        // remove assigned user from ticket
+        $this->boolean($ticket_users->deleteByCriteria([
+            'tickets_id' => $ticket_id,
+            'type'       => \CommonITILActor::ASSIGN,
+        ]))->isTrue();
+
+        $this->boolean($ticket->getFromDB($ticket_id))->isTrue();
+
+        $this->integer($ticket->countUsers(\CommonITILActor::ASSIGN))->isEqualTo(0);
+
+        $this->integer(\Ticket::getById($ticket_id)->fields['status'])->isEqualTo(\Ticket::INCOMING);
+
+        $this->boolean($task->update([
+            'id'                 => $task_id,
+            'tickets_id'         => $ticket_id,
+            'content'            => "De-planned Task",
+            'begin'              => null,
+            'end'                => null,
+        ]))->isTrue();
+
+        $this->integer(\Ticket::getById($ticket_id)->fields['status'])->isEqualTo(\Ticket::INCOMING);
+
+        $this->boolean($task->update([
+            'id'                 => $task_id,
+            'tickets_id'         => $ticket_id,
+            'content'            => "Planned Task",
+            'begin'              => $date_begin_string,
+            'end'                => $date_end_string,
+        ]))->isTrue();
+
+        $this->integer(\Ticket::getById($ticket_id)->fields['status'])->isEqualTo(\Ticket::PLANNED);
+
+        $this->boolean($task->update([
+            'id'                 => $task_id,
+            'tickets_id'         => $ticket_id,
+            'content'            => "De-planned Task",
+            'begin'              => null,
+            'end'                => null,
+        ]))->isTrue();
+
+        $this->integer(\Ticket::getById($ticket_id)->fields['status'])->isEqualTo(\Ticket::INCOMING);
     }
 
     public function testUpdateParentStatus()

--- a/tests/functional/TicketTask.php
+++ b/tests/functional/TicketTask.php
@@ -403,6 +403,58 @@ class TicketTask extends DbTestCase
         $this->integer($task->fields['is_private'])->isEqualTo(0);
     }
 
+    /**
+     * Test that the ticket status is correctly updated when the task is scheduled and then unscheduled.
+     *
+     * @return void
+     */
+    public function testDePlanifiedUpdateParentStatus()
+    {
+        $this->login();
+        $ticket_id = $this->getNewTicket();
+        $task = new \TicketTask();
+
+        $uid = getItemByTypeName('User', TU_USER, true);
+        $date_begin = new \DateTime(); // ==> now
+        $date_begin_string = $date_begin->format('Y-m-d H:i:s');
+        $date_end = new \DateTime(); // ==> +2days
+        $date_end->add(new \DateInterval('P2D'));
+        $date_end_string = $date_end->format('Y-m-d H:i:s');
+
+        $task_id = $task->add([
+            'pending'            => 0,
+            'tickets_id'         => $ticket_id,
+            'content'            => "Planned Task",
+            'state'              => \Planning::TODO,
+            'users_id_tech'      => $uid,
+            'begin'              => $date_begin_string,
+            'end'                => $date_end_string,
+        ]);
+        $this->integer($task_id)->isGreaterThan(0);
+
+        $this->integer(\Ticket::getById($ticket_id)->fields['status'])->isEqualTo(\Ticket::PLANNED);
+
+        $this->boolean($task->update([
+            'id'                 => $task_id,
+            'tickets_id'         => $ticket_id,
+            'content'            => "De-planned Task",
+            'begin'              => null,
+            'end'                => null,
+        ]))->isTrue();
+
+        $this->integer(\Ticket::getById($ticket_id)->fields['status'])->isEqualTo(\Ticket::ASSIGNED);
+
+        $this->boolean($task->update([
+            'id'                 => $task_id,
+            'tickets_id'         => $ticket_id,
+            'content'            => "Planned Task",
+            'begin'              => $date_begin_string,
+            'end'                => $date_end_string,
+        ]))->isTrue();
+
+        $this->integer(\Ticket::getById($ticket_id)->fields['status'])->isEqualTo(\Ticket::PLANNED);
+    }
+
     public function testUpdateParentStatus()
     {
         $this->login();

--- a/tests/functional/TicketTask.php
+++ b/tests/functional/TicketTask.php
@@ -500,6 +500,26 @@ class TicketTask extends DbTestCase
         ]))->isTrue();
 
         $this->integer(\Ticket::getById($ticket_id)->fields['status'])->isEqualTo(\Ticket::INCOMING);
+
+        // Check that adding a followup on a ticket that has the CommonITILObject::PLANNED status will not fail.
+        $this->boolean($task->update([
+            'id'                 => $task_id,
+            'tickets_id'         => $ticket_id,
+            'content'            => "Planned Task",
+            'begin'              => $date_begin_string,
+            'end'                => $date_end_string,
+        ]))->isTrue();
+
+        $this->integer(\Ticket::getById($ticket_id)->fields['status'])->isEqualTo(\Ticket::PLANNED);
+
+        $followup = new \ITILFollowup();
+        $this->integer($followup->add([
+            'itemtype'   => 'Ticket',
+            'items_id'   => $ticket_id,
+            'content'    => 'Followup on planned ticket',
+        ]))->isGreaterThan(0);
+
+        $this->integer(\Ticket::getById($ticket_id)->fields['status'])->isEqualTo(\Ticket::PLANNED);
     }
 
     public function testUpdateParentStatus()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !32381

When a task is de-scheduled, the ticket status remains In progress (Scheduled) instead of being changed back to In progress (Assigned).