### PR TITLE
Fix(LockedField): optimize SQL query with UNION

### DIFF
--- a/src/Lockedfield.php
+++ b/src/Lockedfield.php
@@ -210,17 +210,24 @@ class Lockedfield extends CommonDBTM
         /** @var \DBmysql $DB */
         global $DB;
 
-        $iterator = $DB->request([
+        $subquery1 = new \QuerySubQuery([
             'FROM'   => $this->getTable(),
             'WHERE'  => [
                 'itemtype'  => $itemtype,
-                [
-                    'OR' => [
-                        'items_id'  => $items_id,
-                        'is_global' => 1
-                    ]
-                ]
+                'items_id'  => $items_id,
             ]
+        ]);
+
+        $subquery2 = new \QuerySubQuery([
+            'FROM'   => $this->getTable(),
+            'WHERE'  => [
+                'is_global' => 1
+            ]
+        ]);
+
+        $union = new QueryUnion([$subquery1, $subquery2], false);
+        $iterator = $DB->request([
+            'FROM'   => $union
         ]);
 
         $locks = [];

--- a/src/Lockedfield.php
+++ b/src/Lockedfield.php
@@ -221,7 +221,8 @@ class Lockedfield extends CommonDBTM
         $subquery2 = new \QuerySubQuery([
             'FROM'   => $this->getTable(),
             'WHERE'  => [
-                'is_global' => 1
+                'itemtype' => $itemtype,
+                'is_global' => 1,
             ]
         ]);
 


### PR DESCRIPTION
TRy to optimize ```LockedField``` SQL query by using ```UNION```

![image](https://github.com/glpi-project/glpi/assets/7335054/3d704f8a-d6bc-4d45-a7bb-fcd00202d561)


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33333
