### PR TITLE
Form access control: access decision stategy (affirmative/unanimous)

### DIFF
--- a/install/migrations/update_10.0.x_to_11.0.0/form.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/form.php
@@ -57,7 +57,7 @@ if (!$DB->tableExists('glpi_forms_forms')) {
             `header` longtext,
             `date_mod` timestamp NULL DEFAULT NULL,
             `date_creation` timestamp NULL DEFAULT NULL,
-            `access_decision_strategy` varchar(255) NOT NULL DEFAULT 'unanimous',
+            `access_decision_strategy` varchar(255) NOT NULL DEFAULT 'affirmative',
             PRIMARY KEY (`id`),
             KEY `name` (`name`),
             KEY `entities_id` (`entities_id`),
@@ -219,6 +219,6 @@ if (GLPI_VERSION == "11.0.0-dev") {
         "glpi_forms_forms",
         "access_decision_strategy",
         "string",
-        ['value' => 'unanimous']
+        ['value' => 'affirmative']
     );
 }

--- a/install/migrations/update_10.0.x_to_11.0.0/form.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/form.php
@@ -57,6 +57,7 @@ if (!$DB->tableExists('glpi_forms_forms')) {
             `header` longtext,
             `date_mod` timestamp NULL DEFAULT NULL,
             `date_creation` timestamp NULL DEFAULT NULL,
+            `access_decision_strategy` varchar(255) NOT NULL DEFAULT 'unanimous',
             PRIMARY KEY (`id`),
             KEY `name` (`name`),
             KEY `entities_id` (`entities_id`),
@@ -214,4 +215,10 @@ if (GLPI_VERSION == "11.0.0-dev") {
     $migration->addField("glpi_forms_answerssets", "entities_id", "fkey");
     $migration->addKey("glpi_forms_answerssets", "entities_id");
     $migration->addField("glpi_forms_destinations_formdestinations", "config", "JSON NOT NULL COMMENT 'Extra configuration field(s) depending on the destination type'");
+    $migration->addField(
+        "glpi_forms_forms",
+        "access_decision_strategy",
+        "string",
+        ['value' => 'unanimous']
+    );
 }

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9478,6 +9478,7 @@ CREATE TABLE `glpi_forms_forms` (
     `header` longtext,
     `date_mod` timestamp NULL DEFAULT NULL,
     `date_creation` timestamp NULL DEFAULT NULL,
+    `access_decision_strategy` varchar(255) NOT NULL DEFAULT 'unanimous',
     PRIMARY KEY (`id`),
     KEY `name` (`name`),
     KEY `entities_id` (`entities_id`),

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9478,7 +9478,7 @@ CREATE TABLE `glpi_forms_forms` (
     `header` longtext,
     `date_mod` timestamp NULL DEFAULT NULL,
     `date_creation` timestamp NULL DEFAULT NULL,
-    `access_decision_strategy` varchar(255) NOT NULL DEFAULT 'unanimous',
+    `access_decision_strategy` varchar(255) NOT NULL DEFAULT 'affirmative',
     PRIMARY KEY (`id`),
     KEY `name` (`name`),
     KEY `entities_id` (`entities_id`),

--- a/src/Form/AccessControl/AccessDecisionStrategy.php
+++ b/src/Form/AccessControl/AccessDecisionStrategy.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\AccessControl;
+
+enum AccessDecisionStrategy: string
+{
+    case Affirmative = 'affirmative';
+    case Unanimous = 'unanimous';
+
+    /**
+     * Compute a decision based on the given votes.
+     *
+     * @param bool[] $votes The votes to consider: true for a positive vote and
+     *                      false for a negative vote.
+     * @return bool True if the decision is positive, false otherwise.
+     */
+    public function getDecision(array $votes): bool
+    {
+        return match ($this) {
+            self::Unanimous => !in_array(false, $votes, true),
+            self::Affirmative => in_array(true, $votes, true),
+        };
+    }
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Unanimous => __('Unanimous'),
+            self::Affirmative => __('Affirmative'),
+        };
+    }
+
+    public static function getForDropdown(): array
+    {
+        $strategies = [];
+        foreach (self::cases() as $strategy) {
+            $strategies[$strategy->value] = $strategy->getLabel();
+        }
+
+        return $strategies;
+    }
+}

--- a/src/Form/AccessControl/ControlType/AllowList.php
+++ b/src/Form/AccessControl/ControlType/AllowList.php
@@ -35,6 +35,7 @@
 
 namespace Glpi\Form\AccessControl\ControlType;
 
+use Glpi\Form\AccessControl\FormAccessControl;
 use Glpi\Form\AccessControl\FormAccessParameters;
 use JsonConfigInterface;
 use Glpi\Application\View\TemplateRenderer;
@@ -65,15 +66,17 @@ final class AllowList implements ControlTypeInterface
     }
 
     #[Override]
-    public function renderConfigForm(JsonConfigInterface $config): string
+    public function renderConfigForm(FormAccessControl $access_control): string
     {
+        $config = $access_control->getConfig();
         if (!$config instanceof AllowListConfig) {
             throw new \InvalidArgumentException("Invalid config class");
         }
 
         $twig = TemplateRenderer::getInstance();
         return $twig->render("pages/admin/form/access_control/allow_list.html.twig", [
-            'config' => $config,
+            'access_control' => $access_control,
+            'config'         => $config,
         ]);
     }
 

--- a/src/Form/AccessControl/ControlType/ControlTypeInterface.php
+++ b/src/Form/AccessControl/ControlType/ControlTypeInterface.php
@@ -35,6 +35,7 @@
 
 namespace Glpi\Form\AccessControl\ControlType;
 
+use Glpi\Form\AccessControl\FormAccessControl;
 use Glpi\Form\AccessControl\FormAccessParameters;
 use JsonConfigInterface;
 
@@ -64,11 +65,11 @@ interface ControlTypeInterface
     /**
      * Render the configuration form of this control type.
      *
-     * @param JsonConfigInterface $config
+     * @param FormAccessControl $access_control
      *
      * @return string Rendered content
      */
-    public function renderConfigForm(JsonConfigInterface $config): string;
+    public function renderConfigForm(FormAccessControl $access_control): string;
 
     /**
      * Get weight of this control type (used to sort controls types).

--- a/src/Form/AccessControl/ControlType/DirectAccess.php
+++ b/src/Form/AccessControl/ControlType/DirectAccess.php
@@ -35,6 +35,7 @@
 
 namespace Glpi\Form\AccessControl\ControlType;
 
+use Glpi\Form\AccessControl\FormAccessControl;
 use Glpi\Form\AccessControl\FormAccessParameters;
 use JsonConfigInterface;
 use Glpi\Application\View\TemplateRenderer;
@@ -62,11 +63,12 @@ final class DirectAccess implements ControlTypeInterface
     }
 
     #[Override]
-    public function renderConfigForm(JsonConfigInterface $config): string
+    public function renderConfigForm(FormAccessControl $access_control): string
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
+        $config = $access_control->getConfig();
         if (!$config instanceof DirectAccessConfig) {
             throw new \InvalidArgumentException("Invalid config class");
         }
@@ -81,8 +83,9 @@ final class DirectAccess implements ControlTypeInterface
 
         $twig = TemplateRenderer::getInstance();
         return $twig->render("pages/admin/form/access_control/direct_access.html.twig", [
-            'config' => $config,
-            'url'    => $url,
+            'access_control' => $access_control,
+            'config'         => $config,
+            'url'            => $url,
         ]);
     }
 

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -335,7 +335,7 @@ final class Form extends CommonDBTM
         $strategy = AccessDecisionStrategy::tryFrom(
             $this->fields['access_decision_strategy']
         );
-        return $strategy ?? AccessDecisionStrategy::Unanimous;
+        return $strategy ?? AccessDecisionStrategy::Affirmative;
     }
 
     /**

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -38,6 +38,7 @@ namespace Glpi\Form;
 use CommonDBTM;
 use Entity;
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Form\AccessControl\AccessDecisionStrategy;
 use Glpi\Form\AccessControl\ControlType\ControlTypeInterface;
 use Glpi\Form\AccessControl\FormAccessControl;
 use Glpi\Form\Destination\FormDestination;
@@ -306,6 +307,8 @@ final class Form extends CommonDBTM
      */
     public function getAccessControls(): array
     {
+        // TODO: add lazy loading to prevent getting this content multiple times
+
         $controls = [];
         $raw_controls = (new FormAccessControl())->find([
             Form::getForeignKeyField() => $this->getID(),
@@ -325,6 +328,14 @@ final class Form extends CommonDBTM
         }
 
         return $controls;
+    }
+
+    public function getAccessDecisionStrategy(): AccessDecisionStrategy
+    {
+        $strategy = AccessDecisionStrategy::tryFrom(
+            $this->fields['access_decision_strategy']
+        );
+        return $strategy ?? AccessDecisionStrategy::Unanimous;
     }
 
     /**

--- a/templates/pages/admin/form/access_control.html.twig
+++ b/templates/pages/admin/form/access_control.html.twig
@@ -33,80 +33,101 @@
 
 {# @var \Glpi\Form\Form form #}
 {# @var \Glpi\Form\AccessControl\FormAccessControl[] access_controls #}
+{# @var string[] warnings #}
+{# @var array access_decision_strategies #}
+
+{% import 'components/form/fields_macros.html.twig' as fields %}
 
 <div class="py-2 px-3">
     <div class="col-12 col-lg-6">
-        {% set is_form_disabled = not form.fields.is_active == true %}
-        {% set are_all_controls_disabled = access_controls|filter(control => control.fields.is_active == true)|length == 0 %}
-
-        {# Display warning/info if the form is disabled or has no active access control policies #}
-        <div class="{{ is_form_disabled or are_all_controls_disabled ? "mb-5" : "" }}">
-            {% if is_form_disabled %}
-                <div class="alert alert-warning d-flex align-items-center" role="alert">
-                    <i class="ti ti-alert-triangle me-2"></i>
-                    {{ __("This form is not visible to anyone because it is not active.") }}
-                </div>
-            {% endif %}
-            {% if are_all_controls_disabled %}
-                <div class="alert alert-warning d-flex align-items-center" role="alert">
-                    <i class="ti ti-alert-triangle me-2"></i>
-                    {{ __("This form will not be visible to any users as they are currently no active access policies.") }}
-                </div>
-            {% endif %}
-        </div>
-
-        {# Display each access control policies #}
-        {% for access_control in access_controls %}
-            {% set strategy = access_control.getStrategy() %}
-            {% set config = access_control.getConfig() %}
-
-            {# One form per policy as it is an individual item in the database #}
-            <form
-                method="POST"
-                action="{{ path('/ajax/form/access_control.form.php') }}"
-                data-glpi-acess-control-form
-                data-track-changes="true"
-                data-glpi-submitted-by="access-controls"
-                data-submit-once="true"
-            >
-                <div
-                    class="mb-5"
-                >
-                    <div
-                        {# Disabled item are showed with a lower opacity #}
-                        style="{{ access_control.fields.is_active == false ? "opacity: 0.5" : "" }}"
-                        data-glpi-toggle-control-target
-                    >
-                        <h3 class="d-flex align-items-center">
-                            <i class="{{ strategy.getIcon() }} me-2"></i>
-                            {{ strategy.getLabel() }}
-                            <label class="form-check mb-0 ms-auto form-switch">
-                                <input type="hidden" value="0" name="is_active">
-                                <input
-                                    data-glpi-toggle-control
-                                    class="form-check-input"
-                                    type="checkbox"
-                                    name="is_active"
-                                    value="1"
-                                    {{ access_control.fields.is_active == true ? "checked" : "" }}
-                                >
-                            </label>
-                        </h3>
-                        <div>
-                            {# Render custom config form #}
-                            {{ strategy.renderConfigForm(config)|raw }}
+        <form
+            method="POST"
+            action="{{ path('/front/form/access_control.form.php') }}"
+            data-track-changes="true"
+            data-submit-once="true"
+        >
+            {# Display warnings at the top of the tab #}
+            {% if warnings|length > 0 %}
+                <div class="mb-5">
+                    {% for warning in warnings %}
+                        <div
+                            class="alert alert-warning d-flex align-items-center"
+                            role="alert"
+                        >
+                            <i class="ti ti-alert-triangle me-2"></i>
+                            {{ warning }}
                         </div>
-                    </div>
-
-                    {# Hidden inputs #}
-                    <input type="hidden" name="id" value="{{ access_control.fields.id }}"/>
+                    {% endfor %}
                 </div>
-            </form>
-        {% endfor %}
+            {% endif %}
 
-        {% if form.canUpdate() and form.canUpdateItem() %}
-            {#  Dummy form wrapper to trigger the `data-submit-once` process #}
-            <form data-submit-once>
+            {# Display the main configuration form which will update the
+               \Glpi\Form\Form form object itself #}
+            <h2 class="d-flex align-items-center mb-2">
+                <i class="ti ti-key me-2"></i>
+                {{ __("Access control configuration") }}
+            </h2>
+
+            {{ fields.dropdownArrayField(
+                'access_decision_strategy',
+                form.fields.access_decision_strategy,
+                access_decision_strategies,
+                __('Access strategy'),
+                {
+                    'is_horizontal': false,
+                    'helper': __("%s\n\n %s")|format(
+                        __("Affirmative: access to the form will be granted if at least one access policy is validated."),
+                        __("Unanimous: access to the form will be granted if all access policies are validated."),
+                    )
+                }
+            ) }}
+
+            <div class="hr-text">
+                <i class="ti ti-user-circle"></i>
+                <span>{{ __("Access policies") }}</span>
+            </div>
+
+            {# Display each access control policies #}
+            {% for access_control in access_controls %}
+                {% set strategy = access_control.getStrategy() %}
+                {% set config = access_control.getConfig() %}
+
+                <section
+                    class="mb-5"
+                    style="{{ access_control.fields.is_active == false ? "opacity: 0.5" : "" }}"
+                    {# Disabled item are showed with a lower opacity #}
+                    data-glpi-toggle-control-target
+                    data-glpi-access-control-form
+                    aria-label="{{ strategy.getLabel() }}"
+                >
+                    <h3 class="d-flex align-items-center">
+                        <i class="{{ strategy.getIcon() }} me-2"></i>
+                        {{ strategy.getLabel() }}
+                        <label class="form-check mb-0 ms-auto form-switch">
+                            <input
+                                type="hidden"
+                                value="0"
+                                name="{{ access_control.encodeInputName("is_active") }}"
+                            >
+                            <input
+                                aria-label="{{ __("Active") }}"
+                                data-glpi-toggle-control
+                                class="form-check-input"
+                                type="checkbox"
+                                name="{{ access_control.encodeInputName("is_active") }}"
+                                value="1"
+                                {{ access_control.fields.is_active == true ? "checked" : "" }}
+                            >
+                        </label>
+                    </h3>
+                    <div>
+                        {# Render custom config form #}
+                        {{ strategy.renderConfigForm(access_control)|raw }}
+                    </div>
+                </section>
+            {% endfor %}
+
+            {% if form.canUpdate() and form.canUpdateItem() %}
                 {# Submit button #}
                 <div class="d-flex flex-row-reverse">
                     {# This button will submit the others forms using a custom script #}
@@ -120,8 +141,11 @@
                         {{ __("Save changes") }}
                     </button>
                 </div>
-            </form>
-        {% endif %}
+            {% endif %}
+
+            <input type="hidden" name="id" value="{{ form.fields.id }}"/>
+            <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
+        </form>
     </div>
 </div>
 
@@ -134,44 +158,16 @@
     });
 
     // Toggle state if any input is modified
-    $("form[data-glpi-acess-control-form] :input").on("change", function(e) {
+    $("section[data-glpi-access-control-form] :input").on("change", function(e) {
         // Do not trigger on this is_active checkbox itself
-        if ($(this).prop("name") === "is_active") {
+        if ($(this).data("glpi-toggle-control") !== undefined) {
             return;
         }
 
-        $(this).closest("form").find("[data-glpi-toggle-control]").prop("checked", true);
-        $(this).closest("[data-glpi-toggle-control-target]")
-            .css("opacity", 1)
+        $(this).closest("section")
+            .find("[data-glpi-toggle-control]")
+            .prop("checked", true)
+            .trigger("change")
         ;
-    });
-
-    // Submit multiple forms.
-    // This is needed as each strategy is a dedicated item in the database.
-    $("[data-glpi-submit-id]").closest('form').on("submit", async function(e) {
-        e.preventDefault();
-
-        const submitted_forms = [];
-        const submit = $(this).find("[type=submit]");
-        const submit_id = submit.data("glpi-submit-id");
-
-        $(`[data-glpi-submitted-by="${submit_id}"]`).each(function() {
-            const form = $(this);
-
-            // Get form data with the submit button value manually set.
-            const data = form.serializeArray();
-            data.push({'name': submit.prop("name"), 'value': true});
-
-            submitted_forms.push(
-                $.post({
-                    url: form.prop("action"),
-                    data: $.param(data),
-                })
-            );
-        });
-
-        await Promise.all(submitted_forms);
-        window.glpiUnsavedFormChanges = false;
-        location.reload();
     });
 </script>

--- a/templates/pages/admin/form/access_control/allow_list.html.twig
+++ b/templates/pages/admin/form/access_control/allow_list.html.twig
@@ -31,12 +31,13 @@
  # ---------------------------------------------------------------------
  #}
 
+{# @var \Glpi\Form\AccessControl\ControlType\FormAccessControl access_control #}
 {# @var \Glpi\Form\AccessControl\ControlType\AllowListConfig config #}
 
 {# Multi dropdown (User, Group and Profile) #}
 {{ call(
     "\\Glpi\\Form\\AccessControl\\ControlType\\AllowListDropdown::show",
-    ["_allow_list_dropdown", {
+    [access_control.encodeInputName("_allow_list_dropdown"), {
         'users_id'   : config.getUserIds(),
         'groups_id'  : config.getGroupIds(),
         'profiles_id': config.getProfileIds(),

--- a/templates/pages/admin/form/access_control/direct_access.html.twig
+++ b/templates/pages/admin/form/access_control/direct_access.html.twig
@@ -31,6 +31,7 @@
  # ---------------------------------------------------------------------
  #}
 
+{# @var \Glpi\Form\AccessControl\ControlType\FormAccessControl access_control #}
 {# @var \Glpi\Form\AccessControl\ControlType\DirectAccessConfig config #}
 {# @var string                                                  url #}
 
@@ -57,13 +58,13 @@
 <label class="form-check form-switch">
     <input
         class="form-check-input"
-        name="_allow_unauthenticated"
+        name="{{ access_control.encodeInputName("_allow_unauthenticated") }}"
         type="hidden"
         value="0"
     >
     <input
         class="form-check-input"
-        name="_allow_unauthenticated"
+        name="{{ access_control.encodeInputName("_allow_unauthenticated") }}"
         type="checkbox"
         value="1"
         {{ config.allowUnauthenticated() ? 'checked' : '' }}
@@ -81,4 +82,8 @@
     </span>
 </label>
 
-<input type="hidden" name="_token" value="{{ config.getToken() }}">
+<input
+    type="hidden"
+    {{ access_control.encodeInputName("_token") }}
+    value="{{ config.getToken() }}"
+>

--- a/tests/cypress/e2e/form/access_control.cy.js
+++ b/tests/cypress/e2e/form/access_control.cy.js
@@ -1,0 +1,148 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+describe('Access Control', () => {
+    beforeEach(() => {
+        cy.login();
+        cy.changeProfile('Super-Admin', true);
+
+        cy.createWithAPI('Glpi\\Form\\Form', {
+            'name': '[Tests] Access Control',
+        }).then((form_id) => {
+            const tab = 'Glpi\\Form\\AccessControl\\FormAccessControl$1';
+            cy.visit(`/front/form/form.form.php?id=${form_id}&forcetab=${tab}`);
+        });
+    });
+    it('warnings are displayed', () => {
+        // Quick tests to ensure that warnings are rendered correcly by twig.
+        // We don't check their exact content as it is already validated by unit tests.
+        cy.findAllByRole('alert').should('have.length', 2);
+    });
+    it('can configure the global access stategy', () => {
+        // Ensure the value we want to test is not already selected as it
+        // would make the test pointless
+        cy.findByLabelText("Access strategy ?")
+            .find('option:selected', {force: true})
+            .should('not.have.value', 'affirmative')
+        ;
+
+        // Update value and refresh page
+        cy.findByLabelText("Access strategy ?")
+            .select('affirmative', {force: true})
+        ;
+        cy.findByRole('button', {name: 'Save changes'}).click();
+        cy.findByRole('alert').should('contain.text', 'Item successfully updated');
+
+        // Check value again
+        cy.findByLabelText("Access strategy ?")
+            .find('option:selected', {force: true})
+            .should('have.value', 'affirmative')
+        ;
+    }),
+    it('can configure the allow list policy', () => {
+        cy.findByRole('region', {
+            name: 'Allow specifics users, groups or profiles'
+        }).within(() => {
+            cy.findByRole('checkbox', {name: 'Active'})
+                .should('not.be.checked')
+                .click()
+            ;
+        });
+
+        // TODO: modify the user/group/profile dropdown (unsure how to tests
+        // select2 ajax dropdown for now)
+
+        // Save changes
+        cy.findByRole('button', {name: 'Save changes'}).click();
+        cy.findByRole('alert').should('contain.text', 'Item successfully updated');
+
+        cy.findByRole('region', {
+            name: 'Allow specifics users, groups or profiles'
+        }).within(() => {
+            // Check values are kept after update
+            cy.findByRole('checkbox', {name: 'Active'}).should('be.checked');
+        });
+    });
+    it('can configure the direct access policy', () => {
+        cy.findByRole('region', {
+            name: 'Allow direct access'
+        }).within(() => {
+            cy.findByRole('checkbox', {name: 'Active'})
+                .should('not.be.checked')
+                .click()
+            ;
+            cy.findByRole('checkbox', {name: 'Allow unauthenticated users ?'})
+                .should('not.be.checked')
+                .click()
+            ;
+        });
+
+        // Save changes
+        cy.findByRole('button', {name: 'Save changes'}).click();
+        cy.findByRole('alert').should('contain.text', 'Item successfully updated');
+
+        cy.findByRole('region', {
+            name: 'Allow direct access'
+        }).within(() => {
+            // Check values are kept after update
+            cy.findByRole('checkbox', {name: 'Active'}).should('be.checked');
+            cy.findByRole('checkbox', {
+                name: 'Allow unauthenticated users ?'
+            }).should('be.checked');
+
+            // Make sure link can be copied to clipboard
+            cy.findByLabelText("Click to copy to clipboard").click();
+            cy.window().then((win) => {
+                win.navigator.clipboard.readText().then((text) => {
+                    expect(text).to.contains('token=');
+                });
+            });
+        });
+    });
+    it('activate policy when any input is modified', () => {
+        cy.findByRole('region', {
+            name: 'Allow direct access'
+        }).within(() => {
+            cy.findByRole('checkbox', {name: 'Active'})
+                .should('not.be.checked')
+            ;
+            cy.findByRole('checkbox', {name: 'Allow unauthenticated users ?'})
+                .should('not.be.checked')
+                .click()
+            ;
+            cy.findByRole('checkbox', {name: 'Active'})
+                .should('be.checked')
+            ;
+        });
+    });
+});

--- a/tests/cypress/e2e/form/access_control.cy.js
+++ b/tests/cypress/e2e/form/access_control.cy.js
@@ -53,12 +53,12 @@ describe('Access Control', () => {
         // would make the test pointless
         cy.findByLabelText("Access strategy ?")
             .find('option:selected', {force: true})
-            .should('not.have.value', 'affirmative')
+            .should('not.have.value', 'unanimous')
         ;
 
         // Update value and refresh page
         cy.findByLabelText("Access strategy ?")
-            .select('affirmative', {force: true})
+            .select('unanimous', {force: true})
         ;
         cy.findByRole('button', {name: 'Save changes'}).click();
         cy.findByRole('alert').should('contain.text', 'Item successfully updated');
@@ -66,7 +66,7 @@ describe('Access Control', () => {
         // Check value again
         cy.findByLabelText("Access strategy ?")
             .find('option:selected', {force: true})
-            .should('have.value', 'affirmative')
+            .should('have.value', 'unanimous')
         ;
     }),
     it('can configure the allow list policy', () => {

--- a/tests/src/FormBuilder.php
+++ b/tests/src/FormBuilder.php
@@ -109,7 +109,7 @@ class FormBuilder
         $this->sections = [];
         $this->destinations = [];
         $this->access_control = [];
-        $this->access_decision_strategy = AccessDecisionStrategy::Unanimous;
+        $this->access_decision_strategy = AccessDecisionStrategy::Affirmative;
     }
 
     /**

--- a/tests/src/FormBuilder.php
+++ b/tests/src/FormBuilder.php
@@ -35,6 +35,7 @@
 
 namespace Glpi\Tests;
 
+use Glpi\Form\AccessControl\AccessDecisionStrategy;
 use JsonConfigInterface;
 
 /**
@@ -88,6 +89,11 @@ class FormBuilder
     protected array $access_control;
 
     /**
+     * Form access decision strategy
+     */
+    protected AccessDecisionStrategy $access_decision_strategy;
+
+    /**
      * Constructor
      *
      * @param string $name Form name
@@ -103,6 +109,7 @@ class FormBuilder
         $this->sections = [];
         $this->destinations = [];
         $this->access_control = [];
+        $this->access_decision_strategy = AccessDecisionStrategy::Unanimous;
     }
 
     /**
@@ -369,5 +376,29 @@ class FormBuilder
     ): self {
         $this->access_control[$strategy] = $config;
         return $this;
+    }
+
+    /**
+     * Set form access decision strategy
+     *
+     * @param AccessDecisionStrategy $access_decision_strategy Form access decision strategy
+     *
+     * @return self To allow chain calls
+     */
+    public function setAccessDecisionStrategy(
+        AccessDecisionStrategy $access_decision_strategy
+    ): self {
+        $this->access_decision_strategy = $access_decision_strategy;
+        return $this;
+    }
+
+    /**
+     * Get form access decision strategy
+     *
+     * @return AccessDecisionStrategy Form access decision strategy
+     */
+    public function getAccessDecisionStrategy(): AccessDecisionStrategy
+    {
+        return $this->access_decision_strategy;
     }
 }

--- a/tests/src/FormTesterTrait.php
+++ b/tests/src/FormTesterTrait.php
@@ -60,13 +60,14 @@ trait FormTesterTrait
     {
         // Create form
         $form = $this->createItem(Form::class, [
-            'name'                  => $builder->getName(),
-            'entities_id'           => $builder->getEntitiesId(),
-            'is_recursive'          => $builder->getIsRecursive(),
-            'is_active'             => $builder->getIsActive(),
-            'header'                => $builder->getHeader(),
-            'is_draft'              => $builder->getIsDraft(),
-            '_do_not_init_sections' => true, // We will handle sections ourselves
+            'name'                     => $builder->getName(),
+            'entities_id'              => $builder->getEntitiesId(),
+            'is_recursive'             => $builder->getIsRecursive(),
+            'is_active'                => $builder->getIsActive(),
+            'header'                   => $builder->getHeader(),
+            'is_draft'                 => $builder->getIsDraft(),
+            'access_decision_strategy' => $builder->getAccessDecisionStrategy()->value,
+            '_do_not_init_sections'    => true,                         // We will handle sections ourselves
         ]);
 
         foreach ($builder->getSections() as $section_data) {

--- a/tests/units/Glpi/Form/AccessControl/AccessDecisionStrategy.php
+++ b/tests/units/Glpi/Form/AccessControl/AccessDecisionStrategy.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\AccessControl;
+
+final class AccessDecisionStrategy extends \GLPITestCase
+{
+    public function getDecisionProvider(): iterable
+    {
+        // Test the "Unanimous" strategy
+        yield 'Unanimous strategy with 3 "no" and 0 "yes" votes' => [
+            'strategy' => \Glpi\Form\AccessControl\AccessDecisionStrategy::Unanimous,
+            'votes'    => [false, false, false],
+            'expected' => false
+        ];
+        yield 'Unanimous strategy with 2 "no" and 1 "yes" votes' => [
+            'strategy' => \Glpi\Form\AccessControl\AccessDecisionStrategy::Unanimous,
+            'votes'    => [true, false, false],
+            'expected' => false
+        ];
+        yield 'Unanimous strategy with 1 "no" and 2 "yes" votes' => [
+            'strategy' => \Glpi\Form\AccessControl\AccessDecisionStrategy::Unanimous,
+            'votes'    => [true, true, false],
+            'expected' => false
+        ];
+        yield 'Unanimous strategy with 0 "no" and 3 "yes" votes' => [
+            'strategy' => \Glpi\Form\AccessControl\AccessDecisionStrategy::Unanimous,
+            'votes'    => [true, true, true],
+            'expected' => true
+        ];
+
+        // Test the "Affirmative" strategy
+        yield 'Affirmative strategy with 3 "no" and 0 "yes" votes' => [
+            'strategy' => \Glpi\Form\AccessControl\AccessDecisionStrategy::Affirmative,
+            'votes'    => [false, false, false],
+            'expected' => false
+        ];
+        yield 'Affirmative strategy with 2 "no" and 1 "yes" votes' => [
+            'strategy' => \Glpi\Form\AccessControl\AccessDecisionStrategy::Affirmative,
+            'votes'    => [true, false, false],
+            'expected' => true
+        ];
+        yield 'Affirmative strategy with 1 "no" and 2 "yes" votes' => [
+            'strategy' => \Glpi\Form\AccessControl\AccessDecisionStrategy::Affirmative,
+            'votes'    => [true, true, false],
+            'expected' => true
+        ];
+        yield 'Affirmative strategy with 0 "no" and 3 "yes" votes' => [
+            'strategy' => \Glpi\Form\AccessControl\AccessDecisionStrategy::Affirmative,
+            'votes'    => [true, true, true],
+            'expected' => true
+        ];
+    }
+
+    /**
+     * @dataProvider getDecisionProvider
+     */
+    public function testGetDecision(
+        \Glpi\Form\AccessControl\AccessDecisionStrategy $strategy,
+        array $votes,
+        bool $expected
+    ): void {
+        $this->boolean($strategy->getDecision($votes))->isEqualTo($expected);
+    }
+
+    public function testGetLabel(): void
+    {
+        // Not much to test here, just make sure the code run without error
+        // for all cases
+        $stategies = \Glpi\Form\AccessControl\AccessDecisionStrategy::cases();
+        foreach ($stategies as $strategy) {
+            $this->string($strategy->getLabel())->isNotEmpty();
+        }
+    }
+
+    public function testGetForDropdown(): void
+    {
+        $strategies = \Glpi\Form\AccessControl\AccessDecisionStrategy::getForDropdown();
+
+        foreach ($strategies as $strategy => $label) {
+            $this->string($label)->isNotEmpty();
+            $strategy = \Glpi\Form\AccessControl\AccessDecisionStrategy::tryFrom(
+                $strategy
+            );
+            $this->object($strategy)->isNotNull();
+        }
+    }
+}

--- a/tests/units/Glpi/Form/AccessControl/ControlType/AllowList.php
+++ b/tests/units/Glpi/Form/AccessControl/ControlType/AllowList.php
@@ -36,12 +36,16 @@
 namespace tests\units\Glpi\Form\AccessControl\ControlType;
 
 use Glpi\Form\AccessControl\FormAccessParameters;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
 use JsonConfigInterface;
 use Glpi\Form\AccessControl\ControlType\AllowListConfig;
 use Glpi\Session\SessionInfo;
 
-class AllowList extends \GLPITestCase
+class AllowList extends \DbTestCase
 {
+    use FormTesterTrait;
+
     /**
      * Test the `getLabel` method.
      *
@@ -100,14 +104,19 @@ class AllowList extends \GLPITestCase
 
         // We only validate that the function run without errors.
         // The rendered content should be validated by an E2E test.
-        $this->string($allow_list->renderConfigForm(new AllowListConfig()));
-        $this->string($allow_list->renderConfigForm(new AllowListConfig(
-            user_ids   : [1, 2, 3],
-            group_ids  : [4, 5, 6],
-            profile_ids: [7, 8, 9],
-        )));
+        $form = $this->createForm(
+            (new FormBuilder())
+                ->addAccessControl(
+                    \Glpi\Form\AccessControl\ControlType\AllowList::class,
+                    $this->getFullyConfiguredAllowListConfig()
+                )
+        );
+        $access_control = $this->getAccessControl(
+            $form,
+            \Glpi\Form\AccessControl\ControlType\AllowList::class
+        );
+        $this->string($allow_list->renderConfigForm($access_control));
     }
-
 
     /**
      * Test the `getWeight` method.
@@ -121,7 +130,6 @@ class AllowList extends \GLPITestCase
         // Not much to test here, just ensure the method run without errors
         $this->integer($allow_list->getWeight());
     }
-
 
     /**
      * Test the `createConfigFromUserInput` method.

--- a/tests/units/Glpi/Form/AccessControl/ControlType/DirectAccess.php
+++ b/tests/units/Glpi/Form/AccessControl/ControlType/DirectAccess.php
@@ -36,12 +36,16 @@
 namespace tests\units\Glpi\Form\AccessControl\ControlType;
 
 use Glpi\Form\AccessControl\FormAccessParameters;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
 use JsonConfigInterface;
 use Glpi\Form\AccessControl\ControlType\DirectAccessConfig;
 use Glpi\Session\SessionInfo;
 
-class DirectAccess extends \GLPITestCase
+class DirectAccess extends \DBTestCase
 {
+    use FormTesterTrait;
+
     /**
      * Test the `getLabel` method.
      *
@@ -105,11 +109,21 @@ class DirectAccess extends \GLPITestCase
 
         // We only validate that the function run without errors.
         // The rendered content should be validated by an E2E test.
-        $this->string($direct_access->renderConfigForm(new DirectAccessConfig()));
-        $this->string($direct_access->renderConfigForm(new DirectAccessConfig(
-            token: 'my token',
-            allow_unauthenticated: true,
-        )));
+        $form = $this->createForm(
+            (new FormBuilder())
+                ->addAccessControl(
+                    \Glpi\Form\AccessControl\ControlType\DirectAccess::class,
+                    new DirectAccessConfig(
+                        token: 'my token',
+                        allow_unauthenticated: true,
+                    )
+                )
+        );
+        $access_control = $this->getAccessControl(
+            $form,
+            \Glpi\Form\AccessControl\ControlType\DirectAccess::class
+        );
+        $this->string($direct_access->renderConfigForm($access_control));
     }
 
 

--- a/tests/units/Glpi/Form/AccessControl/FormAccessControl.php
+++ b/tests/units/Glpi/Form/AccessControl/FormAccessControl.php
@@ -530,4 +530,31 @@ class FormAccessControl extends DbTestCase
             ]))
         ;
     }
+
+    public function testEncodeInputName(): void
+    {
+        $form_access_control = new \Glpi\Form\AccessControl\FormAccessControl();
+        $form_access_control->fields = ['id' => 1];
+
+        $this->string($form_access_control->encodeInputName("test"))
+            ->isEqualTo("_access_control_1_test");
+    }
+
+    public function testSplitEncodedInputs(): void
+    {
+        $form_access_control = new \Glpi\Form\AccessControl\FormAccessControl();
+        $inputs = $form_access_control->splitEncodedInputs([
+            'id'                                => 1,
+            'is_active'                         => false,
+            '_access_control_2_is_active'       => true,
+            '_access_control_2_users_id'        => 4,
+            '_access_control_33_is_active'       => true,
+            '_access_control_33_allow_anonymous' => true,
+        ]);
+
+        $this->array($inputs)->isEqualTo([
+            ['id' => 2, 'is_active' => true, 'users_id'  => 4],
+            ['id' => 33, 'is_active' => true, 'allow_anonymous'  => true],
+        ]);
+    }
 }

--- a/tests/units/Glpi/Form/AccessControl/FormAccessControlManager.php
+++ b/tests/units/Glpi/Form/AccessControl/FormAccessControlManager.php
@@ -198,6 +198,10 @@ final class FormAccessControlManager extends DbTestCase
         $form = $this->getFormAccessibleOnlyToTechUserWithMandatoryToken();
 
         // Cases with an unanimous access decision strategy
+        $form = $this->setFormAccessDecisionStrategy(
+            $form,
+            AccessDecisionStrategy::Unanimous
+        );
         $this->setFormAccessDecisionStrategy(
             $form,
             AccessDecisionStrategy::Unanimous

--- a/tests/units/Glpi/Form/Form.php
+++ b/tests/units/Glpi/Form/Form.php
@@ -36,6 +36,7 @@
 namespace tests\units\Glpi\Form;
 
 use DbTestCase;
+use Glpi\Form\AccessControl\AccessDecisionStrategy;
 use Glpi\Form\AccessControl\ControlType\AllowList;
 use Glpi\Form\AccessControl\ControlType\AllowListConfig;
 use Glpi\Form\AccessControl\ControlType\DirectAccess;
@@ -970,6 +971,22 @@ class Form extends DbTestCase
         $this
             ->integer(countElementsInTable(FormAccessControl::getTable()))
             ->isEqualTo(1) // 1 (control)
+        ;
+    }
+
+    public function testGetAccessDecisionStrategy(): void
+    {
+        $form = $this->createForm(
+            (new FormBuilder())
+                ->setAccessDecisionStrategy(AccessDecisionStrategy::Affirmative)
+        );
+        $this
+            ->object($form->getAccessDecisionStrategy())
+            ->isInstanceOf(AccessDecisionStrategy::class)
+        ;
+        $this
+            ->string($form->getAccessDecisionStrategy()->value)
+            ->isEqualTo(AccessDecisionStrategy::Affirmative->value)
         ;
     }
 }


### PR DESCRIPTION
Allow forms policies to be computed in an affirmative/unanimous way.
(Suggested by @cedric-anne here: https://github.com/glpi-project/glpi/pull/16836).

![image](https://github.com/glpi-project/glpi/assets/42734840/55d7bc29-37d5-47e7-abfa-a9e15c3f46d4)

Possible values:

![image](https://github.com/glpi-project/glpi/assets/42734840/46b3d32c-098d-4566-9845-a480eaf597df)

Tooltip explaining the values:

![image](https://github.com/glpi-project/glpi/assets/42734840/697951c0-f6df-4c31-862a-2e105a48babc)

----

To implement this, I've had to rework the twig template containing the access control configuration forms as it was built to update only update policies and the new setting is store into the form object itself.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
