### PR TITLE
Fix(Breadcrumb): Display vertical divider only if needed

### DIFF
--- a/templates/layout/parts/context_links.html.twig
+++ b/templates/layout/parts/context_links.html.twig
@@ -37,8 +37,10 @@
     {% set lists_itemtype = item %}
 {% endif %}
 
-{# @TODO  border-start is not implemented in current boostrap beta (remove border-left when done)  #}
-<ul class="nav navbar-nav border-start border-left ps-1 ps-sm-2 flex-row">
+{% if links['add'] is defined or links|length > 0 %}
+   {# @TODO  border-start is not implemented in current boostrap beta (remove border-left when done)  #}
+   <ul class="nav navbar-nav border-start border-left ps-1 ps-sm-2 flex-row">
+{% endif %}
 
 {% if links['add'] is defined %}
 <li class="nav-item">

--- a/templates/layout/parts/context_links.html.twig
+++ b/templates/layout/parts/context_links.html.twig
@@ -37,7 +37,9 @@
     {% set lists_itemtype = item %}
 {% endif %}
 
-{% if links['add'] is defined or links|length > 0 %}
+{% set display_divider = (links['add'] is defined or links|length > 0) %}
+
+{% if display_divider %}
    {# @TODO  border-start is not implemented in current boostrap beta (remove border-left when done)  #}
    <ul class="nav navbar-nav border-start border-left ps-1 ps-sm-2 flex-row">
 {% endif %}
@@ -104,4 +106,7 @@
    {% endif %}
 
 {% endfor %}
-</ul>
+
+{% if display_divider %}
+   </ul>
+{% endif %}


### PR DESCRIPTION
Display vertical divider only when contextual button are displayed

Before : 

![image](https://github.com/glpi-project/glpi/assets/7335054/36c5b192-f400-41a3-9c1c-3538f3cb1297)

After : 

![image](https://github.com/glpi-project/glpi/assets/7335054/f02afee6-287e-4294-ac44-5451bd97b021)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
