### PR TITLE
Filter forms tags

### DIFF
--- a/ajax/form/form_tags.php
+++ b/ajax/form/form_tags.php
@@ -48,7 +48,10 @@ if (!$form) {
     Response::sendError(400, __('Form not found'));
 }
 
+// Get filter parameter
+$filter = $_GET['filter'] ?? "";
+
 // Get tags
 $tag_manager = new FormTagsManager();
 header('Content-Type: application/json');
-echo json_encode($tag_manager->getTags($form));
+echo json_encode($tag_manager->getTags($form, $filter));

--- a/js/RichText/FormTags.js
+++ b/js/RichText/FormTags.js
@@ -76,7 +76,7 @@ GLPI.RichText.FormTags = class
             {
                 trigger: '#',
                 minChars: 0,
-                fetch: () => this.#fetchItems(),
+                fetch: (filter) => this.#fetchItems(filter),
                 onAction: (autocompleteApi, range, value) => {
                     this.#insertTag(autocompleteApi, range, value);
                 }
@@ -84,10 +84,11 @@ GLPI.RichText.FormTags = class
         );
     }
 
-    async #fetchItems() {
+    async #fetchItems(filter) {
         const url = CFG_GLPI.root_doc + '/ajax/form/form_tags.php';
         const data = await $.get(url, {
             form_id: this.#form_id,
+            filter: filter
         });
 
         return data.map((tag) => ({

--- a/src/Form/Tag/AnswerTagProvider.php
+++ b/src/Form/Tag/AnswerTagProvider.php
@@ -37,7 +37,6 @@ namespace Glpi\Form\Tag;
 
 use Glpi\Form\AnswersSet;
 use Glpi\Form\Form;
-use Glpi\Form\Question;
 use Override;
 
 final class AnswerTagProvider implements TagProviderInterface

--- a/src/Form/Tag/FormTagsManager.php
+++ b/src/Form/Tag/FormTagsManager.php
@@ -40,14 +40,14 @@ use Glpi\Form\Form;
 
 final class FormTagsManager
 {
-    public function getTags(Form $form): array
+    public function getTags(Form $form, string $filter = ""): array
     {
         $tags = [];
         foreach ($this->getTagProviders() as $provider) {
             $tags = array_merge($tags, $provider->getTags($form));
         }
 
-        return $tags;
+        return $this->filterTags($tags, $filter);
     }
 
     public function insertTagsContent(
@@ -109,5 +109,21 @@ final class FormTagsManager
 
             return true;
         });
+    }
+
+    private function filterTags(array $tags, string $filter): array
+    {
+        $filtered_tags = array_filter(
+            $tags,
+            fn($tag) => $tag instanceof Tag && str_contains(
+                $tag->label,
+                $filter
+            )
+        );
+
+        // We must use array_values to ensure there is no gap in the array keys.
+        // If there were gaps, the front end would receive an object instead of
+        // an array which would lead to errors.
+        return array_values($filtered_tags);
     }
 }

--- a/src/Form/Tag/FormTagsManager.php
+++ b/src/Form/Tag/FormTagsManager.php
@@ -47,7 +47,7 @@ final class FormTagsManager
             $tags = array_merge($tags, $provider->getTags($form));
         }
 
-        return $this->filterTags($tags, $filter);
+        return $filter === '' ? $tags : $this->filterTags($tags, $filter);
     }
 
     public function insertTagsContent(

--- a/tests/cypress/e2e/form_tags.cy.js
+++ b/tests/cypress/e2e/form_tags.cy.js
@@ -77,16 +77,28 @@ describe('Form tags', () => {
         // Auto completion is not yet opened
         cy.findByRole("menuitem", {name: "Question: First name"}).should('not.exist');
         cy.findByRole("menuitem", {name: "Question: Last name"}).should('not.exist');
+        cy.findByRole("menuitem", {name: "Answer: First name"}).should('not.exist');
+        cy.findByRole("menuitem", {name: "Answer: Last name"}).should('not.exist');
 
         // Use autocomplete
         cy.findByLabelText("Content").awaitTinyMCE().as("rich_text_editor");
         cy.get("@rich_text_editor").type("#");
         cy.findByRole("menuitem", {name: "Question: First name"}).should('exist');
-        cy.findByRole("menuitem", {name: "Question: Last name"}).should('exist').click();
+        cy.findByRole("menuitem", {name: "Question: Last name"}).should('exist');
+        cy.findByRole("menuitem", {name: "Answer: First name"}).should('exist');
+        cy.findByRole("menuitem", {name: "Answer: Last name"}).should('exist');
+
+        // Filter results
+        cy.get("@rich_text_editor").type("Last");
+        cy.findByRole("menuitem", {name: "Question: First name"}).should('not.exist');
+        cy.findByRole("menuitem", {name: "Question: Last name"}).should('exist');
+        cy.findByRole("menuitem", {name: "Answer: First name"}).should('not.exist');
+        cy.findByRole("menuitem", {name: "Answer: Last name"}).should('exist');
 
         // Auto completion UI is terminated after clicking on the item.
-        cy.findByRole("menuitem", {name: "Question: First name"}).should('not.exist');
+        cy.findByRole("menuitem", {name: "Question: Last name"}).click();
         cy.findByRole("menuitem", {name: "Question: Last name"}).should('not.exist');
+        cy.findByRole("menuitem", {name: "Answer: Last name"}).should('not.exist');
 
         // Item has been inserted into rich text
         cy.get("@rich_text_editor")


### PR DESCRIPTION
Allow form tags to be filtered according to what the user typed.

Exemples:

![image](https://github.com/glpi-project/glpi/assets/42734840/20e4f116-c33f-4586-b9ff-386a40c0a070)

![image](https://github.com/glpi-project/glpi/assets/42734840/7f612f00-51df-43b7-abc2-5f26f366dfe9)

![image](https://github.com/glpi-project/glpi/assets/42734840/2b55ca94-31b8-4e3e-b274-7b08f14583d7)

![image](https://github.com/glpi-project/glpi/assets/42734840/c6b177e1-90fd-4364-a1f3-fe3e9448b4c0)

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
