### PR TITLE
Form: add e2e tests handling question creation

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,7 @@
+{
+    "include": [
+        "./node_modules/cypress",
+        "tests/cypress/**/*.d.ts",
+        "tests/cypress/**/*.js"
+    ]
+}

--- a/templates/pages/admin/form/form_question.html.twig
+++ b/templates/pages/admin/form/form_question.html.twig
@@ -50,10 +50,11 @@
     class="mb-3"
     data-glpi-form-editor-question
 >
-    <div
+    <section
         data-glpi-form-editor-on-click="set-active"
         data-glpi-form-editor-question-details
         class="card {{ question is not null and question.fields.is_mandatory ? 'mandatory-question' : '' }}"
+        aria-label="{{ __("Question details") }}"
     >
         <div
             class="card-status-start bg-primary"
@@ -70,6 +71,7 @@
             {# Display question's title #}
             <div class="d-flex mt-n1 align-items-center">
                 <input
+                    title="{{ __("Question name") }}"
                     class="form-control content-editable-h2 mb-0"
                     type="text"
                     name="name"
@@ -111,6 +113,7 @@
                     __('Description'),
                     base_field_options|merge({
                         'placeholder': __('Add a description...'),
+                        'aria_label': __("Question description"),
                         'enable_richtext': true,
                         'add_body_classes': ['content-editable-tinymce-editor', 'text-muted'],
                         'editor_height': "0",
@@ -221,7 +224,7 @@
             name="rank"
             value="{{ question is not null ? question.fields.rank : 0 }}"
         />
-    </div>
+    </section>
     <div data-glpi-form-editor-question-extra-details>
         {{ include('pages/admin/form/form_toolbar.html.twig', {
             'can_update': can_update,

--- a/templates/pages/admin/form/form_toolbar.html.twig
+++ b/templates/pages/admin/form/form_toolbar.html.twig
@@ -41,8 +41,7 @@
         role="group"
     >
         {# Add question action #}
-        <label
-            for="btn-radio-toolbar-1"
+        <button
             class="btn btn-icon flex-grow-0"
             data-bs-toggle="tooltip"
             data-bs-placement="bottom"
@@ -52,12 +51,11 @@
             <span class="px-2 d-flex align-items-center">
                 <i class="ti ti-circle-plus"></i>
             </span>
-        </label>
+        </button>
 
         {# Add section action #}
         {% set add_section_action_visible = form.getSections()|length > 1 or (form.getSections()|first).getQuestions()|length > 0 %}
-        <label
-            for="btn-radio-toolbar-1"
+        <button
             class="btn btn-icon flex-grow-0 {{ add_section_action_visible ? '' : 'd-none' }}"
             data-bs-toggle="tooltip"
             data-bs-placement="bottom"
@@ -65,6 +63,6 @@
             data-glpi-form-editor-on-click="add-section"
         >
             <i class="ti ti-box-align-top"></i>
-        </label>
+        </button>
     </div>
 {% endif %}

--- a/tests/cypress/e2e/form/form_editor.cy.js
+++ b/tests/cypress/e2e/form/form_editor.cy.js
@@ -65,9 +65,52 @@ describe ('Form editor', () => {
             cy.findByRole('textbox', {'name': 'Form name'})
                 .should('have.value', 'My form name')
             ;
+            cy.findByRole('checkbox', {'name': 'Active'})
+                .should('be.checked')
+                .check()
+            ;
             cy.findByLabelText("Form description")
                 .awaitTinyMCE()
                 .should('have.text', 'My form description')
+            ;
+        });
+    });
+    it('can create a question an fill its main details', () => {
+        cy.createFormWithAPI().visitFormTab('Form');
+        cy.findByRole('button', {'name': 'Add a new question'}).click();
+
+        // Edit form details
+        cy.focused().type("My question"); // Question name is focused by default
+        cy.findByRole('region', {'name': 'Question details'}).within(() => {
+            cy.findByRole('checkbox', {'name': 'Mandatory'})
+                .should('not.be.checked')
+                .check()
+            ;
+            cy.findByLabelText("Question description")
+                .awaitTinyMCE()
+                .type("My question description")
+            ;
+        });
+
+        // Save form and reload page to force new data to be displayed.
+        cy.findByRole('button', {'name': 'Save'}).click();
+        cy.findByRole('alert')
+            .should('contain.text', 'Item successfully updated')
+        ;
+        cy.reload();
+
+        // Validate that the new values are displayed
+        cy.findByRole('region', {'name': 'Question details'}).within(() => {
+            cy.findByRole('textbox', {'name': 'Question name'})
+                .should('have.value', 'My question')
+                .click() // Click to make sure form focus is on the question
+            ;
+            cy.findByRole('checkbox', {'name': 'Mandatory'})
+                .should('be.checked')
+            ;
+            cy.findByLabelText("Question description")
+                .awaitTinyMCE()
+                .should('have.text', 'My question description')
             ;
         });
     });

--- a/tests/cypress/support/commands/form.d.ts
+++ b/tests/cypress/support/commands/form.d.ts
@@ -31,24 +31,9 @@
  * ---------------------------------------------------------------------
  */
 
-Cypress.Commands.add('createFormWithAPI', (
-    fields = {
-        name: "My test form",
+declare namespace Cypress {
+    interface Chainable<Subject> {
+        createFormWithAPI(fields: Object): Chainable<any>
+        visitFormTab(tab_name: string): Chainable<any>
     }
-) => {
-    return cy.createWithAPI('Glpi\\Form\\Form', fields).then((form_id) => {
-        return form_id;
-    });
-});
-
-Cypress.Commands.add('visitFormTab', {prevSubject: true}, (
-    form_id,
-    tab_name
-) => {
-    const fully_qualified_tabs = new Map([
-        ['Form', 'Glpi\\Form\\Form\\Form$main'],
-    ]);
-    const tab = fully_qualified_tabs.get(tab_name);
-
-    return cy.visit(`/front/form/form.form.php?id=${form_id}&forcetab=${tab}`);
-});
+}

--- a/tests/cypress/support/commands/form.js
+++ b/tests/cypress/support/commands/form.js
@@ -31,6 +31,24 @@
  * ---------------------------------------------------------------------
  */
 
-import './commands.js';
-import './commands/form.js';
-import '@testing-library/cypress/add-commands';
+Cypress.Commands.add('createFormWithAPI', (
+    fields = {
+        name: "My test form",
+    }
+) => {
+    return cy.createWithAPI('Glpi\\Form\\Form', fields).then((form_id) => {
+        return form_id;
+    });
+});
+
+Cypress.Commands.add('visitFormTab', {prevSubject: true}, (
+    form_id,
+    tab_key
+) => {
+    const fully_qualified_tabs = new Map([
+        ['Form', 'Glpi\\Form\\Form\\Form$main'],
+    ]);
+    const tab = fully_qualified_tabs.get(tab_key);
+
+    return cy.visit(`/front/form/form.form.php?id=${form_id}&forcetab=${tab}`);
+});


### PR DESCRIPTION
Test the creation of questions from the form editor user interface.

I've added some common boilerplate code related to form creation into new cypress commands (will retrofit existing tests later).
These commands have their own file to avoid polluting the general `command.js` file.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
