### PR TITLE
fix php83/unifiedarchive

### DIFF
--- a/tests/InventoryTestCase.php
+++ b/tests/InventoryTestCase.php
@@ -35,7 +35,7 @@
 
 class InventoryTestCase extends \DbTestCase
 {
-    protected const INV_FIXTURES = GLPI_ROOT . '/vendor/glpi-project/inventory_format/examples/';
+    protected const INV_FIXTURES = GLPI_ROOT . 'vendor/glpi-project/inventory_format/examples/';
 
     /**
      * Path to use to test inventory archive manipulations.

--- a/tests/functional/Glpi/Inventory/Inventory.php
+++ b/tests/functional/Glpi/Inventory/Inventory.php
@@ -4584,12 +4584,12 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         $nbnetequps = countElementsInTable(\NetworkEquipment::getTable());
 
         $json_paths = [
-            self::INV_FIXTURES . 'computer_1.json',
-            self::INV_FIXTURES . 'networkequipment_1.json',
-            self::INV_FIXTURES . 'printer_1.json',
+            realpath(self::INV_FIXTURES . 'computer_1.json'),
+            realpath(self::INV_FIXTURES . 'networkequipment_1.json'),
+            realpath(self::INV_FIXTURES . 'printer_1.json'),
         ];
 
-        UnifiedArchive::archiveFiles($json_paths, self::INVENTORY_ARCHIVE_PATH);
+        UnifiedArchive::create($json_paths, self::INVENTORY_ARCHIVE_PATH);
 
         $conf = new \Glpi\Inventory\Conf();
         $result = $conf->importFiles(['to_inventory.zip' => self::INVENTORY_ARCHIVE_PATH]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

`UnifiedArchive::archiveFiles()` is deprecated.