### PR TITLE
Fix duplicated items for rules pages counter

### DIFF
--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -577,14 +577,7 @@ class RuleCollection extends CommonDBTM
         if (count($this->RuleList->list)) {
             $can_sort = $this->RuleList->list[0]->can_sort && $canedit && $nb;
             $AJAX_INCLUDE = false;
-            Session::initNavigateListItems(
-                $ruletype,
-                sprintf(
-                    __('%1$s = %2$s'),
-                    $this->getRuleClass()->getTypeName(1),
-                    $this->getRuleClass()->getName()
-                )
-            );
+            Session::initNavigateListItems($ruletype);
         }
 
         if ($can_sort) {

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -471,6 +471,7 @@ class RuleCollection extends CommonDBTM
     public function showListRules($target, $options = [])
     {
         /** @var array $CFG_GLPI */
+        /** @var int $AJAX_INCLUDE */
         global $CFG_GLPI, $AJAX_INCLUDE;
 
         $p['inherited'] = 1;

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -471,8 +471,7 @@ class RuleCollection extends CommonDBTM
     public function showListRules($target, $options = [])
     {
         /** @var array $CFG_GLPI */
-        /** @var int $AJAX_INCLUDE */
-        global $CFG_GLPI, $AJAX_INCLUDE;
+        global $CFG_GLPI;
 
         $p['inherited'] = 1;
         $p['childrens'] = 0;
@@ -576,8 +575,7 @@ class RuleCollection extends CommonDBTM
         $can_sort = $canedit && $nb;
         if (count($this->RuleList->list)) {
             $can_sort = $this->RuleList->list[0]->can_sort && $canedit && $nb;
-            $AJAX_INCLUDE = false;
-            Session::initNavigateListItems($ruletype);
+            Session::initNavigateListItems($ruletype, '', '');
         }
 
         if ($can_sort) {

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -471,7 +471,7 @@ class RuleCollection extends CommonDBTM
     public function showListRules($target, $options = [])
     {
         /** @var array $CFG_GLPI */
-        global $CFG_GLPI;
+        global $CFG_GLPI, $AJAX_INCLUDE;
 
         $p['inherited'] = 1;
         $p['childrens'] = 0;
@@ -575,7 +575,15 @@ class RuleCollection extends CommonDBTM
         $can_sort = $canedit && $nb;
         if (count($this->RuleList->list)) {
             $can_sort = $this->RuleList->list[0]->can_sort && $canedit && $nb;
-            Session::initNavigateListItems($ruletype);
+            $AJAX_INCLUDE = false;
+            Session::initNavigateListItems(
+                $ruletype,
+                sprintf(
+                    __('%1$s = %2$s'),
+                    $this->getRuleClass()->getTypeName(1),
+                    $this->getRuleClass()->getName()
+                )
+            );
         }
 
         if ($can_sort) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33283

In the list of rules, there is the right number of corresponding rules. 
![image](https://github.com/glpi-project/glpi/assets/102067890/e312bfeb-0cd7-49c4-81f6-dba2a22961cb)

if I click on the form for one of my rules, the correct number of rules is displayed on the page counter (1/2)
![image](https://github.com/glpi-project/glpi/assets/102067890/dff6c76c-81e1-4584-ad98-50022cdea6bb)

but if I return to the previous page and go back to the rules as before, the page counter doubles.
![image](https://github.com/glpi-project/glpi/assets/102067890/65d00983-4ddc-4c3a-b00f-d763c4d024d9)

