### PR TITLE
11.0/add missing globals 2

### DIFF
--- a/ajax/2fa.php
+++ b/ajax/2fa.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 include('../inc/includes.php');
 

--- a/ajax/actorinformation.php
+++ b/ajax/actorinformation.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 // Direct access to file
 if (strpos($_SERVER['PHP_SELF'], "actorinformation.php")) {
     $AJAX_INCLUDE = 1;

--- a/ajax/actors.php
+++ b/ajax/actors.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 include('../inc/includes.php');
 

--- a/ajax/agent.php
+++ b/ajax/agent.php
@@ -35,6 +35,11 @@
 
 use Glpi\Http\Response;
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 include('../inc/includes.php');
 header("Content-Type: application/json; charset=UTF-8");

--- a/ajax/central.php
+++ b/ajax/central.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 include('../inc/includes.php');
 

--- a/ajax/changesatisfaction.php
+++ b/ajax/changesatisfaction.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 // Direct access to file
 if (strpos($_SERVER['PHP_SELF'], "changesatisfaction.php")) {
     $AJAX_INCLUDE = 1;

--- a/ajax/comments.php
+++ b/ajax/comments.php
@@ -33,8 +33,12 @@
  * ---------------------------------------------------------------------
  */
 
-/** @var array $CFG_GLPI */
-global $CFG_GLPI;
+/**
+ * @var array $CFG_GLPI
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $CFG_GLPI,
+    $AJAX_INCLUDE;
 
 $AJAX_INCLUDE = 1;
 include('../inc/includes.php');

--- a/ajax/common.tabs.php
+++ b/ajax/common.tabs.php
@@ -33,8 +33,14 @@
  * ---------------------------------------------------------------------
  */
 
-/** @var array $CFG_GLPI */
-global $CFG_GLPI;
+/**
+ * @var array $CFG_GLPI
+ * @var bool|null $AJAX_INCLUDE
+ * @var string|null $SECURITY_STRATEGY
+ */
+global $CFG_GLPI,
+    $AJAX_INCLUDE,
+    $SECURITY_STRATEGY;
 
 $SECURITY_STRATEGY = 'no_check'; // specific checks done later to allow anonymous access to public FAQ tabs
 

--- a/ajax/dashboard.php
+++ b/ajax/dashboard.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var string|null $SECURITY_STRATEGY
+ */
+global $SECURITY_STRATEGY;
+
 $SECURITY_STRATEGY = 'no_check'; // specific checks done later to allow anonymous access to embed dashboards
 
 include('../inc/includes.php');

--- a/ajax/displayMessageAfterRedirect.php
+++ b/ajax/displayMessageAfterRedirect.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 include('../inc/includes.php');
 

--- a/ajax/dropdownConnectNetworkPort.php
+++ b/ajax/dropdownConnectNetworkPort.php
@@ -39,8 +39,12 @@
 
 use Glpi\DBAL\QueryExpression;
 
-/** @var \DBmysql $DB */
-global $DB;
+/**
+ * @var \DBmysql $DB
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $DB,
+    $AJAX_INCLUDE;
 
 $AJAX_INCLUDE = 1;
 

--- a/ajax/dropdownDelegationUsers.php
+++ b/ajax/dropdownDelegationUsers.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 // Direct access to file
 if (strpos($_SERVER['PHP_SELF'], "dropdownDelegationUsers.php")) {
     $AJAX_INCLUDE = 1;

--- a/ajax/dropdownInstallVersion.php
+++ b/ajax/dropdownInstallVersion.php
@@ -33,8 +33,12 @@
  * ---------------------------------------------------------------------
  */
 
-/** @var \DBmysql $DB */
-global $DB;
+/**
+ * @var \DBmysql $DB
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $DB,
+    $AJAX_INCLUDE;
 
 if (strpos($_SERVER['PHP_SELF'], "dropdownInstallVersion.php")) {
     $AJAX_INCLUDE = 1;

--- a/ajax/dropdownMassiveActionAddActor.php
+++ b/ajax/dropdownMassiveActionAddActor.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 include('../inc/includes.php');
 

--- a/ajax/dropdownMassiveActionAddValidator.php
+++ b/ajax/dropdownMassiveActionAddValidator.php
@@ -37,8 +37,12 @@
  * @since 0.85
  */
 
-/** @var array $CFG_GLPI */
-global $CFG_GLPI;
+/**
+ * @var array $CFG_GLPI
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $CFG_GLPI,
+    $AJAX_INCLUDE;
 
 $AJAX_INCLUDE = 1;
 include('../inc/includes.php');

--- a/ajax/dropdownMassiveActionAuthMethods.php
+++ b/ajax/dropdownMassiveActionAuthMethods.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 include('../inc/includes.php');
 

--- a/ajax/dropdownRubDocument.php
+++ b/ajax/dropdownRubDocument.php
@@ -33,8 +33,12 @@
  * ---------------------------------------------------------------------
  */
 
-/** @var \DBmysql $DB */
-global $DB;
+/**
+ * @var \DBmysql $DB
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $DB,
+    $AJAX_INCLUDE;
 
 if (strpos($_SERVER['PHP_SELF'], "dropdownRubDocument.php")) {
     $AJAX_INCLUDE = 1;

--- a/ajax/dropdownSoftwareLicense.php
+++ b/ajax/dropdownSoftwareLicense.php
@@ -33,8 +33,12 @@
  * ---------------------------------------------------------------------
  */
 
-/** @var \DBmysql $DB */
-global $DB;
+/**
+ * @var \DBmysql $DB
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $DB,
+    $AJAX_INCLUDE;
 
 if (strpos($_SERVER['PHP_SELF'], "dropdownSoftwareLicense.php")) {
     $AJAX_INCLUDE = 1;

--- a/ajax/dropdownTypeCertificates.php
+++ b/ajax/dropdownTypeCertificates.php
@@ -33,8 +33,12 @@
  * ---------------------------------------------------------------------
  */
 
-/** @var \DBmysql $DB */
-global $DB;
+/**
+ * @var \DBmysql $DB
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $DB,
+    $AJAX_INCLUDE;
 
 if (strpos($_SERVER['PHP_SELF'], "dropdownTypeCertificates.php")) {
     $AJAX_INCLUDE = 1;

--- a/ajax/dropdownValidator.php
+++ b/ajax/dropdownValidator.php
@@ -37,8 +37,12 @@
  * @since 0.85
  */
 
-/** @var array $CFG_GLPI */
-global $CFG_GLPI;
+/**
+ * @var array $CFG_GLPI
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $CFG_GLPI,
+    $AJAX_INCLUDE;
 
 $AJAX_INCLUDE = 1;
 include('../inc/includes.php');

--- a/ajax/entitytreesons.php
+++ b/ajax/entitytreesons.php
@@ -36,8 +36,10 @@
 /**
  * @var array $CFG_GLPI
  * @var \Psr\SimpleCache\CacheInterface $GLPI_CACHE
+ * @var bool|null $AJAX_INCLUDE
  */
-global $CFG_GLPI, $GLPI_CACHE;
+global $CFG_GLPI, $GLPI_CACHE,
+    $AJAX_INCLUDE;
 
 $AJAX_INCLUDE = 1;
 

--- a/ajax/fuzzysearch.php
+++ b/ajax/fuzzysearch.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 include('../inc/includes.php');
 header("Content-Type: text/html; charset=UTF-8");

--- a/ajax/genericdate.php
+++ b/ajax/genericdate.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 include('../inc/includes.php');
 

--- a/ajax/getDropdownUsers.php
+++ b/ajax/getDropdownUsers.php
@@ -37,6 +37,11 @@
  * @since 0.85
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 // Direct access to file
 if (strpos($_SERVER['PHP_SELF'], "getDropdownUsers.php")) {
     $AJAX_INCLUDE = 1;

--- a/ajax/getFileTag.php
+++ b/ajax/getFileTag.php
@@ -37,6 +37,11 @@
  * @since 0.85
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 
 include('../inc/includes.php');

--- a/ajax/getUserPicture.php
+++ b/ajax/getUserPicture.php
@@ -35,6 +35,11 @@
 
 use Glpi\Http\Response;
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 
 include('../inc/includes.php');

--- a/ajax/helpdesk_observer.php
+++ b/ajax/helpdesk_observer.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 include("../inc/includes.php");
 

--- a/ajax/impact.php
+++ b/ajax/impact.php
@@ -39,6 +39,11 @@ const DELTA_ACTION_ADD    = 1;
 const DELTA_ACTION_UPDATE = 2;
 const DELTA_ACTION_DELETE = 3;
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 include('../inc/includes.php');
 

--- a/ajax/inputtext.php
+++ b/ajax/inputtext.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 
 include('../inc/includes.php');

--- a/ajax/item_rack.php
+++ b/ajax/item_rack.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 include('../inc/includes.php');
 header("Content-Type: text/html; charset=UTF-8");

--- a/ajax/itilfollowup.php
+++ b/ajax/itilfollowup.php
@@ -39,6 +39,11 @@
 
 use Glpi\Http\Response;
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 
 include('../inc/includes.php');

--- a/ajax/itilvalidation.php
+++ b/ajax/itilvalidation.php
@@ -39,6 +39,11 @@
 
 use Glpi\Http\Response;
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 
 include('../inc/includes.php');

--- a/ajax/kanban.php
+++ b/ajax/kanban.php
@@ -38,6 +38,11 @@ use Glpi\Features\Kanban;
 use Glpi\Features\Teamwork;
 use Glpi\Http\Response;
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 
 include('../inc/includes.php');

--- a/ajax/knowbase.php
+++ b/ajax/knowbase.php
@@ -33,8 +33,12 @@
  * ---------------------------------------------------------------------
  */
 
-/** @var array $CFG_GLPI */
-global $CFG_GLPI;
+/**
+ * @var array $CFG_GLPI
+ * @var string|null $SECURITY_STRATEGY
+ */
+global $CFG_GLPI,
+    $SECURITY_STRATEGY;
 
 $SECURITY_STRATEGY = 'faq_access';
 

--- a/ajax/mailcollector.php
+++ b/ajax/mailcollector.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 include('../inc/includes.php');
 

--- a/ajax/notificationmailingsettings.php
+++ b/ajax/notificationmailingsettings.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 include('../inc/includes.php');
 

--- a/ajax/planningend.php
+++ b/ajax/planningend.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 include('../inc/includes.php');
 

--- a/ajax/projecttask.php
+++ b/ajax/projecttask.php
@@ -37,6 +37,11 @@
  * @since 9.2
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 
 include('../inc/includes.php');

--- a/ajax/rack.php
+++ b/ajax/rack.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 include('../inc/includes.php');
 header("Content-Type: text/html; charset=UTF-8");

--- a/ajax/resaperiod.php
+++ b/ajax/resaperiod.php
@@ -37,6 +37,11 @@
  * @since 0.84
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 include('../inc/includes.php');
 

--- a/ajax/rule.php
+++ b/ajax/rule.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 include('../inc/includes.php');
 

--- a/ajax/search.php
+++ b/ajax/search.php
@@ -37,6 +37,11 @@ use Glpi\Search\Input\QueryBuilder;
 
 // Direct access to file
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 include('../inc/includes.php');
 header("Content-Type: text/html; charset=UTF-8");

--- a/ajax/solution.php
+++ b/ajax/solution.php
@@ -36,6 +36,11 @@
 use Glpi\Http\Response;
 use Glpi\RichText\RichText;
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 
 include('../inc/includes.php');

--- a/ajax/subvisibility.php
+++ b/ajax/subvisibility.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 // Direct access to file
 if (strpos($_SERVER['PHP_SELF'], "subvisibility.php")) {
     $AJAX_INCLUDE = 1;

--- a/ajax/task.php
+++ b/ajax/task.php
@@ -39,6 +39,11 @@
 
 use Glpi\Http\Response;
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 
 include('../inc/includes.php');

--- a/ajax/telemetry.php
+++ b/ajax/telemetry.php
@@ -35,6 +35,11 @@
 
 use Glpi\Application\View\TemplateRenderer;
 
+/**
+ * @var string|null $SECURITY_STRATEGY
+ */
+global $SECURITY_STRATEGY;
+
 // Must be available during installation. This script already checks for permissions when the flag usually set by the installer is missing.
 $SECURITY_STRATEGY = 'no_check';
 

--- a/ajax/textarea.php
+++ b/ajax/textarea.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 
 include('../inc/includes.php');

--- a/ajax/ticketiteminformation.php
+++ b/ajax/ticketiteminformation.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 // Direct access to file
 if (strpos($_SERVER['PHP_SELF'], "ticketiteminformation.php")) {
     $AJAX_INCLUDE = 1;

--- a/ajax/ticketsatisfaction.php
+++ b/ajax/ticketsatisfaction.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 // Direct access to file
 if (strpos($_SERVER['PHP_SELF'], "ticketsatisfaction.php")) {
     $AJAX_INCLUDE = 1;

--- a/ajax/uemailUpdate.php
+++ b/ajax/uemailUpdate.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 if (strpos($_SERVER['PHP_SELF'], "uemailUpdate.php")) {
     include('../inc/includes.php');

--- a/ajax/unlockobject.php
+++ b/ajax/unlockobject.php
@@ -42,6 +42,11 @@
 // or url should be of the form 'http://.../.../unlockobject.php?requestunlock=1&id=xxxxxx'
 // to send notification to locker of object
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 include('../inc/includes.php');
 header("Content-Type: text/html; charset=UTF-8");

--- a/ajax/updateTrackingDeviceType.php
+++ b/ajax/updateTrackingDeviceType.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $AJAX_INCLUDE;
+
 $AJAX_INCLUDE = 1;
 include('../inc/includes.php');
 

--- a/ajax/visibility.php
+++ b/ajax/visibility.php
@@ -33,8 +33,12 @@
  * ---------------------------------------------------------------------
  */
 
-/** @var array $CFG_GLPI */
-global $CFG_GLPI;
+/**
+ * @var array $CFG_GLPI
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $CFG_GLPI,
+    $AJAX_INCLUDE;
 
 // Direct access to file
 if (strpos($_SERVER['PHP_SELF'], "visibility.php")) {

--- a/front/central.php
+++ b/front/central.php
@@ -33,8 +33,12 @@
  * ---------------------------------------------------------------------
  */
 
-/** @var array $CFG_GLPI */
-global $CFG_GLPI;
+/**
+ * @var array $CFG_GLPI
+ * @var string|null $SECURITY_STRATEGY
+ */
+global $CFG_GLPI,
+    $SECURITY_STRATEGY;
 
 if (isset($_GET["embed"]) && isset($_GET["dashboard"])) {
     $SECURITY_STRATEGY = 'no_check'; // Allow anonymous access for embed dashboards.

--- a/front/cron.php
+++ b/front/cron.php
@@ -33,8 +33,12 @@
  * ---------------------------------------------------------------------
  */
 
-/** @var array $CFG_GLPI */
-global $CFG_GLPI;
+/**
+ * @var array $CFG_GLPI
+ * @var string|null $SECURITY_STRATEGY
+ */
+global $CFG_GLPI,
+    $SECURITY_STRATEGY;
 
 // Ensure current directory when run from crontab
 chdir(__DIR__);

--- a/front/css.php
+++ b/front/css.php
@@ -33,6 +33,14 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var string|null $SECURITY_STRATEGY
+ * @var bool|null $skip_db_check
+ * @var bool|null $dont_check_maintenance_mode
+ */
+global $SECURITY_STRATEGY,
+    $skip_db_check, $dont_check_maintenance_mode;
+
 $SECURITY_STRATEGY = 'no_check'; // CSS must be accessible also on public pages
 
 if (!defined('GLPI_ROOT')) {

--- a/front/document.send.php
+++ b/front/document.send.php
@@ -35,6 +35,11 @@
 
 use Glpi\Inventory\Conf;
 
+/**
+ * @var string|null $SECURITY_STRATEGY
+ */
+global $SECURITY_STRATEGY;
+
 $SECURITY_STRATEGY = 'no_check'; // may allow unauthenticated access, for public FAQ images
 
 include('../inc/includes.php');

--- a/front/form/form_renderer.php
+++ b/front/form/form_renderer.php
@@ -40,7 +40,10 @@ use Glpi\Form\Renderer\FormRenderer;
 use Glpi\Http\Firewall;
 use Glpi\Http\Response;
 
-/** @var array $CFG_GLPI */
+/**
+ * @var string|null $SECURITY_STRATEGY
+ */
+global $SECURITY_STRATEGY;
 
 // Since forms may be available to unauthenticated users, we trust the
 // `canAnswerForm` method to do the required session checks.

--- a/front/helpdesk.faq.php
+++ b/front/helpdesk.faq.php
@@ -33,8 +33,12 @@
  * ---------------------------------------------------------------------
  */
 
-/** @var array $CFG_GLPI */
-global $CFG_GLPI;
+/**
+ * @var array $CFG_GLPI
+ * @var string|null $SECURITY_STRATEGY
+ */
+global $CFG_GLPI,
+    $SECURITY_STRATEGY;
 
 $SECURITY_STRATEGY = 'faq_access';
 

--- a/front/helpdesk.php
+++ b/front/helpdesk.php
@@ -33,8 +33,12 @@
  * ---------------------------------------------------------------------
  */
 
-/** @var array $CFG_GLPI */
-global $CFG_GLPI;
+/**
+ * @var array $CFG_GLPI
+ * @var string|null $SECURITY_STRATEGY
+ */
+global $CFG_GLPI,
+    $SECURITY_STRATEGY;
 
 $SECURITY_STRATEGY = 'no_check'; // Anonymous access may be allowed by configuration.
 

--- a/front/inventory.php
+++ b/front/inventory.php
@@ -36,6 +36,11 @@
 use Glpi\Inventory\Conf;
 use Glpi\Inventory\Request;
 
+/**
+ * @var string|null $SECURITY_STRATEGY
+ */
+global $SECURITY_STRATEGY;
+
 $SECURITY_STRATEGY = 'no_check'; // allow anonymous requests from inventory agent
 
 if (!defined('GLPI_ROOT')) {

--- a/front/locale.php
+++ b/front/locale.php
@@ -38,8 +38,12 @@ use Glpi\Application\ErrorHandler;
 /**
  * @var array $CFG_GLPI
  * @var \Laminas\I18n\Translator\TranslatorInterface $TRANSLATE
+ * @var string|null $SECURITY_STRATEGY
+ * @var bool|null $dont_check_maintenance_mode
  */
-global $CFG_GLPI, $TRANSLATE;
+global $CFG_GLPI, $TRANSLATE,
+    $SECURITY_STRATEGY,
+    $dont_check_maintenance_mode;
 
 $SECURITY_STRATEGY = 'no_check'; // locales must be accessible also on public pages
 

--- a/front/login.php
+++ b/front/login.php
@@ -39,8 +39,12 @@
 
 use Glpi\Application\View\TemplateRenderer;
 
-/** @var array $CFG_GLPI */
-global $CFG_GLPI;
+/**
+ * @var array $CFG_GLPI
+ * @var string|null $SECURITY_STRATEGY
+ */
+global $CFG_GLPI,
+    $SECURITY_STRATEGY;
 
 $SECURITY_STRATEGY = 'no_check';
 

--- a/front/logout.php
+++ b/front/logout.php
@@ -37,8 +37,12 @@
  * @since 0.85
  */
 
-/** @var array $CFG_GLPI */
-global $CFG_GLPI;
+/**
+ * @var array $CFG_GLPI
+ * @var string|null $SECURITY_STRATEGY
+ */
+global $CFG_GLPI,
+    $SECURITY_STRATEGY;
 
 $SECURITY_STRATEGY = 'no_check';
 

--- a/front/lostpassword.php
+++ b/front/lostpassword.php
@@ -35,8 +35,12 @@
 
 use Glpi\Application\View\TemplateRenderer;
 
-/** @var array $CFG_GLPI */
-global $CFG_GLPI;
+/**
+ * @var array $CFG_GLPI
+ * @var string|null $SECURITY_STRATEGY
+ */
+global $CFG_GLPI,
+    $SECURITY_STRATEGY;
 
 $SECURITY_STRATEGY = 'no_check';
 

--- a/front/planning.php
+++ b/front/planning.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var string|null $SECURITY_STRATEGY
+ */
+global $SECURITY_STRATEGY;
+
 if (isset($_GET['genical'])) {
     // A new sssion is generated and destroyed during the ical/webcal export.
     // Prevent sending cookies to browser to ensure that user will not be disconnected when using the export feature.

--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -35,8 +35,12 @@
 
 use Glpi\Event;
 
-/** @var array $CFG_GLPI */
-global $CFG_GLPI;
+/**
+ * @var array $CFG_GLPI
+ * @var bool|null $AJAX_INCLUDE
+ */
+global $CFG_GLPI,
+    $AJAX_INCLUDE;
 
 // avoid reloading js libs
 if (isset($_GET['ajax']) && $_GET['ajax']) {

--- a/front/tracking.injector.php
+++ b/front/tracking.injector.php
@@ -33,8 +33,12 @@
  * ---------------------------------------------------------------------
  */
 
-/** @var array $CFG_GLPI */
-global $CFG_GLPI;
+/**
+ * @var array $CFG_GLPI
+ * @var string|null $SECURITY_STRATEGY
+ */
+global $CFG_GLPI,
+    $SECURITY_STRATEGY;
 
 $SECURITY_STRATEGY = 'no_check'; // Anonymous access may be allowed by configuration.
 

--- a/front/updatepassword.php
+++ b/front/updatepassword.php
@@ -33,10 +33,14 @@
  * ---------------------------------------------------------------------
  */
 
-$SECURITY_STRATEGY = 'no_check';
+/**
+ * @var array $CFG_GLPI
+ * @var string|null $SECURITY_STRATEGY
+ */
+global $CFG_GLPI,
+    $SECURITY_STRATEGY;
 
-/** @var array $CFG_GLPI */
-global $CFG_GLPI;
+$SECURITY_STRATEGY = 'no_check';
 
 include('../inc/includes.php');
 

--- a/install/update.php
+++ b/install/update.php
@@ -49,8 +49,12 @@ include_once(GLPI_CONFIG_DIR . "/config_db.php");
  * @var \DBmysql $DB
  * @var \GLPI $GLPI
  * @var \Psr\SimpleCache\CacheInterface $GLPI_CACHE
+ * @var \Update $update
+ * @var bool $HEADER_LOADED
  */
-global $DB, $GLPI, $GLPI_CACHE;
+global $DB, $GLPI, $GLPI_CACHE,
+    $update,
+    $HEADER_LOADED;
 
 $GLPI = new GLPI();
 $GLPI->initLogger();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Follows #17245. Maybe some are still missing, but it is a bit complicated to detect missing `global` declarations in front/ajax scripts.