### PR TITLE
fix: typo in databaseinstance search function

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -518,7 +518,7 @@ class Database extends CommonDBChild
                     'icon'  => DatabaseInstance::getIcon(),
                     'links' => [
                         'add'    => '/front/databaseinstance.form.php',
-                        'search' => '/front/dabataseinstance.php',
+                        'search' => '/front/databaseinstance.php',
                     ]
                 ]
             ];


### PR DESCRIPTION
### Changed dabataseinstance.php to databaseinstance.php


| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
