### PR TITLE
Fix planning availability form

### DIFF
--- a/src/Planning.php
+++ b/src/Planning.php
@@ -523,7 +523,7 @@ JAVASCRIPT;
                     $task = new ProblemTask();
                 }
                 if ($task->getFromDBByCrit(['tickets_id' => $item->fields['id']])) {
-                    $users['users_id'] = getUserName($task->fields['users_id_tech']);
+                    $users[$task->fields['users_id_tech']] = getUserName($task->fields['users_id_tech']);
                     $group_id = $task->fields['groups_id_tech'];
                     if ($group_id) {
                         foreach (Group_User::getGroupUsers($group_id) as $data2) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

While working on the planning UI migrations, I realized this form had duplicated entries for a user and was also showing SQL errors. Not sure when it broke, but this particular line hasn't changed in 8 years. Took a while for me to find where this form could be displayed (There is a calendar icon button next to the "Period" field when planning a task). Maybe it isn't used very often.

Before:
![Selection_298](https://github.com/glpi-project/glpi/assets/17678637/893b9287-9f25-45ab-98ac-497e52fab2b5)

After:
![Selection_299](https://github.com/glpi-project/glpi/assets/17678637/70e7756f-76d5-4e57-96dd-c9b3054f3a90)