### PR TITLE
Fix incorrect positioning of note content in problem notes

### DIFF
--- a/css/legacy/includes/_styles.scss
+++ b/css/legacy/includes/_styles.scss
@@ -779,6 +779,7 @@
 
    .boxnotetext {
       padding: 5px;
+      margin-top: 1rem;
    }
 
    .error {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !32950

In `Assistance` -> `Problems` and `Notes` tab
If the user's name is too long, this disturbs the content of the note.

Before : 
![Capture d’écran du 2024-05-16 17-10-10](https://github.com/glpi-project/glpi/assets/102067890/2966f864-f5bb-4606-b195-a27ddc481396)

After : 
![Capture d’écran du 2024-05-16 17-13-07](https://github.com/glpi-project/glpi/assets/102067890/5ba4f62d-5d41-4254-8b67-6db17d4c8d20)