### PR TITLE
fix(group): delete users

### DIFF
--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -612,9 +612,7 @@ class Group_User extends CommonDBRelation
                 echo "\n<tr class='tab_bg_" . ($user->isDeleted() ? '1_2' : '1') . "'>";
                 if ($canedit) {
                     echo "<td width='10'>";
-                    if (in_array($user->fields['entities_id'], $_SESSION['glpiactiveentities'])) {
-                        Html::showMassiveActionCheckBox(__CLASS__, $data["linkid"]);
-                    }
+                    Html::showMassiveActionCheckBox(__CLASS__, $data["linkid"]);
                     echo "</td>";
                 }
                 echo "<td>" . $user->getLink();
@@ -684,6 +682,7 @@ class Group_User extends CommonDBRelation
             'condition' => [
                 'is_usergroup' => 1,
             ] + getEntitiesRestrictCriteria(Group::getTable(), '', '', true)
+            + getEntitiesRestrictCriteria(User::getTable(), '', '', true)
         ];
 
        // Define normalized action for add_item and remove_item

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -612,7 +612,12 @@ class Group_User extends CommonDBRelation
                 echo "\n<tr class='tab_bg_" . ($user->isDeleted() ? '1_2' : '1') . "'>";
                 if ($canedit) {
                     echo "<td width='10'>";
-                    Html::showMassiveActionCheckBox(__CLASS__, $data["linkid"]);
+                    if (
+                        Session::canViewAllEntities() 
+                        || Session::haveAccessToOneOfEntities(Profile_User::getUserEntities($data["id"], false))
+                    ) {
+                        Html::showMassiveActionCheckBox(__CLASS__, $data["linkid"]);
+                    }
                     echo "</td>";
                 }
                 echo "<td>" . $user->getLink();
@@ -682,7 +687,6 @@ class Group_User extends CommonDBRelation
             'condition' => [
                 'is_usergroup' => 1,
             ] + getEntitiesRestrictCriteria(Group::getTable(), '', '', true)
-            + getEntitiesRestrictCriteria(User::getTable(), '', '', true)
         ];
 
        // Define normalized action for add_item and remove_item

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -612,7 +612,9 @@ class Group_User extends CommonDBRelation
                 echo "\n<tr class='tab_bg_" . ($user->isDeleted() ? '1_2' : '1') . "'>";
                 if ($canedit) {
                     echo "<td width='10'>";
-                    Html::showMassiveActionCheckBox(__CLASS__, $data["linkid"]);
+                    if (in_array($user->fields['entities_id'], $_SESSION['glpiactiveentities'])) {
+                        Html::showMassiveActionCheckBox(__CLASS__, $data["linkid"]);
+                    }
                     echo "</td>";
                 }
                 echo "<td>" . $user->getLink();

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -613,7 +613,7 @@ class Group_User extends CommonDBRelation
                 if ($canedit) {
                     echo "<td width='10'>";
                     if (
-                        Session::canViewAllEntities() 
+                        Session::canViewAllEntities()
                         || Session::haveAccessToOneOfEntities(Profile_User::getUserEntities($data["id"], false))
                     ) {
                         Html::showMassiveActionCheckBox(__CLASS__, $data["linkid"]);

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -612,10 +612,7 @@ class Group_User extends CommonDBRelation
                 echo "\n<tr class='tab_bg_" . ($user->isDeleted() ? '1_2' : '1') . "'>";
                 if ($canedit) {
                     echo "<td width='10'>";
-                    if (
-                        Session::canViewAllEntities()
-                        || Session::haveAccessToOneOfEntities(Profile_User::getUserEntities($data["id"], false))
-                    ) {
+                    if ($user->canUpdateItem()) {
                         Html::showMassiveActionCheckBox(__CLASS__, $data["linkid"]);
                     }
                     echo "</td>";


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33023

In a group, an admin cannot add users to entities to which he has no access (which is normal), but he could delete them. There was no user entity check on massive actions.

![image](https://github.com/glpi-project/glpi/assets/8530352/df5be3d7-5525-45d8-b3a9-b001e1dde01e)

