### PR TITLE
fix(notification): noAUTO=1

### DIFF
--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -701,14 +701,13 @@ class NotificationTarget extends CommonDBChild
 
         switch ($usertype) {
             case self::EXTERNAL_USER:
+            case self::GLPI_USER:
                 return $CFG_GLPI["url_base"] . "/index.php?redirect=$redirect";
 
-            case self::ANONYMOUS_USER:
-               // No URL
+            // case self::ANONYMOUS_USER:
+            default:
+                // No URL
                 return '';
-
-            case self::GLPI_USER:
-                return $CFG_GLPI["url_base"] . "/index.php?redirect=$redirect&noAUTO=1";
         }
     }
 

--- a/tests/functional/NotificationEventAjax.php
+++ b/tests/functional/NotificationEventAjax.php
@@ -87,7 +87,7 @@ class NotificationEventAjax extends DbTestCase
     {
         global $CFG_GLPI, $DB;
 
-       //enable notifications
+        //enable notifications
         $CFG_GLPI['use_notifications'] = 1;
         $CFG_GLPI['notifications_ajax'] = 1;
 
@@ -104,13 +104,13 @@ class NotificationEventAjax extends DbTestCase
             ])
         )->isGreaterThan(0);
 
-       //event has been raised; it is in the queue!
+        //event has been raised; it is in the queue!
         $queue = getAllDataFromTable('glpi_queuednotifications');
 
-       //no ajax notification configured per default
+        //no ajax notification configured per default
         $this->array($queue)->hasSize(0);
 
-       //add an ajax notification on tickets creation
+        //add an ajax notification on tickets creation
         $iterator = $DB->request([
             'FROM'   => \Notification::getTable(),
             'WHERE'  => [
@@ -145,10 +145,10 @@ class NotificationEventAjax extends DbTestCase
             ])
         )->isGreaterThan(0);
 
-       //event has been raised; it is in the queue!
+        //event has been raised; it is in the queue!
         $queue = getAllDataFromTable('glpi_queuednotifications');
 
-       //no ajax notification configured per default
+        //no ajax notification configured per default
         $this->array($queue)->hasSize(1);
 
         $GLPI_URI = GLPI_URI;
@@ -182,7 +182,7 @@ class NotificationEventAjax extends DbTestCase
             'body_html' => null,
             'body_text' => <<<TEXT
  
-  URL : {$GLPI_URI}/index.php?redirect=ticket_{$ticket->getID()}&#38;noAUTO=1 
+  URL : {$GLPI_URI}/index.php?redirect=ticket_{$ticket->getID()} 
 
  Ticket: Description
 
@@ -222,7 +222,7 @@ TEXT,
         ];
         $this->array($data)->isIdenticalTo($expected);
 
-       //reset
+        //reset
         $CFG_GLPI['use_notifications'] = 0;
         $CFG_GLPI['notifications_ajax'] = 0;
     }

--- a/tests/functional/NotificationTarget.php
+++ b/tests/functional/NotificationTarget.php
@@ -398,16 +398,16 @@ class NotificationTarget extends DbTestCase
             'expected' => '',
         ];
 
-        // GLPI user, `noAUTO=1` parameter added
+        // GLPI user, no `noAUTO=1` parameter
         yield [
             'usertype' => \NotificationTarget::GLPI_USER,
             'redirect' => 'Ticket_24',
-            'expected' => $CFG_GLPI['url_base'] . '/index.php?redirect=Ticket_24&noAUTO=1',
+            'expected' => $CFG_GLPI['url_base'] . '/index.php?redirect=Ticket_24',
         ];
         yield [
             'usertype' => \NotificationTarget::GLPI_USER,
             'redirect' => '/front/test.php?param=test&value=foo bar',
-            'expected' => $CFG_GLPI['url_base'] . '/index.php?redirect=%2Ffront%2Ftest.php%3Fparam%3Dtest%26value%3Dfoo%20bar&noAUTO=1',
+            'expected' => $CFG_GLPI['url_base'] . '/index.php?redirect=%2Ffront%2Ftest.php%3Fparam%3Dtest%26value%3Dfoo%20bar',
         ];
 
         // External user, no `noAUTO` parameter

--- a/tests/functional/NotificationTargetSavedSearch_Alert.php
+++ b/tests/functional/NotificationTargetSavedSearch_Alert.php
@@ -90,6 +90,6 @@ class NotificationTargetSavedSearch_Alert extends DbTestCase
         global $CFG_GLPI;
         $expected_redirect = '%2Ffront%2Fsavedsearch.php%3Faction%3Dload%26id%3D' . $saved_searches_id;
         $this->string($target->data['##savedsearch.url##'])
-            ->isEqualTo($CFG_GLPI['url_base'] . '/index.php?redirect=' . $expected_redirect . '&noAUTO=1');
+            ->isEqualTo($CFG_GLPI['url_base'] . '/index.php?redirect=' . $expected_redirect);
     }
 }


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33345

The link sent in a notification to a user of type "GLPI internal database" contains the parameter noAUTO=1 which stops automatic authentication, but this does not seem to be relevant.
