### PR TITLE
Fix(Core): fix undefined index _emails

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -2387,7 +2387,7 @@ class User extends CommonDBTM
 
             $this->fields = $rule->processAllRules($groups_id, Toolbox::stripslashes_deep($this->fields), [
                 'type'   => Auth::EXTERNAL,
-                'email'  => $this->fields["_emails"],
+                'email'  => $this->fields["_emails"] ?? [],
                 'login'  => $this->fields["name"]
             ]);
 


### PR DESCRIPTION
Prevent ```undefined index``` from ```OauthSSO```  plugin when no email are provide

``` 
2024-04-24 09:00:04] glpiphplog.WARNING : *** PHP Warning (2) : Undefined array key "_emails" in /data/glpi/src/User.php at line 2383
Trace arrière :
src/Auth.php:600 User->getFromSSO()
src/Auth.php:813 Auth->getAlternateAuthSystemsUserLogin()
...etplace/oauthsso/inc/loginfeature.class.php:262 Auth->login()
...e/oauthsso/front/authorization.callback.php:108 GlpiPlugin\Oauthsso\LoginFeature::handleAuthorizationCallback()
public/index.php:82
```


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
