### PR TITLE
Add error status & debug for unknown column with searchText param

### DIFF
--- a/apirest.md
+++ b/apirest.md
@@ -2,35 +2,70 @@
 
 ## Summary
 
-* [Glossary](#glossary)
-* [Important](#important)
-* [Init session](#init-session)
-* [Kill session](#kill-session)
-* [Lost password](#lost-password)
-* [Get my profiles](#get-my-profiles)
-* [Get active profile](#get-active-profile)
-* [Change active profile](#change-active-profile)
-* [Get my entities](#get-my-entities)
-* [Get active entities](#get-active-entities)
-* [Change active entities](#change-active-entities)
-* [Get full session](#get-full-session)
-* [Get GLPI config](#get-glpi-config)
-* [Get an item](#get-an-item)
-* [Get all items](#get-all-items)
-* [Get sub items](#get-sub-items)
-* [Get multiple items](#get-multiple-items)
-* [List searchOptions](#list-searchoptions)
-* [Search items](#search-items)
-* [Add item(s)](#add-items)
-* [Update item(s)](#update-items)
-* [Delete item(s)](#delete-items)
-* [Get available massive actions for an itemtype](#get-available-massive-actions-for-an-itemtype)
-* [Get available massive actions for an item](#get-available-massive-actions-for-an-item)
-* [Get massive action parameters](#get-massive-action-parameters)
-* [Apply massive action](#apply-massive-action)
-* [Special cases](#special-cases)
-* [Errors](#errors)
-* [Servers configuration](#servers-configuration)
+- [GLPI REST API:  Documentation](#glpi-rest-api--documentation)
+  - [Summary](#summary)
+  - [Glossary](#glossary)
+  - [Important](#important)
+  - [Init session](#init-session)
+  - [Kill session](#kill-session)
+  - [Lost password](#lost-password)
+  - [Get my profiles](#get-my-profiles)
+  - [Get active profile](#get-active-profile)
+  - [Change active profile](#change-active-profile)
+  - [Get my entities](#get-my-entities)
+  - [Get active entities](#get-active-entities)
+  - [Change active entities](#change-active-entities)
+  - [Get full session](#get-full-session)
+  - [Get GLPI config](#get-glpi-config)
+  - [Get an item](#get-an-item)
+  - [Get all items](#get-all-items)
+  - [Get sub items](#get-sub-items)
+  - [Get multiple items](#get-multiple-items)
+  - [List searchOptions](#list-searchoptions)
+  - [Search items](#search-items)
+  - [Add item(s)](#add-items)
+  - [Update item(s)](#update-items)
+  - [Delete item(s)](#delete-items)
+  - [Get available massive actions for an itemtype](#get-available-massive-actions-for-an-itemtype)
+  - [Get available massive actions for an item](#get-available-massive-actions-for-an-item)
+  - [Get massive action parameters](#get-massive-action-parameters)
+  - [Apply massive action](#apply-massive-action)
+  - [Special cases](#special-cases)
+    - [Upload a document file](#upload-a-document-file)
+    - [Download a document file](#download-a-document-file)
+    - [Get a user's profile picture](#get-a-users-profile-picture)
+    - [Sanitized content](#sanitized-content)
+  - [Errors](#errors)
+    - [ERROR\_ITEM\_NOT\_FOUND](#error_item_not_found)
+    - [ERROR\_BAD\_ARRAY](#error_bad_array)
+    - [ERROR\_METHOD\_NOT\_ALLOWED](#error_method_not_allowed)
+    - [ERROR\_RIGHT\_MISSING](#error_right_missing)
+    - [ERROR\_SESSION\_TOKEN\_INVALID](#error_session_token_invalid)
+    - [ERROR\_SESSION\_TOKEN\_MISSING](#error_session_token_missing)
+    - [ERROR\_APP\_TOKEN\_PARAMETERS\_MISSING](#error_app_token_parameters_missing)
+    - [ERROR\_WRONG\_APP\_TOKEN\_PARAMETER](#error_wrong_app_token_parameter)
+    - [ERROR\_NOT\_DELETED](#error_not_deleted)
+    - [ERROR\_NOT\_ALLOWED\_IP](#error_not_allowed_ip)
+    - [ERROR\_LOGIN\_PARAMETERS\_MISSING](#error_login_parameters_missing)
+    - [ERROR\_LOGIN\_WITH\_CREDENTIALS\_DISABLED](#error_login_with_credentials_disabled)
+    - [ERROR\_GLPI\_LOGIN\_USER\_TOKEN](#error_glpi_login_user_token)
+    - [ERROR\_GLPI\_LOGIN](#error_glpi_login)
+    - [ERROR\_ITEMTYPE\_NOT\_FOUND\_NOR\_COMMONDBTM](#error_itemtype_not_found_nor_commondbtm)
+    - [ERROR\_SQL](#error_sql)
+    - [ERROR\_RANGE\_EXCEED\_TOTAL](#error_range_exceed_total)
+    - [ERROR\_GLPI\_ADD](#error_glpi_add)
+    - [ERROR\_GLPI\_PARTIAL\_ADD](#error_glpi_partial_add)
+    - [ERROR\_GLPI\_UPDATE](#error_glpi_update)
+    - [ERROR\_GLPI\_PARTIAL\_UPDATE](#error_glpi_partial_update)
+    - [ERROR\_GLPI\_DELETE](#error_glpi_delete)
+    - [ERROR\_GLPI\_PARTIAL\_DELETE](#error_glpi_partial_delete)
+    - [ERROR\_MASSIVEACTION\_KEY](#error_massiveaction_key)
+    - [ERROR\_MASSIVEACTION\_NO\_IDS](#error_massiveaction_no_ids)
+    - [ERROR\_FIELD\_NOT\_FOUND](#error_field_not_found)
+    - [ERROR\_UNKNOWN](#error_unknown)
+  - [Servers configuration](#servers-configuration)
+    - [Apache Httpd](#apache-httpd)
+    - [Nginx](#nginx)
 
 ## Glossary
 
@@ -1786,6 +1821,16 @@ Run 'getMassiveActions' endpoint to see available keys.
 
 No ids supplied when trying to run a massive action.
 
+### ERROR_FIELD_NOT_FOUND
+
+The field specified as the key for the searchText parameter does not exist.
+This field must refer to a column in the table corresponding to the element in the query.
+
+### ERROR_UNKNOWN
+
+An unknown error has occurred.
+This may be due to an unexpected condition encountered by the server or an issue that does not fit into any of the predefined error categories.
+Check the server logs for more details or contact the support team.
 
 ## Servers configuration
 

--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -1220,7 +1220,7 @@ abstract class API
             foreach ($search_values as $filter_field => $filter_value) {
                 if (!$DB->fieldExists($table, $filter_field)) {
                     $this->returnError(
-                        "Field $filter_field is not valid for " . $item->getType() . " item.",
+                        sprintf(__('Field %s is not valid for %s item.'), $filter_field, $item->getType())
                         400,
                         "ERROR_FIELD_NOT_FOUND"
                     );
@@ -1284,9 +1284,9 @@ abstract class API
                 $found[] = $data;
             }
         } else {
-            $message = "An error occurred during the items search.";
+            $message = __('An error occurred during the items search.');
             if ($_SESSION['glpi_use_mode'] === \Session::DEBUG_MODE) {
-                $message .= " For more information, check the GLPI logs.";
+                $message .= " " . __('For more information, check the GLPI logs.');
             }
             $this->returnError(
                 $message,

--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -1218,6 +1218,13 @@ abstract class API
 
             // make text search
             foreach ($search_values as $filter_field => $filter_value) {
+                if (!$DB->fieldExists($table, $filter_field)) {
+                    $this->returnError(
+                        "Field $filter_field is not valid for " . $item->getType() . " item.",
+                        400,
+                        "ERROR_FIELD_NOT_FOUND"
+                    );
+                }
                 if (!empty($filter_value)) {
                     $search_value = Search::makeTextSearch($DB->escape($filter_value));
                     $where .= " AND (" . $DB->quoteName("$table.$filter_field") . " $search_value)";
@@ -1277,9 +1284,13 @@ abstract class API
                 $found[] = $data;
             }
         } else {
+            $message = "An error occurred during the items search.";
+            if ($_SESSION['glpi_use_mode'] === \Session::DEBUG_MODE) {
+                $message .= " For more information, check the GLPI logs.";
+            }
             $this->returnError(
-                'An error occurred during the items search.',
-                400,
+                $message,
+                500,
                 "ERROR_UNKNOWN",
             );
         }

--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -1220,7 +1220,7 @@ abstract class API
             foreach ($search_values as $filter_field => $filter_value) {
                 if (!$DB->fieldExists($table, $filter_field)) {
                     $this->returnError(
-                        sprintf(__('Field %s is not valid for %s item.'), $filter_field, $item->getType())
+                        sprintf(__('Field %s is not valid for %s item.'), $filter_field, $item->getType()),
                         400,
                         "ERROR_FIELD_NOT_FOUND"
                     );

--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -1276,6 +1276,12 @@ abstract class API
 
                 $found[] = $data;
             }
+        } else {
+            $this->returnError(
+                'Error while querying database.' . $this->returnError($DB->error()),
+                400,
+                "ERROR_DATABASE_QUERY",
+            );
         }
 
        // get result full row counts

--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -1278,9 +1278,9 @@ abstract class API
             }
         } else {
             $this->returnError(
-                'Error while querying database.' . $this->returnError($DB->error()),
+                'An error occurred during the items search.',
                 400,
-                "ERROR_DATABASE_QUERY",
+                "ERROR_UNKNOWN",
             );
         }
 

--- a/tests/web/APIRest.php
+++ b/tests/web/APIRest.php
@@ -1488,4 +1488,30 @@ class APIRest extends APIBaseClass
         $this->boolean((bool)$computer->getFromDB($computers_id))->isTrue();
         $this->boolean((bool)$computer->getField('is_deleted'))->isTrue();
     }
+
+    public function testSearchTextResponseCode()
+    {
+        $data = $this->query(
+            'getItems',
+            ['itemtype' => Computer::class,
+                'headers'  => ['Session-Token' => $this->session_token],
+                'query'    => ['searchText' => ['test' => 'test']]
+            ],
+            400,
+            'ERROR_UNKNOWN'
+        );
+
+        $this->variable($data)->isNotFalse();
+
+        $data = $this->query(
+            'getItems',
+            ['itemtype' => Computer::class,
+                'headers'  => ['Session-Token' => $this->session_token],
+                'query'    => ['searchText' => ['name' => 'test']]
+            ],
+            200,
+        );
+
+        $this->variable($data)->isNotFalse();
+    }
 }

--- a/tests/web/APIRest.php
+++ b/tests/web/APIRest.php
@@ -1498,7 +1498,7 @@ class APIRest extends APIBaseClass
                 'query'    => ['searchText' => ['test' => 'test']]
             ],
             400,
-            'ERROR_UNKNOWN'
+            'ERROR_FIELD_NOT_FOUND'
         );
 
         $this->variable($data)->isNotFalse();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33486

# API

Using the searchText parameter with a non-existent key returns a status of 200 with an empty playload. This should return another status with details of the error.

## Before
Request :
![image](https://github.com/glpi-project/glpi/assets/102067890/0c87b851-b1ab-4f5e-b4a8-56adcc085cc8)

Response:
![image](https://github.com/glpi-project/glpi/assets/102067890/2a41698d-0233-49d7-8718-575f59d69a5d)

## After
![image](https://github.com/glpi-project/glpi/assets/102067890/f5090896-8ec9-46ea-ac9d-09cd2036c04e)

