### PR TITLE
Add support of the `--env` option in the console

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -114,6 +114,8 @@ if (isset($_SERVER['argv']) && ($_SERVER['argv'][1] ?? '') === 'locales:compile'
 
 // If "config-dir" option is used in command line, defines GLPI_CONFIG_DIR with its value
 if (array_key_exists('config-dir', $options)) {
+   echo "\n" . 'Usage of the `--config-dir` option is deprecated. Please use the `--env` option instead.' . "\n\n";
+
    $config_dir = $options['config-dir'];
 
    if (false === $config_dir || !@is_dir($config_dir)) {
@@ -129,6 +131,9 @@ if (array_key_exists('config-dir', $options)) {
    define('GLPI_CONFIG_DIR', realpath($config_dir));
 }
 
+if (array_key_exists('env', $options)) {
+    define('GLPI_ENVIRONMENT_TYPE', $options['env']);
+}
 
 // Init GLPI
 define('GLPI_ROOT', dirname(__DIR__));

--- a/src/Glpi/Console/Application.php
+++ b/src/Glpi/Console/Application.php
@@ -132,6 +132,7 @@ class Application extends BaseApplication
 
     protected function getDefaultInputDefinition(): InputDefinition
     {
+        $env_values = [GLPI::ENV_PRODUCTION, GLPI::ENV_STAGING, GLPI::ENV_TESTING, GLPI::ENV_DEVELOPMENT];
 
         $definition = new InputDefinition(
             [
@@ -184,10 +185,17 @@ class Application extends BaseApplication
                     __('Do not ask any interactive question')
                 ),
                 new InputOption(
+                    '--env',
+                    null,
+                    InputOption::VALUE_REQUIRED,
+                    sprintf(__('Environment to use, possible values are: %s'), '`' . implode('`, `', $env_values) . '`'),
+                    suggestedValues: $env_values
+                ),
+                new InputOption(
                     '--config-dir',
                     null,
                     InputOption::VALUE_OPTIONAL,
-                    __('Configuration directory to use')
+                    __('Configuration directory to use. Deprecated option')
                 ),
                 new InputOption(
                     '--no-plugins',

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,10 +22,10 @@ Creating a dedicated database
 -----------------------------
 
 Use the **database:install** CLI command to create a new database,
-only used for the test suite, using the `--config-dir=./tests/config` option:
+only used for the test suite, using the `--env=testing` option:
 
 ```bash
-$ bin/console database:install --config-dir=./tests/config --db-name=glpitests --db-user=root --db-password=xxxx
+$ bin/console database:install --env=testing --db-name=glpitests --db-user=root --db-password=xxxx
 Creating the database...
 Saving configuration file...
 Loading default schema...
@@ -45,8 +45,8 @@ Changing database configuration
 
 Using the same database than the web application is not recommended. Use the `tests/config/config_db.php` file to adjust connection settings.
 
-Running the test suite on developpement env
--------------------------------------------
+Running the test suite on developpement machine
+-----------------------------------------------
 
 There are multiple directories for tests:
 - `tests/functional` for unit and functional tests;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -65,7 +65,7 @@ global $CFG_GLPI, $GLPI_CACHE;
 include(GLPI_ROOT . "/inc/based_config.php");
 
 if (!file_exists(GLPI_CONFIG_DIR . '/config_db.php')) {
-    die("\nConfiguration file for tests not found\n\nrun: php bin/console database:install --config-dir=" . GLPI_CONFIG_DIR . " ...\n\n");
+    die("\nConfiguration file for tests not found\n\nrun: php bin/console database:install --env=testing ...\n\n");
 }
 
 include_once __DIR__ . '/../inc/includes.php';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Since #16373, the GLPI installation will add additional data when `GLPI_ENVIRONMENT_TYPE == 'testing'`. It means that executing `bin/console db:update --config-dir=./tests/config` is not anymore populating the database with the data expected in the test suite. The correct way to do is now to rely on the `GLPI_ENVIRONMENT_TYPE` env variable, for instance by executing `GLPI_ENVIRONMENT_TYPE=testing bin/console db:update`.

The current PR add a `--env` option to be able to define the `GLPI_ENVIRONMENT_TYPE` environment variable.