### PR TITLE
(Feature) Adding user tooltip to internal item view

### DIFF
--- a/templates/components/itilobject/selfservice.html.twig
+++ b/templates/components/itilobject/selfservice.html.twig
@@ -100,6 +100,10 @@
                                     {% set user_fields = user.fields %}
                                     {% set user_fields = user_fields|merge({user_name: user.getFriendlyName()}) %}
                                     {% set user_fields = user_fields|merge({email: user.getDefaultEmail()}) %}
+                                    {% set session_has_read_right = call('Session::haveRight', ['user', constant('READ')]) %}
+                                    {% if session_has_read_right %}
+                                        {% set user_fields = user_fields|merge({login: entry_user.fields['name']}) %}
+                                    {% endif %}
                                     {{ include('components/user/info_card.html.twig', {
                                         'user': user_fields,
                                         'can_edit': true

--- a/templates/components/itilobject/selfservice.html.twig
+++ b/templates/components/itilobject/selfservice.html.twig
@@ -100,8 +100,7 @@
                                     {% set user_fields = user.fields %}
                                     {% set user_fields = user_fields|merge({user_name: user.getFriendlyName()}) %}
                                     {% set user_fields = user_fields|merge({email: user.getDefaultEmail()}) %}
-                                    {% set session_has_read_right = call('Session::haveRight', ['user', constant('READ')]) %}
-                                    {% if session_has_read_right %}
+                                    {% if has_profile_right('user',  constant('READ')) %}
                                         {% set user_fields = user_fields|merge({login: entry_user.fields['name']}) %}
                                     {% endif %}
                                     {{ include('components/user/info_card.html.twig', {

--- a/templates/components/itilobject/selfservice.html.twig
+++ b/templates/components/itilobject/selfservice.html.twig
@@ -100,7 +100,7 @@
                                     {% set user_fields = user.fields %}
                                     {% set user_fields = user_fields|merge({user_name: user.getFriendlyName()}) %}
                                     {% set user_fields = user_fields|merge({email: user.getDefaultEmail()}) %}
-                                    {% if has_profile_right('user',  constant('READ')) %}
+                                    {% if has_profile_right('user', constant('READ')) %}
                                         {% set user_fields = user_fields|merge({login: entry_user.fields['name']}) %}
                                     {% endif %}
                                     {{ include('components/user/info_card.html.twig', {

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -137,8 +137,7 @@
                   {% set user_fields = entry_user.fields %}
                   {% set user_fields = user_fields|merge({user_name: entry_user.getFriendlyName()}) %}
                   {% set user_fields = user_fields|merge({email: entry_user.getDefaultEmail()}) %}
-                  {% set session_has_read_right = call('Session::haveRight', ['user', constant('READ')]) %}
-                  {% if session_has_read_right %}
+                  {% if has_profile_right('user',  constant('READ')) %}
                      {% set user_fields = user_fields|merge({login: entry_user.fields['name']}) %}
                   {% endif %}
                   <span id="timeline-avatar{{ avatar_rand }}">

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -137,7 +137,7 @@
                   {% set user_fields = entry_user.fields %}
                   {% set user_fields = user_fields|merge({user_name: entry_user.getFriendlyName()}) %}
                   {% set user_fields = user_fields|merge({email: entry_user.getDefaultEmail()}) %}
-                  {% if has_profile_right('user',  constant('READ')) %}
+                  {% if has_profile_right('user', constant('READ')) %}
                      {% set user_fields = user_fields|merge({login: entry_user.fields['name']}) %}
                   {% endif %}
                   <span id="timeline-avatar{{ avatar_rand }}">

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -137,6 +137,10 @@
                   {% set user_fields = entry_user.fields %}
                   {% set user_fields = user_fields|merge({user_name: entry_user.getFriendlyName()}) %}
                   {% set user_fields = user_fields|merge({email: entry_user.getDefaultEmail()}) %}
+                  {% set session_has_read_right = call('Session::haveRight', ['user', constant('READ')]) %}
+                  {% if session_has_read_right %}
+                     {% set user_fields = user_fields|merge({login: entry_user.fields['name']}) %}
+                  {% endif %}
                   <span id="timeline-avatar{{ avatar_rand }}">
                      {{ include('components/user/picture.html.twig', {
                         'users_id': users_id,

--- a/templates/components/user/link_with_tooltip.html.twig
+++ b/templates/components/user/link_with_tooltip.html.twig
@@ -44,8 +44,7 @@
         {% set user_fields = user.fields %}
         {% set user_fields = user_fields|merge({user_name: user.getFriendlyName()}) %}
         {% set user_fields = user_fields|merge({email: user.getDefaultEmail()}) %}
-        {% set session_has_read_right = call('Session::haveRight', ['user', constant('READ')]) %}
-        {% if session_has_read_right %}
+        {% if has_profile_right('user',  constant('READ')) %}
             {% set user_fields = user_fields|merge({login: user.fields['name']}) %}
         {% endif %}
         {% do call(

--- a/templates/components/user/link_with_tooltip.html.twig
+++ b/templates/components/user/link_with_tooltip.html.twig
@@ -44,7 +44,7 @@
         {% set user_fields = user.fields %}
         {% set user_fields = user_fields|merge({user_name: user.getFriendlyName()}) %}
         {% set user_fields = user_fields|merge({email: user.getDefaultEmail()}) %}
-        {% if has_profile_right('user',  constant('READ')) %}
+        {% if has_profile_right('user', constant('READ')) %}
             {% set user_fields = user_fields|merge({login: user.fields['name']}) %}
         {% endif %}
         {% do call(

--- a/templates/components/user/link_with_tooltip.html.twig
+++ b/templates/components/user/link_with_tooltip.html.twig
@@ -44,6 +44,10 @@
         {% set user_fields = user.fields %}
         {% set user_fields = user_fields|merge({user_name: user.getFriendlyName()}) %}
         {% set user_fields = user_fields|merge({email: user.getDefaultEmail()}) %}
+        {% set session_has_read_right = call('Session::haveRight', ['user', constant('READ')]) %}
+        {% if session_has_read_right %}
+            {% set user_fields = user_fields|merge({login: user.fields['name']}) %}
+        {% endif %}
         {% do call(
             'Html::showToolTip',
             [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !32593

Linked to this Pull request : #16974 
The tooltips were only displayed in the item list and not when we went to the item page. This pull request adds this functionality.

**Ticket page**
![image](https://github.com/glpi-project/glpi/assets/107540223/053488e6-aa4c-49cc-8479-4145deb93fcf)

**Computer page**
![image](https://github.com/glpi-project/glpi/assets/107540223/ed051e80-9882-454c-be87-5d502f24a5dd)
