### PR TITLE
Rely on tested PHP version for PHP lint checks

### DIFF
--- a/.github/actions/init_build.sh
+++ b/.github/actions/init_build.sh
@@ -1,27 +1,12 @@
 #!/bin/bash
 set -e -u -x -o pipefail
 
-# Stable versions contains only 3 groups of digits separated by a dot,
-# i.e. no "dev", "alpha", "beta, "rc", ... keyword.
-STABLE_REGEX="^[0-9]+\.[0-9]+\.[0-9]+$"
-PHP_MAJOR_VERSION="$(echo $PHP_VERSION | cut -d '.' -f 1,2 | sed 's/\.//')"
-CHECK_PLATFORM_REQS="false"
-if [[ "$PHP_VERSION" =~ $STABLE_REGEX && "$PHP_MAJOR_VERSION" -lt "82" ]]; then
-    CHECK_PLATFORM_REQS="true"
-fi
-
-# Validate composer config
-composer validate --strict
-if [[ "$CHECK_PLATFORM_REQS" == "true" ]]; then
-  composer check-platform-reqs;
-fi
-
 # Install dependencies
-COMPOSER_ADD_OPTS=""
-if [[ "$CHECK_PLATFORM_REQS" == "false" ]]; then
-  COMPOSER_ADD_OPTS="--ignore-platform-reqs";
-fi
-bin/console dependencies install --composer-options="$COMPOSER_ADD_OPTS --prefer-dist --no-progress"
+# Ignore the PHP version requirement as some dependencies are explicitely marking themselves as incompatible
+# with future PHP versions they were not able to test when they release their own versions
+# (see https://github.com/laminas/laminas-diactoros/issues/117#issuecomment-1267306142).
+# The `+` suffix on `php+` indicates that we ignore the upper bound of our dependencies, see https://getcomposer.org/doc/03-cli.md#install-i
+bin/console dependencies install --composer-options="--ignore-platform-req=php+ --prefer-dist --no-progress"
 
 # Compile translation files
 php bin/console locales:compile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,10 @@ jobs:
       - name: "Show versions"
         run: |
           .github/actions/init_show-versions.sh
+      - name: "Force used PHP version"
+        run: |
+          docker compose exec -T app composer config --unset platform.php
+          docker compose exec -T app composer require "php:>=${{ matrix.php-version }}" --ignore-platform-req=php+ --no-install --no-scripts
       - name: "Build dependencies / translations"
         run: |
           docker compose exec -T app .github/actions/init_build.sh

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,7 +14,6 @@ parameters:
         - stubs/glpi_constants.php
     ignoreErrors:
         - '/Call to static method \w+\(\) on an unknown class phpCAS/'
-        - '/Class Ldap\\Connection not found/'
         - '/Class phpCAS not found/'
         - '/Instantiated class (DB|DBSlave) not found/'
         - '/Instantiated class XHProfRuns_Default not found/'

--- a/src/User.php
+++ b/src/User.php
@@ -1913,7 +1913,10 @@ class User extends CommonDBTM
             return false;
         }
 
-        if (is_resource($ldap_connection) || $ldap_connection instanceof \Ldap\Connection) {
+        if (
+            is_resource($ldap_connection)
+            || (class_exists(\Ldap\Connection::class) && $ldap_connection instanceof \Ldap\Connection)
+        ) {
            //Set all the search fields
             $this->fields['password'] = "";
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

PHPStan relies on the required PHP version found in the `composer.json` to adapt its behaviour. It means that some error will not be found until we change our requirements, see errors that had to be fixed in #16943 .

By forcing the PHP requirement and the `config.platform.php` entry of the `composer.json` file to match the effective PHP version tested by our lint tasks, we may detect errors earlier.