### PR TITLE
Add missing 'getIcon()' function to the AllAssets class

### DIFF
--- a/src/AllAssets.php
+++ b/src/AllAssets.php
@@ -47,6 +47,6 @@ class AllAssets extends CommonGLPI
 
     public static function getIcon()
     {
-        return 'fas fa-cubes';
+        return 'ti ti-cube';
     }
 }

--- a/src/AllAssets.php
+++ b/src/AllAssets.php
@@ -44,4 +44,9 @@ class AllAssets extends CommonGLPI
     {
         return _n('Asset', 'Assets', $nb);
     }
+
+    public static function getIcon()
+    {
+        return 'fas fa-cubes';
+    }
 }

--- a/src/AllAssets.php
+++ b/src/AllAssets.php
@@ -47,6 +47,6 @@ class AllAssets extends CommonGLPI
 
     public static function getIcon()
     {
-        return 'ti ti-cube';
+        return 'ti ti-packages';
     }
 }

--- a/src/Html.php
+++ b/src/Html.php
@@ -1522,7 +1522,7 @@ HTML;
                     $menu['assets']['content']['allassets']['title']            = __('Global');
                     $menu['assets']['content']['allassets']['shortcut']         = '';
                     $menu['assets']['content']['allassets']['page']             = '/front/allassets.php';
-                    $menu['assets']['content']['allassets']['icon']             = 'fas fa-list';
+                    $menu['assets']['content']['allassets']['icon']             = AllAssets::getIcon();
                     $menu['assets']['content']['allassets']['links']['search']  = '/front/allassets.php';
                     break;
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33468

The Advenced dashboard plugin uses a `getIcon()` function on certain classes for saved searches, for example. However, for a saved search that concerns all assets, we need the `getIcon()` function of the AllAssets class, but it doesn't exist.
