### PR TITLE
Fix planning widget rendering (again)

### DIFF
--- a/js/planning.js
+++ b/js/planning.js
@@ -617,11 +617,10 @@ var GLPIPlanning  = {
             }
         });
 
-        // Load the last known view only if it is valid (else load default view)
-        const view = this.calendar.isValidViewType(options.default_view) ?
-            options.default_view :
-            default_options.default_view;
-        this.calendar.changeView(view);
+        // If current view is invalid (e.g. with a disabled advanced planning plugin), load default view
+        if (!this.calendar.isValidViewType(options.default_view)) {
+            this.calendar.changeView(default_options.default_view);
+        }
 
         $('.planning_on_central a')
             .mousedown(function() {


### PR DESCRIPTION
As explained previously in #13939, the planning widget cause some rendering conflict with gridstack if it re-render itself right after being loaded.

This issue re-appeared after #16439, which trigger a re-render by calling `this.calendar.changeView(view)` after the calendar is loaded.

We can avoid this re-render by only calling this method if the current view in invalid.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
