### PR TITLE
Make tags filtering case insensitive

### DIFF
--- a/src/Form/Tag/FormTagsManager.php
+++ b/src/Form/Tag/FormTagsManager.php
@@ -116,8 +116,8 @@ final class FormTagsManager
         $filtered_tags = array_filter(
             $tags,
             fn($tag) => $tag instanceof Tag && str_contains(
-                $tag->label,
-                $filter
+                strtoupper($tag->label),
+                strtoupper($filter)
             )
         );
 

--- a/tests/units/Glpi/Form/Tag/FormTagsManager.php
+++ b/tests/units/Glpi/Form/Tag/FormTagsManager.php
@@ -129,6 +129,15 @@ final class FormTagsManager extends DbTestCase
                 $this->getTagByName($tags, 'Answer: Last name'),
             ],
         ];
+        yield 'With "last" filter' => [
+            'form'     => $form,
+            'filter'   => "last",
+            'expected' => [
+                // Must still match despite the case difference.
+                $this->getTagByName($tags, 'Question: Last name'),
+                $this->getTagByName($tags, 'Answer: Last name'),
+            ],
+        ];
     }
 
     /**


### PR DESCRIPTION
Small followup to #17175, we do not want the search to be case sensitive.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |