### PR TITLE
Fix notification template translation preview

### DIFF
--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -456,13 +456,13 @@ HTML;
          var reloadTab = function (add) {
             var active_link = $('main #tabspanel .nav-item .nav-link.active');
 
-            // Update href and load tab contents
-            var currenthref = active_link.attr('href');
-            active_link.attr('href', currenthref + '&' + add);
+            // Update target AJAX endpoint URL and load tab contents
+            var current_url = active_link.data('glpi-ajax-content');
+            active_link.data('glpi-ajax-content', current_url + '&' + add);
             loadTabContents(active_link, true);
 
-            // Restore href
-            active_link.attr('href', currenthref);
+            // Restore URL
+            active_link.data('glpi-ajax-content', current_url);
          };
 
          var loadAllTabs = () => {

--- a/src/Html.php
+++ b/src/Html.php
@@ -4545,9 +4545,7 @@ JS;
 
         // Some variables need to be json encoded
         $on_change = json_encode($on_change);
-        if (!empty($placeholder)) {
-            $placeholder = json_encode($placeholder);
-        }
+        $placeholder = json_encode($placeholder);
 
         $js = <<<JS
             select2_configs['{$field_id}'] = {
@@ -4555,13 +4553,13 @@ JS;
                 field_id: '{$field_id}',
                 width: '{$width}',
                 multiple: '{$multiple}',
-                placeholder: '{$placeholder}',
+                placeholder: {$placeholder},
                 allowclear: {$allowclear},
                 ajax_limit_count: {$CFG_GLPI['ajax_limit_count']},
                 dropdown_max: {$CFG_GLPI['dropdown_max']},
                 url: '{$url}',
                 parent_id_field: '{$parent_id_field}',
-                on_change: '{$on_change}',
+                on_change: {$on_change},
                 templateResult: {$templateResult},
                 templateSelection: {$templateSelection},
                 params: {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. The dropdown `on_change` and `placeholder` options were encoded to JSON and then surrounded by simple quotes, resulting in unexpected quotes surrounding, e.g. `'"reloadTab()"'` instead of `"reloadTab()"`.

2. The `reloadTab()` logic was broken since #17156.