### PR TITLE
Fix(Core): fix TWIG template error

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -70,6 +70,7 @@ define("READ_ASSIGNED", 256);
 define("UPDATE_ASSIGNED", 512);
 define("READ_OWNED", 1024);
 define("UPDATE_OWNED", 2048);
+define("RECURSIVE", 4096);
 
 // set the default app_name
 $CFG_GLPI['app_name'] = 'GLPI';

--- a/inc/define.php
+++ b/inc/define.php
@@ -70,7 +70,6 @@ define("READ_ASSIGNED", 256);
 define("UPDATE_ASSIGNED", 512);
 define("READ_OWNED", 1024);
 define("UPDATE_OWNED", 2048);
-define("RECURSIVE", 4096);
 
 // set the default app_name
 $CFG_GLPI['app_name'] = 'GLPI';

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -2483,6 +2483,24 @@ class CommonDBTM extends CommonGLPI
     }
 
 
+    public function canRecurs()
+    {
+
+        if (
+            $this->isEntityAssign()
+            && $this->maybeRecursive()
+        ) {
+            if (
+                static::canCreate()
+                && Session::haveAccessToEntity($this->getEntityID())
+            ) {
+                // Can make recursive if recursive access to entity
+                return Session::haveRecursiveAccessToEntity($this->getEntityID());
+            }
+        }
+        return false;
+    }
+
     /**
      * Can I change recursive flag to false
      * check if there is "linked" object in another entity
@@ -2966,21 +2984,6 @@ class CommonDBTM extends CommonGLPI
                     return true;
                 }
                 return (static::canCreate() && $this->canCreateItem());
-
-            case RECURSIVE:
-                if (
-                    $this->isEntityAssign()
-                    && $this->maybeRecursive()
-                ) {
-                    if (
-                        static::canCreate()
-                        && Session::haveAccessToEntity($this->getEntityID())
-                    ) {
-                       // Can make recursive if recursive access to entity
-                        return Session::haveRecursiveAccessToEntity($this->getEntityID());
-                    }
-                }
-                break;
         }
         return false;
     }

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -2967,7 +2967,7 @@ class CommonDBTM extends CommonGLPI
                 }
                 return (static::canCreate() && $this->canCreateItem());
 
-            case 'recursive':
+            case RECURSIVE:
                 if (
                     $this->isEntityAssign()
                     && $this->maybeRecursive()

--- a/templates/components/form/header_content.html.twig
+++ b/templates/components/form/header_content.html.twig
@@ -145,7 +145,7 @@
                {% if item is instanceof('CommonDBChild') %}
                   {% set comment  = __('Can՛t change this attribute. It՛s inherited from its parent.') %}
                   {% set disabled = true %}
-               {% elseif not item.can(id, constant('UPDATE')) %}
+               {% elseif not item.can(id, constant('RECURSIVE')) %}
                   {% set comment  = __('You are not allowed to change the visibility flag for child entities.') %}
                   {% set disabled = true %}
                {% elseif not item.canUnrecurs() %}

--- a/templates/components/form/header_content.html.twig
+++ b/templates/components/form/header_content.html.twig
@@ -145,7 +145,7 @@
                {% if item is instanceof('CommonDBChild') %}
                   {% set comment  = __('Can՛t change this attribute. It՛s inherited from its parent.') %}
                   {% set disabled = true %}
-               {% elseif not item.can(id, 'recursive') %}
+               {% elseif not item.can(id, constant('UPDATE')) %}
                   {% set comment  = __('You are not allowed to change the visibility flag for child entities.') %}
                   {% set disabled = true %}
                {% elseif not item.canUnrecurs() %}

--- a/templates/components/form/header_content.html.twig
+++ b/templates/components/form/header_content.html.twig
@@ -145,7 +145,7 @@
                {% if item is instanceof('CommonDBChild') %}
                   {% set comment  = __('Can՛t change this attribute. It՛s inherited from its parent.') %}
                   {% set disabled = true %}
-               {% elseif not item.can(id, constant('RECURSIVE')) %}
+               {% elseif not item.canRecurs() %}
                   {% set comment  = __('You are not allowed to change the visibility flag for child entities.') %}
                   {% set disabled = true %}
                {% elseif not item.canUnrecurs() %}


### PR DESCRIPTION
Since https://github.com/glpi-project/glpi/pull/11968

An error occurs when trying to display an asset (assigned to the root entity and recursively) from a sub-entity

![image](https://github.com/glpi-project/glpi/assets/7335054/7b4d37b9-86ae-4615-8cf3-891f7c89102c)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
