### PR TITLE
Remove the `$PLUGINS_EXCLUDED` global variable hack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,7 @@ The present file will list all changes made to the project; according to the
 - `Glpi\Application\ErrorHandler` constructor visibility has been changed to private.
 - `GLPI::initErrorHandler()` does not return any value anymore.
 - The `inc/autoload.function.php`, `inc/db.function.php` and `inc/define.php` file has been removed and the corresponding global functions, constants and variables are now loaded and initialized automatically.
+- `Plugin::init()` and `Plugin::checkStates()` methods signature changed. It is not anymore possible to exclude specific plugins.
 
 #### Deprecated
 - Usage of `MAIL_SMTPSSL` and `MAIL_SMTPTLS` constants.
@@ -223,6 +224,7 @@ The present file will list all changes made to the project; according to the
 #### Removed
 - `GLPI_USE_CSRF_CHECK`, `GLPI_USE_IDOR_CHECK`, `GLPI_CSRF_EXPIRES`, `GLPI_CSRF_MAX_TOKENS` and `GLPI_IDOR_EXPIRES` constants.
 - `$CFG_GLPI_PLUGINS` global variable.
+- `$PLUGINS_EXCLUDED` global variable.
 - Usage of `csrf_compliant` plugins hook.
 - Usage of `migratetypes` plugin hooks.
 - Usage of `planning_scheduler_key` plugins hook.

--- a/ajax/marketplace.php
+++ b/ajax/marketplace.php
@@ -33,9 +33,6 @@
  * ---------------------------------------------------------------------
  */
 
-/** @var array $PLUGINS_EXCLUDED */
-global $PLUGINS_EXCLUDED;
-
 // follow download progress of a plugin with a minimal loading of files
 // So we get a ajax answer in 5ms instead 100ms
 if (($_GET["action"] ?? null) == "get_dl_progress") {
@@ -50,13 +47,6 @@ if (($_GET["action"] ?? null) == "get_dl_progress") {
     echo $_SESSION['marketplace_dl_progress'][$_GET['key']] ?? 0;
     exit;
 }
-
-if (in_array($_POST["action"] ?? null, ['download_plugin', 'update_plugin'])) {
-   // Do not load plugin that will be updated, to be able to load its new information
-   // by redefining its plugin_version_ function after files replacement.
-    $PLUGINS_EXCLUDED = [$_POST['key']];
-}
-
 
 // get common marketplace action, load GLPI framework
 include("../inc/includes.php");
@@ -90,6 +80,11 @@ if (isset($_POST['key']) && isset($_POST["action"])) {
     }
     if ($_POST["action"] == "disable_plugin") {
         $marketplace_ctrl->disablePlugin();
+    }
+    if ($_POST["action"] == "suspend_plugin") {
+        header("Content-Type: application/json; charset=UTF-8");
+        echo json_encode(['success' => $marketplace_ctrl->suspendPlugin()]);
+        exit();
     }
 
     echo MarketplaceView::getButtons($_POST['key']);

--- a/inc/includes.php
+++ b/inc/includes.php
@@ -43,7 +43,6 @@ use Glpi\Toolbox\URL;
  * @var bool|null $AJAX_INCLUDE
  * @var bool $FOOTER_LOADED
  * @var bool $HEADER_LOADED
- * @var bool|null $PLUGINS_EXCLUDED
  * @var bool|null $PLUGINS_INCLUDED
  * @var string|null $SECURITY_STRATEGY
  * @var string $CURRENTCSRFTOKEN
@@ -52,7 +51,7 @@ global $CFG_GLPI,
     $GLPI_CACHE,
     $AJAX_INCLUDE,
     $FOOTER_LOADED, $HEADER_LOADED,
-    $PLUGINS_EXCLUDED, $PLUGINS_INCLUDED,
+    $PLUGINS_INCLUDED,
     $SECURITY_STRATEGY,
     $CURRENTCSRFTOKEN
 ;
@@ -102,9 +101,8 @@ AssetDefinitionManager::getInstance()->registerAssetsAutoload();
 if (!isset($PLUGINS_INCLUDED)) {
    // PLugin already included
     $PLUGINS_INCLUDED = 1;
-    $PLUGINS_EXCLUDED = isset($PLUGINS_EXCLUDED) ? $PLUGINS_EXCLUDED : [];
     $plugin = new Plugin();
-    $plugin->init(true, $PLUGINS_EXCLUDED);
+    $plugin->init(true);
 }
 
 // Assets classes bootstraping.

--- a/js/marketplace.js
+++ b/js/marketplace.js
@@ -54,27 +54,44 @@ $(document).ready(function() {
             .removeClass()
             .addClass('fas fa-spinner fa-spin');
 
-        if (action === 'download_plugin'
-          || action === 'update_plugin') {
-            followDownloadProgress(button);
-        }
-
-        ajax_done = false;
-        $.post(ajax_url, {
-            'action': action,
-            'key': plugin_key
-        }).done(function(html) {
-            ajax_done = true;
-
-            if (html.indexOf("cleaned") !== -1 && installed) {
-                li.remove();
-            } else {
-                html = html.replace('cleaned', '');
-                buttons.html(html);
-                displayAjaxMessageAfterRedirect();
-                addTooltips();
+        const executeAction = function () {
+            if (action === 'download_plugin'
+              || action === 'update_plugin') {
+                followDownloadProgress(button);
             }
-        });
+
+            ajax_done = false;
+            $.post(ajax_url, {
+                'action': action,
+                'key': plugin_key
+            }).done(function(html) {
+                ajax_done = true;
+
+                if (html.indexOf("cleaned") !== -1 && installed) {
+                    li.remove();
+                } else {
+                    html = html.replace('cleaned', '');
+                    buttons.html(html);
+                    displayAjaxMessageAfterRedirect();
+                    addTooltips();
+                }
+            });
+        };
+
+        if (action === 'download_plugin' || action === 'update_plugin') {
+            // Specific case for plugin code source replacement.
+            // The plugin execution must be suspended first to ensure that its `setup.php` file is not loaded before
+            // its new version is downloaded.
+            $.post(ajax_url, {
+                'action': 'suspend_plugin',
+                'key': plugin_key
+            }).done(function() {
+                executeAction();
+            });
+            return;
+        } else {
+            executeAction();
+        }
     });
 
     // sort control

--- a/src/Glpi/Marketplace/Controller.php
+++ b/src/Glpi/Marketplace/Controller.php
@@ -570,6 +570,21 @@ class Controller extends CommonGLPI
         return $this->setPluginState("unactivate") == Plugin::NOTACTIVATED;
     }
 
+    /**
+     * Suspend current plugin
+     *
+     * @return bool
+     */
+    public function suspendPlugin(): bool
+    {
+        $plugin = new Plugin();
+        if ($plugin->getFromDBbyDir($this->plugin_key)) {
+            return $plugin->suspend();
+        }
+
+        return true;
+    }
+
 
     /**
      * Clean (remove database data) current plugin

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -77,7 +77,8 @@ class Plugin extends CommonDBTM
     const TOBECONFIGURED = 3;
 
     /**
-     * @var int Plugin is installed but not enabled
+     * @var int Plugin is installed but has not been activated yet, or has been deactivated either by the user or
+     *          by the GLPI update process.
      */
     const NOTACTIVATED   = 4;
 
@@ -97,7 +98,7 @@ class Plugin extends CommonDBTM
     const REPLACED       = 7;
 
     /**
-     * @var int Plugin is installed and enabled, but its execution is suspended.
+     * @var int Plugin is installed and enabled, but its execution has suspended by the plugin update process.
      */
     const SUSPENDED      = 8;
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -79,6 +79,7 @@ class Plugin extends CommonDBTM
     /**
      * @var int Plugin is installed but has not been activated yet, or has been deactivated either by the user or
      *          by the GLPI update process.
+     * @TODO Do not set plugins to this state during the GLPI update process.
      */
     const NOTACTIVATED   = 4;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In #8019, we introduced a hack to prevent an issue when trying to download, from the marketplace, a new version of an active plugin. The idea was to prevent this plugin from being loaded, to prevent a `Cannot redeclare plugin_version_XXX()` error that was caused by a double loading of the `setup.php` file (a first time before the code source replacement, and a second time after the download process).

This logic was a hack, and it is a pain to make it compatible with a centralized Kernel (job started in #17278). I propose to split the operation into 2 requests:
 - the first request suspends the plugin execution;
 - the second request download the new version and install it.

I introduced a new `SUSPENDED` state that may be used later in the GLPI upgrade process to differenciate plugins that were suspended by the upgrade process and plugins that were already disabled before the upgrade.

I had to apply the patch on GLPI 10.0 to be able to test it, as no plugin in the marketplace is currently available for GLPI 11.0.