### PR TITLE
Add accent colors to form tags

### DIFF
--- a/src/Form/Tag/AnswerTagProvider.php
+++ b/src/Form/Tag/AnswerTagProvider.php
@@ -41,6 +41,8 @@ use Override;
 
 final class AnswerTagProvider implements TagProviderInterface
 {
+    public const ACCENT_COLOR = "teal";
+
     #[Override]
     public function getTags(Form $form): array
     {
@@ -50,6 +52,7 @@ final class AnswerTagProvider implements TagProviderInterface
                 label: sprintf(__('Answer: %s'), $questions->fields['name']),
                 value: $questions->getId(),
                 provider: self::class,
+                color: self::ACCENT_COLOR,
             );
         }
 

--- a/src/Form/Tag/QuestionTagProvider.php
+++ b/src/Form/Tag/QuestionTagProvider.php
@@ -42,6 +42,8 @@ use Override;
 
 final class QuestionTagProvider implements TagProviderInterface
 {
+    public const ACCENT_COLOR = "orange";
+
     #[Override]
     public function getTags(Form $form): array
     {
@@ -51,6 +53,7 @@ final class QuestionTagProvider implements TagProviderInterface
                 label: sprintf(__('Question: %s'), $questions->fields['name']),
                 value: $questions->getId(),
                 provider: self::class,
+                color: self::ACCENT_COLOR,
             );
         }
 

--- a/src/Form/Tag/Tag.php
+++ b/src/Form/Tag/Tag.php
@@ -48,6 +48,7 @@ final readonly class Tag
         string $label,
         string $value,
         string $provider,
+        string $color,
     ) {
         $this->label = $label;
 
@@ -57,6 +58,7 @@ final readonly class Tag
             "data-form-tag"          => "true",
             "data-form-tag-value"    => $value,
             "data-form-tag-provider" => $provider,
+            "class"                  => "bg-$color-lt"
         ];
         $properties = implode(" ", array_map(
             fn($key, $value) => sprintf('%s="%s"', htmlspecialchars($key), htmlspecialchars($value)),

--- a/src/RichText/RichText.php
+++ b/src/RichText/RichText.php
@@ -576,7 +576,7 @@ JAVASCRIPT;
             $config = $config->dropElement($dropped_element);
         }
 
-        // Allow style attribute
+        // Allow class and style attribute
         $config = $config->allowAttribute('style', '*');
 
         if (GLPI_ALLOW_IFRAME_IN_RICH_TEXT) {
@@ -588,12 +588,13 @@ JAVASCRIPT;
             // required for proper display of autocompleted tags
             'contenteditable',
 
-            // required for user mentions
+            // required for user mentions and form tags
             'data-user-mention',
             'data-user-id',
             'data-form-tag',
             'data-form-tag-value',
             'data-form-tag-provider',
+            'class',
         ];
         foreach ($rich_text_completion_attributes as $attribute) {
             $config = $config->allowAttribute($attribute, 'span');

--- a/tests/units/Glpi/Form/Tag/AnswerTagProvider.php
+++ b/tests/units/Glpi/Form/Tag/AnswerTagProvider.php
@@ -63,11 +63,13 @@ final class AnswerTagProvider extends DbTestCase
                     label: 'Answer: First name',
                     value: $this->getQuestionId($form, 'First name'),
                     provider: \Glpi\Form\Tag\AnswerTagProvider::class,
+                    color: \Glpi\Form\Tag\AnswerTagProvider::ACCENT_COLOR,
                 ),
                 new Tag(
                     label: 'Answer: Last name',
                     value: $this->getQuestionId($form, 'Last name'),
                     provider: \Glpi\Form\Tag\AnswerTagProvider::class,
+                    color: \Glpi\Form\Tag\AnswerTagProvider::ACCENT_COLOR,
                 ),
             ]
         ];

--- a/tests/units/Glpi/Form/Tag/FormTagsManager.php
+++ b/tests/units/Glpi/Form/Tag/FormTagsManager.php
@@ -59,21 +59,25 @@ final class FormTagsManager extends DbTestCase
                 label: 'Question: First name',
                 value: $this->getQuestionId($form, 'First name'),
                 provider: QuestionTagProvider::class,
+                color: QuestionTagProvider::ACCENT_COLOR,
             ),
             new Tag(
                 label: 'Question: Last name',
                 value: $this->getQuestionId($form, 'Last name'),
                 provider: QuestionTagProvider::class,
+                color: QuestionTagProvider::ACCENT_COLOR,
             ),
             new Tag(
                 label: 'Answer: First name',
                 value: $this->getQuestionId($form, 'First name'),
                 provider: AnswerTagProvider::class,
+                color: AnswerTagProvider::ACCENT_COLOR,
             ),
             new Tag(
                 label: 'Answer: Last name',
                 value: $this->getQuestionId($form, 'Last name'),
                 provider: AnswerTagProvider::class,
+                color: AnswerTagProvider::ACCENT_COLOR,
             )
         ];
 

--- a/tests/units/Glpi/Form/Tag/QuestionTagProvider.php
+++ b/tests/units/Glpi/Form/Tag/QuestionTagProvider.php
@@ -62,11 +62,13 @@ final class QuestionTagProvider extends DbTestCase
                     label: 'Question: First name',
                     value: $this->getQuestionId($form, 'First name'),
                     provider: \Glpi\Form\Tag\QuestionTagProvider::class,
+                    color: \Glpi\Form\Tag\QuestionTagProvider::ACCENT_COLOR,
                 ),
                 new Tag(
                     label: 'Question: Last name',
                     value: $this->getQuestionId($form, 'Last name'),
                     provider: \Glpi\Form\Tag\QuestionTagProvider::class,
+                    color: \Glpi\Form\Tag\QuestionTagProvider::ACCENT_COLOR,
                 ),
             ]
         ];

--- a/tests/units/Glpi/Form/Tag/Tag.php
+++ b/tests/units/Glpi/Form/Tag/Tag.php
@@ -56,11 +56,12 @@ final class Tag extends DbTestCase
         $tag = $this->getTagByName($tags, 'Question: First name');
         $question_id = $this->getQuestionId($form, 'First name');
         $provider = QuestionTagProvider::class;
+        $color = QuestionTagProvider::ACCENT_COLOR;
 
         $this->string(json_encode($tag))->isEqualTo(
             json_encode([
                 'label' => 'Question: First name',
-                'html' => "<span contenteditable=\"false\" data-form-tag=\"true\" data-form-tag-value=\"$question_id\" data-form-tag-provider=\"$provider\">Question: First name</span>"
+                'html' => "<span contenteditable=\"false\" data-form-tag=\"true\" data-form-tag-value=\"$question_id\" data-form-tag-provider=\"$provider\" class=\"bg-$color-lt\">Question: First name</span>"
             ])
         );
     }

--- a/tests/units/Glpi/RichText/RichText.php
+++ b/tests/units/Glpi/RichText/RichText.php
@@ -398,7 +398,8 @@ HTML,
         $tag = new Tag(
             label: __("My label"),
             value: 5, // Fake id
-            provider: AnswerTagProvider::class
+            provider: AnswerTagProvider::class,
+            color: AnswerTagProvider::ACCENT_COLOR,
         );
         yield 'Html content of form tags should not be modified' => [
             'content' => $tag->html,


### PR DESCRIPTION
Add accent colors to help distinguish different types of tags.

![image](https://github.com/glpi-project/glpi/assets/42734840/b4682277-b0f9-4071-927a-0b139a36b4e8)


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
