### PR TITLE
Fix default sort search option

### DIFF
--- a/src/Glpi/Search/Input/QueryBuilder.php
+++ b/src/Glpi/Search/Input/QueryBuilder.php
@@ -670,7 +670,8 @@ final class QueryBuilder implements SearchInputInterface
             // that no ORDER BY clause will be set
             $default_values["disable_order_by_fallback"] = true;
         } else {
-            $default_values["sort"]    = 1;
+            // Search engine will automatically determine the best sorting column (ID or the first displayed column)
+            $default_values["sort"]    = 0;
         }
         $default_values["is_deleted"]  = 0;
         $default_values["as_map"]      = 0;

--- a/tests/functional/Search.php
+++ b/tests/functional/Search.php
@@ -2497,7 +2497,7 @@ class Search extends DbTestCase
         $this->string($data['sql']['search'])
          ->contains("`glpi_computers`.`name` AS `ITEM_SearchTest\Computer_1`")
          ->contains("`glpi_computers`.`id` AS `ITEM_SearchTest\Computer_1_id`")
-         ->contains("ORDER BY `ITEM_SearchTest\Computer_1` ASC");
+         ->contains("ORDER BY `id`");
     }
 
     public function testGroupParamAfterMeta()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In #16607, the search engine was changed to default to using the `id` search option for the default sort rather than whichever option had ID 1 (usually is the ID, but it is the content for followups). There was one place still defaulting to 1 for the sort instead of 0, so it wasn't being automatically determined and the default sort for followups was still the content.