### PR TITLE
Fix missing form data when multi-select empty

### DIFF
--- a/inc/db.function.php
+++ b/inc/db.function.php
@@ -522,7 +522,7 @@ function getDateCriteria($field, $begin, $end)
 /**
  * Export an array to be stored in a simple field in the database
  *
- * @param $TAB Array to export / encode (one level depth)
+ * @param array|'' $TAB Array to export / encode (one level depth)
  *
  * @return string containing encoded array
  **/

--- a/src/Config.php
+++ b/src/Config.php
@@ -248,10 +248,8 @@ class Config extends CommonDBTM
             }
         }
 
-        if (isset($input['_update_devices_in_menu'])) {
-            $input['devices_in_menu'] = exportArrayToDB(
-                (isset($input['devices_in_menu']) ? $input['devices_in_menu'] : [])
-            );
+        if (isset($input['devices_in_menu'])) {
+            $input['devices_in_menu'] = exportArrayToDB(empty($input['devices_in_menu']) ? [] : $input['devices_in_menu']);
         }
 
        // lock mechanism update

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -2075,7 +2075,7 @@ final class DbUtils
     /**
      * Export an array to be stored in a simple field in the database
      *
-     * @param array $array Array to export / encode (one level depth)
+     * @param array|'' $array Array to export / encode (one level depth)
      *
      * @return string containing encoded array
      */

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -2195,6 +2195,7 @@ JAVASCRIPT;
             $elements = [ 0 => $param['emptylabel'] ] + $elements;
         }
 
+        $original_field_name = $name;
         if ($param["multiple"]) {
             $field_name = $name . "[]";
         } else {
@@ -2214,6 +2215,10 @@ JAVASCRIPT;
             }
             $output .= '<span class="form-control" readonly style="width: ' . $param["width"] . '">' . implode(', ', $to_display) . '</span>';
         } else {
+            if ($param['multiple']) {
+                // Fix for multiple select not sending any form data when no option is selected
+                $output .= "<input type='hidden' name='$original_field_name' value=''>";
+            }
             $output  .= "<select name='$field_name' id='$field_id'";
 
             if ($param['width'] !== '') {

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -330,11 +330,7 @@ class Profile extends CommonDBTM
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        if (isset($input["_helpdesk_item_types"])) {
-            if ((!isset($input["helpdesk_item_type"])) || (!is_array($input["helpdesk_item_type"]))) {
-                $input["helpdesk_item_type"] = [];
-            }
-           // Linear_HIT: $input["helpdesk_item_type"] = array_keys($input["helpdesk_item_type"]
+        if (isset($input["helpdesk_item_type"])) {
             $input["helpdesk_item_type"] = exportArrayToDB($input["helpdesk_item_type"]);
         }
 
@@ -1248,7 +1244,7 @@ class Profile extends CommonDBTM
 
         echo "<tr>";
         echo "<td>" . __('Associable items to tickets, changes and problems') . "</td>";
-        echo "<td><input type='hidden' name='_helpdesk_item_types' value='1'>";
+        echo "<td>";
         self::dropdownHelpdeskItemtypes(['values' => $this->fields["helpdesk_item_type"]]);
 
         echo "</td>";
@@ -1629,7 +1625,7 @@ class Profile extends CommonDBTM
 
         echo "<tr>";
         echo "<td>" . __('Associable items to tickets, changes and problems') . "</td>";
-        echo "<td><input type='hidden' name='_helpdesk_item_types' value='1'>";
+        echo "<td>";
         self::dropdownHelpdeskItemtypes(['values' => $this->fields["helpdesk_item_type"]]);
         echo "</td>";
         echo "</tr>";

--- a/tests/cypress/e2e/general_config.cy.js
+++ b/tests/cypress/e2e/general_config.cy.js
@@ -1,0 +1,84 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+describe('Notifications', () => {
+    beforeEach(() => {
+        cy.login();
+        cy.changeProfile('Super-Admin', true);
+    });
+
+    it('Change devices in menu', () => {
+        cy.visit('/front/config.form.php');
+        cy.get('#tabspanel .nav-item').contains('Assets').within((nav_link) => {
+            cy.wrap(nav_link).click();
+        });
+
+        cy.get('.tab-content .tab-pane.active[id^="tab"]').within(() => {
+            cy.get('label').contains('Devices displayed in menu').next().within(() => {
+                cy.get('select').select(['Simcard items', 'Case items'], {force: true});
+            });
+            cy.get('button').contains('Save').click();
+        });
+
+        cy.get('#navbar-menu').within(() => {
+            cy.get('.nav-item.dropdown').contains('Assets').click();
+            cy.get('.dropdown-item').contains('Simcard items').should('exist');
+            cy.get('.dropdown-item').contains('Case items').should('exist');
+        });
+
+        cy.get('.tab-content .tab-pane.active[id^="tab"]').within(() => {
+            cy.get('label').contains('Devices displayed in menu').next().within(() => {
+                cy.get('select').select(['Case items'], {force: true});
+            });
+            cy.get('button').contains('Save').click();
+        });
+
+        cy.get('#navbar-menu').within(() => {
+            cy.get('.nav-item.dropdown').contains('Assets').click();
+            cy.get('.dropdown-item').contains('Simcard items').should('not.exist');
+            cy.get('.dropdown-item').contains('Case items').should('exist');
+        });
+
+        cy.get('.tab-content .tab-pane.active[id^="tab"]').within(() => {
+            cy.get('label').contains('Devices displayed in menu').next().within(() => {
+                cy.get('select').select([], {force: true});
+            });
+            cy.get('button').contains('Save').click();
+        });
+
+        cy.get('#navbar-menu').within(() => {
+            cy.get('.nav-item.dropdown').contains('Assets').click();
+            cy.get('.dropdown-item').contains('Simcard items').should('not.exist');
+            cy.get('.dropdown-item').contains('Case items').should('not.exist');
+        });
+    });
+});

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -51,7 +51,7 @@ Cypress.Commands.add('login', (username = 'e2e_tests', password = 'glpi') => {
             cy.visit('/');
             cy.title().should('eq', 'Authentication - GLPI');
             cy.findByRole('textbox', {'name': "Login"}).type(username);
-            cy.findByLabelText("Password").type(password);
+            cy.findByLabelText("Password", {exact: false}).type(password);
             cy.findByRole('checkbox', {name: "Remember me"}).check();
             // Select 'local' from the 'auth' dropdown
             cy.findByLabelText("Login source").select('local', { force: true });

--- a/tests/functional/Glpi/Asset/AssetDefinitionManager.php
+++ b/tests/functional/Glpi/Asset/AssetDefinitionManager.php
@@ -167,8 +167,8 @@ class AssetDefinitionManager extends DbTestCase
         $itemtypes = importArrayFromDB($profile->fields["helpdesk_item_type"]);
         $itemtypes[] = $class;
         $this->updateItem(Profile::class, $profile->getID(), [
-            'helpdesk_item_type' => exportArrayToDB($itemtypes),
-        ]);
+            'helpdesk_item_type' => $itemtypes,
+        ], ['helpdesk_item_type']);
 
         yield [
             $definition,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When a multiple-select dropdown has no options selected, no form data is sent to GLPI so that field is ignored. This made it impossible to handle removing all selections from a dropdown unless the missing field was treated specially as if it were an empty selection. That special handling is not correct though as partial updates via the API(s) are possible and failing to specify a multiselect field in an API update request should not delete the value.

The fix adds a hidden input with the same name just before the select element in the DOM. If the browser decides to send the data for the select, the hidden input is ignored.

This may cause some breaks besides the one I found immediately for the devices_in_menu config options. On some other dropdowns it seemed to work without issue. Other cases may be found as work on the UI continues, during beta testing, or through added E2E tests.