### PR TITLE
fix(entity): prevent warning on history tab

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -3747,7 +3747,7 @@ class Entity extends CommonTreeDropdown
 
             case 'tickettemplates_id':
                 $strategy = $values['tickettemplates_strategy'] ?? $values[$field];
-                if ($values['tickettemplates_strategy'] == self::CONFIG_PARENT) {
+                if ($strategy == self::CONFIG_PARENT) {
                     return __('Inheritance of the parent entity');
                 }
                 return Dropdown::getDropdownName(TicketTemplate::getTable(), $values[$field]);


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

![image](https://github.com/glpi-project/glpi/assets/8530352/a15b7056-3214-4ce0-86b0-708a355f91e9)

```
glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "tickettemplates_strategy" in .../src/Entity.php at line 3750
  Backtrace :
  src/CommonDBTM.php:4944                            Entity::getSpecificValueToDisplay()
  src/Log.php:722                                    CommonDBTM->getValueToDisplay()
  src/Log.php:325                                    Log::getHistoryData()
  src/Log.php:110                                    Log::showForItem()
  src/CommonGLPI.php:694                             Log::displayTabContentForItem()
  ajax/common.tabs.php:120                           CommonGLPI::displayStandardTab()
  public/index.php:82                                require()
```
