### PR TITLE
fix: add maybeDeleted to check

### DIFF
--- a/src/CommonDBConnexity.php
+++ b/src/CommonDBConnexity.php
@@ -309,22 +309,24 @@ abstract class CommonDBConnexity extends CommonDBTM
            // Solution 1 : If we cannot create the new item or delete the old item,
            // then we cannot update the item
             unset($new_item->fields);
+
             if (
-                !$new_item->can(-1, CREATE, $input)
-                || !$this->can($this->getID(), DELETE)
-                || !$this->can($this->getID(), PURGE)
+                $new_item->can(-1, CREATE, $input)
+                && (!$this->maybeDeleted() || $this->can($this->getID(), DELETE))
+                && $this->can($this->getID(), PURGE)
             ) {
-                Session::addMessageAfterRedirect(
-                    sprintf(
-                        __('Cannot update item %s #%s: not enough right on the parent(s) item(s)'),
-                        $new_item->getTypeName(),
-                        $new_item->getID()
-                    ),
-                    INFO,
-                    true
-                );
-                return false;
+                return true;
             }
+            Session::addMessageAfterRedirect(
+                sprintf(
+                    __('Cannot update item %s #%s: not enough right on the parent(s) item(s)'),
+                    $new_item->getTypeName(),
+                    $new_item->getID()
+                ),
+                INFO,
+                true
+            );
+            return false;
 
            // Solution 2 : simple check ! Can we update the item with new values ?
            // if (!$new_item->can($input['id'], 'w')) {


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33193

When the item cannot be deleted, with the `is_deleted` column, the test was always false, making the update impossible. Case with `infocom`.
