### PR TITLE
fix: typo in search function

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -473,7 +473,7 @@ class Database extends CommonDBChild
                     'icon'  => DatabaseInstance::getIcon(),
                     'links' => [
                         'add'    => '/front/databaseinstance.form.php',
-                        'search' => '/front/dabataseinstance.php',
+                        'search' => '/front/databaseinstance.php',
                     ]
                 ]
             ];


### PR DESCRIPTION
Changed 'dabataseinstance.php' to 'databaseinstance.php'


| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Tests pass?   | yes
