### PR TITLE
Simplify the way form destinations fields are handled

### DIFF
--- a/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
+++ b/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
@@ -145,9 +145,9 @@ abstract class AbstractCommonITILFormDestination extends AbstractFormDestination
     {
         // Handle array fields
         if (str_ends_with($field_key, '[]')) {
-            return "config[" . rtrim($field_key, '[]') . "][value][]";
+            return "config[" . rtrim($field_key, '[]') . "][]";
         }
 
-        return "config[$field_key][value]";
+        return "config[$field_key]";
     }
 }

--- a/src/Glpi/Form/Destination/CommonITILField/ContentField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ContentField.php
@@ -59,7 +59,7 @@ class ContentField implements ConfigFieldInterface
     #[Override]
     public function renderConfigForm(
         Form $form,
-        ?array $config,
+        mixed $configurated_value,
         string $input_name,
         array $display_options
     ): string {
@@ -83,7 +83,7 @@ TWIG;
         return $twig->renderFromStringTemplate($template, [
             'form_id'    => $form->fields['id'],
             'label'      => $this->getLabel(),
-            'value'      => $config['value'] ?? '',
+            'value'      => $configurated_value ?? '',
             'input_name' => $input_name,
             'options'    => $display_options,
         ]);
@@ -91,17 +91,17 @@ TWIG;
 
     #[Override]
     public function applyConfiguratedValueToInputUsingAnswers(
-        ?array $config,
+        mixed $configurated_value,
         array $input,
         AnswersSet $answers_set
     ): array {
-        if (is_null($config)) {
+        if (is_null($configurated_value)) {
             return $input;
         }
 
         $tag_manager = new FormTagsManager();
         $input['content'] = $tag_manager->insertTagsContent(
-            $config['value'],
+            $configurated_value,
             $answers_set
         );
 

--- a/src/Glpi/Form/Destination/CommonITILField/TitleField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/TitleField.php
@@ -58,7 +58,7 @@ class TitleField implements ConfigFieldInterface
     #[Override]
     public function renderConfigForm(
         Form $form,
-        ?array $config,
+        mixed $configurated_value,
         string $input_name,
         array $display_options
     ): string {
@@ -76,7 +76,7 @@ TWIG;
         $twig = TemplateRenderer::getInstance();
         return $twig->renderFromStringTemplate($template, [
             'label'      => $this->getLabel(),
-            'value'      => $config['value'] ?? '',
+            'value'      => $configurated_value ?? '',
             'input_name' => $input_name,
             'options'    => $display_options,
         ]);
@@ -84,15 +84,15 @@ TWIG;
 
     #[Override]
     public function applyConfiguratedValueToInputUsingAnswers(
-        ?array $config,
+        mixed $configurated_value,
         array $input,
         AnswersSet $answers_set
     ): array {
-        if (is_null($config)) {
+        if (is_null($configurated_value)) {
             return $input;
         }
 
-        $input['name'] = $config['value'];
+        $input['name'] = $configurated_value;
 
         return $input;
     }

--- a/src/Glpi/Form/Destination/ConfigFieldInterface.php
+++ b/src/Glpi/Form/Destination/ConfigFieldInterface.php
@@ -59,7 +59,7 @@ interface ConfigFieldInterface
      * Render the input field for this configuration.
      *
      * @param Form       $form
-     * @param array|null $config
+     * @param mixed      $config
      * @param string     $input_name Input name supplied by the controller.
      *                               Must be reused in the actual input field.
      * @param array      $display_options Common twig options to display the
@@ -69,7 +69,7 @@ interface ConfigFieldInterface
      */
     public function renderConfigForm(
         Form $form,
-        ?array $config,
+        mixed $configurated_value,
         string $input_name,
         array $display_options
     ): string;
@@ -77,7 +77,7 @@ interface ConfigFieldInterface
     /**
      * Apply configurated value to the given input.
      *
-     * @param array|null $config May be null if there is no configuration for
+     * @param mixed      $config May be null if there is no configuration for
      *                           this field.
      * @param array      $input
      * @param AnswersSet $answers_set
@@ -85,7 +85,7 @@ interface ConfigFieldInterface
      * @return array
      */
     public function applyConfiguratedValueToInputUsingAnswers(
-        ?array $config,
+        mixed $configurated_value,
         array $input,
         AnswersSet $answers_set
     ): array;

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/ContentField.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/ContentField.php
@@ -50,13 +50,13 @@ final class ContentField extends DbTestCase
     public function testApplyConfiguratedValueToInputUsingAnswers(): void
     {
         $tag = $this->getDummyTag();
-        $config = ['value' => "My custom content using tags: {$tag->html}"];
+        $value = "My custom content using tags: {$tag->html}";
 
         $field = new \Glpi\Form\Destination\CommonITILField\ContentField();
         $input = $field->applyConfiguratedValueToInputUsingAnswers(
-            config     : $config,
-            input      : [],
-            answers_set: $this->getFakeAnswers(),
+            configurated_value: $value,
+            input             : [],
+            answers_set       : $this->getFakeAnswers(),
         );
 
         $this->string($input['content'])->isEqualTo(

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/TitleField.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/TitleField.php
@@ -42,13 +42,13 @@ final class TitleField extends GLPITestCase
 {
     public function testApplyConfiguratedValueToInputUsingAnswers(): void
     {
-        $config = ['value' => 'My custom title'];
+        $value = 'My custom title';
 
         $field = new \Glpi\Form\Destination\CommonITILField\TitleField();
         $input = $field->applyConfiguratedValueToInputUsingAnswers(
-            config: $config,
-            input: [],
-            answers_set: new AnswersSet()
+            configurated_value: $value,
+            input             : [],
+            answers_set       : new AnswersSet()
         );
 
         $this->string($input['name'])->isEqualTo('My custom title');

--- a/tests/functional/Glpi/Form/Destination/FormDestinationTicket.php
+++ b/tests/functional/Glpi/Form/Destination/FormDestinationTicket.php
@@ -53,11 +53,11 @@ class FormDestinationTicket extends AbstractFormDestinationType
     {
         yield 'Simple field' => [
             'field_key' => 'title',
-            'expected'  => 'config[title][value]',
+            'expected'  => 'config[title]',
         ];
         yield 'Array field' => [
             'field_key' => 'my_values[]',
-            'expected'  => 'config[my_values][value][]',
+            'expected'  => 'config[my_values][]',
         ];
     }
 

--- a/tests/src/Form/Destination/AbstractFormDestinationType.php
+++ b/tests/src/Form/Destination/AbstractFormDestinationType.php
@@ -78,8 +78,8 @@ abstract class AbstractFormDestinationType extends DbTestCase
                     $this->getTestedInstance()::class,
                     'test',
                     [
-                        'title'   => ['value' => 'My title'],
-                        'content' => ['value' => "My content"],
+                        'title'   => "My title",
+                        'content' => "My content",
                     ]
                 )
         );


### PR DESCRIPTION
There is a stupid value wrapping using arrays which make destination config looks like this:
```php
[
    'title' => ['value' => 'my ticket title'],
    'content' => ['value' => 'my ticket content'],
]
```

This was built that way to support more complex values but I am not sure it will ever be needed.
With that in mind, it make sense to simplify it like this:
```php
[
    'title' => 'my ticket title',
    'content' => 'my ticket content',
]
```

| Q             | A
| ------------- | ---
| Bug fix?      |  no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
