### PR TITLE
Fix install process when it starts with an empty config file

### DIFF
--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2377,8 +2377,10 @@ class Toolbox
         global $DB;
 
         if (null === $database) {
-           // Use configured DB if no $db is defined in parameters
-            include_once(GLPI_CONFIG_DIR . "/config_db.php");
+            // Use configured DB if no $db is defined in parameters
+            if (!class_exists('DB', false)) {
+                include(GLPI_CONFIG_DIR . "/config_db.php");
+            }
             $database = new DB();
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #17024

Since #15772, in the installation step, the db config file is included to check whether it contains an empty config file. See
https://github.com/glpi-project/glpi/blob/039d7305a140013811233a934e33f6d62830d4d7/install/install.php#L540-L543

Side effect of this is that, when the `Toolbox::createSchema()` method is call after the new config is store in the file, the `include_once` has no effect. As the `include_once` was here only to ensure that the `DB` class is not declared twice (this would result in a fatal error), we can replace the `once` logic by a check on `DB` class existence.

To reproduce the issue:
 - create a `config/config_db.php` file that has no contents,
 - go to the installation process
 - see that the install fails after the database selection