### PR TITLE
Remove unused `$CFG_GLPI_PLUGINS` global variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,7 @@ The present file will list all changes made to the project; according to the
 
 #### Removed
 - `GLPI_USE_CSRF_CHECK`, `GLPI_USE_IDOR_CHECK`, `GLPI_CSRF_EXPIRES`, `GLPI_CSRF_MAX_TOKENS` and `GLPI_IDOR_EXPIRES` constants.
+- `$CFG_GLPI_PLUGINS` global variable.
 - Usage of `csrf_compliant` plugins hook.
 - Usage of `migratetypes` plugin hooks.
 - Usage of `planning_scheduler_key` plugins hook.

--- a/inc/based_config.php
+++ b/inc/based_config.php
@@ -329,15 +329,12 @@ define('GLPI_I18N_DIR', GLPI_ROOT . "/locales");
 
 /**
  * @var array $PLUGIN_HOOKS
- * @var array $CFG_GLPI_PLUGINS
  * @var array $LANG
  */
 global $PLUGIN_HOOKS,
-    $CFG_GLPI_PLUGINS,
     $LANG
 ;
 
 // For plugins
 $PLUGIN_HOOKS     = [];
-$CFG_GLPI_PLUGINS = [];
 $LANG             = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I did not find any reference to this variable in any of the plugins that are listed on the plugin catalog.