### PR TITLE
Fix followups entities restriction

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -4573,8 +4573,38 @@ JAVASCRIPT;
                     break;
                 }
 
+                // Build base condition using entity restrictions
+                $condition = "(";
+                $condition .= getEntitiesRestrictRequest(
+                    '',
+                    'glpi_tickets_items_id_' . self::computeComplexJoinID([
+                        'condition' => 'AND REFTABLE.`itemtype` = "' . Ticket::getType() . '"'
+                    ]),
+                    'entities_id',
+                    ''
+                );
+                $condition .= " OR ";
+                $condition .= getEntitiesRestrictRequest(
+                    '',
+                    'glpi_changes_items_id_' . self::computeComplexJoinID([
+                        'condition' => 'AND REFTABLE.`itemtype` = "' . Change::getType() . '"'
+                    ]),
+                    'entities_id',
+                    ''
+                );
+                $condition .= " OR ";
+                $condition .= getEntitiesRestrictRequest(
+                    '',
+                    'glpi_problems_items_id_' . self::computeComplexJoinID([
+                        'condition' => 'AND REFTABLE.`itemtype` = "' . Problem::getType() . '"'
+                    ]),
+                    'entities_id',
+                    ''
+                );
+                $condition .= ") ";
+
                 $in = "IN ('" . implode("','", $allowed_is_private) . "')";
-                $condition = "(`glpi_itilfollowups`.`is_private` $in ";
+                $condition .= " AND (`glpi_itilfollowups`.`is_private` $in ";
 
                // Now filter on parent item visiblity
                 $condition .= "AND (";
@@ -5836,6 +5866,45 @@ JAVASCRIPT;
                         }
                     }
                 }
+                break;
+
+            case ITILFollowup::class:
+                $out .= self::addLeftJoin(
+                    $itemtype,
+                    $ref_table,
+                    $already_link_tables,
+                    Ticket::getTable(),
+                    'items_id',
+                    false,
+                    '',
+                    [
+                        'condition' => 'AND REFTABLE.`itemtype` = "' . Ticket::getType() . '"'
+                    ]
+                );
+                $out .= self::addLeftJoin(
+                    $itemtype,
+                    $ref_table,
+                    $already_link_tables,
+                    Change::getTable(),
+                    'items_id',
+                    false,
+                    '',
+                    [
+                        'condition' => 'AND REFTABLE.`itemtype` = "' . Change::getType() . '"'
+                    ]
+                );
+                $out .= self::addLeftJoin(
+                    $itemtype,
+                    $ref_table,
+                    $already_link_tables,
+                    Problem::getTable(),
+                    'items_id',
+                    false,
+                    '',
+                    [
+                        'condition' => 'AND REFTABLE.`itemtype` = "' . Problem::getType() . '"'
+                    ]
+                );
                 break;
 
             default:

--- a/tests/functional/ITILFollowup.php
+++ b/tests/functional/ITILFollowup.php
@@ -35,10 +35,14 @@
 
 namespace tests\units;
 
+use Change;
 use CommonITILActor;
 use DbTestCase;
 use Glpi\Toolbox\Sanitizer;
 use ITILFollowup as CoreITILFollowup;
+use Problem;
+use QueryExpression;
+use Search;
 use Ticket;
 use Ticket_User;
 use User;
@@ -633,5 +637,71 @@ HTML
         $this->boolean(
             $this->callPrivateMethod($followup, 'isParentAlreadyLoaded')
         )->isEqualTo($is_parent_loaded);
+    }
+
+    public function testAddDefaultWhereTakeEntitiesIntoAccount(): void
+    {
+        $this->login();
+        $this->setEntity('_test_child_2', false);
+
+        // Add followups in the correct entity, they should be counted
+        $number_of_visible_followups = $this->countVisibleFollowupsForLoggedInUser();
+        $this->createFollowupInEntityForType('_test_child_2', Ticket::class);
+        $this->createFollowupInEntityForType('_test_child_2', Problem::class);
+        $this->createFollowupInEntityForType('_test_child_2', Change::class);
+        $this->integer(
+            $this->countVisibleFollowupsForLoggedInUser()
+        )->isEqualTo($number_of_visible_followups + 3);
+
+        // Add followups in the correct entity, they should NOT be counted
+        $number_of_visible_followups = $this->countVisibleFollowupsForLoggedInUser();
+        $this->createFollowupInEntityForType('_test_root_entity', Ticket::class);
+        $this->createFollowupInEntityForType('_test_root_entity', Problem::class);
+        $this->createFollowupInEntityForType('_test_root_entity', Change::class);
+        $this->integer(
+            $this->countVisibleFollowupsForLoggedInUser()
+        )->isEqualTo($number_of_visible_followups); // No new followups visible
+    }
+
+    private function countVisibleFollowupsForLoggedInUser(): int
+    {
+        /** @var \DBMysql $DB */
+        global $DB;
+
+        $already_linked_tables = [];
+        $results = $DB->request([
+            'COUNT' => 'number_of_followups',
+            'FROM' => CoreITILFollowup::getTable(),
+            'JOIN' => [
+                new QueryExpression(
+                    Search::addDefaultJoin(
+                        CoreITILFollowup::class,
+                        CoreITILFollowup::getTable(),
+                        $already_linked_tables
+                    )
+                )
+            ],
+            'WHERE' => new QueryExpression(
+                Search::addDefaultWhere(CoreITILFollowup::class)
+            ),
+        ]);
+
+        return (int) iterator_to_array($results)[0]['number_of_followups'];
+    }
+
+    private function createFollowupInEntityForType(
+        string $entity_name,
+        string $itemtype
+    ): void {
+        $itil = $this->createItem($itemtype, [
+            'entities_id' => getItemByTypeName('Entity', $entity_name, true),
+            'name'        => 'Test ticket',
+            'content'     => '',
+        ]);
+        $this->createItem(CoreITILFollowup::class, [
+            'itemtype' => $itemtype,
+            'items_id' => $itil->getID(),
+            'content'  => 'Test followup',
+        ]);
     }
 }

--- a/tests/functional/ITILFollowup.php
+++ b/tests/functional/ITILFollowup.php
@@ -644,23 +644,23 @@ HTML
         $this->login();
         $this->setEntity('_test_child_2', false);
 
-        // Add followups in the correct entity, they should be counted
+        // Add followups in an entity our user can see
         $number_of_visible_followups = $this->countVisibleFollowupsForLoggedInUser();
         $this->createFollowupInEntityForType('_test_child_2', Ticket::class);
         $this->createFollowupInEntityForType('_test_child_2', Problem::class);
         $this->createFollowupInEntityForType('_test_child_2', Change::class);
         $this->integer(
             $this->countVisibleFollowupsForLoggedInUser()
-        )->isEqualTo($number_of_visible_followups + 3);
+        )->isEqualTo($number_of_visible_followups + 3); // 3 new followup found
 
-        // Add followups in the correct entity, they should NOT be counted
+        // Add followups in a visible that our user can't see
         $number_of_visible_followups = $this->countVisibleFollowupsForLoggedInUser();
         $this->createFollowupInEntityForType('_test_root_entity', Ticket::class);
         $this->createFollowupInEntityForType('_test_root_entity', Problem::class);
         $this->createFollowupInEntityForType('_test_root_entity', Change::class);
         $this->integer(
             $this->countVisibleFollowupsForLoggedInUser()
-        )->isEqualTo($number_of_visible_followups); // No new followups visible
+        )->isEqualTo($number_of_visible_followups); // No new followups found
     }
 
     private function countVisibleFollowupsForLoggedInUser(): int


### PR DESCRIPTION
ITILFollowups do not have any entities restrictions in their `addDefaultWhere` method.

This mean that any "listing" using the `addDefaultWhere` method may return data from inaccessible entities (for exemple: an API request on `GET /ITIlFollowup`).

I suspect this issue happens on all `CommonDBChild` and `CommonDBRelation` items.
I am planning on fixing it for all timeline related items (in separate PR) as they impact directly the unread messages plugin.

I do not plan to fix all the others types as it would require a lot more work and the need to maintain new itemtypes in the future which is not acceptable.
It would be better to fix this everywhere with some mutual code but it doesn't seem possible without an important rewrite of the `addDefaultWhere` and `addDefaultJoin` methods that can't be done on a minor version.

I can look into it for `main` if I get the greenlight.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
