### PR TITLE
Fix pager and limit for non-form pages

### DIFF
--- a/templates/components/dropdown/limit.html.twig
+++ b/templates/components/dropdown/limit.html.twig
@@ -40,7 +40,8 @@
 {% endif %}
 
 {% if not no_onchange %}
-   {% set href = "location.href='" ~ href ~ "glpilist_limit='+this.value+'" ~ additional_params ~ "'" %}
+   {% set href_separator = '?' in href ? '&' : '?' %}
+   {% set href = "location.href='" ~ href ~ href_separator ~ "glpilist_limit='+this.value+'" ~ additional_params ~ "'" %}
    {% if is_tab is defined and is_tab == true %}
       {% set href = "javascript:reloadTab('glpilist_limit='+this.value+'" ~ additional_params ~ "');" %}
    {% endif %}

--- a/templates/components/pager.html.twig
+++ b/templates/components/pager.html.twig
@@ -39,7 +39,8 @@
     {% endif %}
 {% endif %}
 
-{% set href = href ~ "&start=%start%" ~ additional_params %}
+{% set href_separator = '?' in href ? '&' : '?' %}
+{% set href = href ~ href_separator ~ "start=%start%" ~ additional_params %}
 {% if is_tab is defined and is_tab == true %}
    {% set href = "javascript:reloadTab('start=%start%" ~ additional_params ~ "');" %}
 {% endif %}
@@ -71,6 +72,7 @@
     {% set limitdropdown = include('components/dropdown/limit.html.twig', {
         'no_onchange': fluid_search|default(false),
         'select_class': 'search-limit-dropdown',
+        'href': href|replace({'%start%': start}),
     }) %}
     <span class="search-limit d-none d-md-block">
         {{ __('%s rows / page')|format(limitdropdown)|raw }}

--- a/templates/pages/admin/events_list.html.twig
+++ b/templates/pages/admin/events_list.html.twig
@@ -43,7 +43,7 @@
                <div class="card-header search-header pe-0">
                   {% if count > 0 %}
                      {% set limitdropdown = include('components/dropdown/limit.html.twig', {
-                        'href': target ~ '?',
+                        'href': target,
                         'additional_params': 'sort=' ~ sort ~ '&order=' ~ order
                      }) %}
                      <div class="ms-auto d-inline-flex align-items-center d-none d-md-block search-limit">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Passing href from pager to limit dropdown was broken because of a non-replaced placeholder.
Passing href to limit directly required manually putting a `?` or `&` at the end of the URL.