### PR TITLE
Show user LDAP information on a dedicated tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -403,6 +403,7 @@ The present file will list all changes made to the project; according to the
 - `Toolbox::sodiumEncrypt()`
 - `Toolbox::unclean_cross_side_scripting_deep()`
 - `Transfer::manageConnectionComputer()`
+- `User::showDebug()`
 - `User::title()`
 - `XML` class.
 - Usage of `Search::addOrderBy` signature with ($itemtype, $ID, $order) parameters

--- a/src/User.php
+++ b/src/User.php
@@ -5930,7 +5930,14 @@ JAVASCRIPT;
                         echo '<td>' . htmlspecialchars($key) . '</td>';
                         echo '<td>';
                         unset($values['count']);
-                        echo implode(', ', array_map(fn ($value) => htmlspecialchars($value), $values));
+                        $printed_values = [];
+                        foreach ($values as $value) {
+                            if (str_contains($key, 'password')) {
+                                $value = '********';
+                            }
+                            $printed_values[] = htmlspecialchars($value);
+                        }
+                        echo implode(', ', $printed_values);
                         echo '</td>';
                         echo '</tr>';
                     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

User LDAP information are only available when the debug mode is active as they are located in the debug tab.

I propose to move them into a dedicated tab, and to give access to it as long as the current user has the `Read user authentication, synchronization method and 2FA` right.

I just rework a bit the view to have an acceptable rendering, but I guess some more improvements could be done. I have no time for this, and I consider it is still better than the previous rendering and can still be merged.

Before:
![image](https://github.com/glpi-project/glpi/assets/33253653/379cf2a0-03db-4ae0-9a5f-02f9844eb561)


After:
![image](https://github.com/glpi-project/glpi/assets/33253653/81cf8b95-4154-4d1c-84d4-b82adfbbc223)
