### PR TITLE
Fix CronTaskLog access in legacy API

### DIFF
--- a/src/CronTaskLog.php
+++ b/src/CronTaskLog.php
@@ -44,6 +44,8 @@ class CronTaskLog extends CommonDBTM
     const STATE_STOP  = 2;
     const STATE_ERROR = 3;
 
+    public static $rightname        = 'config';
+
 
     /**
      * Clean old event for a task


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Missing right name was making the read permission check in the legacy API fail. I made it use the same right name as CronTask.