### PR TITLE
fix(webhook): onfocus for clientsecret field

### DIFF
--- a/templates/pages/setup/webhook/webhook_security.html.twig
+++ b/templates/pages/setup/webhook/webhook_security.html.twig
@@ -125,7 +125,10 @@
       {{ fields.passwordField('clientsecret', item.fields['clientsecret'], __('Client Secret'), {
          is_disclosable: true,
          readonly: true,
-         more_atributes: 'autocomplete=off onfocus=this.removeAttribute(\"readonly\");',
+         additional_attributes: {
+            autocomplete: 'off',
+            onfocus: 'this.removeAttribute("readonly");'
+         }
       }) }}
 
       <script>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A

Before this fix, it was impossible to click on the "Client Secret" field in the Security tab of a Webhook.
