### PR TITLE
Add Impact Capacity

### DIFF
--- a/install/migrations/update_10.0.x_to_11.0.0/assets.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/assets.php
@@ -50,6 +50,7 @@ if (!$DB->tableExists('glpi_assets_assetdefinitions')) {
             `system_name` varchar(255) DEFAULT NULL,
             `label` varchar(255) NOT NULL,
             `icon` varchar(255) DEFAULT NULL,
+            `picture` text,
             `comment` text,
             `is_active` tinyint NOT NULL DEFAULT '0',
             `capacities` JSON NOT NULL,
@@ -74,6 +75,7 @@ SQL;
         'after' => 'system_name',
         'update' => $DB::quoteName('system_name'),
     ]);
+    $migration->addField('glpi_assets_assetdefinitions', 'picture', 'text');
 }
 
 $ADDTODISPLAYPREF['Glpi\\Asset\\AssetDefinition'] = [2, 3, 4, 5, 6];

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9906,6 +9906,7 @@ CREATE TABLE `glpi_assets_assetdefinitions` (
   `system_name` varchar(255) DEFAULT NULL,
   `label` varchar(255) NOT NULL,
   `icon` varchar(255) DEFAULT NULL,
+  `picture` text,
   `comment` text,
   `is_active` tinyint NOT NULL DEFAULT '0',
   `capacities` JSON NOT NULL,

--- a/src/Glpi/Asset/AssetDefinition.php
+++ b/src/Glpi/Asset/AssetDefinition.php
@@ -43,6 +43,7 @@ use Glpi\Asset\CustomFieldType\TextType;
 use Glpi\CustomObject\AbstractDefinition;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\Features\AssetImage;
 use Glpi\Search\SearchOption;
 use Group;
 use Location;
@@ -56,6 +57,8 @@ use User;
  */
 final class AssetDefinition extends AbstractDefinition
 {
+    use AssetImage;
+
     public static function getSectorizedDetails(): array
     {
         return ['config', self::class];
@@ -265,7 +268,14 @@ TWIG, $twig_params);
                 $input[$json_field] = [];
             }
         }
+        $input = $this->managePictures($input);
         return parent::prepareInputForAdd($input);
+    }
+
+    public function prepareInputForUpdate($input)
+    {
+        $input = $this->managePictures($input);
+        return parent::prepareInputForUpdate($input);
     }
 
     protected function prepareInput(array $input): array|bool

--- a/src/Glpi/Asset/Capacity/HasImpactCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasImpactCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2024 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -89,13 +88,16 @@ class HasImpactCapacity extends AbstractCapacity
             false
         );
 
-        $enabled_types = json_decode(Config::getConfigurationValue('core', Impact::CONF_ENABLED), true) ?? [];
+        CommonGLPI::registerStandardTab($classname, Impact::class, 2);
+    }
+
+    public function onCapacityEnabled(string $classname): void
+    {
+        $enabled_types = json_decode(Config::getConfigurationValue('core', Impact::CONF_ENABLED)) ?? [];
         if (!in_array($classname, $enabled_types, true)) {
             $enabled_types[] = $classname;
             Config::setConfigurationValues('core', [Impact::CONF_ENABLED => json_encode($enabled_types)]);
         }
-
-        CommonGLPI::registerStandardTab($classname, Impact::class, 2);
     }
 
     public function onCapacityDisabled(string $classname): void
@@ -105,9 +107,11 @@ class HasImpactCapacity extends AbstractCapacity
 
         unset($CFG_GLPI['impact_asset_types'][$classname]);
 
-        $enabled_types = json_decode(Config::getConfigurationValue('core', Impact::CONF_ENABLED), true) ?? [];
-        $enabled_types = array_diff($enabled_types, [$classname]);
-        Config::setConfigurationValues('core', [Impact::CONF_ENABLED => json_encode($enabled_types)]);
+        $enabled_types = json_decode(Config::getConfigurationValue('core', Impact::CONF_ENABLED)) ?? [];
+        if (in_array($classname, $enabled_types, true)) {
+            $enabled_types = array_diff($enabled_types, [$classname]);
+            Config::setConfigurationValues('core', [Impact::CONF_ENABLED => json_encode($enabled_types)]);
+        }
 
         $relation = new ImpactRelation();
         $relation->deleteByCriteria([

--- a/src/Glpi/Asset/Capacity/HasImpactCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasImpactCapacity.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Asset\Capacity;
+
+use CommonGLPI;
+use Config;
+use Impact;
+use ImpactItem;
+use ImpactRelation;
+use Toolbox;
+
+class HasImpactCapacity extends AbstractCapacity
+{
+    public function getLabel(): string
+    {
+        return Impact::getTypeName(1);
+    }
+
+    public function getIcon(): string
+    {
+        return Impact::getIcon();
+    }
+
+    private function countImpactRelations(string $classname): int
+    {
+        return countElementsInTable(ImpactRelation::getTable(), [
+            'OR' => [
+                'itemtype_source' => $classname,
+                'itemtype_impacted' => $classname
+            ]
+        ]);
+    }
+
+    public function isUsed(string $classname): bool
+    {
+        //NOTE: This doesn't consider cases where assets exist inside graphs on other asset types. Maybe there is no good solution since it involves scanning every graph.
+        return parent::isUsed($classname)
+            && $this->countImpactRelations($classname) > 0;
+    }
+
+    public function getCapacityUsageDescription(string $classname): string
+    {
+        $impact_count = $this->countImpactRelations($classname);
+        $asset_count = $this->countAssets($classname);
+
+        return sprintf(__('%1$s impact relations involving %2$s assets'), $impact_count, $asset_count);
+    }
+
+    public function onClassBootstrap(string $classname): void
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        $CFG_GLPI['impact_asset_types'][$classname] = Toolbox::getPictureUrl(
+            $classname::getDefinition()->fields['picture'],
+            false
+        );
+
+        $enabled_types = json_decode(Config::getConfigurationValue('core', Impact::CONF_ENABLED), true) ?? [];
+        if (!in_array($classname, $enabled_types, true)) {
+            $enabled_types[] = $classname;
+            Config::setConfigurationValues('core', [Impact::CONF_ENABLED => json_encode($enabled_types)]);
+        }
+
+        CommonGLPI::registerStandardTab($classname, Impact::class, 2);
+    }
+
+    public function onCapacityDisabled(string $classname): void
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        unset($CFG_GLPI['impact_asset_types'][$classname]);
+
+        $enabled_types = json_decode(Config::getConfigurationValue('core', Impact::CONF_ENABLED), true) ?? [];
+        $enabled_types = array_diff($enabled_types, [$classname]);
+        Config::setConfigurationValues('core', [Impact::CONF_ENABLED => json_encode($enabled_types)]);
+
+        $relation = new ImpactRelation();
+        $relation->deleteByCriteria([
+            'OR' => [
+                'itemtype_source' => $classname,
+                'itemtype_impacted' => $classname,
+            ]
+        ], true, false);
+
+        $impact_item = new ImpactItem();
+        $impact_item->deleteByCriteria([
+            'itemtype' => $classname,
+        ], true, false);
+
+        // Clean history related to links
+        $this->deleteRelationLogs($classname, ImpactItem::class);
+    }
+}

--- a/src/Glpi/Asset/Capacity/HasImpactCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasImpactCapacity.php
@@ -63,6 +63,25 @@ class HasImpactCapacity extends AbstractCapacity
         ]);
     }
 
+    private function countAssetsUsingImpact(string $classname): int
+    {
+        $source_assets_count = \countDistinctElementsInTable(
+            ImpactRelation::getTable(),
+            'items_id_source',
+            [
+                'itemtype_source' => $classname,
+            ]
+        );
+        $impacted_assets_count = \countDistinctElementsInTable(
+            ImpactRelation::getTable(),
+            'items_id_impacted',
+            [
+                'itemtype_impacted' => $classname,
+            ]
+        );
+        return $source_assets_count + $impacted_assets_count;
+    }
+
     public function isUsed(string $classname): bool
     {
         //NOTE: This doesn't consider cases where assets exist inside graphs on other asset types. Maybe there is no good solution since it involves scanning every graph.
@@ -73,7 +92,7 @@ class HasImpactCapacity extends AbstractCapacity
     public function getCapacityUsageDescription(string $classname): string
     {
         $impact_count = $this->countImpactRelations($classname);
-        $asset_count = $this->countAssets($classname);
+        $asset_count = $this->countAssetsUsingImpact($classname);
 
         return sprintf(__('%1$s impact relations involving %2$s assets'), $impact_count, $asset_count);
     }

--- a/src/Glpi/Asset/Capacity/HasImpactCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasImpactCapacity.php
@@ -109,7 +109,7 @@ class HasImpactCapacity extends AbstractCapacity
 
         $enabled_types = json_decode(Config::getConfigurationValue('core', Impact::CONF_ENABLED)) ?? [];
         if (in_array($classname, $enabled_types, true)) {
-            $enabled_types = array_diff($enabled_types, [$classname]);
+            $enabled_types = \array_values(\array_diff($enabled_types, [$classname]));
             Config::setConfigurationValues('core', [Impact::CONF_ENABLED => json_encode($enabled_types)]);
         }
 

--- a/src/Glpi/Asset/Capacity/HasImpactCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasImpactCapacity.php
@@ -114,17 +114,25 @@ class HasImpactCapacity extends AbstractCapacity
         }
 
         $relation = new ImpactRelation();
-        $relation->deleteByCriteria([
-            'OR' => [
-                'itemtype_source' => $classname,
-                'itemtype_impacted' => $classname,
-            ]
-        ], true, false);
+        $relation->deleteByCriteria(
+            [
+                'OR' => [
+                    'itemtype_source' => $classname,
+                    'itemtype_impacted' => $classname,
+                ]
+            ],
+            force: true,
+            history: false
+        );
 
         $impact_item = new ImpactItem();
-        $impact_item->deleteByCriteria([
-            'itemtype' => $classname,
-        ], true, false);
+        $impact_item->deleteByCriteria(
+            [
+                'itemtype' => $classname,
+            ],
+            force: true,
+            history: false
+        );
 
         // Clean history related to links
         $this->deleteRelationLogs($classname, ImpactItem::class);

--- a/src/Glpi/Features/AssetImage.php
+++ b/src/Glpi/Features/AssetImage.php
@@ -50,7 +50,7 @@ trait AssetImage
      */
     public function managePictures($input)
     {
-        foreach (['picture_front', 'picture_rear'] as $name) {
+        foreach (['picture_front', 'picture_rear', 'picture'] as $name) {
             if (
                 isset($input["_blank_$name"])
                 && $input["_blank_$name"]

--- a/src/Impact.php
+++ b/src/Impact.php
@@ -1771,7 +1771,7 @@ TWIG, $twig_params);
     public static function getEnabledItemtypes(): array
     {
         // Get configured values
-        $enabled_itemtypes = json_decode(Config::getConfigurationValue('core', self::CONF_ENABLED), true) ?? [];
+        $enabled_itemtypes = json_decode(Config::getConfigurationValue('core', self::CONF_ENABLED)) ?? [];
 
         if (!count($enabled_itemtypes)) {
             return [];

--- a/src/ImpactItem.php
+++ b/src/ImpactItem.php
@@ -35,6 +35,7 @@
 
 /**
  * @since 9.5.0
+ * @todo Shouldn't this extend CommonDBChild?
  */
 class ImpactItem extends CommonDBTM
 {

--- a/templates/pages/admin/customobjects/main.html.twig
+++ b/templates/pages/admin/customobjects/main.html.twig
@@ -166,4 +166,14 @@
         item.fields['icon'],
         __('Icon'),
     ) }}
+
+    {% if item.fields['picture'] is not empty %}
+        {{ fields.imageField('picture', item.fields['picture']|picture_url, field['label'], {
+            'clearable': (not item.isNewItem() and item.canUpdateItem())
+        }) }}
+    {% else %}
+        {{ fields.fileField('picture', null, _n('Picture', 'Pictures', 1), {
+            'onlyimages': true
+        }) }}
+    {% endif %}
 {% endblock %}

--- a/templates/pages/admin/customobjects/main.html.twig
+++ b/templates/pages/admin/customobjects/main.html.twig
@@ -167,13 +167,15 @@
         __('Icon'),
     ) }}
 
-    {% if item.fields['picture'] is not empty %}
-        {{ fields.imageField('picture', item.fields['picture']|picture_url, field['label'], {
-            'clearable': (not item.isNewItem() and item.canUpdateItem())
-        }) }}
-    {% else %}
-        {{ fields.fileField('picture', null, _n('Picture', 'Pictures', 1), {
-            'onlyimages': true
-        }) }}
+    {% if item.isField('picture') %}
+        {% if item.fields['picture'] is not empty %}
+            {{ fields.imageField('picture', item.fields['picture']|picture_url, field['label'], {
+                'clearable': (not item.isNewItem() and item.canUpdateItem())
+            }) }}
+        {% else %}
+            {{ fields.fileField('picture', null, _n('Picture', 'Pictures', 1), {
+                'onlyimages': true
+            }) }}
+        {% endif %}
     {% endif %}
 {% endblock %}

--- a/tests/functional/Glpi/Asset/Capacity/HasImpactCapacity.php
+++ b/tests/functional/Glpi/Asset/Capacity/HasImpactCapacity.php
@@ -1,0 +1,313 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Asset\Capacity;
+
+use DbTestCase;
+use Entity;
+use Glpi\Tests\Asset\CapacityUsageTestTrait;
+use ImpactItem;
+use Log;
+
+class HasImpactCapacity extends DbTestCase
+{
+    use CapacityUsageTestTrait;
+
+    protected function getTargetCapacity(): string
+    {
+        return \Glpi\Asset\Capacity\HasImpactCapacity::class;
+    }
+
+    public function testCapacityActivation(): void
+    {
+        global $CFG_GLPI;
+
+        $root_entity_id = getItemByTypeName(Entity::class, '_test_root_entity', true);
+
+        $definition_1 = $this->initAssetDefinition(
+            capacities: [
+                \Glpi\Asset\Capacity\HasImpactCapacity::class,
+                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+            ]
+        );
+        $classname_1  = $definition_1->getAssetClassName();
+        $definition_2 = $this->initAssetDefinition(
+            capacities: [
+                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+            ]
+        );
+        $classname_2  = $definition_2->getAssetClassName();
+        $definition_3 = $this->initAssetDefinition(
+            capacities: [
+                \Glpi\Asset\Capacity\HasImpactCapacity::class,
+                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+            ]
+        );
+        $classname_3  = $definition_3->getAssetClassName();
+
+        $has_impact_mapping = [
+            $classname_1 => true,
+            $classname_2 => false,
+            $classname_3 => true,
+        ];
+
+        $enabled_impact_types = json_decode(\Config::getConfigurationValue('core', \Impact::CONF_ENABLED), true) ?? [];
+        foreach ($has_impact_mapping as $classname => $has_impact) {
+            // Check that the class is globally registered
+            if ($has_impact) {
+                $this->array($CFG_GLPI['impact_asset_types'])->hasKey($classname);
+                $this->array($enabled_impact_types)->contains($classname);
+            } else {
+                $this->array($CFG_GLPI['impact_asset_types'])->notHasKey($classname);
+                $this->array($enabled_impact_types)->notContains($classname);
+            }
+
+            $item = $this->createItem($classname, ['name' => __FUNCTION__, 'entities_id' => $root_entity_id]);
+            $this->login(); // must be logged in to get tabs list
+            if ($has_impact) {
+                $this->array($item->defineAllTabs())->hasKey('Impact$1');
+            } else {
+                $this->array($item->defineAllTabs())->notHasKey('Impact$1');
+            }
+        }
+    }
+
+    public function testCapacityDeactivation(): void
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        $root_entity_id = getItemByTypeName(Entity::class, '_test_root_entity', true);
+
+        $definition_1 = $this->initAssetDefinition(
+            capacities: [
+                \Glpi\Asset\Capacity\HasImpactCapacity::class,
+                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+            ]
+        );
+        $classname_1  = $definition_1->getAssetClassName();
+        $definition_2 = $this->initAssetDefinition(
+            capacities: [
+                \Glpi\Asset\Capacity\HasImpactCapacity::class,
+                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+            ]
+        );
+        $classname_2  = $definition_2->getAssetClassName();
+
+        $item_1          = $this->createItem(
+            $classname_1,
+            [
+                'name' => __FUNCTION__,
+                'entities_id' => $root_entity_id,
+            ]
+        );
+        $item_2          = $this->createItem(
+            $classname_2,
+            [
+                'name' => __FUNCTION__,
+                'entities_id' => $root_entity_id,
+            ]
+        );
+
+        $impact_item_1 = $this->createItem(
+            \ImpactRelation::class,
+            [
+                'itemtype_source'           => $item_1::class,
+                'items_id_source'           => $item_1->getID(),
+                'itemtype_impacted'         => 'Computer',
+                'items_id_impacted'         => getItemByTypeName('Computer', '_test_pc01', true),
+            ]
+        );
+        $impact_item_2 = $this->createItem(
+            \ImpactRelation::class,
+            [
+                'itemtype_source'             => 'Computer',
+                'items_id_source'             => getItemByTypeName('Computer', '_test_pc01', true),
+                'itemtype_impacted'           => $item_2::class,
+                'items_id_impacted'           => $item_2->getID(),
+            ]
+        );
+
+        $this->object(\ImpactRelation::getById($impact_item_1->getID()))->isInstanceOf(\ImpactRelation::class);
+        $this->object(\ImpactRelation::getById($impact_item_2->getID()))->isInstanceOf(\ImpactRelation::class);
+        $this->array($CFG_GLPI['impact_asset_types'])->hasKey($classname_1);
+        $this->array($CFG_GLPI['impact_asset_types'])->hasKey($classname_2);
+
+        $this->boolean($definition_1->update(['id' => $definition_1->getID(), 'capacities' => []]))->isTrue();
+        $this->boolean(\ImpactRelation::getById($impact_item_1->getID()))->isFalse();
+        $this->array($CFG_GLPI['impact_asset_types'])->notHasKey($classname_1);
+
+        $this->object(\ImpactRelation::getById($impact_item_2->getID()))->isInstanceOf(\ImpactRelation::class);
+        $this->array($CFG_GLPI['impact_asset_types'])->hasKey($classname_2);
+    }
+
+    public function provideIsUsed(): iterable
+    {
+        yield [
+            'target_classname' => \ImpactRelation::class,
+        ];
+    }
+
+    /**
+     * Test if the method isUsed returns true if the capacity can be disabled
+     * without data loss.
+     *
+     * @dataProvider provideIsUsed
+     * @return void
+     */
+    public function testIsUsed(
+        string $target_classname,
+        array $target_fields = [],
+        ?string $relation_classname = null,
+        array $relation_fields = [],
+    ): void {
+        global $DB;
+
+        // Retrieve the test root entity
+        $entity_id = $this->getTestRootEntity(true);
+
+        // Create custom asset definition with the target capacity enabled
+        $definition = $this->initAssetDefinition(
+            capacities: [$this->getTargetCapacity()]
+        );
+
+        // Create our test subject
+        $subject = $this->createItem($definition->getAssetClassName(), [
+            'name' => 'Test asset',
+            'entities_id' => $entity_id,
+        ]);
+        $computers_id = getItemByTypeName('Computer', '_test_pc01', true);
+
+        // Check that the capacity can be disabled
+        $capacity = new ($this->getTargetCapacity());
+        $this->boolean($capacity->isUsed($definition->getAssetClassName()))->isFalse();
+
+        // Create item
+        $target_fields['itemtype_source'] = $definition->getAssetClassName();
+        $target_fields['items_id_source'] = $subject->getID();
+        $target_fields['itemtype_impacted'] = 'Computer';
+        $target_fields['items_id_impacted'] = $computers_id;
+
+        $item = $this->createItem($target_classname, $target_fields);
+
+        // Check that the capacity can't be safely disabled
+        $this->boolean($capacity->isUsed($definition->getAssetClassName()))->isTrue();
+
+        $item->delete(['id' => $item->getID()], true);
+        $this->boolean($capacity->isUsed($definition->getAssetClassName()))->isFalse();
+
+        // Check when the custom asset on the other side of the relation
+        $target_fields['itemtype_source'] = 'Computer';
+        $target_fields['items_id_source'] = $computers_id;
+        $target_fields['itemtype_impacted'] = $definition->getAssetClassName();
+        $target_fields['items_id_impacted'] = $subject->getID();
+
+        $this->createItem($target_classname, $target_fields);
+
+        // Check that the capacity can't be safely disabled
+        $this->boolean($capacity->isUsed($definition->getAssetClassName()))->isTrue();
+    }
+
+    public function provideGetCapacityUsageDescription(): iterable
+    {
+        yield [
+            'target_classname' => \ImpactRelation::class,
+            'expected' => '%d impact relations involving %d assets'
+        ];
+    }
+
+    /**
+     * Test if the getCapacityUsageDescription method returns a correct description
+     * of the capacity usage.
+     *
+     * @dataProvider provideGetCapacityUsageDescription
+     * @return void
+     */
+    public function testGetCapacityUsageDescription(
+        string $target_classname,
+        string $expected,
+        array $target_fields = [],
+        ?string $relation_classname = null,
+        array $relation_fields = [],
+    ): void {
+        global $DB;
+
+        $capacity = new ($this->getTargetCapacity());
+
+        // Retrieve the test root entity
+        $entity_id = $this->getTestRootEntity(true);
+
+        // Create custom asset definition with the target capacity enabled
+        $definition = $this->initAssetDefinition(
+            capacities: [$this->getTargetCapacity()]
+        );
+
+        // Create our test subject
+        $subject = $this->createItem($definition->getAssetClassName(), [
+            'name' => 'Test asset',
+            'entities_id' => $entity_id,
+        ]);
+
+        // Create item
+        $this->createItem($target_classname, [
+            'itemtype_source' => $definition->getAssetClassName(),
+            'items_id_source' => $subject->getID(),
+            'itemtype_impacted' => 'Computer',
+            'items_id_impacted' => getItemByTypeName('Computer', '_test_pc01', true),
+        ]);
+
+        // Check that the capacity usage description is correct
+        $expectedValue = sprintf($expected, 1, 1);
+        $this->string($capacity->getCapacityUsageDescription($definition->getAssetClassName()))->isEqualTo($expectedValue);
+
+        // Create a second subject
+        $subject2 = $this->createItem($definition->getAssetClassName(), [
+            'name' => 'Test asset 2',
+            'entities_id' => $entity_id,
+        ]);
+
+        // Create a second item
+        $this->createItem($target_classname, [
+            'itemtype_impacted' => $definition->getAssetClassName(),
+            'items_id_impacted' => $subject2->getID(),
+            'itemtype_source' => 'Computer',
+            'items_id_source' => getItemByTypeName('Computer', '_test_pc01', true),
+        ]);
+
+        // Check that the capacity usage description is correct
+        $expectedValue = sprintf($expected, 2, 2);
+        $this->string($capacity->getCapacityUsageDescription($definition->getAssetClassName()))->isEqualTo($expectedValue);
+    }
+}

--- a/tests/functional/Glpi/Asset/Capacity/HasImpactCapacity.php
+++ b/tests/functional/Glpi/Asset/Capacity/HasImpactCapacity.php
@@ -35,11 +35,12 @@
 
 namespace tests\units\Glpi\Asset\Capacity;
 
+use Config;
 use DbTestCase;
 use Entity;
 use Glpi\Tests\Asset\CapacityUsageTestTrait;
-use ImpactItem;
-use Log;
+use Impact;
+use ImpactRelation;
 
 class HasImpactCapacity extends DbTestCase
 {
@@ -83,7 +84,7 @@ class HasImpactCapacity extends DbTestCase
             $classname_3 => true,
         ];
 
-        $enabled_impact_types = json_decode(\Config::getConfigurationValue('core', \Impact::CONF_ENABLED), true) ?? [];
+        $enabled_impact_types = json_decode(Config::getConfigurationValue('core', Impact::CONF_ENABLED)) ?? [];
         foreach ($has_impact_mapping as $classname => $has_impact) {
             // Check that the class is globally registered
             if ($has_impact) {
@@ -142,7 +143,7 @@ class HasImpactCapacity extends DbTestCase
         );
 
         $impact_item_1 = $this->createItem(
-            \ImpactRelation::class,
+            ImpactRelation::class,
             [
                 'itemtype_source'           => $item_1::class,
                 'items_id_source'           => $item_1->getID(),
@@ -151,7 +152,7 @@ class HasImpactCapacity extends DbTestCase
             ]
         );
         $impact_item_2 = $this->createItem(
-            \ImpactRelation::class,
+            ImpactRelation::class,
             [
                 'itemtype_source'             => 'Computer',
                 'items_id_source'             => getItemByTypeName('Computer', '_test_pc01', true),
@@ -160,23 +161,23 @@ class HasImpactCapacity extends DbTestCase
             ]
         );
 
-        $this->object(\ImpactRelation::getById($impact_item_1->getID()))->isInstanceOf(\ImpactRelation::class);
-        $this->object(\ImpactRelation::getById($impact_item_2->getID()))->isInstanceOf(\ImpactRelation::class);
+        $this->object(ImpactRelation::getById($impact_item_1->getID()))->isInstanceOf(ImpactRelation::class);
+        $this->object(ImpactRelation::getById($impact_item_2->getID()))->isInstanceOf(ImpactRelation::class);
         $this->array($CFG_GLPI['impact_asset_types'])->hasKey($classname_1);
         $this->array($CFG_GLPI['impact_asset_types'])->hasKey($classname_2);
 
         $this->boolean($definition_1->update(['id' => $definition_1->getID(), 'capacities' => []]))->isTrue();
-        $this->boolean(\ImpactRelation::getById($impact_item_1->getID()))->isFalse();
+        $this->boolean(ImpactRelation::getById($impact_item_1->getID()))->isFalse();
         $this->array($CFG_GLPI['impact_asset_types'])->notHasKey($classname_1);
 
-        $this->object(\ImpactRelation::getById($impact_item_2->getID()))->isInstanceOf(\ImpactRelation::class);
+        $this->object(ImpactRelation::getById($impact_item_2->getID()))->isInstanceOf(ImpactRelation::class);
         $this->array($CFG_GLPI['impact_asset_types'])->hasKey($classname_2);
     }
 
     public function provideIsUsed(): iterable
     {
         yield [
-            'target_classname' => \ImpactRelation::class,
+            'target_classname' => ImpactRelation::class,
         ];
     }
 
@@ -193,8 +194,6 @@ class HasImpactCapacity extends DbTestCase
         ?string $relation_classname = null,
         array $relation_fields = [],
     ): void {
-        global $DB;
-
         // Retrieve the test root entity
         $entity_id = $this->getTestRootEntity(true);
 
@@ -262,8 +261,6 @@ class HasImpactCapacity extends DbTestCase
         ?string $relation_classname = null,
         array $relation_fields = [],
     ): void {
-        global $DB;
-
         $capacity = new ($this->getTargetCapacity());
 
         // Retrieve the test root entity


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Adds ability to enabled impact graphs for custom asset types and specify the image to use in the graphs.
Also adds support for impact type pictures in the uploaded picture directory `files/_pictures` rather than just the `pics` folder or pictures provided through a PHP script.