### PR TITLE
[HLAPI] Use active entity as default during item creation

### DIFF
--- a/src/Glpi/Api/HL/Search.php
+++ b/src/Glpi/Api/HL/Search.php
@@ -1325,6 +1325,9 @@ final class Search
     public static function createBySchema(array $schema, array $request_params, array $get_route, array $extra_get_route_params = []): Response
     {
         $itemtype = self::getItemtypeFromSchema($schema);
+        if (!isset($request_params['entity']) && isset($_SESSION['glpiactive_entity'])) {
+            $request_params['entity'] = $_SESSION['glpiactive_entity'];
+        }
         $input = self::getInputParamsBySchema($schema, $request_params);
 
         /** @var CommonDBTM $item */

--- a/tests/functional/Glpi/Api/HL/Controller/AssetController.php
+++ b/tests/functional/Glpi/Api/HL/Controller/AssetController.php
@@ -421,4 +421,36 @@ class AssetController extends \HLAPITestCase
                 });
         });
     }
+
+    public function testCreateInOtherEntities()
+    {
+        $this->login();
+
+        $request = new Request('POST', '/Assets/Computer', [
+            'GLPI-Entity' => getItemByTypeName('Entity', '_test_child_1', true),
+        ]);
+        $request->setParameter('name', 'Test');
+        $new_location = null;
+        $this->api->call($request, function ($call) use (&$new_location) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->isOK()
+                ->headers(function ($headers) use (&$new_location) {
+                    $this->array($headers)->hasKey('Location');
+                    $this->string($headers['Location'])->startWith('/Assets/Computer/');
+                    $new_location = $headers['Location'];
+                });
+        });
+
+        $this->api->call(new Request('GET', $new_location), function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->isOK()
+                ->jsonContent(function ($content) {
+                    $this->array($content)->hasKey('entity');
+                    $this->array($content['entity'])->hasKey('name');
+                    $this->string($content['entity']['name'])->isEqualTo('_test_child_1');
+                });
+        });
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When creating an item through the API, the current entity (determined by GLPI-Entity header) should be used if the entity ID is not explicitly specified in the parameters.