### PR TITLE
Fix JS error when configuration URL is blank

### DIFF
--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -366,7 +366,7 @@ JAVASCRIPT;
                 // If base URL is not configured, fallback to current URL domain + GLPI base dir.
                 base_url = window.location.origin + '/' + CFG_GLPI.root_doc;
             }
-            const href_url_params = new URL(url, CFG_GLPI.url_base).searchParams;
+            const href_url_params = new URL(url, base_url).searchParams;
             var target = tablink.attr('data-bs-target');
 
             const updateCurrentTab = () => {

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -361,7 +361,11 @@ JAVASCRIPT;
          var url_hash = window.location.hash;
          var loadTabContents = function (tablink, force_reload = false, update_session_tab = true) {
             var url = tablink.attr('href');
-            const href_url_params = new URL(url, CFG_GLPI.url_base).searchParams;
+            if (CFG_GLPI.url_base != '') {
+                const href_url_params = new URL(url, CFG_GLPI.url_base).searchParams;
+            } else {
+                const href_url_params = new URLSearchParams($(tablink).prop('href'));
+            }
             var target = tablink.attr('data-bs-target');
 
             const updateCurrentTab = () => {

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -361,11 +361,12 @@ JAVASCRIPT;
          var url_hash = window.location.hash;
          var loadTabContents = function (tablink, force_reload = false, update_session_tab = true) {
             var url = tablink.attr('href');
-            if (CFG_GLPI.url_base != '') {
-                const href_url_params = new URL(url, CFG_GLPI.url_base).searchParams;
-            } else {
-                const href_url_params = new URLSearchParams($(tablink).prop('href'));
+            var base_url = CFG_GLPI.url_base;
+            if (base_url === '') {
+                // If base URL is not configured, fallback to current URL domain + GLPI base dir.
+                base_url = window.location.origin + '/' + CFG_GLPI.root_doc;
             }
+            const href_url_params = new URL(url, CFG_GLPI.url_base).searchParams;
             var target = tablink.attr('data-bs-target');
 
             const updateCurrentTab = () => {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #16963

This fixes a JS error preventing to display any page. 

This reintroduce for some cases original issue (see #16703), but anyway, proposed fix was probably not working when configuration URL is incorrect. Since we never ask user to properly configure that URL (and it does not seems really mandatory elsewhere); I'm not sure the original fix was correct.