### PR TITLE
Prevent profile right matrix overflow

### DIFF
--- a/templates/components/checkbox_matrix.html.twig
+++ b/templates/components/checkbox_matrix.html.twig
@@ -31,7 +31,7 @@
  # ---------------------------------------------------------------------
  #}
 
-<div class="mx-n2 mb-4">
+<div class="mx-n2 mb-4 overflow-x-auto">
    <table class="table table-hover card-table">
       <thead>
          {% if title is not empty %}

--- a/templates/components/checkbox_matrix.html.twig
+++ b/templates/components/checkbox_matrix.html.twig
@@ -31,7 +31,7 @@
  # ---------------------------------------------------------------------
  #}
 
-<div class="mx-n2 mb-4 overflow-x-auto">
+<div class="mx-n2 mb-4 table-responsive">
    <table class="table table-hover card-table">
       <thead>
          {% if title is not empty %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Prevent profile right matrix tables from overflowing outside the tab pane. Each matrix section will now have a horizontal scrollbar when needed to handle the extra content.