### PR TITLE
Fix ticket processing criterias in the personal view

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4831,25 +4831,31 @@ JAVASCRIPT;
                         break;
 
                     case "process":
-                        $options['criteria'][0]['field']      = 5; // users_id_assign
-                        $options['criteria'][0]['searchtype'] = 'equals';
-                        $options['criteria'][0]['value']      = Session::getLoginUserID();
-                        $options['criteria'][0]['link']       = 'AND';
-
-                        $options['criteria'][5]['field']      = 12; // status
-                        $options['criteria'][5]['searchtype'] = 'equals';
-                        $options['criteria'][5]['value']      = 2;
-                        $options['criteria'][5]['link']       = 'AND';
-
-                        $options['criteria'][7]['link']       = 'OR';
-                        $options['criteria'][7]['criteria'][0]['link']       = 'AND';
-                        $options['criteria'][7]['criteria'][0]['field']      = 12; // status
-                        $options['criteria'][7]['criteria'][0]['searchtype'] = 'equals';
-                        $options['criteria'][7]['criteria'][0]['value']      = 1;
-                        $options['criteria'][7]['criteria'][1]['link']       = 'AND';
-                        $options['criteria'][7]['criteria'][1]['field']      = 5; // users_id_assign
-                        $options['criteria'][7]['criteria'][1]['searchtype'] = 'equals';
-                        $options['criteria'][7]['criteria'][1]['value']      = Session::getLoginUserID();
+                        $options['criteria'] = [
+                            [
+                                'field'        => 5,
+                                'searchtype'   => 'equals',
+                                'value'        => 'myself',
+                                'link'         => 'OR',
+                            ],
+                            [
+                                'link' => 'AND',
+                                'criteria' => [
+                                    [
+                                        'link'        => 'AND',
+                                        'field'       => 12,
+                                        'searchtype'  => 'equals',
+                                        'value'       => Ticket::INCOMING,
+                                    ],
+                                    [
+                                        'link'        => 'OR',
+                                        'field'       => 12,
+                                        'searchtype'  => 'equals',
+                                        'value'       => Ticket::ASSIGNED,
+                                    ]
+                                ]
+                            ]
+                        ];
 
                         $main_header = "<a href=\"" . Ticket::getSearchURL() . "?" .
                          Toolbox::append_params($options, '&amp;') . "\">" .

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4836,7 +4836,7 @@ JAVASCRIPT;
                                 'field'        => 5,
                                 'searchtype'   => 'equals',
                                 'value'        => 'myself',
-                                'link'         => 'OR',
+                                'link'         => 'AND',
                             ],
                             [
                                 'link' => 'AND',

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4851,7 +4851,7 @@ JAVASCRIPT;
                                         'link'        => 'OR',
                                         'field'       => 12,
                                         'searchtype'  => 'equals',
-                                        'value'       => Ticket::ASSIGNED,
+                                        'value'       => 'process',
                                     ]
                                 ]
                             ]

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4836,10 +4836,20 @@ JAVASCRIPT;
                         $options['criteria'][0]['value']      = Session::getLoginUserID();
                         $options['criteria'][0]['link']       = 'AND';
 
-                        $options['criteria'][1]['field']      = 12; // status
-                        $options['criteria'][1]['searchtype'] = 'equals';
-                        $options['criteria'][1]['value']      = 'process';
-                        $options['criteria'][1]['link']       = 'AND';
+                        $options['criteria'][5]['field']      = 12; // status
+                        $options['criteria'][5]['searchtype'] = 'equals';
+                        $options['criteria'][5]['value']      = 2;
+                        $options['criteria'][5]['link']       = 'AND';
+
+                        $options['criteria'][7]['link']       = 'OR';
+                        $options['criteria'][7]['criteria'][0]['link']       = 'AND';
+                        $options['criteria'][7]['criteria'][0]['field']      = 12; // status
+                        $options['criteria'][7]['criteria'][0]['searchtype'] = 'equals';
+                        $options['criteria'][7]['criteria'][0]['value']      = 1;
+                        $options['criteria'][7]['criteria'][1]['link']       = 'AND';
+                        $options['criteria'][7]['criteria'][1]['field']      = 5; // users_id_assign
+                        $options['criteria'][7]['criteria'][1]['searchtype'] = 'equals';
+                        $options['criteria'][7]['criteria'][1]['value']      = Session::getLoginUserID();
 
                         $main_header = "<a href=\"" . Ticket::getSearchURL() . "?" .
                          Toolbox::append_params($options, '&amp;') . "\">" .


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33018

In the personal view, the number of tickets being processed differs from the number of results that appear when you click on the filter.
In this example we are supposed to have 6 tickets in process
![image](https://github.com/glpi-project/glpi/assets/102067890/ebc8af2b-1963-427b-a716-f9caf41973bf)

But in reality, the filter only takes into account tickets in "Progressing (assigned)" status. However, some users apply rules that assign "New" status to certain tickets, even if technicians are assigned to them. In our case, therefore, we only have 4 tickets in the results.
![image](https://github.com/glpi-project/glpi/assets/102067890/c9511c3c-f3b2-412d-9df4-7598c0d6376a)

One possibility is to modify the filter criteria in this way: 
![image](https://github.com/glpi-project/glpi/assets/102067890/d306e775-cf78-43e1-bc08-08d8ba426455)

