### PR TITLE
Remove default timezone hack

### DIFF
--- a/inc/based_config.php
+++ b/inc/based_config.php
@@ -37,15 +37,6 @@ if (!defined('GLPI_ROOT')) {
     define('GLPI_ROOT', dirname(__FILE__, 2));
 }
 
-// Notice problem  for date function :
-$tz = ini_get('date.timezone');
-if (!empty($tz)) {
-    date_default_timezone_set($tz);
-} else {
-    date_default_timezone_set(@date_default_timezone_get());
-}
-
-
 // Check if dependencies are up to date
 $needrun  = false;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

As documented in https://www.php.net/manual/en/function.date-default-timezone-set.php:
> Instead of using this function to set the default timezone in your script, you can also use the INI setting [date.timezone](https://www.php.net/manual/en/datetime.configuration.php#ini.date.timezone) to set the default timezone.

This hack was made to handle empty values of the `date.timezone` configuration, but since PHP 8.2 (the minimum PHP version for GLPI 11.0), an empty value will emit a warning (see https://www.php.net/manual/en/datetime.configuration.php).

IMHO, due to this warning, administrators will fix their PHP configuration and we will not anymore have to handle this empty value case.