### PR TITLE
Improve handling of search errors

### DIFF
--- a/src/Glpi/Search/Output/HTMLSearchOutput.php
+++ b/src/Glpi/Search/Output/HTMLSearchOutput.php
@@ -65,8 +65,9 @@ abstract class HTMLSearchOutput extends AbstractSearchOutput
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
+        $search_error = false;
         if (!isset($data['data']) || !isset($data['data']['totalcount'])) {
-            return false;
+            $search_error = true;
         }
 
         $search     = $data['search'];
@@ -175,6 +176,7 @@ abstract class HTMLSearchOutput extends AbstractSearchOutput
 
         $rand = mt_rand();
         TemplateRenderer::getInstance()->display('components/search/display_data.html.twig', [
+            'search_error'         => $search_error,
             'data'                => $data,
             'union_search_type'   => $CFG_GLPI["union_search_type"],
             'rand'                => $rand,
@@ -217,14 +219,16 @@ abstract class HTMLSearchOutput extends AbstractSearchOutput
         ] + ($params['extra_twig_params'] ?? []));
 
         // Add items in item list
-        foreach ($data['data']['rows'] as $row) {
-            if ($itemtype !== \AllAssets::class) {
-                \Session::addToNavigateListItems($itemtype, $row["id"]);
-            } else {
-                // In case of a global search, reset and empty navigation list to ensure navigation in
-                // item header context is not shown. Indeed, this list does not support navigation through
-                // multiple itemtypes, so it should not be displayed in global search context.
-                \Session::initNavigateListItems($row['TYPE'] ?? $data['itemtype']);
+        if (isset($data['data']['rows'])) {
+            foreach ($data['data']['rows'] as $row) {
+                if ($itemtype !== \AllAssets::class) {
+                    \Session::addToNavigateListItems($itemtype, $row["id"]);
+                } else {
+                    // In case of a global search, reset and empty navigation list to ensure navigation in
+                    // item header context is not shown. Indeed, this list does not support navigation through
+                    // multiple itemtypes, so it should not be displayed in global search context.
+                    \Session::initNavigateListItems($row['TYPE'] ?? $data['itemtype']);
+                }
             }
         }
 

--- a/src/Glpi/Search/Output/MapSearchOutput.php
+++ b/src/Glpi/Search/Output/MapSearchOutput.php
@@ -80,7 +80,7 @@ final class MapSearchOutput extends HTMLSearchOutput
         global $CFG_GLPI;
 
         $itemtype = $data['itemtype'];
-        if ($data['data']['totalcount'] > 0) {
+        if (isset($data['data']['totalcount']) && $data['data']['totalcount'] > 0) {
             $target = $data['search']['target'];
             $criteria = $data['search']['criteria'];
             array_pop($criteria);

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -4751,8 +4751,6 @@ final class SQLProvider implements SearchProviderInterface
                         "sql query fails (too many tables). " .
                         "Please use 'Items seen' criterion instead")
                 );
-            } else if ($_SESSION['glpi_use_mode'] === Session::DEBUG_MODE) {
-                echo $DBread->error();
             }
         }
         Profiler::getInstance()->stop('SQLProvider::constructData');

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -4751,7 +4751,7 @@ final class SQLProvider implements SearchProviderInterface
                         "sql query fails (too many tables). " .
                         "Please use 'Items seen' criterion instead")
                 );
-            } else {
+            } else if ($_SESSION['glpi_use_mode'] === Session::DEBUG_MODE) {
                 echo $DBread->error();
             }
         }

--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -181,7 +181,7 @@
                 {% endif %}
 
 
-                {% if can_config and count > 0 %}
+                {% if can_config %}
                     <button class="show_displaypreference_modal  btn btn-sm btn-ghost-secondary"
                         type="button"
                         title="{{ __('Select default items to show') }}"

--- a/templates/components/search/display_data.html.twig
+++ b/templates/components/search/display_data.html.twig
@@ -31,6 +31,7 @@
  # ---------------------------------------------------------------------
  #}
 
+{% import 'components/alerts_macros.html.twig' as alerts %}
 {% set is_ajax = data['searchform_id'] is defined and data['searchform_id'] is not null %}
 {% set fluid_search = fluid_search|default(true) %}
 {% if not is_ajax %}
@@ -78,9 +79,11 @@
                 </div>
             {% endif %}
         {% elseif data['search']['as_map'] == 1 %}
-            <div class="alert alert-info mb-0 rounded-0 border-top-0 border-bottom-0 border-right-0" role="alert">
-            {{ __('No item found') }}
-            </div>
+            {% if search_error %}
+                {{ alerts.alert_danger(__('An error occured during the search'), __('Consider changing the search criteria or adjusting the displayed columns.')) }}
+            {% else %}
+                {{ alerts.alert_info(__('No item found')) }}
+            {% endif %}
         {% endif %}
     </form>
 </div>

--- a/templates/components/search/table.html.twig
+++ b/templates/components/search/table.html.twig
@@ -31,6 +31,7 @@
  # ---------------------------------------------------------------------
  #}
 
+{% import 'components/alerts_macros.html.twig' as alerts %}
 {% set searchform_id = data['searchform_id']|default('search_' ~ rand) %}
 {% set massive_action_form_id = massive_action_form_id ?? "" %}
 
@@ -103,9 +104,11 @@
          {% if count == 0 %}
             <tr>
                <td colspan="{{ data['data']['cols']|length }}">
-                  <div class="alert alert-info mb-0 rounded-0 border-top-0 border-bottom-0 border-right-0" role="alert">
-                     {{ __('No item found') }}
-                  </div>
+                  {% if search_error %}
+                      {{ alerts.alert_danger(__('An error occured during the search'), __('Consider changing the search criteria or adjusting the displayed columns.')) }}
+                  {% else %}
+                      {{ alerts.alert_info(__('No item found')) }}
+                  {% endif %}
                </td>
             </tr>
          {% else %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Currently when a SQL error occurs during a search, the SQL error is output to the page even when not in debug mode/dev environment. In this case, the controls are also completely missing.

With this PR, the SQL error is hidden unless in debug mode. It also lets the controls be displayed so that the criteria or displayed columns can be adjusted.