### PR TITLE
Prevent `symfony` components to be updated to 7.x version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -97,3 +97,6 @@ updates:
       twig:
         patterns:
           - "twig/*"
+    ignore:
+      - dependency-name: "symfony/*"
+        versions: [">= 7"]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

It is preferable to use the same major version for all the `symfony` components we use. Since some of the libraries we use are not compatible with `symfony` 7.x, dependabot is proposing an update to 7.x only for some components, for instance:
![image](https://github.com/glpi-project/glpi/assets/33253653/48a9b0f3-bf45-4d0f-a182-bc21823037c6)

To prevent this, I propose to explicitely ignore versions >= 7.x for now.
