### PR TITLE
Force tab reload after an ajax update

### DIFF
--- a/js/common_ajax_controller.js
+++ b/js/common_ajax_controller.js
@@ -76,6 +76,7 @@ class GlpiCommonAjaxController
             this.#handleFriendlyNameUpdate(response);
             this.#handleTrashbinStatus(response, form);
             this.#handleRedirect(response);
+            this.#removeCachedTabsContent();
 
             // Trigger a custom event to allow the client to execute an handler
             // after the form has been successfully submitted
@@ -206,5 +207,17 @@ class GlpiCommonAjaxController
 
         // Redirect to specified page
         window.location = response.redirect;
+    }
+
+    #removeCachedTabsContent() {
+        $('[data-glpi-tab-content]').each((index, element) => {
+            const is_current_tab = $(element).hasClass('active');
+            if (is_current_tab) {
+                return;
+            }
+
+            $(element).html("");
+        });
+
     }
 }

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -375,7 +375,7 @@ HTML;
             echo "<div class='tab-content p-2 flex-grow-1 card $border' style='min-height: 150px'>";
             foreach ($tabs as $val) {
                 $id = str_replace('\\', '_', $val['id']);
-                echo "<div class='tab-pane fade' role='tabpanel' id='{$id}'></div>";
+                echo "<div data-glpi-tab-content class='tab-pane fade' role='tabpanel' id='{$id}'></div>";
             }
             echo  "</div>"; // .tab-content
             echo "</div>"; // .container-fluid
@@ -446,7 +446,7 @@ HTML;
             // Restore href
             active_link.attr('href', currenthref);
          };
-         
+
          var loadAllTabs = () => {
              const tabs = $('#$tabdiv_id a[data-bs-toggle=\"tab\"]');
              tabs.each((index, tab) => {

--- a/tests/cypress/e2e/ajax_controller.cy.js
+++ b/tests/cypress/e2e/ajax_controller.cy.js
@@ -1,0 +1,65 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+describe('Ajax Controller', () => {
+    beforeEach(() => {
+        cy.login();
+        cy.changeProfile('Super-Admin', true);
+    });
+    it('refresh tabs on update', () => {
+        cy.createWithAPI('Glpi\\Form\\Form', {
+            'name': '[Test] Ajax Controller: refresh tabs on update',
+        }).then((form_id) => {
+            // Go to form main tab
+            const tab = 'Glpi\\Form\\Form$main';
+            cy.visit(`/front/form/form.form.php?id=${form_id}&forcetab=${tab}`);
+
+            // Load the history tab
+            cy.findByRole('tab', {'name': "Historical 2"}).click();
+            cy.findAllByRole('row').should('have.length', 3); // 2 entries + header
+            cy.findByRole('tab', {'name': "Form"}).click();
+
+            // Modify and save form
+            cy.findByRole('checkbox', {'name': "Active"}).click();
+            cy.findByRole('button', {'name': "Save"}).click();
+            cy.findByRole('alert').should('exist').and(
+                'contains.text',
+                'Item successfully updated'
+            );
+
+            // Go to history tab, it must be updated with a new entry
+            cy.findByRole('tab', {'name': "Historical 2"}).click();
+            cy.findAllByRole('row').should('have.length', 4); // 3 entries + header
+        });
+    });
+});


### PR DESCRIPTION
Improve the AJAX controller by removing cached tabs when an object is updated.

GLPI tabs are loaded once when clicked and then are kept in cache.
This is good for "standard" forms, however it is not ideal for items updated by the AJAX controller.

Indeed, as the AJAX controller can update an item without forcing a page reload, this mean any cached tab data is kept and will thus no longer be accurate until the user manually refresh the page.

To counter this, we just need to clear the cached content after an AJAX update is done.

In the following demo, you can see the history being updated in "real time" thanks to these changes:

![ajax_tabs_update](https://github.com/glpi-project/glpi/assets/42734840/18c5d670-5238-4c40-859d-fbe68bfeea3a)

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
