### PR TITLE
fix(user): used items list

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -5120,7 +5120,10 @@ HTML;
                     $itemtable = getTableForItemType($itemtype);
                     $iterator_params = [
                         'FROM'   => $itemtable,
-                        'WHERE'  => ['OR' => $group_where]
+                        'WHERE'  => [
+                            'entities_id' => $this->getEntities(),
+                            'OR'          => $group_where
+                        ]
                     ];
 
                     if ($item->maybeTemplate()) {


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33023

The list of items of a group did not take into account the entity of the item. A user could therefore list items on entities to which he had no access.

In my example, the user has access to only one entity (Root entity > entity2).

Before (phone1 appears, even though he has no access to it):
![image](https://github.com/glpi-project/glpi/assets/8530352/07d57523-866a-4fc7-b75b-ca9fd9d8edca)

After:
![image](https://github.com/glpi-project/glpi/assets/8530352/66b03316-d088-4a89-9173-0bb8f112f436)

_Same in the "managed items" tab._
