### PR TITLE
Fix ticket survey central list widget

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -84,6 +84,8 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface
     public const ANONYMIZE_USE_NICKNAME_USER   = 4;
     /** @var int Replace the group's name with a generic name */
     public const ANONYMIZE_USE_GENERIC_GROUP   = 5;
+    /** @var int Maximum number of days that can be configured for survey validity */
+    public const MAX_INQUEST_DURATION_DAYS = 180;
 
     // Const values used for the scene configuration dropdown
     public const SCENE_INHERIT = "inherit";

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4095,7 +4095,7 @@ JAVASCRIPT;
 
                 // Is the survey still valid?
                 $is_valid = $duration_cache[$entities_id] === 0
-                    || (strtotime($result['date_begin']) + $duration_cache[$entities_id] * DAY_TIMESTAMP) > strtotime($_SESSION['glpi_currenttime']);
+                    || (\Safe\strtotime($result['date_begin']) + $duration_cache[$entities_id] * DAY_TIMESTAMP) > \Safe\strtotime($_SESSION['glpi_currenttime']);
                 if (!$is_valid) {
                     // Remove the result from the list
                     unset($results[$k]);

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4005,7 +4005,17 @@ JAVASCRIPT;
                         'glpi_tickets.status'   => self::CLOSED,
                         [
                             'OR'                   => [
-                                'glpi_entities.inquest_config' => Entity::CONFIG_PARENT, // We need to resolve the inquest_duration in PHP
+                                [
+                                    'glpi_tickets.entities_id' => ['<>', 0], // Root entity never inherits
+                                    'glpi_entities.inquest_config' => Entity::CONFIG_PARENT, // We need to resolve the inquest_duration in PHP
+                                    // We can ignore any tickets closed more than Entity::MAX_INQUEST_DURATION_DAYS days ago as no survey is valid after that
+                                    new QueryExpression(
+                                        QueryFunction::dateDiff(
+                                            expression1: 'glpi_tickets.closedate',
+                                            expression2: QueryFunction::curDate()
+                                        ) . ' <= ' . Entity::MAX_INQUEST_DURATION_DAYS
+                                    )
+                                ],
                                 'glpi_entities.inquest_duration' => 0,
                                 new QueryExpression(
                                     QueryFunction::dateDiff(

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4003,18 +4003,18 @@ JAVASCRIPT;
                     $WHERE,
                     [
                         'glpi_tickets.status'   => self::CLOSED,
+                        // We can ignore any tickets closed more than Entity::MAX_INQUEST_DURATION_DAYS days ago as no survey is valid after that
+                        new QueryExpression(
+                            QueryFunction::dateDiff(
+                                expression1: QueryFunction::curDate(),
+                                expression2: 'glpi_tickets.closedate'
+                            ) . ' <= ' . Entity::MAX_INQUEST_DURATION_DAYS
+                        ),
                         [
-                            'OR'                   => [
+                            'OR' => [
                                 [
                                     'glpi_tickets.entities_id' => ['<>', 0], // Root entity never inherits
                                     'glpi_entities.inquest_config' => Entity::CONFIG_PARENT, // We need to resolve the inquest_duration in PHP
-                                    // We can ignore any tickets closed more than Entity::MAX_INQUEST_DURATION_DAYS days ago as no survey is valid after that
-                                    new QueryExpression(
-                                        QueryFunction::dateDiff(
-                                            expression1: 'glpi_tickets.closedate',
-                                            expression2: QueryFunction::curDate()
-                                        ) . ' <= ' . Entity::MAX_INQUEST_DURATION_DAYS
-                                    )
                                 ],
                                 'glpi_entities.inquest_duration' => 0,
                                 new QueryExpression(

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -3824,6 +3824,7 @@ JAVASCRIPT;
             return false;
         }
 
+        $SELECT = ['glpi_tickets.id', 'glpi_tickets.date_mod'];
         $JOINS = [];
         $WHERE = [
             'glpi_tickets.is_deleted' => 0,
@@ -3974,7 +3975,10 @@ JAVASCRIPT;
                 );
                 break;
 
-            case "survey": // tickets dont l'enqu??te de satisfaction n'est pas remplie et encore valide
+            case "survey": // tickets for which the satisfaction survey has not been completed and is still valid
+                $SELECT[] = 'glpi_tickets.entities_id';
+                $SELECT[] = 'glpi_entities.inquest_config';
+                $SELECT[] = 'glpi_ticketsatisfactions.date_begin';
                 $JOINS['INNER JOIN'] = [
                     'glpi_ticketsatisfactions' => [
                         'ON' => [
@@ -3999,19 +4003,21 @@ JAVASCRIPT;
                     $WHERE,
                     [
                         'glpi_tickets.status'   => self::CLOSED,
-                        ['OR'                   => [
-                            'glpi_entities.inquest_duration' => 0,
-                            new QueryExpression(
-                                QueryFunction::dateDiff(
-                                    expression1: QueryFunction::dateAdd(
-                                        date: 'glpi_ticketsatisfactions.date_begin',
-                                        interval: new QueryExpression($DB::quoteName('glpi_entities.inquest_duration')),
-                                        interval_unit: 'DAY'
-                                    ),
-                                    expression2: QueryFunction::curDate()
-                                ) . ' > 0'
-                            ),
-                        ],
+                        [
+                            'OR'                   => [
+                                'glpi_entities.inquest_config' => Entity::CONFIG_PARENT, // We need to resolve the inquest_duration in PHP
+                                'glpi_entities.inquest_duration' => 0,
+                                new QueryExpression(
+                                    QueryFunction::dateDiff(
+                                        expression1: QueryFunction::dateAdd(
+                                            date: 'glpi_ticketsatisfactions.date_begin',
+                                            interval: new QueryExpression($DB::quoteName('glpi_entities.inquest_duration')),
+                                            interval_unit: 'DAY'
+                                        ),
+                                        expression2: QueryFunction::curDate()
+                                    ) . ' > 0'
+                                ),
+                            ],
                         ],
                         'glpi_ticketsatisfactions.date_answered'  => null,
                     ]
@@ -4038,7 +4044,7 @@ JAVASCRIPT;
         }
 
         $criteria = [
-            'SELECT'          => ['glpi_tickets.id', 'glpi_tickets.date_mod'],
+            'SELECT'          => $SELECT,
             'DISTINCT'        => true,
             'FROM'            => 'glpi_tickets',
             'LEFT JOIN'       => [
@@ -4062,8 +4068,32 @@ JAVASCRIPT;
             $criteria = array_merge_recursive($criteria, $JOINS);
         }
 
-        $iterator = $DB->request($criteria);
-        $total_row_count = count($iterator);
+        $results = iterator_to_array($DB->request($criteria), false);
+
+        if ($status === 'survey') {
+            $duration_cache = [];
+            // Evaluate the resolved inquest_duration for any results with inquest_config = Entity::CONFIG_PARENT
+            foreach ($results as $k => $result) {
+                if ($result['inquest_config'] !== Entity::CONFIG_PARENT) {
+                    // No need to evaluate the duration for this result
+                    continue;
+                }
+                $entities_id = $result['entities_id'];
+                if (!isset($duration_cache[$entities_id])) {
+                    $duration_cache[$entities_id] = Entity::getUsedConfig('inquest_config', $entities_id, 'inquest_duration');
+                }
+
+                // Is the survey still valid?
+                $is_valid = $duration_cache[$entities_id] === 0
+                    || (strtotime($result['date_begin']) + $duration_cache[$entities_id] * DAY_TIMESTAMP) > strtotime($_SESSION['glpi_currenttime']);
+                if (!$is_valid) {
+                    // Remove the result from the list
+                    unset($results[$k]);
+                }
+            }
+        }
+
+        $total_row_count = count($results);
         $displayed_row_count = min((int) $_SESSION['glpidisplay_count_on_home'], $total_row_count);
 
         if ($total_row_count > 0) {
@@ -4460,7 +4490,7 @@ JAVASCRIPT;
                     ],
                     __('Description'),
                 ];
-                foreach ($iterator as $data) {
+                foreach ($results as $data) {
                     $showprivate = false;
                     if (Session::haveRight('followup', ITILFollowup::SEEPRIVATE)) {
                         $showprivate = true;

--- a/templates/pages/admin/entity/survey_config.html.twig
+++ b/templates/pages/admin/entity/survey_config.html.twig
@@ -56,7 +56,7 @@
 {{ fields.dropdownNumberField('inquest_duration' ~ config_suffix, inquest_duration, __('Duration of survey'), {
     full_width: true,
     min: 1,
-    max: 100,
+    max: constant('Entity::MAX_INQUEST_DURATION_DAYS'),
     unit: 'day',
     toadd: {
         0: __('Unspecified')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12219

When a ticket's entity has the survey configuration inherited from a parent, the central list could see a duration of 0 (no limit) instead of the inherited value. This PR makes it retrieve the `inquest_config` value in the SQL and additionally the results with `inquest_config` set to be inherited. Then, for each result that has an inherited config the duration is resolved within PHP and the validity of the survey checked again.