### PR TITLE
Network Port Twig UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ The present file will list all changes made to the project; according to the
 - External Links `Link or filename` and `File content` fields now use Twig templates instead of a custom tag syntax.
 - Itemtypes associated with External links are now in the main form rather than a separate tab.
 - The `Computer_Item` class has been replaced by the `\Glpi\Asset\Asset_PeripheralAsset` class.
+- List of network ports in a VLAN form now shows the NetworkPort link in a breadcrumb manner (MyServer > eth0 where MyServer is a link to the computer and eth0 is a link to the port).
 
 ### Deprecated
 - Survey URL tags `TICKETCATEGORY_ID` and `TICKETCATEGORY_NAME` are deprecated and replaced by `ITILCATEGORY_ID` and `ITILCATEGORY_NAME` respectively.
@@ -136,6 +137,9 @@ The present file will list all changes made to the project; according to the
 - `Lock::getLocksQueryInfosByItemType()` has been made private.
 - `DBmysql::request()`, `DBmysqlIterator::buildQuery()` and `DBmysqlIterator::execute()` methods signatures changed.
 -  Some values for the `$type` parameters of several `Stat` methods have changed to match English spelling (technicien -> technician).
+- `showInstantiationForm()` method for Network Port classes are now expected to output HTML for a flex form instead of a table.
+- `NetworkName::showFormForNetworkPort()` now outputs HTML for a flex form instead of a table.
+- `NetworkPortInstantiation::showSocketField()`, `NetworkPortInstantiation::showMacField()`, `NetworkPortInstantiation::showNetworkCardField` now outputs HTML for a flex form instead of a table.
 
 #### Deprecated
 - Usage of `MAIL_SMTPSSL` and `MAIL_SMTPTLS` constants.

--- a/ajax/networkname.php
+++ b/ajax/networkname.php
@@ -33,17 +33,25 @@
  * ---------------------------------------------------------------------
  */
 
-/**
- * Local instantiation of NetworkPort. Among others, loopback (ie.: 127.0.0.1).
- * @since 0.84
- */
-class NetworkPortLocal extends NetworkPortInstantiation
-{
-    public $canHaveVLAN = false;
-    public $haveMAC     = false;
+use Glpi\Event;
 
-    public static function getTypeName($nb = 0)
-    {
-        return __('Local loop port');
-    }
+include('../inc/includes.php');
+
+header("Content-Type: text/html; charset=UTF-8");
+Html::header_nocache();
+
+Session::checkLoginUser();
+
+$nn = new NetworkName();
+if (isset($_POST["unaffect"])) {
+    $nn->check($_POST['id'], UPDATE);
+    $nn::unaffectAddressByID($_POST['id']);
+    Event::log(
+        $_POST["id"],
+        "networkname",
+        4,
+        "inventory",
+        //TRANS: %s is the user login
+        sprintf(__('%s updates an item'), $_SESSION["glpiname"])
+    );
 }

--- a/src/CommonDBChild.php
+++ b/src/CommonDBChild.php
@@ -263,7 +263,7 @@ abstract class CommonDBChild extends CommonDBConnexity
 
 
     /**
-     * \brief recursively display the items of this
+     * Recursively display the items of this
      *
      * @param array  $recursiveItems    items of the current elements (see recursivelyGetItems())
      * @param string $elementToDisplay  what to display : 'Type', 'Name', 'Link'

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -33,6 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\Plugin\Hooks;
 use Glpi\Socket;
@@ -1344,82 +1345,21 @@ class NetworkPort extends CommonDBChild
             return false;
         }
 
-        $this->initForm($ID, $options);
-
         $recursiveItems = $this->recursivelyGetItems();
         if (count($recursiveItems) > 0) {
             $lastItem             = $recursiveItems[count($recursiveItems) - 1];
-            $lastItem_entities_id = $lastItem->getField('entities_id');
+            $options['entities_id'] = $lastItem->getField('entities_id');
         } else {
-            $lastItem_entities_id = $_SESSION['glpiactive_entity'];
+            $options['entities_id'] = $_SESSION['glpiactive_entity'];
         }
 
-        $options['entities_id'] = $lastItem_entities_id;
-        $this->showFormHeader($options);
-
-        echo "<tr class='tab_bg_1'><td>";
-        self::displayRecursiveItems($recursiveItems, 'Type');
-        echo "&nbsp;:</td>\n<td>";
-
-       // Need these to update information
-        echo "<input type='hidden' name='items_id' value='" . $this->fields["items_id"] . "'>\n";
-        echo "<input type='hidden' name='itemtype' value='" . $this->fields["itemtype"] . "'>\n";
-        echo "<input type='hidden' name='_create_children' value='1'>\n";
-        echo "<input type='hidden' name='instantiation_type' value='" .
-             $this->fields["instantiation_type"] . "'>\n";
-
-        $this->displayRecursiveItems($recursiveItems, "Link");
-        echo "</td>\n";
-        $colspan = 2;
-
-        if (!$options['several']) {
-            $colspan++;
-        }
-        echo "<td rowspan='$colspan'>" . __('Comments') . "</td>";
-        echo "<td rowspan='$colspan' class='middle'>";
-        echo "<textarea class='form-control' rows='$colspan' name='comment' >" .
-             $this->fields["comment"] . "</textarea>";
-        echo "</td></tr>\n";
-
-        if (!$options['several']) {
-            echo "<tr class='tab_bg_1'><td>" . _n('Port number', 'Port numbers', 1) . "</td>\n";
-            echo "<td>";
-            echo Html::input('logical_number', ['value' => $this->fields['logical_number'], 'size' => 5]);
-            echo "</td></tr>\n";
-        } else {
-            echo "<tr class='tab_bg_1'><td>" . _n('Port number', 'Port numbers', Session::getPluralNumber()) . "</td>\n";
-            echo "<td>";
-            echo "<input type='hidden' name='several' value='yes'>";
-            echo "<input type='hidden' name='logical_number' value=''>\n";
-            echo __('from') . "&nbsp;";
-            Dropdown::showNumber('from_logical_number', ['value' => 0]);
-            echo "&nbsp;" . __('to') . "&nbsp;";
-            Dropdown::showNumber('to_logical_number', ['value' => 0]);
-            echo "</td></tr>\n";
-        }
-
-        echo "<tr class='tab_bg_1'><td>" . __('Name') . "</td>\n";
-        echo "<td>";
-        echo Html::input('name', ['value' => $this->fields['name']]);
-        echo "</td></tr>\n";
-
-        echo "<tr class='tab_bg_1'><td>" . __('Alias') . "</td>\n";
-        echo "<td>";
-        echo Html::input('ifalias', ['value' => $this->fields['ifalias']]);
-        echo "</td></tr>\n";
-
-        $instantiation = $this->getInstantiation();
-        if ($instantiation !== false) {
-            echo "<tr class='tab_bg_1'><th colspan='4'>" . $instantiation::getTypeName(1) . "</th></tr>\n";
-            $instantiation->showInstantiationForm($this, $options, $recursiveItems);
-            unset($instantiation);
-        }
-
-        if (!$options['several']) {
-            NetworkName::showFormForNetworkPort($this->getID());
-        }
-
-        $this->showFormButtons($options);
+        TemplateRenderer::getInstance()->display('pages/assets/networkport/form.html.twig', [
+            'item'   => $this,
+            'recursive_items' => $recursiveItems,
+            'instantiation' => $this->getInstantiation(),
+            'params' => $options,
+            'no_inventory_footer' => true
+        ]);
 
         return true;
     }
@@ -1782,7 +1722,7 @@ class NetworkPort extends CommonDBChild
                 if ($_SESSION['glpishow_count_on_tabs']) {
                     $nb = self::countForItem($item);
                 }
-                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
             }
         }
 
@@ -1798,13 +1738,14 @@ class NetworkPort extends CommonDBChild
             }
             $nbAggregates = countElementsInTable(
                 'glpi_networkportaggregates',
+                //FIXME This seems prone to false positives. Assume that networkports_id_list is a JSON array. Searching %1% would match 1, 10, 31, 100, etc.
                 ['networkports_id_list'   => ['LIKE', '%"' . $item->getField('id') . '"%']]
             );
             if ($nbAggregates > 0) {
                 $aggregates = self::createTabEntry(
                     NetworkPortAggregate::getTypeName(Session::getPluralNumber()),
                     $nbAggregates,
-                    $item::getType()
+                    $item::class
                 );
             } else {
                 $aggregates = '';
@@ -1869,7 +1810,7 @@ class NetworkPort extends CommonDBChild
         }
 
         $itemtype = $this->fields['itemtype'];
-        /** @var CommonDBTM */
+        /** @var CommonDBTM $itemtype */
         $equipment = new $itemtype();
 
         if ($equipment->getFromDB($this->fields['items_id'])) {

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1738,7 +1738,6 @@ class NetworkPort extends CommonDBChild
             }
             $nbAggregates = countElementsInTable(
                 'glpi_networkportaggregates',
-                //FIXME This seems prone to false positives. Assume that networkports_id_list is a JSON array. Searching %1% would match 1, 10, 31, 100, etc.
                 ['networkports_id_list'   => ['LIKE', '%"' . $item->getField('id') . '"%']]
             );
             if ($nbAggregates > 0) {

--- a/src/NetworkPortAggregate.php
+++ b/src/NetworkPortAggregate.php
@@ -33,10 +33,10 @@
  * ---------------------------------------------------------------------
  */
 
-/// NetworkPortAggregate class : aggregate instantiation of NetworkPort. Aggregate can represent a
-/// trunk on switch, specific port under that regroup several ethernet ports to manage Ethernet
-/// Bridging.
-/// @since 0.84
+/**
+ * Aggregate instantiation of NetworkPort. Aggregate can represent a trunk on switch, specific port under that regroup several ethernet ports to manage Ethernet Bridging.
+ * @since 0.84
+ */
 class NetworkPortAggregate extends NetworkPortInstantiation
 {
     public static function getTypeName($nb = 0)
@@ -44,10 +44,8 @@ class NetworkPortAggregate extends NetworkPortInstantiation
         return __('Aggregation port');
     }
 
-
     public function prepareInputForAdd($input)
     {
-
         if ((isset($input['networkports_id_list'])) && is_array($input['networkports_id_list'])) {
             $input['networkports_id_list'] = exportArrayToDB($input['networkports_id_list']);
         } else {
@@ -55,11 +53,9 @@ class NetworkPortAggregate extends NetworkPortInstantiation
         }
         return parent::prepareInputForAdd($input);
     }
-
 
     public function prepareInputForUpdate($input)
     {
-
         if ((isset($input['networkports_id_list'])) && is_array($input['networkports_id_list'])) {
             $input['networkports_id_list'] = exportArrayToDB($input['networkports_id_list']);
         } else {
@@ -68,10 +64,8 @@ class NetworkPortAggregate extends NetworkPortInstantiation
         return parent::prepareInputForAdd($input);
     }
 
-
     public function showInstantiationForm(NetworkPort $netport, $options, $recursiveItems)
     {
-
         if (
             isset($this->fields['networkports_id_list'])
             && is_string($this->fields['networkports_id_list'])
@@ -80,12 +74,9 @@ class NetworkPortAggregate extends NetworkPortInstantiation
                         = importArrayFromDB($this->fields['networkports_id_list']);
         }
 
-        echo "<tr class='tab_bg_1'>";
         $this->showMacField($netport, $options);
-        $this->showNetworkPortSelector($recursiveItems, $this->getType());
-        echo "</tr>";
+        $this->showNetworkPortSelector($recursiveItems, static::class);
     }
-
 
     public function getInstantiationHTMLTableHeaders(
         HTMLTableGroup $group,
@@ -94,13 +85,11 @@ class NetworkPortAggregate extends NetworkPortInstantiation
         HTMLTableHeader $father = null,
         array $options = []
     ) {
-
-        $group->addHeader('Origin', __('Origin port'), $super);
+        $group->addHeader('Origin', __s('Origin port'), $super);
 
         parent::getInstantiationHTMLTableHeaders($group, $super, $internet_super, $father, $options);
         return null;
     }
-
 
     public function getInstantiationHTMLTable(
         NetworkPort $netport,
@@ -108,7 +97,6 @@ class NetworkPortAggregate extends NetworkPortInstantiation
         HTMLTableCell $father = null,
         array $options = []
     ) {
-
         if (
             isset($this->fields['networkports_id_list'])
             && is_string($this->fields['networkports_id_list'])

--- a/src/NetworkPortAlias.php
+++ b/src/NetworkPortAlias.php
@@ -33,9 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
-/// NetworkPortAlias class : alias instantiation of NetworkPort. An alias can be use to define VLAN
-/// tagged ports. It is use in old version of Linux to define several IP addresses to a given port.
-/// @since 0.84
+/**
+ * Alias instantiation of NetworkPort. An alias can be use to define VLAN tagged ports.
+ * It is used in old versiond of Linux to define several IP addresses to a given port.
+ * @since 0.84
+ */
 class NetworkPortAlias extends NetworkPortInstantiation
 {
     public static function getTypeName($nb = 0)
@@ -43,12 +45,9 @@ class NetworkPortAlias extends NetworkPortInstantiation
         return __('Alias port');
     }
 
-
     public function prepareInput($input)
     {
-
-       // Try to get mac address from the instantiation ...
-
+        // Try to get mac address from the instantiation ...
         if (
             !isset($input['mac'])
             && isset($input['networkports_id_alias'])
@@ -62,28 +61,21 @@ class NetworkPortAlias extends NetworkPortInstantiation
         return $input;
     }
 
-
     public function prepareInputForAdd($input)
     {
         return parent::prepareInputForAdd($this->prepareInput($input));
     }
-
 
     public function prepareInputForUpdate($input)
     {
         return parent::prepareInputForUpdate($this->prepareInput($input));
     }
 
-
     public function showInstantiationForm(NetworkPort $netport, $options, $recursiveItems)
     {
-
-        echo "<tr class='tab_bg_1'>";
         $this->showMacField($netport, $options);
-        $this->showNetworkPortSelector($recursiveItems, $this->getType());
-        echo "</tr>";
+        $this->showNetworkPortSelector($recursiveItems, static::class);
     }
-
 
     public function getInstantiationHTMLTableHeaders(
         HTMLTableGroup $group,
@@ -92,13 +84,11 @@ class NetworkPortAlias extends NetworkPortInstantiation
         HTMLTableHeader $father = null,
         array $options = []
     ) {
-
-        $group->addHeader('Origin', __('Origin port'), $super);
+        $group->addHeader('Origin', __s('Origin port'), $super);
 
         parent::getInstantiationHTMLTableHeaders($group, $super, $internet_super, $father, $options);
         return null;
     }
-
 
     public function getInstantiationHTMLTable(
         NetworkPort $netport,
@@ -106,7 +96,6 @@ class NetworkPortAlias extends NetworkPortInstantiation
         HTMLTableCell $father = null,
         array $options = []
     ) {
-
         $row->addCell(
             $row->getHeaderByName('Instantiation', 'Origin'),
             $this->getInstantiationNetworkPortHTMLTable()

--- a/src/NetworkPortConnectionLog.php
+++ b/src/NetworkPortConnectionLog.php
@@ -135,7 +135,7 @@ class NetworkPortConnectionLog extends CommonDBChild
                 $citem->getFromDB($cport->fields["items_id"]);
 
                 $cport_link = sprintf(
-                    "<a href='%1\$s'>%2\$s</a>",
+                    '<a href="%1$s">%2$s</a>',
                     htmlspecialchars($cport::getFormURLWithID($cport->fields['id'])),
                     htmlspecialchars(trim($cport->fields['name']) === '' ? __('Without name') : $cport->fields['name'])
                 );

--- a/src/NetworkPortDialup.php
+++ b/src/NetworkPortDialup.php
@@ -33,16 +33,18 @@
  * ---------------------------------------------------------------------
  */
 
-/// NetworkPortDialup class : dialup instantiation of NetworkPort. A dialup connexion also known as
-/// point-to-point protocol allows connexion between to sites through specific connexion
-/// @since 0.84
+use Glpi\Application\View\TemplateRenderer;
+
+/**
+ * Dialup instantiation of NetworkPort. A dialup connection (also known a point-to-point protocol) allows connection between to sites through specific connections.
+ * @since 0.84
+ */
 class NetworkPortDialup extends NetworkPortInstantiation
 {
     public static function getTypeName($nb = 0)
     {
         return __('Connection by dial line - Dialup Port');
     }
-
 
     public function getInstantiationHTMLTableHeaders(
         HTMLTableGroup $group,
@@ -52,12 +54,11 @@ class NetworkPortDialup extends NetworkPortInstantiation
         array $options = []
     ) {
 
-        $header = $group->addHeader('Connected', __('Connected to'), $super);
+        $header = $group->addHeader('Connected', __s('Connected to'), $super);
 
         parent::getInstantiationHTMLTableHeaders($group, $super, $internet_super, $header, $options);
         return null;
     }
-
 
     public function getInstantiationHTMLTable(
         NetworkPort $netport,
@@ -69,17 +70,22 @@ class NetworkPortDialup extends NetworkPortInstantiation
         return $this->getInstantiationHTMLTableWithPeer($netport, $row, $father, $options);
     }
 
-
     public function showInstantiationForm(NetworkPort $netport, $options, $recursiveItems)
     {
-
-        echo "<tr class='tab_bg_1'>";
-        $this->showMacField($netport, $options);
-
-        echo "<td>" . __('Connected to') . '</td><td>';
-        self::showConnection($netport, true);
-        echo "</td>";
-
-        echo "</tr>";
+        $twig_params = [
+            'item' => $this,
+            'netport' => $netport,
+            'params' => $options,
+            'connection_label' => __('Connected to')
+        ];
+        // language=Twig
+        echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
+            {% import 'components/form/fields_macros.html.twig' as fields %}
+            {% do call([item, 'showMacField'], [netport, params]) %}
+            {% set connection_field %}
+                {% do call([item, 'showConnection'], [netport, true]) %}
+            {% endset %}
+            {{ fields.htmlField('', connection_field, connection_label) }}
+TWIG, $twig_params);
     }
 }

--- a/src/NetworkPortFiberchannel.php
+++ b/src/NetworkPortFiberchannel.php
@@ -33,6 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\View\TemplateRenderer;
 use Glpi\Socket;
 
 /**
@@ -47,17 +48,14 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation
         return __('Fiber channel port');
     }
 
-
     public function getNetworkCardInterestingFields()
     {
         return ['link.mac' => 'mac'];
     }
 
-
     public function prepareInput($input)
     {
-
-        if (isset($input['speed']) && ($input['speed'] == 'speed_other_value')) {
+        if (isset($input['speed']) && ($input['speed'] === 'speed_other_value')) {
             if (!isset($input['speed_other_value'])) {
                 unset($input['speed']);
             } else {
@@ -72,34 +70,22 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation
         return $input;
     }
 
-
     public function prepareInputForAdd($input)
     {
         return parent::prepareInputForAdd($this->prepareInput($input));
     }
-
 
     public function prepareInputForUpdate($input)
     {
         return parent::prepareInputForUpdate($this->prepareInput($input));
     }
 
-
     public function showInstantiationForm(NetworkPort $netport, $options, $recursiveItems)
     {
-
         if (!$options['several']) {
-            echo "<tr class='tab_bg_1'>";
             $this->showSocketField($netport, $options, $recursiveItems);
             $this->showNetworkCardField($netport, $options, $recursiveItems);
-            echo "</tr>\n";
         }
-
-        echo "<tr class='tab_bg_1'>";
-        echo "<td>" . __('World Wide Name') . "</td><td>\n";
-        echo Html::input('wwn', ['value' => $this->fields['wwn']]);
-        echo "</td>";
-        echo "<td>" . __('Fiber channel port speed') . "</td><td>\n";
 
         $standard_speeds = self::getPortSpeed();
         if (
@@ -111,27 +97,35 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation
             $speed = true;
         }
 
-        Dropdown::showFromArray(
-            'speed',
-            $standard_speeds,
-            ['value' => $this->fields['speed'],
-                'other' => $speed
-            ]
-        );
-        echo "</td></tr>\n";
-
-        echo "<tr class='tab_bg_1'>\n";
-        $this->showMacField($netport, $options);
-        echo "<td>" . __('Connected to') . '</td><td>';
-        self::showConnection($netport, true);
-        echo "</td></tr>\n";
-
-        echo "<tr class='tab_bg_1'>";
-        echo "<td>" . NetworkPortFiberchannelType::getTypeName(0) . "</td><td>\n";
-        Dropdown::show('NetworkPortFiberchannelType', ['name' => 'networkportfiberchanneltypes_id', 'value' => $this->fields['networkportfiberchanneltypes_id']]);
-        echo "</td></tr>\n";
+        $twig_params = [
+            'item' => $this,
+            'netport' => $netport,
+            'params' => $options,
+            'connection_label' => __('Connected to'),
+            'standard_speeds' => $standard_speeds,
+            'speed' => $speed,
+            'speed_label' => __('Fiber channel port speed'),
+        ];
+        // language=Twig
+        echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
+            {% import 'components/form/fields_macros.html.twig' as fields %}
+            {{ fields.textField('wwn', item.fields['wwn'], __('World Wide Name')) }}
+            {{ fields.dropdownArrayField('speed', item.fields['speed'], standard_speeds, speed_label, {
+                other: speed
+            }) }}
+            {% do call([item, 'showMacField'], [netport, params]) %}
+            {% set connection_field %}
+                {% do call([item, 'showConnection'], [netport, true]) %}
+            {% endset %}
+            {{ fields.htmlField('', connection_field, connection_label) }}
+            {{ fields.dropdownField(
+                'NetworkPortFiberchannelType',
+                'networkportfiberchanneltypes_id',
+                item.fields['networkportfiberchanneltypes_id'],
+                'NetworkPortFiberchannelType'|itemtype_name
+            ) }}
+TWIG, $twig_params);
     }
-
 
     public function getInstantiationHTMLTableHeaders(
         HTMLTableGroup $group,
@@ -140,9 +134,7 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation
         HTMLTableHeader $father = null,
         array $options = []
     ) {
-
-        $display_options = &$options['display_options'];
-        $header          = $group->addHeader('Connected', __('Connected to'), $super);
+        $header          = $group->addHeader('Connected', __s('Connected to'), $super);
 
         DeviceNetworkCard::getHTMLTableHeader(
             'NetworkPortFiberchannel',
@@ -152,14 +144,13 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation
             $options
         );
 
-        $group->addHeader('speed', __('Fiber channel port speed'), $super, $header);
-        $group->addHeader('wwn', __('World Wide Name'), $super, $header);
-        $group->addHeader('Socket', _n('Network socket', 'Network sockets', 1), $super, $header);
+        $group->addHeader('speed', __s('Fiber channel port speed'), $super, $header);
+        $group->addHeader('wwn', __s('World Wide Name'), $super, $header);
+        $group->addHeader('Socket', _sn('Network socket', 'Network sockets', 1), $super, $header);
 
         parent::getInstantiationHTMLTableHeaders($group, $super, $internet_super, $header, $options);
         return $header;
     }
-
 
     protected function getPeerInstantiationHTMLTable(
         NetworkPort $netport,
@@ -167,7 +158,6 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation
         HTMLTableCell $father = null,
         array $options = []
     ) {
-
         DeviceNetworkCard::getHTMLTableCellsForItem($row, $this, $father, $options);
 
         if (!empty($this->fields['speed'])) {
@@ -186,19 +176,15 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation
         Socket::getHTMLTableCellsForItem($row, $this, $father, $options);
     }
 
-
     public function getInstantiationHTMLTable(
         NetworkPort $netport,
         HTMLTableRow $row,
         HTMLTableCell $father = null,
         array $options = []
     ) {
-
         return $this->getInstantiationHTMLTableWithPeer($netport, $row, $father, $options);
     }
 
-
-   // TODO why this? you don't have search engine for this object
     public function rawSearchOptions()
     {
         $tab = [];
@@ -222,7 +208,7 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation
 
         $tab[] = [
             'id'                 => '11',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'wwn',
             'name'               => __('World Wide Name'),
             'massiveaction'      => false,
@@ -230,7 +216,7 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation
 
         $tab[] = [
             'id'                 => '12',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'speed',
             'name'               => __('Fiber channel port speed'),
             'massiveaction'      => false,
@@ -248,7 +234,6 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation
         return $tab;
     }
 
-
     /**
      * Transform a port speed from string to integerer and vice-versa
      *
@@ -259,41 +244,35 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation
      **/
     public static function transformPortSpeed($val, $to_string)
     {
-
         if ($to_string) {
-            if (($val % 1000) == 0) {
+            if (($val % 1000) === 0) {
                 //TRANS: %d is the speed
                 return sprintf(__('%d Gbit/s'), $val / 1000);
             }
 
-            if ((($val % 100) == 0) && ($val > 1000)) {
+            if ((($val % 100) === 0) && ($val > 1000)) {
                 $val /= 100;
-               //TRANS: %f is the speed
+                //TRANS: %f is the speed
                 return sprintf(__('%.1f Gbit/s'), $val / 10);
             }
 
-           //TRANS: %d is the speed
+            //TRANS: %d is the speed
             return sprintf(__('%d Mbit/s'), $val);
         }
 
         $val = preg_replace('/\s+/', '', strtolower($val));
 
         $number = sscanf($val, "%f%s", $speed, $unit);
-        if ($number != 2) {
+        if ($number !== 2) {
             return false;
         }
 
-        if (($unit == 'mbit/s') || ($unit == 'mb/s')) {
-            return (int)$speed;
-        }
-
-        if (($unit == 'gbit/s') || ($unit == 'gb/s')) {
-            return (int)($speed * 1000);
-        }
-
-        return false;
+        return match ($unit) {
+            'mbit/s', 'mb/s' => (int) $speed,
+            'gbit/s', 'gb/s' => ($speed * 1000),
+            default => false,
+        };
     }
-
 
     /**
      * Get the possible value for Ethernet port speed
@@ -304,8 +283,8 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation
      **/
     public static function getPortSpeed($val = null)
     {
-
-        $tmp = [0     => '',
+        $tmp = [
+            0     => '',
                    //TRANS: %d is the speed
             10    => sprintf(__('%d Mbit/s'), 10),
             100   => sprintf(__('%d Mbit/s'), 100),
@@ -317,21 +296,11 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation
         if (is_null($val)) {
             return $tmp;
         }
-        if (isset($tmp[$val])) {
-            return $tmp[$val];
-        }
-        return self::transformPortSpeed($val, true);
+        return $tmp[$val] ?? self::transformPortSpeed($val, true);
     }
 
-
-    /**
-     * @param $field
-     * @param $values
-     * @param $options   array
-     **/
     public static function getSpecificValueToDisplay($field, $values, array $options = [])
     {
-
         if (!is_array($values)) {
             $values = [$field => $values];
         }
@@ -342,16 +311,8 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation
         return parent::getSpecificValueToDisplay($field, $values, $options);
     }
 
-
-    /**
-     * @param $field
-     * @param $name            (default '')
-     * @param $values          (defaul '')
-     * @param $options   array
-     */
     public static function getSpecificValueToSelect($field, $name = '', $values = '', array $options = [])
     {
-
         if (!is_array($values)) {
             $values = [$field => $values];
         }
@@ -365,11 +326,6 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation
         return parent::getSpecificValueToSelect($field, $name, $values, $options);
     }
 
-
-    /**
-     * @param $tab         array
-     * @param $joinparams  array
-     **/
     public static function getSearchOptionsToAddForInstantiation(array &$tab, array $joinparams)
     {
         $tab[] = [

--- a/src/NetworkPortFiberchannel.php
+++ b/src/NetworkPortFiberchannel.php
@@ -105,11 +105,12 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation
             'standard_speeds' => $standard_speeds,
             'speed' => $speed,
             'speed_label' => __('Fiber channel port speed'),
+            'wwn_label' => __('World Wide Name'),
         ];
         // language=Twig
         echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
             {% import 'components/form/fields_macros.html.twig' as fields %}
-            {{ fields.textField('wwn', item.fields['wwn'], __('World Wide Name')) }}
+            {{ fields.textField('wwn', item.fields['wwn'], wwn_label) }}
             {{ fields.dropdownArrayField('speed', item.fields['speed'], standard_speeds, speed_label, {
                 other: speed
             }) }}

--- a/src/NetworkPortMetrics.php
+++ b/src/NetworkPortMetrics.php
@@ -44,49 +44,25 @@ class NetworkPortMetrics extends CommonDBChild
     public static $items_id        = 'networkports_id';
     public $dohistory              = false;
 
-    /**
-     * Get name of this type by language of the user connected
-     *
-     * @param integer $nb number of elements
-     *
-     * @return string name of this type
-     */
     public static function getTypeName($nb = 0)
     {
         return __('Network port metrics');
     }
 
-    /**
-     * Get the tab name used for item
-     *
-     * @param object $item the item object
-     * @param integer $withtemplate 1 if is a template form
-     * @return string|array name of the tab
-     */
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-
         $array_ret = [];
 
-        if ($item->getType() == 'NetworkPort') {
+        if ($item::class === NetworkPort::class) {
             $cnt = countElementsInTable([static::getTable()], [static::$items_id => $item->getField('id')]);
-            $array_ret[] = self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $cnt, $item::getType());
+            $array_ret[] = self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $cnt, $item::class);
         }
         return $array_ret;
     }
 
-
-    /**
-     * Display the content of the tab
-     *
-     * @param object $item
-     * @param integer $tabnum number of the tab to display
-     * @param integer $withtemplate 1 if is a template form
-     * @return boolean
-     */
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
     {
-        if ($item->getType() == NetworkPort::getType() && $item->getID() > 0) {
+        if ($item::class === NetworkPort::class && $item->getID() > 0) {
             $metrics = new self();
             $metrics->showMetrics($item);
             return true;
@@ -115,7 +91,7 @@ class NetworkPortMetrics extends CommonDBChild
         $filters = array_merge($filters, $user_filters);
 
         $iterator = $DB->request([
-            'FROM'   => $this->getTable(),
+            'FROM'   => static::getTable(),
             'WHERE'  => [
                 static::$items_id  => $netport->fields['id']
             ] + $filters
@@ -133,11 +109,9 @@ class NetworkPortMetrics extends CommonDBChild
     {
         $raw_metrics = $this->getMetrics($netport);
 
-       //build graph data
+        // build graph data
         $params = [
-            'label'         => $this->getTypeName(),
             'icon'          => NetworkPort::getIcon(),
-            'apply_filters' => [],
         ];
 
         $bytes_series = [];
@@ -202,18 +176,15 @@ class NetworkPortMetrics extends CommonDBChild
         echo "</div>";
     }
 
-    private function getLabelFor($key)
+    private function getLabelFor($key): string
     {
-        switch ($key) {
-            case 'ifinbytes':
-                return __('Input megabytes');
-            case 'ifoutbytes':
-                return __('Output megabytes');
-            case 'ifinerrors':
-                return __('Input errors');
-            case 'ifouterrors':
-                return __('Output errors');
-        }
+        return match ($key) {
+            'ifinbytes' => __('Input megabytes'),
+            'ifoutbytes' => __('Output megabytes'),
+            'ifinerrors' => __('Input errors'),
+            'ifouterrors' => __('Output errors'),
+            default => $key,
+        };
     }
 
     public static function getIcon()

--- a/src/NetworkPortMigration.php
+++ b/src/NetworkPortMigration.php
@@ -131,7 +131,7 @@ class NetworkPortMigration extends CommonDBChild
 
         $number_errors = 0;
         foreach (self::getMotives() as $key => $name) {
-            if ($this->fields[$key] == 1) {
+            if ($this->fields[$key] === 1) {
                 $number_errors++;
             }
         }
@@ -148,7 +148,6 @@ class NetworkPortMigration extends CommonDBChild
         $network = new IPNetwork();
 
         $number_real_errors = 0;
-
 
         if (
             (!$address->setAddressFromString($this->fields['ip']))
@@ -168,27 +167,23 @@ class NetworkPortMigration extends CommonDBChild
                 $params["exclude IDs"] = $this->fields["address"];
             }
 
-            if (isset($this->fields["entities_id"])) {
-                $entity = $this->fields["entities_id"];
-            } else {
-                $entity = -1;
-            }
+            $entity = $this->fields["entities_id"] ?? -1;
             $networkports_ids = IPNetwork::searchNetworks("equals", $params, $entity, false);
 
-            if (count($networkports_ids) == 0) {
+            if (count($networkports_ids) === 0) {
                 $network = null;
             } else {
                 $network->getFromDB($networkports_ids[0]);
             }
         }
 
-        if ($this->fields['unknown_interface_type'] == 1) {
+        if ($this->fields['unknown_interface_type'] === 1) {
             $options['canedit'] = true;
             $number_real_errors++;
             $interface_cell = "th";
 
-            echo "<tr class='tab_bg_1'><th>" . $motives['unknown_interface_type'] . "</th>\n" .
-              "<td>" . __('Transform this network port to');
+            echo "<tr class='tab_bg_1'><th>" . htmlspecialchars($motives['unknown_interface_type']) . "</th>\n" .
+              "<td>" . __s('Transform this network port to');
             echo "</td><td colspan=2>";
             Dropdown::showItemTypes(
                 'transform_to',
@@ -199,75 +194,75 @@ class NetworkPortMigration extends CommonDBChild
             echo "</td></tr>\n";
         }
 
-        if ($this->fields['invalid_network'] == 1) {
+        if ($this->fields['invalid_network'] === 1) {
             $number_real_errors++;
             $network_cell = "th";
             $address_cell = "th";
-            echo "<tr class='tab_bg_1'><th>" . $motives['invalid_network'] . "</th>\n<td colspan=3>";
+            echo "<tr class='tab_bg_1'><th>" . htmlspecialchars($motives['invalid_network']) . "</th>\n<td colspan=3>";
             if ($network !== null) {
-                printf(__('Network port information conflicting with %s'), $network->getLink());
+                printf(__s('Network port information conflicting with %s'), $network->getLink());
             } else {
                 if ($address === null || $netmask === null) {
-                    echo __('Invalid address or netmask');
+                    echo __s('Invalid address or netmask');
                 } else {
-                    echo __('No conflicting network');
+                    echo __s('No conflicting network');
                 }
                 echo "&nbsp;<a href='" . Toolbox::getItemTypeFormURL('IPNetwork') . "'>" .
-                  __('you may have to add a network') . "</a>";
+                  __s('you may have to add a network') . "</a>";
             }
             echo "</td></tr>\n";
         }
 
-        if ($this->fields['invalid_gateway'] == 1) {
+        if ($this->fields['invalid_gateway'] === 1) {
             $number_real_errors++;
             $gateway_cell = "th";
-            echo "<tr class='tab_bg_1'><th>" . $motives['invalid_gateway'] . "</th>\n<td colspan=3>";
+            echo "<tr class='tab_bg_1'><th>" . htmlspecialchars($motives['invalid_gateway']) . "</th>\n<td colspan=3>";
             if ($network !== null) {
-                printf(__('Append a correct gateway to the network %s'), $network->getLink());
+                printf(__s('Append a correct gateway to the network %s'), $network->getLink());
             } else {
                 printf(
-                    __('%1$s: %2$s'),
-                    __('Unknown network'),
-                    "<a href='" . Toolbox::getItemTypeFormURL('IPNetwork') . "'>" . __('Add a network') . "
+                    __s('%1$s: %2$s'),
+                    __s('Unknown network'),
+                    "<a href='" . Toolbox::getItemTypeFormURL('IPNetwork') . "'>" . __s('Add a network') . "
                     </a>"
                 );
             }
             echo "</td></tr>\n";
         }
 
-        if ($this->fields['invalid_address'] == 1) {
+        if ($this->fields['invalid_address'] === 1) {
             $number_real_errors++;
             $address_cell = "th";
-            echo "<tr class='tab_bg_1'><th>" . $motives['invalid_address'] . "</th>\n<td colspan=3>";
+            echo "<tr class='tab_bg_1'><th>" . htmlspecialchars($motives['invalid_address']) . "</th>\n<td colspan=3>";
             $networkPort = new NetworkPort();
             if ($networkPort->getFromDB($this->getID())) {
                 $number_real_errors++;
                 echo "<a href='" . $networkPort->getLinkURL() . "'>" .
-                   __('Add a correct IP to the network port') . "</a>";
+                   __s('Add a correct IP to the network port') . "</a>";
             } else {
-                echo __('Unknown network port');
+                echo __s('Unknown network port');
             }
             echo "</td></tr>\n";
         }
 
-        if ($number_real_errors == 0) {
+        if ($number_real_errors === 0) {
             echo "<tr class='tab_bg_1'><th colspan='3'>" .
-              __('I don\'t understand why this migration error is not deleted.');
+              __s('I don\'t understand why this migration error is not deleted.');
             echo "</th><th>";
             Html::showSimpleForm(
-                $this->getFormURL(),
+                static::getFormURL(),
                 'delete',
-                __('You can delete this migration error'),
+                __s('You can delete this migration error'),
                 ['id' => $this->getID()]
             );
             echo "</th></tr>\n";
         } else {
-            echo "<tr class='tab_bg_1'><th>" . __('At all events') . "</th>\n";
+            echo "<tr class='tab_bg_1'><th>" . __s('At all events') . "</th>\n";
             echo "<td colspan='3'>";
             Html::showSimpleForm(
-                $this->getFormURL(),
+                static::getFormURL(),
                 'delete',
-                __('You can delete this migration error'),
+                __s('You can delete this migration error'),
                 ['id' => $this->getID()]
             );
 
@@ -276,31 +271,31 @@ class NetworkPortMigration extends CommonDBChild
 
         echo "<tr class='tab_bg_1'><td colspan='4'>&nbsp;</td></tr>\n";
 
-        echo "<tr class='tab_bg_1'><th colspan='4'>" . __('Original network port information') . "</th>" .
+        echo "<tr class='tab_bg_1'><th colspan='4'>" . __s('Original network port information') . "</th>" .
            "</tr>\n";
 
         echo "<tr class='tab_bg_1'><td>";
-        $this->displayRecursiveItems($recursiveItems, 'Type');
+        static::displayRecursiveItems($recursiveItems, 'Type');
         echo "</td>\n<td>";
-        $this->displayRecursiveItems($recursiveItems, "Link");
+        static::displayRecursiveItems($recursiveItems, "Link");
         echo "</td>\n";
 
-        echo "<td>" . __('Comments') . "</td>";
-        echo "<td class='middle'>" . $this->fields["comment"] . "</td></tr>\n";
+        echo "<td>" . __s('Comments') . "</td>";
+        echo "<td class='middle'>" . htmlspecialchars($this->fields["comment"]) . "</td></tr>\n";
 
-        echo "<tr class='tab_bg_1'><td>" . __('Network address') . "</td>\n";
-        echo "<$network_cell>" . $this->fields['subnet'] . "</$network_cell>\n";
+        echo "<tr class='tab_bg_1'><td>" . __s('Network address') . "</td>\n";
+        echo "<$network_cell>" . htmlspecialchars($this->fields['subnet']) . "</$network_cell>\n";
 
-        echo "<td>" . IPNetmask::getTypeName(1) . "</td>\n";
-        echo "<$network_cell>" . $this->fields['netmask'] . "</$network_cell></tr>\n";
+        echo "<td>" . htmlspecialchars(IPNetmask::getTypeName(1)) . "</td>\n";
+        echo "<$network_cell>" . htmlspecialchars($this->fields['netmask']) . "</$network_cell></tr>\n";
 
-        echo "<tr class='tab_bg_1'><td>" . IPAddress::getTypeName(1) . "</td>\n";
-        echo "<$address_cell>" . $this->fields['ip'] . "</$address_cell>\n";
+        echo "<tr class='tab_bg_1'><td>" . htmlspecialchars(IPAddress::getTypeName(1)) . "</td>\n";
+        echo "<$address_cell>" . htmlspecialchars($this->fields['ip']) . "</$address_cell>\n";
 
-        echo "<td>" . __('Gateway') . "</td>\n";
-        echo "<$gateway_cell>" . $this->fields['gateway'] . "</$gateway_cell></tr>\n";
+        echo "<td>" . __s('Gateway') . "</td>\n";
+        echo "<$gateway_cell>" . htmlspecialchars($this->fields['gateway']) . "</$gateway_cell></tr>\n";
 
-        echo "<tr class='tab_bg_1'><td>" . NetworkInterface::getTypeName(1) . "</td><$interface_cell>\n";
+        echo "<tr class='tab_bg_1'><td>" . htmlspecialchars(NetworkInterface::getTypeName(1)) . "</td><$interface_cell>\n";
         $iterator = $DB->request([
             'SELECT' => 'name',
             'FROM'   => 'glpi_networkinterfaces',
@@ -308,9 +303,9 @@ class NetworkPortMigration extends CommonDBChild
         ]);
         if (count($iterator)) {
             $row = $iterator->current();
-            echo $row['name'];
+            echo htmlspecialchars($row['name']);
         } else {
-            echo __('Unknown interface');
+            echo __s('Unknown interface');
         }
         echo "</$interface_cell>";
         echo "<$interface_cell></$interface_cell>";
@@ -355,7 +350,7 @@ class NetworkPortMigration extends CommonDBChild
         switch ($ma->getAction()) {
             case 'transform_to':
                 $input = $ma->getInput();
-                if (isset($input["transform_to"]) && !empty($input["transform_to"])) {
+                if (!empty($input["transform_to"])) {
                     $networkport = new NetworkPort();
                     foreach ($ids as $id) {
                         if (

--- a/src/NetworkPortType.php
+++ b/src/NetworkPortType.php
@@ -47,7 +47,6 @@ class NetworkPortType extends CommonDropdown
 
     public function getAdditionalFields()
     {
-
         return [
             [
                 'name'   => 'value_decimal',
@@ -73,7 +72,7 @@ class NetworkPortType extends CommonDropdown
 
         $tab[] = [
             'id'                 => '10',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'value_decimal',
             'name'               => __('Decimal'),
             'datatype'           => 'integer'
@@ -81,7 +80,7 @@ class NetworkPortType extends CommonDropdown
 
         $tab[] = [
             'id'                 => '11',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'is_importable',
             'name'               => __('Import'),
             'datatype'           => 'bool'
@@ -89,7 +88,7 @@ class NetworkPortType extends CommonDropdown
 
         $tab[] = [
             'id'                 => '12',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'instantiation_type',
             'name'               => __('Instanciation type'),
             'datatype'           => 'itemtypename',
@@ -161,7 +160,7 @@ class NetworkPortType extends CommonDropdown
          */
         global $DB, $GLPI_CACHE;
 
-        if (null === $type || empty($type)) {
+        if (empty($type)) {
             return self::DEFAULT_TYPE;
         }
 
@@ -184,7 +183,7 @@ class NetworkPortType extends CommonDropdown
             $name = $entry['name'];
             $othername = "$name ($num)";
 
-            if ($type === $num || $type == $name || $type == $othername) {
+            if (in_array($type, [$num, $name, $othername], true)) {
                 return $entry['instantiation_type'] ?? self::DEFAULT_TYPE;
             }
         }

--- a/src/NetworkPortWifi.php
+++ b/src/NetworkPortWifi.php
@@ -55,13 +55,13 @@ class NetworkPortWifi extends NetworkPortInstantiation
         if (!$options['several']) {
             echo "<tr class='tab_bg_1'>\n";
             $this->showNetworkCardField($netport, $options, $recursiveItems);
-            echo "<td>" . WifiNetwork::getTypeName(1) . "</td><td>";
+            echo "<td>" . htmlspecialchars(WifiNetwork::getTypeName(1)) . "</td><td>";
             WifiNetwork::dropdown(['value'  => $this->fields["wifinetworks_id"]]);
             echo "</td>";
             echo "</tr>\n";
 
             echo "<tr class='tab_bg_1'>\n";
-            echo "<td>" . __('Wifi mode') . "</td>";
+            echo "<td>" . __s('Wifi mode') . "</td>";
             echo "<td>";
 
             Dropdown::showFromArray(
@@ -71,7 +71,7 @@ class NetworkPortWifi extends NetworkPortInstantiation
             );
 
             echo "</td>\n";
-            echo "<td>" . __('Wifi protocol version') . "</td><td>";
+            echo "<td>" . __s('Wifi protocol version') . "</td><td>";
 
             Dropdown::showFromArray(
                 'version',

--- a/src/NetworkPort_Vlan.php
+++ b/src/NetworkPort_Vlan.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\View\TemplateRenderer;
+
 class NetworkPort_Vlan extends CommonDBRelation
 {
    // From CommonDBRelation
@@ -117,7 +119,6 @@ class NetworkPort_Vlan extends CommonDBRelation
             ],
             'WHERE'     => ['networkports_id' => $ID]
         ]);
-        $number = count($iterator);
 
         $vlans  = [];
         $used   = [];
@@ -127,84 +128,76 @@ class NetworkPort_Vlan extends CommonDBRelation
         }
 
         if ($canedit) {
-            echo "<div class='firstbloc'>\n";
-            echo "<form method='post' action='" . static::getFormURL() . "'>\n";
-            echo "<table class='tab_cadre_fixe'>\n";
-            echo "<tr><th colspan='4'>" . __('Associate a VLAN') . "</th></tr>";
-
-            echo "<tr class='tab_bg_1'><td class='right'>";
-            echo "<input type='hidden' name='networkports_id' value='$ID'>";
-            Vlan::dropdown(['used' => $used]);
-            echo "</td>";
-            echo "<td class='right'>" . __('Tagged') . "</td>";
-            echo "<td class='left'><input type='checkbox' name='tagged' value='1'></td>";
-            echo "<td><input type='submit' name='add' value='" . _sx('button', 'Associate') .
-                    "' class='btn btn-primary'>";
-            echo "</td></tr>\n";
-
-            echo "</table>\n";
-            Html::closeForm();
-            echo "</div>\n";
-        }
-
-        echo "<div class='spaced'>";
-        if ($canedit && $number) {
-            Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
-            $massiveactionparams = ['num_displayed' => min($_SESSION['glpilist_limit'], $number),
-                'container'     => 'mass' . __CLASS__ . $rand
+            $twig_params = [
+                'id' => $ID,
+                'used' => $used,
+                'tagged_label' => __('Tagged'),
+                'btn_label' => _sx('button', 'Associate'),
             ];
-            Html::showMassiveActions($massiveactionparams);
+            // language=Twig
+            echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
+                {% import 'components/form/fields_macros.html.twig' as fields %}
+                <div class="mb-3">
+                    <form method="post" action="{{ 'NetworkPort_Vlan'|itemtype_form_path }}">
+                        <div class="d-flex">
+                            <input type="hidden" name="networkports_id" value="{{ id }}">
+                            <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}">
+                            {{ fields.dropdownField('Vlan', 'vlans_id', 0, null, {
+                                no_label: true,
+                                used: used
+                            }) }}
+                            {{ fields.checkboxField('tagged', 0, tagged_label) }}
+                        </div>
+                        <div class="d-flex flex-row-reverse">
+                            <button type="submit" name="add" class="btn btn-primary">{{ btn_label }}</button>
+                        </div>
+                    </form>
+                </div>
+TWIG, $twig_params);
         }
-        echo "<table class='tab_cadre_fixehov'>";
 
-        $header_begin  = "<tr>";
-        $header_top    = '';
-        $header_bottom = '';
-        $header_end    = '';
-        if ($canedit && $number) {
-            $header_top    .= "<th width='10'>";
-            $header_top    .= Html::getCheckAllAsCheckbox('mass' . __CLASS__ . $rand) . "</th>";
-            $header_bottom .= "<th width='10'>";
-            $header_bottom .= Html::getCheckAllAsCheckbox('mass' . __CLASS__ . $rand) . "</th>";
-        }
-        $header_end .= "<th>" . __('Name') . "</th>";
-        $header_end .= "<th>" . Entity::getTypeName(1) . "</th>";
-        $header_end .= "<th>" . __('Tagged') . "</th>";
-        $header_end .= "<th>" . __('ID TAG') . "</th>";
-        $header_end .= "</tr>";
-        echo $header_begin . $header_top . $header_end;
-
-        $used = [];
+        $entries = [];
+        $entity_cache = [];
+        $vlan = new Vlan();
         foreach ($vlans as $data) {
-            echo "<tr class='tab_bg_1'>";
-            if ($canedit) {
-                echo "<td>";
-                Html::showMassiveActionCheckBox(__CLASS__, $data["assocID"]);
-                echo "</td>";
+            $vlan->getFromResultSet($data);
+
+            if (!isset($entity_cache[$data['entities_id']])) {
+                $entity_cache[$data['entities_id']] = Dropdown::getDropdownName("glpi_entities", $data["entities_id"]);
             }
-            $name = $data["name"];
-            if ($_SESSION["glpiis_ids_visible"] || empty($data["name"])) {
-                $name = sprintf(__('%1$s (%2$s)'), $name, $data["id"]);
-            }
-            echo "<td class='b'>
-               <a href='" . Vlan::getFormURLWithID($data['id']) . "'>" . $name .
-              "</a>";
-            echo "</td>";
-            echo "<td>" . Dropdown::getDropdownName("glpi_entities", $data["entities_id"]);
-            echo "</td><td>" . Dropdown::getYesNo($data["tagged"]) . "</td>";
-            echo "<td>" . $data["tag"] . "</td>";
-            echo "</tr>";
+            $entries[] = [
+                'itemtype'      => self::class,
+                'id'            => $data['assocID'],
+                'name'          => $vlan->getLink(),
+                'entities_id'   => $entity_cache[$data['entities_id']],
+                'tagged'        => Dropdown::getYesNo($data["tagged"]),
+                'tag'           => $data['tag']
+            ];
         }
-        if ($number) {
-            echo $header_begin . $header_top . $header_end;
-        }
-        echo "</table>";
-        if ($canedit && $number) {
-            $massiveactionparams['ontop'] = false;
-            Html::showMassiveActions($massiveactionparams);
-            Html::closeForm();
-        }
-        echo "</div>";
+
+        TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
+            'is_tab' => true,
+            'nopager' => true,
+            'nofilter' => true,
+            'nosort' => true,
+            'columns' => [
+                'name' => __('Name'),
+                'entities_id' => Entity::getTypeName(1),
+                'tagged' => __('Tagged'),
+                'tag' => __('ID TAG')
+            ],
+            'formatters' => [
+                'name' => 'raw_html'
+            ],
+            'entries' => $entries,
+            'total_number' => count($entries),
+            'filtered_number' => count($entries),
+            'showmassiveactions' => $canedit,
+            'massiveactionparams' => [
+                'num_displayed' => count($entries),
+                'container'     => 'mass' . static::class . mt_rand(),
+            ]
+        ]);
     }
 
     public static function showForVlan(Vlan $vlan)
@@ -220,7 +213,6 @@ class NetworkPort_Vlan extends CommonDBRelation
         }
 
         $canedit = $vlan->canEdit($ID);
-        $rand    = mt_rand();
 
         $iterator = $DB->request([
             'SELECT'    => [
@@ -239,69 +231,44 @@ class NetworkPort_Vlan extends CommonDBRelation
             ],
             'WHERE'     => ['vlans_id' => $ID]
         ]);
-        $number = count($iterator);
 
-        $vlans  = [];
-        $used   = [];
-        foreach ($iterator as $line) {
-            $used[$line["id"]]       = $line["id"];
-            $vlans[$line["assocID"]] = $line;
-        }
-
-        echo "<div class='spaced'>";
-        if ($canedit && $number) {
-            Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
-            $massiveactionparams = ['num_displayed' => min($_SESSION['glpilist_limit'], $number),
-                'container'     => 'mass' . __CLASS__ . $rand
+        $entries = [];
+        $entity_cache = [];
+        $netport = new NetworkPort();
+        foreach ($iterator as $data) {
+            $netport->getFromResultSet($data);
+            if (!isset($entity_cache[$data['entities_id']])) {
+                $entity_cache[$data['entities_id']] = Dropdown::getDropdownName("glpi_entities", $data["entities_id"]);
+            }
+            $entries[] = [
+                'itemtype'      => self::class,
+                'id'            => $data['assocID'],
+                'name'          => $netport->getLink(),
+                'entities_id'   => $entity_cache[$data['entities_id']]
             ];
-            Html::showMassiveActions($massiveactionparams);
         }
-        echo "<table class='tab_cadre_fixehov'>";
 
-        $header_begin  = "<tr>";
-        $header_top    = '';
-        $header_bottom = '';
-        $header_end    = '';
-        if ($canedit && $number) {
-            $header_top    .= "<th width='10'>";
-            $header_top    .= Html::getCheckAllAsCheckbox('mass' . __CLASS__ . $rand) . "</th>";
-            $header_bottom .= "<th width='10'>";
-            $header_bottom .= Html::getCheckAllAsCheckbox('mass' . __CLASS__ . $rand) . "</th>";
-        }
-        $header_end .= "<th>" . __('Name') . "</th>";
-        $header_end .= "<th>" . Entity::getTypeName(1) . "</th>";
-        $header_end .= "</tr>";
-        echo $header_begin . $header_top . $header_end;
-
-        $used = [];
-        foreach ($vlans as $data) {
-            echo "<tr class='tab_bg_1'>";
-            if ($canedit) {
-                echo "<td>";
-                Html::showMassiveActionCheckBox(__CLASS__, $data["assocID"]);
-                echo "</td>";
-            }
-            $name = $data["name"];
-            if ($_SESSION["glpiis_ids_visible"] || empty($data["name"])) {
-                $name = sprintf(__('%1$s (%2$s)'), $name, $data["id"]);
-            }
-            echo "<td class='b'>
-               <a href='" . NetworkPort::getFormURLWithID($data['id']) . "'>" . $name .
-              "</a>";
-            echo "</td>";
-            echo "<td>" . Dropdown::getDropdownName("glpi_entities", $data["entities_id"]);
-            echo "</tr>";
-        }
-        if ($number) {
-            echo $header_begin . $header_top . $header_end;
-        }
-        echo "</table>";
-        if ($canedit && $number) {
-            $massiveactionparams['ontop'] = false;
-            Html::showMassiveActions($massiveactionparams);
-            Html::closeForm();
-        }
-        echo "</div>";
+        TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
+            'is_tab' => true,
+            'nopager' => true,
+            'nofilter' => true,
+            'nosort' => true,
+            'columns' => [
+                'name' => __('Name'),
+                'entities_id' => Entity::getTypeName(1),
+            ],
+            'formatters' => [
+                'name' => 'raw_html'
+            ],
+            'entries' => $entries,
+            'total_number' => count($entries),
+            'filtered_number' => count($entries),
+            'showmassiveactions' => $canedit,
+            'massiveactionparams' => [
+                'num_displayed' => count($entries),
+                'container'     => 'mass' . static::class . mt_rand(),
+            ]
+        ]);
     }
 
     /**

--- a/src/Vlan.php
+++ b/src/Vlan.php
@@ -48,32 +48,19 @@ class Vlan extends CommonDropdown
         return _n('VLAN', 'VLANs', $nb);
     }
 
-
     public function getAdditionalFields()
     {
-
-        return [['name'     => 'tag',
-            'label'    => __('ID TAG'),
-            'type'     => '',
-            'list'     => true
-        ]
+        return [
+            [
+                'name'     => 'tag',
+                'label'    => __('ID TAG'),
+                'type'     => 'integer',
+                'min'      => 1,
+                'max'      => 4094,
+                'list'     => true
+            ]
         ];
     }
-
-
-    public function displaySpecificTypeField($ID, $field = [], array $options = [])
-    {
-
-        if ($field['name'] == 'tag') {
-            Dropdown::showNumber('tag', [
-                'value' => $this->fields['tag'],
-                'min'   => 1,
-                'max'   => (pow(2, 12) - 2),
-                'width' => '100%',
-            ]);
-        }
-    }
-
 
     public function rawSearchOptions()
     {
@@ -81,7 +68,7 @@ class Vlan extends CommonDropdown
 
         $tab[] = [
             'id'                 => '11',
-            'table'              => $this->getTable(),
+            'table'              => static::getTable(),
             'field'              => 'tag',
             'name'               => __('ID TAG'),
             'datatype'           => 'number',
@@ -95,7 +82,6 @@ class Vlan extends CommonDropdown
 
     public function cleanDBonPurge()
     {
-
         $this->deleteChildrenAndRelationsFromDb(
             [
                 IPNetwork_Vlan::class,
@@ -104,16 +90,14 @@ class Vlan extends CommonDropdown
         );
     }
 
-
     /**
-     * @since 0.84
-     *
      * @param $itemtype
-     * @param $base            HTMLTableBase object
-     * @param $super           HTMLTableSuperHeader object (default NULL
-     * @param $father          HTMLTableHeader object (default NULL)
-     * @param $options   array
-     **/
+     * @param HTMLTableBase $base
+     * @param HTMLTableSuperHeader|null $super
+     * @param HTMLTableHeader|null $father
+     * @param array $options
+     * @since 0.84
+     */
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
@@ -121,8 +105,7 @@ class Vlan extends CommonDropdown
         HTMLTableHeader $father = null,
         array $options = []
     ) {
-
-        $column_name = __CLASS__;
+        $column_name = self::class;
 
         if (isset($options['dont_display'][$column_name])) {
             return;
@@ -133,38 +116,34 @@ class Vlan extends CommonDropdown
         }
     }
 
-
     /**
+     * @param HTMLTableRow|null $row object (default NULL)
+     * @param CommonDBTM|null $item object (default NULL)
+     * @param HTMLTableCell|null $father object (default NULL)
+     * @param array $options
      * @since 0.84
-     *
-     * @param $row             HTMLTableRow object (default NULL)
-     * @param $item            CommonDBTM object (default NULL)
-     * @param $father          HTMLTableCell object (default NULL)
-     * @param $options   array
-     **/
+     */
     public static function getHTMLTableCellsForItem(
         HTMLTableRow $row = null,
         CommonDBTM $item = null,
         HTMLTableCell $father = null,
         array $options = []
     ) {
-        $column_name = __CLASS__;
+        $column_name = self::class;
 
         if (isset($options['dont_display'][$column_name])) {
             return;
         }
 
-        if (empty($item)) {
-            if (empty($father)) {
+        if ($item === null) {
+            if ($father === null) {
                 return;
             }
             $item = $father->getItem();
         }
 
-        $canedit = (isset($options['canedit']) && $options['canedit']);
-
-        if ($item->getType() == 'NetworkPort_Vlan') {
-            if (isset($item->fields["tagged"]) && ($item->fields["tagged"] == 1)) {
+        if ($item::class === NetworkPort_Vlan::class) {
+            if (isset($item->fields["tagged"]) && ($item->fields["tagged"] === 1)) {
                 $tagged_msg = __('Tagged');
             } else {
                 $tagged_msg = __('Untagged');
@@ -172,18 +151,18 @@ class Vlan extends CommonDropdown
 
             $vlan = new self();
             if ($vlan->getFromDB($options['items_id'])) {
-                $content = sprintf(__('%1$s - %2$s'), $vlan->getName(), $tagged_msg);
+                $content = htmlspecialchars(sprintf(__('%1$s - %2$s'), $vlan->getName(), $tagged_msg));
                 $content .= Html::showToolTip(
-                    sprintf(
+                    htmlspecialchars(sprintf(
                         __('%1$s: %2$s'),
                         __('ID TAG'),
                         $vlan->fields['tag']
-                    ) . "<br>" .
-                                          sprintf(
-                                              __('%1$s: %2$s'),
-                                              __('Comments'),
-                                              $vlan->fields['comment']
-                                          ),
+                    )) . "<br>" .
+                    htmlspecialchars(sprintf(
+                        __('%1$s: %2$s'),
+                        __('Comments'),
+                        $vlan->fields['comment']
+                    )),
                     ['display' => false]
                 );
 
@@ -194,7 +173,6 @@ class Vlan extends CommonDropdown
 
     public function defineTabs($options = [])
     {
-
         $ong = [];
         $this->addDefaultFormTab($ong)
          ->addStandardTab('NetworkPort_Vlan', $ong, $options);

--- a/templates/components/form/networkname.html.twig
+++ b/templates/components/form/networkname.html.twig
@@ -152,8 +152,8 @@
 
                   {{ fields.htmlField(
                      '_vrtual',
-                     show_child|raw,
-                     ip_label ~ add_child,
+                      (add_child ~ show_child)|raw,
+                     ip_label,
                      field_options
                   ) }}
                </div> {# .row #}

--- a/templates/pages/assets/networkport/form.html.twig
+++ b/templates/pages/assets/networkport/form.html.twig
@@ -1,0 +1,77 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% extends 'generic_show_form.html.twig' %}
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
+{% block form_fields %}
+    <input type="hidden" name="items_id" value="{{ item.fields['items_id'] }}">
+    <input type="hidden" name="itemtype" value="{{ item.fields['itemtype'] }}">
+    <input type="hidden" name="_create_children" value="1">
+    <input type="hidden" name="instantiation_type" value="{{ item.fields['instantiation_type'] }}">
+
+    {% set type_label = call('NetworkPort::displayRecursiveItems', [recursive_items, 'Type', false]) %}
+    {% set type_value = call('NetworkPort::displayRecursiveItems', [recursive_items, 'Link', false]) %}
+    {{ fields.htmlField('', type_value, type_label) }}
+
+    {% if not params.several %}
+        {{ fields.numberField('logical_number', item.fields['logical_number'], _n('Port number', 'Port number', 1)) }}
+    {% else %}
+        {% set logical_num_field %}
+            <div class="d-flex">
+                {{ fields.numberField('from_logical_number', 0, null, {
+                    no_label: true,
+                    mb: ''
+                }) }}
+                <span class="mx-1 mt-2 text-nowrap">--></span>
+                {{ fields.numberField('to_logical_number', 0, null, {
+                    no_label: true,
+                    mb: ''
+                }) }}
+            </div>
+        {% endset %}
+        {{ fields.htmlField('', logical_num_field, _n('Port number', 'Port number', 1)) }}
+    {% endif %}
+    {{ fields.textField('name', item.fields['name'], __('Name')) }}
+    {{ fields.textField('ifalias', item.fields['ifalias'], __('Alias')) }}
+    {{ fields.textareaField('comment', item.fields['comment'], __('Comments')) }}
+
+    {% if instantiation != false %}
+        {{ fields.smallTitle(get_class(instantiation)|itemtype_name) }}
+        {{ call([instantiation, 'showInstantiationForm'], [item, params, recursive_items]) }}
+    {% endif %}
+
+    {% if not params.several %}
+        {{ call('NetworkName::showFormForNetworkPort', [item.getID()]) }}
+    {% endif %}
+{% endblock %}

--- a/templates/pages/assets/networkport/networkname_short.html.twig
+++ b/templates/pages/assets/networkport/networkname_short.html.twig
@@ -1,0 +1,79 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
+{{ fields.smallTitle('NetworkName'|itemtype_name) }}
+{% set networkname_field %}
+    <div class="btn-group btn-group-sm flex-grow-1" role="group">
+        <input class="form-control" name="NetworkName_name" value="{{ item.fields['name'] }}">
+        {% set info_url = item.isNewItem() ? 'NetworkName'|itemtype_search_path : item.getLinkURL() %}
+        {% set info_label = item.isNewItem() ? __('Show %s')|format('NetworkName'|itemtype_name(get_plural_number())) : item.getName() %}
+        <a role="button" class="btn btn-outline-secondary p-2" title="{{ info_label }}" href="{{ info_url }}">
+            <i class="fas fa-info"></i>
+        </a>
+        {% if not item.isNewItem() %}
+            <button type="button" name="unaffect_networkname" class="btn btn-outline-secondary p-2" title="{{ __('Dissociate') }}">
+                <i class="ti ti-circle-minus text-danger"></i>
+            </button>
+            <script>
+                $('button[name="unaffect_networkname"]').on('click', () => {
+                    $.post(
+                        '{{ path('ajax/networkname.php') }}',
+                        {
+                            id: {{ item.getID() }},
+                            unaffect: 1
+                        },
+                    ).then(() => {
+                        window.location.reload();
+                    });
+                });
+            </script>
+            <input type="hidden" name="NetworkName_id" value="{{ item.getID() }}">
+        {% endif %}
+    </div>
+{% endset %}
+{{ fields.htmlField('', networkname_field, 'NetworkName'|itemtype_name) }}
+
+{{ fields.dropdownField('FQDN', 'NetworkName_fqdns_id', item.fields['fqdns_id'], 'FQDN'|itemtype_name, {
+    entity: item.getEntityID(),
+    displaywith: ['view']
+}) }}
+
+{% if canedit %}
+    {% set ip_field %}
+        {% do call('IPAddress::showAddChildButtonForItemForm', [item, 'NetworkName__ipaddresses', canedit]) %}
+        {% do call('IPAddress::showChildsForItemForm', [item, 'NetworkName__ipaddresses', canedit]) %}
+    {% endset %}
+    {{ fields.htmlField('', ip_field, 'IPAddress'|itemtype_name(get_plural_number())) }}
+{% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Notable UX Changes:
- List of network ports in a VLAN form now shows the NetworkPort link in a breadcrumb manner (MyServer > eth0 where MyServer is a link to the computer and eth0 is a link to the port).
- The Network Name section of a port was reworked. The link labeled "Network name" which took you to the network name item is now removed. The network name itself now shows the text field which allows freeform entry along with 2 grouped buttons (same style as dropdowns). The first button either takes you to the network name if one is linked, or to the search page. The second button allows you to dissociate the network name.