### PR TITLE
Add missing global declarations

### DIFF
--- a/api.php
+++ b/api.php
@@ -45,6 +45,12 @@ use Glpi\Http\JSONResponse;
 use Glpi\Http\Request;
 use Glpi\Http\Response;
 
+/**
+ * @var GLPI $GLPI
+ * @var \Psr\SimpleCache\CacheInterface $GLPI_CACHE
+ */
+global $GLPI, $GLPI_CACHE;
+
 define('GLPI_ROOT', __DIR__);
 define('DO_NOT_CHECK_HTTP_REFERER', 1);
 ini_set('session.use_cookies', 0);

--- a/apirest.php
+++ b/apirest.php
@@ -39,6 +39,12 @@
 
 use Glpi\Cache\CacheManager;
 
+/**
+ * @var GLPI $GLPI
+ * @var \Psr\SimpleCache\CacheInterface $GLPI_CACHE
+ */
+global $GLPI, $GLPI_CACHE;
+
 define('GLPI_ROOT', __DIR__);
 ini_set('session.use_cookies', 0);
 

--- a/caldav.php
+++ b/caldav.php
@@ -42,6 +42,7 @@ ini_set('session.use_cookies', 0);
 
 include_once(GLPI_ROOT . '/inc/includes.php');
 
+/** @var array $CFG_GLPI */
 global $CFG_GLPI;
 
 $server = new Glpi\CalDAV\Server();

--- a/inc/config.php
+++ b/inc/config.php
@@ -46,8 +46,17 @@ use Glpi\Toolbox\VersionParser;
  * @var array $CFG_GLPI
  * @var \GLPI $GLPI;
  * @var \Psr\SimpleCache\CacheInterface $GLPI_CACHE
+ * @var bool $skip_db_check
+ * @var bool $dont_check_maintenance_mode
+ * @var bool $USEDBREPLICATE
+ * @var bool $DBCONNECTION_REQUIRED
  */
-global $CFG_GLPI, $GLPI, $GLPI_CACHE;
+global $CFG_GLPI,
+    $GLPI,
+    $GLPI_CACHE,
+    $skip_db_check, $dont_check_maintenance_mode,
+    $USEDBREPLICATE, $DBCONNECTION_REQUIRED
+;
 
 include_once(GLPI_ROOT . "/inc/based_config.php");
 

--- a/inc/config.php
+++ b/inc/config.php
@@ -46,10 +46,10 @@ use Glpi\Toolbox\VersionParser;
  * @var array $CFG_GLPI
  * @var \GLPI $GLPI;
  * @var \Psr\SimpleCache\CacheInterface $GLPI_CACHE
- * @var bool $skip_db_check
- * @var bool $dont_check_maintenance_mode
- * @var bool $USEDBREPLICATE
- * @var bool $DBCONNECTION_REQUIRED
+ * @var bool|null $skip_db_check
+ * @var bool|null $dont_check_maintenance_mode
+ * @var bool|null $USEDBREPLICATE
+ * @var bool|null $DBCONNECTION_REQUIRED
  */
 global $CFG_GLPI,
     $GLPI,

--- a/inc/define.php
+++ b/inc/define.php
@@ -36,6 +36,20 @@
 use Glpi\Asset\Asset_PeripheralAsset;
 use Glpi\SocketModel;
 
+/**
+ * @var array $CFG_GLPI
+ * @var int $DEFAULT_PLURAL_NUMBER
+ * @var array $PLUGIN_HOOKS
+ * @var array $CFG_GLPI_PLUGINS
+ * @var array $LANG
+ */
+global $CFG_GLPI,
+    $DEFAULT_PLURAL_NUMBER,
+    $PLUGIN_HOOKS,
+    $CFG_GLPI_PLUGINS,
+    $LANG
+;
+
 // Current version of GLPI
 define('GLPI_VERSION', '11.0.0-dev');
 

--- a/inc/includes.php
+++ b/inc/includes.php
@@ -40,8 +40,21 @@ use Glpi\Toolbox\URL;
 /**
  * @var array $CFG_GLPI
  * @var \Psr\SimpleCache\CacheInterface $GLPI_CACHE
+ * @var bool $AJAX_INCLUDE
+ * @var bool $FOOTER_LOADED
+ * @var bool $HEADER_LOADED
+ * @var bool $PLUGINS_EXCLUDED
+ * @var bool $PLUGINS_INCLUDED
+ * @var string $SECURITY_STRATEGY
  */
-global $CFG_GLPI, $GLPI_CACHE;
+global $CFG_GLPI,
+    $GLPI_CACHE,
+    $AJAX_INCLUDE,
+    $FOOTER_LOADED, $HEADER_LOADED,
+    $PLUGINS_EXCLUDED, $PLUGINS_INCLUDED,
+    $SECURITY_STRATEGY,
+    $CURRENTCSRFTOKEN
+;
 
 if (!defined('GLPI_ROOT')) {
     define('GLPI_ROOT', dirname(__DIR__));
@@ -74,7 +87,7 @@ if (
     && ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE)
 ) {
     // Start the debug profile
-    $profile = \Glpi\Debug\Profile::getCurrent();
+    \Glpi\Debug\Profile::getCurrent();
 }
 
 // Mark if Header is loaded or not :

--- a/inc/includes.php
+++ b/inc/includes.php
@@ -40,12 +40,13 @@ use Glpi\Toolbox\URL;
 /**
  * @var array $CFG_GLPI
  * @var \Psr\SimpleCache\CacheInterface $GLPI_CACHE
- * @var bool $AJAX_INCLUDE
+ * @var bool|null $AJAX_INCLUDE
  * @var bool $FOOTER_LOADED
  * @var bool $HEADER_LOADED
- * @var bool $PLUGINS_EXCLUDED
- * @var bool $PLUGINS_INCLUDED
- * @var string $SECURITY_STRATEGY
+ * @var bool|null $PLUGINS_EXCLUDED
+ * @var bool|null $PLUGINS_INCLUDED
+ * @var string|null $SECURITY_STRATEGY
+ * @var string $CURRENTCSRFTOKEN
  */
 global $CFG_GLPI,
     $GLPI_CACHE,

--- a/index.php
+++ b/index.php
@@ -45,6 +45,12 @@ if (
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Plugin\Hooks;
 
+/**
+ * @var array $CFG_GLPI
+ * @var array $PLUGIN_HOOKS
+ */
+global $CFG_GLPI, $PLUGIN_HOOKS;
+
 //Load GLPI constants
 define('GLPI_ROOT', __DIR__);
 include(GLPI_ROOT . "/inc/based_config.php");
@@ -83,8 +89,6 @@ if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
     }
     die();
 } else {
-    /** @var array $CFG_GLPI */
-    global $CFG_GLPI;
     include(GLPI_ROOT . "/inc/includes.php");
 
     //Try to detect GLPI agent calls


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

These declarations are currently optional because these scripts are included/executed in the global scope, but it may change in a near future, for instance in #17213.

Adding the `global` declaration for these global variables should anyway have no impact on the code execution, and may help IDE / code analysis tools to detect issues.