### PR TITLE
Fix visibility of Knowbase button (Search solution)

### DIFF
--- a/templates/components/itilobject/timeline/form_solution.html.twig
+++ b/templates/components/itilobject/timeline/form_solution.html.twig
@@ -124,7 +124,7 @@
                <div class="col-12 col-xl-5 col-xxl-4 order-first order-md-last pe-0 pe-xxl-auto">
                   <div class="row">
                      {% if candedit %}
-                        {% if can_read_kb %}
+                        {% if can_read_kb and not nokb %}
                            {% set search_solution_button %}
                               <a href="{{ path('/front/knowbaseitem.php?item_itemtype=' ~ item.getType() ~ '&item_items_id=' ~ item.getID() ~ '&forcetab=Knowbase$1') }}"
                                  class="btn btn-secondary overflow-hidden text-nowrap" type="submit"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33306

The button linked to the knowledge base solution was visible in the bulk actions form, whereas it is impossible to add a knowledge base solution to several tickets simultaneously. (This button has now been removed from the massive actions form on the tickets page).

**Before**
![image](https://github.com/glpi-project/glpi/assets/107540223/31f9bf49-71ee-4b41-a976-c3f10c2222c5)

**After**
![image](https://github.com/glpi-project/glpi/assets/107540223/e5321e82-9a70-4baf-a086-1554b7895436)



