### PR TITLE
New hook : enable choosing the icon of an item in impact analysis

### DIFF
--- a/ajax/impact.php
+++ b/ajax/impact.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\Http\Response;
+use Glpi\Plugin\Hooks;
 
 const DELTA_ACTION_ADD    = 1;
 const DELTA_ACTION_UPDATE = 2;
@@ -41,6 +42,11 @@ const DELTA_ACTION_DELETE = 3;
 
 /** @var $this \Glpi\Controller\LegacyFileLoadController */
 $this->setAjax();
+
+/**
+ * @var array $CFG_GLPI
+ */
+global $CFG_GLPI;
 
 // Send UTF8 Headers
 header("Content-Type: application/json; charset=UTF-8");
@@ -64,9 +70,21 @@ switch ($_SERVER['REQUEST_METHOD']) {
                 if (empty($itemtype)) {
                     Response::sendError(400, "Missing itemtype");
                 }
-
+                $icon = $CFG_GLPI["impact_asset_types"][$itemtype];
                 // Execute search
+
                 $assets = Impact::searchAsset($itemtype, json_decode($used), $filter, $page);
+                foreach ($assets['items'] as $index => $item) {
+                    $plugin_icon = Plugin::doHookFunction(Hooks::SET_ITEM_IMPACT_ICON, [
+                        'itemtype' => $itemtype,
+                        'items_id' => $item['id']
+                    ]);
+                    if ($plugin_icon && is_string($plugin_icon)) {
+                        $icon = ltrim($plugin_icon, '/');
+                    }
+                    $item['image'] = $CFG_GLPI['root_doc'] . '/' . $icon;
+                    $assets['items'][$index] = $item;
+                }
                 header('Content-Type: application/json');
                 echo json_encode($assets);
                 break;
@@ -81,7 +99,7 @@ switch ($_SERVER['REQUEST_METHOD']) {
                     Response::sendError(400, "Missing itemtype or items_id");
                 }
 
-               // Check that the the target asset exist
+               // Check that the target asset exist
                 if (!Impact::assetExist($itemtype, $items_id)) {
                     Response::sendError(400, "Object[class=$itemtype, id=$items_id] doesn't exist");
                 }

--- a/js/impact.js
+++ b/js/impact.js
@@ -3670,7 +3670,7 @@ var GLPIImpact = {
                     }
 
                     var str = '<p class="' + cssClass + '" data-id="' + value['id'] + '" data-type="' + itemtype + '">';
-                    str += '<img src="' + $(GLPIImpact.selectors.sideSearch + " img").attr('src') + '"></img>';
+                    str += `<img src='${_.escape(value['image'])}'></img>`;
                     str += value["name"];
 
                     if (isHidden) {

--- a/src/Glpi/Plugin/Hooks.php
+++ b/src/Glpi/Plugin/Hooks.php
@@ -116,6 +116,7 @@ class Hooks
     const TIMELINE_ACTIONS        = 'timeline_actions';  // (keys: item, rand)
     const TIMELINE_ANSWER_ACTIONS = 'timeline_answer_actions';  // (keys: item)
     const SHOW_IN_TIMELINE        = 'show_in_timeline';  // (keys: item)
+    const SET_ITEM_IMPACT_ICON    = 'set_item_impact_icon'; // (keys: itemtype, items_id)
 
    // Security hooks (data to encypt)
     const SECURED_FIELDS  = 'secured_fields';

--- a/src/Impact.php
+++ b/src/Impact.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Plugin\Hooks;
 
 /**
  * @since 9.5.0
@@ -1018,6 +1019,14 @@ JS);
                 continue;
             }
 
+            $plugin_icon = Plugin::doHookFunction(Hooks::SET_ITEM_IMPACT_ICON, [
+                'itemtype' => $itemtype,
+                'items_id' => 0
+            ]);
+            if ($plugin_icon && is_string($plugin_icon)) {
+                $icon = ltrim($plugin_icon, '/');
+            }
+
            // Skip if not enabled
             if (!self::isEnabled($itemtype)) {
                 continue;
@@ -1300,6 +1309,15 @@ JS);
 
         // Get web path to the image matching the itemtype from config
         $image_name = $CFG_GLPI["impact_asset_types"][get_class($item)] ?? "";
+
+        $plugin_icon = Plugin::doHookFunction(Hooks::SET_ITEM_IMPACT_ICON, [
+            'itemtype' => get_class($item),
+            'items_id' => $item->getID()
+        ]);
+        if ($plugin_icon && is_string($plugin_icon)) {
+            $image_name = ltrim($plugin_icon, '/');
+        }
+
         $image_name = self::checkIcon($image_name);
 
         // Define basic data of the new node


### PR DESCRIPTION
Add a new hook to enable changing the icon of an item in the impact anlysis.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
