### PR TITLE
Stricter method definitions for permission methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,7 +141,7 @@ The present file will list all changes made to the project; according to the
 - `showInstantiationForm()` method for Network Port classes are now expected to output HTML for a flex form instead of a table.
 - `NetworkName::showFormForNetworkPort()` now outputs HTML for a flex form instead of a table.
 - `NetworkPortInstantiation::showSocketField()`, `NetworkPortInstantiation::showMacField()`, `NetworkPortInstantiation::showNetworkCardField` now outputs HTML for a flex form instead of a table.
-- Many methods now have strict type hints for their parameters and return types.
+- `CommonGLPI::can*()` and `CommonDBTM::can*()` methods now have strict type hints for their parameters and return types.
 
 #### Deprecated
 - Usage of `MAIL_SMTPSSL` and `MAIL_SMTPTLS` constants.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,7 @@ The present file will list all changes made to the project; according to the
 - `showInstantiationForm()` method for Network Port classes are now expected to output HTML for a flex form instead of a table.
 - `NetworkName::showFormForNetworkPort()` now outputs HTML for a flex form instead of a table.
 - `NetworkPortInstantiation::showSocketField()`, `NetworkPortInstantiation::showMacField()`, `NetworkPortInstantiation::showNetworkCardField` now outputs HTML for a flex form instead of a table.
+- Many methods now have strict type hints for their parameters and return types.
 
 #### Deprecated
 - Usage of `MAIL_SMTPSSL` and `MAIL_SMTPTLS` constants.

--- a/src/APIClient.php
+++ b/src/APIClient.php
@@ -55,12 +55,12 @@ class APIClient extends CommonDBTM
         'app_token'
     ];
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return Session::haveRight(static::$rightname, UPDATE);
     }
 
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         return Session::haveRight(static::$rightname, UPDATE);
     }

--- a/src/AllAssets.php
+++ b/src/AllAssets.php
@@ -35,7 +35,7 @@
 
 class AllAssets extends CommonGLPI
 {
-    public static function canView()
+    public static function canView(): bool
     {
         return Session::getCurrentInterface() == "central";
     }

--- a/src/Appliance_Item_Relation.php
+++ b/src/Appliance_Item_Relation.php
@@ -76,13 +76,13 @@ class Appliance_Item_Relation extends CommonDBRelation
         return $types;
     }
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return Appliance_Item::canUpdate();
     }
 
 
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
         $app_item = new Appliance_Item();
         $app_item->getFromDB($this->fields[Appliance_Item::getForeignKeyField()]);

--- a/src/Asset/AssetDefinition.php
+++ b/src/Asset/AssetDefinition.php
@@ -64,13 +64,13 @@ final class AssetDefinition extends CommonDBTM
         return 'ti ti-database-cog';
     }
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         // required due to usage of `config` rightname
         return static::canUpdate();
     }
 
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         // required due to usage of `config` rightname
         return static::canUpdate();

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -183,12 +183,12 @@ class AuthLDAP extends CommonDBTM
         return _n('LDAP directory', 'LDAP directories', $nb);
     }
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return static::canUpdate();
     }
 
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         return static::canUpdate();
     }

--- a/src/AuthLdapReplicate.php
+++ b/src/AuthLdapReplicate.php
@@ -40,12 +40,12 @@ class AuthLdapReplicate extends CommonDBTM
 {
     public static $rightname = 'config';
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return static::canUpdate();
     }
 
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         return static::canUpdate();
     }

--- a/src/AuthMail.php
+++ b/src/AuthMail.php
@@ -56,12 +56,12 @@ class AuthMail extends CommonDBTM
         return $input;
     }
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return static::canUpdate();
     }
 
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         return static::canUpdate();
     }

--- a/src/Blacklist.php
+++ b/src/Blacklist.php
@@ -72,7 +72,7 @@ class Blacklist extends CommonDropdown
         return 0;
     }
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return static::canUpdate();
     }
@@ -81,7 +81,7 @@ class Blacklist extends CommonDropdown
     /**
      * @since 0.85
      */
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         return static::canUpdate();
     }

--- a/src/BlacklistedMailContent.php
+++ b/src/BlacklistedMailContent.php
@@ -58,13 +58,13 @@ class BlacklistedMailContent extends CommonDropdown
     }
 
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return static::canUpdate();
     }
 
 
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         return static::canUpdate();
     }

--- a/src/Change.php
+++ b/src/Change.php
@@ -90,7 +90,7 @@ class Change extends CommonITILObject
     }
 
 
-    public static function canView()
+    public static function canView(): bool
     {
         return Session::haveRightsOr(self::$rightname, [self::READALL, self::READMY]);
     }
@@ -101,7 +101,7 @@ class Change extends CommonITILObject
      *
      * @return boolean
      **/
-    public function canViewItem()
+    public function canViewItem(): bool
     {
 
         if (!$this->checkEntity(true)) {
@@ -130,7 +130,7 @@ class Change extends CommonITILObject
      *
      * @return boolean
      **/
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
 
         if (!Session::haveAccessToEntity($this->getEntityID())) {

--- a/src/ChangeCost.php
+++ b/src/ChangeCost.php
@@ -45,19 +45,19 @@ class ChangeCost extends CommonITILCost
     public static $items_id  = 'changes_id';
 
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return Session::haveRight('change', UPDATE);
     }
 
 
-    public static function canView()
+    public static function canView(): bool
     {
         return Session::haveRightsOr('change', [Change::READALL, Change::READMY]);
     }
 
 
-    public static function canUpdate()
+    public static function canUpdate(): bool
     {
         return Session::haveRight('change', UPDATE);
     }

--- a/src/ChangeTask.php
+++ b/src/ChangeTask.php
@@ -44,13 +44,13 @@ class ChangeTask extends CommonITILTask
     }
 
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return Session::haveRight('change', UPDATE)
           || Session::haveRight(self::$rightname, parent::ADDALLITEM);
     }
 
-    public static function canUpdate()
+    public static function canUpdate(): bool
     {
         return Session::haveRight('change', UPDATE)
           || Session::haveRight(self::$rightname, parent::UPDATEALL);
@@ -74,7 +74,7 @@ class ChangeTask extends CommonITILTask
      *
      * @return boolean
      **/
-    public function canViewItem()
+    public function canViewItem(): bool
     {
         return $this->canReadITILItem();
     }
@@ -85,7 +85,7 @@ class ChangeTask extends CommonITILTask
      *
      * @return boolean
      **/
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
 
         if (!$this->canReadITILItem()) {
@@ -113,7 +113,7 @@ class ChangeTask extends CommonITILTask
      *
      * @return boolean
      **/
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
 
         if (!$this->canReadITILItem()) {
@@ -137,7 +137,7 @@ class ChangeTask extends CommonITILTask
      *
      * @return boolean
      **/
-    public function canPurgeItem()
+    public function canPurgeItem(): bool
     {
         return $this->canUpdateItem();
     }

--- a/src/CommonDBChild.php
+++ b/src/CommonDBChild.php
@@ -105,7 +105,7 @@ abstract class CommonDBChild extends CommonDBConnexity
     /**
      * @since 0.84
      **/
-    public static function canCreate()
+    public static function canCreate(): bool
     {
 
         if ((static::$rightname) && (!Session::haveRight(static::$rightname, CREATE))) {
@@ -118,7 +118,7 @@ abstract class CommonDBChild extends CommonDBConnexity
     /**
      * @since 0.84
      **/
-    public static function canView()
+    public static function canView(): bool
     {
         if ((static::$rightname) && (!Session::haveRight(static::$rightname, READ))) {
             return false;
@@ -130,7 +130,7 @@ abstract class CommonDBChild extends CommonDBConnexity
     /**
      * @since 0.84
      **/
-    public static function canUpdate()
+    public static function canUpdate(): bool
     {
         if ((static::$rightname) && (!Session::haveRight(static::$rightname, UPDATE))) {
             return false;
@@ -142,7 +142,7 @@ abstract class CommonDBChild extends CommonDBConnexity
     /**
      * @since 0.84
      **/
-    public static function canDelete()
+    public static function canDelete(): bool
     {
         if ((static::$rightname) && (!Session::haveRight(static::$rightname, DELETE))) {
             return false;
@@ -154,7 +154,7 @@ abstract class CommonDBChild extends CommonDBConnexity
     /**
      * @since 0.85
      **/
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         if ((static::$rightname) && (!Session::haveRight(static::$rightname, PURGE))) {
             return false;
@@ -166,7 +166,7 @@ abstract class CommonDBChild extends CommonDBConnexity
     /**
      * @since 0.84
      **/
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
         return $this->canChildItem('canUpdateItem', 'canUpdate');
     }
@@ -175,7 +175,7 @@ abstract class CommonDBChild extends CommonDBConnexity
     /**
      * @since 0.84
      **/
-    public function canViewItem()
+    public function canViewItem(): bool
     {
         return $this->canChildItem('canViewItem', 'canView');
     }
@@ -184,7 +184,7 @@ abstract class CommonDBChild extends CommonDBConnexity
     /**
      * @since 0.84
      **/
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
         return $this->canChildItem('canUpdateItem', 'canUpdate');
     }
@@ -193,7 +193,7 @@ abstract class CommonDBChild extends CommonDBConnexity
     /**
      * @since 0.84
      **/
-    public function canDeleteItem()
+    public function canDeleteItem(): bool
     {
         return $this->canChildItem('canUpdateItem', 'canUpdate');
     }

--- a/src/CommonDBRelation.php
+++ b/src/CommonDBRelation.php
@@ -594,7 +594,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
     /**
      * @since 0.84
      **/
-    public static function canCreate()
+    public static function canCreate(): bool
     {
 
         if ((static::$rightname) && (!Session::haveRight(static::$rightname, CREATE))) {
@@ -607,7 +607,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
     /**
      * @since 0.84
      **/
-    public static function canView()
+    public static function canView(): bool
     {
         if ((static::$rightname) && (!Session::haveRight(static::$rightname, READ))) {
             return false;
@@ -620,7 +620,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
     /**
      * @since 0.84
      **/
-    public static function canUpdate()
+    public static function canUpdate(): bool
     {
         if ((static::$rightname) && (!Session::haveRight(static::$rightname, UPDATE))) {
             return false;
@@ -632,7 +632,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
     /**
      * @since 0.84
      **/
-    public static function canDelete()
+    public static function canDelete(): bool
     {
         if ((static::$rightname) && (!Session::haveRight(static::$rightname, DELETE))) {
             return false;
@@ -644,7 +644,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
     /**
      * @since 0.85
      **/
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         if ((static::$rightname) && (!Session::haveRight(static::$rightname, PURGE))) {
             return false;
@@ -656,7 +656,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
     /**
      * @since 0.84
      **/
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
         return $this->canRelationItem(
             'canUpdateItem',
@@ -670,7 +670,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
     /**
      * @since 0.84
      **/
-    public function canViewItem()
+    public function canViewItem(): bool
     {
         return $this->canRelationItem('canViewItem', 'canView', false, true);
     }
@@ -679,7 +679,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
     /**
      * @since 0.84
      **/
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
 
         return $this->canRelationItem(
@@ -694,7 +694,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
     /**
      * @since 0.84
      **/
-    public function canDeleteItem()
+    public function canDeleteItem(): bool
     {
 
         return $this->canRelationItem(
@@ -709,7 +709,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
     /**
      * @since 9.3.2
      */
-    public function canPurgeItem()
+    public function canPurgeItem(): bool
     {
 
         return $this->canRelationItem(

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -2344,13 +2344,13 @@ class CommonDBTM extends CommonGLPI
      * Have I the global right to add an item for the Object
      * May be overloaded if needed (ex Ticket)
      *
-     * @since 0.83
-     *
      * @param string $type itemtype of object to add
      *
      * @return boolean
-     **/
-    public function canAddItem($type)
+     **@since 0.83
+     *
+     */
+    public function canAddItem(string $type): bool
     {
         return $this->can($this->getID(), UPDATE);
     }
@@ -2365,7 +2365,7 @@ class CommonDBTM extends CommonGLPI
      *
      * @return boolean
      **/
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
 
         if (!$this->checkEntity()) {
@@ -2384,7 +2384,7 @@ class CommonDBTM extends CommonGLPI
      *
      * @return boolean
      **/
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
 
         if (!$this->checkEntity(true)) {
@@ -2403,7 +2403,7 @@ class CommonDBTM extends CommonGLPI
      *
      * @return boolean
      **/
-    public function canDeleteItem()
+    public function canDeleteItem(): bool
     {
 
         if (!$this->checkEntity(true)) {
@@ -2418,11 +2418,11 @@ class CommonDBTM extends CommonGLPI
      *
      * Default is true and check entity if the objet is entity assign
      *
-     * @since 0.85
-     *
      * @return boolean
-     **/
-    public function canPurgeItem()
+     **@since 0.85
+     *
+     */
+    public function canPurgeItem(): bool
     {
 
         if (!$this->checkEntity(true)) {
@@ -2447,7 +2447,7 @@ class CommonDBTM extends CommonGLPI
      *
      * @return boolean
      **/
-    public function canViewItem()
+    public function canViewItem(): bool
     {
 
         if (!$this->checkEntity(true)) {
@@ -2464,11 +2464,11 @@ class CommonDBTM extends CommonGLPI
      *
      * @param integer $ID ID to check
      *
-     * @since 0.85
-     *
      * @return boolean
-     **/
-    public function canEdit($ID)
+     **@since 0.85
+     *
+     */
+    public function canEdit($ID): bool
     {
 
         if ($this->maybeDeleted()) {
@@ -2858,12 +2858,12 @@ class CommonDBTM extends CommonGLPI
      * Check right on an item
      *
      * @param integer $ID    ID of the item (-1 if new item)
-     * @param mixed   $right Right to check : r / w / recursive / READ / UPDATE / DELETE
+     * @param int $right Right to check : r / w / recursive / READ / UPDATE / DELETE
      * @param array   $input array of input data (used for adding item) (default NULL)
      *
      * @return boolean
      **/
-    public function can($ID, $right, array &$input = null)
+    public function can($ID, int $right, array &$input = null): bool
     {
         if (Session::isInventory()) {
             return true;
@@ -3008,12 +3008,12 @@ class CommonDBTM extends CommonGLPI
      * Check right on an item with block
      *
      * @param integer $ID    ID of the item (-1 if new item)
-     * @param mixed   $right Right to check : r / w / recursive
-     * @param array   $input array of input data (used for adding item) (default NULL)
+     * @param int $right Right to check
+     * @param ?array $input array of input data (used for adding item) (default NULL)
      *
      * @return void
      **/
-    public function check($ID, $right, array &$input = null)
+    public function check($ID, int $right, ?array &$input = null): void
     {
         // Check item exists
         if (!$this->checkIfExistOrNew($ID)) {
@@ -3062,13 +3062,12 @@ class CommonDBTM extends CommonGLPI
     /**
      * Check global right on an object
      *
-     * @param mixed $right Right to check : c / r / w / d
+     * @param int $right Right to check
      *
-     * @return void
+     * @return bool
      **/
-    public function checkGlobal($right)
+    public function checkGlobal(int $right): bool
     {
-
         if (!$this->canGlobal($right)) {
            // Gestion timeout session
             Session::redirectIfNotLoggedIn();
@@ -3085,31 +3084,20 @@ class CommonDBTM extends CommonGLPI
     /**
      * Get global right on an object
      *
-     * @param mixed $right Right to check : c / r / w / d / READ / UPDATE / CREATE / DELETE
+     * @param int $right Right to check: READ / UPDATE / CREATE / DELETE
      *
      * @return bool
      **/
-    public function canGlobal($right)
+    public function canGlobal(int $right): bool
     {
-
-        switch ($right) {
-            case READ:
-                return static::canView();
-
-            case UPDATE:
-                return static::canUpdate();
-
-            case CREATE:
-                return static::canCreate();
-
-            case DELETE:
-                return static::canDelete();
-
-            case PURGE:
-                return static::canPurge();
-        }
-
-        return false;
+        return match ($right) {
+            READ => static::canView(),
+            UPDATE => static::canUpdate(),
+            CREATE => static::canCreate(),
+            DELETE => static::canDelete(),
+            PURGE => static::canPurge(),
+            default => false,
+        };
     }
 
 

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -3064,9 +3064,9 @@ class CommonDBTM extends CommonGLPI
      *
      * @param int $right Right to check
      *
-     * @return bool
+     * @return void
      **/
-    public function checkGlobal(int $right): bool
+    public function checkGlobal(int $right): void
     {
         if (!$this->canGlobal($right)) {
            // Gestion timeout session

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -103,7 +103,6 @@ class CommonGLPI implements CommonGLPIInterface
      */
     private static $othertabs = [];
 
-
     public function __construct()
     {
     }
@@ -121,7 +120,6 @@ class CommonGLPI implements CommonGLPIInterface
         return __('General');
     }
 
-
     /**
      * Return the simplified localized label of the current Type in the context of a form.
      * Avoid to recall the type in the label (Computer status -> Status)
@@ -134,7 +132,6 @@ class CommonGLPI implements CommonGLPIInterface
     {
         return static::getTypeName();
     }
-
 
     /**
      * Return the type of the object : class name
@@ -152,32 +149,22 @@ class CommonGLPI implements CommonGLPIInterface
      * so, id and input parameters are unused.
      *
      * @param integer $ID    ID of the item (-1 if new item)
-     * @param mixed   $right Right to check : r / w / recursive / READ / UPDATE / DELETE
-     * @param array   $input array of input data (used for adding item) (default NULL)
+     * @param int $right Right to check : r / w / recursive / READ / UPDATE / DELETE
+     * @param ?array   $input array of input data (used for adding item) (default NULL)
      *
      * @return boolean
      **/
-    public function can($ID, $right, array &$input = null)
+    public function can($ID, int $right, array &$input = null): bool
     {
-        switch ($right) {
-            case READ:
-                return static::canView();
-
-            case UPDATE:
-                return static::canUpdate();
-
-            case DELETE:
-                return static::canDelete();
-
-            case PURGE:
-                return static::canPurge();
-
-            case CREATE:
-                return static::canCreate();
-        }
-        return false;
+        return match ($right) {
+            READ => static::canView(),
+            UPDATE => static::canUpdate(),
+            DELETE => static::canDelete(),
+            PURGE => static::canPurge(),
+            CREATE => static::canCreate(),
+            default => false,
+        };
     }
-
 
     /**
      * Have I the global right to "create" the Object
@@ -185,14 +172,13 @@ class CommonGLPI implements CommonGLPIInterface
      *
      * @return boolean
      **/
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         if (static::$rightname) {
             return Session::haveRight(static::$rightname, CREATE);
         }
         return false;
     }
-
 
     /**
      * Have I the global right to "view" the Object
@@ -203,14 +189,13 @@ class CommonGLPI implements CommonGLPIInterface
      *
      * @return boolean
      **/
-    public static function canView()
+    public static function canView(): bool
     {
         if (static::$rightname) {
             return Session::haveRight(static::$rightname, READ);
         }
         return false;
     }
-
 
     /**
      * Have I the global right to "update" the Object
@@ -220,14 +205,13 @@ class CommonGLPI implements CommonGLPIInterface
      *
      * @return boolean
      **/
-    public static function canUpdate()
+    public static function canUpdate(): bool
     {
         if (static::$rightname) {
             return Session::haveRight(static::$rightname, UPDATE);
         }
         return false;
     }
-
 
     /**
      * Have I the global right to "delete" the Object
@@ -236,14 +220,13 @@ class CommonGLPI implements CommonGLPIInterface
      *
      * @return boolean
      **/
-    public static function canDelete()
+    public static function canDelete(): bool
     {
         if (static::$rightname) {
             return Session::haveRight(static::$rightname, DELETE);
         }
         return false;
     }
-
 
     /**
      * Have I the global right to "purge" the Object
@@ -252,14 +235,13 @@ class CommonGLPI implements CommonGLPIInterface
      *
      * @return boolean
      **/
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         if (static::$rightname) {
             return Session::haveRight(static::$rightname, PURGE);
         }
         return false;
     }
-
 
     /**
      * Register tab on an objet
@@ -282,7 +264,6 @@ class CommonGLPI implements CommonGLPIInterface
         }
     }
 
-
     /**
      * Get the array of Tab managed by other types
      * Getter for plugin (ex PDF) to access protected property
@@ -302,7 +283,6 @@ class CommonGLPI implements CommonGLPIInterface
         }
         return [];
     }
-
 
     /**
      * Define tabs to display
@@ -327,7 +307,6 @@ class CommonGLPI implements CommonGLPIInterface
 
         return $ong;
     }
-
 
     /**
      * return all the tabs for current object
@@ -373,7 +352,6 @@ class CommonGLPI implements CommonGLPIInterface
         return $onglets;
     }
 
-
     /**
      * Add standard define tab
      *
@@ -385,7 +363,6 @@ class CommonGLPI implements CommonGLPIInterface
      **/
     public function addStandardTab($itemtype, array &$ong, array $options)
     {
-
         $withtemplate = 0;
         if (isset($options['withtemplate'])) {
             $withtemplate = $options['withtemplate'];
@@ -453,7 +430,6 @@ class CommonGLPI implements CommonGLPIInterface
         $ong[static::getType() . '$main'] = '<span>' . $icon . static::getTypeName(1) . '</span>';
         return $this;
     }
-
 
     /**
      * get menu content
@@ -537,7 +513,6 @@ class CommonGLPI implements CommonGLPIInterface
         return false;
     }
 
-
     /**
      * get additional menu content
      *
@@ -549,7 +524,6 @@ class CommonGLPI implements CommonGLPIInterface
     {
         return false;
     }
-
 
     /**
      * Get forbidden actions for menu : may be add / template
@@ -563,7 +537,6 @@ class CommonGLPI implements CommonGLPIInterface
         return [];
     }
 
-
     /**
      * Get additional menu options
      *
@@ -575,7 +548,6 @@ class CommonGLPI implements CommonGLPIInterface
     {
         return false;
     }
-
 
     /**
      * Get additional menu links
@@ -589,7 +561,6 @@ class CommonGLPI implements CommonGLPIInterface
         return false;
     }
 
-
     /**
      * Get menu shortcut
      *
@@ -602,7 +573,6 @@ class CommonGLPI implements CommonGLPIInterface
         return '';
     }
 
-
     /**
      * Get menu name
      *
@@ -614,7 +584,6 @@ class CommonGLPI implements CommonGLPIInterface
     {
         return static::getTypeName(Session::getPluralNumber());
     }
-
 
     /**
      * Get Tab Name used for itemtype
@@ -634,7 +603,6 @@ class CommonGLPI implements CommonGLPIInterface
         return '';
     }
 
-
     /**
      * show Tab content
      *
@@ -650,7 +618,6 @@ class CommonGLPI implements CommonGLPIInterface
     {
         return false;
     }
-
 
     /**
      * display standard tab contents
@@ -782,7 +749,6 @@ class CommonGLPI implements CommonGLPIInterface
         return $text;
     }
 
-
     /**
      * Redirect to the list page from which the item was selected
      * Default to the search engine for the type
@@ -810,7 +776,6 @@ class CommonGLPI implements CommonGLPIInterface
         }
     }
 
-
     /**
      * is the current object a new  one - Always false here (virtual Objet)
      *
@@ -822,7 +787,6 @@ class CommonGLPI implements CommonGLPIInterface
     {
         return false;
     }
-
 
     /**
      * is the current object a new one - Always true here (virtual Objet)
@@ -838,7 +802,6 @@ class CommonGLPI implements CommonGLPIInterface
         return true;
     }
 
-
     /**
      * Get the search page URL for the current classe
      *
@@ -850,7 +813,6 @@ class CommonGLPI implements CommonGLPIInterface
     {
         return Toolbox::getItemTypeTabsURL(get_called_class(), $full);
     }
-
 
     /**
      * Get the search page URL for the current class
@@ -864,7 +826,6 @@ class CommonGLPI implements CommonGLPIInterface
         return Toolbox::getItemTypeSearchURL(get_called_class(), $full);
     }
 
-
     /**
      * Get the form page URL for the current class
      *
@@ -876,7 +837,6 @@ class CommonGLPI implements CommonGLPIInterface
     {
         return Toolbox::getItemTypeFormURL(get_called_class(), $full);
     }
-
 
     /**
      * Get the form page URL for the current class and point to a specific ID
@@ -896,7 +856,6 @@ class CommonGLPI implements CommonGLPIInterface
         $link    .= (strpos($link, '?') ? '&' : '?') . 'id=' . $id;
         return $link;
     }
-
 
     /**
      * Show tabs content
@@ -1010,7 +969,6 @@ class CommonGLPI implements CommonGLPIInterface
             );
         }
     }
-
 
     /**
      * Show tabs
@@ -1295,7 +1253,6 @@ class CommonGLPI implements CommonGLPIInterface
         echo "</div>";
     }
 
-
     /**
      * List infos in debug tab
      *
@@ -1330,7 +1287,6 @@ class CommonGLPI implements CommonGLPIInterface
             }
         }
     }
-
 
     /**
      * Update $_SESSION to set the display options.
@@ -1383,7 +1339,6 @@ class CommonGLPI implements CommonGLPIInterface
         }
     }
 
-
     /**
      * Load display options to $_SESSION
      *
@@ -1432,8 +1387,6 @@ class CommonGLPI implements CommonGLPIInterface
         }
         return $display_options;
     }
-
-
 
     /**
      * Show display options
@@ -1492,7 +1445,6 @@ class CommonGLPI implements CommonGLPIInterface
         }
     }
 
-
     /**
      * Get available display options array
      *
@@ -1504,7 +1456,6 @@ class CommonGLPI implements CommonGLPIInterface
     {
         return [];
     }
-
 
     /**
      * Get link for display options
@@ -1541,7 +1492,6 @@ class CommonGLPI implements CommonGLPIInterface
         return $link;
     }
 
-
     /**
      * Get error message for item
      *
@@ -1554,28 +1504,17 @@ class CommonGLPI implements CommonGLPIInterface
      **/
     public function getErrorMessage($error, $object = '')
     {
-
         if (empty($object) && $this instanceof CommonDBTM) {
             $object = $this->getLink();
         }
-        switch ($error) {
-            case ERROR_NOT_FOUND:
-                return sprintf(__('%1$s: %2$s'), $object, __('Unable to get item'));
-
-            case ERROR_RIGHT:
-                return sprintf(__('%1$s: %2$s'), $object, __('Authorization error'));
-
-            case ERROR_COMPAT:
-                return sprintf(__('%1$s: %2$s'), $object, __('Incompatible items'));
-
-            case ERROR_ON_ACTION:
-                return sprintf(__('%1$s: %2$s'), $object, __('Error on executing the action'));
-
-            case ERROR_ALREADY_DEFINED:
-                return sprintf(__('%1$s: %2$s'), $object, __('Item already defined'));
-        }
-
-        return '';
+        return match ($error) {
+            ERROR_NOT_FOUND => sprintf(__('%1$s: %2$s'), $object, __('Unable to get item')),
+            ERROR_RIGHT => sprintf(__('%1$s: %2$s'), $object, __('Authorization error')),
+            ERROR_COMPAT => sprintf(__('%1$s: %2$s'), $object, __('Incompatible items')),
+            ERROR_ON_ACTION => sprintf(__('%1$s: %2$s'), $object, __('Error on executing the action')),
+            ERROR_ALREADY_DEFINED => sprintf(__('%1$s: %2$s'), $object, __('Item already defined')),
+            default => '',
+        };
     }
 
     /**

--- a/src/CommonITILActor.php
+++ b/src/CommonITILActor.php
@@ -122,14 +122,14 @@ abstract class CommonITILActor extends CommonDBRelation
         return count($iterator) > 0;
     }
 
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
         return (parent::canUpdateItem()
               || (isset($this->fields['users_id'])
                   && ((int) $this->fields['users_id'] === Session::getLoginUserID())));
     }
 
-    public function canDeleteItem()
+    public function canDeleteItem(): bool
     {
         return (parent::canDeleteItem()
               || (isset($this->fields['users_id'])

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -11228,7 +11228,7 @@ abstract class CommonITILObject extends CommonDBTM
      *
      * @return boolean
      **/
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
         if (!$this->checkEntity()) {
             return false;
@@ -11237,7 +11237,7 @@ abstract class CommonITILObject extends CommonDBTM
         return self::canUpdate();
     }
 
-    public function canDeleteItem()
+    public function canDeleteItem(): bool
     {
 
         if (!$this->checkEntity()) {

--- a/src/CommonITILSatisfaction.php
+++ b/src/CommonITILSatisfaction.php
@@ -88,7 +88,7 @@ abstract class CommonITILSatisfaction extends CommonDBTM
         return [$itemtype, $this->fields[$itemtype::getForeignKeyField()]];
     }
 
-    public static function canUpdate()
+    public static function canUpdate(): bool
     {
         /** @var CommonITILObject $itemtype */
         $itemtype = static::getItemtype();
@@ -100,7 +100,7 @@ abstract class CommonITILSatisfaction extends CommonDBTM
      *
      * @return boolean
      **/
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
         /** @var CommonITILObject $itemtype */
         $itemtype = static::getItemtype();

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -134,7 +134,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         return true;
     }
 
-    public static function canView()
+    public static function canView(): bool
     {
         if (!Session::haveRightsOr(static::$rightname, [self::SEEPUBLIC, self::SEEPRIVATE])) {
             return false;

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -105,7 +105,7 @@ abstract class CommonITILValidation extends CommonDBChild
     }
 
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return Session::haveRightsOr(static::$rightname, static::getCreateRights());
     }
@@ -116,7 +116,7 @@ abstract class CommonITILValidation extends CommonDBChild
      *
      * @return boolean
      **/
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
 
         if (
@@ -129,7 +129,7 @@ abstract class CommonITILValidation extends CommonDBChild
     }
 
 
-    public static function canView()
+    public static function canView(): bool
     {
 
         return Session::haveRightsOr(
@@ -143,7 +143,7 @@ abstract class CommonITILValidation extends CommonDBChild
     }
 
 
-    public static function canUpdate()
+    public static function canUpdate(): bool
     {
 
         return Session::haveRightsOr(
@@ -161,7 +161,7 @@ abstract class CommonITILValidation extends CommonDBChild
      *
      * @return boolean
      **/
-    public function canDeleteItem()
+    public function canDeleteItem(): bool
     {
 
         if (
@@ -179,7 +179,7 @@ abstract class CommonITILValidation extends CommonDBChild
      *
      * @return boolean
      */
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
         $is_target = static::canValidate($this->fields[static::$items_id]);
         if (

--- a/src/CommonItilObject_Item.php
+++ b/src/CommonItilObject_Item.php
@@ -58,7 +58,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
         return $forbidden;
     }
 
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
         $obj = new static::$itemtype_1();
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -109,13 +109,13 @@ class Config extends CommonDBTM
     }
 
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return false;
     }
 
 
-    public function canViewItem()
+    public function canViewItem(): bool
     {
         if (
             isset($this->fields['context'])

--- a/src/Contract_Item.php
+++ b/src/Contract_Item.php
@@ -57,7 +57,7 @@ class Contract_Item extends CommonDBRelation
     }
 
 
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
 
        // Try to load the contract

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -98,7 +98,7 @@ class CronTask extends CommonDBTM
         return $ong;
     }
 
-    public static function canDelete()
+    public static function canDelete(): bool
     {
         return false;
     }

--- a/src/DefaultFilter.php
+++ b/src/DefaultFilter.php
@@ -71,7 +71,7 @@ class DefaultFilter extends CommonDBTM implements FilterableInterface
     {
         return "ti ti-filter";
     }
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return static::canUpdate();
     }

--- a/src/Document.php
+++ b/src/Document.php
@@ -99,14 +99,14 @@ class Document extends CommonDBTM
         return 'd';
     }
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         // Have right to add document OR ticket followup
         return (Session::haveRight('document', CREATE)
               || Session::haveRight('followup', ITILFollowup::ADDMYTICKET));
     }
 
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
         if (isset($this->input['itemtype'], $this->input['items_id'])) {
             if ($item = getItemForItemtype($this->input['itemtype'])) {

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -64,7 +64,7 @@ class Document_Item extends CommonDBRelation
         return $forbidden;
     }
 
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
         if ($this->fields['itemtype'] === 'Ticket') {
             $ticket = new Ticket();

--- a/src/DomainRecord.php
+++ b/src/DomainRecord.php
@@ -169,7 +169,7 @@ class DomainRecord extends CommonDBChild
         return $tab;
     }
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         if (count($_SESSION['glpiactiveprofile']['managed_domainrecordtypes'])) {
             return true;
@@ -177,7 +177,7 @@ class DomainRecord extends CommonDBChild
         return parent::canCreate();
     }
 
-    public static function canUpdate()
+    public static function canUpdate(): bool
     {
         if (count($_SESSION['glpiactiveprofile']['managed_domainrecordtypes'])) {
             return true;
@@ -185,7 +185,7 @@ class DomainRecord extends CommonDBChild
         return parent::canUpdate();
     }
 
-    public static function canDelete()
+    public static function canDelete(): bool
     {
         if (count($_SESSION['glpiactiveprofile']['managed_domainrecordtypes'])) {
             return true;
@@ -193,7 +193,7 @@ class DomainRecord extends CommonDBChild
         return parent::canDelete();
     }
 
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         if (count($_SESSION['glpiactiveprofile']['managed_domainrecordtypes'])) {
             return true;
@@ -201,12 +201,12 @@ class DomainRecord extends CommonDBChild
         return parent::canPurge();
     }
 
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
         return count($_SESSION['glpiactiveprofile']['managed_domainrecordtypes']);
     }
 
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
         return parent::canUpdateItem()
          && ($_SESSION['glpiactiveprofile']['managed_domainrecordtypes'] === [-1]
@@ -214,7 +214,7 @@ class DomainRecord extends CommonDBChild
          );
     }
 
-    public function canDeleteItem()
+    public function canDeleteItem(): bool
     {
         return parent::canDeleteItem()
          && ($_SESSION['glpiactiveprofile']['managed_domainrecordtypes'] === [-1]
@@ -222,7 +222,7 @@ class DomainRecord extends CommonDBChild
          );
     }
 
-    public function canPurgeItem()
+    public function canPurgeItem(): bool
     {
         return parent::canPurgeItem()
          && ($_SESSION['glpiactiveprofile']['managed_domainrecordtypes'] === [-1]

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -234,31 +234,31 @@ class Entity extends CommonTreeDropdown
         return _n('Entity', 'Entities', $nb);
     }
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         // Do not show the create button if no recusive access on current entity
         return parent::canCreate() && Session::haveRecursiveAccessToEntity(Session::getActiveEntity());
     }
 
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
         // Check the parent
         return Session::haveRecursiveAccessToEntity($this->getField('entities_id'));
     }
 
-    public static function canUpdate()
+    public static function canUpdate(): bool
     {
         return (Session::haveRightsOr(self::$rightname, [UPDATE, self::UPDATEHELPDESK])
               || Session::haveRight('notification', UPDATE));
     }
 
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
         // Check the current entity
         return Session::haveAccessToEntity($this->getField('id'));
     }
 
-    public function canViewItem()
+    public function canViewItem(): bool
     {
         // Check the current entity
         return Session::haveAccessToEntity($this->getField('id'));

--- a/src/Features/AssignableAsset.php
+++ b/src/Features/AssignableAsset.php
@@ -40,12 +40,12 @@ use Session;
 
 trait AssignableAsset
 {
-    public static function canView()
+    public static function canView(): bool
     {
         return Session::haveRightsOr(static::$rightname, [READ, READ_ASSIGNED, READ_OWNED]);
     }
 
-    public function canViewItem()
+    public function canViewItem(): bool
     {
         if (!parent::canViewItem()) {
             return false;
@@ -65,12 +65,12 @@ trait AssignableAsset
         return true;
     }
 
-    public static function canUpdate()
+    public static function canUpdate(): bool
     {
         return Session::haveRightsOr(static::$rightname, [UPDATE, UPDATE_ASSIGNED, UPDATE_OWNED]);
     }
 
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
         if (!parent::canUpdateItem()) {
             return false;

--- a/src/FieldUnicity.php
+++ b/src/FieldUnicity.php
@@ -55,12 +55,12 @@ class FieldUnicity extends CommonDropdown
         return __('Fields unicity');
     }
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return static::canUpdate();
     }
 
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         return static::canUpdate();
     }

--- a/src/Fieldblacklist.php
+++ b/src/Fieldblacklist.php
@@ -49,7 +49,7 @@ class Fieldblacklist extends CommonDropdown
     }
 
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return static::canUpdate();
     }
@@ -57,7 +57,7 @@ class Fieldblacklist extends CommonDropdown
     /**
      * @since 0.85
      **/
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         return static::canUpdate();
     }

--- a/src/Form/AccessControl/FormAccessControl.php
+++ b/src/Form/AccessControl/FormAccessControl.php
@@ -99,14 +99,14 @@ final class FormAccessControl extends CommonDBChild
     }
 
     #[Override]
-    public static function canView()
+    public static function canView(): bool
     {
         // Must be able to view forms
         return Form::canView();
     }
 
     #[Override]
-    public function canViewItem()
+    public function canViewItem(): bool
     {
         $form = Form::getByID($this->fields['forms_forms_id']);
         if (!$form) {
@@ -118,14 +118,14 @@ final class FormAccessControl extends CommonDBChild
     }
 
     #[Override]
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         // Must be able to update parent form
         return Form::canUpdate();
     }
 
     #[Override]
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
         $form = Form::getByID($this->input['forms_forms_id']);
         if (!$form) {
@@ -137,14 +137,14 @@ final class FormAccessControl extends CommonDBChild
     }
 
     #[Override]
-    public static function canUpdate()
+    public static function canUpdate(): bool
     {
         // Must be able to update forms
         return Form::canUpdate();
     }
 
     #[Override]
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
         $form = Form::getByID($this->fields['forms_forms_id']);
         if (!$form) {
@@ -156,28 +156,28 @@ final class FormAccessControl extends CommonDBChild
     }
 
     #[Override]
-    public static function canDelete()
+    public static function canDelete(): bool
     {
         // Never deleted from the UX
         return false;
     }
 
     #[Override]
-    public function canDeleteItem()
+    public function canDeleteItem(): bool
     {
         // Never deleted from the UX
         return false;
     }
 
     #[Override]
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         // Never purged from the UX
         return false;
     }
 
     #[Override]
-    public function canPurgeItem()
+    public function canPurgeItem(): bool
     {
         // Never purged from the UX
         return false;

--- a/src/Form/AnswersSet.php
+++ b/src/Form/AnswersSet.php
@@ -170,21 +170,21 @@ final class AnswersSet extends CommonDBChild
     }
 
     #[Override]
-    public static function canUpdate()
+    public static function canUpdate(): bool
     {
         // Answers set can't be updated from the UI
         return false;
     }
 
     #[Override]
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         // Answers set can't be created from the UI
         return false;
     }
 
     #[Override]
-    public static function canDelete()
+    public static function canDelete(): bool
     {
         // Any form administrator may delete answers
         return Form::canUpdate();

--- a/src/Form/Destination/FormDestination.php
+++ b/src/Form/Destination/FormDestination.php
@@ -120,14 +120,14 @@ final class FormDestination extends CommonDBChild
     }
 
     #[Override]
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         // Must be able to update forms
         return Form::canUpdate();
     }
 
     #[Override]
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
         $form = Form::getByID($this->fields['forms_forms_id']);
         if (!$form) {
@@ -139,14 +139,14 @@ final class FormDestination extends CommonDBChild
     }
 
     #[Override]
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         // Must be able to update forms
         return Form::canUpdate();
     }
 
     #[Override]
-    public function canPurgeItem()
+    public function canPurgeItem(): bool
     {
         $form = Form::getByID($this->fields['forms_forms_id']);
         if (!$form) {

--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -105,7 +105,7 @@ class ITILFollowup extends CommonDBChild
         return true;
     }
 
-    public static function canView()
+    public static function canView(): bool
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
@@ -123,7 +123,7 @@ class ITILFollowup extends CommonDBChild
         return false;
     }
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return Session::haveRight('change', UPDATE)
              || Session::haveRight('problem', UPDATE)
@@ -135,7 +135,7 @@ class ITILFollowup extends CommonDBChild
     }
 
 
-    public function canViewItem()
+    public function canViewItem(): bool
     {
 
         if ($this->isParentAlreadyLoaded()) {
@@ -166,7 +166,7 @@ class ITILFollowup extends CommonDBChild
     }
 
 
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
         if (
             !isset($this->fields['itemtype'])
@@ -193,7 +193,7 @@ class ITILFollowup extends CommonDBChild
     }
 
 
-    public function canPurgeItem()
+    public function canPurgeItem(): bool
     {
         if ($this->isParentAlreadyLoaded()) {
             $itilobject = $this->item;
@@ -212,7 +212,7 @@ class ITILFollowup extends CommonDBChild
     }
 
 
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
 
         if (

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -74,7 +74,7 @@ class ITILSolution extends CommonDBChild
         return '';
     }
 
-    public static function canView()
+    public static function canView(): bool
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
@@ -88,31 +88,31 @@ class ITILSolution extends CommonDBChild
         return false;
     }
 
-    public static function canUpdate()
+    public static function canUpdate(): bool
     {
        //always true, will rely on ITILSolution::canUpdateItem
         return true;
     }
 
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
         return $this->item->maySolve();
     }
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
        //always true, will rely on ITILSolution::canCreateItem
         return true;
     }
 
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
         $item = new $this->fields['itemtype']();
         $item->getFromDB($this->fields['items_id']);
         return $item->canSolve();
     }
 
-    public function canEdit($ID)
+    public function canEdit($ID): bool
     {
         return $this->item->maySolve();
     }

--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -1889,7 +1889,7 @@ JS;
      * @since 9.1.7
      * @see CommonDBChild::canUpdateItem()
      **/
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
         return Session::haveRight(static::$rightname, UPDATE);
     }
@@ -1899,7 +1899,7 @@ JS;
      * @since 9.1.7
      * @see CommonDBChild::canPurgeItem()
      **/
-    public function canPurgeItem()
+    public function canPurgeItem(): bool
     {
         return Session::haveRight(static::$rightname, PURGE);
     }
@@ -1909,7 +1909,7 @@ JS;
      * @since 9.1.7
      * @see CommonDBChild::canCreateItem()
      **/
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
         return Session::haveRight(static::$rightname, CREATE);
     }

--- a/src/Item_Ticket.php
+++ b/src/Item_Ticket.php
@@ -53,7 +53,7 @@ class Item_Ticket extends CommonItilObject_Item
         return _n('Ticket item', 'Ticket items', $nb);
     }
 
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
         // Not item linked for closed tickets
         $ticket = new Ticket();

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -85,17 +85,17 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
         return static::getTypeName(Session::getPluralNumber());
     }
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return Session::haveRightsOr(self::$rightname, [CREATE, self::PUBLISHFAQ]);
     }
 
-    public static function canUpdate()
+    public static function canUpdate(): bool
     {
         return Session::haveRightsOr(self::$rightname, [UPDATE, self::KNOWBASEADMIN]);
     }
 
-    public static function canView()
+    public static function canView(): bool
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
@@ -104,7 +104,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
               || ((Session::getLoginUserID() === false) && $CFG_GLPI["use_public_faq"]));
     }
 
-    public function canViewItem()
+    public function canViewItem(): bool
     {
         if ($this->fields['users_id'] === Session::getLoginUserID()) {
             return true;
@@ -121,7 +121,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
         return (Session::haveRight(self::$rightname, READ) && $this->haveVisibilityAccess());
     }
 
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
         // Personal knowbase or visibility and write access
         return (Session::haveRight(self::$rightname, self::KNOWBASEADMIN)

--- a/src/KnowbaseItemCategory.php
+++ b/src/KnowbaseItemCategory.php
@@ -49,7 +49,7 @@ class KnowbaseItemCategory extends CommonTreeDropdown
         return _n('Knowledge base category', 'Knowledge base categories', $nb);
     }
 
-    public static function canView()
+    public static function canView(): bool
     {
         if (Session::getCurrentInterface() == "helpdesk") {
             return true;

--- a/src/KnowbaseItem_KnowbaseItemCategory.php
+++ b/src/KnowbaseItem_KnowbaseItemCategory.php
@@ -52,7 +52,7 @@ class KnowbaseItem_KnowbaseItemCategory extends CommonDBRelation
 
     public static $rightname = 'knowbase';
 
-    public function canPurgeItem()
+    public function canPurgeItem(): bool
     {
         return Session::haveRight(static::$rightname, UPDATE);
     }

--- a/src/Lockedfield.php
+++ b/src/Lockedfield.php
@@ -54,17 +54,17 @@ class Lockedfield extends CommonDBTM
         return _n('Locked field', 'Locked fields', $nb);
     }
 
-    public static function canView()
+    public static function canView(): bool
     {
         return self::canUpdate();
     }
 
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         return Session::haveRight(self::$rightname, UPDATE);
     }
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return Session::haveRight(self::$rightname, UPDATE);
     }

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -108,13 +108,13 @@ class MailCollector extends CommonDBTM
     }
 
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return static::canUpdate();
     }
 
 
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         return static::canUpdate();
     }

--- a/src/Marketplace/View.php
+++ b/src/Marketplace/View.php
@@ -73,7 +73,7 @@ class View extends CommonGLPI
     }
 
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return self::canUpdate();
     }

--- a/src/MigrationCleaner.php
+++ b/src/MigrationCleaner.php
@@ -63,7 +63,7 @@ class MigrationCleaner extends CommonGLPI
     }
 
 
-    public static function canView()
+    public static function canView(): bool
     {
         /** @var \DBmysql $DB */
         global $DB;

--- a/src/NetworkPortMigration.php
+++ b/src/NetworkPortMigration.php
@@ -50,7 +50,7 @@ class NetworkPortMigration extends CommonDBChild
         return __('Network port migration');
     }
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return false;
     }

--- a/src/Notepad.php
+++ b/src/Notepad.php
@@ -67,7 +67,7 @@ class Notepad extends CommonDBChild
     }
 
 
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
 
         if (
@@ -80,7 +80,7 @@ class Notepad extends CommonDBChild
     }
 
 
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
 
         if (

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -535,7 +535,7 @@ class Notification extends CommonDBTM implements FilterableInterface
     }
 
 
-    public function canViewItem()
+    public function canViewItem(): bool
     {
 
         if (
@@ -554,7 +554,7 @@ class Notification extends CommonDBTM implements FilterableInterface
      *
      * @return boolean
      **/
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
 
         if (

--- a/src/NotificationTemplate.php
+++ b/src/NotificationTemplate.php
@@ -71,7 +71,7 @@ class NotificationTemplate extends CommonDBTM
         return 'ti ti-template';
     }
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return static::canUpdate();
     }
@@ -80,7 +80,7 @@ class NotificationTemplate extends CommonDBTM
     /**
      * @since 0.85
      **/
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         return static::canUpdate();
     }

--- a/src/PendingReason_Item.php
+++ b/src/PendingReason_Item.php
@@ -541,60 +541,60 @@ class PendingReason_Item extends CommonDBRelation
         return $timeline_item->input;
     }
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return ITILFollowup::canUpdate() || TicketTask::canUpdate() || ChangeTask::canUpdate() || ProblemTask::canUpdate();
     }
 
-    public static function canView()
+    public static function canView(): bool
     {
         return ITILFollowup::canView() || TicketTask::canView() || ChangeTask::canView() || ProblemTask::canView();
     }
 
-    public static function canUpdate()
+    public static function canUpdate(): bool
     {
         return ITILFollowup::canUpdate() || TicketTask::canUpdate() || ChangeTask::canUpdate() || ProblemTask::canUpdate();
     }
 
-    public static function canDelete()
+    public static function canDelete(): bool
     {
         return ITILFollowup::canUpdate() || TicketTask::canUpdate() || ChangeTask::canUpdate() || ProblemTask::canUpdate();
     }
 
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         return ITILFollowup::canUpdate() || TicketTask::canUpdate() || ChangeTask::canUpdate() || ProblemTask::canUpdate();
     }
 
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
         $itemtype = $this->fields['itemtype'];
         $item = $itemtype::getById($this->fields['items_id']);
         return $item->canUpdateItem();
     }
 
-    public function canViewItem()
+    public function canViewItem(): bool
     {
         $itemtype = $this->fields['itemtype'];
         $item = $itemtype::getById($this->fields['items_id']);
         return $item->canViewItem();
     }
 
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
         $itemtype = $this->fields['itemtype'];
         $item = $itemtype::getById($this->fields['items_id']);
         return $item->canUpdateItem();
     }
 
-    public function canDeleteItem()
+    public function canDeleteItem(): bool
     {
         $itemtype = $this->fields['itemtype'];
         $item = $itemtype::getById($this->fields['items_id']);
         return $item->canUpdateItem();
     }
 
-    public function canPurgeItem()
+    public function canPurgeItem(): bool
     {
         $itemtype = $this->fields['itemtype'];
         $item = $itemtype::getById($this->fields['items_id']);

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -162,7 +162,7 @@ class Planning extends CommonGLPI
         return 'p';
     }
 
-    public static function canView()
+    public static function canView(): bool
     {
         return Session::haveRightsOr(self::$rightname, [self::READMY, self::READGROUP,
             self::READALL

--- a/src/PlanningExternalEvent.php
+++ b/src/PlanningExternalEvent.php
@@ -66,7 +66,7 @@ class PlanningExternalEvent extends CommonDBTM implements CalDAVCompatibleItemIn
         return $ong;
     }
 
-    public static function canUpdate()
+    public static function canUpdate(): bool
     {
         // we permits globally to update this object,
         // as users can update their onw items
@@ -77,7 +77,7 @@ class PlanningExternalEvent extends CommonDBTM implements CalDAVCompatibleItemIn
         ]);
     }
 
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
         if (!$this->canUpdateBGEvents()) {
             return false;
@@ -95,7 +95,7 @@ class PlanningExternalEvent extends CommonDBTM implements CalDAVCompatibleItemIn
         return parent::canUpdateItem();
     }
 
-    public function canPurgeItem()
+    public function canPurgeItem(): bool
     {
         if (!$this->canUpdateBGEvents()) {
             return false;

--- a/src/PlanningRecall.php
+++ b/src/PlanningRecall.php
@@ -49,12 +49,12 @@ class PlanningRecall extends CommonDBChild
         return _n('Planning reminder', 'Planning reminders', $nb);
     }
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return true;
     }
 
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
         return (int) $this->fields['users_id'] === Session::getLoginUserID();
     }

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -92,7 +92,7 @@ class Problem extends CommonITILObject
     }
 
 
-    public static function canView()
+    public static function canView(): bool
     {
         return Session::haveRightsOr(self::$rightname, [self::READALL, self::READMY]);
     }
@@ -103,7 +103,7 @@ class Problem extends CommonITILObject
      *
      * @return boolean
      **/
-    public function canViewItem()
+    public function canViewItem(): bool
     {
 
         if (!Session::haveAccessToEntity($this->getEntityID(), $this->isRecursive())) {
@@ -133,7 +133,7 @@ class Problem extends CommonITILObject
      *
      * @return boolean
      **/
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
 
         if (!Session::haveAccessToEntity($this->getEntityID())) {

--- a/src/ProblemCost.php
+++ b/src/ProblemCost.php
@@ -45,19 +45,19 @@ class ProblemCost extends CommonITILCost
     public static $items_id  = 'problems_id';
 
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return Session::haveRight('problem', UPDATE);
     }
 
 
-    public static function canView()
+    public static function canView(): bool
     {
         return Session::haveRightsOr('problem', [Problem::READALL, Problem::READMY]);
     }
 
 
-    public static function canUpdate()
+    public static function canUpdate(): bool
     {
         return Session::haveRight('problem', UPDATE);
     }

--- a/src/ProblemTask.php
+++ b/src/ProblemTask.php
@@ -44,20 +44,20 @@ class ProblemTask extends CommonITILTask
     }
 
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return Session::haveRight('problem', UPDATE)
           || Session::haveRight(self::$rightname, parent::ADDALLITEM);
     }
 
-    public static function canUpdate()
+    public static function canUpdate(): bool
     {
         return Session::haveRight('problem', UPDATE)
           || Session::haveRight(self::$rightname, parent::UPDATEALL);
     }
 
 
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         return Session::haveRight('problem', UPDATE);
     }
@@ -80,7 +80,7 @@ class ProblemTask extends CommonITILTask
      *
      * @return boolean
      **/
-    public function canViewItem()
+    public function canViewItem(): bool
     {
         return $this->canReadITILItem();
     }
@@ -91,7 +91,7 @@ class ProblemTask extends CommonITILTask
      *
      * @return boolean
      **/
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
         if (!$this->canReadITILItem()) {
             return false;
@@ -118,7 +118,7 @@ class ProblemTask extends CommonITILTask
      *
      * @return boolean
      **/
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
 
         if (!$this->canReadITILItem()) {
@@ -142,7 +142,7 @@ class ProblemTask extends CommonITILTask
      *
      * @return boolean
      **/
-    public function canPurgeItem()
+    public function canPurgeItem(): bool
     {
         return $this->canUpdateItem();
     }

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -4354,7 +4354,7 @@ class Profile extends CommonDBTM
         ;
     }
 
-    public function canPurgeItem()
+    public function canPurgeItem(): bool
     {
         // We can't delete the last super admin profile
         if ($this->isLastSuperAdminProfile()) {

--- a/src/Profile_User.php
+++ b/src/Profile_User.php
@@ -77,7 +77,7 @@ class Profile_User extends CommonDBRelation
 
 
    // TODO CommonDBConnexity : check in details if we can replace canCreateItem by canRelationItem ...
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
 
         $user = new User();
@@ -88,7 +88,7 @@ class Profile_User extends CommonDBRelation
              && Session::haveAccessToEntity($this->fields['entities_id']);
     }
 
-    public function canPurgeItem()
+    public function canPurgeItem(): bool
     {
         // We can't delete the last super admin profile authorization
         if ($this->isLastSuperAdminAuthorization()) {

--- a/src/Project.php
+++ b/src/Project.php
@@ -88,7 +88,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
         return _n('Project', 'Projects', $nb);
     }
 
-    public static function canView()
+    public static function canView(): bool
     {
         return Session::haveRightsOr(self::$rightname, [self::READALL, self::READMY]);
     }
@@ -98,7 +98,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
      *
      * @return boolean
      **/
-    public function canViewItem()
+    public function canViewItem(): bool
     {
         if (!parent::canViewItem()) {
             return false;
@@ -117,7 +117,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
      *
      * @return boolean
      **/
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
         if (!Session::haveAccessToEntity($this->getEntityID())) {
             return false;

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -82,7 +82,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
         return 'ti ti-list-check';
     }
 
-    public static function canView()
+    public static function canView(): bool
     {
         return (Session::haveRightsOr('project', [Project::READALL, Project::READMY])
               || Session::haveRight(self::$rightname, self::READMY));
@@ -93,7 +93,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
      *
      * @return boolean
      **/
-    public function canViewItem()
+    public function canViewItem(): bool
     {
         if (!Session::haveAccessToEntity($this->getEntityID(), $this->isRecursive())) {
             return false;
@@ -112,12 +112,12 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
         return false;
     }
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return (Session::haveRight('project', UPDATE));
     }
 
-    public static function canUpdate()
+    public static function canUpdate(): bool
     {
         return (parent::canUpdate()
               || Session::haveRight(self::$rightname, self::UPDATEMY));
@@ -128,7 +128,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
      *
      * @return boolean
      **/
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
         if (!Session::haveAccessToEntity($this->getEntityID())) {
             return false;

--- a/src/QueuedNotification.php
+++ b/src/QueuedNotification.php
@@ -51,7 +51,7 @@ class QueuedNotification extends CommonDBTM
         return __('Notification queue');
     }
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         // Everybody can create : human and cron
         return Session::getLoginUserID(false);

--- a/src/QueuedWebhook.php
+++ b/src/QueuedWebhook.php
@@ -53,18 +53,18 @@ class QueuedWebhook extends CommonDBChild
         return __('Webhook queue');
     }
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
        // Everybody can create : human and cron
         return Session::getLoginUserID(false);
     }
 
-    public static function canDelete()
+    public static function canDelete(): bool
     {
         return Session::haveRight(static::$rightname, UPDATE);
     }
 
-    public static function canUpdate()
+    public static function canUpdate(): bool
     {
         // No standard update is allowed
         return false;

--- a/src/RSSFeed.php
+++ b/src/RSSFeed.php
@@ -60,17 +60,17 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria
         return _n('Personal RSS feed', 'Personal RSS feed', $nb);
     }
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return (Session::haveRightsOr(self::$rightname, [CREATE, self::PERSONAL]));
     }
 
-    public static function canView()
+    public static function canView(): bool
     {
         return (Session::haveRightsOr(self::$rightname, [READ, self::PERSONAL]));
     }
 
-    public function canViewItem()
+    public function canViewItem(): bool
     {
         // Is my rssfeed or is in visibility
         return (($this->fields['users_id'] === Session::getLoginUserID())
@@ -78,13 +78,13 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria
                   && $this->haveVisibilityAccess()));
     }
 
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
         // Is my rssfeed
         return (int)$this->fields['users_id'] === Session::getLoginUserID();
     }
 
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
         return (($this->fields['users_id'] === Session::getLoginUserID())
               || (Session::haveRight('rssfeed_public', UPDATE)
@@ -95,7 +95,7 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria
      * @since 0.85
      * for personal rss feed
      **/
-    public static function canUpdate()
+    public static function canUpdate(): bool
     {
         return (Session::haveRightsOr(self::$rightname, [UPDATE, self::PERSONAL]));
     }
@@ -104,12 +104,12 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria
      * @since 0.85
      * for personal rss feed
      **/
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         return (Session::haveRightsOr(self::$rightname, [PURGE, self::PERSONAL]));
     }
 
-    public function canPurgeItem()
+    public function canPurgeItem(): bool
     {
         return (($this->fields['users_id'] === Session::getLoginUserID())
               || (Session::haveRight(self::$rightname, PURGE)

--- a/src/RefusedEquipment.php
+++ b/src/RefusedEquipment.php
@@ -244,7 +244,7 @@ class RefusedEquipment extends CommonDBTM
         return true;
     }
 
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         return static::canUpdate();
     }

--- a/src/Reminder.php
+++ b/src/Reminder.php
@@ -71,17 +71,17 @@ class Reminder extends CommonDBVisible implements
     }
 
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return (Session::haveRightsOr(self::$rightname, [CREATE, self::PERSONAL]));
     }
 
-    public static function canView()
+    public static function canView(): bool
     {
         return (Session::haveRightsOr(self::$rightname, [READ, self::PERSONAL]));
     }
 
-    public function canViewItem()
+    public function canViewItem(): bool
     {
         // Is my reminder or is in visibility
         return ($this->fields['users_id'] == Session::getLoginUserID()
@@ -89,32 +89,32 @@ class Reminder extends CommonDBVisible implements
                   && $this->haveVisibilityAccess()));
     }
 
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
         // Is my reminder
         return ($this->fields['users_id'] == Session::getLoginUserID());
     }
 
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
         return ($this->fields['users_id'] == Session::getLoginUserID()
               || (Session::haveRight(self::$rightname, UPDATE)
                   && $this->haveVisibilityAccess()));
     }
 
-    public function canPurgeItem()
+    public function canPurgeItem(): bool
     {
         return ($this->fields['users_id'] === Session::getLoginUserID()
               || (Session::haveRight(self::$rightname, PURGE)
                   && $this->haveVisibilityAccess()));
     }
 
-    public static function canUpdate()
+    public static function canUpdate(): bool
     {
         return (Session::haveRightsOr(self::$rightname, [UPDATE, self::PERSONAL]));
     }
 
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         return (Session::haveRightsOr(self::$rightname, [PURGE, self::PERSONAL]));
     }

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -348,22 +348,22 @@ class Reservation extends CommonDBChild
               && (strtotime($this->fields["begin"]) < strtotime($this->fields["end"])));
     }
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return (Session::haveRight(self::$rightname, ReservationItem::RESERVEANITEM));
     }
 
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
         return self::canCreate();
     }
 
-    public static function canUpdate()
+    public static function canUpdate(): bool
     {
         return (Session::haveRight(self::$rightname, ReservationItem::RESERVEANITEM));
     }
 
-    public static function canDelete()
+    public static function canDelete(): bool
     {
         return (Session::haveRight(self::$rightname, ReservationItem::RESERVEANITEM));
     }

--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -57,7 +57,7 @@ class ReservationItem extends CommonDBChild
 
     public $taborientation           = 'horizontal';
 
-    public static function canView()
+    public static function canView(): bool
     {
         return Session::haveRightsOr(self::$rightname, [READ, self::RESERVEANITEM]);
     }

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -3443,12 +3443,12 @@ JS
         echo "</div>";
     }
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return static::canUpdate();
     }
 
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         return static::canUpdate();
     }

--- a/src/RuleCommonITILObjectCollection.php
+++ b/src/RuleCommonITILObjectCollection.php
@@ -59,7 +59,7 @@ abstract class RuleCommonITILObjectCollection extends RuleCollection
         return $matches[1];
     }
 
-    public static function canView()
+    public static function canView(): bool
     {
         $rule_class = (new static())->getRuleClassName();
         return Session::haveRightsOr(static::$rightname, [READ, $rule_class::PARENT]);

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -151,7 +151,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
         parent::processMassiveActionsForOneItemtype($ma, $item, $ids);
     }
 
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
 
         if ($this->fields['is_private'] == 1) {
@@ -161,7 +161,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
         return parent::canCreateItem();
     }
 
-    public function canViewItem()
+    public function canViewItem(): bool
     {
         if ($this->fields['is_private'] == 1) {
             return (Session::haveRight('config', READ)

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -72,12 +72,12 @@ class Socket extends CommonDBChild
         return NetworkPort::getIcon();
     }
 
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
         return Session::haveRight(static::$rightname, CREATE);
     }
 
-    public function canPurgeItem()
+    public function canPurgeItem(): bool
     {
         return Session::haveRight(static::$rightname, PURGE);
     }

--- a/src/SsoVariable.php
+++ b/src/SsoVariable.php
@@ -54,7 +54,7 @@ class SsoVariable extends CommonDropdown
     }
 
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return static::canUpdate();
     }
@@ -63,7 +63,7 @@ class SsoVariable extends CommonDropdown
     /**
      * @since 0.85
      **/
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         return static::canUpdate();
     }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -178,7 +178,7 @@ class Ticket extends CommonITILObject
     }
 
 
-    public static function canUpdate()
+    public static function canUpdate(): bool
     {
 
        // To allow update of urgency and category for post-only
@@ -198,7 +198,7 @@ class Ticket extends CommonITILObject
     }
 
 
-    public static function canView()
+    public static function canView(): bool
     {
         return (Session::haveRightsOr(
             self::$rightname,
@@ -217,7 +217,7 @@ class Ticket extends CommonITILObject
      *
      * @return boolean
      **/
-    public function canViewItem()
+    public function canViewItem(): bool
     {
         if (!Session::haveAccessToEntity($this->getEntityID())) {
             return false;
@@ -535,7 +535,7 @@ class Ticket extends CommonITILObject
      *
      * @return boolean
      **/
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
 
         if (!Session::haveAccessToEntity($this->getEntityID())) {
@@ -550,7 +550,7 @@ class Ticket extends CommonITILObject
      *
      * @return boolean
      **/
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
         if (!$this->checkEntity()) {
             return false;
@@ -612,7 +612,7 @@ class Ticket extends CommonITILObject
     /**
      * @since 0.85
      **/
-    public static function canDelete()
+    public static function canDelete(): bool
     {
 
        // to allow delete for self-service only if no action on the ticket
@@ -641,7 +641,7 @@ class Ticket extends CommonITILObject
      *
      * @return boolean
      **/
-    public function canDeleteItem()
+    public function canDeleteItem(): bool
     {
 
         if (!Session::haveAccessToEntity($this->getEntityID())) {
@@ -2005,13 +2005,13 @@ class Ticket extends CommonITILObject
     /**
      * Overloaded from commonDBTM
      *
-     * @since 0.83
-     *
-     * @param $type itemtype of object to add
+     * @param $type string of object to add
      *
      * @return boolean
-     **/
-    public function canAddItem($type)
+     **@since 0.83
+     *
+     */
+    public function canAddItem(string $type): bool
     {
 
         if ($type == 'Document') {

--- a/src/TicketTask.php
+++ b/src/TicketTask.php
@@ -44,13 +44,13 @@ class TicketTask extends CommonITILTask
     }
 
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return (Session::haveRight(self::$rightname, parent::ADDALLITEM)
               || Session::haveRight('ticket', Ticket::OWN));
     }
 
-    public static function canUpdate()
+    public static function canUpdate(): bool
     {
         return (Session::haveRight(self::$rightname, parent::UPDATEALL)
               || Session::haveRight('ticket', Ticket::OWN));
@@ -74,7 +74,7 @@ class TicketTask extends CommonITILTask
      *
      * @return boolean
      **/
-    public function canViewItem()
+    public function canViewItem(): bool
     {
 
         if (!$this->canReadITILItem()) {
@@ -118,7 +118,7 @@ class TicketTask extends CommonITILTask
      *
      * @return boolean
      **/
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
 
         if (!$this->canReadITILItem()) {
@@ -148,7 +148,7 @@ class TicketTask extends CommonITILTask
      *
      * @return boolean
      **/
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
 
         if (!$this->canReadITILItem()) {
@@ -179,7 +179,7 @@ class TicketTask extends CommonITILTask
      *
      * @return boolean
      **/
-    public function canPurgeItem()
+    public function canPurgeItem(): bool
     {
         $ticket = new Ticket();
         if (

--- a/src/TicketValidation.php
+++ b/src/TicketValidation.php
@@ -70,7 +70,7 @@ class TicketValidation extends CommonITILValidation
     /**
      * @since 0.85
      **/
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
 
         if ($this->canChildItem('canViewItem', 'canView')) {

--- a/src/User.php
+++ b/src/User.php
@@ -147,7 +147,7 @@ class User extends CommonDBTM
         return $links;
     }
 
-    public function canViewItem()
+    public function canViewItem(): bool
     {
         if (
             Session::canViewAllEntities()
@@ -159,7 +159,7 @@ class User extends CommonDBTM
     }
 
 
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
 
        // Will be created from form, with selected entity/profile
@@ -191,7 +191,7 @@ class User extends CommonDBTM
     }
 
 
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
 
         $entities = Profile_User::getUserEntities($this->fields['id'], false);
@@ -205,7 +205,7 @@ class User extends CommonDBTM
     }
 
 
-    public function canDeleteItem()
+    public function canDeleteItem(): bool
     {
         if ($this->isLastSuperAdminUser()) {
             return false;
@@ -228,7 +228,7 @@ class User extends CommonDBTM
     }
 
 
-    public function canPurgeItem()
+    public function canPurgeItem(): bool
     {
         return $this->canDeleteItem();
     }

--- a/src/ValidatorSubstitute.php
+++ b/src/ValidatorSubstitute.php
@@ -66,27 +66,27 @@ final class ValidatorSubstitute extends CommonDBTM
         return false;
     }
 
-    public static function canView()
+    public static function canView(): bool
     {
         return true;
     }
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return true;
     }
 
-    public static function canDelete()
+    public static function canDelete(): bool
     {
         return true;
     }
 
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         return true;
     }
 
-    public function canViewItem()
+    public function canViewItem(): bool
     {
         if (!isset($this->fields['users_id'])) {
             return false;
@@ -94,7 +94,7 @@ final class ValidatorSubstitute extends CommonDBTM
         return $this->fields['users_id'] == Session::getLoginUserID();
     }
 
-    public function canCreateItem()
+    public function canCreateItem(): bool
     {
         if (!isset($this->fields['users_id'])) {
             return false;
@@ -103,7 +103,7 @@ final class ValidatorSubstitute extends CommonDBTM
         return $this->fields['users_id'] == Session::getLoginUserID();
     }
 
-    public function canUpdateItem()
+    public function canUpdateItem(): bool
     {
         if (!isset($this->fields['users_id'])) {
             return false;
@@ -111,7 +111,7 @@ final class ValidatorSubstitute extends CommonDBTM
         return $this->fields['users_id'] == Session::getLoginUserID();
     }
 
-    public function canDeleteItem()
+    public function canDeleteItem(): bool
     {
         if (!isset($this->fields['users_id'])) {
             return false;
@@ -119,7 +119,7 @@ final class ValidatorSubstitute extends CommonDBTM
         return $this->fields['users_id'] == Session::getLoginUserID();
     }
 
-    public function canPurgeItem()
+    public function canPurgeItem(): bool
     {
         if (!isset($this->fields['users_id'])) {
             return false;

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -79,17 +79,17 @@ class Webhook extends CommonDBTM implements FilterableInterface
         return _n('Webhook', 'Webhooks', $nb);
     }
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return static::canUpdate();
     }
 
-    public static function canPurge()
+    public static function canPurge(): bool
     {
         return static::canUpdate();
     }
 
-    public static function canDelete()
+    public static function canDelete(): bool
     {
         return static::canUpdate();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Enforce stricter method parameter and return types on common can* and check* methods. The parameter type for IDs was not changed as there are still places where an empty string is used as an ID.