### PR TITLE
Fix - Filter contracts displayed by entity in the search option

### DIFF
--- a/src/Contract.php
+++ b/src/Contract.php
@@ -189,7 +189,7 @@ class Contract extends CommonDBTM
                 ]
             ],
             'condition'          => [
-                'NEWTABLE.entities_id' => getSonsOf('glpi_entities', $_SESSION['glpiactive_entity']),
+                'NEWTABLE.entities_id' => getSonsOf('glpi_entities', $_SESSION['glpiactive_entity'] ?? 0),
             ]
         ];
 

--- a/src/Contract.php
+++ b/src/Contract.php
@@ -197,7 +197,7 @@ class Contract extends CommonDBTM
             'jointype'   => 'child',
             'beforejoin' => [
                 'table'      => 'glpi_contracts',
-                'joinparams' => $joinparams,
+                'joinparams' => $joinparams
             ]
         ];
 

--- a/src/Contract.php
+++ b/src/Contract.php
@@ -187,6 +187,9 @@ class Contract extends CommonDBTM
                 'joinparams' => [
                     'jointype' => 'itemtype_item'
                 ]
+            ],
+            'condition'          => [
+                'NEWTABLE.entities_id' => getSonsOf('glpi_entities', $_SESSION['glpiactive_entity']),
             ]
         ];
 
@@ -194,7 +197,7 @@ class Contract extends CommonDBTM
             'jointype'   => 'child',
             'beforejoin' => [
                 'table'      => 'glpi_contracts',
-                'joinparams' => $joinparams
+                'joinparams' => $joinparams,
             ]
         ];
 

--- a/src/Contract.php
+++ b/src/Contract.php
@@ -189,7 +189,7 @@ class Contract extends CommonDBTM
                 ]
             ],
             'condition'          => [
-                'NEWTABLE.entities_id' => $_SESSION['glpiactiveentities'],
+                'NEWTABLE.entities_id' => $_SESSION['glpiactiveentities'] ?? '0',
             ]
         ];
 

--- a/src/Contract.php
+++ b/src/Contract.php
@@ -189,7 +189,7 @@ class Contract extends CommonDBTM
                 ]
             ],
             'condition'          => [
-                'NEWTABLE.entities_id' => getSonsOf('glpi_entities', $_SESSION['glpiactive_entity'] ?? 0),
+                'NEWTABLE.entities_id' => $_SESSION['glpiactiveentities'],
             ]
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !32425

Fixed the bug that allowed a computer's contract to be seen in the search options, even if it was not in an entity that the current user was supposed to be able to see.

_Exemple : Contract in entity 2, computer and user in entity 1_
**Before**
![image](https://github.com/glpi-project/glpi/assets/107540223/6bc13b06-2c62-4b8a-b0a5-2d60e78475b8)

**Now**
![image](https://github.com/glpi-project/glpi/assets/107540223/4e6e8123-695c-4265-8ba1-7a9e6e4edce7)
