### PR TITLE
Do not show rand number for some ImportEntity criteria

### DIFF
--- a/src/RuleImportEntity.php
+++ b/src/RuleImportEntity.php
@@ -180,11 +180,11 @@ class RuleImportEntity extends Rule
                 return true;
 
             case Rule::PATTERN_EXISTS:
-                echo Dropdown::showYesNo($name, 1, 0);
+                Dropdown::showYesNo($name, 1, 0);
                 return true;
 
             case Rule::PATTERN_DOES_NOT_EXISTS:
-                echo Dropdown::showYesNo($name, 1, 0);
+                Dropdown::showYesNo($name, 1, 0);
                 return true;
         }
         return false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Bug noticed during UI work on `main`. Issue could be seen at least with the Domain criteria with the exists/not exists option.