### PR TITLE
Add PHP 64 bits requirement in `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     },
     "require": {
         "php": ">=8.2",
+        "php-64bit": "*",
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-dom": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d8b409d9975334d3e6a5c68d645636f8",
+    "content-hash": "e1986dd16686fba822a29e80fab51b41",
     "packages": [
         {
             "name": "apereo/phpcas",
@@ -8642,6 +8642,7 @@
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.2",
+        "php-64bit": "*",
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-dom": "*",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Using a 64 bits version of PHP is now mandatory (see #14133).
Since composer 2.6, it is possible to add it as a requirement (see https://github.com/composer/composer/pull/11334).