### PR TITLE
Fix merged ticket responses not being added to parent ticket

### DIFF
--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -728,7 +728,26 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         // Assign technician to main item  from task
         self::assignTechFromtask($this->input);
 
+        if ($this->input["_job"]->getType() == 'Ticket') {
+            self::addToMergedTickets();
+        }
+
         parent::post_addItem();
+    }
+
+    private function addToMergedTickets(): void
+    {
+        $merged = Ticket::getMergedTickets($this->fields['tickets_id']);
+        foreach ($merged as $ticket_id) {
+            $input = $this->fields;
+            $input['tickets_id'] = $ticket_id;
+            $input['sourceitems_id'] = $this->fields['tickets_id'];
+            unset($input['id']);
+            $input['uuid'] = \Ramsey\Uuid\Uuid::uuid4();
+
+            $task = new static();
+            $task->add($input);
+        }
     }
 
     public function post_getEmpty()

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -214,7 +214,22 @@ class Document_Item extends CommonDBRelation
 
             $ticket->update($input);
         }
+
+        self::addToMergedTickets();
+
         parent::post_addItem();
+    }
+
+    private function addToMergedTickets(): void
+    {
+        $merged = Ticket::getMergedTickets($this->fields['items_id']);
+        foreach ($merged as $ticket_id) {
+            $input = $this->input;
+            $input['items_id'] = $ticket_id;
+
+            $document = new self();
+            $document->add($input);
+        }
     }
 
     public function post_purgeItem()

--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -308,7 +308,22 @@ class ITILFollowup extends CommonDBChild
             Log::HISTORY_ADD_SUBITEM
         );
 
+        self::addToMergedTickets();
+
         parent::post_addItem();
+    }
+
+    private function addToMergedTickets(): void
+    {
+        $merged = Ticket::getMergedTickets($this->fields['items_id']);
+        foreach ($merged as $ticket_id) {
+            $input = $this->input;
+            $input['items_id'] = $ticket_id;
+            $input['sourceitems_id'] = $this->fields['items_id'];
+
+            $followup = new self();
+            $followup->add($input);
+        }
     }
 
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -6198,6 +6198,39 @@ JAVASCRIPT;
         return true;
     }
 
+    /**
+     * Get the list of tickets in which the ticket has been merged
+     *
+     * @param int $id The ID of the ticket
+     *
+     * @return array The list of tickets that have ticket with ID $id as son
+     */
+    public static function getMergedTickets(int $id): array
+    {
+        /**
+         * @var \DBmysql $DB
+         */
+        global $DB;
+
+        //look for merged tickets
+        $merged = [];
+        $iterator = $DB->request(
+            [
+                'FROM' => Ticket_Ticket::getTable(),
+                'SELECT' => ['tickets_id_2'],
+                'DISTINCT' => true,
+                'WHERE' => [
+                    'tickets_id_1' => $id,
+                    'link'        => Ticket_Ticket::SON_OF
+                ]
+            ]
+        );
+        foreach ($iterator as $data) {
+            $merged[] = $data['tickets_id_2'];
+        }
+        return $merged;
+    }
+
 
     /**
      * Check profiles and detect where criteria from existing rights


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !32514

### Description

When merging a **C**hild **ticket C** into a **P**arent **ticket P**, the following issues were observed:

1. **Merging Process:**
   - The content of **ticket C** is successfully added to **ticket P**.
   - The status of **ticket C** is set to "deleted".

2. **Post-Merge Responses:**
   - Responses posted to **ticket C** (now merged and deleted) are correctly added and visible.
   - Responses sent to **ticket C** are not added to **ticket P**. Instead, they remain visible in **ticket C**, which is no longer tracked due to its deleted status. However, they should be present in the parent ticket.

### Resolution
To solve this problem, a post-add response step has been added, which detects parent tickets (if the ticket in question is a merged ticket) and then duplicates the tracking in the parent ticket.