### PR TITLE
Fix cluster items count

### DIFF
--- a/src/Item_Cluster.php
+++ b/src/Item_Cluster.php
@@ -55,7 +55,7 @@ class Item_Cluster extends CommonDBRelation
         if ($_SESSION['glpishow_count_on_tabs']) {
             $nb = self::countForMainItem($item);
         }
-        return self::createTabEntry(_n('Item', 'Items', $nb));
+        return self::createTabEntry(_n('Item', 'Items', $nb), $nb);
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33477

Number of items in cluster not displayed.

**Before**
![image](https://github.com/glpi-project/glpi/assets/107540223/07094db2-0ab1-4d92-be8c-820897641648)

**After**
![image](https://github.com/glpi-project/glpi/assets/107540223/0dfd7a40-e101-402e-a61b-b6bf594c55be)
