### PR TITLE
[HLAPI] Allow exporting ITIL stats to pdf, csv, xlsx, and ods

### DIFF
--- a/src/Api/HL/Doc/Route.php
+++ b/src/Api/HL/Doc/Route.php
@@ -51,8 +51,8 @@ class Route
     /**
      * @param string $description
      * @param string[] $methods
-     * @param array<Parameter|array{name: string, description?: string, location?: string, schema?: array{type?: string, format?: string}, example?: string, required?: bool}> $parameters
-     * @param array<Response|array{methods?: array<string>, description?: string, headers?: array, schema?: array{type?: string, format?: string}, examples?: array}> $responses
+     * @param array<Parameter|array{name: string, description?: string, location?: string, schema?: array{type?: string, format?: string, enum?: array}, example?: string, required?: bool}> $parameters
+     * @param array<Response|array{methods?: array<string>, description?: string, headers?: array, schema?: array{type?: string, format?: string}, examples?: array, media_type?: string}> $responses
      */
     public function __construct(string $description = '', array $methods = [], array $parameters = [], array $responses = [])
     {

--- a/src/Search/Output/Spreadsheet.php
+++ b/src/Search/Output/Spreadsheet.php
@@ -99,7 +99,6 @@ abstract class Spreadsheet extends ExportSearchOutput
         if (
             !isset($data['data'])
             || !isset($data['data']['totalcount'])
-            || $data['data']['count'] <= 0
             || $data['search']['as_map'] != 0
         ) {
             return false;

--- a/src/Stat.php
+++ b/src/Stat.php
@@ -438,15 +438,11 @@ class Stat extends CommonGLPI
         $is_html_output = is_a($output, HTMLSearchOutput::class);
         $html_output = '';
 
-        if ($numrows === 0) {
-            if ($is_html_output) {
-                echo $output::showHeader(0, 0);
-                echo '<div class="alert alert-info">' . __s('No statistics are available') . '</div>';
-                echo $output::showFooter('', 0);
-                return;
-            } else {
-                throw new \RuntimeException(__('No statistics are available'));
-            }
+        if ($numrows === 0 && $is_html_output) {
+            echo $output::showHeader(0, 0);
+            echo '<div class="alert alert-info">' . __s('No statistics are available') . '</div>';
+            echo $output::showFooter('', 0);
+            return;
         }
 
         $headers = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Requires #17010.
Unlike the different export formats enabled by the ResultFormatterMiddleware, these endpoints don't export the API response as a different format. Instead, it uses the exact same export logic as the web UI but returns the file content as the response body with the possible PDF, XLSX, CSV and ODS formats. These endpoints always export all results and the PDF orientation is always landscape.

Users may utilize these endpoints to get reports on a schedule.