### PR TITLE
Do not erase valid refresh tokens during SMTP Oauth connection

### DIFF
--- a/src/GLPIMailer.php
+++ b/src/GLPIMailer.php
@@ -138,7 +138,8 @@ class GLPIMailer extends PHPMailer
         if (
             $this->oauth instanceof OAuthTokenProvider
             && $result === true
-            && ($refresh_token = $this->oauth->getOauthToken()->getRefreshToken() ?? null) !== (new GLPIKey())->decrypt($CFG_GLPI['smtp_oauth_refresh_token'])
+            && ($refresh_token = $this->oauth->getOauthToken()->getRefreshToken() ?? null) !== null
+            && $refresh_token !== (new GLPIKey())->decrypt($CFG_GLPI['smtp_oauth_refresh_token'])
         ) {
             // The refresh token may be refreshed itself.
             // Be sure to always store any new refresh token.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !32689

In #16830, a logic was introduced to store any new refresh token received during SMTP Oauth connection (Azure provider case). This logic was not handling the fact that the SMTP Oauth connection will not always provide a new refresh token (Google provider case).