### PR TITLE
Fix new ticket from notification glpi

### DIFF
--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -2219,7 +2219,12 @@ class MailCollector extends CommonDBTM
            // message-id header does not match GLPI format.
             return false;
         }
-
+        //FIX to create ticket from notification from contracts
+        $items_id = $matches['items_id'];
+        if ($items_id == 0) {
+            return false;
+        }
+        
         $uuid = $matches['uuid'];
         if (empty($uuid)) {
            // message-id corresponds to old format, without uuid.

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -2219,10 +2219,16 @@ class MailCollector extends CommonDBTM
            // message-id header does not match GLPI format.
             return false;
         }
-        //FIX to create ticket from notification from contracts
-        $items_id = $matches['items_id'];
-        if ($items_id == 0) {
-            return false;
+        //FIX to create ticket from notification from GLPI to not blacklist it
+        $itemtype = $matches['itemtype'];
+        switch ($itemtype) {
+            //If notification from contract
+            case 'Contract':
+                return false;               
+            //If notification from Software License
+            case 'SoftwareLicense':
+                return false;               
+                
         }
         
         $uuid = $matches['uuid'];

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -2224,13 +2224,12 @@ class MailCollector extends CommonDBTM
         switch ($itemtype) {
             //If notification from contract
             case 'Contract':
-                return false;               
+                return false;
             //If notification from Software License
             case 'SoftwareLicense':
-                return false;               
-                
+                return false;
         }
-        
+
         $uuid = $matches['uuid'];
         if (empty($uuid)) {
            // message-id corresponds to old format, without uuid.

--- a/src/Search.php
+++ b/src/Search.php
@@ -4344,16 +4344,18 @@ JAVASCRIPT;
 
             case 'ProjectTask':
                 $condition  = '';
-                $teamtable  = 'glpi_projecttaskteams';
                 $condition .= "`glpi_projects`.`is_template` = 0";
-                $condition .= " AND ((`$teamtable`.`itemtype` = 'User'
-                             AND `$teamtable`.`items_id` = '" . Session::getLoginUserID() . "')";
-                if (count($_SESSION['glpigroups'])) {
-                    $condition .= " OR (`$teamtable`.`itemtype` = 'Group'
-                                    AND `$teamtable`.`items_id`
-                                       IN (" . implode(",", $_SESSION['glpigroups']) . "))";
+                if (!Session::haveRight("projecttask", Project::READALL)) {
+                    $teamtable  = 'glpi_projecttaskteams';
+                    $condition .= " AND ((`$teamtable`.`itemtype` = 'User'
+                                 AND `$teamtable`.`items_id` = '" . Session::getLoginUserID() . "')";
+                    if (count($_SESSION['glpigroups'])) {
+                        $condition .= " OR (`$teamtable`.`itemtype` = 'Group'
+                                        AND `$teamtable`.`items_id`
+                                           IN (" . implode(",", $_SESSION['glpigroups']) . "))";
+                    }
+                    $condition .= ") ";
                 }
-                $condition .= ") ";
                 break;
 
             case 'Project':


### PR DESCRIPTION
Hi, as part of our workflow the Notifications from expiration contracts are sent to new ticket 
But the GLPI are blacklisting all emails notifications came from GLPI, this fix create a conditional to accept Notifications 


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #16711, #16735
