### PR TITLE
Clean Auth Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@ The present file will list all changes made to the project; according to the
 - Defining "users_id_validate" field without defining "itemtype_target"/"items_id_target" in "CommonITILValidation".
 - Usage of `name` and `users_id_validate` options in `CommonITILValidation::dropdownValidator()`.
 - Usage of `verbatim_value` Twig filter.
+- `Auth::getErr()`
 - `AuthLDAP::dropdownUserDeletedActions()`
 - `AuthLDAP::getOptions()`
 - `CommonITILObject::isValidator()`

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -185,7 +185,8 @@ class Auth extends CommonGLPI
         /** @var \DBmysql $DB */
         global $DB;
 
-        $result = $DB->request('glpi_users', [
+        $result = $DB->request([
+            'FROM' => 'glpi_users',
             'LEFT JOIN' => [
                 'glpi_useremails' => [
                     'FKEY' => [
@@ -1639,7 +1640,7 @@ class Auth extends CommonGLPI
      */
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
     {
-        if ($item::class === 'User') {
+        if ($item::class === User::class) {
             self::showSynchronizationForm($item);
         }
         return true;

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -43,27 +43,27 @@ use LDAP\Connection;
  */
 class AuthLDAP extends CommonDBTM
 {
-    const SIMPLE_INTERFACE = 'simple';
-    const EXPERT_INTERFACE = 'expert';
+    public const SIMPLE_INTERFACE = 'simple';
+    public const EXPERT_INTERFACE = 'expert';
 
-    const ACTION_IMPORT      = 0;
-    const ACTION_SYNCHRONIZE = 1;
-    const ACTION_ALL         = 2;
+    public const ACTION_IMPORT      = 0;
+    public const ACTION_SYNCHRONIZE = 1;
+    public const ACTION_ALL         = 2;
 
-    const USER_IMPORTED      = 0;
-    const USER_SYNCHRONIZED  = 1;
-    const USER_DELETED_LDAP  = 2;
-    const USER_RESTORED_LDAP = 3;
+    public const USER_IMPORTED      = 0;
+    public const USER_SYNCHRONIZED  = 1;
+    public const USER_DELETED_LDAP  = 2;
+    public const USER_RESTORED_LDAP = 3;
 
-   //Import user by giving his login
-    const IDENTIFIER_LOGIN = 'login';
+    /** Import user by giving his login */
+    public const IDENTIFIER_LOGIN = 'login';
 
-   //Import user by giving his email
-    const IDENTIFIER_EMAIL = 'email';
+    /** Import user by giving his email */
+    public const IDENTIFIER_EMAIL = 'email';
 
-    const GROUP_SEARCH_USER    = 0;
-    const GROUP_SEARCH_GROUP   = 1;
-    const GROUP_SEARCH_BOTH    = 2;
+    public const GROUP_SEARCH_USER    = 0;
+    public const GROUP_SEARCH_GROUP   = 1;
+    public const GROUP_SEARCH_BOTH    = 2;
 
     /**
      * Deleted user strategy: preserve user.
@@ -127,40 +127,40 @@ class AuthLDAP extends CommonDBTM
      * @var integer
      * @since 10.0.0
      */
-    const RESTORED_USER_PRESERVE = 0;
+    public const RESTORED_USER_PRESERVE = 0;
 
     /**
      * Restored user strategy: Restore user from trash
      * @var integer
      * @since 10.0.0
      */
-    const RESTORED_USER_RESTORE = 1;
+    public const RESTORED_USER_RESTORE = 1;
 
     /**
      * Restored user strategy: Re-enable user
      * @var integer
      * @since 10.0.0
      */
-    const RESTORED_USER_ENABLE  = 3;
+    public const RESTORED_USER_ENABLE  = 3;
 
     /**
      * List of TLS versions
      * @var array
      * @since 11.0.0
      */
-    const TLS_VERSIONS = [
+    public const TLS_VERSIONS = [
         '1.0' => '1.0',
         '1.1' => '1.1',
         '1.2' => '1.2',
         '1.3' => '1.3'
     ];
 
-   // From CommonDBTM
+    // From CommonDBTM
     public $dohistory = true;
 
     public static $rightname = 'config';
 
-   //connection caching stuff
+    /** connection caching stuff */
     public static $conn_cache = [];
 
     public static $undisclosedFields = [
@@ -169,12 +169,12 @@ class AuthLDAP extends CommonDBTM
 
     /**
      * Message of last error occured during connection.
-     * @var string
+     * @var ?string
      */
     private static ?string $last_error;
     /**
      * Numero of last error occured during connection.
-     * @var int
+     * @var ?int
      */
     private static ?int $last_errno;
 
@@ -195,7 +195,6 @@ class AuthLDAP extends CommonDBTM
 
     public function post_getEmpty()
     {
-
         $this->fields['port']                        = '389';
         $this->fields['condition']                   = '';
         $this->fields['login_field']                 = 'uid';
@@ -228,7 +227,6 @@ class AuthLDAP extends CommonDBTM
         $this->fields['end_date_field']              = '';
     }
 
-
     /**
      * Preconfig datas for standard system
      *
@@ -238,7 +236,6 @@ class AuthLDAP extends CommonDBTM
      */
     public function preconfig($type)
     {
-
         switch ($type) {
             case 'AD':
                 $this->fields['port']                      = "389";
@@ -311,7 +308,6 @@ class AuthLDAP extends CommonDBTM
 
     public function prepareInputForUpdate($input)
     {
-
         if (isset($input["rootdn_passwd"])) {
             if (empty($input["rootdn_passwd"])) {
                 unset($input["rootdn_passwd"]);
@@ -327,7 +323,7 @@ class AuthLDAP extends CommonDBTM
        // Set attributes in lower case
         if (count($input)) {
             foreach ($input as $key => $val) {
-                if (preg_match('/_field$/', $key)) {
+                if (str_ends_with($key, '_field')) {
                     $input[$key] = Toolbox::strtolower($val);
                 }
             }
@@ -339,7 +335,7 @@ class AuthLDAP extends CommonDBTM
             && isset($input['sync_field'])
             && $this->isSyncFieldUsed()
         ) {
-            if ($input['sync_field'] == $this->fields['sync_field']) {
+            if ($input['sync_field'] === $this->fields['sync_field']) {
                 unset($input['sync_field']);
             } else {
                 Session::addMessageAfterRedirect(
@@ -360,7 +356,6 @@ class AuthLDAP extends CommonDBTM
 
     public static function getSpecificValueToDisplay($field, $values, array $options = [])
     {
-
         if (!is_array($values)) {
             $values = [$field => $values];
         }
@@ -373,7 +368,6 @@ class AuthLDAP extends CommonDBTM
 
     public static function getSpecificValueToSelect($field, $name = '', $values = '', array $options = [])
     {
-
         if (!is_array($values)) {
             $values = [$field => $values];
         }
@@ -418,7 +412,7 @@ class AuthLDAP extends CommonDBTM
                             'is_recursive' => $is_recursive,
                             'type'         => $input['ldap_import_type'][$id]
                         ];
-                        if (AuthLDAP::ldapImportGroup($group_dn, $options)) {
+                        if (self::ldapImportGroup($group_dn, $options)) {
                             $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
                         } else {
                             $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
@@ -439,8 +433,8 @@ class AuthLDAP extends CommonDBTM
                 }
                 foreach ($ids as $id) {
                     if (
-                        AuthLDAP::ldapImportUserByServerId(
-                            ['method' => AuthLDAP::IDENTIFIER_LOGIN,
+                        self::ldapImportUserByServerId(
+                            ['method' => self::IDENTIFIER_LOGIN,
                                 'value'  => $id
                             ],
                             $_SESSION['ldap_import']['mode'],
@@ -471,7 +465,6 @@ class AuthLDAP extends CommonDBTM
      */
     public function showForm($ID, array $options = [])
     {
-
         if (!Config::canUpdate()) {
             return false;
         }
@@ -487,7 +480,7 @@ class AuthLDAP extends CommonDBTM
         if (Toolbox::canUseLdap()) {
             $this->showFormHeader($options);
             if (empty($ID)) {
-                $target = $this->getFormURL();
+                $target = static::getFormURL();
                 echo "<tr class='tab_bg_2'><td>" . __('Preconfiguration') . "</td> ";
                 echo "<td colspan='3'>";
                 echo "<a href='$target?preconfig=AD'>" . __('Active Directory') . "</a>";
@@ -637,7 +630,6 @@ class AuthLDAP extends CommonDBTM
      */
     public function showFormAdvancedConfig()
     {
-
         $ID = $this->getField('id');
         $hidden = '';
 
@@ -753,7 +745,7 @@ class AuthLDAP extends CommonDBTM
         global $DB;
 
         $ID     = $this->getField('id');
-        $target = $this->getFormURL();
+        $target = static::getFormURL();
         $rand   = mt_rand();
 
         AuthLdapReplicate::addNewReplicateForm($target, $ID);
@@ -839,7 +831,6 @@ class AuthLDAP extends CommonDBTM
      */
     public static function dropdownGroupSearchType(array $options)
     {
-
         $p = [
             'name'    => 'group_search_type',
             'value'   => self::GROUP_SEARCH_USER,
@@ -876,10 +867,7 @@ class AuthLDAP extends CommonDBTM
         if (is_null($val)) {
             return $tmp;
         }
-        if (isset($tmp[$val])) {
-            return $tmp[$val];
-        }
-        return NOT_AVAILABLE;
+        return $tmp[$val] ?? NOT_AVAILABLE;
     }
 
     /**
@@ -889,7 +877,6 @@ class AuthLDAP extends CommonDBTM
      */
     public function showFormGroupsConfig()
     {
-
         $ID = $this->getField('id');
 
         echo "<div class='center'>";
@@ -1045,7 +1032,6 @@ class AuthLDAP extends CommonDBTM
 
     public function defineTabs($options = [])
     {
-
         $ong = [];
         $this->addDefaultFormTab($ong);
         $this->addStandardTab(__CLASS__, $ong, $options);
@@ -1061,12 +1047,12 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => 'common',
-            'name'               => $this->getTypeName(1)
+            'name'               => static::getTypeName(1)
         ];
 
         $tab[] = [
             'id'                 => '1',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'name',
             'name'               => __('Name'),
             'datatype'           => 'itemlink',
@@ -1075,7 +1061,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '2',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'id',
             'name'               => __('ID'),
             'datatype'           => 'number',
@@ -1084,7 +1070,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '3',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'host',
             'name'               => __('Server'),
             'datatype'           => 'string'
@@ -1092,7 +1078,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '4',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'port',
             'name'               => _n('Port', 'Ports', 1),
             'datatype'           => 'integer'
@@ -1100,7 +1086,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '5',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'basedn',
             'name'               => __('BaseDN'),
             'datatype'           => 'string'
@@ -1108,7 +1094,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '6',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'condition',
             'name'               => __('Connection filter'),
             'datatype'           => 'text'
@@ -1116,7 +1102,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '7',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'is_default',
             'name'               => __('Default server'),
             'datatype'           => 'bool',
@@ -1125,7 +1111,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '8',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'login_field',
             'name'               => __('Login field'),
             'massiveaction'      => false,
@@ -1134,7 +1120,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '9',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'realname_field',
             'name'               => __('Surname'),
             'massiveaction'      => false,
@@ -1143,7 +1129,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '10',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'firstname_field',
             'name'               => __('First name'),
             'massiveaction'      => false,
@@ -1152,7 +1138,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '11',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'phone_field',
             'name'               =>  _x('ldap', 'Phone'),
             'massiveaction'      => false,
@@ -1161,7 +1147,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '12',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'phone2_field',
             'name'               => __('Phone 2'),
             'massiveaction'      => false,
@@ -1170,7 +1156,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '13',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'mobile_field',
             'name'               => __('Mobile phone'),
             'massiveaction'      => false,
@@ -1179,7 +1165,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '14',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'title_field',
             'name'               => _x('person', 'Title'),
             'massiveaction'      => false,
@@ -1188,7 +1174,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '15',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'category_field',
             'name'               => _n('Category', 'Categories', 1),
             'massiveaction'      => false,
@@ -1197,7 +1183,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '16',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'comment',
             'name'               => __('Comments'),
             'datatype'           => 'text'
@@ -1205,7 +1191,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '17',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'email1_field',
             'name'               => _n('Email', 'Emails', 1),
             'massiveaction'      => false,
@@ -1214,7 +1200,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '25',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'email2_field',
             'name'               => sprintf(__('%1$s %2$s'), _n('Email', 'Emails', 1), '2'),
             'massiveaction'      => false,
@@ -1223,7 +1209,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '26',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'email3_field',
             'name'               => sprintf(__('%1$s %2$s'), _n('Email', 'Emails', 1), '3'),
             'massiveaction'      => false,
@@ -1232,7 +1218,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '27',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'email4_field',
             'name'               => sprintf(__('%1$s %2$s'), _n('Email', 'Emails', 1), '4'),
             'massiveaction'      => false,
@@ -1241,7 +1227,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '18',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'use_dn',
             'name'               => __('Use DN in the search'),
             'datatype'           => 'bool',
@@ -1250,7 +1236,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '19',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'date_mod',
             'name'               => __('Last update'),
             'datatype'           => 'datetime',
@@ -1259,7 +1245,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '121',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'date_creation',
             'name'               => __('Creation date'),
             'datatype'           => 'datetime',
@@ -1268,7 +1254,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '20',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'language_field',
             'name'               => __('Language'),
             'massiveaction'      => false,
@@ -1277,7 +1263,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '21',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'group_field',
             'name'               => __('User attribute containing its groups'),
             'massiveaction'      => false,
@@ -1286,7 +1272,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '22',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'group_condition',
             'name'               => __('Filter to search in groups'),
             'massiveaction'      => false,
@@ -1295,7 +1281,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '23',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'group_member_field',
             'name'               => __('Group attribute containing its users'),
             'massiveaction'      => false,
@@ -1304,7 +1290,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '24',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'group_search_type',
             'datatype'           => 'specific',
             'name'               => __('Search type'),
@@ -1313,7 +1299,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '30',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'is_active',
             'name'               => __('Active'),
             'datatype'           => 'bool'
@@ -1321,7 +1307,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '28',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'sync_field',
             'name'               => __('Synchronization field'),
             'massiveaction'      => false,
@@ -1330,7 +1316,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '29',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'responsible_field',
             'name'               => __('Supervisor'),
             'massiveaction'      => false,
@@ -1339,7 +1325,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '31',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'inventory_domain',
             'name'               => __('Domain name used by inventory tool'),
             'massiveaction'      => false,
@@ -1348,7 +1334,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '32',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'timeout',
             'name'               => __('Timeout'),
             'massiveaction'      => false,
@@ -1361,7 +1347,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '33',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'begin_date_field',
             'name'               => __('Valid since'),
             'massiveaction'      => false,
@@ -1370,7 +1356,7 @@ class AuthLDAP extends CommonDBTM
 
         $tab[] = [
             'id'                 => '34',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'end_date_field',
             'name'               => __('Valid until'),
             'massiveaction'      => false,
@@ -1394,7 +1380,8 @@ class AuthLDAP extends CommonDBTM
 
         if (!empty($ldap_servers)) {
             foreach ($ldap_servers as $value) {
-                $fields = ['Server'            => 'host',
+                $fields = [
+                    'Server'            => 'host',
                     'Port'              => 'port',
                     'BaseDN'            => 'basedn',
                     'Connection filter' => 'condition',
@@ -1419,7 +1406,6 @@ class AuthLDAP extends CommonDBTM
         ];
     }
 
-
     /**
      * Get LDAP fields to sync to GLPI data from a glpi_authldaps array
      *
@@ -1431,7 +1417,8 @@ class AuthLDAP extends CommonDBTM
     {
 
         $ret    = [];
-        $fields = ['login_field'               => 'name',
+        $fields = [
+            'login_field'               => 'name',
             'email1_field'              => 'email1',
             'email2_field'              => 'email2',
             'email3_field'              => 'email3',
@@ -1455,13 +1442,12 @@ class AuthLDAP extends CommonDBTM
         ];
 
         foreach ($fields as $key => $val) {
-            if (isset($authtype_array[$key]) && !empty($authtype_array[$key])) {
+            if (!empty($authtype_array[$key])) {
                 $ret[$val] = $authtype_array[$key];
             }
         }
         return $ret;
     }
-
 
     /**
      * Display LDAP filter
@@ -1473,7 +1459,6 @@ class AuthLDAP extends CommonDBTM
      */
     public static function displayLdapFilter($target, $users = true)
     {
-
         $config_ldap = new self();
         if (!isset($_SESSION['ldap_server'])) {
             throw new \RuntimeException('LDAP server must be set!');
@@ -1540,7 +1525,6 @@ class AuthLDAP extends CommonDBTM
         echo "</div>";
     }
 
-
     /**
      * Converts LDAP timestamps over to Unix timestamps
      *
@@ -1554,7 +1538,7 @@ class AuthLDAP extends CommonDBTM
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-       //Check if timestamp is well format, otherwise return ''
+        // Check if timestamp is well format, otherwise return ''
         if (!preg_match("/[\d]{14}(\.[\d]{0,4})*Z/", $ldapstamp)) {
             return '';
         }
@@ -1571,7 +1555,6 @@ class AuthLDAP extends CommonDBTM
         return $stamp;
     }
 
-
     /**
      * Converts a Unix timestamp to an LDAP timestamps
      *
@@ -1584,7 +1567,6 @@ class AuthLDAP extends CommonDBTM
         return date("YmdHis", strtotime($date)) . '.0Z';
     }
 
-
     /**
      * Return the LDAP field to use for user synchronization
      * It may be sync_field if defined, or login_field
@@ -1596,9 +1578,8 @@ class AuthLDAP extends CommonDBTM
     {
         if (!empty($this->fields['sync_field'])) {
             return $this->fields['sync_field'];
-        } else {
-            return $this->fields['login_field'];
         }
+        return $this->fields['login_field'];
     }
 
     /**
@@ -1611,9 +1592,8 @@ class AuthLDAP extends CommonDBTM
     {
         if (!empty($this->fields['sync_field'])) {
             return 'sync_field';
-        } else {
-            return 'name';
         }
+        return 'name';
     }
 
     /**
@@ -1645,10 +1625,11 @@ class AuthLDAP extends CommonDBTM
     /**
      * Test a LDAP connection
      *
-     * @param integer $auths_id     ID of the LDAP server
+     * @param integer $auths_id ID of the LDAP server
      * @param integer $replicate_id use a replicate if > 0 (default -1)
      *
      * @return boolean connection succeeded?
+     * @throws SodiumException
      */
     public static function testLDAPConnection($auths_id, $replicate_id = -1)
     {
@@ -1662,7 +1643,7 @@ class AuthLDAP extends CommonDBTM
         }
 
        //Test connection to a replicate
-        if ($replicate_id != -1) {
+        if ($replicate_id !== -1) {
             $replicate = new AuthLdapReplicate();
             $replicate->getFromDB($replicate_id);
             $host = $replicate->fields["host"];
@@ -1691,11 +1672,12 @@ class AuthLDAP extends CommonDBTM
         return false;
     }
 
-
     /**
      * Test if a socket connection is possible towards the LDAP server.
      *
+     * @param Connection|null $connection
      * @return array [success => boolean, message => string]
+     * @used-by self::testLDAPServer()
      */
     private function testLDAPSockopen(?Connection &$connection): array
     {
@@ -1733,7 +1715,9 @@ class AuthLDAP extends CommonDBTM
     /**
      * Test if basedn field is correctly configured.
      *
+     * @param Connection|null $connection
      * @return array [success => boolean, message => string]
+     * @used-by self::testLDAPServer()
      */
     private function testLDAPBaseDN(?Connection &$connection): array
     {
@@ -1753,7 +1737,9 @@ class AuthLDAP extends CommonDBTM
     /**
      * Test if a LDAP connect object initialisation is possible.
      *
+     * @param Connection|null $connection
      * @return array [success => boolean, message => string]
+     * @used-by self::testLDAPServer()
      */
     private function testLDAPURI(?Connection &$connection): array
     {
@@ -1773,7 +1759,9 @@ class AuthLDAP extends CommonDBTM
     /**
      * Test if a LDAP bind is possible.
      *
+     * @param Connection|null $connection
      * @return array [success => boolean, message => string]
+     * @used-by self::testLDAPServer()
      */
     private function testLDAPBind(?Connection &$connection): array
     {
@@ -1815,7 +1803,9 @@ class AuthLDAP extends CommonDBTM
     /**
      * Test if a LDAP search is possible.
      *
+     * @param Connection|null $connection
      * @return array [success => boolean, message => string]
+     * @used-by self::testLDAPServer()
      */
     private function testLDAPSearch(?Connection &$connection): array
     {
@@ -1895,7 +1885,6 @@ class AuthLDAP extends CommonDBTM
         }
     }
 
-
     /**
      * Show LDAP users to add or synchronise
      *
@@ -1903,7 +1892,6 @@ class AuthLDAP extends CommonDBTM
      */
     public static function showLdapUsers()
     {
-
         $values = [
             'order' => 'DESC',
             'start' => 0,
@@ -1930,15 +1918,13 @@ class AuthLDAP extends CommonDBTM
 
                 Html::printPager($values['start'], $numrows, $_SERVER['PHP_SELF'], '');
 
-               // delete end
+                // delete end
                 array_splice($ldap_users, $values['start'] + $_SESSION['glpilist_limit']);
-               // delete begin
+                // delete begin
                 if ($values['start'] > 0) {
                     array_splice($ldap_users, 0, $values['start']);
                 }
 
-                $form_action = '';
-                $textbutton  = '';
                 if ($_SESSION['ldap_import']['mode']) {
                     $textbutton  = _x('button', 'Synchronize');
                     $form_action = __CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'sync';
@@ -2094,9 +2080,9 @@ class AuthLDAP extends CommonDBTM
         $config_ldap
     ) {
 
-       //If paged results cannot be used (PHP < 5.4)
-        $cookie   = ''; //Cookie used to perform query using pages
-        $count    = 0;  //Store the number of results ldap_search
+        // If paged results cannot be used (PHP < 5.4)
+        $cookie   = ''; // Cookie used to perform query using pages
+        $count    = 0;  // Store the number of results ldap_search
 
         do {
             if (self::isLdapPageSizeAvailable($config_ldap)) {
@@ -2222,7 +2208,6 @@ class AuthLDAP extends CommonDBTM
         return true;
     }
 
-
     /**
      * Get the list of LDAP users to add/synchronize
      *
@@ -2272,7 +2257,7 @@ class AuthLDAP extends CommonDBTM
         if (!$res) {
             return false;
         }
-        if ($values['order'] != "DESC") {
+        if ($values['order'] !== "DESC") {
             $values['order'] = "ASC";
         }
         $ds = $config_ldap->connect();
@@ -2282,12 +2267,12 @@ class AuthLDAP extends CommonDBTM
            //Search for ldap login AND modifyTimestamp,
            //which indicates the last update of the object in directory
             $attrs = [$config_ldap->fields['login_field'], "modifyTimestamp"];
-            if ($field_for_sync != $config_ldap->fields['login_field']) {
+            if ($field_for_sync !== $config_ldap->fields['login_field']) {
                 $attrs[] = $field_for_sync;
             }
 
            // Try a search to find the DN
-            if ($values['ldap_filter'] == '') {
+            if ($values['ldap_filter'] === '') {
                 $filter = "(" . $field_for_sync . "=*)";
                 if (!empty($config_ldap->fields['condition'])) {
                     $filter = "(& $filter " . $config_ldap->fields['condition'] . ")";
@@ -2327,7 +2312,7 @@ class AuthLDAP extends CommonDBTM
             'ORDER'  => ['name ' . $values['order']]
         ];
 
-        if ($values['mode'] != self::ACTION_IMPORT) {
+        if ($values['mode'] !== self::ACTION_IMPORT) {
             $select['WHERE'] = [
                 'authtype'  => [-1, Auth::NOT_YET_AUTHENTIFIED, Auth::LDAP, Auth::EXTERNAL, Auth::CAS],
                 'auths_id'  => $options['authldaps_id']
@@ -2340,7 +2325,7 @@ class AuthLDAP extends CommonDBTM
             $tmpuser = new User();
 
            //Ldap add : fill the array with the login of the user
-            if ($values['mode'] == self::ACTION_IMPORT) {
+            if ($values['mode'] === self::ACTION_IMPORT) {
                 $glpi_users[$user['name']] = $user['name'];
             } else {
                //Ldap synchronisation : look if the user exists in the directory
@@ -2359,13 +2344,13 @@ class AuthLDAP extends CommonDBTM
                         }
                         $glpi_users[] = ['id'         => $user['id'],
                             'user'       => $userfound['name'],
-                            $field_for_sync => (isset($userfound[$config_ldap->fields['sync_field']]) ? $userfound[$config_ldap->fields['sync_field']] : 'NULL'),
+                            $field_for_sync => ($userfound[$config_ldap->fields['sync_field']] ?? 'NULL'),
                             'timestamp'  => $user_infos[$userfound[$field_for_sync]]['timestamp'],
                             'date_sync'  => $tmpuser->fields['date_sync'],
                             'dn'         => $user['user_dn']
                         ];
                     } else if (
-                        ($values['mode'] == self::ACTION_ALL)
+                        ($values['mode'] === self::ACTION_ALL)
                           || (($ldap_users[$user[$field_for_db]] - strtotime($user['date_sync'])) > 0)
                     ) {
                        //If entry was modified or if script should synchronize all the users
@@ -2378,18 +2363,18 @@ class AuthLDAP extends CommonDBTM
                         ];
                     }
                 } else if (
-                    ($values['mode'] == self::ACTION_ALL)
+                    ($values['mode'] === self::ACTION_ALL)
                         && !$limitexceeded
                 ) {
-                   // Only manage deleted user if ALL (because of entity visibility in delegated mode)
+                    // Only manage deleted user if ALL (because of entity visibility in delegated mode)
 
-                    if ($user['auths_id'] == $options['authldaps_id']) {
-                        if (!$userfound && $user['is_deleted_ldap'] == 0) {
-                             //If user is marked as coming from LDAP, but is not present in it anymore
+                    if ($user['auths_id'] === $options['authldaps_id']) {
+                        if (!$userfound && (int) $user['is_deleted_ldap'] === 0) {
+                             // If user is marked as coming from LDAP, but is not present in it anymore
                              User::manageDeletedUserInLdap($user['id']);
                              $results[self::USER_DELETED_LDAP]++;
-                        } elseif ($userfound && $user['is_deleted_ldap'] == 1) {
-                           // User is marked as coming from LDAP, but was previously deleted
+                        } elseif ($userfound && (int) $user['is_deleted_ldap'] === 1) {
+                            // User is marked as coming from LDAP, but was previously deleted
                             User::manageRestoredUserInLdap($user['id']);
                             $results[self::USER_RESTORED_LDAP]++;
                         }
@@ -2398,14 +2383,14 @@ class AuthLDAP extends CommonDBTM
             }
         }
 
-       //If add, do the difference between ldap users and glpi users
-        if ($values['mode'] == self::ACTION_IMPORT) {
+        // If add, do the difference between ldap users and glpi users
+        if ($values['mode'] === self::ACTION_IMPORT) {
             $diff    = array_diff_ukey($ldap_users, $glpi_users, 'strcasecmp');
             $list    = [];
             $tmpuser = new User();
 
             foreach ($diff as $user) {
-               //If user dn exists in DB, it means that user login field has changed
+                // If user dn exists in DB, it means that user login field has changed
                 if (!$tmpuser->getFromDBByDn($user_infos[$user]["user_dn"])) {
                     $entry  = ["user"      => $user_infos[$user][$config_ldap->fields['login_field']],
                         "timestamp" => $user_infos[$user]["timestamp"],
@@ -2417,7 +2402,7 @@ class AuthLDAP extends CommonDBTM
                     $list[] = $entry;
                 }
             }
-            if ($values['order'] == 'DESC') {
+            if ($values['order'] === 'DESC') {
                 rsort($list);
             } else {
                 sort($list);
@@ -2427,7 +2412,6 @@ class AuthLDAP extends CommonDBTM
         }
         return $glpi_users;
     }
-
 
     /**
      * Check if a user DN exists in a ldap user search result
@@ -2441,17 +2425,15 @@ class AuthLDAP extends CommonDBTM
      */
     public static function dnExistsInLdap($ldap_infos, $user_dn)
     {
-
         $found = false;
         foreach ($ldap_infos as $ldap_info) {
-            if ($ldap_info['user_dn'] == $user_dn) {
+            if ($ldap_info['user_dn'] === $user_dn) {
                 $found = $ldap_info;
                 break;
             }
         }
         return $found;
     }
-
 
     /**
      * Show LDAP groups to add or synchronize in an entity
@@ -2615,7 +2597,6 @@ class AuthLDAP extends CommonDBTM
         }
     }
 
-
     /**
      * Get all LDAP groups from a ldap server which are not already in an entity
      *
@@ -2726,14 +2707,13 @@ class AuthLDAP extends CommonDBTM
 
             usort(
                 $groups,
-                function ($a, $b) use ($order) {
-                    return $order == 'DESC' ? strcasecmp($b['cn'], $a['cn']) : strcasecmp($a['cn'], $b['cn']);
+                static function ($a, $b) use ($order) {
+                    return $order === 'DESC' ? strcasecmp($b['cn'], $a['cn']) : strcasecmp($a['cn'], $b['cn']);
                 }
             );
         }
         return $groups;
     }
-
 
     /**
      * Get the group's cn by giving his DN
@@ -2745,7 +2725,6 @@ class AuthLDAP extends CommonDBTM
      */
     public static function getGroupCNByDn($ldap_connection, $group_dn)
     {
-
         $sr = @ldap_read($ldap_connection, $group_dn, "objectClass=*", ["cn"]);
         if ($sr === false) {
             // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
@@ -2764,12 +2743,11 @@ class AuthLDAP extends CommonDBTM
             return false;
         }
         $v  = self::get_entries_clean($ldap_connection, $sr);
-        if (!is_array($v) || (count($v) == 0) || empty($v[0]["cn"][0])) {
+        if (!is_array($v) || (count($v) === 0) || empty($v[0]["cn"][0])) {
             return false;
         }
         return $v[0]["cn"][0];
     }
-
 
     /**
      * Set groups from ldap
@@ -2800,7 +2778,7 @@ class AuthLDAP extends CommonDBTM
         $extra_attribute = ($search_in_groups ? "cn" : $config_ldap->fields["group_field"]);
         $attrs           = ["dn", $extra_attribute];
 
-        if ($filter == '') {
+        if ($filter === '') {
             if ($search_in_groups) {
                 $filter = (!empty($config_ldap->fields['group_condition'])
                        ? $config_ldap->fields['group_condition'] : "(objectclass=*)");
@@ -2863,19 +2841,19 @@ class AuthLDAP extends CommonDBTM
             }
 
             if (in_array(ldap_errno($ldap_connection), [4,11])) {
-               // openldap return 4 for Size limit exceeded
+                // openldap return 4 for Size limit exceeded
                 $limitexceeded = true;
             }
 
             $infos  = self::get_entries_clean($ldap_connection, $sr);
             if (in_array(ldap_errno($ldap_connection), [4,11])) {
-               // openldap return 4 for Size limit exceeded
+                // openldap return 4 for Size limit exceeded
                 $limitexceeded = true;
             }
 
             $count += $infos['count'];
-           //If page results are enabled and the number of results is greater than the maximum allowed
-           //warn user that limit is exceeded and stop search
+            // If page results are enabled and the number of results is greater than the maximum allowed
+            // warn user that limit is exceeded and stop search
             if (
                 self::isLdapPageSizeAvailable($config_ldap)
                 && $config_ldap->fields['ldap_maxlimit']
@@ -2905,7 +2883,7 @@ class AuthLDAP extends CommonDBTM
                                 $ou[] = $tmptab[1];
                             }
 
-                           /// Search in DB for group with ldap_group_dn
+                            // Search in DB for group with ldap_group_dn
                             if (
                                 ($config_ldap->fields["group_field"] == 'dn')
                                 && (count($ou) > 0)
@@ -2946,7 +2924,6 @@ class AuthLDAP extends CommonDBTM
         return $groups;
     }
 
-
     /**
      * Form to choose a ldap server
      *
@@ -2967,14 +2944,14 @@ class AuthLDAP extends CommonDBTM
             'ORDER'  => 'name ASC'
         ]);
 
-        if (count($iterator) == 1) {
-           //If only one server, do not show the choose ldap server window
+        if (count($iterator) === 1) {
+            // If only one server, do not show the choose ldap server window
             $ldap                    = $iterator->current();
             $_SESSION["ldap_server"] = $ldap["id"];
             Html::redirect($_SERVER['PHP_SELF']);
         }
 
-        echo TemplateRenderer::getInstance()->render('pages/admin/ldap.choose_directory.html.twig', [
+        TemplateRenderer::getInstance()->display('pages/admin/ldap.choose_directory.html.twig', [
             'target'          => $target,
             'nb_ldap_servers' => count($iterator),
         ]);
@@ -3010,7 +2987,7 @@ class AuthLDAP extends CommonDBTM
                 $user_field = 'sync_field';
                 $id_field   = $authldap->fields['sync_field'];
             }
-            return AuthLDAP::ldapImportUserByServerId(
+            return self::ldapImportUserByServerId(
                 [
                     'method'             => self::IDENTIFIER_LOGIN,
                     'value'              => $user->fields[$user_field],
@@ -3028,12 +3005,13 @@ class AuthLDAP extends CommonDBTM
     /**
      * Import a user from a specific ldap server
      *
-     * @param array   $params      of parameters: method (IDENTIFIER_LOGIN or IDENTIFIER_EMAIL) + value
-     * @param boolean $action      synchoronize (true) or import (false)
+     * @param array $params of parameters: method (IDENTIFIER_LOGIN or IDENTIFIER_EMAIL) + value
+     * @param boolean $action synchoronize (true) or import (false)
      * @param integer $ldap_server ID of the LDAP server to use
-     * @param boolean $display     display message information on redirect (false by default)
+     * @param boolean $display display message information on redirect (false by default)
      *
      * @return array|boolean  with state, else false
+     * @throws SodiumException
      */
     public static function ldapImportUserByServerId(
         array $params,
@@ -3076,7 +3054,7 @@ class AuthLDAP extends CommonDBTM
             $search_parameters['method']                         = $params['method'];
             $search_parameters['fields'][self::IDENTIFIER_LOGIN] = $params['identifier_field'];
 
-            if ($params['method'] == self::IDENTIFIER_EMAIL) {
+            if ($params['method'] === self::IDENTIFIER_EMAIL) {
                 $search_parameters['fields'][self::IDENTIFIER_EMAIL]
                                        = $config_ldap->fields['email1_field'];
             }
@@ -3110,7 +3088,7 @@ class AuthLDAP extends CommonDBTM
                             $config_ldap->fields,
                             $user_dn,
                             $login,
-                            ($action == self::ACTION_IMPORT)
+                            ($action === self::ACTION_IMPORT)
                         )
                     ) {
                         //Get the ID by sync field (Used to check if restoration is needed)
@@ -3139,7 +3117,7 @@ class AuthLDAP extends CommonDBTM
                       // (picture managed in User::post_addItem and prepareInputForUpdate)
                         unset($input['picture']);
 
-                        if ($action == self::ACTION_IMPORT) {
+                        if ($action === self::ACTION_IMPORT) {
                             $input["authtype"] = Auth::LDAP;
                             $input["auths_id"] = $ldap_server;
                             // Display message after redirect
@@ -3152,7 +3130,7 @@ class AuthLDAP extends CommonDBTM
                                 'id'     => $user->fields["id"]
                             ];
                         }
-                      //Get the ID by user name
+                       // Get the ID by user name
                         if (!($id = User::getIdByfield($params['user_field'], $login))) {
                            //In case user id as changed : get id by dn
                             $id = User::getIdByfield('user_dn', $user_dn);
@@ -3169,7 +3147,7 @@ class AuthLDAP extends CommonDBTM
                     }
                     return false;
                 }
-                if ($action != self::ACTION_IMPORT) {
+                if ($action !== self::ACTION_IMPORT) {
                     $users_id = User::getIdByField($params['user_field'], $params['value']);
                     User::manageDeletedUserInLdap($users_id);
                     return ['action' => self::USER_DELETED_LDAP,
@@ -3184,35 +3162,34 @@ class AuthLDAP extends CommonDBTM
         return false;
     }
 
-
     /**
      * Import grousp from an LDAP directory
      *
      * @param string $group_dn dn of the group to import
-     * @param array  $options  array for
+     * @param array $options array for
      *             - authldaps_id
      *             - entities_id where group must to be imported
      *             - is_recursive
      *
      * @return integer|false
+     * @throws SodiumException
      */
     public static function ldapImportGroup($group_dn, $options = [])
     {
-
         $config_ldap = new self();
         $res         = $config_ldap->getFromDB($options['authldaps_id']);
 
-       // we prevent some delay...
+        // we prevent some delay...
         if (!$res) {
             return false;
         }
 
-       //Connect to the directory
+        // Connect to the directory
         $ds = $config_ldap->connect();
         if ($ds) {
             $group_infos = self::getGroupByDn($ds, $group_dn);
             $group       = new Group();
-            if ($options['type'] == "groups") {
+            if ($options['type'] === "groups") {
                 return $group->add(["name"          => $group_infos["cn"][0],
                     "ldap_group_dn" => $group_infos["dn"],
                     "entities_id"   => $options['entities_id'],
@@ -3229,16 +3206,15 @@ class AuthLDAP extends CommonDBTM
         return false;
     }
 
-
     /**
      * Open LDAP connection to current server
      *
-     * @return resource|boolean
+     * @return boolean|Connection
+     * @throws SodiumException
      */
     public function connect()
     {
-
-        return $this->connectToServer(
+        return self::connectToServer(
             $this->fields['host'],
             $this->fields['port'],
             $this->fields['rootdn'],
@@ -3252,7 +3228,6 @@ class AuthLDAP extends CommonDBTM
             $this->fields['tls_version']
         );
     }
-
 
     /**
      * Connect to a LDAP server
@@ -3269,7 +3244,7 @@ class AuthLDAP extends CommonDBTM
      * @param string  $tls_version          TLS VERSION (default '')
      * @param bool    $silent_bind_errors   Indicates whether bind errors must be silented
      *
-     * @return false|\LDAP\Connection link to the LDAP server : false if connection failed
+     * @return false|Connection link to the LDAP server : false if connection failed
      */
     public static function connectToServer(
         $host,
@@ -3288,7 +3263,7 @@ class AuthLDAP extends CommonDBTM
         self::$last_errno = null;
         self::$last_error = null;
 
-        $ds = @ldap_connect($host, intval($port));
+        $ds = @ldap_connect($host, (int) $port);
 
         if ($ds === false) {
             trigger_error(
@@ -3382,7 +3357,7 @@ class AuthLDAP extends CommonDBTM
             return $ds;
         }
 
-        if ($login != '') {
+        if ($login !== '') {
             // Auth bind
             $b = @ldap_bind($ds, $login, $password);
         } else {
@@ -3401,7 +3376,7 @@ class AuthLDAP extends CommonDBTM
                             "Unable to bind to LDAP server `%s:%s` %s",
                             $host,
                             $port,
-                            ($login != '' ? "with RDN `$login`" : 'anonymously')
+                            ($login !== '' ? "with RDN `$login`" : 'anonymously')
                         )
                     ),
                     E_USER_WARNING
@@ -3417,11 +3392,12 @@ class AuthLDAP extends CommonDBTM
     /**
      * Try to connect to a ldap server
      *
-     * @param array  $ldap_method ldap_method array to use
-     * @param string $login       User Login
-     * @param string $password    User Password
+     * @param array $ldap_method ldap_method array to use
+     * @param string $login User Login
+     * @param string $password User Password
      *
-     * @return resource|boolean link to the LDAP server : false if connection failed
+     * @return Connection|boolean link to the LDAP server : false if connection failed
+     * @throws SodiumException
      */
     public static function tryToConnectToServer($ldap_method, $login, $password)
     {
@@ -3524,7 +3500,6 @@ class AuthLDAP extends CommonDBTM
         return getAllDataFromTable('glpi_authldaps', ['ORDER' => 'is_default DESC']);
     }
 
-
     /**
      * Is the LDAP authentication used?
      *
@@ -3535,7 +3510,6 @@ class AuthLDAP extends CommonDBTM
         return (countElementsInTable('glpi_authldaps', ['is_active' => 1]) > 0);
     }
 
-
     /**
      * Import a user from ldap
      * Check all the directories. When the user is found, then import it
@@ -3544,10 +3518,10 @@ class AuthLDAP extends CommonDBTM
      *                 array('name'=>'glpi') or array('email' => 'test at test.com')
      *
      * @return array|boolean false if fail
+     * @throws SodiumException
      */
     public static function importUserFromServers($options = [])
     {
-
         $auth   = new Auth();
         $params = [];
         if (isset($options['name'])) {
@@ -3561,8 +3535,8 @@ class AuthLDAP extends CommonDBTM
 
         $auth->user_present = $auth->userExists($options);
 
-       //If the user does not exists
-        if ($auth->user_present == 0) {
+        // If the user does not exists
+        if ($auth->user_present === 0) {
             $auth->getAuthMethods();
             $ldap_methods = $auth->authtypes["ldap"];
 
@@ -3572,7 +3546,7 @@ class AuthLDAP extends CommonDBTM
                     $params['identifier_field']   = $ldap_method['login_field'];
                     $params['user_field']         = 'name';
                     $result = self::ldapImportUserByServerId($params, 0, $ldap_method["id"], true);
-                    if ($result != false) {
+                    if ($result !== false) {
                         return $result;
                     }
                 }
@@ -3588,7 +3562,6 @@ class AuthLDAP extends CommonDBTM
         return false;
     }
 
-
     /**
      * Authentify a user by checking a specific directory
      *
@@ -3603,7 +3576,6 @@ class AuthLDAP extends CommonDBTM
      */
     public static function ldapAuth($auth, $login, $password, $ldap_method, $user_dn, ?bool &$error = null)
     {
-
         $auth->auth_succeded = false;
         $auth->extauth       = 1;
 
@@ -3649,7 +3621,6 @@ class AuthLDAP extends CommonDBTM
         return $auth;
     }
 
-
     /**
      * Try to authentify a user by checking all the directories
      *
@@ -3689,7 +3660,7 @@ class AuthLDAP extends CommonDBTM
             $known_servers_id = array_column(iterator_to_array($known_servers), 'auths_id');
             usort(
                 $ldap_methods,
-                function (array $a, array $b) use ($known_servers_id) {
+                static function (array $a, array $b) use ($known_servers_id) {
                     if (in_array($a['id'], $known_servers_id) && !in_array($b['id'], $known_servers_id)) {
                         return -1;
                     }
@@ -3739,7 +3710,6 @@ class AuthLDAP extends CommonDBTM
         return $auth;
     }
 
-
     /**
      * Get dn for a user
      *
@@ -3757,7 +3727,6 @@ class AuthLDAP extends CommonDBTM
      */
     public static function searchUserDn($ds, $options = [], ?bool &$error = null)
     {
-
         $values = [
             'basedn'            => '',
             'login_field'       => '',
@@ -3771,18 +3740,17 @@ class AuthLDAP extends CommonDBTM
             $values[$key] = $value;
         }
 
-       //By default authenticate users by login
+        // By default authenticate users by login
         $login_attr      = $values['search_parameters']['fields'][self::IDENTIFIER_LOGIN];
-        $sync_attr       = (isset($values['search_parameters']['fields']['sync_field'])) ?
-         $values['search_parameters']['fields']['sync_field'] : null;
+        $sync_attr       = $values['search_parameters']['fields']['sync_field'] ?? null;
 
         $attrs = ["dn"];
         foreach ($values['search_parameters']['fields'] as $attr) {
             $attrs[] = $attr;
         }
 
-       //First : if a user dn is provided, look for it in the directory
-       //Before trying to find the user using his login_field
+        // First : if a user dn is provided, look for it in the directory
+        // Before trying to find the user using his login_field
         if ($values['user_dn']) {
             $info = self::getUserByDn($ds, $values['user_dn'], $attrs, true, $error);
 
@@ -3804,7 +3772,7 @@ class AuthLDAP extends CommonDBTM
 
        // Try a search to find the DN
         $filter_value = $values['user_params']['value'];
-        if ($values['login_field'] == 'objectguid' && self::isValidGuid($filter_value)) {
+        if ($values['login_field'] === 'objectguid' && self::isValidGuid($filter_value)) {
             $filter_value = self::guidToHex($filter_value);
         } else {
             $filter_value = ldap_escape($filter_value, '', LDAP_ESCAPE_FILTER);
@@ -3838,7 +3806,7 @@ class AuthLDAP extends CommonDBTM
             return false;
         }
 
-        if (is_array($info) && ($info['count'] == 1)) {
+        if (is_array($info) && ($info['count'] === 1)) {
             $ret = [
                 'dn'        => $info[0]['dn'],
                 $login_attr => $info[0][$login_attr][0]
@@ -3850,7 +3818,6 @@ class AuthLDAP extends CommonDBTM
         }
         return false;
     }
-
 
     /**
      * Get an object from LDAP by giving his DN
@@ -3899,7 +3866,6 @@ class AuthLDAP extends CommonDBTM
         return false;
     }
 
-
     /**
      * Get user by domain name
      *
@@ -3933,7 +3899,6 @@ class AuthLDAP extends CommonDBTM
         return self::getObjectByDn($ds, "objectClass=*", $group_dn, ["cn"]);
     }
 
-
     /**
      * Manage values stored in session
      *
@@ -3944,8 +3909,8 @@ class AuthLDAP extends CommonDBTM
      */
     public static function manageValuesInSession($options = [], $delete = false)
     {
-
-        $fields = ['action', 'authldaps_id', 'basedn', 'begin_date', 'criterias',  'end_date',
+        $fields = [
+            'action', 'authldaps_id', 'basedn', 'begin_date', 'criterias',  'end_date',
             'entities_id', 'interface', 'ldap_filter', 'mode'
         ];
 
@@ -4001,13 +3966,13 @@ class AuthLDAP extends CommonDBTM
             }
             if (
                 isset($_SESSION['ldap_import']['begin_date'])
-                && ($_SESSION['ldap_import']['begin_date'] == 'NULL')
+                && ($_SESSION['ldap_import']['begin_date'] === 'NULL')
             ) {
                 $_SESSION['ldap_import']['begin_date'] = '';
             }
             if (
                 isset($_SESSION['ldap_import']['end_date'])
-                && ($_SESSION['ldap_import']['end_date'] == 'NULL')
+                && ($_SESSION['ldap_import']['end_date'] === 'NULL')
             ) {
                 $_SESSION['ldap_import']['end_date'] = '';
             }
@@ -4017,7 +3982,7 @@ class AuthLDAP extends CommonDBTM
 
             $authldap = new self();
            //Filter computation
-            if ($_SESSION['ldap_import']['interface'] == self::SIMPLE_INTERFACE) {
+            if ($_SESSION['ldap_import']['interface'] === self::SIMPLE_INTERFACE) {
                 $entity = new Entity();
 
                 if (
@@ -4026,7 +3991,7 @@ class AuthLDAP extends CommonDBTM
                 ) {
                     $authldap->getFromDB($_SESSION['ldap_import']['authldaps_id']);
 
-                    if ($_SESSION['ldap_import']['authldaps_id'] == NOT_AVAILABLE) {
+                    if ($_SESSION['ldap_import']['authldaps_id'] === NOT_AVAILABLE) {
                        // authldaps_id wasn't submitted by the user -> take entity config
                         $_SESSION['ldap_import']['authldaps_id'] = $entity->getField('authldaps_id');
                     }
@@ -4038,13 +4003,13 @@ class AuthLDAP extends CommonDBTM
                         $_SESSION['ldap_import']['basedn'] = $authldap->getField('basedn');
                     }
 
-                    if ($entity->getField('entity_ldapfilter') != NOT_AVAILABLE) {
+                    if ($entity->getField('entity_ldapfilter') !== NOT_AVAILABLE) {
                         $_SESSION['ldap_import']['entity_filter']
                         = $entity->getField('entity_ldapfilter');
                     }
                 } else {
                     if (
-                        $_SESSION['ldap_import']['authldaps_id'] == NOT_AVAILABLE
+                        $_SESSION['ldap_import']['authldaps_id'] === NOT_AVAILABLE
                         || !$_SESSION['ldap_import']['authldaps_id']
                     ) {
                         $_SESSION['ldap_import']['authldaps_id'] = self::getDefault();
@@ -4061,7 +4026,7 @@ class AuthLDAP extends CommonDBTM
                 }
             } else {
                 if (
-                    $_SESSION['ldap_import']['authldaps_id'] == NOT_AVAILABLE
+                    $_SESSION['ldap_import']['authldaps_id'] === NOT_AVAILABLE
                     || !$_SESSION['ldap_import']['authldaps_id']
                 ) {
                     $_SESSION['ldap_import']['authldaps_id'] = self::getDefault();
@@ -4073,7 +4038,7 @@ class AuthLDAP extends CommonDBTM
                 }
                 if (
                     !isset($_SESSION['ldap_import']['ldap_filter'])
-                    || $_SESSION['ldap_import']['ldap_filter'] == ''
+                    || $_SESSION['ldap_import']['ldap_filter'] === ''
                 ) {
                     $authldap->getFromDB($_SESSION['ldap_import']['authldaps_id']);
                     $_SESSION['ldap_import']['basedn']      = $authldap->getField('basedn');
@@ -4085,7 +4050,6 @@ class AuthLDAP extends CommonDBTM
         }
     }
 
-
     /**
      * Show import user form
      *
@@ -4095,8 +4059,7 @@ class AuthLDAP extends CommonDBTM
      */
     public static function showUserImportForm(AuthLDAP $authldap)
     {
-
-       //Get data related to entity (directory and ldap filter)
+        // Get data related to entity (directory and ldap filter)
         $authldap->getFromDB($_SESSION['ldap_import']['authldaps_id']);
 
         echo "<form method='post' action='" . $_SERVER['PHP_SELF'] . "'>";
@@ -4104,8 +4067,8 @@ class AuthLDAP extends CommonDBTM
         echo "<h2 class='center mb-3'>" . ($_SESSION['ldap_import']['mode'] ? __('Synchronizing already imported users')
                                                       : __('Import new users'));
 
-       // Expert interface allow user to override configuration.
-       // If not coming from the ticket form, then give expert/simple link
+        // Expert interface allow user to override configuration.
+        // If not coming from the ticket form, then give expert/simple link
         if (
             (Config::canUpdate()
             || Entity::canUpdate())
@@ -4204,10 +4167,8 @@ class AuthLDAP extends CommonDBTM
                 }
 
                 if (
-                    (isset($_SESSION['ldap_import']['begin_date'])
-                    && !empty($_SESSION['ldap_import']['begin_date']))
-                    || (isset($_SESSION['ldap_import']['end_date'])
-                    && !empty($_SESSION['ldap_import']['end_date']))
+                    !empty($_SESSION['ldap_import']['begin_date'])
+                    || !empty($_SESSION['ldap_import']['end_date'])
                 ) {
                     $enabled = 1;
                 } else {
@@ -4218,7 +4179,7 @@ class AuthLDAP extends CommonDBTM
                 echo "<table class='table card-table'>";
 
                 if (
-                    ($_SESSION['ldap_import']['authldaps_id'] !=  NOT_AVAILABLE)
+                    ($_SESSION['ldap_import']['authldaps_id'] !==  NOT_AVAILABLE)
                     && ($_SESSION['ldap_import']['authldaps_id'] > 0)
                 ) {
                     $field_counter = 0;
@@ -4251,13 +4212,13 @@ class AuthLDAP extends CommonDBTM
                     ];
                     $available_fields = [];
                     foreach ($fields as $field => $label) {
-                        if (isset($authldap->fields[$field]) && ($authldap->fields[$field] != '')) {
+                        if (isset($authldap->fields[$field]) && ($authldap->fields[$field] !== '')) {
                             $available_fields[$field] = $label;
                         }
                     }
                     echo "<tr><td colspan='4' class='border-bottom-0'><h4>" . __('Search criteria for users') . "</h4></td></tr>";
                     foreach ($available_fields as $field => $label) {
-                        if ($field_counter == 0) {
+                        if ($field_counter === 0) {
                             echo "<tr>";
                         }
                         echo "<td style='width: 250px' class='text-end'><label for='criterias$field'>$label</label></td><td>";
@@ -4268,7 +4229,7 @@ class AuthLDAP extends CommonDBTM
                         }
                         echo "<input type='text' class='form-control' id='criterias$field' name='criterias[$field]' value='$field_value'>";
                         echo "</td>";
-                        if ($field_counter == 2) {
+                        if ($field_counter === 2) {
                             echo "</tr>";
                             $field_counter = 0;
                         }
@@ -4286,7 +4247,7 @@ class AuthLDAP extends CommonDBTM
         }
 
         if (
-            ($_SESSION['ldap_import']['authldaps_id'] !=  NOT_AVAILABLE)
+            ($_SESSION['ldap_import']['authldaps_id'] !==  NOT_AVAILABLE)
             && ($_SESSION['ldap_import']['authldaps_id'] > 0)
         ) {
             if ($_SESSION['ldap_import']['authldaps_id']) {
@@ -4317,7 +4278,6 @@ class AuthLDAP extends CommonDBTM
         return countElementsInTable('glpi_authldaps', ['is_active' => 1]);
     }
 
-
     /**
      * Build LDAP filter
      *
@@ -4327,7 +4287,7 @@ class AuthLDAP extends CommonDBTM
      */
     public static function buildLdapFilter(AuthLDAP $authldap)
     {
-       //Build search filter
+        // Build search filter
         $counter = 0;
         $filter  = '';
 
@@ -4336,14 +4296,14 @@ class AuthLDAP extends CommonDBTM
             && ($_SESSION['ldap_import']['interface'] == self::SIMPLE_INTERFACE)
         ) {
             foreach ($_SESSION['ldap_import']['criterias'] as $criteria => $value) {
-                if ($value != '') {
+                if ($value !== '') {
                     $begin = 0;
                     $end   = 0;
                     if (($length = strlen($value)) > 0) {
-                        if ($value[0] == '^') {
+                        if ($value[0] === '^') {
                              $begin = 1;
                         }
-                        if ($value[$length - 1] == '$') {
+                        if ($value[$length - 1] === '$') {
                             $end = 1;
                         }
                     }
@@ -4359,21 +4319,16 @@ class AuthLDAP extends CommonDBTM
             $filter = "(" . $authldap->getField("login_field") . "=*)";
         }
 
-       //If time restriction
-        $begin_date = (isset($_SESSION['ldap_import']['begin_date'])
-                     && !empty($_SESSION['ldap_import']['begin_date'])
+        // If time restriction
+        $begin_date = (!empty($_SESSION['ldap_import']['begin_date'])
                         ? $_SESSION['ldap_import']['begin_date'] : null);
-        $end_date   = (isset($_SESSION['ldap_import']['end_date'])
-                     && !empty($_SESSION['ldap_import']['end_date'])
+        $end_date   = (!empty($_SESSION['ldap_import']['end_date'])
                         ? $_SESSION['ldap_import']['end_date'] : null);
         $filter    .= self::addTimestampRestrictions($begin_date, $end_date);
         $ldap_condition = $authldap->getField('condition');
-       //Add entity filter and filter filled in directory's configuration form
-        return  "(&" . (isset($_SESSION['ldap_import']['entity_filter'])
-                    ? $_SESSION['ldap_import']['entity_filter']
-                    : '') . " $filter $ldap_condition)";
+        // Add entity filter and filter filled in directory's configuration form
+        return  "(&" . ($_SESSION['ldap_import']['entity_filter'] ?? '') . " $filter $ldap_condition)";
     }
-
 
     /**
      * Add timestamp restriction
@@ -4385,14 +4340,13 @@ class AuthLDAP extends CommonDBTM
      */
     public static function addTimestampRestrictions($begin_date, $end_date)
     {
-
         $condition = '';
-       //If begin date
+        // If begin date
         if (!empty($begin_date)) {
             $stampvalue = self::date2ldapTimeStamp($begin_date);
             $condition .= "(modifyTimestamp>=" . $stampvalue . ")";
         }
-       //If end date
+        // If end date
         if (!empty($end_date)) {
             $stampvalue = self::date2ldapTimeStamp($end_date);
             $condition .= "(modifyTimestamp<=" . $stampvalue . ")";
@@ -4400,17 +4354,16 @@ class AuthLDAP extends CommonDBTM
         return $condition;
     }
 
-
     /**
      * Search user
      *
      * @param AuthLDAP $authldap AuthLDAP object
      *
      * @return void
+     * @throws SodiumException
      */
     public static function searchUser(AuthLDAP $authldap)
     {
-
         if (
             self::connectToServer(
                 $authldap->getField('host'),
@@ -4428,7 +4381,7 @@ class AuthLDAP extends CommonDBTM
         ) {
             self::showLdapUsers();
         } else {
-            echo "<div class='center b firstbloc'>" . __('Unable to connect to the LDAP directory');
+            echo "<div class='center b firstbloc'>" . __s('Unable to connect to the LDAP directory');
         }
     }
 
@@ -4442,10 +4395,8 @@ class AuthLDAP extends CommonDBTM
         /** @var \DBmysql $DB */
         global $DB;
 
-        foreach ($DB->request('glpi_authldaps', ['is_default' => 1, 'is_active' => 1]) as $data) {
-            return $data['id'];
-        }
-        return 0;
+        $it = $DB->request('glpi_authldaps', ['is_default' => 1, 'is_active' => 1]);
+        return count($it) ? $it->current()['id'] : 0;
     }
 
     public function post_updateItem($history = true)
@@ -4453,9 +4404,9 @@ class AuthLDAP extends CommonDBTM
         /** @var \DBmysql $DB */
         global $DB;
 
-        if (in_array('is_default', $this->updates) && $this->input["is_default"] == 1) {
+        if (in_array('is_default', $this->updates, true) && (int) $this->input["is_default"] === 1) {
             $DB->update(
-                $this->getTable(),
+                static::getTable(),
                 ['is_default' => 0],
                 ['id' => ['<>', $this->input['id']]]
             );
@@ -4467,9 +4418,9 @@ class AuthLDAP extends CommonDBTM
         /** @var \DBmysql $DB */
         global $DB;
 
-        if (isset($this->fields['is_default']) && $this->fields["is_default"] == 1) {
+        if (isset($this->fields['is_default']) && (int) $this->fields["is_default"] === 1) {
             $DB->update(
-                $this->getTable(),
+                static::getTable(),
                 ['is_default' => 0],
                 ['id' => ['<>', $this->fields['id']]]
             );
@@ -4478,8 +4429,7 @@ class AuthLDAP extends CommonDBTM
 
     public function prepareInputForAdd($input)
     {
-
-       //If it's the first ldap directory then set it as the default directory
+        // If it's the first ldap directory then set it as the default directory
         if (!self::getNumberOfServers()) {
             $input['is_default'] = 1;
         }
@@ -4488,7 +4438,7 @@ class AuthLDAP extends CommonDBTM
             $input['can_support_pagesize'] = 0;
         }
 
-        if (isset($input["rootdn_passwd"]) && !empty($input["rootdn_passwd"])) {
+        if (!empty($input["rootdn_passwd"])) {
             $input["rootdn_passwd"] = (new GLPIKey())->encrypt($input["rootdn_passwd"]);
         }
 
@@ -4496,7 +4446,6 @@ class AuthLDAP extends CommonDBTM
 
         return $input;
     }
-
 
     /**
      * Get LDAP deleted user action options.
@@ -4606,7 +4555,6 @@ class AuthLDAP extends CommonDBTM
      */
     public static function dropdownUserRestoredActions($value = 0)
     {
-
         $options = self::getLdapRestoredUserActionOptions();
         asort($options);
         return Dropdown::showFromArray('user_restored_ldap', $options, ['value' => $value]);
@@ -4623,7 +4571,7 @@ class AuthLDAP extends CommonDBTM
         global $DB;
 
         $ldaps = [];
-       // Always get default first
+        // Always get default first
 
         $iterator = $DB->request([
             'SELECT' => ['id'],
@@ -4645,7 +4593,6 @@ class AuthLDAP extends CommonDBTM
         return $ldaps;
     }
 
-
     /**
      * Show date restriction form
      *
@@ -4655,7 +4602,6 @@ class AuthLDAP extends CommonDBTM
      */
     public static function showDateRestrictionForm($options = [])
     {
-
         echo "<table class='table'>";
         echo "<tr>";
 
@@ -4671,14 +4617,11 @@ class AuthLDAP extends CommonDBTM
         if ($enabled) {
             echo "<td style='width: 250px' class='text-end border-bottom-0'>" . __('View updated users') . "</td>";
             echo "<td class='border-bottom-0'>" . __('from') . "";
-            $begin_date = (isset($_SESSION['ldap_import']['begin_date'])
-                           ? $_SESSION['ldap_import']['begin_date'] : '');
+            $begin_date = ($_SESSION['ldap_import']['begin_date'] ?? '');
             Html::showDateTimeField("begin_date", ['value'    => $begin_date]);
             echo "</td>";
             echo "<td class='border-bottom-0'>" . __('to') . "";
-            $end_date = (isset($_SESSION['ldap_import']['end_date'])
-                        ? $_SESSION['ldap_import']['end_date']
-                        : date('Y-m-d H:i:s', time() - DAY_TIMESTAMP));
+            $end_date = ($_SESSION['ldap_import']['end_date'] ?? date('Y-m-d H:i:s', time() - DAY_TIMESTAMP));
             Html::showDateTimeField("end_date", ['value'    => $end_date]);
             echo "</td></tr>";
             echo "<tr><td colspan='4'>";
@@ -4751,7 +4694,6 @@ class AuthLDAP extends CommonDBTM
         return true;
     }
 
-
     /**
      * Get ldap query results and clean them at the same time
      *
@@ -4776,7 +4718,6 @@ class AuthLDAP extends CommonDBTM
         }
         return $entries;
     }
-
 
     /**
      * Get all replicate servers for a master one
@@ -4885,13 +4826,13 @@ class AuthLDAP extends CommonDBTM
                 $value = $infos[$field];
             }
         }
-        if ($field != 'objectguid') {
+        if ($field !== 'objectguid') {
             return $value;
         }
 
-       //handle special objectguid from AD directories
+        // handle special objectguid from AD directories
         try {
-           //prevent double encoding
+            // prevent double encoding
             if (!self::isValidGuid($value)) {
                 $value = self::guidToString($value);
                 if (!self::isValidGuid($value)) {
@@ -4899,7 +4840,7 @@ class AuthLDAP extends CommonDBTM
                 }
             }
         } catch (\Throwable $e) {
-           //well... this is not an objectguid apparently
+            // well... this is not an objectguid apparently
             $value = $infos[$field];
         }
 
@@ -5003,7 +4944,7 @@ class AuthLDAP extends CommonDBTM
         $config_ldap   = new AuthLDAP();
         $config_ldap->getFromDB($values['authldaps_id']);
 
-        if (!is_array($ldap_users) || count($ldap_users) == 0) {
+        if (!is_array($ldap_users) || count($ldap_users) === 0) {
             return $users;
         }
 
@@ -5033,8 +4974,8 @@ class AuthLDAP extends CommonDBTM
                 $user_to_add['link'] = Toolbox::getItemTypeFormURL('User') . '?id=' . $userinfos['id'];
             }
 
-            $user_to_add['stamp']      = (isset($userinfos["timestamp"])) ? $userinfos["timestamp"] : '';
-            $user_to_add['date_sync']  = (isset($userinfos["date_sync"])) ? $userinfos["date_sync"] : '';
+            $user_to_add['stamp']      = $userinfos["timestamp"] ?? '';
+            $user_to_add['date_sync']  = $userinfos["date_sync"] ?? '';
 
             $user_to_add['uid'] = $userinfos['user'];
             if ($config_ldap->isSyncFieldEnabled()) {
@@ -5058,7 +4999,7 @@ class AuthLDAP extends CommonDBTM
     {
         if (
             isset($input['tls_certfile'])
-            && strlen($input['tls_certfile']) > 0
+            && $input['tls_certfile'] !== ''
             && (!Filesystem::isFilepathSafe($input['tls_certfile']) || !file_exists($input['tls_certfile']))
         ) {
             Session::addMessageAfterRedirect(
@@ -5071,7 +5012,7 @@ class AuthLDAP extends CommonDBTM
 
         if (
             isset($input['tls_keyfile'])
-            && strlen($input['tls_keyfile']) > 0
+            && $input['tls_keyfile'] !== ''
             && (!Filesystem::isFilepathSafe($input['tls_keyfile']) || !file_exists($input['tls_keyfile']))
         ) {
             Session::addMessageAfterRedirect(
@@ -5085,7 +5026,6 @@ class AuthLDAP extends CommonDBTM
         return true;
     }
 
-
     public static function getIcon()
     {
         return "far fa-address-book";
@@ -5094,7 +5034,7 @@ class AuthLDAP extends CommonDBTM
     /**
      * Get date (Y-m-d H:i:s) from ldap value
      *
-     * @param string $data Value found in LDAP
+     * @param string $date Value found in LDAP
      *
      * @return string
      */
@@ -5102,7 +5042,7 @@ class AuthLDAP extends CommonDBTM
     {
         // See https://www.epochconverter.com/ldap
 
-        if (strlen($date) == 18 && intval($date) > 0) {
+        if (strlen($date) === 18 && (int) $date > 0) {
             // 18-digit LDAP/FILETIME timestamps
             // $date is the number of "100-nanoseconds-intervals" since 01/01/1601
             // Divide by 10M to convert to seconds (10M nano seconds = 0.01 seconds = 1 "100-nanoseconds-intervals")
@@ -5111,7 +5051,7 @@ class AuthLDAP extends CommonDBTM
             // See https://learn.microsoft.com/en-us/windows/win32/sysinfo/converting-a-time-t-value-to-a-file-time?redirectedfrom=MSDN
             $time = intval($date) / (10000000) - 11644473600;
             return $time > 0 ? date('Y-m-d H:i:s', $time) : '';
-        } elseif (preg_match('/^(\d{14})\.0Z$/', $date, $matches)) {
+        } else if (preg_match('/^(\d{14})\.0Z$/', $date, $matches)) {
             // Ymdhis.0Z LDAP timestamps
             $date = DateTime::createFromFormat('YmdHis', $matches[1]);
             return $date ? $date->format('Y-m-d H:i:s') : '';

--- a/src/AuthLdapReplicate.php
+++ b/src/AuthLdapReplicate.php
@@ -52,7 +52,6 @@ class AuthLdapReplicate extends CommonDBTM
 
     public function getForbiddenStandardMassiveAction()
     {
-
         $forbidden   = parent::getForbiddenStandardMassiveAction();
         $forbidden[] = 'update';
         return $forbidden;
@@ -60,8 +59,7 @@ class AuthLdapReplicate extends CommonDBTM
 
     public function prepareInputForAdd($input)
     {
-
-        if (isset($input["port"]) && (intval($input["port"]) == 0)) {
+        if (isset($input["port"]) && ((int) $input["port"] == 0)) {
             $input["port"] = 389;
         }
         return $input;
@@ -69,7 +67,6 @@ class AuthLdapReplicate extends CommonDBTM
 
     public function prepareInputForUpdate($input)
     {
-
         return $this->prepareInputForAdd($input);
     }
 
@@ -83,7 +80,6 @@ class AuthLdapReplicate extends CommonDBTM
      */
     public static function addNewReplicateForm($target, $master_id)
     {
-
         echo "<form action='$target' method='post' name='add_replicate_form' id='add_replicate_form'>";
         echo "<div class='center'>";
         echo "<table class='tab_cadre_fixe'>";

--- a/src/AuthMail.php
+++ b/src/AuthMail.php
@@ -50,8 +50,7 @@ class AuthMail extends CommonDBTM
 
     public function prepareInputForUpdate($input)
     {
-
-        if (isset($input['mail_server']) && !empty($input['mail_server'])) {
+        if (!empty($input['mail_server'])) {
             $input["connect_string"] = Toolbox::constructMailServerConfig($input);
         }
         return $input;
@@ -69,8 +68,7 @@ class AuthMail extends CommonDBTM
 
     public function prepareInputForAdd($input)
     {
-
-        if (isset($input['mail_server']) && !empty($input['mail_server'])) {
+        if (!empty($input['mail_server'])) {
             $input["connect_string"] = Toolbox::constructMailServerConfig($input);
         }
         return $input;
@@ -78,7 +76,6 @@ class AuthMail extends CommonDBTM
 
     public function defineTabs($options = [])
     {
-
         $ong = [];
         $this->addDefaultFormTab($ong);
         $this->addStandardTab(__CLASS__, $ong, $options);
@@ -98,7 +95,7 @@ class AuthMail extends CommonDBTM
 
         $tab[] = [
             'id'                 => '1',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'name',
             'name'               => __('Name'),
             'datatype'           => 'itemlink',
@@ -107,7 +104,7 @@ class AuthMail extends CommonDBTM
 
         $tab[] = [
             'id'                 => '2',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'id',
             'name'               => __('ID'),
             'datatype'           => 'number',
@@ -116,7 +113,7 @@ class AuthMail extends CommonDBTM
 
         $tab[] = [
             'id'                 => '3',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'host',
             'name'               => __('Server'),
             'datatype'           => 'string'
@@ -124,7 +121,7 @@ class AuthMail extends CommonDBTM
 
         $tab[] = [
             'id'                 => '4',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'connect_string',
             'name'               => __('Connection string'),
             'massiveaction'      => false,
@@ -133,7 +130,7 @@ class AuthMail extends CommonDBTM
 
         $tab[] = [
             'id'                 => '6',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'is_active',
             'name'               => __('Active'),
             'datatype'           => 'bool'
@@ -141,7 +138,7 @@ class AuthMail extends CommonDBTM
 
         $tab[] = [
             'id'                 => '19',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'date_mod',
             'name'               => __('Last update'),
             'datatype'           => 'datetime',
@@ -150,7 +147,7 @@ class AuthMail extends CommonDBTM
 
         $tab[] = [
             'id'                 => '16',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'comment',
             'name'               => __('Comments'),
             'datatype'           => 'text'
@@ -169,7 +166,6 @@ class AuthMail extends CommonDBTM
      */
     public function showForm($ID, array $options = [])
     {
-
         if (!Config::canUpdate()) {
             return false;
         }
@@ -220,7 +216,6 @@ class AuthMail extends CommonDBTM
      */
     public function showFormTestMail()
     {
-
         $ID = $this->getField('id');
 
         if ($this->getFromDB($ID)) {
@@ -244,7 +239,6 @@ class AuthMail extends CommonDBTM
         }
     }
 
-
     /**
      * Is the Mail authentication used?
      *
@@ -254,7 +248,6 @@ class AuthMail extends CommonDBTM
     {
         return (countElementsInTable('glpi_authmails', ['is_active' => 1]) > 0);
     }
-
 
     /**
      * Test a connexion to the IMAP/POP server
@@ -267,7 +260,6 @@ class AuthMail extends CommonDBTM
      */
     public static function testAuth($connect_string, $login, $password)
     {
-
         $auth = new Auth();
         return $auth->connection_imap(
             $connect_string,
@@ -275,7 +267,6 @@ class AuthMail extends CommonDBTM
             Toolbox::decodeFromUtf8($password)
         );
     }
-
 
     /**
      * Authenticate a user by checking a specific mail server
@@ -289,8 +280,7 @@ class AuthMail extends CommonDBTM
      */
     public static function mailAuth($auth, $login, $password, $mail_method)
     {
-
-        if (isset($mail_method["connect_string"]) && !empty($mail_method["connect_string"])) {
+        if (!empty($mail_method["connect_string"])) {
             $auth->auth_succeded = $auth->connection_imap(
                 $mail_method["connect_string"],
                 $login,
@@ -300,14 +290,13 @@ class AuthMail extends CommonDBTM
                  $auth->extauth      = 1;
                  $auth->user_present = $auth->user->getFromDBbyName($login);
                  $auth->user->getFromIMAP($mail_method, Toolbox::decodeFromUtf8($login));
-                 //Update the authentication method for the current user
+                 // Update the authentication method for the current user
                  $auth->user->fields["authtype"] = Auth::MAIL;
                  $auth->user->fields["auths_id"] = $mail_method["id"];
             }
         }
         return $auth;
     }
-
 
     /**
      * Try to authenticate a user by checking all the mail server
@@ -323,7 +312,6 @@ class AuthMail extends CommonDBTM
      */
     public static function tryMailAuth($auth, $login, $password, $auths_id = 0, $break = true)
     {
-
         if ($auths_id <= 0) {
             foreach ($auth->authtypes["mail"] as $mail_method) {
                 if (!$auth->auth_succeded && $mail_method['is_active']) {
@@ -335,7 +323,7 @@ class AuthMail extends CommonDBTM
                 }
             }
         } else if (array_key_exists($auths_id, $auth->authtypes["mail"])) {
-           //Check if the mail server indicated as the last good one still exists !
+            // Check if the mail server indicated as the last good one still exists !
             $auth = self::mailAuth($auth, $login, $password, $auth->authtypes["mail"][$auths_id]);
         }
         return $auth;
@@ -351,7 +339,7 @@ class AuthMail extends CommonDBTM
         /** @var CommonDBTM $item */
         if (!$withtemplate && $item->can($item->getField('id'), READ)) {
             $ong = [];
-            $ong[1] = _sx('button', 'Test');    // test connexion
+            $ong[1] = _sx('button', 'Test');    // test connection
 
             return $ong;
         }
@@ -368,7 +356,6 @@ class AuthMail extends CommonDBTM
         }
         return true;
     }
-
 
     public static function getIcon()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

No substantial changes given how complex this code is.
Changes mostly consist of:
- PHPDoc fixes
- Removing redundant `isset` when followed by `empty` checks
- Adding `public` to consts (the default visibility)
- Replacing some lines with the shorter ?? version
- Replacing $this->getTable with static::getTable
- Deprecate Auth::getErr as a TODO note specified