### PR TITLE
Remove support of HTML code in fields helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,7 @@ The present file will list all changes made to the project; according to the
 - `Glpi\Dashboard\Filters\AbstractFilter::field()` method has been made protected.
 - Usage of `CommonITILValidation::dropdownValidator()` with the `name` and `users_id_validate` options are no longer supported. Use `prefix` and `itemtype_target`/`items_id_target` respectively instead.
 - Namespaced plugins files must be placed in a subdirectory of the plugin `src` directory that corresponds to the second part of the plugin namespace (e.g. `src/Myplugin/` for a plugin called `myplugin`).
+- The `helper` property of form fields will not support anymore the presence of HTML code.
 
 #### Deprecated
 - Usage of `MAIL_SMTPSSL` and `MAIL_SMTPTLS` constants.

--- a/src/NotificationAjaxSetting.php
+++ b/src/NotificationAjaxSetting.php
@@ -65,7 +65,7 @@ class NotificationAjaxSetting extends NotificationSetting
             $crontask->getFromDBbyName('QueuedNotification', 'queuednotificationcleanstaleajax');
 
             TemplateRenderer::getInstance()->display('pages/setup/notification/ajax_setting.html.twig', [
-                'stale_crontask_link' => $crontask->getLink(),
+                'stale_crontask_name' => $crontask->getName(),
                 'item' => $this,
                 'params' => [
                     'candel' => false,

--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -433,12 +433,15 @@
 
     {% set helper = '' %}
     {% if options.helper %}
+        {# `|escape` must be called before call to `|nl2br` to ensure that special chars in the text will escaped twice. #}
+        {# Indeed, otherwise, due to the usage of `data-bs-html="true"`, any code snippet would be interpreted. #}
+        {% set helper_safe_text = options.helper|escape|nl2br %}
         {% set helper %}
         <span class="form-help"
               data-bs-toggle="popover"
               data-bs-placement="top"
               data-bs-html="true"
-              data-bs-content="{{ options.helper|raw|nl2br|escape }}">
+              data-bs-content="{{ helper_safe_text }}">
             ?
         </span>
         {% endset %}

--- a/templates/pages/assistance/planning/external_event.html.twig
+++ b/templates/pages/assistance/planning/external_event.html.twig
@@ -129,7 +129,7 @@
     {{ fields.dropdownField('User', 'users_id_guests[]', item.fields['users_id_guests'], __('Guests'), {
         right: 'all',
         multiple: true,
-        helper: __("Each guest will have a read-only copy of this event")|e
+        helper: __("Each guest will have a read-only copy of this event")
     }|merge(field_options)) }}
     {{ _self.null_field() }}
 

--- a/templates/pages/setup/general/preferences_setup.html.twig
+++ b/templates/pages/setup/general/preferences_setup.html.twig
@@ -356,10 +356,8 @@
 
    {{ fields.smallTitle(_n('Notification', 'Notifications', get_plural_number()), 'ti ti-bell') }}
    {% set enable_notif_helper %}
-      <ul>
-         <li>{{ __('Disable notifications by default on ITIL objects actor configuration, with ability to derogate to it.') }}</li>
-         <li>{{ __('Disable all notifications on all other objects, without ability to derogate to it.') }}</li>
-      </ul>
+      • {{ __('Disable notifications by default on ITIL objects actor configuration, with ability to derogate to it.') }}
+      • {{ __('Disable all notifications on all other objects, without ability to derogate to it.') }}
    {% endset %}
    {{ fields.dropdownYesNo('is_notif_enable_default', config['is_notif_enable_default'], __('Enable notifications'), field_options|merge({
       helper: enable_notif_helper

--- a/templates/pages/setup/ldap/form.html.twig
+++ b/templates/pages/setup/ldap/form.html.twig
@@ -74,7 +74,7 @@
     }) }}
 
     {{ fields.dropdownYesNo('use_bind', item.fields['use_bind'], __('Use bind'), {
-        helper: __("Indicates whether a simple bind operation should be used during connection to LDAP server. Disabling this behaviour can be required when LDAPS bind is used.")|e('html')
+        helper: __("Indicates whether a simple bind operation should be used during connection to LDAP server. Disabling this behaviour can be required when LDAPS bind is used.")
     }|merge(field_options)) }}
     {{ fields.nullField() }}
     <script>
@@ -106,7 +106,7 @@
 
     {{ fields.textField('login_field', item.fields['login_field'], __('Login field'), field_options) }}
     {{ fields.textField('sync_field', item.fields['sync_field'], __('Synchronization field'), {
-        helper: __('Synchronization field cannot be changed once in use.')|e('html'),
+        helper: __('Synchronization field cannot be changed once in use.'),
         disabled: item.isSyncFieldEnabled() and item.isSyncFieldUsed()
     }|merge(field_options)) }}
 

--- a/templates/pages/setup/notification/ajax_setting.html.twig
+++ b/templates/pages/setup/notification/ajax_setting.html.twig
@@ -58,7 +58,7 @@
     }) }}
 
     {{ fields.dropdownNumberField('notifications_ajax_expiration_delay', config['notifications_ajax_expiration_delay'], __('Validity period of notifications (in days)'), {
-        helper: __('Notifications older than the selected value will not be displayed. Expired notifications will be deleted by the %s crontask.')|e|format(stale_crontask_link)|raw,
+        helper: __('Notifications older than the selected value will not be displayed. Expired notifications will be deleted by the %s crontask.')|format(stale_crontask_name),
         toadd: {
             0: __('Unlimited')
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

We do not really use this feature and it is prone to security issues.

I had to make the following changes:
 - In the `Enable notifications` field helper, I replaced usage of `<ul>`/`</li>` by the `•`. The rendering is pretty similar. I do not know it it may be a problem for the accessibility of the text. We could eventually remove the bullet points.
 - In the `Validity period of notifications` (for AJAX notification), I replaced a link to a crontask form by the name of the crontask. Anyway, the link was nearly impossible to access, as the tooltip dissapear as long as you loose the focus on the tooltip icon (this happens when you try to access the tooltip contents).