### PR TITLE
Fix cluster item tab in Computer & NetworkEquipment page

### DIFF
--- a/src/Cluster.php
+++ b/src/Cluster.php
@@ -167,6 +167,34 @@ class Cluster extends CommonDBTM
         );
     }
 
+    /**
+     * Get the cluster of an item
+     *
+     * @param CommonDBTM $item
+     *
+     * @return Cluster|null
+     */
+    public static function getClusterByItem($item)
+    {
+        $itemCluster = new Item_Cluster();
+        $itemtype = $item->getType();
+        if (
+            $itemCluster->getFromDBByCrit([
+                'itemtype' => $item->getType(),
+                'items_id' => $item->getID()
+            ])
+        ) {
+            if ($itemCluster->fields['clusters_id'] != 0) {
+                $cluster = new self();
+                $cluster->getFromDB($itemCluster->fields['clusters_id']);
+
+                return $cluster;
+            }
+        }
+
+        return null;
+    }
+
 
     public static function getIcon()
     {

--- a/src/Cluster.php
+++ b/src/Cluster.php
@@ -174,7 +174,7 @@ class Cluster extends CommonDBTM
      *
      * @return Cluster|null
      */
-    public static function getClusterByItem($item)
+    public static function getClusterByItem(CommonDBTM $item): ?Cluster
     {
         $itemCluster = new Item_Cluster();
         if (

--- a/src/Cluster.php
+++ b/src/Cluster.php
@@ -177,7 +177,6 @@ class Cluster extends CommonDBTM
     public static function getClusterByItem($item)
     {
         $itemCluster = new Item_Cluster();
-        $itemtype = $item->getType();
         if (
             $itemCluster->getFromDBByCrit([
                 'itemtype' => $item->getType(),

--- a/src/Cluster.php
+++ b/src/Cluster.php
@@ -176,19 +176,14 @@ class Cluster extends CommonDBTM
      */
     public static function getClusterByItem(CommonDBTM $item): ?Cluster
     {
-        $itemCluster = new Item_Cluster();
+        $cluster = new self();
+        $item_cluster = new Item_Cluster();
         if (
-            $itemCluster->getFromDBByCrit([
-                'itemtype' => $item->getType(),
-                'items_id' => $item->getID()
-            ])
+            $item_cluster->getFromDBByCrit(['itemtype' => $item->getType(), 'items_id' => $item->getID()])
+            && $item_cluster->fields['clusters_id'] != 0
+            && $cluster->getFromDB($item_cluster->fields['clusters_id'])
         ) {
-            if ($itemCluster->fields['clusters_id'] != 0) {
-                $cluster = new self();
-                $cluster->getFromDB($itemCluster->fields['clusters_id']);
-
-                return $cluster;
-            }
+            return $cluster;
         }
 
         return null;

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -480,7 +480,8 @@ class CommonDBTM extends CommonGLPI
             'item'   => $this,
             'params' => $options,
             'no_header' => !$new_item && !$in_modal,
-        ] + ($additional_var ?? []));
+            'cluster' => $cluster,
+        ]);
         return true;
     }
 

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -467,14 +467,22 @@ class CommonDBTM extends CommonGLPI
      */
     public function showForm($ID, array $options = [])
     {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
         $this->initForm($ID, $options);
         $new_item = static::isNewID($ID);
         $in_modal = (bool) ($_GET['_in_modal'] ?? false);
+        if (!$new_item && (in_array($this->getType(), $CFG_GLPI['cluster_types']))) {
+            $additional_var = [
+                'cluster' => Cluster::getClusterByItem($this)
+            ];
+        }
         TemplateRenderer::getInstance()->display('generic_show_form.html.twig', [
             'item'   => $this,
             'params' => $options,
-            'no_header' => !$new_item && !$in_modal
-        ]);
+            'no_header' => !$new_item && !$in_modal,
+        ] + ($additional_var ?? []));
         return true;
     }
 

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -475,7 +475,7 @@ class CommonDBTM extends CommonGLPI
         $in_modal = (bool) ($_GET['_in_modal'] ?? false);
         $cluster = !$new_item && in_array(static::class, $CFG_GLPI['cluster_types'], true)
             ? Cluster::getClusterByItem($this)
-            : null
+            : null;
         TemplateRenderer::getInstance()->display('generic_show_form.html.twig', [
             'item'   => $this,
             'params' => $options,

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -473,11 +473,9 @@ class CommonDBTM extends CommonGLPI
         $this->initForm($ID, $options);
         $new_item = static::isNewID($ID);
         $in_modal = (bool) ($_GET['_in_modal'] ?? false);
-        if (!$new_item && (in_array($this->getType(), $CFG_GLPI['cluster_types']))) {
-            $additional_var = [
-                'cluster' => Cluster::getClusterByItem($this)
-            ];
-        }
+        $cluster = !$new_item && in_array(static::class, $CFG_GLPI['cluster_types'], true)
+            ? Cluster::getClusterByItem($this)
+            : null
         TemplateRenderer::getInstance()->display('generic_show_form.html.twig', [
             'item'   => $this,
             'params' => $options,

--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -143,7 +143,7 @@
                            ])|raw }}
                         {% endif %}
                      {% endset %}
-                    {% if dc_breadcrumbs|trim|length > 0 %}
+                     {% if dc_breadcrumbs|trim|length > 0 %}
                         {{ fields.htmlField(
                         '',
                         dc_breadcrumbs,

--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -152,19 +152,14 @@
                         {% set conditions_met = conditions_met + 1 %}
                     {% endif %}
 
-                    {% set cluster = null %}
-                    {% if item_type == 'Computer' or item_type == 'NetworkEquipment' %}
-                        {% set cluster = call('Cluster::getClusterByItem', [item]) %}
-                        {% if cluster is not null %}
-                            {{ fields.htmlField(
-                                '',
-                                cluster.getLink(),
-                                _n('Cluster', 'Clusters', 1),
-                            ) }}
-                            {% set conditions_met = conditions_met + 1 %}
-                        {% endif %}
+                    {% if cluster is not null %}
+                        {{ fields.htmlField(
+                            '',
+                            cluster.getLink(),
+                            _n('Cluster', 'Clusters', 1),
+                        ) }}
+                        {% set conditions_met = conditions_met + 1 %}
                     {% endif %}
-
                     {% if conditions_met == 1 %}
                         {{ fields.nullField() }}
                     {% endif %}

--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -134,6 +134,8 @@
                         ) }}
                      {% endif %}
 
+
+                     {% set conditions_met = 0 %}
                      {% set dc_breadcrumbs %}
                         {% if item is usingtrait('Glpi\\Features\\DCBreadcrumb') %}
                            {{ call(item.getType() ~ '::renderDcBreadcrumb', [
@@ -141,14 +143,31 @@
                            ])|raw }}
                         {% endif %}
                      {% endset %}
-                     {% if dc_breadcrumbs|trim|length > 0 %}
+                    {% if dc_breadcrumbs|trim|length > 0 %}
                         {{ fields.htmlField(
-                           '',
-                           dc_breadcrumbs,
-                           __('Data center position'),
+                        '',
+                        dc_breadcrumbs,
+                        __('Data center position'),
                         ) }}
-                        {{ fields.nullField() }} {# set an empty space in front of dc breadcrumb #}
-                     {% endif %}
+                        {% set conditions_met = conditions_met + 1 %}
+                    {% endif %}
+
+                    {% set cluster = null %}
+                    {% if item_type == 'Computer' or item_type == 'NetworkEquipment' %}
+                        {% set cluster = call('Cluster::getClusterByItem', [item]) %}
+                        {% if cluster is not null %}
+                            {{ fields.htmlField(
+                                '',
+                                cluster.getLink(),
+                                __('Cluster'),
+                            ) }}
+                            {% set conditions_met = conditions_met + 1 %}
+                        {% endif %}
+                    {% endif %}
+
+                    {% if conditions_met == 1 %}
+                        {{ fields.nullField() }}
+                    {% endif %}
 
                      {% if item.isField('locations_id') %}
                         {{ fields.dropdownField(

--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -159,7 +159,7 @@
                             {{ fields.htmlField(
                                 '',
                                 cluster.getLink(),
-                                __('Cluster'),
+                                _n('Cluster', 'Clusters', 1),
                             ) }}
                             {% set conditions_met = conditions_met + 1 %}
                         {% endif %}

--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -145,9 +145,9 @@
                      {% endset %}
                      {% if dc_breadcrumbs|trim|length > 0 %}
                         {{ fields.htmlField(
-                        '',
-                        dc_breadcrumbs,
-                        __('Data center position'),
+                           '',
+                           dc_breadcrumbs,
+                           __('Data center position'),
                         ) }}
                         {% set conditions_met = conditions_met + 1 %}
                     {% endif %}

--- a/tests/functional/Cluster.php
+++ b/tests/functional/Cluster.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use DbTestCase;
+
+/* Test for inc/change.class.php */
+
+class Cluster extends DbTestCase
+{
+    public function getSpecificValueToGetClusterByItem()
+    {
+        $computer = new \Computer();
+        $computer->add([
+            'name' => 'getClusterByItem',
+            'entities_id' => '0',
+        ]);
+
+        $cluster = new \Cluster();
+        $cluster_id = $cluster->add([
+            'name' => 'getClusterByItem',
+            'entities_id' => '0',
+        ]);
+
+        $network_equipment = new \NetworkEquipment();
+        $network_equipment->add([
+            'name' => 'getClusterByItem',
+            'entities_id' => '0',
+        ]);
+        return [
+            [
+                'values' => [
+                    'item' => $computer,
+                    'cluster' => $cluster,
+                ],
+                'expected' => $cluster_id,
+            ],
+            [
+                'values' => [
+                    'item' => $network_equipment,
+                    'cluster' => $cluster,
+                ],
+                'expected' => $cluster_id,
+            ],
+
+        ];
+    }
+
+    /**
+     * @dataProvider getSpecificValueToGetClusterByItem
+     */
+    public function testgetClusterByItem($values, $expected)
+    {
+
+        $item_cluster = new \Item_Cluster();
+        $item_cluster_id = $item_cluster->add([
+            'items_id' => $values['item']->getID(),
+            'itemtype' => $values['item']->getType(),
+            'clusters_id' => $values['cluster']->getID(),
+        ]);
+
+        $this->integer($item_cluster_id)->isGreaterThan(0);
+
+        $cluster = new \Cluster();
+        $result = $cluster->getClusterByItem($values['item']);
+        $this->integer($result->getID())->isEqualTo($expected);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33477

In Computer and NetworkDevice, we can't see that it's part of a cluster when registering it as a tab (like all the other elements in "Management" such as DB instances, Appliances etc.).

**Before**
![image](https://github.com/glpi-project/glpi/assets/107540223/e39c339a-d3b2-4c22-80c9-4b190f4aca34)

**After**
![image](https://github.com/glpi-project/glpi/assets/107540223/c2586463-fb4c-4d9f-95cd-33a63760fdd4)


