### PR TITLE
Remove buggy undocumented `debug=2` support in Rest API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,6 +266,7 @@ The present file will list all changes made to the project; according to the
 - `Entity::getDefaultContractValues()`
 - `GLPI::getErrorHandler()`
 - `GLPI::getLogLevel()`
+- `Glpi\Api\API::showDebug()`
 - `Glpi\Api\API::returnSanitizedContent()`
 - `Glpi\Dashboard\Filter::dates()`
 - `Glpi\Dashboard\Filter::dates_mod()`

--- a/src/Glpi/Api/API.php
+++ b/src/Glpi/Api/API.php
@@ -2379,17 +2379,6 @@ abstract class API
 
 
     /**
-     * Show API Debug
-     *
-     * @return void
-     */
-    protected function showDebug()
-    {
-        Html::printCleanArray($this);
-    }
-
-
-    /**
      * Show API header
      *
      * in debug, it add body and some libs (essentialy to colorise markdown)

--- a/src/Glpi/Api/APIRest.php
+++ b/src/Glpi/Api/APIRest.php
@@ -140,10 +140,6 @@ class APIRest extends API
             if (empty($this->debug)) {
                 $this->debug = 1;
             }
-
-            if ($this->debug >= 2) {
-                $this->showDebug();
-            }
         }
 
         // retrieve session (if exist)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This piece of code is related to the usage of a `?debug=2` parameter in the Rest API. It is not documented, and when trying to use it, it fails with the following error:
```
glpiphplog.CRITICAL:   *** Uncaught Exception TypeError: count(): Argument #1 ($value) must be of type Countable|array, Glpi\Api\APIRest given in /var/www/glpi/src/Html.php at line 3959
  Backtrace :
  src/Glpi/Api/API.php:2388                          Html::printCleanArray()
  src/Glpi/Api/APIRest.php:145                       Glpi\Api\API->showDebug()
  apirest.php:67                                     Glpi\Api\APIRest->call()
  public/index.php:83                                require()
```

I am not sure it even worked. As it is undocumented, I propose to drop this.