### PR TITLE
Drop support of old `Event` class name

### DIFF
--- a/install/migrations/update_10.0.x_to_11.0.0/event.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/event.php
@@ -33,7 +33,13 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Event;
+
 /**
  * @var array $ADDTODISPLAYPREF
+ * @var \Migration $migration
  */
+
 $ADDTODISPLAYPREF['Glpi\Event'] = [155, 156, 157, 158, 159, 160];
+
+$migration->renameItemtype('Event', Event::class);

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -474,11 +474,6 @@ final class DbUtils
             return null;
         }
 
-        if ($itemtype === 'Event') {
-           //to avoid issues when pecl-event is installed...
-            $itemtype = 'Glpi\\Event';
-        }
-
         $classname = $this->fixItemtypeCase($itemtype);
 
         if (!is_subclass_of($classname, CommonGLPI::class, true)) {

--- a/tests/functional/Transfer.php
+++ b/tests/functional/Transfer.php
@@ -66,7 +66,6 @@ class Transfer extends DbTestCase
                 '/^DB.*/',
                 '/^SlaLevel.*/',
                 '/^OlaLevel.*/',
-                'Event',
                 'Glpi\\Event',
                 'KnowbaseItem',
                 '/SavedSearch.*/',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

There are many pieces of GLPI code that are using something like `$itemtype::getTypeName()` or `new $itemtype()` without previously normalizing the `$itemtype` value using the `getItemForItemtype()` method. The remaining `Event` itemtypes values in the database, are probably unsupported since a long time ago.
Anyway, I think the best solution here is to fix values from DB in order to remove the runtime transformation from `Event` to `Glpi\Event`.