### PR TITLE
Fix return and param type

### DIFF
--- a/inc/db.function.php
+++ b/inc/db.function.php
@@ -448,7 +448,7 @@ function formatUserName($ID, $login, $realname, $firstname, $link = 0, $cut = 0,
  *                      (default =0)
  *@param $disable_anon   bool  disable anonymization of username.
  *
- *@return string : username string (realname if not empty and name if realname is empty).
+ *@return string[]|string : username string (realname if not empty and name if realname is empty).
  **/
 function getUserName($ID, $link = 0, $disable_anon = false)
 {

--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -77,7 +77,7 @@ abstract class CommonDropdown extends CommonDBTM
      *
      * @since 0.85
      *
-     * @return true if translation is available, false otherwise
+     * @return boolean true if translation is available, false otherwise
      **/
     public function maybeTranslated()
     {

--- a/src/DBConnection.php
+++ b/src/DBConnection.php
@@ -305,7 +305,7 @@ class DBConnection extends CommonDBTM
     /**
      * Indicates is the DB replicate is active or not
      *
-     * @return true if active / false if not active
+     * @return boolean true if active / false if not active
      **/
     public static function isDBSlaveActive()
     {

--- a/src/DBConnection.php
+++ b/src/DBConnection.php
@@ -318,7 +318,7 @@ class DBConnection extends CommonDBTM
      *
      * @param integer $choice  Host number (default NULL)
      *
-     * @return DBmysql object
+     * @return DBmysql|void object
      **/
     public static function getDBSlaveConf($choice = null)
     {

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -1680,7 +1680,7 @@ final class DbUtils
      *                      (default =0)
      * @param $disable_anon   bool  disable anonymization of username.
      *
-     * @return string username string (realname if not empty and name if realname is empty).
+     * @return string[]|string username string (realname if not empty and name if realname is empty).
      */
     public function getUserName($ID, $link = 0, $disable_anon = false)
     {

--- a/src/DropdownTranslation.php
+++ b/src/DropdownTranslation.php
@@ -81,9 +81,9 @@ class DropdownTranslation extends CommonDBChild
 
 
     /**
-     * @param $item            CommonGLPI object
-     * @param $tabnum          (default 1)
-     * @param $withtemplate    (default 0)
+     * @param CommonGLPI $item            CommonGLPI object
+     * @param integer $tabnum          (default 1)
+     * @param integer $withtemplate    (default 0)
      **/
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
     {
@@ -201,10 +201,10 @@ class DropdownTranslation extends CommonDBChild
     /**
      * Return the number of translations for a field in a language
      *
-     * @param $itemtype
-     * @param $items_id
-     * @param $field
-     * @param $language
+     * @param string $itemtype
+     * @param int|string $items_id
+     * @param string $field
+     * @param string $language
      *
      * @return integer the number of translations for this field
      **/
@@ -225,7 +225,7 @@ class DropdownTranslation extends CommonDBChild
     /**
      * Return the number of translations for an item
      *
-     * @param item
+     * @param CommonDBTM item
      *
      * @return integer the number of translations for this item
      **/
@@ -247,8 +247,8 @@ class DropdownTranslation extends CommonDBChild
     /**
      * Check if a field's translation can be added or updated
      *
-     * @param $input          translation's fields
-     * @param $add    boolean true if a transaltion must be added, false if updated (true by default)
+     * @param mixed $input          translation's fields
+     * @param bool $add    boolean true if a transaltion must be added, false if updated (true by default)
      *
      * @return boolean true if translation can be added/update, false otherwise
      **/
@@ -270,8 +270,8 @@ class DropdownTranslation extends CommonDBChild
     /**
      * Generate completename associated with a tree dropdown
      *
-     * @param $input array    of user values
-     * @param $add   boolean  true if translation is added, false if update (tgrue by default)
+     * @param mixed $input array    of user values
+     * @param bool $add   boolean  true if translation is added, false if update (tgrue by default)
      *
      * @return void
      **/

--- a/src/DropdownTranslation.php
+++ b/src/DropdownTranslation.php
@@ -202,7 +202,7 @@ class DropdownTranslation extends CommonDBChild
      * Return the number of translations for a field in a language
      *
      * @param string $itemtype
-     * @param int|string $items_id
+     * @param int $items_id
      * @param string $field
      * @param string $language
      *
@@ -247,7 +247,7 @@ class DropdownTranslation extends CommonDBChild
     /**
      * Check if a field's translation can be added or updated
      *
-     * @param mixed $input          translation's fields
+     * @param bool $input          translation's fields
      * @param bool $add    boolean true if a transaltion must be added, false if updated (true by default)
      *
      * @return boolean true if translation can be added/update, false otherwise
@@ -270,7 +270,7 @@ class DropdownTranslation extends CommonDBChild
     /**
      * Generate completename associated with a tree dropdown
      *
-     * @param mixed $input array    of user values
+     * @param array $input     array of user values
      * @param bool $add   boolean  true if translation is added, false if update (tgrue by default)
      *
      * @return void

--- a/src/DropdownTranslation.php
+++ b/src/DropdownTranslation.php
@@ -201,10 +201,10 @@ class DropdownTranslation extends CommonDBChild
     /**
      * Return the number of translations for a field in a language
      *
-     * @param itemtype
-     * @param items_id
-     * @param field
-     * @param language
+     * @param $itemtype
+     * @param $items_id
+     * @param $field
+     * @param $language
      *
      * @return integer the number of translations for this field
      **/
@@ -250,7 +250,7 @@ class DropdownTranslation extends CommonDBChild
      * @param $input          translation's fields
      * @param $add    boolean true if a transaltion must be added, false if updated (true by default)
      *
-     * @return true if translation can be added/update, false otherwise
+     * @return boolean true if translation can be added/update, false otherwise
      **/
     public function checkBeforeAddorUpdate($input, $add = true)
     {
@@ -783,7 +783,7 @@ JAVASCRIPT
     /**
      * Is dropdown item translation functionality active
      *
-     * @return true if active, false if not
+     * @return boolean true if active, false if not
      **/
     public static function isDropdownTranslationActive()
     {

--- a/src/FieldUnicity.php
+++ b/src/FieldUnicity.php
@@ -532,7 +532,7 @@ class FieldUnicity extends CommonDropdown
     /**
      * Delete all criterias for an itemtype
      *
-     * @param itemtype
+     * @param $itemtype
      *
      * @return void
      **/

--- a/src/FieldUnicity.php
+++ b/src/FieldUnicity.php
@@ -532,7 +532,7 @@ class FieldUnicity extends CommonDropdown
     /**
      * Delete all criterias for an itemtype
      *
-     * @param $itemtype
+     * @param string $itemtype
      *
      * @return void
      **/

--- a/src/Fieldblacklist.php
+++ b/src/Fieldblacklist.php
@@ -372,7 +372,7 @@ class Fieldblacklist extends CommonDropdown
 
 
     /**
-     * @param $field  (default '')
+     * @param string $field  (default '')
      **/
     public function selectValues($field = '')
     {
@@ -398,10 +398,10 @@ class Fieldblacklist extends CommonDropdown
     /**
      * Check if a field & value are blacklisted or not
      *
-     * @param $itemtype      itemtype of the blacklisted field
-     * @param $entities_id   the entity in which the field must be saved
-     * @param $field         the field to check
-     * @param $value         the field's value
+     * @param string $itemtype      itemtype of the blacklisted field
+     * @param int|string $entities_id   the entity in which the field must be saved
+     * @param string $field         the field to check
+     * @param array|string $value         the field's value
      *
      * @return true is value if blacklisted, false otherwise
      **/

--- a/src/Fieldblacklist.php
+++ b/src/Fieldblacklist.php
@@ -399,9 +399,9 @@ class Fieldblacklist extends CommonDropdown
      * Check if a field & value are blacklisted or not
      *
      * @param string $itemtype      itemtype of the blacklisted field
-     * @param int|string $entities_id   the entity in which the field must be saved
+     * @param int $entities_id   the entity in which the field must be saved
      * @param string $field         the field to check
-     * @param array|string $value         the field's value
+     * @param string $value         the field's value
      *
      * @return true is value if blacklisted, false otherwise
      **/

--- a/src/Fieldblacklist.php
+++ b/src/Fieldblacklist.php
@@ -398,10 +398,10 @@ class Fieldblacklist extends CommonDropdown
     /**
      * Check if a field & value are blacklisted or not
      *
-     * @param itemtype      itemtype of the blacklisted field
-     * @param entities_id   the entity in which the field must be saved
-     * @param field         the field to check
-     * @param value         the field's value
+     * @param $itemtype      itemtype of the blacklisted field
+     * @param $entities_id   the entity in which the field must be saved
+     * @param $field         the field to check
+     * @param $value         the field's value
      *
      * @return true is value if blacklisted, false otherwise
      **/

--- a/src/IPNetwork.php
+++ b/src/IPNetwork.php
@@ -834,7 +834,7 @@ class IPNetwork extends CommonImplicitTreeDropdown
      * @param IPAddress|integer[] $networkNetmask  (see \ref parameterType) the netmask of the network
      * @param integer             $version         of IP : only usefull for binary array as input (default 0)
      *
-     * @return true if the network owns the IP address
+     * @return boolean true if the network owns the IP address
      **/
     public static function checkIPFromNetwork($address, $networkAddress, $networkNetmask, $version = 0)
     {

--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -287,8 +287,8 @@ class Infocom extends CommonDBChild
     /**
      * Fill, if necessary, automatically some dates when status changes
      *
-     * @param item          CommonDBTM object: the item whose status have changed
-     * @param action_add    true if object is added, false if updated (true by default)
+     * @param $item          CommonDBTM object: the item whose status have changed
+     * @param $action_add    true if object is added, false if updated (true by default)
      *
      * @return void
      **/
@@ -335,10 +335,10 @@ class Infocom extends CommonDBChild
     /**
      * Automatically manage copying one date to another is necessary
      *
-     * @param infocoms   array of item's infocom to modify
-     * @param field            the date to modify (default '')
-     * @param action           the action to peform (copy from another date) (default 0)
-     * @param params     array of additional parameters needed to perform the task
+     * @param $infocoms   array of item's infocom to modify
+     * @param $field            the date to modify (default '')
+     * @param $action           the action to peform (copy from another date) (default 0)
+     * @param $params     array of additional parameters needed to perform the task
      *
      * @return void
      **/

--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -287,8 +287,8 @@ class Infocom extends CommonDBChild
     /**
      * Fill, if necessary, automatically some dates when status changes
      *
-     * @param $item          CommonDBTM object: the item whose status have changed
-     * @param $action_add    true if object is added, false if updated (true by default)
+     * @param CommonDBTM $item          CommonDBTM object: the item whose status have changed
+     * @param boolean $action_add    true if object is added, false if updated (true by default)
      *
      * @return void
      **/
@@ -335,10 +335,10 @@ class Infocom extends CommonDBChild
     /**
      * Automatically manage copying one date to another is necessary
      *
-     * @param $infocoms   array of item's infocom to modify
-     * @param $field            the date to modify (default '')
-     * @param $action           the action to peform (copy from another date) (default 0)
-     * @param $params     array of additional parameters needed to perform the task
+     * @param array $infocoms   array of item's infocom to modify
+     * @param string $field            the date to modify (default '')
+     * @param integer $action           the action to peform (copy from another date) (default 0)
+     * @param array $params     array of additional parameters needed to perform the task
      *
      * @return void
      **/

--- a/src/KnowbaseItemTranslation.php
+++ b/src/KnowbaseItemTranslation.php
@@ -416,7 +416,7 @@ class KnowbaseItemTranslation extends CommonDBChild
     /**
      * Get already translated languages for item
      *
-     * @param $item
+     * @param CommonDBTM $item
      *
      * @return array of already translated languages
      **/

--- a/src/KnowbaseItemTranslation.php
+++ b/src/KnowbaseItemTranslation.php
@@ -368,7 +368,7 @@ class KnowbaseItemTranslation extends CommonDBChild
     /**
      * Is kb item translation functionality active
      *
-     * @return true if active, false if not
+     * @return boolean true if active, false if not
      **/
     public static function isKbTranslationActive()
     {
@@ -384,9 +384,9 @@ class KnowbaseItemTranslation extends CommonDBChild
      * It be translated if translation if globally on and item is an instance of CommonDropdown
      * or CommonTreeDropdown and if translation is enabled for this class
      *
-     * @param item the item to check
+     * @param $item the item to check
      *
-     * @return true if item can be translated, false otherwise
+     * @return boolean true if item can be translated, false otherwise
      **/
     public static function canBeTranslated(CommonGLPI $item)
     {
@@ -416,7 +416,7 @@ class KnowbaseItemTranslation extends CommonDBChild
     /**
      * Get already translated languages for item
      *
-     * @param item
+     * @param $item
      *
      * @return array of already translated languages
      **/

--- a/src/PlanningRecall.php
+++ b/src/PlanningRecall.php
@@ -102,9 +102,9 @@ class PlanningRecall extends CommonDBChild
     /**
      * Retrieve an item from the database
      *
-     * @param $itemtype     string   itemtype to get
-     * @param $items_id     integer  id of the item
-     * @param $users_id     integer  id of the user
+     * @param string $itemtype     string   itemtype to get
+     * @param integer $items_id     integer  id of the item
+     * @param integer $users_id     integer  id of the user
      *
      * @return boolean true if succeed else false
      **/
@@ -214,9 +214,9 @@ class PlanningRecall extends CommonDBChild
     /**
      * Update planning recal date when changing begin of planning
      *
-     * @param $itemtype  string   itemtype to get
-     * @param $items_id  integer  id of the item
-     * @param $begin     datetime new begin date
+     * @param string $itemtype  string   itemtype to get
+     * @param integer $items_id  integer  id of the item
+     * @param string $begin     datetime new begin date
      *
      * @return boolean true if succeed else false
      **/

--- a/src/PlanningRecall.php
+++ b/src/PlanningRecall.php
@@ -106,7 +106,7 @@ class PlanningRecall extends CommonDBChild
      * @param $items_id     integer  id of the item
      * @param $users_id     integer  id of the user
      *
-     * @return true if succeed else false
+     * @return boolean true if succeed else false
      **/
     public function getFromDBForItemAndUser($itemtype, $items_id, $users_id)
     {
@@ -218,7 +218,7 @@ class PlanningRecall extends CommonDBChild
      * @param $items_id  integer  id of the item
      * @param $begin     datetime new begin date
      *
-     * @return true if succeed else false
+     * @return boolean true if succeed else false
      **/
     public static function managePlanningUpdates($itemtype, $items_id, $begin)
     {

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -608,7 +608,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
      *     - target form target
      *     - projects_id ID of the software for add process
      *
-     * @return true if displayed  false if item not found or not right to display
+     * @return boolean true if displayed  false if item not found or not right to display
      **/
     public function showForm($ID, array $options = [])
     {

--- a/src/ReminderTranslation.php
+++ b/src/ReminderTranslation.php
@@ -310,9 +310,9 @@ class ReminderTranslation extends CommonDBChild
      * It be translated if translation if globally on and item is an instance of CommonDropdown
      * or CommonTreeDropdown and if translation is enabled for this class
      *
-     * @param item the item to check
+     * @param $item the item to check
      *
-     * @return true if item can be translated, false otherwise
+     * @return boolean true if item can be translated, false otherwise
      **/
     public static function canBeTranslated(CommonGLPI $item)
     {
@@ -342,7 +342,7 @@ class ReminderTranslation extends CommonDBChild
     /**
      * Get already translated languages for item
      *
-     * @param item
+     * @param $item
      *
      * @return array of already translated languages
      **/

--- a/src/ReminderTranslation.php
+++ b/src/ReminderTranslation.php
@@ -310,7 +310,7 @@ class ReminderTranslation extends CommonDBChild
      * It be translated if translation if globally on and item is an instance of CommonDropdown
      * or CommonTreeDropdown and if translation is enabled for this class
      *
-     * @param CommonDBTM $item the item to check
+     * @param CommonGLPI $item the item to check
      *
      * @return boolean true if item can be translated, false otherwise
      **/

--- a/src/ReminderTranslation.php
+++ b/src/ReminderTranslation.php
@@ -310,7 +310,7 @@ class ReminderTranslation extends CommonDBChild
      * It be translated if translation if globally on and item is an instance of CommonDropdown
      * or CommonTreeDropdown and if translation is enabled for this class
      *
-     * @param $item the item to check
+     * @param CommonDBTM $item the item to check
      *
      * @return boolean true if item can be translated, false otherwise
      **/
@@ -342,7 +342,7 @@ class ReminderTranslation extends CommonDBChild
     /**
      * Get already translated languages for item
      *
-     * @param $item
+     * @param CommonDBTM $item
      *
      * @return array of already translated languages
      **/

--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -124,7 +124,7 @@ class ReservationItem extends CommonDBChild
      * @param $itemtype   type of the item
      * @param $ID         ID of the item
      *
-     * @return true if succeed else false
+     * @return boolean true if succeed else false
      **/
     public function getFromDBbyItem($itemtype, $ID)
     {

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -1004,7 +1004,7 @@ JAVASCRIPT;
     /**
      * Export rules in a xml format
      *
-     * @param $items array the input data to transform to xml
+     * @param array $items array the input data to transform to xml
      *
      * @since 0.85
      *

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -1004,7 +1004,7 @@ JAVASCRIPT;
     /**
      * Export rules in a xml format
      *
-     * @param items array the input data to transform to xml
+     * @param $items array the input data to transform to xml
      *
      * @since 0.85
      *
@@ -1159,7 +1159,7 @@ JAVASCRIPT;
      * @param integer $condition          the rulecriteria condition
      * @param stirng  $criterion          the criterion
      *
-     * @return true if a criterion is a dropdown, false otherwise
+     * @return boolean true if a criterion is a dropdown, false otherwise
      **/
     public static function isCriteraADropdown($available_criteria, $condition, $criterion)
     {

--- a/src/SavedSearch_Alert.php
+++ b/src/SavedSearch_Alert.php
@@ -107,7 +107,7 @@ class SavedSearch_Alert extends CommonDBChild
      *     - target for the Form
      *     - computers_id ID of the computer for add process
      *
-     * @return true if displayed  false if item not found or not right to display
+     * @return boolean true if displayed  false if item not found or not right to display
      **/
     public function showForm($ID, array $options = [])
     {

--- a/src/Session.php
+++ b/src/Session.php
@@ -1434,7 +1434,7 @@ class Session
      *  Force active Tab for an itemtype
      *
      * @param string  $itemtype item type
-     * @param integer $tab      ID of the tab
+     * @param mixed $tab      ID of the tab
      *
      * @return void
      **/

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -183,7 +183,7 @@ class Socket extends CommonDBChild
      *     - itemtype type of the item for add process
      *     - items_id ID of the item for add process
      *
-     * @return true if displayed  false if item not found or not right to display
+     * @return boolean true if displayed  false if item not found or not right to display
      **/
     public function showForm($ID, array $options = [])
     {

--- a/src/SoftwareVersion.php
+++ b/src/SoftwareVersion.php
@@ -101,7 +101,7 @@ class SoftwareVersion extends CommonDBChild
      *     - target form target
      *     - softwares_id ID of the software for add process
      *
-     * @return true if displayed  false if item not found or not right to display
+     * @return boolean true if displayed  false if item not found or not right to display
      *
      **/
     public function showForm($ID, array $options = [])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

When I tried to update some plugins to phpstan 5, I got errors related to incorrect return types and parameters.