### PR TITLE
Impact : Permit use only one asset to create a compound

### DIFF
--- a/js/impact.js
+++ b/js/impact.js
@@ -2477,8 +2477,8 @@ var GLPIImpact = {
     */
     addCompoundFromSelection: _.debounce(function(){
         // Check that there is enough selected nodes
-        if (GLPIImpact.eventData.boxSelected.length < 2) {
-            alert(__("You need to select at least 2 assets to make a group"));
+        if (GLPIImpact.eventData.boxSelected.length < 1) {
+            alert(__("You need to select at least 1 asset to make a group"));
         } else {
             // Create the compound
             var newCompound = GLPIImpact.cy.add({


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

It will be interesting to use only on object to create a compound like that for example : 

![image](https://github.com/glpi-project/glpi/assets/13178158/43bf3c90-4c91-478c-a68b-6fdd42eb60a8)

