### PR TITLE
Fix ambiguous `assets_assetdefinitions_id` column in asset reports

### DIFF
--- a/src/Report.php
+++ b/src/Report.php
@@ -309,7 +309,7 @@ class Report extends CommonGLPI
                 ],
                 'WHERE'     => [
                     "$table_item.is_deleted"   => 0
-                ] + getEntitiesRestrictCriteria($table_item) + $itemtype::getSystemSQLCriteria(),
+                ] + getEntitiesRestrictCriteria($table_item) + $itemtype::getSystemSQLCriteria($table_item),
                 'GROUPBY'   => "$type_table.name"
             ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
