### PR TITLE
Add missing search option (Creation date) for Software Licenses

### DIFF
--- a/src/SoftwareLicense.php
+++ b/src/SoftwareLicense.php
@@ -486,6 +486,15 @@ class SoftwareLicense extends CommonTreeDropdown
         ];
 
         $tab[] = [
+            'id'                 => '121',
+            'table'              => $this->getTable(),
+            'field'              => 'date_creation',
+            'name'               => __('Creation date'),
+            'datatype'           => 'datetime',
+            'massiveaction'      => false
+        ];
+
+        $tab[] = [
             'id'                 => '24',
             'table'              => 'glpi_users',
             'field'              => 'name',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33225

Creation date search option was missing from Software Licenses.