### PR TITLE
Fix user mentions handling in rich text sanitizer

### DIFF
--- a/src/RichText/RichText.php
+++ b/src/RichText/RichText.php
@@ -583,6 +583,19 @@ JAVASCRIPT;
             $config = $config->allowElement('iframe')->dropAttribute('srcdoc', '*');
         }
 
+        // Keep attributes specific to rich text auto completion
+        $rich_text_completion_attributes = [
+            // required for proper display of autocompleted tags
+            'contenteditable',
+
+            // required for user mentions
+            'data-user-mention',
+            'data-user-id',
+        ];
+        foreach ($rich_text_completion_attributes as $attribute) {
+            $config = $config->allowAttribute($attribute, 'span');
+        }
+
         return new HtmlSanitizer($config);
     }
 }

--- a/tests/units/Glpi/RichText/RichText.php
+++ b/tests/units/Glpi/RichText/RichText.php
@@ -370,6 +370,22 @@ HTML,
                 ];
             }
         }
+
+        yield 'User mention tag must be preserved' => [
+            'content' => <<<HTML
+<p>
+  Hi <span contenteditable="false" data-user-mention="true" data-user-id="2">@glpi</span>&nbsp;
+  ...
+</p>
+HTML,
+            'encode_output_entities' => false,
+            'expected_result' => <<<HTML
+<p>
+  Hi <span contenteditable="false" data-user-mention="true" data-user-id="2">&#64;glpi</span> 
+  ...
+</p>
+HTML,
+        ];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Since migration from `htmlawed` to `symfony/html-sanitizer`, user mentions were not refreshed properly on display.