### PR TITLE
Detect and block Cron and CLI running as Root user

### DIFF
--- a/.composer-require-checker.config.json
+++ b/.composer-require-checker.config.json
@@ -4,7 +4,7 @@
 
     "date", "pcre", "reflection", "spl",
 
-    "exif", "ldap", "pcntl"
+    "exif", "ldap", "pcntl", "posix"
   ],
   "symbol-whitelist": [
     "// Missing constant in Alpine Linux",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ The present file will list all changes made to the project; according to the
 - Itemtypes associated with External links are now in the main form rather than a separate tab.
 - The `Computer_Item` class has been replaced by the `\Glpi\Asset\Asset_PeripheralAsset` class.
 - List of network ports in a VLAN form now shows the NetworkPort link in a breadcrumb manner (MyServer > eth0 where MyServer is a link to the computer and eth0 is a link to the port).
+- Running `front/cron.php` or `bin/console` will attempt to check and block execution if running as root.
 
 ### Deprecated
 - Survey URL tags `TICKETCATEGORY_ID` and `TICKETCATEGORY_NAME` are deprecated and replaced by `ITILCATEGORY_ID` and `ITILCATEGORY_NAME` respectively.

--- a/bin/console
+++ b/bin/console
@@ -34,6 +34,24 @@
  * ---------------------------------------------------------------------
  */
 
+// Try detecting if we are running with the root user (Not available on Windows)
+if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+    // Translation functions not available here
+    echo "\t" . 'ERROR: running as root is not allowed' . "\n";
+    echo "\t" . 'You should run the script as the same user that your web server runs as to avoid file permissions being ruined' . "\n";
+    if (in_array('-n', $_SERVER['argv'], true) || in_array('--no-interaction', $_SERVER['argv'], true)) {
+        exit(1);
+    } else {
+        echo "\t" . 'Do you want to continue anyway? [yes/no]' . ' ';
+        $handle = fopen('php://stdin', 'rb');
+        $line = fgets($handle);
+        fclose($handle);
+        if (trim($line) !== 'yes') {
+            exit(1);
+        }
+    }
+}
+
 // Extract command line arguments
 $options = [];
 if (isset($_SERVER['argv'])) {

--- a/bin/console
+++ b/bin/console
@@ -37,17 +37,21 @@
 // Try detecting if we are running with the root user (Not available on Windows)
 if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
     // Translation functions not available here
-    echo "\t" . 'ERROR: running as root is not allowed' . "\n";
-    echo "\t" . 'You should run the script as the same user that your web server runs as to avoid file permissions being ruined' . "\n";
-    if (in_array('-n', $_SERVER['argv'], true) || in_array('--no-interaction', $_SERVER['argv'], true)) {
-        exit(1);
-    } else {
-        echo "\t" . 'Do you want to continue anyway? [yes/no]' . ' ';
-        $handle = fopen('php://stdin', 'rb');
-        $line = fgets($handle);
-        fclose($handle);
-        if (trim($line) !== 'yes') {
+    echo "\t" . 'WARNING: running as root is discouraged.' . "\n";
+    echo "\t" . 'You should run the script as the same user that your web server runs as to avoid file permissions being ruined.' . "\n";
+
+    if (!in_array('--allow-superuser', $_SERVER['argv'], true)) {
+        if (in_array('-n', $_SERVER['argv'], true) || in_array('--no-interaction', $_SERVER['argv'], true)) {
+            echo "\t" . 'Use --allow-superuser option to bypass this limitation.' . "\n";
             exit(1);
+        } else {
+            echo "\t" . 'Do you want to continue anyway? [yes/No]' . ' ';
+            $handle = fopen('php://stdin', 'rb');
+            $line = fgets($handle);
+            fclose($handle);
+            if (trim($line) !== 'yes' && trim($line) !== 'y') {
+                exit(1);
+            }
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -120,7 +120,8 @@
     },
     "suggest": {
         "ext-ldap": "Used to provide LDAP authentication and synchronization",
-        "ext-sodium": "Used to provide strong encryption for sensitive data in database"
+        "ext-sodium": "Used to provide strong encryption for sensitive data in database",
+        "ext-posix": "Used to detect scripts running as root"
     },
     "config": {
         "optimize-autoloader": true,

--- a/front/cron.php
+++ b/front/cron.php
@@ -43,17 +43,21 @@ $SECURITY_STRATEGY = 'no_check'; // in GLPI mode, cronjob can also be triggered 
 
 // Try detecting if we are running with the root user (Not available on Windows)
 if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
-    echo "\t" . __('ERROR: running as root is not allowed') . "\n";
-    echo "\t" . __('You should run the script as the same user that your web server runs as to avoid file permissions being ruined') . "\n";
-    exit(1);
+    // Translation functions not available here
+    echo "\t" . 'WARNING: running as root is discouraged.' . "\n";
+    echo "\t" . 'You should run the script as the same user that your web server runs as to avoid file permissions being ruined.' . "\n";
+    if (!in_array('--allow-superuser', $_SERVER['argv'], true)) {
+        echo "\t" . 'Use --allow-superuser option to bypass this limitation.' . "\n";
+        exit(1);
+    }
 }
 
 include('../inc/includes.php');
 
 if (!is_writable(GLPI_LOCK_DIR)) {
    //TRANS: %s is a directory
-    echo "\t" . sprintf(__('ERROR: %s is not writable') . "\n", GLPI_LOCK_DIR);
-    echo "\t" . __('Run the script as the same user that your web server runs as') . "\n";
+    echo "\t" . sprintf(__('ERROR: %s is not writable.') . "\n", GLPI_LOCK_DIR);
+    echo "\t" . __('Run the script as the same user that your web server runs as.') . "\n";
     exit(1);
 }
 

--- a/front/cron.php
+++ b/front/cron.php
@@ -41,12 +41,19 @@ chdir(__DIR__);
 
 $SECURITY_STRATEGY = 'no_check'; // in GLPI mode, cronjob can also be triggered from public pages
 
+// Try detecting if we are running with the root user (Not available on Windows)
+if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+    echo "\t" . __('ERROR: running as root is not allowed') . "\n";
+    echo "\t" . __('You should run the script as the same user that your web server runs as to avoid file permissions being ruined') . "\n";
+    exit(1);
+}
+
 include('../inc/includes.php');
 
 if (!is_writable(GLPI_LOCK_DIR)) {
    //TRANS: %s is a directory
     echo "\t" . sprintf(__('ERROR: %s is not writable') . "\n", GLPI_LOCK_DIR);
-    echo "\t" . __('run script as apache user') . "\n";
+    echo "\t" . __('Run the script as the same user that your web server runs as') . "\n";
     exit(1);
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

A source of far too many forum posts, issue reports, etc where people end up with broken GLPI file permissions.
The most common case is when an administrator sets up a cron job for the GLPI automatic actions and simply adds the entry to the system's crontab rather than the web server user's crontab (or specifying the web server user in the system crontab entry).

This PR attempts to detect when the cron script and the GLPI CLI are run as root. If the root user is detected, execution will stop before any file ownership can be ruined.

This uses the `posix` extension which is included with PHP and enabled by default (except on Windows where it doesn't apply at all).