### PR TITLE
feat(forms): check update right to show form destination actions

### DIFF
--- a/src/Form/Destination/FormDestination.php
+++ b/src/Form/Destination/FormDestination.php
@@ -114,6 +114,7 @@ final class FormDestination extends CommonDBChild
             'destinations'                 => $item->getDestinations(),
             'available_destinations_types' => $manager->getDestinationTypesDropdownValues(),
             'active_destination'           => $active,
+            'can_update'                   => self::canUpdate(),
         ]);
 
         return true;
@@ -136,6 +137,13 @@ final class FormDestination extends CommonDBChild
 
         // Must be able to update the parent form
         return $form->canUpdateItem();
+    }
+
+    #[Override]
+    public static function canUpdate(): bool
+    {
+        // Must be able to update forms
+        return Form::canUpdate();
     }
 
     #[Override]

--- a/templates/pages/admin/form/form_destination.html.twig
+++ b/templates/pages/admin/form/form_destination.html.twig
@@ -37,6 +37,7 @@
 {# @var \Glpi\Form\Form                               form #}
 {# @var \Glpi\Form\Desination\FormDestination         destinations #}
 {# @var int|null                                      active_destination #}
+{# @var boolean                                       can_update #}
 
 <div class="py-2 px-3">
     <h2 class="d-flex">
@@ -80,16 +81,18 @@
                                 </div>
 
                                 {# Submit button to delete the destination #}
-                                <div class="d-flex flex-row-reverse mt-3">
-                                    <button class="btn btn-primary ms-2" name="update" type="submit">
-                                        <i class="ti ti-device-floppy me-2"></i>
-                                        {{ __("Update item") }}
-                                    </button>
-                                    <button class="btn btn-ghost-danger" name="purge" type="submit">
-                                        <i class="ti ti-trash me-2"></i>
-                                        {{ __("Delete") }}
-                                    </button>
-                                </div>
+                                {% if can_update %}
+                                    <div class="d-flex flex-row-reverse mt-3">
+                                        <button class="btn btn-primary ms-2" name="update" type="submit">
+                                            <i class="ti ti-device-floppy me-2"></i>
+                                            {{ __("Update item") }}
+                                        </button>
+                                        <button class="btn btn-ghost-danger" name="purge" type="submit">
+                                            <i class="ti ti-trash me-2"></i>
+                                            {{ __("Delete") }}
+                                        </button>
+                                    </div>
+                                {% endif %}
 
                                 {# Hidden values #}
                                 <input type="hidden" name="id" value="{{ destination.getID() }}"/>


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

The `Delete` and `Update item` actions are now hidden when the user does not have the right to update the form.

With update right :
![image](https://github.com/glpi-project/glpi/assets/42278610/d5fae03f-1060-4dcd-bff2-20268b36095e)

Without :
![image](https://github.com/glpi-project/glpi/assets/42278610/00eab831-be58-4819-b81e-124998c804c8)
