### PR TITLE
Drop handling of custom GLPI session files directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ The present file will list all changes made to the project; according to the
 - List of network ports in a VLAN form now shows the NetworkPort link in a breadcrumb manner (MyServer > eth0 where MyServer is a link to the computer and eth0 is a link to the port).
 - Running `front/cron.php` or `bin/console` will attempt to check and block execution if running as root.
 - Testing LDAP replicates now shows results as toast notifications rather than inside the replicate tab after a page reload.
+- Session files are no longer stored on a specific directory and the handling of these files is now delegated to the native PHP handler.
 
 ### Deprecated
 - Survey URL tags `TICKETCATEGORY_ID` and `TICKETCATEGORY_NAME` are deprecated and replaced by `ITILCATEGORY_ID` and `ITILCATEGORY_NAME` respectively.
@@ -220,6 +221,7 @@ The present file will list all changes made to the project; according to the
 
 #### Removed
 - `GLPI_USE_CSRF_CHECK`, `GLPI_USE_IDOR_CHECK`, `GLPI_CSRF_EXPIRES`, `GLPI_CSRF_MAX_TOKENS` and `GLPI_IDOR_EXPIRES` constants.
+- `GLPI_SESSION_DIR` constant.
 - Usage of `csrf_compliant` plugins hook.
 - Usage of `migratetypes` plugin hooks.
 - Usage of `planning_scheduler_key` plugins hook.
@@ -257,6 +259,7 @@ The present file will list all changes made to the project; according to the
 - `Contract::commonListHeader()`
 - `Contract::getContractRenewalIDByName()`
 - `Contract::showShort()`
+- `CronTask::cronSession()`
 - `DbUtils::regenerateTreeCompleteName()`
 - `Document::uploadDocument()`
 - `Document::showUploadedFilesDropdown()`
@@ -366,6 +369,8 @@ The present file will list all changes made to the project; according to the
 - `Search::getMetaReferenceItemtype()`
 - `Search::outputData()`
 - `Search::sylk_clean()`
+- `Session::canWriteSessionFiles()`
+- `Session::setPath()`
 - `SlaLevel::showForSLA()`. Replaced by `LevelAgreementLevel::showForLA()`.
 - `SLM::setTicketCalendar()`
 - `SoftwareLicense::getSonsOf()`

--- a/ajax/marketplace.php
+++ b/ajax/marketplace.php
@@ -44,7 +44,6 @@ if (($_GET["action"] ?? null) == "get_dl_progress") {
     }
 
     include_once GLPI_ROOT . '/inc/based_config.php';
-    Session::setPath();
     Session::start();
 
     echo $_SESSION['marketplace_dl_progress'][$_GET['key']] ?? 0;

--- a/front/login.php
+++ b/front/login.php
@@ -52,11 +52,7 @@ include('../inc/includes.php');
 
 
 if (!isset($_SESSION["glpicookietest"]) || ($_SESSION["glpicookietest"] != 'testcookie')) {
-    if (!Session::canWriteSessionFiles()) {
-        Html::redirect($CFG_GLPI['root_doc'] . "/index.php?error=2");
-    } else {
-        Html::redirect($CFG_GLPI['root_doc'] . "/index.php?error=1");
-    }
+    Html::redirect($CFG_GLPI['root_doc'] . "/index.php?error=1");
 }
 
 if (isset($_POST['totp_code']) && is_array($_POST['totp_code'])) {

--- a/inc/based_config.php
+++ b/inc/based_config.php
@@ -111,7 +111,6 @@ if (!isCommandLine()) {
             'GLPI_PICTURE_DIR'     => '{GLPI_VAR_DIR}/_pictures', // Path for picture storage
             'GLPI_PLUGIN_DOC_DIR'  => '{GLPI_VAR_DIR}/_plugins', // Path for plugins documents storage
             'GLPI_RSS_DIR'         => '{GLPI_VAR_DIR}/_rss', // Path for rss storage
-            'GLPI_SESSION_DIR'     => '{GLPI_VAR_DIR}/_sessions', // Path for sessions storage
             'GLPI_TMP_DIR'         => '{GLPI_VAR_DIR}/_tmp', // Path for temp storage
             'GLPI_UPLOAD_DIR'      => '{GLPI_VAR_DIR}/_uploads', // Path for upload storage
             "GLPI_INVENTORY_DIR"   => '{GLPI_VAR_DIR}/_inventories', //Path for inventories

--- a/inc/config.php
+++ b/inc/config.php
@@ -60,7 +60,6 @@ global $CFG_GLPI,
 
 include_once(GLPI_ROOT . "/inc/based_config.php");
 
-Session::setPath();
 Session::start();
 
 // Default Use mode

--- a/index.php
+++ b/index.php
@@ -61,7 +61,6 @@ if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
         Html::redirect("install/install.php");
     } else {
         // Init session (required by header display logic)
-        Session::setPath();
         Session::start();
         Session::loadLanguage('', false);
         // Prevent inclusion of debug informations in footer, as they are based on vars that are not initialized here.
@@ -122,9 +121,7 @@ if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
                 $errors[] = __('You must accept cookies to reach this application');
                 break;
 
-            case 2: // GLPI_SESSION_DIR not writable
-                $errors[] = __('Logins are not possible at this time. Please contact your administrator.');
-                break;
+            // case 2 was for issues with GLPI_SESSION_DIR write access
 
             case 3:
                 $errors[] = __('Your session has expired. Please log in again.');

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -490,18 +490,6 @@ $empty_data_builder = new class
                 'hourmin' => 0,
                 'hourmax' => 24,
             ], [
-                'id' => 12,
-                'itemtype' => 'CronTask',
-                'name' => 'session',
-                'frequency' => DAY_TIMESTAMP,
-                'param' => null,
-                'state' => CronTask::STATE_WAITING,
-                'mode' => CronTask::MODE_INTERNAL,
-                'lastrun' => null,
-                'logs_lifetime' => 30,
-                'hourmin' => 0,
-                'hourmax' => 24,
-            ], [
                 'id' => 13,
                 'itemtype' => 'CronTask',
                 'name' => 'graph',

--- a/install/install.php
+++ b/install/install.php
@@ -516,12 +516,6 @@ function update1($dbname)
 
 //------------Start of install script---------------------------
 
-
-// Use default session dir if not writable
-if (is_writable(GLPI_SESSION_DIR)) {
-    Session::setPath();
-}
-
 Session::start();
 error_reporting(0); // we want to check system before affraid the user.
 

--- a/install/migrations/update_10.0.x_to_11.0.0/crontask.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/crontask.php
@@ -35,5 +35,23 @@
 
 /**
  * @var array $ADDTODISPLAYPREF
+ * @var \DBmysql $DB
+ * @var \Migration $migration
  */
+
+// Delete the "Clean expired sessions" crontask
+$session_crontask_req = [
+    'FROM' => 'glpi_crontasks',
+    'WHERE' => [
+        'itemtype'  => 'CronTask',
+        'name'      => 'session',
+    ]
+];
+$session_crontask_id = $DB->request($session_crontask_req)->current()['id'] ?? null;
+if ($session_crontask_id !== null) {
+    $migration->addPostQuery($DB->buildDelete('glpi_crontasklogs', ['crontasks_id' => $session_crontask_id]));
+    $migration->addPostQuery($DB->buildDelete('glpi_crontasks', ['id' => $session_crontask_id]));
+}
+
+// Add new display preferences
 $ADDTODISPLAYPREF['CronTask'] = [5, 6, 17, 18];

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -1510,49 +1510,6 @@ TWIG, ['msg' => __('Last run list')]);
     }
 
     /**
-     * Garbage collector for expired file session
-     *
-     * @param CronTask $task for log
-     *
-     * @return integer
-     * @used-by self
-     **/
-    public static function cronSession(CronTask $task)
-    {
-        // max time to keep the file session
-        $maxlifetime = ini_get('session.gc_maxlifetime');
-        if ($maxlifetime == 0) {
-            $maxlifetime = WEEK_TIMESTAMP;
-        }
-        $nb = 0;
-        foreach (glob(GLPI_SESSION_DIR . "/sess_*") as $filename) {
-            if ((filemtime($filename) + $maxlifetime) < time()) {
-                // Delete session file if not delete before
-                if (@unlink($filename)) {
-                    $nb++;
-                }
-            }
-        }
-
-        $task->setVolume($nb);
-        if ($nb) {
-           //TRANS: % %1$d is a number, %2$s is a number of seconds
-            $task->log(sprintf(
-                _n(
-                    'Clean %1$d session file created since more than %2$s seconds',
-                    'Clean %1$d session files created since more than %2$s seconds',
-                    $nb
-                ) . "\n",
-                $nb,
-                $maxlifetime
-            ));
-            return 1;
-        }
-
-        return 0;
-    }
-
-    /**
      * Circular logs
      *
      * @since 0.85
@@ -1839,9 +1796,6 @@ TWIG, ['msg' => __('Last run list')]);
             'logs'        => [
                 'description' => __('Clean old logs'),
                 'parameter'   => __('System logs retention period (in days, 0 for infinite)')
-            ],
-            'session'     => [
-                'description' => __('Clean expired sessions')
             ],
             'graph'       => [
                 'description' => __('Clean generated graphics')

--- a/src/Glpi/Api/HL/Middleware/CookieAuthMiddleware.php
+++ b/src/Glpi/Api/HL/Middleware/CookieAuthMiddleware.php
@@ -47,7 +47,6 @@ class CookieAuthMiddleware extends AbstractMiddleware implements AuthMiddlewareI
             // Need to destroy the current session, enable cookie use, and then restart the session
             session_destroy();
             ini_set('session.use_cookies', '1');
-            Session::setPath();
             Session::start();
             // unset the response to indicate a successful auth
             $input->response = null;

--- a/src/Glpi/Console/Application.php
+++ b/src/Glpi/Console/Application.php
@@ -374,14 +374,6 @@ class Application extends BaseApplication
      */
     private function initSession()
     {
-
-        if (!Session::canWriteSessionFiles()) {
-            throw new \Symfony\Component\Console\Exception\RuntimeException(
-                sprintf(__('Cannot write in "%s" directory.'), GLPI_SESSION_DIR)
-            );
-        }
-
-        Session::setPath();
         Session::start();
 
        // Default value for use mode

--- a/src/Glpi/System/Requirement/DirectoryWriteAccess.php
+++ b/src/Glpi/System/Requirement/DirectoryWriteAccess.php
@@ -88,12 +88,6 @@ class DirectoryWriteAccess extends AbstractRequirement
             case realpath(GLPI_RSS_DIR):
                 $title = __('Permissions for rss files');
                 break;
-            case realpath(GLPI_SESSION_DIR):
-                $title = __('Permissions for session files');
-                $session_handler = ini_get('session.save_handler');
-                $optional = $session_handler !== false && strtolower($session_handler) !== 'files';
-                $description = __('If you have "session.save_handler" set to something besides "files" in your php.ini, this is not required.');
-                break;
             case realpath(GLPI_TMP_DIR):
                 $title = __('Permissions for temporary files');
                 break;

--- a/src/Glpi/System/Status/StatusChecker.php
+++ b/src/Glpi/System/Status/StatusChecker.php
@@ -504,25 +504,6 @@ final class StatusChecker
                     'status' => self::STATUS_OK
                 ]
             ];
-            $session_handler = ini_get('session.save_handler');
-            if ($session_handler !== false && strtolower($session_handler) === 'files') {
-                // Check session dir (useful when NFS mounted))
-                if (!is_dir(GLPI_SESSION_DIR)) {
-                    $status['session_dir'] = [
-                        'status' => self::STATUS_PROBLEM,
-                        'status_msg'   => sprintf(_x('glpi_status', '%s variable is not a directory'), 'GLPI_SESSION_DIR')
-                    ];
-                    $status['status'] = self::STATUS_PROBLEM;
-                } else if (!is_writable(GLPI_SESSION_DIR)) {
-                    $status['session_dir'] = [
-                        'status' => self::STATUS_PROBLEM,
-                        'status_msg'   => sprintf(_x('glpi_status', '%s variable is not writable'), 'GLPI_SESSION_DIR')
-                    ];
-                    $status['status'] = self::STATUS_PROBLEM;
-                }
-            } else {
-                $status['session_dir']['status_msg'] = _x('glpi_status', 'PHP is not configured to use the "files" session save handler');
-            }
         }
 
         return $status;

--- a/src/Glpi/System/Variables.php
+++ b/src/Glpi/System/Variables.php
@@ -58,7 +58,6 @@ class Variables
             'GLPI_PICTURE_DIR',
             'GLPI_PLUGIN_DOC_DIR',
             'GLPI_RSS_DIR',
-            'GLPI_SESSION_DIR',
             'GLPI_TMP_DIR',
             'GLPI_UPLOAD_DIR',
         ];

--- a/src/Session.php
+++ b/src/Session.php
@@ -213,24 +213,6 @@ class Session
         }
     }
 
-
-    /**
-     * Set the directory where are store the session file
-     *
-     * @return void
-     **/
-    public static function setPath()
-    {
-
-        if (
-            ini_get("session.save_handler") == "files"
-            && session_status() !== PHP_SESSION_ACTIVE
-        ) {
-            session_save_path(GLPI_SESSION_DIR);
-        }
-    }
-
-
     /**
      * Start the GLPI php session
      *
@@ -2296,17 +2278,6 @@ class Session
     {
         // TODO (11.0 refactoring): replace references to $_SESSION['glpi_currenttime'] by a call to this function
         return $_SESSION['glpi_currenttime'] ?? null;
-    }
-
-    /**
-     * Checks if the GLPI sessions directory can be written to if the PHP session save handler is set to "files".
-     * @return bool True if the directory is writable, or if the session save handler is not set to "files".
-     */
-    public static function canWriteSessionFiles(): bool
-    {
-        $session_handler = ini_get('session.save_handler');
-        return $session_handler !== false
-            && (strtolower($session_handler) !== 'files' || is_writable(GLPI_SESSION_DIR));
     }
 
     /**

--- a/src/Update.php
+++ b/src/Update.php
@@ -80,13 +80,6 @@ class Update
      */
     public function initSession()
     {
-        if (Session::canWriteSessionFiles()) {
-            Session::setPath();
-        } else {
-            if (isCommandLine()) {
-                die("Can't write in " . GLPI_SESSION_DIR . "\n");
-            }
-        }
         Session::start();
 
         if (isCommandLine()) {

--- a/stubs/glpi_constants.php
+++ b/stubs/glpi_constants.php
@@ -50,7 +50,6 @@ define('GLPI_MARKETPLACE_DIR', null);
 define('GLPI_PICTURE_DIR', null);
 define('GLPI_PLUGIN_DOC_DIR', null);
 define('GLPI_RSS_DIR', null);
-define('GLPI_SESSION_DIR', null);
 define('GLPI_THEMES_DIR', null);
 define('GLPI_TMP_DIR', null);
 define('GLPI_UPLOAD_DIR', null);

--- a/tests/functional/DbUtils.php
+++ b/tests/functional/DbUtils.php
@@ -413,7 +413,7 @@ class DbUtils extends DbTestCase
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_configs', 'context'))->isGreaterThan(0)
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_tickets', 'entities_id'))->isGreaterThanOrEqualTo(2)
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_crontasks', 'itemtype', ['frequency' => '86400']))->isIdenticalTo(21)
-            ->integer($this->testedInstance->countDistinctElementsInTable('glpi_crontasks', 'id', ['frequency' => '86400']))->isIdenticalTo(27)
+            ->integer($this->testedInstance->countDistinctElementsInTable('glpi_crontasks', 'id', ['frequency' => '86400']))->isIdenticalTo(26)
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_configs', 'context', ['name' => 'version']))->isIdenticalTo(1)
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_configs', 'id', ['context' => 'fakecontext']))->isIdenticalTo(0);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I guess that the handling of a custom session files directory was made to be able to easilly share the session files accross multiple servers in a load-balanced configuration. IMHO, this is not a good solution for this problem. Indeed, there are many ways to do it without requiring this custom implementation:
1. It is possible to change the PHP `session.save_path` configuration in order to save session files on a shared NFS.
2. It is possible to change the PHP `session.save_handler` configuration in order to use a handler that would be able to share data accross different servers, for instance Redis.
3. It is possible to configure the load balancer to force the user to stay on the same server. It is a basic load balancer feature and I guess it is the best option.

Also, our custom implementation may lead to unexpected issues (see https://github.com/glpi-project/glpi/issues/13841#issuecomment-2172881738 for instance).