### PR TITLE
Fix software tests fixtures

### DIFF
--- a/tests/fixtures/inventories/softwares/02-test_software_with_special_chars_with_version.json
+++ b/tests/fixtures/inventories/softwares/02-test_software_with_special_chars_with_version.json
@@ -7,7 +7,7 @@
             "dns": "127.0.0.53",
             "lastloggeduser": "stanisla",
             "memory": 32042,
-            "name": "pc_test_2",
+            "name": "pc_test",
             "swap": 2047,
             "uuid": "3a82e620-d7da-11dd-ad0f-bcee7b8c72b2",
             "vmsystem": "Physical"

--- a/tests/fixtures/inventories/softwares/03-test_software_with_special_chars_and_without_version.json
+++ b/tests/fixtures/inventories/softwares/03-test_software_with_special_chars_and_without_version.json
@@ -7,7 +7,7 @@
             "dns": "127.0.0.53",
             "lastloggeduser": "stanisla",
             "memory": 32042,
-            "name": "pc_test_3",
+            "name": "pc_test",
             "swap": 2047,
             "uuid": "3a82e620-d7da-11dd-ad0f-bcee7b8c72b2",
             "vmsystem": "Physical"

--- a/tests/fixtures/inventories/softwares/04-test_software_with_special_chars_and_with_version_and_os.json
+++ b/tests/fixtures/inventories/softwares/04-test_software_with_special_chars_and_with_version_and_os.json
@@ -7,28 +7,10 @@
             "dns": "127.0.0.53",
             "lastloggeduser": "stanisla",
             "memory": 32042,
-            "name": "pc_test_5",
+            "name": "pc_test",
             "swap": 2047,
             "uuid": "3a82e620-d7da-11dd-ad0f-bcee7b8c72b2",
             "vmsystem": "Physical"
-        },
-        "operatingsystem": {
-            "arch": "x86_64&",
-            "boot_time": "2023-01-26 14:15:33",
-            "dns_domain": ".",
-            "fqdn": "stanislas-asus-desktop..",
-            "full_name": "Ubuntu & 22.04.1 \n LTS",
-            "hostid": "007f0101",
-            "install_date": "2022-09-14 10:35:07",
-            "kernel_name": "linux",
-            "kernel_version": "5.15.0-52-generic",
-            "name": "Ubuntu &",
-            "ssh_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICYWwKX1KRqEzIjEsWMQrFX5xDHjx8uTv/aqNaZ6Xk6m",
-            "timezone": {
-              "name": "Europe/Paris",
-              "offset": "+0100"
-            },
-            "version": "22.04.1 LTS (Jammy Jellyfish)"
         },
         "softwares": [
             {

--- a/tests/fixtures/inventories/softwares/05-test_software_with_special_chars_and_without_version_and_os.json
+++ b/tests/fixtures/inventories/softwares/05-test_software_with_special_chars_and_without_version_and_os.json
@@ -7,7 +7,7 @@
             "dns": "127.0.0.53",
             "lastloggeduser": "stanisla",
             "memory": 32042,
-            "name": "pc_test_6",
+            "name": "pc_test",
             "swap": 2047,
             "uuid": "3a82e620-d7da-11dd-ad0f-bcee7b8c72b2",
             "vmsystem": "Physical"

--- a/tests/fixtures/inventories/softwares/05-test_software_with_special_chars_and_without_version_and_os.json
+++ b/tests/fixtures/inventories/softwares/05-test_software_with_special_chars_and_without_version_and_os.json
@@ -12,24 +12,6 @@
             "uuid": "3a82e620-d7da-11dd-ad0f-bcee7b8c72b2",
             "vmsystem": "Physical"
         },
-        "operatingsystem": {
-            "arch": "x86_64&",
-            "boot_time": "2023-01-26 14:15:33",
-            "dns_domain": ".",
-            "fqdn": "stanislas-asus-desktop..",
-            "full_name": "\"Ubuntu\" & 22.04.1 LTS",
-            "hostid": "007f0101",
-            "install_date": "2022-09-14 10:35:07",
-            "kernel_name": "linux",
-            "kernel_version": "5.15.0-52-generic",
-            "name": "\"Ubuntu\" &",
-            "ssh_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICYWwKX1KRqEzIjEsWMQrFX5xDHjx8uTv/aqNaZ6Xk6m",
-            "timezone": {
-              "name": "Europe/Paris",
-              "offset": "+0100"
-            },
-            "version": "22.04.1 LTS (Jammy Jellyfish)"
-        },
         "softwares": [
             {
                 "arch": "neutral",


### PR DESCRIPTION
Two issues here:
* Tests always look for a computer named "pc_test", see https://github.com/glpi-project/glpi/blob/10.0/bugfixes/tests/functional/Glpi/Inventory/Assets/Software.php#L799
* Test expect one software (see https://github.com/glpi-project/glpi/blob/10.0/bugfixes/tests/functional/Glpi/Inventory/Assets/Software.php#L832) but if there is an operating system, we got two.