### PR TITLE
refactor(forms): centralize end user input name

### DIFF
--- a/ajax/form/answer.php
+++ b/ajax/form/answer.php
@@ -36,7 +36,6 @@
 use Glpi\Form\AnswersHandler\AnswersHandler;
 use Glpi\Form\EndUserInputNameProvider;
 use Glpi\Form\Form;
-use Glpi\Form\Question;
 use Glpi\Http\Response;
 
 include('../../inc/includes.php');
@@ -60,7 +59,7 @@ if (!$form) {
 }
 
 // Validate the 'answers' parameter by filtering and reindexing the $_POST array.
-$answers = EndUserInputNameProvider::getAnswers();
+$answers = (new EndUserInputNameProvider())->getAnswers($_POST);
 if (empty($answers)) {
     Response::sendError(400, __('Invalid answers'));
 }

--- a/ajax/form/answer.php
+++ b/ajax/form/answer.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\Form\AnswersHandler\AnswersHandler;
+use Glpi\Form\EndUserInputNameProvider;
 use Glpi\Form\Form;
 use Glpi\Form\Question;
 use Glpi\Http\Response;
@@ -59,20 +60,7 @@ if (!$form) {
 }
 
 // Validate the 'answers' parameter by filtering and reindexing the $_POST array.
-// It first filters the keys that match a specific regex pattern,
-// then reindexes the array by transforming the keys to integers.
-$answers = array_reduce(
-    array_keys($_POST),
-    function ($carry, $key) {
-        if (preg_match(Question::END_USER_INPUT_NAME_REGEX, $key)) {
-            $question_id = (int) preg_replace(Question::END_USER_INPUT_NAME_REGEX, '$1', $key);
-            $carry[$question_id] = $_POST[$key];
-        }
-        return $carry;
-    },
-    []
-);
-
+$answers = EndUserInputNameProvider::getAnswers();
 if (empty($answers)) {
     Response::sendError(400, __('Invalid answers'));
 }

--- a/src/Form/EndUserInputNameProvider.php
+++ b/src/Form/EndUserInputNameProvider.php
@@ -36,7 +36,7 @@
 namespace Glpi\Form;
 
 /**
- * Helpdesk form
+ * Utility class to provide the end user input name
  */
 final class EndUserInputNameProvider
 {
@@ -49,20 +49,21 @@ final class EndUserInputNameProvider
      * @param Question $question
      * @return string
      */
-    public static function getEndUserInputName(Question $question): string
+    public function getEndUserInputName(Question $question): string
     {
-        return sprintf(static::END_USER_INPUT_NAME, $question->getID());
+        return sprintf(self::END_USER_INPUT_NAME, $question->getID());
     }
 
     /**
      * Get the answers submitted by the end user
      * The answers are indexed by question ID
      *
+     * @param array $inputs The inputs submitted by the end user
      * @return array
      */
-    public static function getAnswers(): array
+    public function getAnswers(array $inputs): array
     {
-        $filteredAnswers = self::filterAnswers($_POST);
+        $filteredAnswers = self::filterAnswers($inputs);
         $reindexedAnswers = self::reindexAnswers($filteredAnswers);
 
         return $reindexedAnswers;
@@ -75,7 +76,7 @@ final class EndUserInputNameProvider
      * @param array $answers
      * @return array
      */
-    private static function filterAnswers(array $answers): array
+    private function filterAnswers(array $answers): array
     {
         return array_filter(
             $answers,
@@ -93,7 +94,7 @@ final class EndUserInputNameProvider
      * @param array $answers
      * @return array
      */
-    private static function reindexAnswers(array $answers): array
+    private function reindexAnswers(array $answers): array
     {
         return array_reduce(
             array_keys($answers),

--- a/src/Form/EndUserInputNameProvider.php
+++ b/src/Form/EndUserInputNameProvider.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form;
+
+/**
+ * Helpdesk form
+ */
+final class EndUserInputNameProvider
+{
+    public const END_USER_INPUT_NAME = 'answers_%d';
+    public const END_USER_INPUT_NAME_REGEX = '/^_?answers_(\d+)$/';
+
+    /**
+     * Get the end user input name for a given question
+     *
+     * @param Question $question
+     * @return string
+     */
+    public static function getEndUserInputName(Question $question): string
+    {
+        return sprintf(static::END_USER_INPUT_NAME, $question->getID());
+    }
+
+    /**
+     * Get the answers submitted by the end user
+     * The answers are indexed by question ID
+     *
+     * @return array
+     */
+    public static function getAnswers(): array
+    {
+        $filteredAnswers = self::filterAnswers($_POST);
+        $reindexedAnswers = self::reindexAnswers($filteredAnswers);
+
+        return $reindexedAnswers;
+    }
+
+    /**
+     * Filter the answers submitted by the end user
+     * Only the answers that match the end user input name pattern are kept
+     *
+     * @param array $answers
+     * @return array
+     */
+    private static function filterAnswers(array $answers): array
+    {
+        return array_filter(
+            $answers,
+            function ($key) {
+                return preg_match(self::END_USER_INPUT_NAME_REGEX, $key);
+            },
+            ARRAY_FILTER_USE_KEY
+        );
+    }
+
+    /**
+     * Reindex the answers submitted by the end user
+     * The answers are indexed by question ID
+     *
+     * @param array $answers
+     * @return array
+     */
+    private static function reindexAnswers(array $answers): array
+    {
+        return array_reduce(
+            array_keys($answers),
+            function ($carry, $key) use ($answers) {
+                $question_id = (int) preg_replace(self::END_USER_INPUT_NAME_REGEX, '$1', $key);
+                $carry[$question_id] = $answers[$key];
+                return $carry;
+            },
+            []
+        );
+    }
+}

--- a/src/Form/Question.php
+++ b/src/Form/Question.php
@@ -46,6 +46,9 @@ use ReflectionClass;
  */
 final class Question extends CommonDBChild
 {
+    public const END_USER_INPUT_NAME = 'answers_%d';
+    public const END_USER_INPUT_NAME_REGEX = '/^_?answers_(\d+)$/';
+
     public static $itemtype = Section::class;
     public static $items_id = 'forms_sections_id';
 
@@ -119,6 +122,11 @@ final class Question extends CommonDBChild
     protected function getForm(): Form
     {
         return $this->getItem()->getItem();
+    }
+
+    public function getEndUserInputName(): string
+    {
+        return sprintf(static::END_USER_INPUT_NAME, $this->getID());
     }
 
     public function prepareInputForAdd($input)

--- a/src/Form/Question.php
+++ b/src/Form/Question.php
@@ -46,9 +46,6 @@ use ReflectionClass;
  */
 final class Question extends CommonDBChild
 {
-    public const END_USER_INPUT_NAME = 'answers_%d';
-    public const END_USER_INPUT_NAME_REGEX = '/^_?answers_(\d+)$/';
-
     public static $itemtype = Section::class;
     public static $items_id = 'forms_sections_id';
 
@@ -126,7 +123,7 @@ final class Question extends CommonDBChild
 
     public function getEndUserInputName(): string
     {
-        return sprintf(static::END_USER_INPUT_NAME, $this->getID());
+        return EndUserInputNameProvider::getEndUserInputName($this);
     }
 
     public function prepareInputForAdd($input)

--- a/src/Form/Question.php
+++ b/src/Form/Question.php
@@ -123,7 +123,7 @@ final class Question extends CommonDBChild
 
     public function getEndUserInputName(): string
     {
-        return EndUserInputNameProvider::getEndUserInputName($this);
+        return (new EndUserInputNameProvider())->getEndUserInputName($this);
     }
 
     public function prepareInputForAdd($input)

--- a/src/Form/QuestionType/AbstractQuestionTypeActors.php
+++ b/src/Form/QuestionType/AbstractQuestionTypeActors.php
@@ -263,7 +263,7 @@ TWIG;
         {% import 'components/form/fields_macros.html.twig' as fields %}
 
         {% set actors_dropdown = call('Glpi\\\\Form\\\\Dropdown\\\\FormActorsDropdown::show', [
-            'answers[' ~ question.fields.id ~ ']',
+            question.getEndUserInputName(),
             value,
             {
                 'multiple': is_multiple_actors,
@@ -272,7 +272,7 @@ TWIG;
         ]) %}
 
         {{ fields.htmlField(
-            'answers[' ~ question.fields.id ~ ']',
+            question.getEndUserInputName(),
             actors_dropdown,
             '',
             {

--- a/src/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
+++ b/src/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
@@ -105,7 +105,7 @@ TWIG;
             <input
                 type="{{ input_type|e('html_attr') }}"
                 class="form-control"
-                name="answers[{{ question.fields.id|e('html_attr') }}]"
+                name="{{ question.getEndUserInputName() }}"
                 value="{{ question.fields.default_value|e('html_attr') }}"
                 {{ question.fields.is_mandatory ? 'required' : '' }}
             >

--- a/src/Form/QuestionType/QuestionTypeDateTime.php
+++ b/src/Form/QuestionType/QuestionTypeDateTime.php
@@ -347,7 +347,7 @@ TWIG;
             <input
                 type="{{ input_type|e('html_attr') }}"
                 class="form-control"
-                name="answers[{{ question.fields.id|e('html_attr') }}]"
+                name="{{ question.getEndUserInputName() }}"
                 value="{{ default_value|e('html_attr') }}"
                 {{ question.fields.is_mandatory ? 'required' : '' }}
             >

--- a/src/Form/QuestionType/QuestionTypeLongText.php
+++ b/src/Form/QuestionType/QuestionTypeLongText.php
@@ -105,7 +105,7 @@ TWIG;
             {% import 'components/form/fields_macros.html.twig' as fields %}
 
             {{ fields.textareaField(
-                "answers[" ~ question.fields.id ~ "]",
+                question.getEndUserInputName(),
                 question.fields.default_value,
                 "",
                 {

--- a/src/Form/QuestionType/QuestionTypeUrgency.php
+++ b/src/Form/QuestionType/QuestionTypeUrgency.php
@@ -124,7 +124,7 @@ TWIG;
         {% import 'components/form/fields_macros.html.twig' as fields %}
 
         {{ fields.dropdownArrayField(
-            'answers[' ~ question.fields.id ~ ']',
+            question.getEndUserInputName(),
             value,
             urgency_levels,
             '',

--- a/tests/functional/Glpi/Form/EndUserInputNameProvider.php
+++ b/tests/functional/Glpi/Form/EndUserInputNameProvider.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form;
+
+use DbTestCase;
+use Glpi\Form\QuestionType\QuestionTypeShortText;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+
+class EndUserInputNameProvider extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public function testGetEndUserInputName()
+    {
+        // Create a new form
+        $form = $this->createForm(
+            (new FormBuilder())
+                ->addQuestion('Name', QuestionTypeShortText::class)
+        );
+
+        // Check that the end user input name contains the question ID
+        // and if the regex match with the generated end user input name
+        foreach ($form->getQuestions() as $question) {
+            $this->string($question->getEndUserInputName())
+                ->contains($question->getID())
+                ->match(\Glpi\Form\EndUserInputNameProvider::END_USER_INPUT_NAME_REGEX);
+        }
+    }
+
+    public function testGetAnswers()
+    {
+        // Create a new form
+        $form = $this->createForm(
+            (new FormBuilder())
+                ->addQuestion('Name', QuestionTypeShortText::class)
+                ->addQuestion('Email', QuestionTypeShortText::class)
+        );
+
+        // Generate the answers
+        $_POST = [
+            $form->getQuestions()[array_keys($form->getQuestions())[0]]->getEndUserInputName() => 'John Doe',
+            $form->getQuestions()[array_keys($form->getQuestions())[1]]->getEndUserInputName() => 'john.doe@mail.mail',
+            'invalid_input' => 'invalid_value',
+        ];
+
+        // Check that the answers are correctly indexed by question ID
+        $this->array(\Glpi\Form\EndUserInputNameProvider::getAnswers())
+            ->hasSize(2)
+            ->isEqualTo([
+                $form->getQuestions()[array_keys($form->getQuestions())[0]]->getID() => 'John Doe',
+                $form->getQuestions()[array_keys($form->getQuestions())[1]]->getID() => 'john.doe@mail.mail',
+            ]);
+    }
+}

--- a/tests/functional/Glpi/Form/EndUserInputNameProvider.php
+++ b/tests/functional/Glpi/Form/EndUserInputNameProvider.php
@@ -71,14 +71,14 @@ class EndUserInputNameProvider extends DbTestCase
         );
 
         // Generate the answers
-        $_POST = [
+        $inputs = [
             $form->getQuestions()[array_keys($form->getQuestions())[0]]->getEndUserInputName() => 'John Doe',
             $form->getQuestions()[array_keys($form->getQuestions())[1]]->getEndUserInputName() => 'john.doe@mail.mail',
             'invalid_input' => 'invalid_value',
         ];
 
         // Check that the answers are correctly indexed by question ID
-        $this->array(\Glpi\Form\EndUserInputNameProvider::getAnswers())
+        $this->array((new \Glpi\Form\EndUserInputNameProvider())->getAnswers($inputs))
             ->hasSize(2)
             ->isEqualTo([
                 $form->getQuestions()[array_keys($form->getQuestions())[0]]->getID() => 'John Doe',


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

A method has been added to centralize the input names of the question types on the final form interface. The format has also been modified so that the answers to the questions are no longer stored in a single attribute. This is similar to the way FormCreator works, and simplifies the path for the upcoming arrival of the `File` question type.