### PR TITLE
Redirect user to HTTPS context when session is not allowed on HTTP

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -199,6 +199,8 @@ TWIG, $twig_params);
     }
     // Check version
     if (!isset($_GET["donotcheckversion"]) && !Update::isDbUpToDate()) {
+        Session::checkCookieSecureConfig();
+
         // Prevent debug bar to be displayed when an admin user was connected with debug mode when codebase was updated.
         Toolbox::setDebugMode(Session::NORMAL_MODE);
 

--- a/index.php
+++ b/index.php
@@ -86,7 +86,6 @@ if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
     /** @var array $CFG_GLPI */
     global $CFG_GLPI;
     include(GLPI_ROOT . "/inc/includes.php");
-    $_SESSION["glpicookietest"] = 'testcookie';
 
     //Try to detect GLPI agent calls
     $rawdata = file_get_contents("php://input");
@@ -94,6 +93,10 @@ if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
         include_once(GLPI_ROOT . '/front/inventory.php');
         die();
     }
+
+    Session::checkCookieSecureConfig();
+
+    $_SESSION["glpicookietest"] = 'testcookie';
 
     // For compatibility reason
     if (isset($_GET["noCAS"])) {

--- a/install/install.php
+++ b/install/install.php
@@ -60,6 +60,8 @@ Config::detectRootDoc();
 
 $GLPI_CACHE = (new CacheManager())->getInstallerCacheInstance();
 
+Session::checkCookieSecureConfig();
+
 //Print a correct  Html header for application
 function header_html($etape)
 {

--- a/install/update.php
+++ b/install/update.php
@@ -60,6 +60,8 @@ $GLPI_CACHE = (new CacheManager())->getInstallerCacheInstance();
 
 Config::detectRootDoc();
 
+Session::checkCookieSecureConfig();
+
 if (!($DB instanceof DBmysql)) { // $DB can have already been init in install.php script
     $DB = new DB();
 }

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -1756,8 +1756,8 @@ class Auth extends CommonGLPI
         $cookie_lifetime = empty($cookie_value) ? time() - 3600 : time() + $CFG_GLPI['login_remember_time'];
         $cookie_path     = ini_get('session.cookie_path');
         $cookie_domain   = ini_get('session.cookie_domain');
-        $cookie_secure   = (bool)ini_get('session.cookie_secure');
-        $cookie_httponly = (bool)ini_get('session.cookie_httponly');
+        $cookie_secure   = filter_var(ini_get('session.cookie_secure'), FILTER_VALIDATE_BOOLEAN);
+        $cookie_httponly = filter_var(ini_get('session.cookie_httponly'), FILTER_VALIDATE_BOOLEAN);
         $cookie_samesite = ini_get('session.cookie_samesite');
 
         if (empty($cookie_value) && !isset($_COOKIE[$cookie_name])) {

--- a/src/System/Requirement/SessionsSecurityConfiguration.php
+++ b/src/System/Requirement/SessionsSecurityConfiguration.php
@@ -55,8 +55,8 @@ class SessionsSecurityConfiguration extends AbstractRequirement
     {
         $is_cli = isCommandLine();
 
-        $cookie_secure   = (bool)ini_get('session.cookie_secure');
-        $cookie_httponly = (bool)ini_get('session.cookie_httponly');
+        $cookie_secure   = filter_var(ini_get('session.cookie_secure'), FILTER_VALIDATE_BOOLEAN);
+        $cookie_httponly = filter_var(ini_get('session.cookie_httponly'), FILTER_VALIDATE_BOOLEAN);
         $cookie_samesite = ini_get('session.cookie_samesite');
 
         $is_https_request = ($_SERVER['HTTPS'] ?? 'off') === 'on' || (int)($_SERVER['SERVER_PORT'] ?? null) == 443;

--- a/templates/layout/page_card_notlogged.html.twig
+++ b/templates/layout/page_card_notlogged.html.twig
@@ -31,7 +31,7 @@
  # ---------------------------------------------------------------------
  #}
 
-{% set theme = config('palette') %}
+{% set theme = config('palette')|default('auror') %}
 {% if css_files is not defined %}
    {% set css_files = [
        {'path': 'public/lib/base.css'},

--- a/templates/pages/https_only.html.twig
+++ b/templates/pages/https_only.html.twig
@@ -1,0 +1,58 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% extends 'layout/page_card_notlogged.html.twig' %}
+
+{% set title = _n('Error', 'Errors', 1) %}
+
+{% block content_block %}
+<div class="alert alert-warning">
+    <div class="d-flex align-items-center">
+        <div class="me-4">
+            <i class="ti ti-alert-triangle fa-2x"></i>
+        </div>
+        <div>
+            <h4 class="alert-title">
+                {{ _n('Error', 'Errors', 1) }}
+            </h4>
+            <div>
+                {{ __('The web server is configured to allow session cookies only on secured context (https). Therefore, you must access GLPI on a secured context to be able to use it.') }}
+            </div>
+
+            <a href="{{ secured_url }}" class="btn btn-primary mt-3">
+                <span>{{ __('Access the secured context') }}</span>
+            </a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/tests/units/Glpi/System/Requirement/SessionsSecurityConfiguration.php
+++ b/tests/units/Glpi/System/Requirement/SessionsSecurityConfiguration.php
@@ -39,91 +39,124 @@ class SessionsSecurityConfiguration extends \GLPITestCase
 {
     protected function configProvider(): iterable
     {
-        // Totally unsecure config
-        yield [
-            'cookie_secure'   => '0',
-            'cookie_httponly' => '0',
-            'cookie_samesite' => 'none',
-            'server_https'    => 'on',
-            'server_port'     => '443',
-            'is_valid'        => false,
+        // Boolean values are supposed to be converted by PHP internal logic when the PHP ini files are parsed,
+        // but they will not be converted to boolean when they are programatically set by a `ini_set()` call.
+        $boolean_specs = [
+            [
+                'true'  => true,
+                'false' => false,
+            ],
+            [
+                'true'  => '1',
+                'false' => '0',
+            ],
+            [
+                'true'  => 'true',
+                'false' => 'false',
+            ],
+            [
+                'true'  => 'on',
+                'false' => 'off',
+            ],
+            [
+                'true'  => 'yes',
+                'false' => 'no',
+            ],
+            [
+                'true'  => '1',
+                'false' => 'none',
+            ],
         ];
+        foreach ($boolean_specs as $specs) {
+            $true  = $specs['true'];
+            $false = $specs['false'];
 
-        // Strict config
-        yield [
-            'cookie_secure'   => '1',
-            'cookie_httponly' => '1',
-            'cookie_samesite' => 'strict',
-            'server_https'    => 'on',
-            'server_port'     => '443',
-            'is_valid'        => true,
-        ];
-
-        // cookie_secure can be 0 if query is not on HTTPS
-        yield [
-            'cookie_secure'   => '0',
-            'cookie_httponly' => '1',
-            'cookie_samesite' => 'strict',
-            'server_https'    => 'off',
-            'server_port'     => '80',
-            'is_valid'        => true,
-        ];
-
-        // cookie_secure should be 1 if query is on HTTPS (detected from $_SERVER['HTTPS'])
-        yield [
-            'cookie_secure'   => '0',
-            'cookie_httponly' => '1',
-            'cookie_samesite' => 'strict',
-            'server_https'    => 'on',
-            'server_port'     => null,
-            'is_valid'        => false,
-        ];
-
-        // cookie_secure should be 1 if query is on HTTPS (detected from $_SERVER['SERVER_PORT'])
-        yield [
-            'cookie_secure'   => '0',
-            'cookie_httponly' => '1',
-            'cookie_samesite' => 'strict',
-            'server_https'    => null,
-            'server_port'     => '443',
-            'is_valid'        => false,
-        ];
-
-        // cookie_httponly should be 1
-        yield [
-            'cookie_secure'   => '0',
-            'cookie_httponly' => '0',
-            'cookie_samesite' => 'strict',
-            'server_https'    => 'off',
-            'server_port'     => '80',
-            'is_valid'        => false,
-        ];
-
-        // cookie_samesite should be 'Lax', 'Strict', or ''
-        $samesite_is_valid = [
-            'None' => false,
-            'Lax' => true,
-            'Strict' => true,
-            ''    => true,
-            'NotAnExpectedValue' => false,
-        ];
-        foreach ($samesite_is_valid as $samesite => $is_valid) {
+            // Totally unsecure config
             yield [
-                'cookie_secure'   => '0',
-                'cookie_httponly' => '1',
-                'cookie_samesite' => $samesite,
+                'cookie_secure'   => $false,
+                'cookie_httponly' => $false,
+                'cookie_samesite' => 'none',
+                'server_https'    => 'on',
+                'server_port'     => '443',
+                'is_valid'        => false,
+            ];
+
+            // Strict config
+            yield [
+                'cookie_secure'   => $true,
+                'cookie_httponly' => $true,
+                'cookie_samesite' => 'strict',
+                'server_https'    => 'on',
+                'server_port'     => '443',
+                'is_valid'        => true,
+            ];
+
+            // cookie_secure can be 0 if query is not on HTTPS
+            yield [
+                'cookie_secure'   => $false,
+                'cookie_httponly' => $true,
+                'cookie_samesite' => 'strict',
                 'server_https'    => 'off',
                 'server_port'     => '80',
-                'is_valid'        => $is_valid,
+                'is_valid'        => true,
             ];
+
+            // cookie_secure should be 1 if query is on HTTPS (detected from $_SERVER['HTTPS'])
             yield [
-                'cookie_secure'   => '0',
-                'cookie_httponly' => '1',
-                'cookie_samesite' => strtolower($samesite),
+                'cookie_secure'   => $false,
+                'cookie_httponly' => $true,
+                'cookie_samesite' => 'strict',
+                'server_https'    => 'on',
+                'server_port'     => null,
+                'is_valid'        => false,
+            ];
+
+            // cookie_secure should be 1 if query is on HTTPS (detected from $_SERVER['SERVER_PORT'])
+            yield [
+                'cookie_secure'   => $false,
+                'cookie_httponly' => $true,
+                'cookie_samesite' => 'strict',
+                'server_https'    => null,
+                'server_port'     => '443',
+                'is_valid'        => false,
+            ];
+
+            // cookie_httponly should be 1
+            yield [
+                'cookie_secure'   => $false,
+                'cookie_httponly' => $false,
+                'cookie_samesite' => 'strict',
                 'server_https'    => 'off',
                 'server_port'     => '80',
-                'is_valid'        => $is_valid,
+                'is_valid'        => false,
             ];
+
+            // cookie_samesite should be 'Lax', 'Strict', or ''
+            $samesite_is_valid = [
+                'None' => false,
+                'Lax' => true,
+                'Strict' => true,
+                ''    => true,
+                'NotAnExpectedValue' => false,
+            ];
+            foreach ($samesite_is_valid as $samesite => $is_valid) {
+                yield [
+                    'cookie_secure'   => $false,
+                    'cookie_httponly' => $true,
+                    'cookie_samesite' => $samesite,
+                    'server_https'    => 'off',
+                    'server_port'     => '80',
+                    'is_valid'        => $is_valid,
+                ];
+                yield [
+                    'cookie_secure'   => $false,
+                    'cookie_httponly' => $true,
+                    'cookie_samesite' => strtolower($samesite),
+                    'server_https'    => 'off',
+                    'server_port'     => '80',
+                    'is_valid'        => $is_valid,
+                ];
+            }
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When the `session.cookie_secure` is configured to `true` bug GLPI is accessed on HTTP context, the session is created without any warning, but the corresponding cookie is not sent to the response. It triggers, for instance, the following behaviours:
 - When an administrator accesses to the install page, the `Select your language` step is displayed. When the administrator submit it, nothing happens and the same step is displayed again.
 - When a user access GLPI, the login form is correctly displayed. However, when the user submits it, the following error is displayed: `The action you have requested is not allowed.`.

Since we introduce telles the administrators that `PHP directive "session.cookie_secure" should be set to "on" when GLPI can be accessed on HTTPS protocol.` during the install/update process, I have seen a few times issues/forums posts from people that ere complaining that they were not able to login.

I propose to add a check on the index page and on the install/update pages to display the following error to the user when the session cookie cannot be send with the response:
![image](https://github.com/glpi-project/glpi/assets/33253653/1daceb29-29f0-453d-adc6-4239e5ccdaf7)
The button redisrect to the same URL, but with the `https` scheme.

During my tests, I also noticed that with a `ini_set('session.cookie_secure', 'off')`, `(bool)ini_get('session.cookie_secure')` was evaluated to `true`, instead of the expected `false`. I replaced this casting operation by a the usage of `filter_var(ini_get('session.cookie_secure'), FILTER_VALIDATE_BOOLEAN)` that returns the expected value.