### PR TITLE
Support namespace in low level API

### DIFF
--- a/src/Api/APIRest.php
+++ b/src/Api/APIRest.php
@@ -696,15 +696,18 @@ class APIRest extends API
         int $index
     ): ?string {
         $itemtype = $base_itemtype_part;
+        $has_reached_end_of_namespace_parts = false;
 
-        do {
+        while (!$has_reached_end_of_namespace_parts) {
             $itemtype_part = $this->url_elements[++$index] ?? null;
             $is_valid_part = $this->isValidItemtypePart($itemtype_part);
 
             if ($is_valid_part) {
                 $itemtype .= "\\$itemtype_part";
+            } else {
+                $has_reached_end_of_namespace_parts = true;
             }
-        } while ($is_valid_part);
+        }
 
         return $itemtype;
     }

--- a/tests/web/APIRest.php
+++ b/tests/web/APIRest.php
@@ -40,6 +40,7 @@ use Auth;
 use atoum\atoum;
 use Computer;
 use Config;
+use Glpi\Form\Form;
 use Glpi\Tests\Api\Deprecated\Computer_Item;
 use Glpi\Tests\Api\Deprecated\Computer_SoftwareLicense;
 use Glpi\Tests\Api\Deprecated\Computer_SoftwareVersion;
@@ -3248,5 +3249,38 @@ class APIRest extends atoum
         $computer = new \Computer();
         $this->boolean((bool)$computer->getFromDB($computers_id))->isTrue();
         $this->boolean((bool)$computer->getField('is_deleted'))->isTrue();
+    }
+
+    public function testRequestWithNamespacedItemtype(): void
+    {
+        $headers = ['Session-Token' => $this->session_token];
+
+        $this->query("Glpi/Form/Form", [
+            'headers' => $headers,
+            'verb'    => "GET",
+        ], 200);
+    }
+
+    public function testRequestWithNamespacedItemtypeAndId(): void
+    {
+        $form = $this->createForm();
+        $headers = ['Session-Token' => $this->session_token];
+
+        $this->query("Glpi/Form/Form/{$form->getId()}", [
+            'headers' => $headers,
+            'verb'    => "GET",
+        ], 200);
+    }
+
+    private function createForm(): Form
+    {
+        $form = new Form();
+        $form_id = $form->add([
+            'name' => 'test_form',
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+        ]);
+        $this->integer($form_id)->isGreaterThan(0);
+
+        return $form;
     }
 }


### PR DESCRIPTION
Our low level API didn't support requests on namespaced types like `Glpi\Form\Form::class`.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
