### PR TITLE
Remove unused `$LANG` global variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,7 @@ The present file will list all changes made to the project; according to the
 #### Removed
 - `GLPI_USE_CSRF_CHECK`, `GLPI_USE_IDOR_CHECK`, `GLPI_CSRF_EXPIRES`, `GLPI_CSRF_MAX_TOKENS` and `GLPI_IDOR_EXPIRES` constants.
 - `$CFG_GLPI_PLUGINS` global variable.
+- `$LANG` global variable.
 - `$PLUGINS_EXCLUDED` global variable.
 - Usage of `csrf_compliant` plugins hook.
 - Usage of `migratetypes` plugin hooks.

--- a/inc/based_config.php
+++ b/inc/based_config.php
@@ -318,14 +318,9 @@ if (!isCommandLine()) {
 
 define('GLPI_I18N_DIR', GLPI_ROOT . "/locales");
 
+// For plugins
 /**
  * @var array $PLUGIN_HOOKS
- * @var array $LANG
  */
-global $PLUGIN_HOOKS,
-    $LANG
-;
-
-// For plugins
+global $PLUGIN_HOOKS;
 $PLUGIN_HOOKS     = [];
-$LANG             = [];

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -398,7 +398,6 @@ class Plugin extends CommonDBTM
          */
         global $CFG_GLPI, $TRANSLATE;
 
-       // For compatibility for plugins using $LANG
         $trytoload = 'en_GB';
         if (isset($_SESSION['glpilanguage'])) {
             $trytoload = $_SESSION["glpilanguage"];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This variable is not used by GLPI.

I did not find any usage in plugins that would be affected by this removal. Indeed, the following snippets will still work:
```php
// a simple declaration
global $LANG;
$LANG['pluginkey']['xxx'] = 'value';
```
```php
// will anyway trigger a warning if the corresponding entry is not defined
global $LANG
echo $LANG['pluginkey']['xxx'];
```
```php
// a safe usage
global $LANG;
if (isset($LANG['genericobject'][$class][0])) {
    return $LANG['genericobject'][$class][0];
}
```