### PR TITLE
(Fix) Move smtp logs in NotificationMailingSetting

### DIFF
--- a/install/migrations/update_10.0.15_to_10.0.16/config.php
+++ b/install/migrations/update_10.0.15_to_10.0.16/config.php
@@ -55,7 +55,7 @@ $migration->addPostQuery(
             'id_search_option' => 1,
         ],
         [
-            'NOT' => ['itemtype' => 'NotificationMailingSetting'], // prevent migration to be done twice
+            'itemtype' => 'Config',
             'OR' => $or_criteria,
         ]
     )

--- a/install/migrations/update_10.0.15_to_10.0.16/config.php
+++ b/install/migrations/update_10.0.15_to_10.0.16/config.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var \DBmysql $DB
+ * @var \Migration $migration
+ */
+global $DB, $migration;
+
+// Attach existing mail configuration settings log to NotificationMailingSetting object
+$or_criteria = [];
+foreach (NotificationMailingSetting::getRelatedConfigKeys() as $field) {
+    // `old_value` starts with the field name, followed by a space, then the field value
+    $or_criteria[] = [
+        'old_value' => ['LIKE', $field . '\\ %']
+    ];
+}
+$migration->addPostQuery(
+    $DB->buildUpdate(
+        'glpi_logs',
+        [
+            'itemtype' => 'NotificationMailingSetting',
+            'id_search_option' => 1,
+        ],
+        [
+            'NOT' => ['itemtype' => 'NotificationMailingSetting'], // prevent migration to be done twice
+            'OR' => $or_criteria,
+        ]
+    )
+);

--- a/src/Config.php
+++ b/src/Config.php
@@ -3782,7 +3782,17 @@ HTML;
             $newvalue = $oldvalue = '********';
         }
         $oldvalue = $name . ($context !== 'core' ? ' (' . $context . ') ' : ' ') . $oldvalue;
-        Log::constructHistory($this, ['value' => $oldvalue], ['value' => $newvalue]);
+
+        if (in_array($name, NotificationMailingSetting::getRelatedConfigKeys(), true)) {
+            // Specific case for email notification settings
+            Log::history(
+                1,
+                NotificationMailingSetting::class,
+                [1, Sanitizer::sanitize($oldvalue), Sanitizer::sanitize($newvalue)]
+            );
+        } else {
+            Log::constructHistory($this, ['value' => $oldvalue], ['value' => $newvalue]);
+        }
     }
 
     /**

--- a/src/NotificationMailingSetting.php
+++ b/src/NotificationMailingSetting.php
@@ -57,6 +57,67 @@ class NotificationMailingSetting extends NotificationSetting
         return Notification_NotificationTemplate::MODE_MAIL;
     }
 
+    public function defineTabs($options = [])
+    {
+        $ong = parent::defineTabs($options);
+        $this->addStandardTab('Log', $ong, $options);
+
+        return $ong;
+    }
+
+    /**
+     * Returns the keys of the config entries related to mail notifications.
+     * @return string[]
+     */
+    public static function getRelatedConfigKeys(): array
+    {
+        return [
+            'admin_email',
+            'admin_email_name',
+            'from_email',
+            'from_email_name',
+            'replyto_email',
+            'replyto_email_name',
+            'noreply_email',
+            'noreply_email_name',
+            'attach_ticket_documents_to_mail',
+            'mailing_signature',
+            'smtp_mode',
+            'smtp_max_retries',
+            'smtp_retry_time',
+            'smtp_oauth_provider',
+            'smtp_oauth_client_id',
+            'smtp_oauth_client_secret',
+            'smtp_oauth_options',
+            'smtp_oauth_refresh_token',
+            'smtp_check_certificate',
+            'smtp_host',
+            'smtp_port',
+            'smtp_username',
+            'smtp_passwd',
+            'smtp_sender',
+        ];
+    }
+
+    public function rawSearchOptions()
+    {
+        $tab = [];
+
+        $tab[] = [
+            'id'   => 'common',
+            'name' => __('Characteristics')
+        ];
+
+        $tab[] = [
+            'id'            => 1,
+            'table'         => $this->getTable(),
+            'field'         => 'value',
+            'name'          => __('Value'),
+            'massiveaction' => false
+        ];
+
+        return $tab;
+    }
 
     public function showFormConfig($options = [])
     {

--- a/tests/functional/Config.php
+++ b/tests/functional/Config.php
@@ -778,32 +778,51 @@ class Config extends DbTestCase
                 'name'             => 'unexisting_config',
                 'is_secured'       => false,
                 'old_value_prefix' => 'unexisting_config ',
+                'itemtype'         => \Config::class,
             ],
             [
                 'context'          => 'plugin:tester',
                 'name'             => 'check',
                 'is_secured'       => false,
                 'old_value_prefix' => 'check (plugin:tester) ',
+                'itemtype'         => \Config::class,
             ],
             [
                 'context'          => 'plugin:tester',
                 'name'             => 'passwd',
                 'is_secured'       => true,
                 'old_value_prefix' => 'passwd (plugin:tester) ',
-            ]
+                'itemtype'         => \Config::class,
+            ],
+
+            // Specific cases for smtp settings
+            [
+                'context'          => 'core',
+                'name'             => 'smtp_host',
+                'is_secured'       => false,
+                'old_value_prefix' => 'smtp_host ',
+                'itemtype'         => \NotificationMailingSetting::class,
+            ],
+            [
+                'context'          => 'core',
+                'name'             => 'smtp_oauth_refresh_token',
+                'is_secured'       => true,
+                'old_value_prefix' => 'smtp_oauth_refresh_token ',
+                'itemtype'         => \NotificationMailingSetting::class,
+            ],
         ];
     }
 
     /**
      * @dataProvider logConfigChangeProvider
      */
-    public function testLogConfigChange(string $context, string $name, bool $is_secured, string $old_value_prefix)
+    public function testLogConfigChange(string $context, string $name, bool $is_secured, string $old_value_prefix, string $itemtype)
     {
-        $history_crit = ['itemtype' => \Config::getType(), 'old_value' => ['LIKE', $name . ' %']];
+        $history_crit = ['itemtype' => $itemtype, 'old_value' => ['LIKE', $name . ' %']];
 
         $expected_history = [];
         $history_entry_fields = [
-            'itemtype'         => \Config::getType(),
+            'itemtype'         => $itemtype,
             'items_id'         => 1,
             'itemtype_link'    => '',
             'linked_action'    => 0,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33354

SMTP logs have been moved to a dedicated tab on the e-mail notification side (as this is where SMTP-related options can be set). This avoids filling the general conf logs.

![image](https://github.com/glpi-project/glpi/assets/107540223/d2fbf23f-07f7-4f00-bc73-593920bdebce)
