### PR TITLE
feat: hide duplicate action when comment and question is not focused

### DIFF
--- a/templates/pages/admin/form/form_comment.html.twig
+++ b/templates/pages/admin/form/form_comment.html.twig
@@ -87,6 +87,7 @@
                     data-bs-placement="top"
                     title="{{ __("Duplicate comment") }}"
                     data-glpi-form-editor-on-click="duplicate-comment"
+                    data-glpi-form-editor-comment-extra-details
                 ></i>
             </div>
 

--- a/templates/pages/admin/form/form_question.html.twig
+++ b/templates/pages/admin/form/form_question.html.twig
@@ -90,6 +90,7 @@
                     data-bs-placement="top"
                     title="{{ __("Duplicate question") }}"
                     data-glpi-form-editor-on-click="duplicate-question"
+                    data-glpi-form-editor-question-extra-details
                 ></i>
             </div>
 


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

Currently, the duplicate action button for a comment or question is always visible, even when the question or comment is out of focus.
This PR hides the button when the element is not in focus.