### PR TITLE
Feat(Search): handle polymorphic (itemtype / items_id) criteria

### DIFF
--- a/src/Cable.php
+++ b/src/Cable.php
@@ -188,7 +188,8 @@ class Cable extends CommonDBTM
             'field'              => 'items_id_endpoint_b',
             'name'               => sprintf(__('%s (%s)'), _n('Associated item', 'Associated items', 1), __('Endpoint B')),
             'massiveaction'      => false,
-            'datatype'           => 'specific',
+            'datatype'           => 'polymorphic',
+            'itemtype_list'      => 'socket_types',
             'searchtype'         => 'equals',
             'additionalfields'   => ['itemtype_endpoint_b']
         ];
@@ -210,7 +211,8 @@ class Cable extends CommonDBTM
             'field'              => 'items_id_endpoint_a',
             'name'               => sprintf(__('%s (%s)'), _n('Associated item', 'Associated items', 1), __('Endpoint A')),
             'massiveaction'      => false,
-            'datatype'           => 'specific',
+            'datatype'           => 'polymorphic',
+            'itemtype_list'      => 'socket_types',
             'searchtype'         => 'equals',
             'additionalfields'   => ['itemtype_endpoint_a']
         ];
@@ -339,34 +341,6 @@ class Cable extends CommonDBTM
 
         return $tab;
     }
-
-
-    public static function getSpecificValueToSelect($field, $name = '', $values = '', array $options = [])
-    {
-
-        if (!is_array($values)) {
-            $values = [$field => $values];
-        }
-        $options['display'] = false;
-        switch ($field) {
-            case 'items_id_endpoint_a':
-                if (isset($values['itemtype_endpoint_a']) && !empty($values['itemtype_endpoint_a'])) {
-                    $options['name']  = $name;
-                    $options['value'] = $values[$field];
-                    return Dropdown::show($values['itemtype_endpoint_a'], $options);
-                }
-                break;
-            case 'items_id_endpoint_b':
-                if (isset($values['itemtype_endpoint_b']) && !empty($values['itemtype_endpoint_b'])) {
-                    $options['name']  = $name;
-                    $options['value'] = $values[$field];
-                    return Dropdown::show($values['itemtype_endpoint_b'], $options);
-                }
-                break;
-        }
-        return parent::getSpecificValueToSelect($field, $name, $values, $options);
-    }
-
 
     public static function getSpecificValueToDisplay($field, $values, array $options = [])
     {

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5020,6 +5020,52 @@ class CommonDBTM extends CommonGLPI
             }
 
             switch ($searchoptions['datatype']) {
+                case "polymorphic":
+                    $options['types'] = $CFG_GLPI[$searchoptions['itemtype_list']] ?? [];
+
+                    if (empty($options['types'])) {
+                        trigger_error("'itemtype_list' search option should not be empty", E_USER_WARNING);
+                    }
+
+                    $rand = rand();
+                    $options['itemtype_column'] = rand();
+                    $options['default_value'] = $options['types'][0];
+
+                    $select = '';
+                    $select .= Dropdown::showItemTypes($options['itemtype_column'], $options['types'], [
+                        'value'                 => $options['default_value'],
+                        'display'               => false,
+                        'rand'                  => $rand,
+                        'display_emptychoice'   => false
+                    ]);
+
+                    $p = [
+                        'idtable'   => '__VALUE__',
+                        'rand'      => $rand,
+                        'name'      => $name,
+                        'width'     => 'unset'
+                    ];
+
+                    $select .= Ajax::updateItemOnSelectEvent(
+                        "dropdown_" . $options['itemtype_column'] . $rand,
+                        "result_$rand",
+                        $CFG_GLPI["root_doc"] . "/ajax/dropdownAllItems.php",
+                        $p,
+                        false
+                    );
+
+                    $select .= "<div id='result_$rand'>";
+
+                    $select .= $options['default_value']::dropdown([
+                        'name'                  => $name,
+                        'display_emptychoice'   => true,
+                        'rand'                  => $rand,
+                        'value'                 => $value,
+                        'display'               => false,
+                    ]);
+
+                    $select .= "</div>";
+                    return $select;
                 case "count":
                 case "number":
                 case "integer":


### PR DESCRIPTION
Currently, GLPI can't search correctly on polymorphic linking tables.

Ex with ```Cable``` (and ```Agent```, ```DatabaseInstance``` and other classes with ```searchoption``` ```field``` is ```items_id```)

```php
        $tab[] = [
            'id'                 => '10',
            'table'              => $this->getTable(),
            'field'              => 'items_id_endpoint_a',
            'name'               => sprintf(__('%s (%s)'), _n('Associated item', 'Associated items', 1), __('Endpoint A')),
            'massiveaction'      => false,
            'datatype'           => 'specific',
            'searchtype'         => 'equals',
            'additionalfields'   => ['itemtype_endpoint_a']
        ];
```

The SQL query generated cannot link to the itemtype column to add a left join to the related table.

This PR ttry to handle a new ```datatype``` to handle this case


![image](https://github.com/glpi-project/glpi/assets/7335054/6cb9ad8a-7fc4-48dd-b30f-4fdabe9d3507)


- [x]  Implement ```itemtype``` / ```items_id``` search
- [ ]  Ensure that the search engine also uses the ```itemtype``` input (to add a related ```where``` -> ```itemtype = 'Computer'``` )
- [ ]  Ensure that the search engine also returns the value selected in the ```itemtype``` input to avoid losing selected option when the page is refreshed

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
