### PR TITLE
Fix(Rule): do not import locations in preview mode

### DIFF
--- a/src/Rule.php
+++ b/src/Rule.php
@@ -55,6 +55,8 @@ class Rule extends CommonDBTM
     public $criterias             = [];
    /// Rules can be sorted ?
     public $can_sort              = false;
+    // preview context ?
+    protected $is_preview = false;
    /// field used to order rules
     public $orderby               = 'ranking';
 
@@ -2195,10 +2197,12 @@ class Rule extends CommonDBTM
      **/
     public function showRulePreviewResultsForm($target, $input, $params)
     {
-
         $actions       = $this->getAllActions();
         $check_results = [];
         $output        = [];
+
+        // specify that we are in a test context
+        $this->is_preview = true;
 
        //Test all criteria, without stopping at the first good one
         $this->testCriterias($input, $check_results);
@@ -2688,6 +2692,13 @@ class Rule extends CommonDBTM
                    // $type == regex_result display text
                     if ($type == 'regex_result') {
                         return $this->displayAdditionRuleActionValue($value);
+                    }
+
+                    if ($this->is_preview && !is_numeric($value)) {
+                        // In preview mode, if the value corresponds to a string
+                        // that does not match an existing dropdown entry,
+                        // it will not be imported and therefore tha value will not correspond to a dropdown valid ID.
+                        return $value;
                     }
 
                    // $type == assign

--- a/src/RuleLocation.php
+++ b/src/RuleLocation.php
@@ -64,9 +64,15 @@ class RuleLocation extends Rule
                                 $action->fields["value"],
                                 $regex_result
                             );
-                            $compute_entities_id = $input['entities_id'] ?? 0;
-                            $location = new Location();
-                            $output['locations_id'] = $location->importExternal($regexvalue, $compute_entities_id);
+
+                            // from rule test context just assign regex value to key
+                            if ($this->is_preview) {
+                                $output['locations_id'] = $regexvalue;
+                            } else {
+                                $compute_entities_id = $input['entities_id'] ?? 0;
+                                $location = new Location();
+                                $output['locations_id'] = $location->importExternal($regexvalue, $compute_entities_id);
+                            }
                         }
                     }
                     break;


### PR DESCRIPTION
When testing a location rule 

![image](https://github.com/glpi-project/glpi/assets/7335054/bff7bc08-5ed7-473d-9d89-93443400fa39)

If action concern ```regex_result``` assignation

![image](https://github.com/glpi-project/glpi/assets/7335054/03ac44f0-67f7-4324-85d3-8724959d27df)

GLPI import ```location``` even if we are in rule test context

This PR prevent this without impacting the test result

![image](https://github.com/glpi-project/glpi/assets/7335054/6bdc1af8-5c44-434e-95d5-489d4910f230)


NB : ```importExternal``` is only called from ```RuleLocation``` (other rule are free)

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33250
