### PR TITLE
Fix user group dropdown condition

### DIFF
--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -205,7 +205,14 @@ class Group_User extends CommonDBRelation
                 'condition' => [
                     'is_usergroup' => 1,
                 ] + getEntitiesRestrictCriteria(Group::getTable(), '', '', true)
-            ] + ['NOT' => self::getListForItemParams($user)];
+            ];
+
+            if (count($used) > 0) {
+                $params['condition'][] = [
+                    'NOT' => [Group::getTable() . '.id' => $used]
+                ];
+            }
+
             Group::dropdown($params);
             echo "</td><td>" . _n('Manager', 'Managers', 1) . "</td><td>";
             Dropdown::showYesNo('is_manager');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Change made in #17034 was not correct. Indeed, the `NOT` clause was outside the condition entry. I tried to fix it, by moving it, with the following patch, but it resulted with a fatal error.
```diff
diff --git a/src/Group_User.php b/src/Group_User.php
index 385ad547c4..96a423d1da 100644
--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -205,7 +205,9 @@ class Group_User extends CommonDBRelation
                 'condition' => [
                     'is_usergroup' => 1,
                 ] + getEntitiesRestrictCriteria(Group::getTable(), '', '', true)
-            ] + ['NOT' => self::getListForItemParams($user)];
+                  + ['NOT' => self::getListForItemParams($user)]
+            ];
+
             Group::dropdown($params);
             echo "</td><td>" . _n('Manager', 'Managers', 1) . "</td><td>";
             Dropdown::showYesNo('is_manager');
```

The `getListForItemParams` result cannot be used verbatim in a subquery, so I propose an alternative fix. The `condition` will be stored in session and only its hash will be passed in the query, so it should also fix the initial issue.
