### PR TITLE
Fix(AssetDefinition): prevent PHP warning about missing translation on create

### DIFF
--- a/src/Asset/AssetDefinition.php
+++ b/src/Asset/AssetDefinition.php
@@ -995,7 +995,6 @@ TWIG, ['name' => $name, 'value' => $value]);
      */
     private function getDecodedTranslationsField(): array
     {
-
         $translations = @json_decode($this->fields['translations'], associative: true);
         if (!$this->validateTranslationsArray($translations)) {
             trigger_error(

--- a/src/Asset/AssetDefinition.php
+++ b/src/Asset/AssetDefinition.php
@@ -650,6 +650,10 @@ final class AssetDefinition extends CommonDBTM
      */
     public function getTranslatedName(int $count = 1): string
     {
+        if ($this->isNewItem()) {
+            return '';
+        }
+
         $translations = $this->getDecodedTranslationsField();
         $language = Session::getLanguage();
         $current_translation = $translations[$language] ?? null;
@@ -991,11 +995,6 @@ TWIG, ['name' => $name, 'value' => $value]);
      */
     private function getDecodedTranslationsField(): array
     {
-        // prevent warning when no translation are available (create step)
-        if (empty($this->fields['translations'])) {
-            $this->fields['translations'] = '[]'; // prevent warning to be triggered on each method call
-            return [];
-        }
 
         $translations = @json_decode($this->fields['translations'], associative: true);
         if (!$this->validateTranslationsArray($translations)) {

--- a/src/Asset/AssetDefinition.php
+++ b/src/Asset/AssetDefinition.php
@@ -991,6 +991,12 @@ TWIG, ['name' => $name, 'value' => $value]);
      */
     private function getDecodedTranslationsField(): array
     {
+        // prevent warning when no translation are available (create step)
+        if (empty($this->fields['translations'])) {
+            $this->fields['translations'] = '[]'; // prevent warning to be triggered on each method call
+            return [];
+        }
+
         $translations = @json_decode($this->fields['translations'], associative: true);
         if (!$this->validateTranslationsArray($translations)) {
             trigger_error(


### PR DESCRIPTION
Fix this :
![image](https://github.com/glpi-project/glpi/assets/7335054/6b0b032c-65b2-4e82-b2c2-c4de5b538127)

```shell
[2024-05-06 14:10:20] glpiphplog.WARNING:   *** PHP User Warning (512): Invalid `translations` value (``). in /home/stanislas/TECLIB/DEV/GLPI/main/src/Asset/AssetDefinition.php at line 1002
  Backtrace :
  src/Asset/AssetDefinition.php:1002                 trigger_error()
  src/Asset/AssetDefinition.php:654                  Glpi\Asset\AssetDefinition->getDecodedTranslationsField()
  src/Asset/AssetDefinition.php:82                   Glpi\Asset\AssetDefinition->getTranslatedName()
  src/CommonDBTM.php:5948                            Glpi\Asset\AssetDefinition->computeFriendlyName()
  src/CommonDBTM.php:3690                            CommonDBTM->getFriendlyName()
  src/CommonGLPI.php:1225                            CommonDBTM->getName()
  .../twig/twig/src/Extension/CoreExtension.php:1635 CommonGLPI->getHeaderName()
  ...ates/83/83cb1d5dbb7dc4e31a22a897fd38ba3f.php:48 twig_get_attribute()
  vendor/twig/twig/src/Template.php:394              __TwigTemplate_a1d641ae134360cd1fb6af8c3d282bf8->doDisplay()
  vendor/twig/twig/src/Template.php:367              Twig\Template->displayWithErrorHandling()
  vendor/twig/twig/src/Template.php:379              Twig\Template->display()
  vendor/twig/twig/src/TemplateWrapper.php:38        Twig\Template->render()
  .../twig/twig/src/Extension/CoreExtension.php:1347 Twig\TemplateWrapper->render()
  ...tes/5b/5b0c5b08cf4633d57fd30cce258c96d9.php:119 twig_include()
  vendor/twig/twig/src/Template.php:394              __TwigTemplate_7a30caf14155d653e8b66e3023434fad->doDisplay()
  vendor/twig/twig/src/Template.php:367              Twig\Template->displayWithErrorHandling()
  vendor/twig/twig/src/Template.php:379              Twig\Template->display()
  vendor/twig/twig/src/TemplateWrapper.php:38        Twig\Template->render()
  .../twig/twig/src/Extension/CoreExtension.php:1347 Twig\TemplateWrapper->render()
  ...ates/bb/bb9a33248aefcf5fe6ab393447b28839.php:64 twig_include()
  vendor/twig/twig/src/Template.php:394              __TwigTemplate_02cbc319cab622925b02080ec3a01f21->doDisplay()
  vendor/twig/twig/src/Template.php:367              Twig\Template->displayWithErrorHandling()
  ...ates/8f/8ff920457e8b0138eae24562cf3d538e.php:48 Twig\Template->display()
  vendor/twig/twig/src/Template.php:394              __TwigTemplate_d7bc727e1d310d71ed83da0568816170->doDisplay()
  vendor/twig/twig/src/Template.php:367              Twig\Template->displayWithErrorHandling()
  vendor/twig/twig/src/TemplateWrapper.php:45        Twig\Template->display()
  src/Application/View/TemplateRenderer.php:185      Twig\TemplateWrapper->display()
  src/Asset/AssetDefinition.php:191                  Glpi\Application\View\TemplateRenderer->display()
  src/CommonGLPI.php:701                             Glpi\Asset\AssetDefinition->showForm()
  ajax/common.tabs.php:114                           CommonGLPI::displayStandardTab()
  public/index.php:83                                require()
```



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
