### PR TITLE
Fix(Agent): fix CSS and readonly input

### DIFF
--- a/templates/pages/admin/inventory/agent.html.twig
+++ b/templates/pages/admin/inventory/agent.html.twig
@@ -47,14 +47,13 @@
    {% set target       = params['target'] ?? item.getFormURL() %}
    {% set withtemplate = params['withtemplate'] ?? '' %}
    {% set item_type = item.getType() %}
-   {% set item_has_pictures = item.hasItemtypeOrModelPictures() %}
    {% set field_options = {
        'locked_fields': item.getLockedFields(),
        'rand': rand,
    } %}
 
    <div class="card-body d-flex flex-wrap">
-      <div class="col-12 col-xxl-{{ item_has_pictures ? '9' : '12' }} flex-column">
+      <div class="col-12 flex-column">
          <div class="d-flex flex-row flex-wrap flex-xl-nowrap">
             <div class="row flex-row align-items-start flex-grow-1">
                <div class="row flex-row">
@@ -68,7 +67,7 @@
 
                     {{ fields.htmlField(
                         'agenttypes_id',
-                        call('Dropdown::getDropdownName', ["glpi_agenttypes", item.fields['agenttypes_id']]),
+                        get_item_name('AgentType', item.fields['agenttypes_id']),
                         _n('Agent type', 'Agents types', 1),
                         field_options
                     ) }}
@@ -103,7 +102,7 @@
 
                     {{ fields.htmlField(
                         "itemtype",
-                        call(item.fields['itemtype'] ~ '::getTypeName', [0]),
+                        item.fields['itemtype']|itemtype_name,
                         __('Item type'),
                         field_options
                     ) }}
@@ -190,7 +189,8 @@
                         <div class="hr-text">
                             <i class="ti ti-list"></i>
                             <span>{{ __('Supported tasks') }} </span>
-                            <span class="form-help" data-bs-toggle="popover" data-bs-placement="top" data-bs-html="true" data-bs-content="<i> {{ __('When reported by GLPI agent via native inventory') }}</i>">?</span>
+                            <span class="form-help" data-bs-toggle="popover" data-bs-placement="top" data-bs-html="true"
+                                  data-bs-content="{{ '<i>' ~__('When reported by GLPI agent via native inventory') ~ '</i>' }}">?</span>
                         </div>
 
                         {% for modulefield, modulelabel in {
@@ -217,23 +217,10 @@
             </div> {# .row #}
          </div> {# .flex-row #}
       </div>
-      {% if item_has_pictures %}
-         <div class="col-12 col-xxl-3 flex-column">
-            <div class="flex-row asset-pictures">
-               {{ include('components/form/pictures.html.twig', {'gallery_type': ''}) }}
-            </div>
-         </div>
-      {% endif %}
    </div> {# .card-body #}
 
-   {% if item_type == 'Contract' %}
-      {{ include('components/form/support_hours.html.twig') }}
-   {% endif %}
    {% if no_form_buttons is not defined or no_form_buttons == false %}
       {{ include('components/form/buttons.html.twig') }}
-   {% endif %}
-   {% if no_inventory_footer is not defined or no_inventory_footer == false %}
-      {{ include('components/form/inventory_info.html.twig') }}
    {% endif %}
 
    {% if params['formfooter'] is null or params['formfooter'] == true %}

--- a/templates/pages/admin/inventory/agent.html.twig
+++ b/templates/pages/admin/inventory/agent.html.twig
@@ -66,14 +66,12 @@
                         field_options
                     ) }}
 
-
                     {{ fields.htmlField(
                         'agenttypes_id',
                         call('Dropdown::getDropdownName', ["glpi_agenttypes", item.fields['agenttypes_id']]),
                         __('Agent type'),
                         field_options
                     ) }}
-
 
                     {{ fields.dropdownYesNo(
                     'locked',

--- a/templates/pages/admin/inventory/agent.html.twig
+++ b/templates/pages/admin/inventory/agent.html.twig
@@ -69,7 +69,7 @@
                     {{ fields.htmlField(
                         'agenttypes_id',
                         call('Dropdown::getDropdownName', ["glpi_agenttypes", item.fields['agenttypes_id']]),
-                        __('Agent type'),
+                        _n('Agent type', 'Agents types', 1),
                         field_options
                     ) }}
 

--- a/templates/pages/admin/inventory/agent.html.twig
+++ b/templates/pages/admin/inventory/agent.html.twig
@@ -190,7 +190,7 @@
                             <i class="ti ti-list"></i>
                             <span>{{ __('Supported tasks') }} </span>
                             <span class="form-help" data-bs-toggle="popover" data-bs-placement="top" data-bs-html="true"
-                                  data-bs-content="{{ '<i>' ~__('When reported by GLPI agent via native inventory') ~ '</i>' }}">?</span>
+                                  data-bs-content="{{ '<i>' ~ __('When reported by GLPI agent via native inventory') ~ '</i>' }}">?</span>
                         </div>
 
                         {% for modulefield, modulelabel in {

--- a/templates/pages/admin/inventory/agent.html.twig
+++ b/templates/pages/admin/inventory/agent.html.twig
@@ -31,145 +31,216 @@
  # ---------------------------------------------------------------------
  #}
 
-{% extends "generic_show_form.html.twig" %}
 {% import 'components/form/fields_macros.html.twig' as fields %}
-{% set params  = params ?? [] %}
-{% set field_options = field_options ?? {} %}
 
-{% block more_fields %}
-    {{ fields.dropdownYesNo(
-       'locked',
-       item.fields['locked'],
-       __('Locked'),
-       field_options
-    ) }}
+{% set no_header = no_header|default(not item.isNewItem() and not _get._in_modal|default(false)) %}
+{% set bg = '' %}
+{% if item.isDeleted() %}
+   {% set bg = 'asset-deleted' %}
+{% endif %}
 
-    {{ fields.textField(
-        'deviceid',
-        item.fields['deviceid'],
-        __('Device id'),
-        field_options
-    ) }}
+<div class="asset {{ bg }}">
+   {{ include('components/form/header.html.twig', {'in_twig': true}) }}
 
-    {{ fields.numberField(
-        'port',
-        item.fields['port'],
-        _n('Port', 'Ports', 1),
-        field_options
-    ) }}
+   {% set rand = random() %}
+   {% set params  = params ?? [] %}
+   {% set target       = params['target'] ?? item.getFormURL() %}
+   {% set withtemplate = params['withtemplate'] ?? '' %}
+   {% set item_type = item.getType() %}
+   {% set item_has_pictures = item.hasItemtypeOrModelPictures() %}
+   {% set field_options = {
+       'locked_fields': item.getLockedFields(),
+       'rand': rand,
+   } %}
 
-    {{ fields.htmlField(
-        "Agent",
-        item.fields['remote_addr'],
-        __('Public contact address'),
-        field_options
-    ) }}
+   <div class="card-body d-flex flex-wrap">
+      <div class="col-12 col-xxl-{{ item_has_pictures ? '9' : '12' }} flex-column">
+         <div class="d-flex flex-row flex-wrap flex-xl-nowrap">
+            <div class="row flex-row align-items-start flex-grow-1">
+               <div class="row flex-row">
 
-    {{ fields.dropdownArrayField(
-        'itemtype',
-        item.fields['itemtype'],
-        itemtypes,
-        __('Item type'),
-        field_options
-    ) }}
+                    {{ fields.htmlField(
+                        'name',
+                        item.fields['name'],
+                        __('Name'),
+                        field_options
+                    ) }}
 
-    {% if not item.isNewItem() %}
-        {% set asset_item = get_item(item.fields['itemtype'], item.fields['items_id']) %}
-        {{ fields.htmlField(
-            'items_id',
-            asset_item.getLink(),
-            __('Item link'),
-            field_options
-        ) }}
-        <input type="hidden" name="items_id" value="{{ item.fields['items_id'] }}">
 
-        {% set versions %}
-            {% set versions_array = call("importArrayFromDB", [versions_field]) %}
-            {% if versions_array|length %}
-                <ul>
-                {% for module, version in versions_array %}
-                    <li><strong>{{ module }}</strong>: {{ version }}</li>
-                {% endfor %}
-                </ul>
-            {% elseif versions_field|length %}
-                {{ versions_field }}
-            {% endif %}
-        {% endset %}
-        {{ fields.htmlField(
-            'versions',
-            versions,
-            _n('Version', 'Versions', 1),
-            field_options
-        ) }}
+                    {{ fields.htmlField(
+                        'agenttypes_id',
+                        call('Dropdown::getDropdownName', ["glpi_agenttypes", item.fields['agenttypes_id']]),
+                        __('Agent type'),
+                        field_options
+                    ) }}
 
-        {{ fields.readOnlyField(
-            'tag',
-            item.fields['tag'],
-            __('Tag'),
-            field_options
-        ) }}
 
-        {{ fields.readOnlyField(
-            'useragent',
-            item.fields['useragent'],
-            __('Useragent'),
-            field_options
-        ) }}
+                    {{ fields.dropdownYesNo(
+                    'locked',
+                    item.fields['locked'],
+                    __('Locked'),
+                    field_options
+                    ) }}
 
-        {{ fields.htmlField(
-            'last_contact',
-            call("Html::convDateTime", [item.fields['last_contact']]),
-            __('Last contact'),
-            field_options
-        ) }}
+                    {{ fields.htmlField(
+                        'deviceid',
+                        item.fields['deviceid'],
+                        __('Device ID'),
+                        field_options
+                    ) }}
 
-        <h2 class="header">{{ __('Agent configuration') }}</h2>
+                    {{ fields.numberField(
+                        'port',
+                        item.fields['port'],
+                        _n('Port', 'Ports', 1),
+                        field_options
+                    ) }}
 
-        {% for netfield, netlabel in {
-            'threads_networkdiscovery': __('Network discovery threads'),
-            'timeout_networkdiscovery': __('Network discovery timeout'),
-            'threads_networkinventory': __('Network inventory threads'),
-            'timeout_networkinventory': __('Network inventory timeout'),
-        } %}
-            {% set general = __('General setup') %}
-            {% if config(netfield) != null %}
-                {% set general = "%1$s (%2$s)"|format(general, config(netfield)) %}
-            {% endif %}
+                    {{ fields.htmlField(
+                        "Agent",
+                        item.fields['remote_addr'],
+                        __('Public contact address'),
+                        field_options
+                    ) }}
 
-            {{ fields.dropdownNumberField(
-                netfield,
-                item.fields[netfield],
-                netlabel,
-                field_options|merge({
-                    'min': 1,
-                    'toadd': [
-                        general
-                    ]
-                })
-            ) }}
-        {% endfor %}
+                    {{ fields.htmlField(
+                        "itemtype",
+                        call(item.fields['itemtype'] ~ '::getTypeName', [0]),
+                        __('Item type'),
+                        field_options
+                    ) }}
 
-        <h2 class="header">{{ __('Supported tasks') }}*</h2>
+                    {% if not item.isNewItem() %}
+                        {% set asset_item = get_item(item.fields['itemtype'], item.fields['items_id']) %}
+                        {{ fields.htmlField(
+                            'items_id',
+                            asset_item.getLink(),
+                            __('Item link'),
+                            field_options
+                        ) }}
+                        <input type="hidden" name="items_id" value="{{ item.fields['items_id'] }}">
 
-        {% for modulefield, modulelabel in {
-            'use_module_wake_on_lan': __('Wake on LAN'),
-            'use_module_computer_inventory': __('Computer inventory'),
-            'use_module_esx_remote_inventory': __('ESX remote inventory'),
-            'use_module_network_inventory': __('Network inventory (SNMP)'),
-            'use_module_network_discovery': __('Network discovery (SNMP)'),
-            'use_module_package_deployment': __('Package Deployment'),
-            'use_module_collect_data': __('Collect data'),
-            'use_module_remote_inventory': __('Remote inventory'),
-        } %}
+                        {% set versions %}
+                            {% set versions_array = call("importArrayFromDB", [versions_field]) %}
+                            {% if versions_array|length %}
+                                <ul>
+                                {% for module, version in versions_array %}
+                                    <li><strong>{{ module }}</strong>: {{ version }}</li>
+                                {% endfor %}
+                                </ul>
+                            {% elseif versions_field|length %}
+                                {{ versions_field }}
+                            {% endif %}
+                        {% endset %}
+                        {{ fields.htmlField(
+                            'versions',
+                            versions,
+                            _n('Version', 'Versions', 1),
+                            field_options
+                        ) }}
 
-        {% if item.fields[modulefield] %}
-            {% set html = '<i class="ti ti-check"></i>' %}
-        {% else %}
-            {% set html = '' %}
-        {% endif %}
+                        {{ fields.htmlField(
+                            'tag',
+                            item.fields['tag'],
+                            __('Tag'),
+                            field_options
+                        ) }}
 
-        {{ fields.htmlField('', html, modulelabel) }}
-        {% endfor %}
-        <i>* {{ __('when reported by GLPI agent via native inventory') }}</i>
-    {% endif %}
-{% endblock %}
+                        {{ fields.htmlField(
+                            'useragent',
+                            item.fields['useragent'],
+                            __('Useragent'),
+                            field_options
+                        ) }}
+
+                        {{ fields.htmlField(
+                            'last_contact',
+                            call("Html::convDateTime", [item.fields['last_contact']]),
+                            __('Last contact'),
+                            field_options
+                        ) }}
+
+                        <div class="hr-text">
+                            <i class="ti ti-adjustments"></i>
+                            <span>{{ __('Agent configuration') }}</span>
+                        </div>
+
+                        {% for netfield, netlabel in {
+                            'threads_networkdiscovery': __('Network discovery threads'),
+                            'timeout_networkdiscovery': __('Network discovery timeout'),
+                            'threads_networkinventory': __('Network inventory threads'),
+                            'timeout_networkinventory': __('Network inventory timeout'),
+                        } %}
+                            {% set general = __('General setup') %}
+                            {% if config(netfield) != null %}
+                                {% set general = "%1$s (%2$s)"|format(general, config(netfield)) %}
+                            {% endif %}
+
+                            {{ fields.dropdownNumberField(
+                                netfield,
+                                item.fields[netfield],
+                                netlabel,
+                                field_options|merge({
+                                    'min': 1,
+                                    'toadd': [
+                                        general
+                                    ]
+                                })
+                            ) }}
+                        {% endfor %}
+
+                        <div class="hr-text">
+                            <i class="ti ti-list"></i>
+                            <span>{{ __('Supported tasks') }} </span>
+                            <span class="form-help" data-bs-toggle="popover" data-bs-placement="top" data-bs-html="true" data-bs-content="<i> {{ __('When reported by GLPI agent via native inventory') }}</i>">?</span>
+                        </div>
+
+                        {% for modulefield, modulelabel in {
+                            'use_module_wake_on_lan': __('Wake on LAN'),
+                            'use_module_computer_inventory': __('Computer inventory'),
+                            'use_module_esx_remote_inventory': __('ESX remote inventory'),
+                            'use_module_network_inventory': __('Network inventory (SNMP)'),
+                            'use_module_network_discovery': __('Network discovery (SNMP)'),
+                            'use_module_package_deployment': __('Package Deployment'),
+                            'use_module_collect_data': __('Collect data'),
+                            'use_module_remote_inventory': __('Remote inventory'),
+                        } %}
+
+                        {% if item.fields[modulefield] %}
+                            {% set html = '<i class="ti ti-check green"></i>' %}
+                        {% else %}
+                            {% set html = '<i class="ti ti-x red"></i>' %}
+                        {% endif %}
+
+                        {{ fields.htmlField('', html, modulelabel) }}
+                        {% endfor %}
+                    {% endif %}
+                </div> {# .row #}
+            </div> {# .row #}
+         </div> {# .flex-row #}
+      </div>
+      {% if item_has_pictures %}
+         <div class="col-12 col-xxl-3 flex-column">
+            <div class="flex-row asset-pictures">
+               {{ include('components/form/pictures.html.twig', {'gallery_type': ''}) }}
+            </div>
+         </div>
+      {% endif %}
+   </div> {# .card-body #}
+
+   {% if item_type == 'Contract' %}
+      {{ include('components/form/support_hours.html.twig') }}
+   {% endif %}
+   {% if no_form_buttons is not defined or no_form_buttons == false %}
+      {{ include('components/form/buttons.html.twig') }}
+   {% endif %}
+   {% if no_inventory_footer is not defined or no_inventory_footer == false %}
+      {{ include('components/form/inventory_info.html.twig') }}
+   {% endif %}
+
+   {% if params['formfooter'] is null or params['formfooter'] == true %}
+      <div class="card-footer mx-n2 mb-n2 mt-4">
+         {{ include('components/form/dates.html.twig') }}
+      </div>
+   {% endif %}
+</div>


### PR DESCRIPTION
Abandon ```generic_show_form.html.twig``` to allow read only on native fields such as ```name``` or ```agenttypes_id```.

Before : 

![image](https://github.com/glpi-project/glpi/assets/7335054/edafa70f-4fe7-4857-9074-304fab9729b9)


After : 

![image](https://github.com/glpi-project/glpi/assets/7335054/572b5c15-3075-4b3f-9c34-6c75659ff98d)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
