### PR TITLE
Remove useless specific escaping

### DIFF
--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -1954,7 +1954,7 @@ TWIG, ['msg' => __('Last run list')]);
                 <span class="alert alert-warning p-1 ps-2">
                     <i class="ti ti-alert-triangle me-2"></i>
                     <span>{{ msg }}</span>
-                    <span class="form-help" data-bs-toggle="popover" data-bs-placement="bottom" data-bs-html="true" data-bs-content="{{ warnings|escape('html_attr') }}">
+                    <span class="form-help" data-bs-toggle="popover" data-bs-placement="bottom" data-bs-html="true" data-bs-content="{{ warnings }}">
                         ?
                     </span>
                 </span>

--- a/src/Form/QuestionType/AbstractQuestionTypeSelectable.php
+++ b/src/Form/QuestionType/AbstractQuestionTypeSelectable.php
@@ -171,8 +171,8 @@ abstract class AbstractQuestionTypeSelectable extends AbstractQuestionType
                     class="w-full"
                     style="border: none transparent; outline: none; box-shadow: none;"
                     name="options[{{ uuid }}]"
-                    value="{{ value|e('html_attr') }}"
-                    placeholder="{{ placeholder|e('html_attr') }}"
+                    value="{{ value }}"
+                    placeholder="{{ placeholder }}"
                 >
                 <i
                     data-glpi-form-editor-question-extra-details
@@ -232,7 +232,7 @@ TWIG;
                     <input
                         type="{{ input_type }}"
                         name="{{ question.getEndUserInputName() }}"
-                        value="{{ value.value|e('html_attr') }}"
+                        value="{{ value.value }}"
                         class="form-check-input" {{ value.checked ? 'checked' : '' }}
                     >
                     <span class="form-check-label">{{ value.value }}</span>

--- a/src/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
+++ b/src/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
@@ -59,10 +59,10 @@ abstract class AbstractQuestionTypeShortAnswer extends AbstractQuestionType
         $template = <<<TWIG
             <input
                 class="form-control mb-2"
-                type="{{ input_type|e('html_attr') }}"
+                type="{{ input_type }}"
                 name="default_value"
-                placeholder="{{ input_placeholder|e('html_attr') }}"
-                value="{{ question is not null ? question.fields.default_value|e('html_attr') : '' }}"
+                placeholder="{{ input_placeholder }}"
+                value="{{ question is not null ? question.fields.default_value : '' }}"
             />
 TWIG;
 
@@ -80,10 +80,10 @@ TWIG;
     ): string {
         $template = <<<TWIG
             <input
-                type="{{ input_type|e('html_attr') }}"
+                type="{{ input_type }}"
                 class="form-control"
                 name="{{ question.getEndUserInputName() }}"
-                value="{{ question.fields.default_value|e('html_attr') }}"
+                value="{{ question.fields.default_value }}"
                 {{ question.fields.is_mandatory ? 'required' : '' }}
             >
 TWIG;

--- a/src/Form/QuestionType/QuestionTypeDateTime.php
+++ b/src/Form/QuestionType/QuestionTypeDateTime.php
@@ -176,11 +176,11 @@ class QuestionTypeDateTime extends AbstractQuestionType
                 <div class="col-5">
                     <input
                         class="form-control mb-2"
-                        type="{{ input_type|e('html_attr') }}"
+                        type="{{ input_type }}"
                         id="date_input_{{ rand }}"
                         name="default_value"
-                        placeholder="{{ placeholders.input[input_type_ignore_text]|e('html_attr') }}"
-                        value="{{ default_value|e('html_attr') }}"
+                        placeholder="{{ placeholders.input[input_type_ignore_text] }}"
+                        value="{{ default_value }}"
                         {{ is_default_value_current_time ? 'disabled' : '' }}
                     />
                 </div>
@@ -322,10 +322,10 @@ TWIG;
     ): string {
         $template = <<<TWIG
             <input
-                type="{{ input_type|e('html_attr') }}"
+                type="{{ input_type }}"
                 class="form-control"
                 name="{{ question.getEndUserInputName() }}"
-                value="{{ default_value|e('html_attr') }}"
+                value="{{ default_value }}"
                 {{ question.fields.is_mandatory ? 'required' : '' }}
             >
 TWIG;

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -1809,7 +1809,7 @@ TWIG, $twig_params);
                                 <td class="text-start">
                                     <div class="kb">
                                         {% if data['is_faq'] %}
-                                            <i class="ti ti-help faq" title="{{ faq_tooltip|e('html_attr') }}"></i>
+                                            <i class="ti ti-help faq" title="{{ faq_tooltip }}"></i>
                                         {% endif %}
                                         <a href="{{ 'KnowbaseItem'|itemtype_form_path(data['id']) }}" class="{{ data['is_faq'] ? 'faq' : 'knowbase' }}"
                                            title="{{ name }}">{{ name|u.truncate(80, '(...)') }}</a>

--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -72,7 +72,7 @@
                {{ options.disabled ? 'disabled' : '' }}
                {{ options.multiple ? 'multiple' : '' }} {# Only for emailField #}
                {{ options.required ? 'required' : '' }}
-               {{ options.pattern ? ('pattern="' ~ options.pattern|e('html_attr') ~ '"')|raw : '' }}
+               {% if options.pattern is defined %}pattern="{{ options.pattern }}"{% endif %}
                {% if options.min is defined %}min="{{ options.min }}"{% endif %}
                {% if options.max is defined %}max="{{ options.max }}"{% endif %}
                {% if options.step is defined %}step="{{ options.step }}"{% endif %} />
@@ -383,7 +383,7 @@
     <input type="hidden"   name="{{ name }}" value="0" />
     <input type="checkbox" name="{{ name }}" value="1"
            class="form-check-input {{ options.input_addclass }}"
-           {{ (options.id != null ? 'id="' ~ options.id|e('html_attr') ~ '"' : '')|raw }}
+           {{ (options.id != null ? 'id="' ~ options.id|escape ~ '"' : '')|raw }}
            {{ value == 1 ? 'checked' : '' }}
            {{ options.readonly ? 'readonly' : '' }}
            {{ options.required ? 'required' : '' }}
@@ -402,7 +402,7 @@
 
     <button class="{{ options.class }}" type="{{ type }}" name="{{ name }}" value="{{ value }}"
         {% for attr, value in options.additional_attributes %}
-            {{ attr }}="{{ value|e('html_attr') }}"
+            {{ attr }}="{{ value }}"
         {% endfor %}>
         {% if options.icon is not empty %}
             <i class="{{ options.icon }}" title="{{ options.icon_title }}"></i>
@@ -436,7 +436,7 @@
               data-bs-toggle="popover"
               data-bs-placement="top"
               data-bs-html="true"
-              data-bs-content="{{ options.helper|raw|nl2br|escape('html_attr') }}">
+              data-bs-content="{{ options.helper|raw|nl2br|escape }}">
             ?
         </span>
         {% endset %}

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -48,7 +48,7 @@
             {{ label }}
             {% if helper is not empty %}
                <span class="form-help" data-bs-toggle="popover" data-bs-placement="top" data-bs-html="true"
-                     data-bs-content="{{ helper|e('html_attr') }}">?</span>
+                     data-bs-content="{{ helper }}">?</span>
             {% endif %}
          </h4>
       </div>
@@ -70,7 +70,7 @@
              <span class="ms-2">{{ label }}</span>
             {% if helper is not empty %}
                <span class="form-help" data-bs-toggle="popover" data-bs-placement="top" data-bs-html="true"
-                     data-bs-content="{{ helper|e('html_attr') }}">?</span>
+                     data-bs-content="{{ helper }}">?</span>
             {% endif %}
          </h4>
       </div>

--- a/templates/components/itilobject/itilsatisfaction.html.twig
+++ b/templates/components/itilobject/itilsatisfaction.html.twig
@@ -37,7 +37,7 @@
     {% if url is defined %}
         {{ fields.htmlField(
             '',
-            '<a href="' ~ url|e('html_attr') ~ '">' ~ url ~ '</a>',
+            '<a href="' ~ url|escape ~ '">' ~ url|escape ~ '</a>',
             __('External survey'),
             {
                 'input_class' : 'col-xxl-9',

--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -67,7 +67,7 @@
                                 data-bs-toggle="dropdown" data-bs-auto-close="outside">
                             <i class="ti ti-list-search"></i>
                             {% if active_search_name|length %}
-                                <span class="d-none d-xl-inline-block text-truncate" style="max-width: 250px" title="{{ active_search_name|e('html_attr') }}" data-bs-toggle="tooltip" data-bs-placement="top">
+                                <span class="d-none d-xl-inline-block text-truncate" style="max-width: 250px" title="{{ active_search_name }}" data-bs-toggle="tooltip" data-bs-placement="top">
                                     {{ active_search_name }}
                                 </span>
                             {% else %}
@@ -86,7 +86,7 @@
                                 data-bs-toggle="dropdown" data-bs-auto-close="outside">
                         <i class="ti ti-arrows-sort"></i>
                         {% set sort_names = (active_sort_name|length ? active_sort_name : __("Sort")) %}
-                        <span class="d-none d-xl-inline-block text-truncate" style="max-width: 250px" title="{{ sort_names|e('html_attr') }}" data-bs-toggle="tooltip" data-bs-placement="top">
+                        <span class="d-none d-xl-inline-block text-truncate" style="max-width: 250px" title="{{ sort_names }}" data-bs-toggle="tooltip" data-bs-placement="top">
                             {{ sort_names }}
                         </span>
                     </button>

--- a/templates/components/search/query_builder/search_option_value.html.twig
+++ b/templates/components/search/query_builder/search_option_value.html.twig
@@ -51,5 +51,5 @@
 {% endif %}
 
 {% if not display %}
-   <input type="text" class="form-control" size="13" name="{{ inputname }}" value="{{ value|escape('html_attr') }}">
+   <input type="text" class="form-control" size="13" name="{{ inputname }}" value="{{ value }}">
 {% endif %}

--- a/templates/pages/admin/assetdefinition/capacities.html.twig
+++ b/templates/pages/admin/assetdefinition/capacities.html.twig
@@ -64,16 +64,16 @@
             <label class="d-flex align-items-center gap-2 form-check form-switch mt-2">
                 <input type="checkbox"
                     name="capacities[]"
-                    value="{{ get_class(capacity)|e('html_attr') }}"
+                    value="{{ get_class(capacity) }}"
                     class="form-check-input"
                     id="%id%"
-                    data-capacity="{{ get_class(capacity)|e('html_attr') }}"
+                    data-capacity="{{ get_class(capacity) }}"
                     data-is-used="{{ capacity.isUsed(classname) ? 1 : 0 }}"
                     {{ item.hasCapacityEnabled(capacity) ? 'checked' : '' }} />
                 <i class="ti ti-alert-circle-filled text-red fs-2 d-none"
-                    data-capacity="{{ get_class(capacity)|e('html_attr') }}"
+                    data-capacity="{{ get_class(capacity) }}"
                     data-bs-toggle="tooltip"
-                    title="{{ capacity.getCapacityUsageDescription(classname)|e('html_attr') }}"></i>
+                    title="{{ capacity.getCapacityUsageDescription(classname) }}"></i>
             </label>
         {% endset %}
         {{ fields.field('capacities[]', field, label) }}
@@ -95,7 +95,7 @@
                     </div>
                     <div class="list-group list-group-flush list-group-hoverable text-start mt-2">
                         {% for capacity in capacities|filter(capacity => capacity.isUsed(classname)) %}
-                            <div class="list-group-item p-3 d-none" data-capacity="{{ get_class(capacity)|e('html_attr') }}">
+                            <div class="list-group-item p-3 d-none" data-capacity="{{ get_class(capacity) }}">
                                 <div class="row align-items-center">
                                     <div class="col text-truncate ms-6">
                                         <span class="text-reset d-block">{{ capacity.getLabel() }}</span>

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -102,7 +102,7 @@
                                         type="text"
                                         class="form-control content-editable-h1"
                                         name="name"
-                                        value="{{ item.fields.name|e('html_attr') }}"
+                                        value="{{ item.fields.name }}"
                                         data-glpi-form-editor-form-details-name
                                     >
 

--- a/templates/pages/admin/form/form_question.html.twig
+++ b/templates/pages/admin/form/form_question.html.twig
@@ -73,7 +73,7 @@
                     class="form-control content-editable-h2 mb-0"
                     type="text"
                     name="name"
-                    value="{{ question is not null ? question.fields.name|e('html_attr') : '' }}"
+                    value="{{ question is not null ? question.fields.name : '' }}"
                     placeholder="{{ __("New question") }}"
                     data-glpi-form-editor-dynamic-input
                     data-glpi-form-editor-on-input="compute-dynamic-input"

--- a/templates/pages/admin/form/form_section.html.twig
+++ b/templates/pages/admin/form/form_section.html.twig
@@ -81,7 +81,7 @@
                         type="text"
                         class="form-control content-editable-h2 mb-0"
                         name="name"
-                        value="{{ section is not null ? section.fields.name|e('html_attr') : '' }}"
+                        value="{{ section is not null ? section.fields.name : '' }}"
                         placeholder="{{ __("New section") }}"
                         data-glpi-form-editor-section-details-name
                     >

--- a/templates/pages/setup/general/performance.html.twig
+++ b/templates/pages/setup/general/performance.html.twig
@@ -35,7 +35,7 @@
 
 {% macro icon_msg(message, icon) %}
    <td class="icons_block">
-      <i class="{{ icon }}" title="{{ message|e('html_attr') }}" data-bs-toggle="tooltip"></i>
+      <i class="{{ icon }}" title="{{ message }}" data-bs-toggle="tooltip"></i>
       <span class="sr-only">{{ message }}</span>
    </td>
 {% endmacro %}

--- a/templates/pages/setup/general/systeminfo_table.html.twig
+++ b/templates/pages/setup/general/systeminfo_table.html.twig
@@ -85,7 +85,7 @@ Database:
 
 Requirements:
    {%- for requirement in core_requirements -%}
-      {{ "\n" }}<img src="{{ path('/pics/') ~ requirement['status'] ~ '_min.png' }}" alt="{{ requirement['messages']|join(' ')|e('html_attr') }}"/>{{ requirement['messages']|join("\n") }}
+      {{ "\n" }}<img src="{{ path('/pics/') ~ requirement['status'] ~ '_min.png' }}" alt="{{ requirement['messages']|join(' ') }}"/>{{ requirement['messages']|join("\n") }}
    {%- endfor -%}
 {% endset %}
 

--- a/templates/pages/tools/savedsearch/save_button.html.twig
+++ b/templates/pages/tools/savedsearch/save_button.html.twig
@@ -46,4 +46,4 @@
         title="{{ __('Save current search') }}" data-bs-toggle="tooltip" data-bs-placement="bottom">
    <i class="ti ti-bookmark-plus {{ active ? 'active text-yellow' : '' }}"></i>
 </button>
-<div id="savedsearch-modal" class="modal" data-params="{{ params|json_encode|e('html_attr') }}"></div>
+<div id="savedsearch-modal" class="modal" data-params="{{ params|json_encode }}"></div>

--- a/templates/stencil/editor.html.twig
+++ b/templates/stencil/editor.html.twig
@@ -113,7 +113,7 @@
                     </div>
                 </div>
                 <div class="col-auto">
-                    <button type="button" id="save-zone-data-{{ rand }}" class="btn btn-primary" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ (params['save_zone_data_label']|default(__("Save zone data")) ~ ' (' ~ _x('keyboard', 'Enter') ~ ')')|escape('html_attr') }}">
+                    <button type="button" id="save-zone-data-{{ rand }}" class="btn btn-primary" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ (params['save_zone_data_label']|default(__("Save zone data")) ~ ' (' ~ _x('keyboard', 'Enter') ~ ')') }}">
                         <i class="ti ti-device-floppy"></i>
                         {% if params.save_zone_data_label is defined %}
                             <span>{{ params['save_zone_data_label'] }}</span>
@@ -125,7 +125,7 @@
                         <i class="ti ti-trash"></i>
                         <span>{{ __("Reset") }}</span>
                     </button>
-                    <button type="button" id="cancel-zone-data-{{ rand }}" class="btn btn-outline-danger" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ (__("Cancel") ~ ' (' ~ _x('keyboard', 'Esc') ~ ')')|escape('html_attr') }}">
+                    <button type="button" id="cancel-zone-data-{{ rand }}" class="btn btn-outline-danger" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ (__("Cancel") ~ ' (' ~ _x('keyboard', 'Esc') ~ ')') }}">
                         <i class="ti ti-x"></i>
                         <span>{{ __("Cancel") }}</span>
                     </button>

--- a/templates/stencil/parts/zones.html.twig
+++ b/templates/stencil/parts/zones.html.twig
@@ -36,12 +36,12 @@
         {% if stencil.getZonePopover(params.is_editor_view, zone) != null %}
             {% set popover_attrs %}
                 data-bs-toggle="popover" data-bs-html="true"
-                data-bs-content="{{ stencil.getZonePopover(params.is_editor_view, zone)|e('html_attr') }}"
+                data-bs-content="{{ stencil.getZonePopover(params.is_editor_view, zone) }}"
             {% endset %}
         {% else %}
             {% set tooltip_attrs %}
                 data-bs-toggle="tooltip"
-                data-bs-title="{{ zone['label']|e('html_attr') }}"
+                data-bs-title="{{ zone['label'] }}"
             {% endset %}
         {% endif %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I asked myself if it was mandatory to use the specific `html_attr` strategy to escape values that were printed in HTML attributes. It seems that only HTML special chars (`"`, `>` and `<`) must be encoded into HTML entities to protect the value as long as the attribute value is surrounded by quotes. Encoding special chars is the default Twig strategy, so we can safely remove the specific `|e('html_attr')` escaping filter.