### PR TITLE
Improve FilterableTrait performances

### DIFF
--- a/src/Glpi/Search/Output/AbstractSearchOutput.php
+++ b/src/Glpi/Search/Output/AbstractSearchOutput.php
@@ -166,4 +166,9 @@ abstract class AbstractSearchOutput
      * @return string HTML to display
      */
     abstract public static function showEndLine(bool $is_header_line): string;
+
+    public function canDisplayResultsContainerWithoutExecutingSearch(): bool
+    {
+        return false;
+    }
 }

--- a/src/Glpi/Search/Output/HTMLSearchOutput.php
+++ b/src/Glpi/Search/Output/HTMLSearchOutput.php
@@ -160,7 +160,8 @@ abstract class HTMLSearchOutput extends AbstractSearchOutput
                 }
 
                 // remove latitute and longitude if as map is enabled
-                if ($data['search']['as_map'] == 1) {
+                $as_map = $data['search']['as_map'] ?? 0;
+                if ($as_map == 1) {
                     unset($used_soptions_names[array_search(__('Latitude'), $used_soptions_names)]);
                     unset($used_soptions_names[array_search(__('Longitude'), $used_soptions_names)]);
                 }

--- a/src/Glpi/Search/Output/HTMLSearchOutput.php
+++ b/src/Glpi/Search/Output/HTMLSearchOutput.php
@@ -39,6 +39,7 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\Dashboard\Grid;
 use Glpi\Search\CriteriaFilter;
 use Glpi\Search\SearchOption;
+use Override;
 use SavedSearch;
 use Ticket;
 
@@ -48,6 +49,12 @@ use Ticket;
  */
 abstract class HTMLSearchOutput extends AbstractSearchOutput
 {
+    #[Override]
+    public function canDisplayResultsContainerWithoutExecutingSearch(): bool
+    {
+        return true;
+    }
+
     public static function showPreSearchDisplay(string $itemtype): void
     {
         if (
@@ -65,8 +72,13 @@ abstract class HTMLSearchOutput extends AbstractSearchOutput
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
+        $search_was_executed = $params['execute_search'] ?? true;
         $search_error = false;
-        if (!isset($data['data']) || !isset($data['data']['totalcount'])) {
+
+        if (
+            $search_was_executed
+            && (!isset($data['data']) || !isset($data['data']['totalcount']))
+        ) {
             $search_error = true;
         }
 
@@ -176,7 +188,8 @@ abstract class HTMLSearchOutput extends AbstractSearchOutput
 
         $rand = mt_rand();
         TemplateRenderer::getInstance()->display('components/search/display_data.html.twig', [
-            'search_error'         => $search_error,
+            'search_error'        => $search_error,
+            'search_was_executed' => $search_was_executed,
             'data'                => $data,
             'union_search_type'   => $CFG_GLPI["union_search_type"],
             'rand'                => $rand,

--- a/src/Glpi/Search/SearchEngine.php
+++ b/src/Glpi/Search/SearchEngine.php
@@ -627,8 +627,23 @@ final class SearchEngine
     {
         $data = self::prepareDataForSearch($itemtype, $params, $forced_display);
         $search_provider_class = self::getSearchProviderClass($params);
-        $search_provider_class::constructSQL($data);
-        $search_provider_class::constructData($data);
+
+        $output = self::getOutputForLegacyKey(
+            $params['display_type'] ?? \Search::HTML_OUTPUT,
+            $params
+        );
+        if (!$output->canDisplayResultsContainerWithoutExecutingSearch()) {
+            // Force search execution
+            $execute_search = true;
+        } else {
+            // Search execution is optional
+            $execute_search = $params['execute_search'] ?? true;
+        }
+
+        if ($execute_search) {
+            $search_provider_class::constructSQL($data);
+            $search_provider_class::constructData($data);
+        }
 
         return $data;
     }

--- a/templates/components/search/criteria_filter.html.twig
+++ b/templates/components/search/criteria_filter.html.twig
@@ -50,6 +50,7 @@
             {# Display search results, hidden until a search is executed #}
             <div id="criteria_filter_preview" class="d-none">
                 <h2>{{ __("Preview") }}</h2>
+                {% set params = params|merge({ 'execute_search': false }) %}
                 {% do call('Glpi\\Search\\SearchEngine::showOutput', [itemtype, params]) %}
             </div>
         </div>
@@ -60,7 +61,7 @@
               <p class="empty-title">{{ __("No filter found") }}</p>
               <p class="empty-subtitle text-muted">{{ __("There is no filter defined yet for this item.") }}</p>
               <div class="empty-action">
-                <a id="enable_filter_action" class="btn btn-primary"><i class="ti ti-plus me-2"></i>{{ __("Create a filter") }}</a>
+                <button id="enable_filter_action" class="btn btn-primary"><i class="ti ti-plus me-2"></i>{{ __("Create a filter") }}</button>
               </div>
             </div>
         </div>

--- a/templates/components/search/criteria_filter.html.twig
+++ b/templates/components/search/criteria_filter.html.twig
@@ -50,7 +50,7 @@
             {# Display search results, hidden until a search is executed #}
             <div id="criteria_filter_preview" class="d-none">
                 <h2>{{ __("Preview") }}</h2>
-                {% set params = params|merge({ 'execute_search': false }) %}
+                {% set params = params|merge({'execute_search': false}) %}
                 {% do call('Glpi\\Search\\SearchEngine::showOutput', [itemtype, params]) %}
             </div>
         </div>

--- a/templates/components/search/criteria_filter.html.twig
+++ b/templates/components/search/criteria_filter.html.twig
@@ -61,7 +61,7 @@
               <p class="empty-title">{{ __("No filter found") }}</p>
               <p class="empty-subtitle text-muted">{{ __("There is no filter defined yet for this item.") }}</p>
               <div class="empty-action">
-                <button id="enable_filter_action" class="btn btn-primary"><i class="ti ti-plus me-2"></i>{{ __("Create a filter") }}</button>
+                <button id="enable_filter_action" type="button" class="btn btn-primary"><i class="ti ti-plus me-2"></i>{{ __("Create a filter") }}</button>
               </div>
             </div>
         </div>

--- a/templates/components/search/criteria_filter_actions.html.twig
+++ b/templates/components/search/criteria_filter_actions.html.twig
@@ -110,8 +110,8 @@
                 $("#{{ delete_action_id }}").prop('disabled', false);
             });
 
-            // Trigger preview
-            form.find('button[name=search]').click();
+            // Hide preview since its content may not match the saved value
+            $("#criteria_filter_preview").addClass("d-none");
         });
 
         // Delete action

--- a/templates/components/search/table.html.twig
+++ b/templates/components/search/table.html.twig
@@ -101,16 +101,21 @@
          </tr>
       </thead>
       <tbody>
+
          {% if count == 0 %}
-            <tr>
-               <td colspan="{{ data['data']['cols']|length }}">
-                  {% if search_error %}
-                      {{ alerts.alert_danger(__('An error occured during the search'), __('Consider changing the search criteria or adjusting the displayed columns.')) }}
-                  {% else %}
-                      {{ alerts.alert_info(__('No item found')) }}
-                  {% endif %}
-               </td>
-            </tr>
+            {% if not search_was_executed %}
+               {# Nothing to display #}
+            {% else %}
+               <tr>
+                  <td colspan="{{ data['data']['cols']|length }}">
+                     {% if search_error %}
+                        {{ alerts.alert_danger(__('An error occured during the search'), __('Consider changing the search criteria or adjusting the displayed columns.')) }}
+                     {% else %}
+                        {{ alerts.alert_info(__('No item found')) }}
+                     {% endif %}
+                  </td>
+               </tr>
+            {% endif %}
          {% else %}
             {% for rowkey, row in data['data']['rows'] %}
                <tr>

--- a/tests/cypress/e2e/search/filterable.cy.js
+++ b/tests/cypress/e2e/search/filterable.cy.js
@@ -1,0 +1,106 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+describe('Filterable', () => {
+    beforeEach(() => {
+        cy.login();
+        cy.changeProfile('Super-Admin', true);
+    });
+
+    it('preview results are only loaded when explicitly requester', () => {
+        // We will be looking for the computer name directly so it must be unique.
+        const computer_name = "Computer for Filterable tests [" + Cypress._.uniqueId() + "]";
+
+        describe("Set up data and go to webhook page", () => {
+            cy.createWithAPI("Computer", {"name": computer_name})
+                .as("test_computer_id")
+            ;
+            cy.createWithAPI("Webhook", {
+                "name": "Test webhook",
+                "itemtype": "Computer",
+            }).as("webhook_id");
+
+            cy.get('@webhook_id').then((webhook_id) => {
+                const url = `/front/webhook.form.php`;
+                const tab = "Glpi\\Search\\CriteriaFilter$1"
+                cy.visit(`${url}?id=${webhook_id}&forcetab=${tab}`);
+            });
+        });
+
+        describe("Create filter", () => {
+            cy.findByRole("button", {"name": "Create a filter"}).click();
+
+            // TODO: bad selector here, we must add accessiblity labels to
+            // the search engine in order to be able to use findByRole instead.
+            // -> cy.findByRole("textbox", {"name": "Items seen"})
+            cy.get('input[name="criteria[0][value]"').type(computer_name);
+            cy.findByRole("button", {"name": "Save"}).click();
+            cy.findByRole("alert").should("exist")
+                .and("contains.text", "Filter saved")
+            ;
+        });
+
+        describe("Check that the preview results are not loaded", () => {
+            cy.findByRole("link", {'name' : computer_name}).should('not.exist');
+        });
+
+        describe("Load preview results", () => {
+            // Protecting against false positive by demonstrating that if the
+            // preview was shown our computer link would be displayed.
+            cy.findByRole("button", {"name": "Preview results"}).click();
+            cy.findByRole("link", {'name' : computer_name}).should('exist');
+        });
+
+        describe("Reload page and make sure preview was not executed", () => {
+            cy.reload();
+
+            // We will force the hidden preview content to be displayed as it
+            // make it easier to query it with accessiblity selectors.
+            cy.get("#criteria_filter_preview")
+                .should('exist')
+                .invoke("removeClass", "d-none")
+            ;
+
+            cy.get("#criteria_filter_preview").within(() => {
+                cy.findByRole("heading", {
+                    'name' : "Preview",
+                }).should('exist');
+
+                // Computer link should not be present
+                cy.findByRole("link", {
+                    'name' : computer_name,
+                }).should('not.exist');
+            });
+        });
+    });
+});

--- a/tests/cypress/e2e/search/filterable.cy.js
+++ b/tests/cypress/e2e/search/filterable.cy.js
@@ -52,7 +52,7 @@ describe('Filterable', () => {
 
             cy.get('@webhook_id').then((webhook_id) => {
                 const url = `/front/webhook.form.php`;
-                const tab = "Glpi\\Search\\CriteriaFilter$1"
+                const tab = "Glpi\\Search\\CriteriaFilter$1";
                 cy.visit(`${url}?id=${webhook_id}&forcetab=${tab}`);
             });
         });

--- a/tests/functional/Search.php
+++ b/tests/functional/Search.php
@@ -38,6 +38,7 @@ namespace tests\units;
 use Change;
 use CommonDBTM;
 use CommonITILActor;
+use Computer;
 use DBConnection;
 use DbTestCase;
 use Document;

--- a/tests/functional/Search.php
+++ b/tests/functional/Search.php
@@ -38,7 +38,6 @@ namespace tests\units;
 use Change;
 use CommonDBTM;
 use CommonITILActor;
-use Computer;
 use DBConnection;
 use DbTestCase;
 use Document;


### PR DESCRIPTION
(Requested by @orthagh).

Filters on webhook/notifications are hard to manage on big databases due to potential slow search queries that are executed when previewing the filter results.

A quick image to remind you what this feature look like:
![image](https://github.com/glpi-project/glpi/assets/42734840/b94c4db3-32a9-4f11-8c17-9b4ff17ef6d6)

### Save button behavior

The first issue is that saving a filter also update the preview; thus forcing execution of a potential slow query.

Now, the preview is no longer updated when a filter is saved.
It is instead hidden (thus avoiding displaying preview information that may be outdated), if the user want to confirm the results again he is free to manually click the preview button and check the results.

### Prevent useless background query

The second issue is that an useless preview search query is executed when the page is loaded.
This was not meant to be this way and is just a side effect of using the search engine in our page.

The default behavior of the search engine is to run its query when it is rendered, so its content was manually set to `d-none` on the filter page until the user clicked on "preview" for the first time.

This was great at hiding the results but the query is still executed when the page is loaded (and is never actually displayed since clicking "preview" will trigger a new independent ajax search) so it is bad for performances.

To fix this, I've added a specific parameter to the search engine that disable the query execution.
This mean we can still load the search engine output (as its container need to be in the page for ajax searches to work) without any real content.

This new parameter is only supported by the `HtmlTableOutput` output type to be safe, we could enable it for others outputs (map ?) later if needed.

This solution seems the simpler given the actual state of our search engine.
I don't think we can do better until it is rewritten.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33503
