### PR TITLE
Allow content to be inserted after inputs labels

### DIFF
--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -815,7 +815,6 @@
       'add_field_attribs': {},
       'center': false,
       'label_align': 'end',
-      'insert_content_after_label': '',
    }|merge(options) %}
 
    {% if options.icon_label %}
@@ -864,11 +863,7 @@
 
    <div class="form-field row align-items-center {{ options.field_class }} {{ options.add_field_class }} {{ options.mb }}" {{ extra_attribs|raw }}>
       {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
-      {# options.label_class contains the expected col size and must be applied to the wrapper div and not the label itself here #}
-      <div class="d-flex align-items-center {{ options.label_class }}">
-         {{ _inputs.label(label, id, options, 'col-form-label ' ~ options.add_label_class) }}
-         {{ options.insert_content_after_label|raw }}
-      </div>
+      {{ _inputs.label(label, id, options, 'col-form-label ' ~ options.label_class ~ ' ' ~ options.add_label_class) }}
       {% if options.center %}
          {% set flex_class = "d-flex align-items-center" %}
       {% endif %}

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -864,8 +864,9 @@
 
    <div class="form-field row align-items-center {{ options.field_class }} {{ options.add_field_class }} {{ options.mb }}" {{ extra_attribs|raw }}>
       {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
-      <div class="d-flex align-items-center">
-         {{ _inputs.label(label, id, options, 'col-form-label ' ~ options.label_class ~ ' ' ~ options.add_label_class) }}
+      {# options.label_class contains the expected col size and must be applied to the wrapper div and not the label itself here #}
+      <div class="d-flex align-items-center {{ options.label_class }}">
+         {{ _inputs.label(label, id, options, 'col-form-label ' ~ options.add_label_class) }}
          {{ options.insert_content_after_label|raw }}
       </div>
       {% if options.center %}

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -815,6 +815,7 @@
       'add_field_attribs': {},
       'center': false,
       'label_align': 'end',
+      'insert_content_after_label': '',
    }|merge(options) %}
 
    {% if options.icon_label %}
@@ -863,7 +864,10 @@
 
    <div class="form-field row align-items-center {{ options.field_class }} {{ options.add_field_class }} {{ options.mb }}" {{ extra_attribs|raw }}>
       {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
-      {{ _inputs.label(label, id, options, 'col-form-label ' ~ options.label_class ~ ' ' ~ options.add_label_class) }}
+      <div class="d-flex align-items-center">
+         {{ _inputs.label(label, id, options, 'col-form-label ' ~ options.label_class ~ ' ' ~ options.add_label_class) }}
+         {{ options.insert_content_after_label|raw }}
+      </div>
       {% if options.center %}
          {% set flex_class = "d-flex align-items-center" %}
       {% endif %}
@@ -882,6 +886,7 @@
       'field_class': 'col-12 col-sm-6',
       'add_field_class': '',
       'add_field_attribs': {},
+      'insert_content_after_label': '',
    }|merge(options) %}
 
    {% if options.full_width %}
@@ -898,7 +903,10 @@
 
    <div class="form-field {{ options.field_class }} {{ options.add_field_class }} {{ options.mb }}" {{ extra_attribs|raw }}>
       {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
-      {{ _inputs.label(label, id, options, 'col-form-label ' ~ options.label_class) }}
+      <div class="d-flex align-items-center">
+         {{ _inputs.label(label, id, options, 'col-form-label ' ~ options.label_class) }}
+         {{ options.insert_content_after_label|raw }}
+      </div>
       <div class="{{ options.input_class }} field-container">
          {{ field|raw }}
       </div>

--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -31,8 +31,6 @@
  # ---------------------------------------------------------------------
  #}
 
-{% set rand = random() %}
-
 {% set load_actors = params['load_actors'] ?? true %}
 {% set actors = load_actors ? item.getActorsForType(actortypeint, params) : [] %}
 

--- a/templates/components/itilobject/actors/main.html.twig
+++ b/templates/components/itilobject/actors/main.html.twig
@@ -56,8 +56,10 @@
 {# TODO check allow_email params #}
 
 {% if 'requester' in display_actortypes and (not itiltemplate.isHiddenField('_users_id_requester') or not itiltemplate.isHiddenField('_groups_id_requester')) %}
+   {% set rand = random() %}
    {% set requester_field %}
       {{ include('components/itilobject/actors/field.html.twig', {
+         'rand': rand,
          'item': item,
          'actortypeint': constant('CommonITILActor::REQUESTER'),
          'actortype': 'requester',
@@ -77,7 +79,8 @@
          requester_field,
          _n('Requester', 'Requesters', 1),
          actor_options|merge({
-            required: itiltemplate.isMandatoryField('_users_id_requester') or itiltemplate.isMandatoryField('_groups_id_requester')
+            required: itiltemplate.isMandatoryField('_users_id_requester') or itiltemplate.isMandatoryField('_groups_id_requester'),
+            id: "actor_" ~ rand,
          })
       ) }}
    {% else %}
@@ -86,8 +89,10 @@
 {% endif %}
 
 {% if 'observer' in display_actortypes and (not itiltemplate.isHiddenField('_users_id_observer') or not itiltemplate.isHiddenField('_groups_id_observer')) %}
+   {% set rand = random() %}
    {% set observer_field %}
       {{ include('components/itilobject/actors/field.html.twig', {
+         'rand': rand,
          'item': item,
          'actortypeint': constant('CommonITILActor::OBSERVER'),
          'actortype': 'observer',
@@ -107,7 +112,8 @@
          observer_field,
          _n('Observer', 'Observers', 1),
          actor_options|merge({
-            required: itiltemplate.isMandatoryField('_users_id_observer') or itiltemplate.isMandatoryField('_groups_id_observer')
+            required: itiltemplate.isMandatoryField('_users_id_observer') or itiltemplate.isMandatoryField('_groups_id_observer'),
+            id: "actor_" ~ rand,
          })
       ) }}
    {% else %}
@@ -117,7 +123,9 @@
 
 {% if 'assign' in display_actortypes and (not itiltemplate.isHiddenField('_users_id_assign') or not itiltemplate.isHiddenField('_groups_id_assign') or not itiltemplate.isHiddenField('_supplier_id_assign')) %}
    {% set assign_field %}
+      {% set rand = random() %}
       {{ include('components/itilobject/actors/field.html.twig', {
+         'rand': rand,
          'item': item,
          'actortypeint': constant('CommonITILActor::ASSIGN'),
          'actortype': 'assign',
@@ -137,7 +145,8 @@
          assign_field,
          __('Assigned to'),
          actor_options|merge({
-            required: itiltemplate.isMandatoryField('_users_id_assign') or itiltemplate.isMandatoryField('_groups_id_assign') or itiltemplate.isMandatoryField('_supplier_id_assign')
+            required: itiltemplate.isMandatoryField('_users_id_assign') or itiltemplate.isMandatoryField('_groups_id_assign') or itiltemplate.isMandatoryField('_supplier_id_assign'),
+            id: "actor_" ~ rand,
          })
       ) }}
    {% else %}

--- a/tests/cypress/e2e/selfservice_tickets.cy.js
+++ b/tests/cypress/e2e/selfservice_tickets.cy.js
@@ -131,15 +131,9 @@ describe('Self-Service Tickets', () => {
         });
 
         cy.get('#heading-actor').closest('.accordion-item').within(() => {
-            cy.get('label').contains('Requester').next().within(() => {
-                cy.get('select').should('be.disabled');
-            });
-            cy.get('label').contains('Observer').next().within(() => {
-                cy.get('select').should('be.disabled');
-            });
-            cy.get('label').contains('Assigned to').next().within(() => {
-                cy.get('select').should('be.disabled');
-            });
+            cy.findByLabelText("Requester").should('be.disabled');
+            cy.findByLabelText("Observer").should('be.disabled');
+            cy.findByLabelText("Assigned to").should('be.disabled');
         });
 
         // Statistics


### PR DESCRIPTION
Allow arbitrary HTML content to be inserted after inputs labels in our forms (only for the "vertical field" layout).

For example:

```twig
{% set content %}
    <div class='ms-auto'>test</div>
{% endset %}

{{ fields.textField(
    input_name,
    value,
    label,
    {
        insert_content_after_label: content
    },
) }}
```

![image](https://github.com/glpi-project/glpi/assets/42734840/9979ca0f-3446-4804-a5ff-bcb5aea5024a)

For extra context, this is needed for a new helpdesk forms related feature that I'm working on this week.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
