### PR TITLE
Use Monaco for legacy API examples

### DIFF
--- a/.webpack.config.js
+++ b/.webpack.config.js
@@ -104,7 +104,7 @@ let config = {
         ), // Clean lib dir content
         new MiniCssExtractPlugin(), // Extract styles into CSS files
         new MonacoWebpackPlugin({
-            'languages': ['html', 'javascript', 'typescript', 'json', 'markdown', 'twig', 'css', 'scss'],
+            'languages': ['html', 'javascript', 'typescript', 'json', 'markdown', 'twig', 'css', 'scss', 'shell'],
             'publicPath': '/public/lib/'
         }),
     ],

--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -46,6 +46,7 @@
     --tblr-body-bg: #f5f7fb;
     --tblr-bg-surface: #fff;
     --tblr-bg-surface-tertiary: var(--tblr-gray-50);
+    --tblr-bg-surface-dark: color-mix(in srgb, var(--tblr-bg-surface), var(--tblr-dark) 1.5%);
     --glpi-tabs-bg: color-mix(in srgb, var(--tblr-bg-surface), black 1.5%);
     --glpi-tabs-fg: var(--tblr-muted);
     --glpi-tabs-border-color: var(--tblr-border-color);

--- a/css/includes/_palette_dark.scss
+++ b/css/includes/_palette_dark.scss
@@ -49,6 +49,7 @@
     --tblr-gray-800: color-mix(in srgb, var(--tblr-dark), var(--tblr-light) 84%);
     --tblr-gray-900: var(--tblr-light);
     --tblr-gray-50: var(--tblr-gray-300);
+    --tblr-bg-surface-dark: color-mix(in srgb, var(--tblr-bg-surface), var(--tblr-light) 98.5%);
     --glpi-tabs-active-bg: color-mix(in srgb, var(--tblr-bg-surface), white 10%);
     --glpi-tabs-border-color: transparent;
     --glpi-scrollbar-thumb-color: color-mix(in srgb, var(--tblr-secondary), transparent 75%);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Companion PR to #17059. If both PRs are approved, we should have nothing left using PrismJS in the core and it could be removed.
The trade-off in this PR is that Apache and NGINX config examples at the end of the documentation have no language support. In both cases, it is custom syntax.

For the Apache config, everything is commented out anyways so syntax highlighting doesn't really matter. We could trick it into highlighting by choosing any language with a `#` comment character.
For NGINX, the example as written looks mostly good if highlighted as GraphQL, but may look wrong to anyone that actually knows NGINX configs (not me).

Neither of the above workarounds are currently present in this PR.