### PR TITLE
Fix(Core): Take care of item recursivity to load Dropdown values

### DIFF
--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -106,6 +106,7 @@
                            __('Status'),
                            field_options|merge({
                               'entity': item.fields['entities_id'],
+                              'entity_sons': item.fields['is_recursive'],
                               'condition': condition
                            })
                         ) }}
@@ -120,6 +121,7 @@
                            __('As child of'),
                            field_options|merge({
                               'entity': item.fields['entities_id'],
+                              'entity_sons': item.fields['is_recursive'],
                            })
                         ) }}
                      {% endif %}
@@ -161,6 +163,7 @@
                            'Location'|itemtype_name,
                            field_options|merge({
                               'entity': item.fields['entities_id'],
+                              'entity_sons': item.fields['is_recursive'],
                            })
                         ) }}
                      {% endif %}
@@ -201,6 +204,7 @@
                            'UserTitle'|itemtype_name,
                            field_options|merge({
                               'entity': item.fields['entities_id'],
+                              'entity_sons': item.fields['is_recursive'],
                            })
                         ) }}
                      {% endif %}
@@ -377,6 +381,7 @@
                            __('Technician in charge'),
                            field_options|merge({
                               'entity': item.fields['entities_id'],
+                              'entity_sons': item.fields['is_recursive'],
                               'right': 'own_ticket',
                            })
                         ) }}
@@ -400,6 +405,7 @@
                            __('Group in charge'),
                            field_options|merge({
                               'entity': item.fields['entities_id'],
+                              'entity_sons': item.fields['is_recursive'],
                               'condition': {'is_assign': 1},
                            })
                         ) }}
@@ -478,6 +484,7 @@
                            'User'|itemtype_name,
                            field_options|merge({
                               'entity': item.fields['entities_id'],
+                              'entity_sons': item.fields['is_recursive'],
                               'right': 'all',
                            })
                         ) }}
@@ -542,6 +549,7 @@
                            'Group'|itemtype_name,
                            field_options|merge({
                               'entity': item.fields['entities_id'],
+                              'entity_sons': item.fields['is_recursive'],
                               'condition': {'is_itemgroup': 1},
                            })
                         ) }}


### PR DESCRIPTION
Since the release of version 10.0.15 with the following security fix :

https://github.com/glpi-project/glpi/commit/d02c537d23cbb729fe18b87f71b3c6e84e9892da

A user in a ```sub-entity``` who views an ```asset``` in the ```root entity``` (```recurisf```) can no longer load dropdowns.

![image](https://github.com/glpi-project/glpi/assets/7335054/71b7b242-fbfd-443f-b693-389aa819332b)

When creating the dropdown, the entity_restrict option does not take into account the notion of recursiveness

an empty array is sent

![image](https://github.com/glpi-project/glpi/assets/7335054/0bb5ffdc-8d99-425c-8a22-0f2e9d17343d)

I should see the values visible in the asset entity AND in my current entity (sub-entity)

I think the problem comes from the ```Session::getMatchingActiveEntities``` function, which filters the```active entities``` (```$_SESSION```) with the desired entity (```1 in_array []  => false```) (without taking into account the recusivity of the asset).

By adding ```entity_sons``` option, GLPI also retrieves the asset's sub-entities, which are then filtered to match the current user's active entities  (```1 in_array [1]  => yes```)

![image](https://github.com/glpi-project/glpi/assets/7335054/13d9f7d4-dca4-45b1-bd9f-b03c0de25463)


This PR deserves special attention because of the complexity of the filtering by entity, because I am not aware of the scope of this change and the criticality involved.

in other words, I don't really know what I'm doing.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32875
