### PR TITLE
Fix forcetab parameter on namespaced items

### DIFF
--- a/inc/includes.php
+++ b/inc/includes.php
@@ -35,6 +35,7 @@
 
 use Glpi\Asset\AssetDefinitionManager;
 use Glpi\Http\Firewall;
+use Glpi\Toolbox\URL;
 
 /**
  * @var array $CFG_GLPI
@@ -105,24 +106,12 @@ if (!isset($_SESSION["MESSAGE_AFTER_REDIRECT"])) {
 
 // Manage force tab
 if (isset($_REQUEST['forcetab'])) {
-    if (preg_match('/\/plugins\/([a-zA-Z]+)\/front\/([a-zA-Z]+).form.php/', $_SERVER['PHP_SELF'], $matches)) {
-        $itemtype = 'plugin' . $matches[1] . $matches[2];
-        Session::setActiveTab($itemtype, $_REQUEST['forcetab']);
-    } else if (preg_match('/\/plugins\/([a-zA-Z]+)\/front\/([a-zA-Z]+).php/', $_SERVER['PHP_SELF'], $matches)) {
-        $itemtype = 'plugin' . $matches[1] . $matches[2];
-        Session::setActiveTab($itemtype, $_REQUEST['forcetab']);
-    } else if (preg_match('/\/front\/(.*)\.form.php/', $_SERVER['PHP_SELF'], $matches)) {
-        if (str_contains($matches[1], "/")) {
-            $itemtype = 'Glpi\\' . str_replace("/", "\\", $matches[1]);
-        } else {
-            $itemtype = $matches[1];
-        }
-        Session::setActiveTab($itemtype, $_REQUEST['forcetab']);
-    } else if (preg_match('/([a-zA-Z]+).php/', $_SERVER['PHP_SELF'], $matches)) {
-        $itemtype = $matches[1];
+    $itemtype = URL::extractItemtypeFromUrlPath($_SERVER['PHP_SELF']);
+    if ($itemtype !== null) {
         Session::setActiveTab($itemtype, $_REQUEST['forcetab']);
     }
 }
+
 // Manage tabs
 if (isset($_REQUEST['glpi_tab']) && isset($_REQUEST['itemtype'])) {
     Session::setActiveTab($_REQUEST['itemtype'], $_REQUEST['glpi_tab']);

--- a/inc/includes.php
+++ b/inc/includes.php
@@ -108,11 +108,15 @@ if (isset($_REQUEST['forcetab'])) {
     if (preg_match('/\/plugins\/([a-zA-Z]+)\/front\/([a-zA-Z]+).form.php/', $_SERVER['PHP_SELF'], $matches)) {
         $itemtype = 'plugin' . $matches[1] . $matches[2];
         Session::setActiveTab($itemtype, $_REQUEST['forcetab']);
-    } else if (preg_match('/([a-zA-Z]+).form.php/', $_SERVER['PHP_SELF'], $matches)) {
-        $itemtype = $matches[1];
-        Session::setActiveTab($itemtype, $_REQUEST['forcetab']);
     } else if (preg_match('/\/plugins\/([a-zA-Z]+)\/front\/([a-zA-Z]+).php/', $_SERVER['PHP_SELF'], $matches)) {
         $itemtype = 'plugin' . $matches[1] . $matches[2];
+        Session::setActiveTab($itemtype, $_REQUEST['forcetab']);
+    } else if (preg_match('/\/front\/(.*)\.form.php/', $_SERVER['PHP_SELF'], $matches)) {
+        if (str_contains($matches[1], "/")) {
+            $itemtype = 'Glpi\\' . str_replace("/", "\\", $matches[1]);
+        } else {
+            $itemtype = $matches[1];
+        }
         Session::setActiveTab($itemtype, $_REQUEST['forcetab']);
     } else if (preg_match('/([a-zA-Z]+).php/', $_SERVER['PHP_SELF'], $matches)) {
         $itemtype = $matches[1];

--- a/src/Toolbox/URL.php
+++ b/src/Toolbox/URL.php
@@ -90,6 +90,8 @@ final class URL
      *                     For the "http://example.com/foo/bar.php" page, that
      *                     would be "/foo/bar.php" (= $_SERVER['PHP_SELF']).
      * @return string|null Null if the itemtype could not be extracted.
+     *
+     * @todo Support custom marketplace and plugins URL.
      */
     public static function extractItemtypeFromUrlPath(string $path): ?string
     {

--- a/src/Toolbox/URL.php
+++ b/src/Toolbox/URL.php
@@ -104,10 +104,10 @@ final class URL
 
     private static function isPluginUrlPath(string $path): bool
     {
-        return
-            str_contains($path, '/front/plugins/')
-            || str_contains($path, '/front/marketplace/')
-        ;
+        return preg_match(
+            '/\/(plugins|marketplace)\/([a-zA-Z]+)\/front\//',
+            $path,
+        ) === 1;
     }
 
     private static function extractCoreItemtypeFromUrlPath(string $path): ?string
@@ -128,7 +128,7 @@ final class URL
 
     private static function extractPluginItemtypeFromUrlPath(string $path): ?string
     {
-        $regex = '/\/front\/(?:plugins|marketplace)\/([a-zA-Z]+)\/(.*?)(?:\.form\.php|\.php)/';
+        $regex = '/\/(?:plugins|marketplace)\/([a-zA-Z]+)\/front\/(.*?)(?:\.form\.php|\.php)/';
         if (!preg_match($regex, $path, $matches)) {
             return null;
         }

--- a/src/Toolbox/URL.php
+++ b/src/Toolbox/URL.php
@@ -110,7 +110,7 @@ final class URL
         ;
     }
 
-    private static function extractCoreItemtypeFromUrlPath(?string $path): string
+    private static function extractCoreItemtypeFromUrlPath(string $path): ?string
     {
         $regex = '/\/front\/(.*?)(?:\.form\.php|\.php)/';
         if (!preg_match($regex, $path, $matches)) {
@@ -126,7 +126,7 @@ final class URL
         }
     }
 
-    private static function extractPluginItemtypeFromUrlPath(?string $path): string
+    private static function extractPluginItemtypeFromUrlPath(string $path): ?string
     {
         $regex = '/\/front\/(?:plugins|marketplace)\/([a-zA-Z]+)\/(.*?)(?:\.form\.php|\.php)/';
         if (!preg_match($regex, $path, $matches)) {

--- a/src/Toolbox/URL.php
+++ b/src/Toolbox/URL.php
@@ -145,7 +145,8 @@ final class URL
         }
     }
 
-    private static function extractedPathContainsNamespace(string $path) {
+    private static function extractedPathContainsNamespace(string $path)
+    {
         return str_contains($path, "/");
     }
 }

--- a/src/Toolbox/URL.php
+++ b/src/Toolbox/URL.php
@@ -74,4 +74,78 @@ final class URL
 
         return $url;
     }
+
+    /**
+     * Extract (lowercase) itemtype from a given URL path.
+     *
+     * For example:
+     * - '/front/itemtype.php' will yield 'itemtype'
+     * - '/front/namespace/itemtype.form.php' will yield 'glpi\namespace\itemtype'
+     *
+     * Both .php and .form.php page are supported, and plugins from /plugins or
+     * /marketplace.
+     *
+     * @param string $path The filename of the currently executing script,
+     *                     relative to the document root.
+     *                     For the "http://example.com/foo/bar.php" page, that
+     *                     would be "/foo/bar.php" (= $_SERVER['PHP_SELF']).
+     * @return string|null Null if the itemtype could not be extracted.
+     */
+    public static function extractItemtypeFromUrlPath(string $path): ?string
+    {
+        if (self::isPluginUrlPath($path)) {
+            return self::extractPluginItemtypeFromUrlPath($path);
+        } else {
+            return self::extractCoreItemtypeFromUrlPath($path);
+        }
+    }
+
+    private static function isPluginUrlPath(string $path): bool
+    {
+        return
+            str_contains($path, '/front/plugins/')
+            || str_contains($path, '/front/marketplace/')
+        ;
+    }
+
+    private static function extractCoreItemtypeFromUrlPath(?string $path): string
+    {
+        $regex = '/\/front\/(.*?)(?:\.form\.php|\.php)/';
+        if (!preg_match($regex, $path, $matches)) {
+            return null;
+        }
+
+        $extracted_path = $matches[1];
+
+        if (self::extractedPathContainsNamespace($extracted_path)) {
+            return 'glpi\\' . str_replace("/", "\\", $extracted_path);
+        } else {
+            return $extracted_path;
+        }
+    }
+
+    private static function extractPluginItemtypeFromUrlPath(?string $path): string
+    {
+        $regex = '/\/front\/(?:plugins|marketplace)\/([a-zA-Z]+)\/(.*?)(?:\.form\.php|\.php)/';
+        if (!preg_match($regex, $path, $matches)) {
+            return null;
+        }
+
+        $plugin_name = $matches[1];
+        $extracted_path = $matches[2];
+
+        if (self::extractedPathContainsNamespace($extracted_path)) {
+            return 'glpiplugin\\' . $plugin_name . '\\' . str_replace(
+                "/",
+                "\\",
+                $extracted_path
+            );
+        } else {
+            return 'plugin' . $plugin_name . $extracted_path;
+        }
+    }
+
+    private static function extractedPathContainsNamespace(string $path) {
+        return str_contains($path, "/");
+    }
 }

--- a/src/Toolbox/URL.php
+++ b/src/Toolbox/URL.php
@@ -112,7 +112,7 @@ final class URL
 
     private static function extractCoreItemtypeFromUrlPath(string $path): ?string
     {
-        $regex = '/\/front\/(.*?)(?:\.form\.php|\.php)/';
+        $regex = '/\/front\/(.*?)(?:\.form)?.php/';
         if (!preg_match($regex, $path, $matches)) {
             return null;
         }
@@ -128,7 +128,7 @@ final class URL
 
     private static function extractPluginItemtypeFromUrlPath(string $path): ?string
     {
-        $regex = '/\/(?:plugins|marketplace)\/([a-zA-Z]+)\/front\/(.*?)(?:\.form\.php|\.php)/';
+        $regex = '/\/(?:plugins|marketplace)\/([a-zA-Z]+)\/front\/(.*?)(?:\.form)?\.php/';
         if (!preg_match($regex, $path, $matches)) {
             return null;
         }

--- a/tests/cypress/e2e/tabs.cy.js
+++ b/tests/cypress/e2e/tabs.cy.js
@@ -1,0 +1,51 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+describe('Tabs', () => {
+    beforeEach(() => {
+        cy.login();
+        cy.changeProfile('Super-Admin', true);
+    });
+    it('can use the "forcetab" URL parameter to land on a specific tab', () => {
+        cy.visit("/front/user.form.php?id=2&forcetab=Change_Item$1");
+        cy.findByRole('tab', { name: 'Changes' })
+            .should('have.attr', 'aria-selected', 'true');
+        cy.findByRole('tab', { name: 'Problems' })
+            .should('not.have.attr', 'aria-selected', 'true');
+
+        cy.visit("/front/user.form.php?id=2&forcetab=Item_Problem$1");
+        cy.findByRole('tab', { name: 'Problems' })
+            .should('have.attr', 'aria-selected', 'true');
+        cy.findByRole('tab', { name: 'Changes' })
+            .should('not.have.attr', 'aria-selected', 'true');
+    });
+});

--- a/tests/units/Glpi/Toolbox/URL.php
+++ b/tests/units/Glpi/Toolbox/URL.php
@@ -35,6 +35,9 @@
 
 namespace tests\units\Glpi\Toolbox;
 
+use Glpi\Form\Form;
+use Ticket;
+
 class URL extends \GLPITestCase
 {
     protected function urlProvider(): iterable
@@ -118,5 +121,78 @@ class URL extends \GLPITestCase
     {
         $this->newTestedInstance();
         $this->string($this->testedInstance->sanitizeURL($url))->isEqualTo($expected);
+    }
+
+    public function extractItemtypeFromUrlPathProvider(): iterable
+    {
+        // Core
+        yield 'Core class' => [
+            'path' => '/front/ticket.php',
+            'expected' => Ticket::class,
+        ];
+        yield 'Core class ".form" page' => [
+            'path' => '/front/ticket.form.php',
+            'expected' => Ticket::class,
+        ];
+        yield 'Namespaced core class' => [
+            'path' => '/front/form/form.php',
+            'expected' => Form::class,
+        ];
+        yield 'Namespaced core class ".form" page' => [
+            'path' => '/front/form/form.form.php',
+            'expected' => Form::class,
+        ];
+
+        // Plugins (/plugins)
+        yield 'Plugin class (/plugins)' => [
+            'path' => '/front/plugins/foo/bar.php',
+            'expected' => \PluginFooBar::class,
+        ];
+        yield 'Plugin class ".form" page (/plugins)' => [
+            'path' => '/front/plugins/foo/bar.form.php',
+            'expected' => \PluginFooBar::class,
+        ];
+        yield 'Namespaced plugin class (/plugins)' => [
+            'path' => '/front/plugins/foo/a/b/c/d/e/f/g/bar.php',
+            'expected' => \GlpiPlugin\Foo\A\B\C\D\E\F\G\Bar::class,
+        ];
+        yield 'Namespaced plugin class ".form" page (/plugins)' => [
+            'path' => '/front/plugins/foo/a/b/c/d/e/f/g/bar.form.php',
+            'expected' => \GlpiPlugin\Foo\A\B\C\D\E\F\G\Bar::class,
+        ];
+
+        // Plugins (/marketplace)
+        yield 'Plugin class (/marketplace)' => [
+            'path' => '/front/marketplace/foo/bar.php',
+            'expected' => \PluginFooBar::class,
+        ];
+        yield 'Plugin class ".form" page (/marketplace)' => [
+            'path' => '/front/marketplace/foo/bar.form.php',
+            'expected' => \PluginFooBar::class,
+        ];
+        yield 'Namespaced plugin class (/marketplace)' => [
+            'path' => '/front/marketplace/foo/a/b/c/d/e/f/g/bar.php',
+            'expected' => \GlpiPlugin\Foo\A\B\C\D\E\F\G\Bar::class,
+        ];
+        yield 'Namespaced plugin class ".form" page (/marketplace)' => [
+            'path' => '/front/marketplace/foo/a/b/c/d/e/f/g/bar.form.php',
+            'expected' => \GlpiPlugin\Foo\A\B\C\D\E\F\G\Bar::class,
+        ];
+    }
+
+    /**
+     * @dataProvider extractItemtypeFromUrlPathProvider
+     */
+    public function testExtractItemtypeFromUrlPath(
+        string $path,
+        string $expected
+    ): void {
+        // Functions like Session::setActiveTab() will use the lowercase version
+        // of the itemtype, thus we must expect the lowercase version here.
+        $expected = strtolower($expected);
+
+        $this->newTestedInstance();
+        $itemtype = $this->testedInstance->extractItemtypeFromUrlPath($path);
+        $this->string($itemtype)->isEqualTo($expected);
     }
 }

--- a/tests/units/Glpi/Toolbox/URL.php
+++ b/tests/units/Glpi/Toolbox/URL.php
@@ -145,37 +145,37 @@ class URL extends \GLPITestCase
 
         // Plugins (/plugins)
         yield 'Plugin class (/plugins)' => [
-            'path' => '/front/plugins/foo/bar.php',
+            'path' => '/plugins/foo/front/bar.php',
             'expected' => \PluginFooBar::class,
         ];
         yield 'Plugin class ".form" page (/plugins)' => [
-            'path' => '/front/plugins/foo/bar.form.php',
+            'path' => '/plugins/foo/front/bar.form.php',
             'expected' => \PluginFooBar::class,
         ];
         yield 'Namespaced plugin class (/plugins)' => [
-            'path' => '/front/plugins/foo/a/b/c/d/e/f/g/bar.php',
+            'path' => '/plugins/foo/front/a/b/c/d/e/f/g/bar.php',
             'expected' => \GlpiPlugin\Foo\A\B\C\D\E\F\G\Bar::class,
         ];
         yield 'Namespaced plugin class ".form" page (/plugins)' => [
-            'path' => '/front/plugins/foo/a/b/c/d/e/f/g/bar.form.php',
+            'path' => '/plugins/foo/front/a/b/c/d/e/f/g/bar.form.php',
             'expected' => \GlpiPlugin\Foo\A\B\C\D\E\F\G\Bar::class,
         ];
 
         // Plugins (/marketplace)
         yield 'Plugin class (/marketplace)' => [
-            'path' => '/front/marketplace/foo/bar.php',
+            'path' => '/marketplace/foo/front/bar.php',
             'expected' => \PluginFooBar::class,
         ];
         yield 'Plugin class ".form" page (/marketplace)' => [
-            'path' => '/front/marketplace/foo/bar.form.php',
+            'path' => '/marketplace/foo/front/bar.form.php',
             'expected' => \PluginFooBar::class,
         ];
         yield 'Namespaced plugin class (/marketplace)' => [
-            'path' => '/front/marketplace/foo/a/b/c/d/e/f/g/bar.php',
+            'path' => '/marketplace/foo/front/a/b/c/d/e/f/g/bar.php',
             'expected' => \GlpiPlugin\Foo\A\B\C\D\E\F\G\Bar::class,
         ];
         yield 'Namespaced plugin class ".form" page (/marketplace)' => [
-            'path' => '/front/marketplace/foo/a/b/c/d/e/f/g/bar.form.php',
+            'path' => '/marketplace/foo/front/a/b/c/d/e/f/g/bar.form.php',
             'expected' => \GlpiPlugin\Foo\A\B\C\D\E\F\G\Bar::class,
         ];
     }


### PR DESCRIPTION
Trying to access a specific tab using the `forcetab` parameters on namespaced items does not work.

For example, `/front/form/form.form.php?id=50&forcetab=Glpi\Form\Destination\FormDestination$1` won't work, while `/front/computer.form.php?id=1&forcetab=Item_Line$1` works perfectly.

The issue isn't the namespace in the forcetab parameter (`Glpi\Form\Destination\FormDestination`, which is handled correctly) but instead the file path `/front/form/form.form.php` which is not interpreted correctly by our regex.

See:
![image](https://github.com/glpi-project/glpi/assets/42734840/4e2b1966-eded-4b84-a63a-08511f5af33b)

The regex detect the correct `computer` itemtype when there are no namespace.
For the namespaced `form` itemtype, the regex return only `form` which is an incomplete type. 

To fix this, I've modified the regex this way:
![image](https://github.com/glpi-project/glpi/assets/42734840/32b988ad-cab7-41a5-995c-2db3f2aa9869)

Now we detect correctly `form/form`, which is easy to turn into the correct class name by adding `Glpi\` at the start and replacing slashes by backslashes.

The new regex is placed a bit lower in the code as it is more permissive and would risk being triggerred before the plugin related one.

While it would technically be a bugfix, it is probably safer to handle this in main as most users won't notice the issue.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
