### PR TITLE
Move Item_Cluster form inline with list

### DIFF
--- a/front/item_cluster.form.php
+++ b/front/item_cluster.form.php
@@ -40,39 +40,11 @@ Session::checkCentralAccess();
 $icl = new \Item_Cluster();
 $cluster = new Cluster();
 
-if (isset($_POST['update'])) {
-    $icl->check($_POST['id'], UPDATE);
-   //update existing relation
-    if ($icl->update($_POST)) {
-        $url = $cluster->getFormURLWithID($_POST['clusters_id']);
-    } else {
-        $url = $icl->getFormURLWithID($_POST['id']);
-    }
-    Html::redirect($url);
-} else if (isset($_POST['add'])) {
+if (isset($_POST['add'])) {
     $icl->check(-1, CREATE, $_POST);
     $icl->add($_POST);
     $url = $cluster->getFormURLWithID($_POST['clusters_id']);
-    Html::redirect($url);
-} else if (isset($_POST['purge'])) {
-    $icl->check($_POST['id'], PURGE);
-    $icl->delete($_POST, 1);
-    $url = $cluster->getFormURLWithID($_POST['clusters_id']);
-    Html::redirect($url);
+    Html::back();
 }
 
-if (!isset($_REQUEST['cluster']) && !isset($_REQUEST['id'])) {
-    Html::displayErrorAndDie('Lost');
-}
-
-$params = [];
-if (isset($_REQUEST['id'])) {
-    $params['id'] = $_REQUEST['id'];
-} else {
-    $params = [
-        'clusters_id'   => $_REQUEST['cluster']
-    ];
-}
-
-$menus = ["management", "cluster"];
-Item_Cluster::displayFullPageForItem($params['id'] ?? 0, $menus, $params);
+Html::displayErrorAndDie('Lost');

--- a/src/Item_Cluster.php
+++ b/src/Item_Cluster.php
@@ -168,6 +168,7 @@ class Item_Cluster extends CommonDBRelation
         $twig_params = [
             'item' => $this,
             'used' => $used,
+            'item_label' => _n('Item', 'Items', 1),
         ] + $options;
 
         // language=Twig
@@ -175,7 +176,7 @@ class Item_Cluster extends CommonDBRelation
             {% extends 'generic_show_form.html.twig' %}
             {% import 'components/form/fields_macros.html.twig' as fields %}
             {% block form_fields %}
-                {{ fields.dropdownItemsFromItemtypes('itemtype', _n('Item', 'Items', 1), {
+                {{ fields.dropdownItemsFromItemtypes('itemtype', item_label, {
                     itemtypes: config('cluster_types'),
                     used: used,
                 }) }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Change the form for Item_Cluster items to be inline in the cluster items list tab rather than a separate page.