### PR TITLE
Remove bad HTML sanitization

### DIFF
--- a/js/src/vue/Debug/Widget/SQLRequests.vue
+++ b/js/src/vue/Debug/Widget/SQLRequests.vue
@@ -60,7 +60,7 @@
                     request_id: request_id,
                     num: query['num'],
                     time: query['time'],
-                    query: escapeMarkupText(query['query']),
+                    query: query['query'],
                     rows: query['rows'],
                     warnings: escapeMarkupText(query['warnings']),
                     errors: escapeMarkupText(query['errors']),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Broken since 69e0dee8de0c0df139b42dbfa1a8997888c2af95. The commit broke the highlighting HTML by sanitizing the query after the highlighting elements were added, and forced it to display a wall of gray HTML content instead of the nice, colorful SQL query.
In fact, the escaping of a SQL query here seems unneeded as Monaco is smart enough to properly sanitize the text it is given to colorize. As a test, I tried forcing all the queries to be `<button>test</button>` and with my changes, that content was shown as-is rather than inserting a button HTML element.