### PR TITLE
Fix firewall service instanciation and fix hardcoded strategies

### DIFF
--- a/dependency_injection/legacyConfigProviders.php
+++ b/dependency_injection/legacyConfigProviders.php
@@ -38,7 +38,6 @@ use Glpi\Config\LegacyConfigProviderInterface;
 use Glpi\Config\LegacyConfigurators\BaseConfig;
 use Glpi\Config\LegacyConfigurators\CleanPHPSelfParam;
 use Glpi\Config\LegacyConfigurators\ConfigRest;
-use Glpi\Config\LegacyConfigurators\FirewallConfig;
 use Glpi\Config\LegacyConfigurators\InitializePlugins;
 use Glpi\Config\LegacyConfigurators\ProfilerStart;
 use Glpi\Config\LegacyConfigurators\SessionConfig;
@@ -70,7 +69,6 @@ return static function (ContainerConfigurator $container): void {
     $services->set(CleanPHPSelfParam::class)->tag($tagName, ['priority' => 150]);
     $services->set(SessionConfig::class)->tag($tagName, ['priority' => 130]);
     $services->set(InitializePlugins::class)->tag($tagName, ['priority' => 120]);
-    $services->set(FirewallConfig::class)->tag($tagName, ['priority' => 110]);
 
     // FIXME: This class MUST stay at the end until the entire config is revamped.
     $services->set(ConfigRest::class)->tag($tagName, ['priority' => 10]);

--- a/dependency_injection/services.php
+++ b/dependency_injection/services.php
@@ -36,6 +36,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Glpi\DependencyInjection\PublicService;
 use Glpi\Http\Firewall;
+use Glpi\Http\FirewallInterface;
 
 return static function (ContainerConfigurator $container): void {
     $projectDir = dirname(__DIR__);
@@ -60,7 +61,11 @@ return static function (ContainerConfigurator $container): void {
     $services->load('Glpi\Controller\\', $projectDir . '/src/Glpi/Controller');
     $services->load('Glpi\Http\\', $projectDir . '/src/Glpi/Http');
 
-    $services->set(Firewall::class)->synthetic();
+    $services->set(Firewall::class)
+        ->factory([Firewall::class, 'createDefault'])
+        ->tag('proxy', ['interface' => FirewallInterface::class])
+        ->lazy()
+    ;
 
     if ($container->env() === 'development') {
         $container->extension('web_profiler', [

--- a/src/Glpi/Http/FirewallInterface.php
+++ b/src/Glpi/Http/FirewallInterface.php
@@ -32,33 +32,16 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Config\LegacyConfigurators;
+namespace Glpi\Http;
 
-use Glpi\Config\ConfigProviderHasRequestTrait;
-use Glpi\Config\ConfigProviderWithRequestInterface;
-use Glpi\Config\LegacyConfigProviderInterface;
-use Glpi\Http\Firewall;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-
-final class FirewallConfig implements LegacyConfigProviderInterface, ConfigProviderWithRequestInterface
+interface FirewallInterface
 {
-    use ConfigProviderHasRequestTrait;
-
-    public function __construct(
-        #[Autowire('@service_container')]
-        private readonly ContainerInterface $container
-    ) {
-    }
-
-    public function execute(): void
-    {
-        /**
-         * @var array $CFG_GLPI
-         */
-        global $CFG_GLPI;
-
-        $firewall = new Firewall($CFG_GLPI['root_doc']);
-        $this->container->set(Firewall::class, $firewall);
-    }
+    /**
+     * Apply the firewall strategy for given path.
+     *
+     * @param string $path URL path
+     * @param string $strategy Strategy to apply, or null to fallback to default strategy
+     * @return void
+     */
+    public function applyStrategy(string $path, ?string $strategy): void;
 }

--- a/src/Glpi/Http/FirewallListener.php
+++ b/src/Glpi/Http/FirewallListener.php
@@ -42,7 +42,7 @@ final readonly class FirewallListener implements EventSubscriberInterface
 {
     public const STRATEGY_KEY = '_glpi_security_strategy';
 
-    public function __construct(private Firewall $firewall)
+    public function __construct(private FirewallInterface $firewall)
     {
     }
 

--- a/src/Glpi/Kernel/Kernel.php
+++ b/src/Glpi/Kernel/Kernel.php
@@ -133,7 +133,7 @@ final class Kernel extends BaseKernel
         $routes->import($this->getProjectDir() . '/src/Glpi/Controller', 'attribute');
 
         // Env-specific route files.
-        if (\is_file($path = $this->getProjectDir() . '/routes/'.$this->environment.'.php')) {
+        if (\is_file($path = $this->getProjectDir() . '/routes/' . $this->environment . '.php')) {
             (require $path)($routes->withPath($path), $this);
         }
     }

--- a/tests/functional/Glpi/Http/Firewall.php
+++ b/tests/functional/Glpi/Http/Firewall.php
@@ -118,6 +118,72 @@ class Firewall extends \GLPITestCase
                 ];
             }
         }
+
+        // Hardcoded strategies
+        foreach (['', '/glpi', '/path/to/app'] as $root_doc) {
+            // `/front/central.php` has a specific strategy only if some get parameters are defined
+            yield '/front/central.php without dashboard' => [
+                'root_doc'          => $root_doc,
+                'path'              => $root_doc . '/front/central.php',
+                'expected_strategy' => $default_for_core,
+            ];
+            $_GET['embed'] = '1';
+            $_GET['dashboard'] = 'central';
+            yield '/front/central.php with dashboard' => [
+                'root_doc'          => $root_doc,
+                'path'              => $root_doc . '/front/central.php',
+                'expected_strategy' => 'no_check',
+            ];
+            unset($_GET['embed'], $_GET['dashboard']);
+
+            // `/front/planning.php` has a specific strategy only if some get parameters are defined
+            yield '/front/planning.php without token' => [
+                'root_doc'          => $root_doc,
+                'path'              => $root_doc . '/front/planning.php',
+                'expected_strategy' => $default_for_core,
+            ];
+            $_GET['token'] = 'abc';
+            yield '/front/planning.php with token' => [
+                'root_doc'          => $root_doc,
+                'path'              => $root_doc . '/front/planning.php',
+                'expected_strategy' => 'no_check',
+            ];
+            unset($_GET['token']);
+
+            $legacy_faq_urls = ['/ajax/knowbase.php', '/front/helpdesk.faq.php'];
+            foreach ($legacy_faq_urls as $faq_url) {
+                yield $faq_url => [
+                    'root_doc'          => $root_doc,
+                    'path'              => $root_doc . $faq_url,
+                    'expected_strategy' => 'faq_access',
+                ];
+            }
+
+            $legacy_no_check_urls = [
+                '/ajax/common.tabs.php',
+                '/ajax/dashboard.php',
+                '/ajax/telemetry.php',
+                '/front/cron.php',
+                '/front/css.php',
+                '/front/document.send.php',
+                '/front/form/form_renderer.php',
+                '/front/helpdesk.php',
+                '/front/inventory.php',
+                '/front/locale.php',
+                '/front/login.php',
+                '/front/logout.php',
+                '/front/lostpassword.php',
+                '/front/tracking.injector.php',
+                '/front/updatepassword.php',
+            ];
+            foreach ($legacy_no_check_urls as $no_check_url) {
+                yield $no_check_url => [
+                    'root_doc'          => $root_doc,
+                    'path'              => $root_doc . $no_check_url,
+                    'expected_strategy' => 'no_check',
+                ];
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1) Fixes the following error that appears only when the Kernel is instanciated with the `debug:true` parameter:
```
The "Glpi\Http\Firewall" service is synthetic, it needs to be set at boot time before it can be used.
```

2) Fixes the hardcoded strategies for legacy URLs that were not correctly applied when GLPI is located behing an Apache alias (e.g. http://host/glpi/index.php). I added some tests for these.

For now, I propose to fallback to `$CFG_GLPI['root_doc']` at runtime when the `$âth_prefix` value is not passed in the construcor. Later, we will improve this part by getting this value directly from a dedicated `Config` service.