### PR TITLE
Fix manufacturer registered ids field label

### DIFF
--- a/src/Manufacturer.php
+++ b/src/Manufacturer.php
@@ -64,16 +64,12 @@ class Manufacturer extends CommonDropdown
     public function getAdditionalFields()
     {
 
-        return [['name'  => 'none',
-            'label' => RegisteredID::getTypeName(Session::getPluralNumber()) .
-                                       RegisteredID::showAddChildButtonForItemForm(
-                                           $this,
-                                           '_registeredID',
-                                           null,
-                                           false
-                                       ),
-            'type'  => 'registeredIDChooser'
-        ]
+        return [
+            [
+                'name'  => 'none',
+                'label' => RegisteredID::getTypeName(Session::getPluralNumber()),
+                'type'  => 'registeredIDChooser'
+            ]
         ];
     }
 

--- a/src/Manufacturer.php
+++ b/src/Manufacturer.php
@@ -55,6 +55,7 @@ class Manufacturer extends CommonDropdown
 
         switch ($field['type']) {
             case 'registeredIDChooser':
+                RegisteredID::showAddChildButtonForItemForm($this, '_registeredID');
                 RegisteredID::showChildsForItemForm($this, '_registeredID');
                 break;
         }

--- a/src/RegisteredID.php
+++ b/src/RegisteredID.php
@@ -101,7 +101,7 @@ class RegisteredID extends CommonDBChild
         $registeredIDTypes = self::getRegisteredIDTypes();
 
         if ($canedit) {
-            $result .= "<select name='$type_field'>";
+            $result .= "<select name='$type_field' class='form-select w-auto d-inline'>";
             $result .= "<option value=''>" . Dropdown::EMPTY_VALUE . "</option>";
             foreach ($registeredIDTypes as $name => $label) {
                 $result .= "<option value='$name'";
@@ -110,9 +110,9 @@ class RegisteredID extends CommonDBChild
                 }
                 $result .= ">$label</option>";
             }
-            $result .= "</select> : <input type='text' size='30' name='$main_field' value='$value'>\n";
+            $result .= "</select> : <input type='text' size='30' name='$main_field' value='$value' class='form-control'>\n";
         } else {
-            $result .= "<input type='hidden' name='$main_field' value='$value'>";
+            $result .= "<input type='hidden' name='$main_field' value='$value' class='form-control'>";
             if (!empty($this->fields['device_type'])) {
                 $result .= sprintf(
                     __('%1$s: %2$s'),

--- a/templates/dropdown_form.html.twig
+++ b/templates/dropdown_form.html.twig
@@ -193,12 +193,6 @@
                             {% set fields_params = fields_params|merge({'types': config(field['itemtype_list'])}) %}
                         {% endif %}
                         {{ fields.dropdownItemTypes(field['name'], item.fields[field['name']], field['label'], fields_params) }}
-                    {% elseif type == 'registeredIDChooser' %}
-                        {% set chooser_field %}
-                            {{ call('RegisteredID::showAddChildButtonForItemForm', [item, '_registeredID', null, false])|raw }}
-                            {{ item.displaySpecificTypeField(item.fields['id'], field, fields_params) }}
-                        {% endset %}
-                        {{ fields.field('', chooser_field, field['label']) }}
                     {% else %}
                         {% set field_value %}
                             {{ item.displaySpecificTypeField(item.fields['id'], field, fields_params) }}

--- a/templates/dropdown_form.html.twig
+++ b/templates/dropdown_form.html.twig
@@ -193,6 +193,12 @@
                             {% set fields_params = fields_params|merge({'types': config(field['itemtype_list'])}) %}
                         {% endif %}
                         {{ fields.dropdownItemTypes(field['name'], item.fields[field['name']], field['label'], fields_params) }}
+                    {% elseif type == 'registeredIDChooser' %}
+                        {% set chooser_field %}
+                            {{ call('RegisteredID::showAddChildButtonForItemForm', [item, '_registeredID', null, false])|raw }}
+                            {{ item.displaySpecificTypeField(item.fields['id'], field, fields_params) }}
+                        {% endset %}
+                        {{ fields.field('', chooser_field, field['label']) }}
                     {% else %}
                         {% set field_value %}
                             {{ item.displaySpecificTypeField(item.fields['id'], field, fields_params) }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

HTML in labels is no longer supported. This PR moves the button for adding another ID to the field itself in the same way that was done for devices in #17027.