### PR TITLE
Forms: add tag manager class; insert tag content into the generated tickets

### DIFF
--- a/js/RichText/FormTags.js
+++ b/js/RichText/FormTags.js
@@ -81,26 +81,17 @@ GLPI.RichText.FormTags = class
         const data = await $.get(url);
 
         return data.map((tag) => ({
+            // The `tag` variable is a json encoded instance of Glpi\Form\Tag\Tag
             type: 'autocompleteitem',
-            value: JSON.stringify(tag),
+            value: tag.html,
             text: tag.label,
         }));
     }
 
     #insertTag(autocompleteApi, range, value) {
         this.#editor.selection.setRng(range);
-        this.#editor.insertContent(this.#generateTagHtml(value));
+        this.#editor.insertContent(value + "&nbsp;");
 
         autocompleteApi.hide();
-    }
-
-    #generateTagHtml(value) {
-        const tag = JSON.parse(value);
-        return `
-            <span
-                contenteditable="false"
-                data-form-tag="true"
-            >${tag.label}</span>&nbsp;
-        `;
     }
 };

--- a/src/Form/Destination/CommonITILField/ContentField.php
+++ b/src/Form/Destination/CommonITILField/ContentField.php
@@ -37,6 +37,7 @@ namespace Glpi\Form\Destination\CommonITILField;
 
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Form\Destination\ConfigFieldInterface;
+use Glpi\Form\Tag\FormTagsManager;
 use Override;
 
 class ContentField implements ConfigFieldInterface
@@ -91,7 +92,8 @@ TWIG;
             return $input;
         }
 
-        $input['content'] = $config['value'];
+        $tag_manager = new FormTagsManager();
+        $input['content'] = $tag_manager->insertTagsContent($config['value']);
 
         return $input;
     }

--- a/src/Form/Tag/FormTagsManager.php
+++ b/src/Form/Tag/FormTagsManager.php
@@ -49,7 +49,7 @@ final class FormTagsManager
     public function insertTagsContent(string $content): string
     {
         return preg_replace_callback(
-            '/<span[\S\s]*?data-form-tag[\S\s]*?>[\S\s]*?<\/span>/m',
+            '/<span[\S\s]*?data-form-tag="true"[\S\s]*?>[\S\s]*?<\/span>/m',
             function ($match) {
                 $tag = $match[0];
 

--- a/src/Form/Tag/FormTagsManager.php
+++ b/src/Form/Tag/FormTagsManager.php
@@ -49,7 +49,7 @@ final class FormTagsManager
     public function insertTagsContent(string $content): string
     {
         return preg_replace_callback(
-            '/<span[\S\s]*?data-form-tag="true"[\S\s]*?>[\S\s]*?<\/span>/m',
+            '/<span.*?data-form-tag="true".*?>.*?<\/span>/',
             function ($match) {
                 $tag = $match[0];
 

--- a/src/Form/Tag/FormTagsManager.php
+++ b/src/Form/Tag/FormTagsManager.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Tag;
+
+final class FormTagsManager
+{
+    public function getTags(): array
+    {
+        return [
+            new Tag(label: "Exemple tag 1", value: "exemple-tag-1"),
+            new Tag(label: "Exemple tag 2", value: "exemple-tag-2"),
+            new Tag(label: "Exemple tag 3", value: "exemple-tag-3"),
+        ];
+    }
+
+    public function insertTagsContent(string $content): string
+    {
+        return preg_replace_callback(
+            '/<span[\S\s]*?data-form-tag[\S\s]*?>[\S\s]*?<\/span>/m',
+            function ($match) {
+                $tag = $match[0];
+
+                // Extract  value.
+                preg_match('/data-form-tag-value="([^"]+)"/', $tag, $value_match);
+                if (empty($value_match)) {
+                    return "";
+                }
+
+                // For now, we return the raw value.
+                // In futures improvements, the value will be an id and we will
+                // need to call some kind of object here to transform the id into
+                // the right string value (for exemple, transforming a question
+                // id into its name).
+                return $value_match[1];
+            },
+            $content
+        );
+    }
+}

--- a/src/Form/Tag/Tag.php
+++ b/src/Form/Tag/Tag.php
@@ -33,15 +33,34 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\Form\Form;
-use Glpi\Form\Tag\FormTagsManager;
+namespace Glpi\Form\Tag;
 
-include('../../inc/includes.php');
+/**
+ * Simple data structure that will be json_encoded and sent to the
+ * GLPI.RichText.FormTags component.
+ */
+final readonly class Tag
+{
+    public string $label;
+    public string $html;
 
-// The user must be able to respond to forms.
-Session::checkRight(Form::$rightname, UPDATE);
+    public function __construct(
+        string $label,
+        string $value,
+    ) {
+        $this->label = $label;
 
-// Get tags
-$tag_manager = new FormTagsManager();
-header('Content-Type: application/json');
-echo json_encode($tag_manager->getTags());
+        // Build HTML representation of the tag.
+        $properties = [
+            "contenteditable"     => "false",
+            "data-form-tag"       => "true",
+            "data-form-tag-value" => $value,
+        ];
+        $properties = implode(" ", array_map(
+            fn($key, $value) => "$key=\"$value\"",
+            array_keys($properties),
+            array_values($properties),
+        ));
+        $this->html = "<span $properties>$label</span>";
+    }
+}

--- a/src/Form/Tag/Tag.php
+++ b/src/Form/Tag/Tag.php
@@ -57,10 +57,10 @@ final readonly class Tag
             "data-form-tag-value" => $value,
         ];
         $properties = implode(" ", array_map(
-            fn($key, $value) => "$key=\"$value\"",
+            fn($key, $value) => sprintf('%s="%s"', htmlspecialchars($key), htmlspecialchars($value)),
             array_keys($properties),
             array_values($properties),
         ));
-        $this->html = "<span $properties>$label</span>";
+        $this->html = sprintf('<span %s>%s</span>', $properties, htmlspecialchars($label));
     }
 }

--- a/src/RichText/RichText.php
+++ b/src/RichText/RichText.php
@@ -592,6 +592,7 @@ JAVASCRIPT;
             'data-user-mention',
             'data-user-id',
             'data-form-tag',
+            'data-form-tag-value',
         ];
         foreach ($rich_text_completion_attributes as $attribute) {
             $config = $config->allowAttribute($attribute, 'span');

--- a/tests/cypress/e2e/form_tags.cy.js
+++ b/tests/cypress/e2e/form_tags.cy.js
@@ -76,6 +76,7 @@ describe('Form tags', () => {
             .findByText("Exemple tag 3")
             .should('have.attr', 'contenteditable', 'false')
             .should('have.attr', 'data-form-tag', 'true')
+            .should('have.attr', 'data-form-tag-value', 'exemple-tag-3')
         ;
 
         // Save form
@@ -86,6 +87,7 @@ describe('Form tags', () => {
             .findByText("Exemple tag 3")
             .should('have.attr', 'contenteditable', 'false')
             .should('have.attr', 'data-form-tag', 'true')
+            .should('have.attr', 'data-form-tag-value', 'exemple-tag-3')
         ;
     });
 });

--- a/tests/units/Glpi/Form/Destination/FormDestinationTicket.php
+++ b/tests/units/Glpi/Form/Destination/FormDestinationTicket.php
@@ -36,7 +36,9 @@
 namespace tests\units\Glpi\Form\Destination;
 
 use Glpi\Form\AnswersHandler\AnswersHandler;
+use Glpi\Form\Form;
 use Glpi\Form\QuestionType\QuestionTypeShortText;
+use Glpi\Form\Tag\Tag;
 use Glpi\Tests\Form\Destination\AbstractFormDestinationType;
 use Glpi\Tests\FormBuilder;
 use Glpi\Tests\FormTesterTrait;
@@ -61,6 +63,10 @@ class FormDestinationTicket extends AbstractFormDestinationType
         $answers_handler = AnswersHandler::getInstance();
 
         // Create a form with a single FormDestinationTicket destination
+        $tag = new Tag(
+            label: "Exemple tag 3",
+            value: "exemple-tag-3"
+        );
         $form = $this->createForm(
             (new FormBuilder("Test form 1"))
                 ->addQuestion("Name", QuestionTypeShortText::class)
@@ -69,7 +75,7 @@ class FormDestinationTicket extends AbstractFormDestinationType
                     'test',
                     [
                         'title'   => ['value' => 'Ticket title'],
-                        'content' => ['value' => 'Ticket content'],
+                        'content' => ['value' => "Ticket content: $tag->html"],
                     ]
                 )
         );
@@ -87,7 +93,9 @@ class FormDestinationTicket extends AbstractFormDestinationType
 
         // Check fields
         $ticket = current($tickets);
-        $this->string($ticket['content'])->isEqualTo('Ticket content');
+        $this->string($ticket['content'])
+            ->isEqualTo('Ticket content: exemple-tag-3')
+        ;
 
         // Make sure link with the form answers was created too
         $ticket = array_pop($tickets);

--- a/tests/units/Glpi/Form/Tag/FormTagsManager.php
+++ b/tests/units/Glpi/Form/Tag/FormTagsManager.php
@@ -33,15 +33,37 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\Form\Form;
-use Glpi\Form\Tag\FormTagsManager;
+namespace tests\units\Glpi\Form\Tag;
 
-include('../../inc/includes.php');
+use GLPITestCase;
+use Glpi\Form\Tag\Tag;
 
-// The user must be able to respond to forms.
-Session::checkRight(Form::$rightname, UPDATE);
+final class FormTagsManager extends GLPITestCase
+{
+    public function testGetTags()
+    {
+        $tag_manager = new \Glpi\Form\Tag\FormTagsManager();
+        $tags = $tag_manager->getTags();
+        $this->array($tags)->isNotEmpty();
 
-// Get tags
-$tag_manager = new FormTagsManager();
-header('Content-Type: application/json');
-echo json_encode($tag_manager->getTags());
+        foreach ($tags as $tag) {
+            $this->object($tag)->isInstanceOf(Tag::class);
+        }
+    }
+
+    public function testInsertTagsContent()
+    {
+        $tag_manager = new \Glpi\Form\Tag\FormTagsManager();
+        $tag_1 = new Tag(label: "Exemple tag 1", value: "exemple-tag-1");
+        $tag_2 = new Tag(label: "Exemple tag 2", value: "exemple-tag-2");
+        $tag_3 = new Tag(label: "Exemple tag 3", value: "exemple-tag-3");
+
+        $content_with_tag =
+            "My content: $tag_1->html, $tag_2->html and $tag_3->html"
+        ;
+        $computed_content = $tag_manager->insertTagsContent($content_with_tag);
+        $this->string($computed_content)->isEqualTo(
+            'My content: exemple-tag-1, exemple-tag-2 and exemple-tag-3'
+        );
+    }
+}

--- a/tests/units/Glpi/Form/Tag/Tag.php
+++ b/tests/units/Glpi/Form/Tag/Tag.php
@@ -33,15 +33,23 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\Form\Form;
-use Glpi\Form\Tag\FormTagsManager;
+namespace tests\units\Glpi\Form\Tag;
 
-include('../../inc/includes.php');
+use GLPITestCase;
 
-// The user must be able to respond to forms.
-Session::checkRight(Form::$rightname, UPDATE);
-
-// Get tags
-$tag_manager = new FormTagsManager();
-header('Content-Type: application/json');
-echo json_encode($tag_manager->getTags());
+final class Tag extends GLPITestCase
+{
+    public function testTagCanBeExportedToJson(): void
+    {
+        $tag = new \Glpi\Form\Tag\Tag(
+            label: 'Example tag',
+            value: 'example-tag',
+        );
+        $this->string(json_encode($tag))->isEqualTo(
+            json_encode([
+                'label' => 'Example tag',
+                'html' => '<span contenteditable="false" data-form-tag="true" data-form-tag-value="example-tag">Example tag</span>'
+            ])
+        );
+    }
+}

--- a/tests/units/Glpi/RichText/RichText.php
+++ b/tests/units/Glpi/RichText/RichText.php
@@ -397,6 +397,11 @@ HTML,
             'encode_output_entities' => false,
             'expected_result' => '<span data-form-tag="true">Tag label</span>',
         ];
+        yield 'Do not remove data-form-tag-value property' => [
+            'content' => '<span data-form-tag-value="my-value">Tag label</span>',
+            'encode_output_entities' => false,
+            'expected_result' => '<span data-form-tag-value="my-value">Tag label</span>',
+        ];
     }
 
     /**


### PR DESCRIPTION
* Add a new `FormTagManager` class that will serve as a facade for tag related operations.
* A value can now be defined for a tag, it will be directly inserted into the content after the form is submitted (see exemple at the end)
* Moved tag html generation to the backend. This is better for tests as they can access the actual html implementation by calling `(new Tag(xxx))->html` instead of manually generating the `<span ....>` raw content.
This also mean that we are 100% sure that the content used for the tests is the real content that will be rendered on the htmlpage.

---

Tag value exemple, using this form configuration:

![image](https://github.com/glpi-project/glpi/assets/42734840/7c4d7490-fe7b-4204-9b98-725129b07ba9)

Created ticket:
![image](https://github.com/glpi-project/glpi/assets/42734840/58e8a0dd-1dfa-4640-a0ec-13e7f92119ec)

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
