### PR TITLE
Fix user icon text color in dark theme

### DIFF
--- a/css/includes/_palette_dark.scss
+++ b/css/includes/_palette_dark.scss
@@ -180,4 +180,8 @@ body .modal-header {
     background-color: lighten($dark, 5%);
 }
 
+.avatar {
+    color: $dark;
+}
+
 @import "includes";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !32421

The user icon text was unreadable if the background was light. I had modified the _avatars.scss file but it doesn't do push so I did this via the _palette_dark.scss file.
![image](https://github.com/glpi-project/glpi/assets/107540223/c89174e0-83a3-477e-96aa-99001adc82fb) ![image](https://github.com/glpi-project/glpi/assets/107540223/5c3ef2e0-9e57-4206-8020-1e107e198401)
