### PR TITLE
Exclude some itemtypes from locked fields management

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -539,6 +539,9 @@ $CFG_GLPI['databaseinstance_types'] = ['Computer'];
 
 $CFG_GLPI['agent_types'] = ['Computer', 'Phone'];
 
+//uses regular expressions
+$CFG_GLPI['excluded_locks'] = ['/Device.*/', '/Item_Device.*/'];
+
 $reservations_libs = ['fullcalendar', 'reservations'];
 
 $CFG_GLPI['javascript'] = [

--- a/src/Lockedfield.php
+++ b/src/Lockedfield.php
@@ -146,9 +146,19 @@ class Lockedfield extends CommonDBTM
      */
     public function isHandled(CommonGLPI $item)
     {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
         if (!$item instanceof CommonDBTM) {
             return false;
         }
+
+        foreach ($CFG_GLPI['excluded_locks'] as $excluded_lock) {
+            if (preg_match($excluded_lock, $item->getType())) {
+                return false;
+            }
+        }
+
         $this->item = $item;
         return (bool)$item->isDynamic();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes


Maybe in addition with #17305 if it really improves the query.

I'm not sure we really need to handle locks on Device*; and there are probably other itemtypes that can be excluded (I'm surprised we do not hear from Software* for example).
