### PR TITLE
Fix "now" indicator in reservation calendar

### DIFF
--- a/js/reservations.js
+++ b/js/reservations.js
@@ -44,6 +44,7 @@ var Reservations = function() {
     this.currentv    = null;
     this.defaultDate = null;
     this.can_reserve = true;
+    this.now         = null;
 
     var my = this;
 
@@ -60,6 +61,7 @@ var Reservations = function() {
         if (config.can_reserve != undefined) {
             my.can_reserve = config.can_reserve;
         }
+        my.now          = config.now || null;
     };
 
     my.displayPlanning = function() {
@@ -67,6 +69,7 @@ var Reservations = function() {
             schedulerLicenseKey: my.license_key,
             timeZone: 'UTC',
             nowIndicator: true,
+            now: my.now,// as we set the calendar as UTC, we need to reprecise the current datetime
             theme: true,
             editable: true,
             defaultDate: my.defaultDate,

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -565,6 +565,7 @@ class Reservation extends CommonDBChild
             Session::haveRight("reservation", ReservationItem::RESERVEANITEM)
             && count(self::getReservableItemtypes()) > 0
         ) ? "true" : "false";
+        $now = date("Y-m-d H:i:s");
         $js = <<<JAVASCRIPT
       $(function() {
          var reservation = new Reservations();
@@ -574,6 +575,7 @@ class Reservation extends CommonDBChild
             rand: $rand,
             license_key: '$scheduler_key',
             can_reserve: $can_reserve,
+            now: '$now',
          });
          reservation.displayPlanning();
       });
@@ -1144,6 +1146,7 @@ JAVASCRIPT;
         if (isset($_REQUEST['defaultDate'])) {
             $defaultDate = $_REQUEST['defaultDate'];
         }
+        $now = date("Y-m-d H:i:s");
         $js = <<<JAVASCRIPT
       $(function() {
          var reservation = new Reservations();
@@ -1155,6 +1158,7 @@ JAVASCRIPT;
             currentv: 'listFull',
             defaultDate: '$defaultDate',
             license_key: '$scheduler_key',
+            now: '$now',
          });
          reservation.displayPlanning();
       });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15929

The `now` indicator in the reservations calendar was not displayed at the correct position. I reused the same logic as we already use in the planning calendar.