### PR TITLE
Accessibility improvements

### DIFF
--- a/js/glpi_dialog.js
+++ b/js/glpi_dialog.js
@@ -105,11 +105,11 @@ var glpi_html_dialog = function({
 
     const data_bs_focus = !bs_focus ? 'data-bs-focus="false"' : '';
 
-    var modal = `<div class="modal fade ${modalclass}" id="${id}" role="dialog" ${data_bs_focus}>
+    var modal = `<div class="modal fade ${modalclass}" id="${id}" role="dialog" ${data_bs_focus} aria-labelledby="${id}_title">
          <div class="modal-dialog ${dialogclass}">
             <div class="modal-content">
                <div class="modal-header">
-                  <h4 class="modal-title">${title}</h4>
+                  <h2 id="${id}_title" class="fs-4 modal-title" tabindex="-1">${title}</h2>
                   <button type="button" class="btn-close" data-bs-dismiss="modal"
                            aria-label="${__("Close")}"></button>
                </div>

--- a/src/Glpi/Search/Input/QueryBuilder.php
+++ b/src/Glpi/Search/Input/QueryBuilder.php
@@ -360,7 +360,8 @@ final class QueryBuilder implements SearchInputInterface
             $pattern = $fieldpattern['pattern'];
             $message = $fieldpattern['validation_message'];
 
-            echo "<input type='text' class='form-control' size='13' name='$inputname' value=\"" .
+            $field_title = __s('Criteria value');
+            echo "<input type='text' class='form-control' size='13' aria-label='{$field_title}' name='{$inputname}' value=\"" .
                 htmlescape($request['value']) . "\" pattern=\"" . htmlescape($pattern) . "\">" .
                 "<span class='invalid-tooltip'>" . htmlescape($message) . "</span>";
         }

--- a/templates/components/dropdown/limit.html.twig
+++ b/templates/components/dropdown/limit.html.twig
@@ -74,8 +74,12 @@
 {% if user_pref('list_limit') not in options %}
    {% set options = options|merge([user_pref('list_limit')]) %}
 {% endif %}
-<select class="form-select form-select-sm mx-1 d-inline-block w-auto {{ select_class|default('') }}"
-        {% if not no_onchange %}onChange="{{ href }}"{% endif %}>
+{% set select_name = select_name|default('list_limit') %}
+<select id="{{ select_name|slug }}{{ rand|default(random()) }}" class="form-select form-select-sm mx-1 d-inline-block w-auto {{ select_class|default('') }}"
+        {% if not no_onchange %}onChange="{{ href }}"{% endif %} name="{{ select_name }}"
+        {% for attr, value in additional_attributes %}
+            {{ attr }}="{{ value }}"
+        {% endfor %}>
    {% for value in options|sort %}
       <option value="{{ value }}" {{ value == user_pref('list_limit') ? 'selected' : '' }}>
          {{ value }}

--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -248,7 +248,7 @@
 
         {% if not options.readonly %}
             {% set calendar_icon = options.enableTime ? 'ti ti-calendar-time' : 'ti ti-calendar' %}
-            <button type="button" class="btn btn-outline-secondary btn-sm" data-toggle>
+            <button type="button" class="btn btn-outline-secondary btn-sm" data-toggle title="{{ __('Show date picker') }}">
                 <i class="{{ calendar_icon }}"></i>
             </button>
             {# maybeempty has no distinct purpose, but it was here first #}

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -743,7 +743,7 @@
    {% if not options.include_field %}
       {{ field }}
    {% else %}
-      {% set id    = options.id|length > 0 and options.id != '%id%' ? options.id : (name ~ '_' ~ options.rand) %}
+      {% set id    = options.id|length > 0 and options.id != '%id%' ? options.id : (name|slug ~ '_' ~ options.rand) %}
       {% set field = field|replace({'%id%': id}) %}
       {% set add_field_html = options.add_field_html|length > 0 ? options.add_field_html : '' %}
 

--- a/templates/components/pager.html.twig
+++ b/templates/components/pager.html.twig
@@ -69,6 +69,7 @@
 {# limit the number of adjacents links displayed #}
 {% set adjacents = 2 %}
 {% set skip_adjacents = false %}
+{% set rand = rand|default(random()) %}
 
 <div class="flex-grow-1 d-flex flex-wrap flex-md-nowrap  align-items-center justify-content-between mb-2 search-pager">
     {% if not short_display %}
@@ -77,8 +78,14 @@
                 'no_onchange': fluid_search|default(false),
                 'select_class': 'search-limit-dropdown',
                 'href': href|replace({'%start%': start}),
+                'additional_attributes': short_display ? {
+                    'title': __('Rows per page'),
+                } : {
+                    'aria-labelledby': 'list_limit' ~ rand ~ '_label',
+                },
+                'rand': rand,
             } %}
-            {{ __('rows / page') }}
+            <span id="list_limit{{ rand }}_label">{{ __('rows / page') }}</span>
         </span>
     {% endif %}
     <span class="search-limit {{ short_display ? "" : "d-block d-md-none" }}">

--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -63,7 +63,7 @@
                     </button>
                     {% if not user_pref('show_search_form') %}
                         {% set active_filter_class = is_filter_active ? "btn-active-search" : "btn-ghost-secondary" %}
-                        <button class="btn btn-sm py-1 {{ active_filter_class }} btn-ghost-secondary dropdown-toggle" type="button"
+                        <button class="btn btn-sm py-1 show-search-filters {{ active_filter_class }} btn-ghost-secondary dropdown-toggle" type="button"
                                 data-bs-toggle="dropdown" data-bs-auto-close="outside">
                             <i class="ti ti-list-search"></i>
                             {% if active_search_name|length %}
@@ -82,7 +82,7 @@
 
                 {% if data['search']['as_map'] != 1 %}
                     {% set active_sort_class = active_sort ? "btn-active-sort" : "" %}
-                    <button class="btn btn-sm py-1 {{ active_sort_class }} btn-ghost-secondary dropdown-toggle me-1 me-xl-2" type="button"
+                    <button class="btn btn-sm py-1 show-search-sorts {{ active_sort_class }} btn-ghost-secondary dropdown-toggle me-1 me-xl-2" type="button"
                                 data-bs-toggle="dropdown" data-bs-auto-close="outside">
                         <i class="ti ti-arrows-sort"></i>
                         {% set sort_names = (active_sort_name|length ? active_sort_name : __("Sort")) %}

--- a/templates/components/search/query_builder/search_option_value.html.twig
+++ b/templates/components/search/query_builder/search_option_value.html.twig
@@ -51,5 +51,5 @@
 {% endif %}
 
 {% if not display %}
-   <input type="text" class="form-control" size="13" name="{{ inputname }}" value="{{ value }}">
+   <input type="text" class="form-control" size="13" aria-label="{{ __('Criteria value') }}" name="{{ inputname }}" value="{{ value }}">
 {% endif %}

--- a/templates/pages/assistance/planning/filters.html.twig
+++ b/templates/pages/assistance/planning/filters.html.twig
@@ -46,7 +46,7 @@
                     <h3>
                         {{ headings[filter_heading] }}
                         {% if filter_heading == 'plannings' %}
-                            <a class="planning_link planning_add_filter" href="{{ path('/ajax/planning.php?action=add_planning_form') }}">
+                            <a class="planning_link planning_add_filter" href="{{ path('/ajax/planning.php?action=add_planning_form') }}" title="{{ __('Add a calendar') }}">
                                 <i class="ti ti-circle-plus"></i>
                             </a>
                         {% endif %}

--- a/templates/pages/assistance/planning/single_filter.html.twig
+++ b/templates/pages/assistance/planning/single_filter.html.twig
@@ -49,7 +49,7 @@
         {# Colors not for groups #}
         {% if filter_data.type != 'group_users' and filter_key != 'OnlyBgEvents' %}
             <span class="color_input">
-                <input type="color" name="{{ filter_key }}_color" value="{{ color }}">
+                <input type="color" name="{{ filter_key }}_color" aria-label="{{ __('%s color')|format(title) }}" value="{{ color }}">
             </span>
         {% endif %}
         {% if filter_data.type == 'group_users' %}

--- a/tests/cypress/e2e/Planning/external_event.cy.js
+++ b/tests/cypress/e2e/Planning/external_event.cy.js
@@ -31,29 +31,15 @@
  * ---------------------------------------------------------------------
  */
 
-function terminalLog(violations) {
-    cy.task(
-        'log',
-        `${violations.length} accessibility violation${
-            violations.length === 1 ? '' : 's'
-        } ${violations.length === 1 ? 'was' : 'were'} detected`
-    );
-    // pluck specific keys to keep the table readable
-    const violationData = violations.map(
-        ({ id, impact, description, nodes }) => ({
-            id,
-            impact,
-            description,
-            nodes: JSON.stringify({
-                length: nodes.length,
-                targets: nodes.map(({ target }) => target).join(', ')
-            })
-        })
-    );
-
-    cy.task('table', violationData);
-}
-
-module.exports = {
-    terminalLog
-};
+describe('External event', () => {
+    beforeEach(() => {
+        cy.login();
+        cy.changeProfile('Super-Admin', true);
+    });
+    it('Accessibility - Form', () => {
+        cy.visit('/front/planning.php');
+        cy.disableAnimations();
+        cy.get('#planning_container .fc-slats td:not(.fc-axis)').first().click();
+        cy.get('.modal.show').injectAndCheckA11y();
+    });
+});

--- a/tests/cypress/e2e/Planning/planning_view.cy.js
+++ b/tests/cypress/e2e/Planning/planning_view.cy.js
@@ -31,29 +31,14 @@
  * ---------------------------------------------------------------------
  */
 
-function terminalLog(violations) {
-    cy.task(
-        'log',
-        `${violations.length} accessibility violation${
-            violations.length === 1 ? '' : 's'
-        } ${violations.length === 1 ? 'was' : 'were'} detected`
-    );
-    // pluck specific keys to keep the table readable
-    const violationData = violations.map(
-        ({ id, impact, description, nodes }) => ({
-            id,
-            impact,
-            description,
-            nodes: JSON.stringify({
-                length: nodes.length,
-                targets: nodes.map(({ target }) => target).join(', ')
-            })
-        })
-    );
-
-    cy.task('table', violationData);
-}
-
-module.exports = {
-    terminalLog
-};
+describe('Planning view', () => {
+    beforeEach(() => {
+        cy.login();
+        cy.changeProfile('Super-Admin', true);
+    });
+    it('Accessibility', () => {
+        cy.visit('/front/planning.php');
+        cy.disableAnimations();
+        cy.get('#planning_container').injectAndCheckA11y();
+    });
+});

--- a/tests/cypress/e2e/page_layout.cy.js
+++ b/tests/cypress/e2e/page_layout.cy.js
@@ -31,29 +31,25 @@
  * ---------------------------------------------------------------------
  */
 
-function terminalLog(violations) {
-    cy.task(
-        'log',
-        `${violations.length} accessibility violation${
-            violations.length === 1 ? '' : 's'
-        } ${violations.length === 1 ? 'was' : 'were'} detected`
-    );
-    // pluck specific keys to keep the table readable
-    const violationData = violations.map(
-        ({ id, impact, description, nodes }) => ({
-            id,
-            impact,
-            description,
-            nodes: JSON.stringify({
-                length: nodes.length,
-                targets: nodes.map(({ target }) => target).join(', ')
-            })
-        })
-    );
+describe('Page layout', () => {
+    beforeEach(() => {
+        cy.login();
+        cy.changeProfile('Super-Admin', true);
+    });
+    it('Accessibility', () => {
+        cy.disableAnimations();
+        cy.get('aside.navbar.sidebar .nav-link.dropdown-toggle:visible').each(($el) => {
+            cy.wrap($el).click();
+            cy.get('aside.navbar.sidebar').injectAndCheckA11y();
+        });
 
-    cy.task('table', violationData);
-}
+        cy.get('.navbar-nav.user-menu:visible').click();
+        cy.get('.navbar-nav.user-menu:visible .dropdown-menu').injectAndCheckA11y();
 
-module.exports = {
-    terminalLog
-};
+        cy.get('.navbar-nav.user-menu:visible .dropdown-menu a.entity-dropdown-toggle').click();
+        cy.get('.navbar-nav.user-menu:visible .dropdown-menu a.entity-dropdown-toggle + .dropdown-menu').injectAndCheckA11y();
+
+        cy.visit('/front/computer.php');
+        cy.get('header.navbar').injectAndCheckA11y();
+    });
+});

--- a/tests/cypress/e2e/page_layout.cy.js
+++ b/tests/cypress/e2e/page_layout.cy.js
@@ -34,9 +34,10 @@
 describe('Page layout', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
     });
     it('Accessibility', () => {
+        cy.visit('/front/computer.php');
         cy.disableAnimations();
         cy.get('aside.navbar.sidebar .nav-link.dropdown-toggle:visible').each(($el) => {
             cy.wrap($el).click();
@@ -49,7 +50,6 @@ describe('Page layout', () => {
         cy.get('.navbar-nav.user-menu:visible .dropdown-menu a.entity-dropdown-toggle').click();
         cy.get('.navbar-nav.user-menu:visible .dropdown-menu a.entity-dropdown-toggle + .dropdown-menu').injectAndCheckA11y();
 
-        cy.visit('/front/computer.php');
         cy.get('header.navbar').injectAndCheckA11y();
     });
 });

--- a/tests/cypress/e2e/search_engine.cy.js
+++ b/tests/cypress/e2e/search_engine.cy.js
@@ -31,29 +31,19 @@
  * ---------------------------------------------------------------------
  */
 
-function terminalLog(violations) {
-    cy.task(
-        'log',
-        `${violations.length} accessibility violation${
-            violations.length === 1 ? '' : 's'
-        } ${violations.length === 1 ? 'was' : 'were'} detected`
-    );
-    // pluck specific keys to keep the table readable
-    const violationData = violations.map(
-        ({ id, impact, description, nodes }) => ({
-            id,
-            impact,
-            description,
-            nodes: JSON.stringify({
-                length: nodes.length,
-                targets: nodes.map(({ target }) => target).join(', ')
-            })
-        })
-    );
-
-    cy.task('table', violationData);
-}
-
-module.exports = {
-    terminalLog
-};
+describe('Search engine', () => {
+    beforeEach(() => {
+        cy.login();
+        cy.changeProfile('Super-Admin', true);
+    });
+    it('Accessibility', () => {
+        cy.visit('/front/computer.php');
+        cy.get('div.search_page').within(() => {
+            cy.root().injectAndCheckA11y();
+            cy.get('button.show-search-filters').click();
+            cy.get('div.search-form').injectAndCheckA11y();
+            cy.get('button.show-search-sorts').click();
+            cy.get('div.sort-container').injectAndCheckA11y();
+        });
+    });
+});

--- a/tests/cypress/support/cypress-axe.js
+++ b/tests/cypress/support/cypress-axe.js
@@ -54,9 +54,14 @@ Cypress.Commands.add('injectAndCheckA11y', {prevSubject: 'optional'}, (subject) 
             ['.alert'], // Default Bootstrap/Tabler alert colors don't meet contrast requirements at any level of WCAG.
             ['.nav-pills .nav-link.active'],
             ['span[aria-label]'], // aria-label attribute cannot be used on a span with no valid role attribute. Done by bootstrap.
-
             // Below are items that do not need to be validated
             ['.sf-toolbar'], // Symfony profiler
+            ['.flatpickr input[type="text"]'], // Input labels broken when using altInput option
+            ['*[data-hasqtip]'], // Popper tooltips aren't created as labels for the elements they are attached to, but we use them instead of title attributes.
+            ['aside.navbar.sidebar a.dropdown-item'], // Duplicate accesskeys
+            ['.fancytree-container .fancytree-expander'], // Expand/collapse 'buttons' have no label
+            ['.fancytree-container thead > tr > th'], // Fancytree adds an empty header row to the table
+            ['.search-header .search-controls .show_export_menu'], // Wrapper element that triggers the tooltip is not valid
         ]
     };
     if (subject) {
@@ -64,4 +69,31 @@ Cypress.Commands.add('injectAndCheckA11y', {prevSubject: 'optional'}, (subject) 
         context.include = subject;
     }
     cy.checkA11y(context, null, terminalLog);
+});
+
+/**
+ * @memberof Cypress.Chainable.prototype
+ * @method disableAnimations
+ * @description Disable animations on the page
+ * @returns Chainable
+ */
+Cypress.Commands.add('disableAnimations', () => {
+    cy.get('body').invoke('append', Cypress.$(`
+        <style id="__cypress-animation-disabler">
+            *, *:before, *:after {
+              transition: none !important;
+              animation: none !important;
+            }
+        </style>
+    `));
+});
+
+/**
+ * @memberof Cypress.Chainable.prototype
+ * @method enableAnimations
+ * @description Enable animations on the page
+ * @returns Chainable
+ */
+Cypress.Commands.add('enableAnimations', () => {
+    Cypress.$('#__cypress-animation-disabler').remove();
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fixed:
- Modals from `glpi_html_dialog` were missing a label
- Modals from `glpi_html_dialog` did not capture focus (could not tab through the inputs in the dialog without first clicking inside it)
- Modals from `glpi_html_dialog` had the wrong header level for the title
- The button next to date/datetime inputs had no label
- Automatically generated IDs from names may break labels because the name wasn't slugified
- Planning view button to add a new calendar had no label
- Planning view filter color inputs had no label
- Massive action checkboxes in search results had no label
- Search criteria value input had no label
- List limit control was not properly labeled

New discovered issues that haven't been addressed yet:
- Flatpickr breaks association with labels when `altInput` is true because they make the original input hidden and create a new one. The label becomes associated with the hidden input rather than the visible one.
- There are cases where we use Popper tooltips (qtip) in place of the title attribute, and those tooltips are not considered labels for the elements they are linked to.
- Menu entries the extend CommonDropdown all have the same `accesskey`/shortcut by default
- Fancytree has no label for the expand/collapse 'buttons'
- Fancytree adds an empty table header
- Search results export button triggers both a tooltip and a dropdown menu and it isn't considered correctly labeled. I thought adding 'none' as the role to the wrapper element which triggers the tooltip would fix the issue, but it doesn't. Manually initializing the tooltip on the button itself doesn't work either. It seems like only one plugin can be initialized on an element at once.

Possible solution notes:
- The Fancytree issues may be resolved if the Vue replacement (#16617) can get stabilized and merged.
- Maybe since GLPI has so many menu entries, it is best to not have these shortcuts except maybe for the simplified interface or only the most common entries (Nothing at the CommonDropdown level).
- Even though qtip tooltips look better, they probably shouldn't be used as a replacement for titles/labels.