### PR TITLE
Add form tag providers

### DIFF
--- a/js/RichText/FormTags.js
+++ b/js/RichText/FormTags.js
@@ -50,10 +50,18 @@ GLPI.RichText.FormTags = class
     #editor;
 
     /**
-     * @param {Editor} editor
+     * Target form's id.
+     * @type {Number}}
      */
-    constructor(editor) {
+    #form_id;
+
+    /**
+     * @param {Editor} editor
+     * @param {Number} form_id
+     */
+    constructor(editor, form_id) {
         this.#editor = editor;
+        this.#form_id = form_id;
     }
 
     /**
@@ -78,7 +86,9 @@ GLPI.RichText.FormTags = class
 
     async #fetchItems() {
         const url = CFG_GLPI.root_doc + '/ajax/form/form_tags.php';
-        const data = await $.get(url);
+        const data = await $.get(url, {
+            form_id: this.#form_id,
+        });
 
         return data.map((tag) => ({
             // The `tag` variable is a json encoded instance of Glpi\Form\Tag\Tag

--- a/src/Form/Destination/AbstractCommonITILFormDestination.php
+++ b/src/Form/Destination/AbstractCommonITILFormDestination.php
@@ -46,12 +46,13 @@ use Override;
 abstract class AbstractCommonITILFormDestination extends AbstractFormDestinationType
 {
     #[Override]
-    final public function renderConfigForm(array $config): string
+    final public function renderConfigForm(Form $form, array $config): string
     {
         $twig = TemplateRenderer::getInstance();
         return $twig->render(
             'pages/admin/form/form_destination_commonitil_config.html.twig',
             [
+                'form'   => $form,
                 'item'   => $this,
                 'config' => $config,
             ]
@@ -82,9 +83,10 @@ abstract class AbstractCommonITILFormDestination extends AbstractFormDestination
 
         // Compute input from fields configuration
         foreach ($this->getConfigurableFields() as $field) {
-            $input = $field->applyConfiguratedValue(
+            $input = $field->applyConfiguratedValueToInputUsingAnswers(
+                $config[$field->getKey()] ?? null,
                 $input,
-                $config[$field->getKey()] ?? null
+                $answers_set
             );
         }
 

--- a/src/Form/Destination/CommonITILField/ContentField.php
+++ b/src/Form/Destination/CommonITILField/ContentField.php
@@ -36,7 +36,9 @@
 namespace Glpi\Form\Destination\CommonITILField;
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Form\AnswersSet;
 use Glpi\Form\Destination\ConfigFieldInterface;
+use Glpi\Form\Form;
 use Glpi\Form\Tag\FormTagsManager;
 use Override;
 
@@ -56,6 +58,7 @@ class ContentField implements ConfigFieldInterface
 
     #[Override]
     public function renderConfigForm(
+        Form $form,
         ?array $config,
         string $input_name,
         array $display_options
@@ -71,12 +74,14 @@ class ContentField implements ConfigFieldInterface
                     'enable_richtext': true,
                     'enable_images': false,
                     'enable_form_tags': true,
+                    'form_tags_form_id': form_id
                 })
             ) }}
 TWIG;
 
         $twig = TemplateRenderer::getInstance();
         return $twig->renderFromStringTemplate($template, [
+            'form_id'    => $form->fields['id'],
             'key'        => $this->getKey(),
             'label'      => $this->getLabel(),
             'value'      => $config['value'] ?? '',
@@ -86,14 +91,20 @@ TWIG;
     }
 
     #[Override]
-    public function applyConfiguratedValue(array $input, ?array $config): array
-    {
+    public function applyConfiguratedValueToInputUsingAnswers(
+        ?array $config,
+        array $input,
+        AnswersSet $answers_set
+    ): array {
         if (is_null($config)) {
             return $input;
         }
 
         $tag_manager = new FormTagsManager();
-        $input['content'] = $tag_manager->insertTagsContent($config['value']);
+        $input['content'] = $tag_manager->insertTagsContent(
+            $config['value'],
+            $answers_set
+        );
 
         return $input;
     }

--- a/src/Form/Destination/CommonITILField/TitleField.php
+++ b/src/Form/Destination/CommonITILField/TitleField.php
@@ -36,7 +36,9 @@
 namespace Glpi\Form\Destination\CommonITILField;
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Form\AnswersSet;
 use Glpi\Form\Destination\ConfigFieldInterface;
+use Glpi\Form\Form;
 use Override;
 
 class TitleField implements ConfigFieldInterface
@@ -55,6 +57,7 @@ class TitleField implements ConfigFieldInterface
 
     #[Override]
     public function renderConfigForm(
+        Form $form,
         ?array $config,
         string $input_name,
         array $display_options
@@ -81,8 +84,11 @@ TWIG;
     }
 
     #[Override]
-    public function applyConfiguratedValue(array $input, ?array $config): array
-    {
+    public function applyConfiguratedValueToInputUsingAnswers(
+        ?array $config,
+        array $input,
+        AnswersSet $answers_set
+    ): array {
         if (is_null($config)) {
             return $input;
         }

--- a/src/Form/Destination/ConfigFieldInterface.php
+++ b/src/Form/Destination/ConfigFieldInterface.php
@@ -35,6 +35,9 @@
 
 namespace Glpi\Form\Destination;
 
+use Glpi\Form\AnswersSet;
+use Glpi\Form\Form;
+
 interface ConfigFieldInterface
 {
     /**
@@ -55,6 +58,7 @@ interface ConfigFieldInterface
     /**
      * Render the input field for this configuration.
      *
+     * @param Form       $form
      * @param array|null $config
      * @param string     $input_name Input name supplied by the controller.
      *                               Must be reused in the actual input field.
@@ -64,6 +68,7 @@ interface ConfigFieldInterface
      * @return string
      */
     public function renderConfigForm(
+        Form $form,
         ?array $config,
         string $input_name,
         array $display_options
@@ -72,11 +77,16 @@ interface ConfigFieldInterface
     /**
      * Apply configurated value to the given input.
      *
-     * @param array      $input
      * @param array|null $config May be null if there is no configuration for
      *                           this field.
+     * @param array      $input
+     * @param AnswersSet $answers_set
      *
      * @return array
      */
-    public function applyConfiguratedValue(array $input, ?array $config): array;
+    public function applyConfiguratedValueToInputUsingAnswers(
+        ?array $config,
+        array $input,
+        AnswersSet $answers_set
+    ): array;
 }

--- a/src/Form/Destination/FormDestinationInterface.php
+++ b/src/Form/Destination/FormDestinationInterface.php
@@ -61,9 +61,11 @@ interface FormDestinationInterface
     /**
      * Render the configuration form for this destination type.
      *
+     * @param Form  $form
+     * @param array $config
      * @return string The rendered HTML content
      */
-    public function renderConfigForm(array $config): string;
+    public function renderConfigForm(Form $form, array $config): string;
 
     /**
      * Get itemtype to create

--- a/src/Form/Tag/AnswerTagProvider.php
+++ b/src/Form/Tag/AnswerTagProvider.php
@@ -48,7 +48,7 @@ final class AnswerTagProvider implements TagProviderInterface
         $tags = [];
         foreach ($form->getQuestions() as $questions) {
             $tags[] = new Tag(
-                label: "Answer: {$questions->fields['name']}",
+                label: sprintf(__('Answer: %s'), $questions->fields['name']),
                 value: $questions->getId(),
                 provider: self::class,
             );

--- a/src/Form/Tag/QuestionTagProvider.php
+++ b/src/Form/Tag/QuestionTagProvider.php
@@ -48,7 +48,7 @@ final class QuestionTagProvider implements TagProviderInterface
         $tags = [];
         foreach ($form->getQuestions() as $questions) {
             $tags[] = new Tag(
-                label: "Question: {$questions->fields['name']}",
+                label: sprintf(__('Question: %s'), $questions->fields['name']),
                 value: $questions->getId(),
                 provider: self::class,
             );

--- a/src/Form/Tag/QuestionTagProvider.php
+++ b/src/Form/Tag/QuestionTagProvider.php
@@ -33,22 +33,41 @@
  * ---------------------------------------------------------------------
  */
 
+namespace Glpi\Form\Tag;
+
+use Glpi\Form\AnswersSet;
 use Glpi\Form\Form;
-use Glpi\Form\Tag\FormTagsManager;
-use Glpi\Http\Response;
+use Glpi\Form\Question;
+use Override;
 
-include('../../inc/includes.php');
+final class QuestionTagProvider implements TagProviderInterface
+{
+    #[Override]
+    public function getTags(Form $form): array
+    {
+        $tags = [];
+        foreach ($form->getQuestions() as $questions) {
+            $tags[] = new Tag(
+                label: "Question: {$questions->fields['name']}",
+                value: $questions->getId(),
+                provider: self::class,
+            );
+        }
 
-// The user must be able to respond to forms.
-Session::checkRight(Form::$rightname, UPDATE);
+        return $tags;
+    }
 
-// Get mandatory form parameter
-$form = Form::getById($_GET['form_id'] ?? null);
-if (!$form) {
-    Response::sendError(400, __('Form not found'));
+    #[Override]
+    public function getTagContentForValue(
+        string $value,
+        AnswersSet $answers_set
+    ): string {
+        $id = (int) $value;
+
+        $question = Question::getById((int) $id);
+        if (!$question) {
+            return '';
+        }
+        return $question->fields['name'];
+    }
 }
-
-// Get tags
-$tag_manager = new FormTagsManager();
-header('Content-Type: application/json');
-echo json_encode($tag_manager->getTags($form));

--- a/src/Form/Tag/Tag.php
+++ b/src/Form/Tag/Tag.php
@@ -47,14 +47,16 @@ final readonly class Tag
     public function __construct(
         string $label,
         string $value,
+        string $provider,
     ) {
         $this->label = $label;
 
         // Build HTML representation of the tag.
         $properties = [
-            "contenteditable"     => "false",
-            "data-form-tag"       => "true",
-            "data-form-tag-value" => $value,
+            "contenteditable"        => "false",
+            "data-form-tag"          => "true",
+            "data-form-tag-value"    => $value,
+            "data-form-tag-provider" => $provider,
         ];
         $properties = implode(" ", array_map(
             fn($key, $value) => sprintf('%s="%s"', htmlspecialchars($key), htmlspecialchars($value)),

--- a/src/Form/Tag/TagProviderInterface.php
+++ b/src/Form/Tag/TagProviderInterface.php
@@ -33,22 +33,20 @@
  * ---------------------------------------------------------------------
  */
 
+namespace Glpi\Form\Tag;
+
+use Glpi\Form\AnswersSet;
 use Glpi\Form\Form;
-use Glpi\Form\Tag\FormTagsManager;
-use Glpi\Http\Response;
 
-include('../../inc/includes.php');
+interface TagProviderInterface
+{
+    /**
+     * @return Tag[]
+     */
+    public function getTags(Form $form): array;
 
-// The user must be able to respond to forms.
-Session::checkRight(Form::$rightname, UPDATE);
-
-// Get mandatory form parameter
-$form = Form::getById($_GET['form_id'] ?? null);
-if (!$form) {
-    Response::sendError(400, __('Form not found'));
+    public function getTagContentForValue(
+        string $value,
+        AnswersSet $answers_set
+    ): string;
 }
-
-// Get tags
-$tag_manager = new FormTagsManager();
-header('Content-Type: application/json');
-echo json_encode($tag_manager->getTags($form));

--- a/src/RichText/RichText.php
+++ b/src/RichText/RichText.php
@@ -593,6 +593,7 @@ JAVASCRIPT;
             'data-user-id',
             'data-form-tag',
             'data-form-tag-value',
+            'data-form-tag-provider',
         ];
         foreach ($rich_text_completion_attributes as $attribute) {
             $config = $config->allowAttribute($attribute, 'span');

--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -309,6 +309,7 @@
         'init': true,
         'placeholder': "",
         'enable_form_tags': false,
+        'form_tags_form_id': null,
         'aria_label': "",
     }|merge(options) %}
 
@@ -350,6 +351,7 @@
             $(function() {
                 const form_tags = new GLPI.RichText.FormTags(
                     tinymce.get('{{ options.id }}'),
+                    {{ options.form_tags_form_id }},
                 );
                 form_tags.register();
             });

--- a/templates/pages/admin/form/form_destination.html.twig
+++ b/templates/pages/admin/form/form_destination.html.twig
@@ -76,7 +76,10 @@
                         <div class="accordion-body pt-0">
                             <form method="POST" action="{{ controller_url }}">
                                 <div>
-                                    {{ concrete_destination.renderConfigForm(destination.getConfig())|raw }}
+                                    {{ concrete_destination.renderConfigForm(
+                                        form,
+                                        destination.getConfig()
+                                    )|raw }}
                                 </div>
 
                                 {# Submit button to delete the destination #}

--- a/templates/pages/admin/form/form_destination_commonitil_config.html.twig
+++ b/templates/pages/admin/form/form_destination_commonitil_config.html.twig
@@ -32,12 +32,14 @@
  #}
 
 {# @var Glpi\Form\Destination\AbstractCommonITILFormDestination item #}
+{# @var Glpi\Form\Form\                                         form #}
 {# @var array                                                   config #}
 
 <div>
     {# @var Glpi\Form\Destination\ConfigFieldInterface field #}
     {% for field in item.getConfigurableFields() %}
         {{ field.renderConfigForm(
+            form,
             config[field.getKey()],
             item.formatConfigInputName(field.getKey()),
             {

--- a/tests/cypress/e2e/form_tags.cy.js
+++ b/tests/cypress/e2e/form_tags.cy.js
@@ -31,6 +31,8 @@
  * ---------------------------------------------------------------------
  */
 
+let last_name_question_id;
+
 describe('Form tags', () => {
     beforeEach(() => {
         cy.createWithAPI('Glpi\\Form\\Form', {
@@ -40,6 +42,24 @@ describe('Form tags', () => {
                 'forms_forms_id': form_id,
                 'itemtype': 'Glpi\\Form\\Destination\\FormDestinationTicket',
                 'name': 'Test ticket 1',
+            });
+
+            cy.createWithAPI('Glpi\\Form\\Section', {
+                'name': 'Section 1',
+                'forms_forms_id': form_id,
+            }).then((section_id) => {
+                cy.createWithAPI('Glpi\\Form\\Question', {
+                    'name': 'First name',
+                    'forms_sections_id': section_id,
+                    'type': 'Glpi\\Form\\QuestionType\\QuestionTypeShortText',
+                });
+                cy.createWithAPI('Glpi\\Form\\Question', {
+                    'name': 'Last name',
+                    'forms_sections_id': section_id,
+                    'type': 'Glpi\\Form\\QuestionType\\QuestionTypeShortText',
+                }).then((question_id) => {
+                    last_name_question_id = question_id;
+                });
             });
         });
 
@@ -55,28 +75,25 @@ describe('Form tags', () => {
 
     it('tags autocompletion is loaded and values are preserved on reload', () => {
         // Auto completion is not yet opened
-        cy.findByRole("menuitem", {name: "Exemple tag 1"}).should('not.exist');
-        cy.findByRole("menuitem", {name: "Exemple tag 2"}).should('not.exist');
-        cy.findByRole("menuitem", {name: "Exemple tag 3"}).should('not.exist');
+        cy.findByRole("menuitem", {name: "Question: First name"}).should('not.exist');
+        cy.findByRole("menuitem", {name: "Question: Last name"}).should('not.exist');
 
         // Use autocomplete
         cy.findByLabelText("Content").awaitTinyMCE().as("rich_text_editor");
         cy.get("@rich_text_editor").type("#");
-        cy.findByRole("menuitem", {name: "Exemple tag 1"}).should('exist');
-        cy.findByRole("menuitem", {name: "Exemple tag 2"}).should('exist');
-        cy.findByRole("menuitem", {name: "Exemple tag 3"}).should('exist').click();
+        cy.findByRole("menuitem", {name: "Question: First name"}).should('exist');
+        cy.findByRole("menuitem", {name: "Question: Last name"}).should('exist').click();
 
         // Auto completion UI is terminated after clicking on the item.
-        cy.findByRole("menuitem", {name: "Exemple tag 1"}).should('not.exist');
-        cy.findByRole("menuitem", {name: "Exemple tag 2"}).should('not.exist');
-        cy.findByRole("menuitem", {name: "Exemple tag 3"}).should('not.exist');
+        cy.findByRole("menuitem", {name: "Question: First name"}).should('not.exist');
+        cy.findByRole("menuitem", {name: "Question: Last name"}).should('not.exist');
 
         // Item has been inserted into rich text
         cy.get("@rich_text_editor")
-            .findByText("Exemple tag 3")
+            .findByText("Question: Last name")
             .should('have.attr', 'contenteditable', 'false')
             .should('have.attr', 'data-form-tag', 'true')
-            .should('have.attr', 'data-form-tag-value', 'exemple-tag-3')
+            .should('have.attr', 'data-form-tag-value', last_name_question_id)
         ;
 
         // Save form
@@ -84,10 +101,10 @@ describe('Form tags', () => {
 
         // Rich text content provided by autocompleted values should be displayed properly
         cy.findByLabelText("Content").awaitTinyMCE()
-            .findByText("Exemple tag 3")
+            .findByText("Question: Last name")
             .should('have.attr', 'contenteditable', 'false')
             .should('have.attr', 'data-form-tag', 'true')
-            .should('have.attr', 'data-form-tag-value', 'exemple-tag-3')
+            .should('have.attr', 'data-form-tag-value', last_name_question_id)
         ;
     });
 });

--- a/tests/src/Form/Destination/AbstractFormDestinationType.php
+++ b/tests/src/Form/Destination/AbstractFormDestinationType.php
@@ -252,7 +252,13 @@ abstract class AbstractFormDestinationType extends DbTestCase
     final public function testRenderConfigForm(): void
     {
         $destination = $this->getTestedInstance();
-        $html = $destination->renderConfigForm([]);
+        $html = $destination->renderConfigForm($this->getSimpleForm(), []);
         $this->string($html)->isNotEmpty();
+    }
+
+    private function getSimpleForm(): Form
+    {
+        $builder = new FormBuilder();
+        return $this->createForm($builder);
     }
 }

--- a/tests/src/FormTesterTrait.php
+++ b/tests/src/FormTesterTrait.php
@@ -41,6 +41,7 @@ use Glpi\Form\Destination\FormDestination;
 use Glpi\Form\Form;
 use Glpi\Form\Question;
 use Glpi\Form\Section;
+use Glpi\Form\Tag\Tag;
 use Glpi\Tests\FormBuilder;
 
 /**
@@ -219,5 +220,13 @@ trait FormTesterTrait
 
         $control = array_pop($controls);
         return $control;
+    }
+
+    protected function getTagByName(array $tags, string $name): Tag
+    {
+        return current(array_filter(
+            $tags,
+            fn($tag) => $tag->label === $name,
+        ));
     }
 }

--- a/tests/units/Glpi/Form/Destination/FormDestinationTicket.php
+++ b/tests/units/Glpi/Form/Destination/FormDestinationTicket.php
@@ -63,10 +63,6 @@ class FormDestinationTicket extends AbstractFormDestinationType
         $answers_handler = AnswersHandler::getInstance();
 
         // Create a form with a single FormDestinationTicket destination
-        $tag = new Tag(
-            label: "Exemple tag 3",
-            value: "exemple-tag-3"
-        );
         $form = $this->createForm(
             (new FormBuilder("Test form 1"))
                 ->addQuestion("Name", QuestionTypeShortText::class)
@@ -75,7 +71,7 @@ class FormDestinationTicket extends AbstractFormDestinationType
                     'test',
                     [
                         'title'   => ['value' => 'Ticket title'],
-                        'content' => ['value' => "Ticket content: $tag->html"],
+                        'content' => ['value' => "Ticket content"],
                     ]
                 )
         );
@@ -93,9 +89,7 @@ class FormDestinationTicket extends AbstractFormDestinationType
 
         // Check fields
         $ticket = current($tickets);
-        $this->string($ticket['content'])
-            ->isEqualTo('Ticket content: exemple-tag-3')
-        ;
+        $this->string($ticket['content'])->isEqualTo('Ticket content');
 
         // Make sure link with the form answers was created too
         $ticket = array_pop($tickets);

--- a/tests/units/Glpi/Form/Tag/AnswerTagProvider.php
+++ b/tests/units/Glpi/Form/Tag/AnswerTagProvider.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\Tag;
+
+use DbTestCase;
+use Glpi\Form\AnswersHandler\AnswersHandler;
+use Glpi\Form\AnswersSet;
+use Glpi\Form\Form;
+use Glpi\Form\QuestionType\QuestionTypeShortText;
+use Glpi\Form\Tag\Tag;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+
+final class AnswerTagProvider extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public function getTagsProvider(): iterable
+    {
+        yield 'Form with no questions' => [
+            $this->createForm(new FormBuilder()),
+            []
+        ];
+
+        $form = $this->getFormWithQuestions();
+        yield 'Form with questions' => [
+            'form' => $form,
+            'expected' => [
+                new Tag(
+                    label: 'Answer: First name',
+                    value: $this->getQuestionId($form, 'First name'),
+                    provider: \Glpi\Form\Tag\AnswerTagProvider::class,
+                ),
+                new Tag(
+                    label: 'Answer: Last name',
+                    value: $this->getQuestionId($form, 'Last name'),
+                    provider: \Glpi\Form\Tag\AnswerTagProvider::class,
+                ),
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider getTagsProvider
+     */
+    public function testGetTags(Form $form, array $expected): void
+    {
+        $tagProvider = new \Glpi\Form\Tag\AnswerTagProvider();
+        $tags = $tagProvider->getTags($form);
+        $this->array($tags)->isEqualTo($expected);
+    }
+
+    public function getTagContentForValueProvider(): iterable
+    {
+        $answers_handler = AnswersHandler::getInstance();
+        yield 'Invalid value' => [
+            'value'       => 'not a valid question id',
+            'answers_set' => new AnswersSet(),
+            'expected'    => '',
+        ];
+
+        $form = $this->getFormWithQuestions();
+        $answers = $answers_handler->saveAnswers($form, [
+            $this->getQuestionId($form, "First name") => "John",
+            $this->getQuestionId($form, "Last name") => "Smith",
+        ], 0 /* Invalid user id but we dont care for this here */);
+
+        yield 'Valid value: first name question' => [
+            'value'       => $this->getQuestionId($form, 'First name'),
+            'answers_set' => $answers,
+            'expected'    => 'John',
+        ];
+        yield 'Valid value: last name question' => [
+            'value'       => $this->getQuestionId($form, 'Last name'),
+            'answers_set' => $answers,
+            'expected'    => 'Smith'
+        ];
+    }
+
+    /**
+     * @dataProvider getTagContentForValueProvider
+     */
+    public function testGetTagContentForValue(
+        string $value,
+        AnswersSet $answers_set,
+        string $expected
+    ): void {
+        $tag_provider = new \Glpi\Form\Tag\AnswerTagProvider();
+        $computed_content = $tag_provider->getTagContentForValue(
+            $value,
+            $answers_set,
+        );
+        $this->string($computed_content)->isEqualTo($expected);
+    }
+
+    private function getFormWithQuestions(): Form
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion("First name", QuestionTypeShortText::class);
+        $builder->addQuestion("Last name", QuestionTypeShortText::class);
+        return $this->createForm($builder);
+    }
+}

--- a/tests/units/Glpi/Form/Tag/QuestionTagProvider.php
+++ b/tests/units/Glpi/Form/Tag/QuestionTagProvider.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\Tag;
+
+use DbTestCase;
+use Glpi\Form\AnswersSet;
+use Glpi\Form\Form;
+use Glpi\Form\QuestionType\QuestionTypeShortText;
+use Glpi\Form\Tag\Tag;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+
+final class QuestionTagProvider extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public function getTagsProvider(): iterable
+    {
+        yield 'Form with no questions' => [
+            $this->createForm(new FormBuilder()),
+            []
+        ];
+
+        $form = $this->getFormWithQuestions();
+        yield 'Form with questions' => [
+            'form' => $form,
+            'expected' => [
+                new Tag(
+                    label: 'Question: First name',
+                    value: $this->getQuestionId($form, 'First name'),
+                    provider: \Glpi\Form\Tag\QuestionTagProvider::class,
+                ),
+                new Tag(
+                    label: 'Question: Last name',
+                    value: $this->getQuestionId($form, 'Last name'),
+                    provider: \Glpi\Form\Tag\QuestionTagProvider::class,
+                ),
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider getTagsProvider
+     */
+    public function testGetTags(Form $form, array $expected): void
+    {
+        $tagProvider = new \Glpi\Form\Tag\QuestionTagProvider();
+        $tags = $tagProvider->getTags($form);
+        $this->array($tags)->isEqualTo($expected);
+    }
+
+    public function getTagContentForValueProvider(): iterable
+    {
+        yield 'Invalid value' => [
+            'value' => 'not a valid question id',
+            'expected' => ''
+        ];
+
+        $form = $this->getFormWithQuestions();
+        yield 'Valid value: first name question' => [
+            'value' => $this->getQuestionId($form, 'First name'),
+            'expected' => 'First name'
+        ];
+        yield 'Valid value: last name question' => [
+            'value' => $this->getQuestionId($form, 'Last name'),
+            'expected' => 'Last name'
+        ];
+    }
+
+    /**
+     * @dataProvider getTagContentForValueProvider
+     */
+    public function testGetTagContentForValue(
+        string $value,
+        string $expected
+    ): void {
+        $tag_provider = new \Glpi\Form\Tag\QuestionTagProvider();
+
+        $computed_content = $tag_provider->getTagContentForValue(
+            $value,
+            new AnswersSet(), // Answers don't (yet) matter for this provider.
+        );
+
+        $this->string($computed_content)->isEqualTo($expected);
+    }
+
+    private function getFormWithQuestions(): Form
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion("First name", QuestionTypeShortText::class);
+        $builder->addQuestion("Last name", QuestionTypeShortText::class);
+        return $this->createForm($builder);
+    }
+}

--- a/tests/units/Glpi/Form/Tag/Tag.php
+++ b/tests/units/Glpi/Form/Tag/Tag.php
@@ -35,21 +35,41 @@
 
 namespace tests\units\Glpi\Form\Tag;
 
-use GLPITestCase;
+use DbTestCase;
+use Glpi\Form\Form;
+use Glpi\Form\QuestionType\QuestionTypeShortText;
+use Glpi\Form\Tag\FormTagsManager;
+use Glpi\Form\Tag\QuestionTagProvider;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
 
-final class Tag extends GLPITestCase
+final class Tag extends DbTestCase
 {
+    use FormTesterTrait;
+
     public function testTagCanBeExportedToJson(): void
     {
-        $tag = new \Glpi\Form\Tag\Tag(
-            label: 'Example tag',
-            value: 'example-tag',
-        );
+        $form = $this->getFormWithQuestions();
+        $tag_manager = new FormTagsManager();
+        $tags = $tag_manager->getTags($form);
+
+        $tag = $this->getTagByName($tags, 'Question: First name');
+        $question_id = $this->getQuestionId($form, 'First name');
+        $provider = QuestionTagProvider::class;
+
         $this->string(json_encode($tag))->isEqualTo(
             json_encode([
-                'label' => 'Example tag',
-                'html' => '<span contenteditable="false" data-form-tag="true" data-form-tag-value="example-tag">Example tag</span>'
+                'label' => 'Question: First name',
+                'html' => "<span contenteditable=\"false\" data-form-tag=\"true\" data-form-tag-value=\"$question_id\" data-form-tag-provider=\"$provider\">Question: First name</span>"
             ])
         );
+    }
+
+    private function getFormWithQuestions(): Form
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion("First name", QuestionTypeShortText::class);
+        $builder->addQuestion("Last name", QuestionTypeShortText::class);
+        return $this->createForm($builder);
     }
 }

--- a/tests/units/Glpi/RichText/RichText.php
+++ b/tests/units/Glpi/RichText/RichText.php
@@ -34,6 +34,8 @@
  */
 
 namespace tests\units\Glpi\RichText;
+use Glpi\Form\Tag\AnswerTagProvider;
+use Glpi\Form\Tag\Tag;
 
 /**
  * Test class for src/Glpi/RichText/richtext.class.php
@@ -392,15 +394,15 @@ HTML,
             'expected_result' => '<span contenteditable="true">Editable content</span>',
         ];
 
-        yield 'Do not remove data-form-tag property' => [
-            'content' => '<span data-form-tag="true">Tag label</span>',
+        $tag = new Tag(
+            label: __("My label"),
+            value: 5, // Fake id
+            provider: AnswerTagProvider::class
+        );
+        yield 'Html content of form tags should not be modified' => [
+            'content' => $tag->html,
             'encode_output_entities' => false,
-            'expected_result' => '<span data-form-tag="true">Tag label</span>',
-        ];
-        yield 'Do not remove data-form-tag-value property' => [
-            'content' => '<span data-form-tag-value="my-value">Tag label</span>',
-            'encode_output_entities' => false,
-            'expected_result' => '<span data-form-tag-value="my-value">Tag label</span>',
+            'expected_result' => $tag->html,
         ];
     }
 

--- a/tests/units/Glpi/RichText/RichText.php
+++ b/tests/units/Glpi/RichText/RichText.php
@@ -34,6 +34,7 @@
  */
 
 namespace tests\units\Glpi\RichText;
+
 use Glpi\Form\Tag\AnswerTagProvider;
 use Glpi\Form\Tag\Tag;
 


### PR DESCRIPTION
Add real providers, allowing tags to reuse questions labels and the form's answers.

![image](https://github.com/glpi-project/glpi/assets/42734840/5a0ba250-ea1e-4b3c-87e3-ba3d9651d646)


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
