### PR TITLE
Remove obsolete docker compose file version

### DIFF
--- a/.github/actions/docker-compose-app.yml
+++ b/.github/actions/docker-compose-app.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   app:
     container_name: "app"

--- a/.github/actions/docker-compose-services.yml
+++ b/.github/actions/docker-compose-services.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   db:
     container_name: "db"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Since we use the compose utility directly embed in docker (see #16884), we use the V2 version of the compose utility (see https://docs.docker.com/compose/intro/history/#compose-file-format-versioning). The `version` property of compose files is useless in this version. Moreover, in recent versions, it triggers warnings each time the `docker compose` command is used, and it pollutes logs.

Example of logs pollution I get when executing the test suite on my machine:
![image](https://github.com/glpi-project/glpi/assets/33253653/23e9cfe3-6cee-4e14-9df7-0dbf01a09c65)
