### PR TITLE
Fix insertion/display order of approval status

### DIFF
--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -592,6 +592,23 @@ abstract class CommonITILValidation extends CommonDBChild
         return Dropdown::showFromArray($name, $tab, $p);
     }
 
+    /**
+     * Get Ticket validation approver link
+     *
+     * @param integer   $users_id
+     **/
+    public static function getApprover($users_id)
+    {
+        if ($users_id === null) {
+            return null;
+        }
+
+        $users = User::getById($users_id);
+        $users_link = $users->getLink();
+        $label = $users_link;
+
+        return $label;
+    }
 
     /**
      * Get Ticket validation status Name
@@ -599,11 +616,17 @@ abstract class CommonITILValidation extends CommonDBChild
      * @param integer   $value
      * @param bool      $decorated
      **/
-    public static function getStatus($value, bool $decorated = false)
+    public static function getStatus($value, bool $decorated = false, $users_id = null)
     {
         $statuses = self::getAllStatusArray(true, true);
 
         $label = $statuses[$value] ?? $value;
+
+        if ($users_id) {
+            $users = User::getById($users_id);
+            $users_link = $users->getLink();
+            $label = '&nbsp' . $users_link . ' - ' . $label;
+        }
 
         if ($decorated) {
             $color   = self::getStatusColor($value);
@@ -1229,6 +1252,7 @@ abstract class CommonITILValidation extends CommonDBChild
             'searchtype'         => 'equals',
             'forcegroupby'       => true,
             'massiveaction'      => false,
+            'additionalfields'   => ['users_id_validate'],
             'joinparams'         => [
                 'jointype'           => 'child'
             ]

--- a/src/Search.php
+++ b/src/Search.php
@@ -7409,10 +7409,11 @@ JAVASCRIPT;
                     $out   = '';
                     for ($k = 0; $k < $data[$ID]['count']; $k++) {
                         if ($data[$ID][$k]['name']) {
+                             $user    = TicketValidation::getApprover($data[$ID][$k]['users_id_validate']);
                              $status  = TicketValidation::getStatus($data[$ID][$k]['name']);
                              $bgcolor = TicketValidation::getStatusColor($data[$ID][$k]['name']);
                              $out    .= (empty($out) ? '' : self::LBBR) .
-                                 "<div style=\"background-color:" . $bgcolor . ";\">" . $status . '</div>';
+                                 "<div class='container'> <span style=\"background-color:" . $bgcolor . ";\" class='badge text-dark col col-5'>" . $status . '</span> < ' . $user . '</div>';
                         }
                     }
                     return $out;
@@ -7421,10 +7422,11 @@ JAVASCRIPT;
                     $out   = '';
                     for ($k = 0; $k < $data[$ID]['count']; $k++) {
                         if ($data[$ID][$k]['name']) {
+                            $user     = ChangeValidation::getApprover($data[$ID][$k]['users_id_validate']);
                              $status  = ChangeValidation::getStatus($data[$ID][$k]['name']);
                              $bgcolor = ChangeValidation::getStatusColor($data[$ID][$k]['name']);
                              $out    .= (empty($out) ? '' : self::LBBR) .
-                                 "<div style=\"background-color:" . $bgcolor . ";\">" . $status . '</div>';
+                             "<div class='container'> <span style=\"background-color:" . $bgcolor . ";\" class='badge text-dark col col-5'>" . $status . '</span> < ' . $user . '</div>';
                         }
                     }
                     return $out;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33216

The order in which the status and user lists are displayed is confusing, giving the impression that the first user in the list is linked to the first status in the list (which is not the case).

I tried an ORDER BY, but the two columns refer to different tables. So I chose to display the linked user next to the status. (Only for this display)

**Before**
![image](https://github.com/glpi-project/glpi/assets/107540223/d03e09ce-cffb-434d-bc30-bca18c3a342b)

**After**
![image](https://github.com/glpi-project/glpi/assets/107540223/09d4fcb2-c69d-409f-830f-f2df8a987d09)

