### PR TITLE
Ensure the coverage workflow uses the config from its own branch

### DIFF
--- a/.github/workflows/coverage-schedule.yml
+++ b/.github/workflows/coverage-schedule.yml
@@ -1,0 +1,10 @@
+name: "Code coverage schedule"
+
+on:
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+  run-coverage-workflow:
+    name: "Run coverage workflow"
+    uses: "glpi-project/glpi/.github/workflows/coverage.yml@main"

--- a/.github/workflows/coverage-schedule.yml
+++ b/.github/workflows/coverage-schedule.yml
@@ -8,3 +8,5 @@ jobs:
   run-coverage-workflow:
     name: "Run coverage workflow"
     uses: "glpi-project/glpi/.github/workflows/coverage.yml@main"
+    with:
+      branch: "main"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,8 +3,17 @@ name: "GLPI test code coverage"
 on:
   # Enable execution from the "Code coverage schedule" workflow
   workflow_call:
+    inputs:
+      branch:
+        required: true
+        type: string
   # Enable manual run
   workflow_dispatch:
+    inputs:
+      branch:
+        description: "Target branch"
+        required: true
+        type: string
 
 jobs:
   coverage:
@@ -28,6 +37,8 @@ jobs:
           echo "APP_CONTAINER_HOME=${{ runner.temp }}/app_home" >> $GITHUB_ENV
       - name: "Checkout"
         uses: "actions/checkout@v4"
+        with:
+          ref: ${{ inputs.branch }}
       - name: "Restore dependencies cache"
         uses: actions/cache@v4
         with:
@@ -67,3 +78,4 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: ./tests/coverage-functional/clover.xml,./tests/coverage-ldap/clover.xml,./tests/coverage-imap/clover.xml
+          override_branch: ${{ inputs.branch }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,27 +1,20 @@
 name: "GLPI test code coverage"
 
 on:
-  # Runs coverage suite when a pull request updates workflow file
-  pull_request:
-    paths:
-      - ".github/workflows/coverage.yml"
-  # Runs coverage suite every night
-  schedule:
-    - cron:  '0 0 * * *'
+  # Enable execution from the "Code coverage schedule" workflow
+  workflow_call:
   # Enable manual run
   workflow_dispatch:
 
 jobs:
   coverage:
-    # Do not run scheduled coverage on tier repositories
-    if: github.repository == 'glpi-project/glpi' || github.event_name != 'schedule'
     name: "Code coverage"
     runs-on: "ubuntu-latest"
     strategy:
       fail-fast: false
       matrix:
         include:
-          - {branch: "main", php-version: "8.2", db-image: "mariadb:11.0"}
+          - {php-version: "8.2", db-image: "mariadb:11.0"}
     env:
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml:.github/actions/docker-compose-services.yml"
       APPLICATION_ROOT: "${{ github.workspace }}"
@@ -35,8 +28,6 @@ jobs:
           echo "APP_CONTAINER_HOME=${{ runner.temp }}/app_home" >> $GITHUB_ENV
       - name: "Checkout"
         uses: "actions/checkout@v4"
-        with:
-          ref: ${{ matrix.branch }}
       - name: "Restore dependencies cache"
         uses: actions/cache@v4
         with:
@@ -76,4 +67,3 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: ./tests/coverage-functional/clover.xml,./tests/coverage-ldap/clover.xml,./tests/coverage-imap/clover.xml
-          override_branch: ${{ matrix.branch }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The code coverage workflow is scheduled from the default branch (10.0/bugfixes), but executed with the code from the `main` branch. It causes issues, as the workflow configuration can be incompatible with the target branch.
The current PR will fix this, as iit will permit to use the workflow configuration of the tested branch.