### PR TITLE
feat(forms): add unsaved changes tracking and save-and-preview functionality to form editor

### DIFF
--- a/js/form_editor_controller.js
+++ b/js/form_editor_controller.js
@@ -169,6 +169,26 @@ class GlpiFormEditorController
             }
         });
 
+        // Handle form submit success event
+        $(this.#target).on('glpi-ajax-controller-submit-success', () => {
+            // Reset unsaved changes
+            this.#updatePreviewButton();
+
+            const save_and_preview_button = $(this.#target).find('[data-glpi-form-editor-save-and-preview-action');
+            if (save_and_preview_button.get(0) === $(document.activeElement).get(0)) {
+                // Open the preview page in a new tab
+                window.open(save_and_preview_button.data('glpi-form-editor-preview-url'), '_blank');
+            }
+        });
+
+        let last_form_changes = window.glpiUnsavedFormChanges;
+        setInterval(() => {
+            if (last_form_changes !== window.glpiUnsavedFormChanges) {
+                this.#updatePreviewButton();
+            }
+            last_form_changes = window.glpiUnsavedFormChanges;
+        }, 500);
+
         // Register handlers for each possible editor actions using custom
         // data attributes
         const events = ["click", "change", "input"];
@@ -1625,5 +1645,19 @@ class GlpiFormEditorController
         ids.forEach((id) => {
             tinymce.init(window.tinymce_editor_configs[id]);
         });
+    }
+
+    #updatePreviewButton() {
+        if (window.glpiUnsavedFormChanges) {
+            $(this.#target).find('[data-glpi-form-editor-preview-actions]')
+                .find('[data-glpi-form-editor-preview-action]').addClass('d-none');
+            $(this.#target).find('[data-glpi-form-editor-preview-actions]')
+                .find('[data-glpi-form-editor-save-and-preview-action]').removeClass('d-none');
+        } else {
+            $(this.#target).find('[data-glpi-form-editor-preview-actions]')
+                .find('[data-glpi-form-editor-preview-action]').removeClass('d-none');
+            $(this.#target).find('[data-glpi-form-editor-preview-actions]')
+                .find('[data-glpi-form-editor-save-and-preview-action]').addClass('d-none');
+        }
     }
 }

--- a/templates/pages/admin/form/form_comment.html.twig
+++ b/templates/pages/admin/form/form_comment.html.twig
@@ -49,10 +49,11 @@
     data-glpi-form-editor-block
     data-glpi-form-editor-comment
 >
-    <div
+    <section
         data-glpi-form-editor-on-click="set-active"
         data-glpi-form-editor-comment-details
         class="card"
+        aria-label="{{ __("Comment details") }}"
     >
         <div
             class="card-status-start bg-primary"
@@ -104,6 +105,7 @@
                     __('Description'),
                     base_field_options|merge({
                         'placeholder': __('Add a description...'),
+                        'aria_label': __("Comment description"),
                         'enable_richtext': true,
                         'add_body_classes': ['content-editable-tinymce-editor', 'text-muted'],
                         'editor_height': "0",
@@ -156,7 +158,7 @@
             name="rank"
             value="{{ comment is not null ? comment.fields.rank : 0 }}"
         />
-    </div>
+    </section>
     <div data-glpi-form-editor-comment-extra-details>
         {{ include('pages/admin/form/form_toolbar.html.twig', {
             'can_update': can_update,

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -121,7 +121,7 @@
                                 </div>
 
                                 {# Form's hader #}
-                                <div class="content-editable-tinymce">
+                                <div class="content-editable-tinymce" data-glpi-form-editor-header-description>
                                     {{ fields.textareaField(
                                         'header',
                                         item.fields.header,
@@ -183,18 +183,33 @@
         {# Preview form action #}
         {# Mostly useful to test forms ATM. Final UI/UX are not really thought out #}
         {# TODO: UI/UX #}
-        <a
-            href="{{ path('front/form/form_renderer.php?id=' ~ item.fields.id) }}"
-            target="_blank"
-            class="btn btn-secondary me-auto"
-            type="button"
-            name="preview"
-            form="form-form"
-            title="{{ __("Preview") }}"
-        >
-            <i class="ti ti-eye me-1"></i>
-            <span class="d-none d-xl-block">{{ __("Preview") }}</span>
-        </a>
+        <div class="me-auto" data-glpi-form-editor-preview-actions>
+            <a
+                href="{{ path('front/form/form_renderer.php?id=' ~ item.fields.id) }}"
+                target="_blank"
+                class="btn btn-secondary"
+                type="button"
+                name="preview"
+                form="form-form"
+                title="{{ __("Preview") }}"
+                data-glpi-form-editor-preview-action
+            >
+                <i class="ti ti-eye me-1"></i>
+                <span class="d-none d-xl-block">{{ __("Preview") }}</span>
+            </a>
+            <button
+                class="btn btn-secondary d-none"
+                type="submit"
+                name="update"
+                form="form-form"
+                title="{{ __("Save and preview") }}"
+                data-glpi-form-editor-save-and-preview-action
+                data-glpi-form-editor-preview-url="{{ path('front/form/form_renderer.php?id=' ~ item.fields.id) }}"
+            >
+                <i class="ti ti-eye me-1"></i>
+                <span class="d-none d-xl-block">{{ __("Save and preview") }}</span>
+            </button>
+        </div>
 
         {# Move to trashbin form action #}
         {% if item.canDelete() %}

--- a/templates/pages/admin/form/form_section.html.twig
+++ b/templates/pages/admin/form/form_section.html.twig
@@ -48,9 +48,10 @@
     'no_label'     : true,
 } %}
 
-<div
+<section
     data-glpi-form-editor-section
     class="mt-4"
+    aria-label="{{ __("Form section") }}"
 >
     <div
         class="bg-primary px-2 py-1 rounded-top {{ show_section_form ? "" : "d-none" }}"
@@ -78,6 +79,7 @@
                 <div class="d-flex">
                     {# Section's name #}
                     <input
+                        title="{{ __("Section name") }}"
                         type="text"
                         class="form-control content-editable-h2 mb-0"
                         name="name"
@@ -101,6 +103,8 @@
                             class="ti ti-dots-vertical show"
                             data-bs-toggle="dropdown"
                             aria-expanded="false"
+                            role="button"
+                            aria-label="{{ __('Section actions') }}"
                         ></i>
                         <ul class="dropdown-menu" data-bs-popper="none">
                             <li>
@@ -129,6 +133,7 @@
                                 <a
                                     href="#"
                                     class="dropdown-item {{ section_index == 1 ? "d-none" : "" }}"
+                                    aria-label="{{ __('Merge with previous section') }}"
                                     data-glpi-form-editor-on-click="merge-with-previous-section"
                                 >
                                     <i class="ti ti-arrow-merge me-2"></i>
@@ -162,6 +167,7 @@
                         base_field_options|merge({
                             'enable_richtext': true,
                             'placeholder': __('Add a description to this section...'),
+                            'aria_label': __('Section description'),
                             'add_body_classes': ['content-editable-tinymce-editor', 'text-muted'],
                             'editor_height': "0",
                             'rows' : 1,
@@ -210,5 +216,5 @@
         {% endfor %}
     </div>
 
-</div>
+</section>
 

--- a/tests/cypress.config.js
+++ b/tests/cypress.config.js
@@ -34,6 +34,8 @@
 const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
+    defaultCommandTimeout: 10000,
+    retries: 2,
     viewportWidth: 1920,
     viewportHeight: 1080,
     experimentalStudio: true,

--- a/tests/cypress/e2e/form/form_preview.cy.js
+++ b/tests/cypress/e2e/form/form_preview.cy.js
@@ -1,0 +1,202 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+describe('Form preview', () => {
+    beforeEach(() => {
+        cy.createWithAPI('Glpi\\Form\\Form', {
+            'name': 'Test form preview',
+        }).as('form_id');
+
+        cy.login();
+        cy.changeProfile('Super-Admin', true);
+
+        cy.get('@form_id').then((form_id) => {
+            const tab = 'Glpi\\Form\\Form$1';
+            cy.visit(`/front/form/form.form.php?id=${form_id}&forcetab=${tab}`);
+        });
+    });
+
+    function checkPreviewButton() {
+        // Check the preview button
+        cy.findByRole('button', { 'name': 'Save and preview' }).should('exist');
+
+        // Save the form and check the preview button
+        cy.findByRole('button', { 'name': 'Save' }).click({ force: true });
+        cy.findByRole('alert')
+            .should('contain.text', 'Item successfully updated')
+            .within(() => {
+                cy.findByRole('button', { 'name': 'Close' }).click();
+            });
+        cy.findByRole('link', { 'name': 'Preview' }).should('exist');
+    }
+
+    /**
+     * Test form preview unsaved changes handling in form header
+     * This test case checks the behavior of the form preview when there are unsaved changes in the form header.
+     */
+    it('Test form preview unsaved changes handling in form header', () => {
+        cy.findByRole('textbox', { 'name': 'Form name' }).type('Test form');
+        cy.findByRole('textbox', { 'name': 'Form name' }).blur();
+        checkPreviewButton();
+
+        cy.findByLabelText('Form description')
+            .awaitTinyMCE()
+            .type('My form description');
+
+        // Click on another field to save the TinyMCE content
+        cy.findByRole('textbox', { 'name': 'Form name' }).click();
+
+        checkPreviewButton();
+    });
+
+    /**
+    * Test form preview unsaved changes handling in sections
+    * This test case checks the behavior of the form preview when there are unsaved changes in the sections.
+    */
+    it('Test form preview unsaved changes handling in sections', () => {
+        // Add a new question
+        cy.findByRole('button', { 'name': 'Add a new question' }).click({ force: true });
+
+        // Add a new section
+        cy.findByRole('button', { 'name': 'Add a new section' }).click({ force: true });
+        checkPreviewButton();
+
+        cy.findAllByRole('region', { 'name': 'Form section' }).first().within(() => {
+            // Set the section name
+            cy.findByRole('textbox', { 'name': 'Section name' }).clear();
+            cy.findByRole('textbox', { 'name': 'Section name' }).type('Test section');
+            cy.findByRole('textbox', { 'name': 'Section name' }).blur();
+        });
+        checkPreviewButton();
+
+        cy.findAllByRole('region', { 'name': 'Form section' }).first().within(() => {
+            // Set the section description
+            cy.findByLabelText('Section description')
+                .awaitTinyMCE()
+                .type('My section description');
+
+            // Click on another field to save the TinyMCE content
+            cy.findByRole('textbox', { 'name': 'Section name' }).click();
+        });
+        checkPreviewButton();
+
+        cy.findAllByRole('region', { 'name': 'Form section' }).eq(1).within(() => {
+            // Set the section description
+            cy.findByRole('button', { 'name': 'Section actions' }).click();
+            cy.findByRole('link', { 'name': 'Merge with previous section' }).click();
+        });
+        checkPreviewButton();
+    });
+
+    /**
+     * Test form preview unsaved changes handling in questions
+     * This test case checks the behavior of the form preview when there are unsaved changes in the questions.
+     */
+    it('Test form preview unsaved changes handling in questions', () => {
+        const check = () => {
+            checkPreviewButton();
+
+            // Focus the question
+            cy.findByRole('textbox', { 'name': 'Question name' }).click();
+        };
+
+        // Add a new question
+        cy.findByRole('button', { 'name': 'Add a new question' }).click({ force: true });
+        check();
+
+        // Edit the question name
+        cy.findByRole('textbox', { 'name': 'Question name' }).type('Test question');
+        cy.findByRole('textbox', { 'name': 'Question name' }).blur();
+        check();
+
+        cy.findByRole('region', { 'name': 'Question details' }).within(() => {
+            // Type the question description
+            cy.findByLabelText("Question description")
+                .awaitTinyMCE()
+                .type("My question description");
+        });
+
+        // Click on another field to save the TinyMCE content
+        cy.findByRole('textbox', { 'name': 'Question name' }).click();
+
+        check();
+
+        cy.findByRole('region', { 'name': 'Question details' }).within(() => {
+            // Check the mandatory checkbox
+            cy.findByRole('checkbox', { 'name': 'Mandatory' })
+                .should('not.be.checked')
+                .check();
+        });
+        check();
+
+        // Change the question type
+        cy.findByRole('combobox', { 'name': 'Question sub type' }).select('Emails');
+        check();
+
+        // Change the category question type
+        cy.findByRole('combobox', { 'name': 'Question type' }).select('Long answer');
+        check();
+    });
+
+    /**
+     * Test form preview unsaved changes handling in comments
+     * This test case checks the behavior of the form preview when there are unsaved changes in the comments.
+     */
+    it('Test form preview unsaved changes handling in comments', () => {
+        const check = () => {
+            checkPreviewButton();
+
+            // Focus the comment
+            cy.findByRole('textbox', { 'name': 'Comment title' }).click();
+        };
+
+        // Add a new comment
+        cy.findByRole('button', { 'name': 'Add a new comment' }).click({ force: true });
+
+        // Edit the comment name
+        cy.findByRole('textbox', { 'name': 'Comment title' }).type('Test comment');
+        cy.findByRole('textbox', { 'name': 'Comment title' }).blur();
+        check();
+
+        cy.findByRole('region', { 'name': 'Comment details' }).within(() => {
+            // Type the comment description
+            cy.findByLabelText("Comment description")
+                .awaitTinyMCE()
+                .type("My comment description");
+        });
+
+        // Click on another field to save the TinyMCE content
+        cy.findByRole('textbox', { 'name': 'Comment title' }).click();
+        check();
+    });
+});

--- a/tests/cypress/e2e/form/form_preview.cy.js
+++ b/tests/cypress/e2e/form/form_preview.cy.js
@@ -48,7 +48,7 @@ describe('Form preview', () => {
 
     function checkPreviewButton() {
         // Check the preview button
-        cy.findByRole('button', { 'name': 'Save and preview' }).should('exist');
+        cy.findByRole('button', { 'name': 'Save and preview', timeout: 10000 }).should('exist');
 
         // Save the form and check the preview button
         cy.findByRole('button', { 'name': 'Save' }).click({ force: true });

--- a/tests/cypress/e2e/form/form_preview.cy.js
+++ b/tests/cypress/e2e/form/form_preview.cy.js
@@ -48,7 +48,7 @@ describe('Form preview', () => {
 
     function checkPreviewButton() {
         // Check the preview button
-        cy.findByRole('button', { 'name': 'Save and preview', timeout: 10000 }).should('exist');
+        cy.findByRole('button', { 'name': 'Save and preview' }).should('exist');
 
         // Save the form and check the preview button
         cy.findByRole('button', { 'name': 'Save' }).click({ force: true });
@@ -86,6 +86,10 @@ describe('Form preview', () => {
     it('Test form preview unsaved changes handling in sections', () => {
         // Add a new question
         cy.findByRole('button', { 'name': 'Add a new question' }).click({ force: true });
+        checkPreviewButton();
+
+        // Focus question
+        cy.findByRole('textbox', { 'name': 'Question name' }).click();
 
         // Add a new section
         cy.findByRole('button', { 'name': 'Add a new section' }).click({ force: true });
@@ -160,11 +164,11 @@ describe('Form preview', () => {
         check();
 
         // Change the question type
-        cy.findByRole('combobox', { 'name': 'Question sub type' }).select('Emails');
+        cy.findByRole('combobox', { 'name': 'Text' }).select('Emails');
         check();
 
         // Change the category question type
-        cy.findByRole('combobox', { 'name': 'Question type' }).select('Long answer');
+        cy.findByRole('combobox', { 'name': 'Short answer' }).select('Long answer');
         check();
     });
 


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

This PR solves the problem of the form preview not correctly reflecting the current state of the form in the editor due to unsaved changes. To achieve this, the preview button now saves the form before displaying it, and its text dynamically changes to “Save and Preview” if unsaved changes are detected.