### PR TITLE
Fix automatic notification to create a new ticket

### DIFF
--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -2219,6 +2219,16 @@ class MailCollector extends CommonDBTM
            // message-id header does not match GLPI format.
             return false;
         }
+        //FIX to create ticket from notification from GLPI to not blacklist it
+        $itemtype = $matches['itemtype'];
+        switch ($itemtype) {
+            //If notification from contract
+            case 'Contract':
+                return false;
+            //If notification from Software License
+            case 'SoftwareLicense':
+                return false;
+        }
 
         $uuid = $matches['uuid'];
         if (empty($uuid)) {


### PR DESCRIPTION
Hi, as part of our workflow the Notifications from expiration contracts and expiration software license are sent to new ticket 
But the GLPI are blacklisting all emails notifications came from GLPI, this fix create a conditional to accept Notifications 


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #16711, #16735
