### PR TITLE
Make the notification template preview available outside debug mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -324,12 +324,13 @@ The present file will list all changes made to the project; according to the
 - `NetworkPort::getNetworkPortInstantiationsWithNames()`
 - `NetworkPort::resetConnections()`
 - `NetworkPortInstantiation::getGlobalInstantiationNetworkPortDisplayOptions()`
-- `NetworkPortInstantiation::getInstantiationHTMLTable()` and all sub classes overrrides.
-- `NetworkPortInstantiation::getInstantiationHTMLTableHeaders()` and all sub classes overrrides.
+- `NetworkPortInstantiation::getInstantiationHTMLTable()` and all sub classes overrides.
+- `NetworkPortInstantiation::getInstantiationHTMLTableHeaders()` and all sub classes overrides.
 - `NetworkPortInstantiation::getInstantiationHTMLTableWithPeer()`
 - `NetworkPortInstantiation::getInstantiationNetworkPortDisplayOptions()`
 - `NetworkPortInstantiation::getInstantiationNetworkPortHTMLTable()`
-- `NetworkPortInstantiation::getPeerInstantiationHTMLTable()` and all sub classes overrrides.
+- `NetworkPortInstantiation::getPeerInstantiationHTMLTable()` and all sub classes overrides.
+- `NotificationTemplateTranslation::showDebug()`
 - `OlaLevel::showForSLA()`. Replaced by `LevelAgreementLevel::showForLA()`.
 - `PlanningExternalEvent::addVisibilityRestrict()`
 - `PlanningRecall::specificForm()`

--- a/templates/pages/setup/notification/translation_debug.html.twig
+++ b/templates/pages/setup/notification/translation_debug.html.twig
@@ -34,46 +34,54 @@
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
 <div class="asset">
-   {{ fields.largeTitle(__('Preview')) }}
-   <div class="d-flex">
-      {{ fields.dropdownField(
-         template.fields['itemtype'],
-         template.fields['itemtype']|itemtype_foreign_key,
-         get_saved_option('NotificationTemplateTranslation', template.fields['itemtype']|itemtype_foreign_key, 0),
-         template.fields['itemtype']|itemtype_name,
-         {
-            field_class: 'col-6',
-            on_change: 'reloadTab("' ~ template.fields['itemtype']|itemtype_foreign_key ~ '="+this.value)',
-         }
-      ) }}
+    {{ fields.largeTitle(__('Preview')) }}
 
-      {{ fields.htmlField('', call('NotificationEvent::dropdownEvents', [template.fields['itemtype'], {
-         value: get_saved_option('NotificationTemplateTranslation', template.fields['itemtype']|itemtype_foreign_key ~ '_event', ''),
-         on_change: 'reloadTab("' ~ template.fields['itemtype']|itemtype_foreign_key ~ '_event="+this.value)',
-         display: false
-      }]), 'NotificationEvent'|itemtype_name(1), {
-         field_class: 'col-6'
-      }) }}
-   </div>
+    {% if can_preview %}
+        <div class="d-flex">
+            {{ fields.dropdownField(
+                template.fields['itemtype'],
+                template.fields['itemtype']|itemtype_foreign_key,
+                get_saved_option('NotificationTemplateTranslation', template.fields['itemtype']|itemtype_foreign_key, 0),
+                template.fields['itemtype']|itemtype_name,
+                {
+                    field_class: 'col-6',
+                    on_change: 'reloadTab("' ~ template.fields['itemtype']|itemtype_foreign_key ~ '="+this.value)',
+                }
+            ) }}
 
-   {% if data is not null %}
-      <table class="table table-borderless">
-         <tbody>
-            <tr>
-               <th colspan="2">{{ __('Subject') }}</th>
-            </tr>
-            <tr>
-               <td colspan="2">{{ data['subject'] }}</td>
-            </tr>
-            <tr>
-               <th>{{ __('Email text body') }}</th>
-               <th>{{ __('Email HTML body') }}</th>
-            </tr>
-            <tr>
-               <td>{{ data['content_text']|nl2br }}</td>
-               <td>{{ data['content_html']|raw }}</td>
-            </tr>
-         </tbody>
-      </table>
-   {% endif %}
+            {{ fields.htmlField('', call('NotificationEvent::dropdownEvents', [template.fields['itemtype'], {
+                value: get_saved_option('NotificationTemplateTranslation', template.fields['itemtype']|itemtype_foreign_key ~ '_event', ''),
+                on_change: 'reloadTab("' ~ template.fields['itemtype']|itemtype_foreign_key ~ '_event="+this.value)',
+                display: false
+            }]), 'NotificationEvent'|itemtype_name(1), {
+                field_class: 'col-6'
+            }) }}
+        </div>
+    {% else %}
+        <div class="alert alert-info d-flex align-items-center m-0" role="alert">
+            <i class="fas fa-info-circle me-1"></i>
+            {{ __('The preview is not available for the notifications related to %s.')|format(template.fields['itemtype']|itemtype_name(get_plural_number())) }}
+        </div>
+    {% endif %}
+
+    {% if data is not null %}
+        <table class="table table-borderless">
+            <tbody>
+                <tr>
+                    <th colspan="2">{{ __('Subject') }}</th>
+                </tr>
+                <tr>
+                    <td colspan="2">{{ data['subject'] }}</td>
+                </tr>
+                <tr>
+                    <th>{{ __('Email text body') }}</th>
+                    <th>{{ __('Email HTML body') }}</th>
+                </tr>
+                <tr>
+                    <td>{{ data['content_text']|nl2br }}</td>
+                    <td>{{ data['content_html']|raw }}</td>
+                </tr>
+            </tbody>
+        </table>
+    {% endif %}
 </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The notification template translation preview is currently only available when the debug mode is active, inside the debug tab. I think it make sense to move it in a dedicated tab that can be accessed to any user that has the right to display the corresponding `NotificationTemplateTranslation` item form.

While testing, I figured out that the preview is actually not really relevant on some cases. Indeed, to have a relevant preview, some events requires specific data added by specific pieces of code, for instance: https://github.com/glpi-project/glpi/blob/be75f36dead7cad36a707657ef8d80696c8db6b1/src/NotificationTargetContract.php#L110-L112
Also, the `showDebug()` method istelf had many specific checks, probably obsolete for some of them, like https://github.com/glpi-project/glpi/blob/be75f36dead7cad36a707657ef8d80696c8db6b1/src/NotificationTemplateTranslation.php#L450-L459

I do not know if this feature is really used. I proposed to make it available ouside the `debug mode`, but, if we consider that it is not stable/relevant enough to do it, we could also drop this feature completely.

Requires #17309 to work.