### PR TITLE
remove outline visible for single line monaco editors

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -412,3 +412,7 @@ body .toast {
 .accordion {
     --tblr-accordion-color: var(--tblr-muted);
 }
+
+.monaco-editor {
+    outline: none !important;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

At some point, a blue outline became visible inside the single-line Monaco editors (like the URL field in the webhook form). This outline seems to be present in the regular editor too, but isn't visible. This PR simply removes the outline globally.