### PR TITLE
Support Well-known change-password URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The present file will list all changes made to the project; according to the
 - With a clean install, dashboards now show fake/placeholder data by default with a message indicating you are viewing demonstration data and a button to disable it.
 - Assets that can be assigned to users/groups have new "View assigned" and "Update assigned" rights which give read/update access to users and groups assigned to the asset.
 - `ODS` and `XLS` export of search results.
+- Support for the well-known `change-password" URI which can be used by some password managers to automatically (or assist with) changing a user's password.
 
 ### Changed
 - ITIL Objects can now be linked to any other ITIL Objects similar to the previous Ticket/Ticket links.

--- a/public/index.php
+++ b/public/index.php
@@ -64,6 +64,7 @@ $path       = preg_replace(
 require $glpi_root . '/src/Http/ProxyRouter.php';
 
 $proxy = new \Glpi\Http\ProxyRouter($glpi_root, $path);
+$proxy->handleRedirects();
 
 if ($proxy->isTargetAPhpScript() && $proxy->isPathAllowed() && ($target_file = $proxy->getTargetFile()) !== null) {
     // Ensure `getcwd()` and inclusion path is based on requested file FS location.

--- a/public/index.php
+++ b/public/index.php
@@ -64,7 +64,7 @@ $path       = preg_replace(
 require $glpi_root . '/src/Http/ProxyRouter.php';
 
 $proxy = new \Glpi\Http\ProxyRouter($glpi_root, $path);
-$proxy->handleRedirects();
+$proxy->handleRedirects($uri_prefix);
 
 if ($proxy->isTargetAPhpScript() && $proxy->isPathAllowed() && ($target_file = $proxy->getTargetFile()) !== null) {
     // Ensure `getcwd()` and inclusion path is based on requested file FS location.

--- a/src/Http/ProxyRouter.php
+++ b/src/Http/ProxyRouter.php
@@ -329,7 +329,7 @@ final class ProxyRouter
         readfile($target_file);
     }
 
-    public function handleRedirects()
+    public function handleRedirects(): void
     {
         $this->handleWellKnownURIs();
     }

--- a/src/Http/ProxyRouter.php
+++ b/src/Http/ProxyRouter.php
@@ -259,9 +259,6 @@ final class ProxyRouter
      */
     public function proxify(): void
     {
-        if ($this->handleWellKnownURIs()) {
-            return;
-        }
         if ($this->isPathAllowed() === false) {
             http_response_code(403);
             return;
@@ -332,13 +329,18 @@ final class ProxyRouter
         readfile($target_file);
     }
 
+    public function handleRedirects()
+    {
+        $this->handleWellKnownURIs();
+    }
+
     /**
      * Handle well-known URIs as defined in RFC 5785.
      * https://www.iana.org/assignments/well-known-uris/well-known-uris.xhtml
      *
-     * @return bool
+     * @return bool True if the request was handled, false otherwise.
      */
-    private function handleWellKnownURIs()
+    private function handleWellKnownURIs(): bool
     {
         // Handle well-known URIs
         if (preg_match('/^\/\.well-known\//', $this->path) === 1) {

--- a/src/Http/ProxyRouter.php
+++ b/src/Http/ProxyRouter.php
@@ -329,9 +329,11 @@ final class ProxyRouter
         readfile($target_file);
     }
 
-    public function handleRedirects(): void
+    public function handleRedirects(string $uri_prefix): void
     {
-        $this->handleWellKnownURIs();
+        if ($this->handleWellKnownURIs($uri_prefix)) {
+            exit();
+        }
     }
 
     /**
@@ -340,7 +342,7 @@ final class ProxyRouter
      *
      * @return bool True if the request was handled, false otherwise.
      */
-    private function handleWellKnownURIs(): bool
+    private function handleWellKnownURIs(string $uri_prefix): bool
     {
         // Handle well-known URIs
         if (preg_match('/^\/\.well-known\//', $this->path) === 1) {
@@ -351,7 +353,7 @@ final class ProxyRouter
             // Some password managers can use this URI to help with changing passwords
             // Redirect to the change password page
             if ($requested_uri === 'change-password') {
-                header('Location: /front/updatepassword.php', true, 307);
+                header('Location: ' . $uri_prefix . '/front/updatepassword.php', true, 307);
                 return true;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Adds a redirect from the well-known ([RFC 5785](https://datatracker.ietf.org/doc/html/rfc5785)) change-password URI `.well-known/change-password` to `front/updatepassword.php`. This URI is often utilized by password managers. This is completely handled within the ProxyRouter.