### PR TITLE
Fix Default Tech With Task Template

### DIFF
--- a/ajax/task.php
+++ b/ajax/task.php
@@ -110,6 +110,10 @@ if ($template->fields['taskcategories_id']) {
     }
 }
 
+if ($template->fields['groups_id_tech'] == 0) {
+    unset($template->fields['groups_id_tech']);
+}
+
 if ($template->fields['users_id_tech'] == 0) {
     unset($template->fields['users_id_tech']);
 }

--- a/ajax/task.php
+++ b/ajax/task.php
@@ -111,7 +111,7 @@ if ($template->fields['taskcategories_id']) {
 }
 
 if ($template->fields['users_id_tech'] == 0) {
-    $template->fields['users_id_tech'] = Session::getLoginUserID();
+    unset($template->fields['users_id_tech']);
 }
 
 // Return json response with the template fields

--- a/ajax/task.php
+++ b/ajax/task.php
@@ -110,6 +110,9 @@ if ($template->fields['taskcategories_id']) {
     }
 }
 
+if ($template->fields['users_id_tech'] == 0) {
+    $template->fields['users_id_tech'] = Session::getLoginUserID();
+}
 
 // Return json response with the template fields
 echo json_encode($template->fields);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #0

When use task template without define a users_id_tech, the loaded template blank the users_id_tech field.