### PR TITLE
Add missing TinyMCE license key

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -3897,6 +3897,8 @@ JS;
 
             // init editor
             tinyMCE.init(Object.assign({
+               license_key: 'gpl',
+
                link_default_target: '_blank',
                branding: false,
                selector: '#{$id}',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Prevents a "missing license key" message to be shown in the javascript console.
See https://www.tiny.cloud/docs/tinymce/latest/license-key/#use-tinymce-with-the-gplv2-license