### PR TITLE
No HTML in field labels

### DIFF
--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -440,7 +440,7 @@
     {% endif %}
 
     <label class="{{ class }}" for="{{ id }}">
-        {{ label|raw }}
+        {{ label }}
         {{ locked_mark|raw }}
         {{ required_mark|raw }}
         {{ helper|raw }}

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -797,6 +797,7 @@
       'field_class': 'col-12 col-sm-6',
       'container_id': '',
       'add_field_class': '',
+      'add_label_class': '',
       'add_field_attribs': {},
       'center': false,
       'label_align': 'end',
@@ -848,7 +849,7 @@
 
    <div class="form-field row align-items-center {{ options.field_class }} {{ options.add_field_class }} {{ options.mb }}" {{ extra_attribs|raw }}>
       {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
-      {{ _inputs.label(label, id, options, 'col-form-label ' ~ options.label_class) }}
+      {{ _inputs.label(label, id, options, 'col-form-label ' ~ options.label_class ~ ' ' ~ options.add_label_class) }}
       {% if options.center %}
          {% set flex_class = "d-flex align-items-center" %}
       {% endif %}

--- a/templates/pages/assistance/stats/title.html.twig
+++ b/templates/pages/assistance/stats/title.html.twig
@@ -38,10 +38,11 @@
         'statmenu',
         selected,
         values,
-        "<h3>" ~ __('Select statistics to be displayed') ~ "</h3>",
+        __('Select statistics to be displayed'),
         {
-            'full_width': true,
-            'on_change': 'window.location.href=this.options[this.selectedIndex].value'
+            full_width: true,
+            on_change: 'window.location.href=this.options[this.selectedIndex].value',
+            add_label_class: 'fs-3'
         }
     ) }}
 </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Labels for fields should only contain sanitized text content. As far as I know, there is only one intended case where HTML content was passed as a label for a field. In that case, I don't think it resulted in valid HTML. According to MDN, only phrasing content and the labelable element being labelled is allowed inside a `<label>`. The `<h*>` elements do not fall into either category. I've replaced this usage with the ability to specify some extra classes for the label and adding the `fs-3` class to adjust the text size to match that of a `<h3>` without the semantic change.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label#technical_summary