### PR TITLE
fix(richtext): text color pasting

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -3903,6 +3903,7 @@ JS;
                branding: false,
                selector: '#{$id}',
                text_patterns: false,
+               paste_webkit_styles: 'all',
 
                plugins: {$pluginsjs},
 


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !32846


When copying text with layout (colors, size, bold, etc.). Depending on the browser, not everything was included.

For example, when copying from MS Word to GLPI, the color was pasted in Firefox, but not in Chrome.
