### PR TITLE
Feat(UI): add missing icon fron Central page

### DIFF
--- a/src/Central.php
+++ b/src/Central.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Dashboard\Dashboard;
 use Glpi\Event;
 use Glpi\Plugin\Hooks;
 use Glpi\System\Requirement\PhpSupportedVersion;
@@ -67,15 +68,15 @@ class Central extends CommonGLPI
 
         if ($item->getType() == __CLASS__) {
             $tabs = [
-                1 => __('Personal View'),
-                2 => __('Group View'),
-                3 => __('Global View'),
-                4 => _n('RSS feed', 'RSS feeds', Session::getPluralNumber()),
+                1 => self::createTabEntry(__('Personal View'), 0, null, User::getIcon()),
+                2 => self::createTabEntry(__('Group View'), 0, null, Group::getIcon()),
+                3 => self::createTabEntry(__('Global View'), 0, null, 'ti ti-world'),
+                4 => self::createTabEntry(_n('RSS feed', 'RSS feeds', Session::getPluralNumber()), 0, null, RSSFeed::getIcon()),
             ];
 
             $grid = new Glpi\Dashboard\Grid('central');
             if ($grid::canViewOneDashboard()) {
-                array_unshift($tabs, __('Dashboard'));
+                array_unshift($tabs, self::createTabEntry(__('Dashboard'), 0, null, Dashboard::getIcon()));
             }
 
             return $tabs;

--- a/src/Dashboard/Dashboard.php
+++ b/src/Dashboard/Dashboard.php
@@ -622,4 +622,9 @@ class Dashboard extends \CommonDBTM
         }
         return $this->fields['users_id'] != Session::getLoginUserID();
     }
+
+    public static function getIcon()
+    {
+        return "ti ti-dashboard";
+    }
 }

--- a/templates/layout/parts/menu.html.twig
+++ b/templates/layout/parts/menu.html.twig
@@ -66,7 +66,7 @@
             {% if has_dashboard %}
                <a class="dropdown-item"
                   href="{{ path(firstlevel['default_dashboard']) }}">
-                  <i class="ti ti-dashboard"></i>
+                  <i class="{{ call('Glpi\\Dashboard\\Dashboard::getIcon') }}"></i>
                   {{ __('Dashboard') }}
                </a>
             {% endif %}

--- a/templates/pages/setup/general/preferences_setup.html.twig
+++ b/templates/pages/setup/general/preferences_setup.html.twig
@@ -319,7 +319,7 @@
    {% endif %}
 
    {% if call('\\Glpi\\Dashboard\\Grid::canViewOneDashboard') %}
-      {{ fields.smallTitle(__('Dashboards'), 'ti ti-dashboard', '', 'section-dashboards') }}
+      {{ fields.smallTitle(__('Dashboards'), call('Glpi\\Dashboard\\Dashboard::getIcon'), '', 'section-dashboards') }}
       {% macro dropdownDashboard(name, config, context = 'core', disabled_option = false) %}
          {% do call('\\Glpi\\Dashboard\\Grid::dropdownDashboard', [name, {
             value: config[name],


### PR DESCRIPTION
Add missing icon

![image](https://github.com/glpi-project/glpi/assets/7335054/4d1b373b-50e7-44fc-92f5-b5ea84fc1343)

Replace all ```ti ti-dashboard``` by ```getIcon()``` function


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
