### PR TITLE
Enhance dependencies checks result

### DIFF
--- a/tests/functional/Config.php
+++ b/tests/functional/Config.php
@@ -193,7 +193,12 @@ class Config extends DbTestCase
         }
         sort($expected);
         $this->array($expected)->isNotEmpty();
-        $this->array($actual)->isIdenticalTo($expected);
+
+        $unexpected_libs = array_diff($actual, $expected);
+        $missing_libs    = array_diff($expected, $actual);
+
+        $this->array($unexpected_libs)->isEmpty('Unexpected libs returned by Config::getLibraries(): ' . implode(', ', $unexpected_libs));
+        $this->array($missing_libs)->isEmpty('Missing libs in Config::getLibraries() return value: ' . implode(', ', $missing_libs));
     }
 
     public function testGetLibraryDir()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Everytime we must change the list of our composer dependencies, if we forgot to update the `Config::getLibraries()` return value, the tests fails with an output that does not really help. For instance:
```
=> tests\units\Config::testGetLibraries():
In file /var/www/glpi/tests/functional/Config.php on line 196, array() failed: array(62) is not identical to array(63)
-Expected
+Actual
@@ -1 +1 @@
-array(63) {
+array(62) {
@@ -93 +93 @@
-  string(24) "symfony/framework-bundle"
+  string(22) "symfony/html-sanitizer"
@@ -95 +95 @@
-  string(22) "symfony/html-sanitizer"
+  string(23) "symfony/http-foundation"
@@ -97 +97 @@
-  string(23) "symfony/http-foundation"
+  string(19) "symfony/http-kernel"
@@ -99 +99 @@
-  string(19) "symfony/http-kernel"
+  string(14) "symfony/mailer"
@@ -101 +101 @@
-  string(14) "symfony/mailer"
+  string(12) "symfony/mime"
@@ -103 +103 @@
-  string(12) "symfony/mime"
+  string(22) "symfony/polyfill-ctype"
@@ -105 +105 @@
-  string(22) "symfony/polyfill-ctype"
+  string(22) "symfony/polyfill-iconv"
@@ -107 +107 @@
-  string(22) "symfony/polyfill-iconv"
+  string(25) "symfony/polyfill-mbstring"
@@ -109 +109 @@
-  string(25) "symfony/polyfill-mbstring"
+  string(22) "symfony/polyfill-php83"
@@ -111 +111 @@
-  string(22) "symfony/polyfill-php83"
+  string(15) "symfony/routing"
@@ -113 +113 @@
-  string(15) "symfony/routing"
+  string(16) "tecnickcom/tcpdf"
@@ -115 +115 @@
-  string(16) "tecnickcom/tcpdf"
+  string(23) "thenetworg/oauth2-azure"
@@ -117 +117 @@
-  string(23) "thenetworg/oauth2-azure"
+  string(19) "twig/markdown-extra"
@@ -119 +119 @@
-  string(19) "twig/markdown-extra"
+  string(17) "twig/string-extra"
@@ -121 +121 @@
-  string(17) "twig/string-extra"
+  string(9) "twig/twig"
@@ -123 +123 @@
-  string(9) "twig/twig"
+  string(25) "wapmorgan/unified-archive"
@@ -125,2 +125 @@
-  string(25) "wapmorgan/unified-archive"
-  [[62](https://github.com/glpi-project/glpi/actions/runs/9381385793/job/25830521772?pr=17236#step:12:63)]=>
```

With the proposed change, the output will be something like
```
=> tests\units\Config::testGetLibraries():
In file /var/www/glpi/tests/functional/Config.php on line 200, array() failed: Unexpected libs returned by Config::getLibraries(): foo/bar, some/thing
```
or
```
In file /var/www/glpi/tests/functional/Config.php on line 201, array() failed: Missing libs in Config::getLibraries() return value: foo/bar, some/thing
```
depending on the diff between declared and expected libraries.