### PR TITLE
Fix(TicketTemplate): add missing 'type' field

### DIFF
--- a/src/TicketTemplate.php
+++ b/src/TicketTemplate.php
@@ -115,6 +115,11 @@ class TicketTemplate extends ITILTemplate
                 'name',
                 'glpi_contracts'
             )   => '_contracts_id',
+            $itil_object->getSearchOptionIDByField(
+                'field',
+                'type',
+                'glpi_tickets'
+            )   => 'type',
 
         ];
 

--- a/src/TicketTemplateMandatoryField.php
+++ b/src/TicketTemplateMandatoryField.php
@@ -41,4 +41,11 @@ class TicketTemplateMandatoryField extends ITILTemplateMandatoryField
     public static $itemtype  = 'TicketTemplate';
     public static $items_id  = 'tickettemplates_id';
     public static $itiltype = 'Ticket';
+
+    public static function getExcludedFields()
+    {
+        return [
+            14 => 14, // ticket type has no empty option
+        ];
+    }
 }

--- a/src/TicketTemplateMandatoryField.php
+++ b/src/TicketTemplateMandatoryField.php
@@ -46,6 +46,6 @@ class TicketTemplateMandatoryField extends ITILTemplateMandatoryField
     {
         return [
             14 => 14, // ticket type has no empty option
-        ];
+        ] + parent::getExcludedFields();
     }
 }

--- a/tests/functional/ITILTemplate.php
+++ b/tests/functional/ITILTemplate.php
@@ -229,7 +229,6 @@ class ITILTemplate extends DbTestCase
                     180 => 'Internal time to resolve',
                     185 => 'Internal time to own',
                     193 => 'Contract',
-                    14 => 'Type',
                 ]
             ], [
                 'Change',


### PR DESCRIPTION
Add missing ```type``` field only for ```Ticket template``` 

![image](https://github.com/glpi-project/glpi/assets/7335054/dbed2bd3-a43d-44be-addd-55ee9eccae54)

It is excluded from ```MandatoryField``` because ```type``` has no empty option a default value is necessarily used

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33298
