### PR TITLE
Add dedicated e2e login tests

### DIFF
--- a/front/csrf.php
+++ b/front/csrf.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+$SECURITY_STRATEGY = 'no_check';
+
+include('../inc/includes.php');
+
+if (GLPI_ENVIRONMENT_TYPE !== 'testing') {
+    http_response_code(400);
+    die;
+}
+
+header('Content-Type: application/json');
+echo json_encode([
+    'token' => Session::getNewCSRFToken()
+]);

--- a/front/login.php
+++ b/front/login.php
@@ -50,6 +50,13 @@ $SECURITY_STRATEGY = 'no_check';
 
 include('../inc/includes.php');
 
+if (GLPI_ENVIRONMENT_TYPE === 'testing' && !isset($_SESSION['namfield'])) {
+    // Direct login attempt by the e2e tests.
+    $_SESSION['namfield'] = "username";
+    $_SESSION['pwdfield'] = "password";
+    $_SESSION['rmbfield'] = "remember_me";
+    $_SESSION["glpicookietest"] = 'testcookie';
+}
 
 if (!isset($_SESSION["glpicookietest"]) || ($_SESSION["glpicookietest"] != 'testcookie')) {
     if (!Session::canWriteSessionFiles()) {

--- a/tests/cypress/e2e/login.cy.js
+++ b/tests/cypress/e2e/login.cy.js
@@ -1,0 +1,53 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+describe('Login tests', () => {
+    it('can login from the local database', () => {
+        cy.visit('/');
+        cy.title().should('eq', 'Authentication - GLPI');
+        cy.findByRole('textbox', {'name': "Login"}).type('e2e_tests');
+        cy.findByLabelText("Password").type('glpi');
+        cy.findByRole('checkbox', {name: "Remember me"}).check();
+        // Select 'local' from the 'auth' dropdown
+        cy.findByLabelText("Login source").select('local', { force: true });
+
+        cy.findByRole('button', {name: "Sign in"}).click();
+        // After logging in, the url should contain /front/central.php or /front/helpdesk.public.php
+        cy.url().should('match', /\/front\/(central|helpdesk.public).php/);
+
+        cy.getCookies().should('have.length.gte', 2).then((cookies) => {
+            // Should be two cookies starting with 'glpi_' and one of them should end with '_rememberme'
+            expect(cookies.filter((cookie) => cookie.name.startsWith('glpi_'))).to.have.length(2);
+            expect(cookies.filter((cookie) => cookie.name.startsWith('glpi_') && cookie.name.endsWith('_rememberme'))).to.have.length(1);
+        });
+    });
+});

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -47,20 +47,20 @@ Cypress.Commands.add('login', (username = 'e2e_tests', password = 'glpi') => {
     cy.session(
         username,
         () => {
-            cy.blockGLPIDashboards();
-            cy.visit('/');
-            cy.title().should('eq', 'Authentication - GLPI');
-            cy.findByRole('textbox', {'name': "Login"}).type(username);
-            cy.findByLabelText("Password", {exact: false}).type(password);
-            cy.findByRole('checkbox', {name: "Remember me"}).check();
-            // Select 'local' from the 'auth' dropdown
-            cy.findByLabelText("Login source").select('local', { force: true });
-            // TODO: should be
-            // cy.findByRole('combobox', {name: "Login source"}).select2('local', { force: true });
-
-            cy.findByRole('button', {name: "Sign in"}).click();
-            // After logging in, the url should contain /front/central.php or /front/helpdesk.public.php
-            cy.url().should('match', /\/front\/(central|helpdesk.public).php/);
+            cy.request('/front/csrf.php').its('body.token').then((csrf) => {
+                cy.request({
+                    method: 'POST',
+                    url: '/front/login.php',
+                    form: true,
+                    body: {
+                        username        : username,
+                        password        : password,
+                        remember_me     : 'on',
+                        auth            : 'local',
+                        _glpi_csrf_token: csrf,
+                    }
+                });
+            });
         },
         {
             validate: () => {


### PR DESCRIPTION
### Why do we need a dedicated login test ?

Our first implementation of e2e tests uses GLPI UI to login before a given test.

As per cypress official recommandations, this should be avoided: https://docs.cypress.io/guides/references/best-practices#Organizing-Tests-Logging-In-Controlling-State.

More details can be found in the cypress presentation from the assertjs 2018 conference: https://www.youtube.com/watch?v=5XQOK0v_YRE

To sum it up, the login process should be validated from the UI **once in a dedicated test**.
Then, **all others tests** should programmatically log into the application using some kind of direct HTTP requests.

Thus, I have moved the current login implementation into a dedicated test and added a new programmatic login command that can be used for all others tests.

### Programmatic login

To implements programmatic login, we have two barriers:
- The login form inputs names are randomized (thus we can't just do a POST request with the username and password keys). 
- We have a CSRF token.

### Randomized inputs

To fix the randomized names issue, I've added some changes to the login front file.
It will now use predetermined names (username, password, remember_me) if it receives a request from a `testing` environnements that doesn't come from the UI.

### CSRF

For the CSRF tokens, cypress give some example of the possibles strategies here: https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/logging-in__csrf-tokens/cypress/e2e/logging-in-csrf-tokens-spec.cy.js

I've chosen the 3rd strategy "expose CSRF via a route when not in production", which should bring the most performances while being easy to maintain.

The CSRF token will thus be retrieved by doing a `GET` request on `front/csrf.php`, a special page that does not return anything if the environnements is not `testing`.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
