### PR TITLE
Use Monaco for telemetry preview

### DIFF
--- a/ajax/telemetry.php
+++ b/ajax/telemetry.php
@@ -33,7 +33,9 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\View\TemplateRenderer;
 // Must be available during installation. This script already checks for permissions when the flag usually set by the installer is missing.
+
 $SECURITY_STRATEGY = 'no_check';
 
 include('../inc/includes.php');
@@ -45,11 +47,24 @@ if (!($_SESSION['telemetry_from_install'] ?? false)) {
     Session::checkRight("config", READ);
 }
 
-echo Html::css("public/lib/prismjs.css");
-echo Html::script("public/lib/prismjs.js");
+echo Html::css("public/lib/monaco.css");
 
-$infos = Telemetry::getTelemetryInfos();
-echo "<p>" . __("We only collect the following data: plugins usage, performance and responsiveness statistics about user interface features, memory, and hardware configuration.") . "</p>";
-echo "<pre><code class='language-json'>";
-echo json_encode($infos, JSON_PRETTY_PRINT);
-echo "</code></pre>";
+$twig_params = [
+    'info' => json_encode(Telemetry::getTelemetryInfos(), JSON_PRETTY_PRINT),
+    'description' => __("We only collect the following data: plugins usage, performance and responsiveness statistics about user interface features, memory, and hardware configuration.")
+];
+// language=Twig
+echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
+    <p>{{ description }}</p>
+    <div id='telemetry-preview' style="height: 400px"></div>
+    <script type="module">
+        import('{{ path("js/modules/Monaco/MonacoEditor.js") }}').then(() => {
+            window.GLPI.Monaco.createEditor('telemetry-preview', 'javascript', `{{ info|escape('js') }}`, [], {
+                readOnly: true,
+                minimap: {
+                    enabled: false
+                }
+            });
+        });
+    </script>
+TWIG, $twig_params);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Continued work on unifying the GLPI UI/UX by removing the use of different libraries for syntax highlighting/code editing (prismjs, codemirror, etc). This PR replaces the syntax highlighting done by PrismJS for the telemetry preview with a readonly Monaco editor (used an editor instead of just highlighting to enable the search and folding functionality).

PrismJS is still used in the legacy API documentation and that part is not addressed in this PR.