### PR TITLE
Fix more missing empty multiselect dropdown values

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -4759,8 +4759,8 @@ JS;
             unset($options['selected']);
         }
         $select = '';
-        $original_field_name = rtrim($name, '[]');
         if (isset($options['multiple']) && $options['multiple']) {
+            $original_field_name = htmlspecialchars(rtrim($name, '[]'));
             $select .= "<input type='hidden' name='$original_field_name' value=''>";
         }
         $select .= sprintf(

--- a/src/Html.php
+++ b/src/Html.php
@@ -4758,7 +4758,12 @@ JS;
             $selected = $options['selected'];
             unset($options['selected']);
         }
-        $select = sprintf(
+        $select = '';
+        $original_field_name = rtrim($name, '[]');
+        if (isset($options['multiple']) && $options['multiple']) {
+            $select .= "<input type='hidden' name='$original_field_name' value=''>";
+        }
+        $select .= sprintf(
             '<select name="%1$s" %2$s>',
             htmlspecialchars($name),
             self::parseAttributes($options)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

#17074 had only fixed clearing multi-select dropdowns when they were created by `Dropdown::showFromArray`. Dropdowns for an itemtype were being created by `Html::select` which didn't have the fix added.