### PR TITLE
Fixing a few css problems linekd to dark mods reported.

### DIFF
--- a/css/includes/components/_networkport.scss
+++ b/css/includes/components/_networkport.scss
@@ -65,12 +65,14 @@
 
     &.cotrunk {
         background-color: silver;
+        @if $is-dark {
+            color: $dark;
+        }
     }
 
     &.aggregated,
     .aggregated {
         background-color: teal;
-        color: white;
         padding-left: 2em;
 
         a {
@@ -99,5 +101,10 @@
     td.netport {
         text-align: center;
         width: 25%;
+    }
+    @if $is_dark {
+        color: $dark
+    } @else {
+        color: $light
     }
 }

--- a/css/includes/components/_richtext.scss
+++ b/css/includes/components/_richtext.scss
@@ -86,9 +86,12 @@ body.mce-content-body {
         max-height: 350px;
         position: relative;
         overflow: hidden;
-
         .read_more {
-            background: linear-gradient(to bottom, rgba(255, 255, 255, 0%) 0%, #f1f4e3 100%);
+            @if not $is_dark {
+                background: linear-gradient(to bottom, rgba(255, 255, 255, 0%) 0%, #f1f4e3 100%);
+            } @else {
+                background: linear-gradient(to bottom, rgba(255, 255, 255, 0%) 0%, $dark 100%);
+            }
         }
     }
 }

--- a/css/legacy/includes/_styles.scss
+++ b/css/legacy/includes/_styles.scss
@@ -368,11 +368,17 @@
 
    .tab_bg_1_2 {
       background-color: #cf9b9b;
+      @if $is_dark {
+         color: $dark;
+      }
    }
 
 
    .tab_bg_2_2 {
       background-color: #cf9b9b;
+      @if $is_dark {
+        color: $dark;
+     }
    }
 
    .tab_date {

--- a/css/palettes/darker.scss
+++ b/css/palettes/darker.scss
@@ -46,7 +46,7 @@ $secondary-fg: #f3f3f3;
 $dark: #242323;
 $light: #aaa;
 $link-color: #888;
-$text-muted: #757d91;
+$text-muted: $dark;
 $mainmenu_bg: #414141;
 $mainmenu_fg: #f4f6fa;
 $logo: "../pics/logos/logo-GLPI-100-white.png";
@@ -74,5 +74,6 @@ $border-color: rgba(101, 109, 119, 16%);
 $table-head-bg: #2c3b4f;
 $table-head-color: $light;
 $itil-secondary-bg: #222121 !default;
+$code-color: rgb(180, 180, 180);
 
 @import "../includes/palette_dark";

--- a/css/palettes/midnight.scss
+++ b/css/palettes/midnight.scss
@@ -48,7 +48,7 @@ $dark-mode-darken: #000;
 $color-contrast-dark: #1a1a1a;
 $light: #e6e6e6;
 $link-color: #b6c3e0;
-$text-muted: #c6cad2;
+$text-muted: $dark;
 $mainmenu_bg: #2f3f64;
 $mainmenu_fg: #f4f6fa;
 $logo: "../pics/logos/logo-GLPI-100-white.png";
@@ -82,5 +82,6 @@ $itil-secondary-bg: #1d2531 !default;
 $timeline-fup-bg: #1c2430 !default;
 $timeline-fup-fg: #8892a8 !default;
 $timeline-fup-border: #2f3d50 !default;
+$code-color: rgb(180, 180, 180);
 
 @import "../includes/palette_dark";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !32421

**Foundu effect for texts that are too long**
*Before*
![image](https://github.com/glpi-project/glpi/assets/107540223/62ad85ba-e218-4046-9669-80cf443a4af3)
*After*
![image](https://github.com/glpi-project/glpi/assets/107540223/77ed6a08-bd1e-4ffe-8d68-733fe99f4f34)

**Code texts**
*Before*
![image](https://github.com/glpi-project/glpi/assets/107540223/44b51d4f-78dc-4b4d-8242-00233491cfe1)
*After*
![image](https://github.com/glpi-project/glpi/assets/107540223/aa177ddc-d9bb-40be-b7f1-3dcc696847d1)

**Computer network ports**
*Before*
![image](https://github.com/glpi-project/glpi/assets/107540223/437aa15c-eff3-433d-baa1-fcfb88622ea2)
*After*
![image](https://github.com/glpi-project/glpi/assets/107540223/7ed3163d-e9d7-4397-9718-d7ddb99374de)

**Consummable low alert level**
*Before*
![image](https://github.com/glpi-project/glpi/assets/107540223/b3d50d21-d3d1-4a6e-bcc0-788d02d1c75d)
*After*
![image](https://github.com/glpi-project/glpi/assets/107540223/ce98ff96-7251-4f63-94da-01bf933d0e4e)

**User icon**
*Before*
![image](https://github.com/glpi-project/glpi/assets/107540223/d64fadc4-0b89-474f-81ba-74f586d75409)
*After*
![image](https://github.com/glpi-project/glpi/assets/107540223/a3f98334-4aed-4030-aff5-4b02809d8298)
