### PR TITLE
show forgot password link only for local accounts

### DIFF
--- a/templates/pages/login.html.twig
+++ b/templates/pages/login.html.twig
@@ -57,11 +57,27 @@
                         {{ __('Password') }}
 
                         {% if show_lost_password %}
-                            <span class="form-label-description">
+                            <span class="form-label-description forgot_password {{ config('display_login_source') ? 'd-none' : '' }}">
                                 <a href="{{ path('front/lostpassword.php?lostpassword=1') }}">
                                     {{ __('Forgotten password?') }}
                                 </a>
                             </span>
+                            {% if config('display_login_source') %}
+                                <script>
+                                    $(() => {
+                                        if ($('select[name="auth"]').val() === 'local') {
+                                            $('.forgot_password').removeClass('d-none');
+                                        }
+                                        $('select[name="auth"]').on('change', function () {
+                                            if ($(this).val() === 'local') {
+                                                $('.forgot_password').removeClass('d-none');
+                                            } else {
+                                                $('.forgot_password').addClass('d-none');
+                                            }
+                                        });
+                                    });
+                                </script>
+                            {% endif %}
                         {% endif %}
                     </label>
                     <input type="password" class="form-control" id="login_password" name="{{ pwdfield }}" placeholder="" autocomplete="off" tabindex="2"/>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Based on forum post:
https://forum.glpi-project.org/viewtopic.php?id=289797

The forgot password feature only works for local accounts, but the link on the login page is always shown. This PR makes it shown only when the local source is selected, or when the login source dropdown isn't shown at all.