### PR TITLE
Add some self-service ticket e2e tests

### DIFF
--- a/tests/cypress.config.js
+++ b/tests/cypress.config.js
@@ -36,6 +36,7 @@ const { defineConfig } = require("cypress");
 module.exports = defineConfig({
     viewportWidth: 1920,
     viewportHeight: 1080,
+    experimentalStudio: true,
     e2e: {
         baseUrl: "http://localhost:80",
         setupNodeEvents(on) {

--- a/tests/cypress/e2e/selfservice_tickets.cy.js
+++ b/tests/cypress/e2e/selfservice_tickets.cy.js
@@ -36,7 +36,7 @@ describe('Self-Service Tickets', () => {
         cy.login();
         cy.changeProfile('Self-Service', true);
     });
-    it('Create a ticket', () => {
+    it('Create and view ticket', () => {
         cy.visit('/');
 
         cy.get('aside.sidebar').contains('Create a ticket').click();
@@ -44,13 +44,112 @@ describe('Self-Service Tickets', () => {
 
         cy.get('form.new-itil-object').within(() => {
             cy.get('input[name="name"]').type('My first ticket');
+            cy.get('select[name="itilcategories_id"]').validateSelect2Loading();
+            cy.get('select[data-actor-type="observer"]').validateSelect2Loading();
+            // Location dropdown may not be present if there are no locations
+            if (Cypress.$('select[name="locations_id"]').length) {
+                cy.get('select[name="locations_id"]').validateSelect2Loading();
+            }
             cy.get('textarea[name="content"]').awaitTinyMCE().then(() => {
-                cy.get('textarea[name="content"]').type('This is my first ticket in GLPI. I sure hope it works.', { interactive: true });
+                cy.get('textarea[name="content"]').type('This is my first ticket in GLPI. I sure hope it works.', {interactive: true});
             });
-            cy.get('button[type="submit"]').contains('Submit message').click();
+            cy.get('button').contains('Submit message').click();
+            cy.url().should('include', '/front/tracking.injector.php').then(() => {
+                cy.wrap(Cypress.$('main#page img')).should('have.attr', 'src', '/pics/ok.png');
+            });
         });
 
-        cy.url().should('include', '/front/tracking.injector.php');
-        cy.get('main#page img').should('have.attr', 'src', '/pics/ok.png');
+        // A toast notification should be shown with the ticket number
+        cy.get('#messages_after_redirect .toast-body').should('be.visible').within((toast) => {
+            cy.wrap(toast).invoke('text').should('contain', 'Thank you for using our automatic helpdesk system');
+            cy.wrap(toast).find('a').click();
+        });
+
+        cy.url().should('include', '/front/ticket.form.php');
+
+        // Check the available tabs
+        cy.get('#tabspanel .nav-item').its('length').should('be.gte', 4);
+        cy.get('#tabspanel .nav-item').contains('Ticket').click();
+        cy.get('#tabspanel .nav-item').contains('Ticket').should('have.class', 'active');
+
+        // Verify the ticket name and content are in the timeline
+        cy.get('div.timeline-item:nth-child(1)').should('have.class', 'ITILContent');
+        cy.get('div.timeline-item.ITILContent .card-title').should(f => expect(f.text().trim()).equals('My first ticket'));
+        cy.get('div.timeline-item.ITILContent .rich_text_container').should(f => expect(f.text().trim()).equals('This is my first ticket in GLPI. I sure hope it works.'));
+
+        // Check the details panel
+        cy.get('#item-main').within(() => {
+            cy.get('label').contains('Entity').next().within(() => {
+                cy.get('.glpi-badge').should(badge => expect(badge.text().trim()).to.not.be.empty);
+            });
+            cy.get('label').contains('Opening date').next().within(() => {
+                cy.get('input[type="text"]').invoke('val').should('match', /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+                cy.get('input[type="text"]').should('be.disabled');
+                cy.get('button').click();
+                cy.get('.flatpickr-calendar.open').should('not.exist');
+            });
+            cy.get('label').contains('Type').next().within(() => {
+                cy.get('.select2-selection__rendered').invoke('text').should(t => expect(t.trim()).to.be.oneOf(['Incident', 'Request']));
+                cy.get('select').should('be.disabled');
+            });
+            // No technician assigned and no updates, so category can still be changed
+            cy.get('label').contains('Category').next().within(() => {
+                cy.get('select').should('not.be.disabled');
+            });
+            cy.get('label').contains('Status').next().within((field) => {
+                cy.wrap(field).should(f => expect(f.text().trim()).to.not.be.empty);
+                cy.wrap(field).find('i').should('have.class', 'itilstatus');
+            });
+            // No technician assigned and no updates, so urgency can still be changed
+            cy.get('label').contains('Urgency').next().within(() => {
+                cy.get('.select2-selection__rendered').invoke('text').should(t => expect(t.trim()).to.be.oneOf([
+                    'Very low', 'Low', 'Medium', 'High', 'Very high'
+                ]));
+                cy.get('select').should('not.be.disabled');
+            });
+            cy.get('label').contains('Priority').next().within(() => {
+                cy.get('.select2-selection__rendered').invoke('text').should(t => expect(t.trim()).to.be.oneOf([
+                    'Very low', 'Low', 'Medium', 'High', 'Very high', 'Major'
+                ]));
+                cy.get('select').should('be.disabled');
+            });
+            // Location dropdown may not be present if there are no locations
+            if (Cypress.$('select[name="locations_id"]').length) {
+                cy.get('label').contains('Location').next().within(() => {
+                    cy.get('select').should('be.disabled');
+                });
+            }
+            cy.get('label').contains('Approval').next().within((field) => {
+                cy.wrap(field).invoke('text').should(t => expect(t.trim()).to.be.oneOf([
+                    'Waiting for approval', 'Refused', 'Granted', 'Not subject to approval'
+                ]));
+            });
+            cy.get('label').contains('External ID').next().within(() => {
+                cy.get('input').should('be.disabled');
+            });
+        });
+
+        cy.get('#heading-actor').closest('.accordion-item').within(() => {
+            cy.get('label').contains('Requester').next().within(() => {
+                cy.get('select').should('be.disabled');
+            });
+            cy.get('label').contains('Observer').next().within(() => {
+                cy.get('select').should('be.disabled');
+            });
+            cy.get('label').contains('Assigned to').next().within(() => {
+                cy.get('select').should('be.disabled');
+            });
+        });
+
+        // Statistics
+        cy.get('#tabspanel .nav-item').contains('Statistics').should('exist');
+        // Approvals should not be visible
+        cy.get('#tabspanel .nav-item').contains('Approvals').should('not.exist');
+        // Knowledge base
+        cy.get('#tabspanel .nav-item').contains('Knowledge base').should('exist');
+        // Items
+        cy.get('#tabspanel .nav-item').contains('Items').should('exist');
+        // All
+        cy.get('#tabspanel .nav-item').contains('All').should('exist');
     });
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

- Enables experimental "Cypress Studio" which lets you generate test code by interacting with the browser inside Cypress. May be helpful for devs that aren't very familiar with Cypress yet or aren't comfortable with JavaScript.
https://docs.cypress.io/guides/references/cypress-studio

Tests:
 - The dropdowns on the new ticket form which get their results through AJAX requests can all be opened and have their results loaded properly.
  - Ticket can be created.
  - The "OK" checkmark image and a toast notification are shown after the ticket is submitted.
  - The ticket form loads by clicking the link in the notification.
  - The timeline has the content which matches the title and content that was typed for the ticket.
  - The fields on the right side are all disabled except category and urgency (No tech is assigned yet).
  - The expected tabs are shown.