### PR TITLE
Add CLI commands for managing users

### DIFF
--- a/src/Glpi/Console/User/CreateCommand.php
+++ b/src/Glpi/Console/User/CreateCommand.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Console\User;
+
+use Glpi\Console\AbstractCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+class CreateCommand extends AbstractCommand
+{
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this->setName('user:create');
+        $this->setDescription(__('Create a new local GLPI user'));
+
+        $this->addArgument('username', InputArgument::REQUIRED, __('Login'));
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): ?int
+    {
+        $user_input = ['name' => $input->getArgument('username')];
+
+        $user = new \User();
+        if ($user->getFromDBbyName($user_input['name'])) {
+            $output->writeln(__('User already exists'));
+            return 1;
+        }
+
+        // Ask for password and then confirm it
+        $helper = $this->getHelper('question');
+        $question = new Question(__('Enter password'));
+        $question->setHidden(true);
+        $question->setHiddenFallback(false);
+        $password = $helper->ask($input, $output, $question);
+        $question = new Question(__('Confirm password'));
+        $question->setHidden(true);
+        $question->setHiddenFallback(false);
+        $password2 = $helper->ask($input, $output, $question);
+        if ($password !== $password2) {
+            $output->writeln(__('Passwords do not match'));
+            return 1;
+        }
+        $user_input['password'] = $password;
+        $user_input['password2'] = $password;
+
+        if ($user->add($user_input)) {
+            $output->writeln(__('User created'));
+            return 0;
+        } else {
+            $output->writeln(__('Failed to create user'));
+            return 1;
+        }
+    }
+}

--- a/src/Glpi/Console/User/DisableCommand.php
+++ b/src/Glpi/Console/User/DisableCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Console\User;
+
+use Glpi\Console\AbstractCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DisableCommand extends AbstractCommand
+{
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this->setName('user:disable');
+        $this->setDescription(__('Disable a GLPI user'));
+
+        $this->addArgument('username', InputArgument::REQUIRED, __('Login'));
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): ?int
+    {
+        $username = $input->getArgument('username');
+        $user = new \User();
+        if ($user->getFromDBbyName($username)) {
+            $user->update([
+                'id' => $user->getID(),
+                'is_active' => 0
+            ]);
+            $output->writeln(__('User disabled'));
+            return 0;
+        } else {
+            $output->writeln(__('User not found'));
+            return 1;
+        }
+    }
+}

--- a/src/Glpi/Console/User/EnableCommand.php
+++ b/src/Glpi/Console/User/EnableCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Console\User;
+
+use Glpi\Console\AbstractCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class EnableCommand extends AbstractCommand
+{
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this->setName('user:enable');
+        $this->setDescription(__('Enable a GLPI user'));
+
+        $this->addArgument('username', InputArgument::REQUIRED, __('Login'));
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): ?int
+    {
+        $username = $input->getArgument('username');
+        $user = new \User();
+        if ($user->getFromDBbyName($username)) {
+            $user->update([
+                'id' => $user->getID(),
+                'is_active' => 1
+            ]);
+            $output->writeln(__('User enabled'));
+            return 0;
+        } else {
+            $output->writeln(__('User not found'));
+            return 1;
+        }
+    }
+}

--- a/src/Glpi/Console/User/GrantCommand.php
+++ b/src/Glpi/Console/User/GrantCommand.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Console\User;
+
+use Glpi\Console\AbstractCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+class GrantCommand extends AbstractCommand
+{
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this->setName('user:grant');
+        $this->setDescription(__('Reset the password of a local GLPI user'));
+
+        $this->addArgument('username', InputArgument::REQUIRED, __('Login'));
+        $this->addOption('profile', 'p', InputOption::VALUE_REQUIRED, \Profile::getTypeName(1));
+        $this->addOption('entity', 'e', InputOption::VALUE_REQUIRED, \Entity::getTypeName(1), 0);
+        $this->addOption('recursive', 'r', InputOption::VALUE_NONE, __('Recursive'));
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): ?int
+    {
+        $username = $input->getArgument('username');
+        $profile = $input->getOption('profile');
+        $entity = $input->getOption('entity');
+        $recursive = $input->getOption('recursive');
+
+        if (!is_numeric($profile)) {
+            $output->writeln(__('Profile ID must be numeric'));
+            return 1;
+        }
+        if (!is_numeric($entity)) {
+            $output->writeln(__('Entity ID must be numeric'));
+            return 1;
+        }
+
+        $user = new \User();
+        if (!$user->getFromDBbyName($username)) {
+            $output->writeln(__('User not found'));
+            return 1;
+        }
+
+        $profile_user = new \Profile_User();
+        $profile_user_input = [
+            'users_id' => $user->getID(),
+            'profiles_id' => $profile,
+            'entities_id' => $entity,
+            'is_recursive' => $recursive
+        ];
+        if ($profile_user->add($profile_user_input)) {
+            $output->writeln(__('Profile granted'));
+            return 0;
+        } else {
+            $output->writeln(__('Failed to grant profile'));
+            return 1;
+        }
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output): void
+    {
+        // Ask for the profile if not provided and provide a list of available profiles
+        if (!$input->getOption('profile')) {
+            $input->setOption('profile', $this->askForProfile($input, $output));
+        }
+    }
+
+    private function askForProfile(InputInterface $input, OutputInterface $output): string
+    {
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        $profiles = [];
+        $it = $DB->request([
+            'SELECT' => ['id', 'name'],
+            'FROM' => \Profile::getTable()
+        ]);
+        foreach ($it as $row) {
+            $profiles[$row['id']] = $row['name'];
+        }
+
+        $helper = $this->getHelper('question');
+        $question = new Question(\Profile::getTypeName(1));
+        $question->setAutocompleterValues(array_keys($profiles));
+        return $helper->ask($input, $output, $question);
+    }
+}

--- a/src/Glpi/Console/User/ResetCommand.php
+++ b/src/Glpi/Console/User/ResetCommand.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Console\User;
+
+use Glpi\Console\AbstractCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+class ResetCommand extends AbstractCommand
+{
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this->setName('user:reset');
+        $this->setDescription(__('Reset the password of a local GLPI user'));
+
+        $this->addArgument('username', InputArgument::REQUIRED, __('Login'));
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): ?int
+    {
+        $user_input = ['name' => $input->getArgument('username')];
+
+        $user = new \User();
+        if (!$user->getFromDBbyName($user_input['name'])) {
+            $output->writeln(__('User not found'));
+            return 1;
+        }
+
+        if ($user->fields['authtype'] !== \Auth::DB_GLPI) {
+            $output->writeln(__("The authentication method configuration doesn't allow you to change your password."));
+            return 1;
+        }
+
+        $user_input['id'] = $user->getID();
+
+        // Ask for new password and then confirm it
+        $helper = $this->getHelper('question');
+        $question = new Question(__('Enter password'));
+        $question->setHidden(true);
+        $question->setHiddenFallback(false);
+        $password = $helper->ask($input, $output, $question);
+        $question = new Question(__('Confirm password'));
+        $question->setHidden(true);
+        $question->setHiddenFallback(false);
+        $password2 = $helper->ask($input, $output, $question);
+        if ($password !== $password2) {
+            $output->writeln(__('Passwords do not match'));
+            return 1;
+        }
+        $user_input['password'] = $password;
+        $user_input['password2'] = $password;
+
+
+        if ($user->update($user_input)) {
+            $output->writeln(__('Reset password successful.'));
+            return 0;
+        } else {
+            $output->writeln(__('Unable to reset password, please contact your administrator'));
+            return 1;
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Adds the following CLI commands:
- user:create - Create a new local GLPI user
- user:enable - Enable a user
- user:disable - Disable a user
- user:reset - Reset the password for a local GLPI user
- user:grant - Grant a profile assignment to a user

Should help prevent GLPI administrators from locking themselves out of the application and requiring a restore from a backup (assuming they had any).