### PR TITLE
Verify OauthSMTP SSL certificates when proxy is used

### DIFF
--- a/src/Mail/SMTP/OauthConfig.php
+++ b/src/Mail/SMTP/OauthConfig.php
@@ -119,7 +119,6 @@ final class OauthConfig
                     $config['proxy_name'],
                     $config['proxy_port']
                 );
-            $provider_options['verify'] = false;
         }
 
         $provider = new $provider_class(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The SSL certificate verification was disabled on SMTP Oauth connection only when a proxy was configured.
Having this option was not intentionnal (it was copied/pasted from the OauthIMAP plugin implementation, problably also copied/pasted from somewhere else).

There is no reason to not check certificates when a connection is made through proxies. There are many usages in GLPI an plugins that are using the Guzzle client with the same proxy configuration and all of them are not disabling the SSL verification.