### PR TITLE
Add correct type to form toolbar buttons

### DIFF
--- a/templates/pages/admin/form/form_toolbar.html.twig
+++ b/templates/pages/admin/form/form_toolbar.html.twig
@@ -47,6 +47,7 @@
             data-bs-placement="bottom"
             title="{{ __("Add a new question") }}"
             data-glpi-form-editor-on-click="add-question"
+            type="button"
         >
             <span class="px-2 d-flex align-items-center">
                 <i class="ti ti-circle-plus"></i>
@@ -61,6 +62,7 @@
             data-bs-placement="bottom"
             title="{{ __("Add a new section") }}"
             data-glpi-form-editor-on-click="add-section"
+            type="button"
         >
             <i class="ti ti-box-align-top"></i>
         </button>


### PR DESCRIPTION
While transforming some invalid `label` tags into `button`, I forgot the default button type is `submit` which cause form editor changes to be accidentally saved when clicking on these buttons.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
