### PR TITLE
Validate search criteria

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -2738,6 +2738,13 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Controller/ApiController.php',
 ];
 $ignoreErrors[] = [
+    // identifier: identical.alwaysFalse
+    'message' => '#^Strict comparison using \\=\\=\\= between null and \'development\' will always evaluate to false\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/src/Glpi/Search/Input/QueryBuilder.php',
+];
+$ignoreErrors[] = [
+	// identifier: identical.alwaysFalse
 	'message' => '#^Strict comparison using \\=\\=\\= between null and \'development\' will always evaluate to false\\.$#',
 	'identifier' => 'identical.alwaysFalse',
 	'count' => 1,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,9 @@ The present file will list all changes made to the project; according to the
 - `CartridgeItem::addCompatibleType()` method is now static.
 - `Rule::initRule()` has been made final and non static and its signature changed.
 - `Clonable::clone()` and `Clonable::cloneMultiple()` methods now accept a `$clone_as_template` parameter to allow creating templates.
+- `enable_partial_warnings` option removed from `SavedSearch::displayMine()`.
+- `enable_partial_warnings` option removed from `SavedSearch::execute()`.
+- `enable_partial_warnings` option removed from `SavedSearch::getMine()`.
 - `Transfer` class is now final.
 - `Transfer::addNotToBeTransfer()` method is now private.
 - `Transfer::addToAlreadyTransfer()` method is now private.
@@ -496,6 +499,7 @@ The present file will list all changes made to the project; according to the
 - `RuleImportComputerCollection` class.
 - `RuleMatchedLog::showFormAgent()`.
 - `RuleMatchedLog::showItemForm()`.
+- `SavedSearch::prepareQueryToUse()`
 - `Search::SYLK_OUTPUT` constant.
 - `Search::computeTitle()`
 - `Search::csv_clean()`

--- a/ajax/savedsearch.php
+++ b/ajax/savedsearch.php
@@ -83,8 +83,7 @@ if ($action == 'display_mine') {
     header("Content-Type: text/html; charset=UTF-8");
     $savedsearch->displayMine(
         $_GET["itemtype"],
-        (bool) ($_GET["inverse"] ?? false),
-        false
+        (bool) ($_GET["inverse"] ?? false)
     );
 }
 

--- a/js/common.js
+++ b/js/common.js
@@ -1951,14 +1951,14 @@ function setupAdaptDropdown(config)
     return select2_el;
 }
 
-function displaySessionMessages() {
+window.displaySessionMessages = () => {
     $.ajax({
         method: 'GET',
         url: (CFG_GLPI.root_doc + "/ajax/displayMessageAfterRedirect.php"),
         data: {
             'get_raw': true
         }
-    }).done((messages) => {
+    }).then((messages) => {
         $.each(messages, (level, level_messages) => {
             $.each(level_messages, (index, message) => {
                 switch (parseInt(level)) {
@@ -1974,4 +1974,4 @@ function displaySessionMessages() {
             });
         });
     });
-}
+};

--- a/js/modules/Search/Table.js
+++ b/js/modules/Search/Table.js
@@ -31,7 +31,7 @@
  * ---------------------------------------------------------------------
  */
 
-/* global bootstrap, validateFormWithBootstrap */
+/* global bootstrap, validateFormWithBootstrap, displaySessionMessages */
 
 import GenericView from './GenericView.js';
 
@@ -227,6 +227,7 @@ window.GLPI.Search.Table = class Table extends GenericView {
                 this.getResultsView().setID(ajax_container.find(".masssearchform").attr('id'));
 
                 this.getElement().trigger('search_refresh', [this.getElement()]);
+                displaySessionMessages();
                 this.hideLoadingSpinner();
                 this.shiftSelectAllCheckbox();
             }, () => {

--- a/phpunit/functional/SavedSearch_UserTest.php
+++ b/phpunit/functional/SavedSearch_UserTest.php
@@ -85,10 +85,12 @@ class SavedSearch_UserTest extends DbTestCase
                 'sort'             => '2',
                 'order'            => 'DESC',
                 'savedsearches_id' => $bk_id,
-                'criteria'         => [0 => ['field' => '5',
-                    'searchtype' => 'equals',
-                    'value' => $uid
-                ]
+                'criteria'         => [
+                    0 => [
+                        'field' => '5',
+                        'searchtype' => 'equals',
+                        'value' => $uid
+                    ]
                 ],
                 'reset'            => 'reset',
             ],

--- a/phpunit/functional/SearchTest.php
+++ b/phpunit/functional/SearchTest.php
@@ -1353,9 +1353,10 @@ class SearchTest extends DbTestCase
         $this->assertEquals(
             [
                 'reset'        => 1,
+                'itemtype'     => 'Ticket',
                 'start'        => 0,
-                'order'        => 'DESC',
-                'sort'         => 19,
+                'order'        => ['DESC'],
+                'sort'         => [19],
                 'is_deleted'   => 0,
                 'criteria'     => [
                     0 => [
@@ -1401,8 +1402,8 @@ class SearchTest extends DbTestCase
             [
                 'reset'        => 1,
                 'start'        => 0,
-                'order'        => 'DESC',
-                'sort'         => 2,
+                'order'        => ['DESC'],
+                'sort'         => [2],
                 'is_deleted'   => 0,
                 'criteria'     => [
                     0 => [
@@ -1426,9 +1427,10 @@ class SearchTest extends DbTestCase
         $this->assertEquals(
             [
                 'reset'      => 1,
+                'itemtype'   => 'Computer',
                 'start'      => 0,
-                'order'      => 'ASC',
-                'sort'       => 0,
+                'order'      => ['ASC'],
+                'sort'       => [0],
                 'is_deleted' => 0,
                 'criteria'   => [
                     [
@@ -1476,8 +1478,8 @@ class SearchTest extends DbTestCase
             [
                 'reset'        => 1,
                 'start'        => 0,
-                'order'        => 'DESC',
-                'sort'         => 31,
+                'order'        => ['DESC'],
+                'sort'         => [31],
                 'is_deleted'   => 0,
                 'criteria'     => [
                     0 => [
@@ -5012,6 +5014,76 @@ class SearchTest extends DbTestCase
             ],
         ];
         $this->assertEquals($expected, $items);
+    }
+
+    public function testInvalidCriteria()
+    {
+        $search_params = [
+            'is_deleted'   => 0,
+            'criteria'     => [
+                [
+                    'field' => 10000, // Not a valid search option
+                    'searchtype' => 'contains',
+                    'value' => 'any string'
+                ]
+            ]
+        ];
+
+        $data = $this->doSearch('Computer', $search_params);
+        $this->assertGreaterThan(8, $data['data']['totalcount']);
+        $this->hasSessionMessages(WARNING, ['Some search criteria were removed because they are invalid']);
+
+        $search_params = [
+            'is_deleted'   => 0,
+            'criteria'     => [
+                [
+                    'field' => 10000, // Not a valid search option
+                    'searchtype' => 'contains',
+                    'value' => 'any string'
+                ],
+                [
+                    'field' => 1, // name
+                    'searchtype' => 'contains',
+                    'value' => '_test_pc_with_encoded_comment'
+                ]
+            ]
+        ];
+
+        $data = $this->doSearch('Computer', $search_params);
+        // Only the valid 'name' criterion should be taken into account
+        $this->assertEquals(1, $data['data']['totalcount']);
+        $this->hasSessionMessages(WARNING, ['Some search criteria were removed because they are invalid']);
+    }
+
+    public function testInvalidMetacriteria()
+    {
+        $search_params = [
+            'is_deleted'   => 0,
+            'criteria'     => [
+                [
+                    'itemtype' => 'Agent',
+                    'field' => 10000, // Not a valid search option
+                    'searchtype' => 'contains',
+                    'value' => 'any string'
+                ]
+            ]
+        ];
+
+        $data = $this->doSearch('Computer', $search_params);
+        $this->assertGreaterThan(8, $data['data']['totalcount']);
+        $this->hasSessionMessages(WARNING, ['Some search criteria were removed because they are invalid']);
+    }
+
+    public function testInvalidSort()
+    {
+        $search_params = [
+            'is_deleted'   => 0,
+            'sort'         => [10000], // Not a valid search option
+            'order' => ['ASC']
+        ];
+
+        $data = $this->doSearch('Computer', $search_params);
+        $this->assertEquals([0], $data['search']['sort']);
     }
 }
 

--- a/src/Glpi/Search/Input/QueryBuilder.php
+++ b/src/Glpi/Search/Input/QueryBuilder.php
@@ -900,7 +900,7 @@ final class QueryBuilder implements SearchInputInterface
             $params['order'] = ['ASC'];
         }
 
-        if (count($invalid_criteria) > 0) {
+        if (!($params['silent_validation'] ?? false) && count($invalid_criteria) > 0) {
             // There is probably no need to show more information about the invalid criteria
             Session::addMessageAfterRedirect(__s('Some search criteria were removed because they are invalid'), false, WARNING);
             if (GLPI_ENVIRONMENT_TYPE === GLPI::ENV_DEVELOPMENT || $_SESSION['glpi_use_mode'] === Session::DEBUG_MODE) {

--- a/src/Glpi/Search/Input/QueryBuilder.php
+++ b/src/Glpi/Search/Input/QueryBuilder.php
@@ -873,11 +873,11 @@ final class QueryBuilder implements SearchInputInterface
                 // In the criteria array, the search options are from the metatype POV (Agent Name for example is ID 1 in criteria array, but 900 from the POV of Computer)
                 $valid_meta_opts = SearchOption::getOptionsForItemtype($criterion['itemtype']);
                 if (!isset($valid_meta_opts[(int) $criterion['field']])) {
-                    $invalid_criteria[] = $k;
+                    $invalid_criteria[] = (int) $criterion['field'];
                     unset($params['criteria'][$k]);
                 }
             } else if (!isset($valid_main_opts[(int) $criterion['field']])) {
-                $invalid_criteria[] = $k;
+                $invalid_criteria[] = (int) $criterion['field'];
                 unset($params['criteria'][$k]);
             }
         }

--- a/src/Glpi/Search/Input/QueryBuilder.php
+++ b/src/Glpi/Search/Input/QueryBuilder.php
@@ -869,7 +869,7 @@ final class QueryBuilder implements SearchInputInterface
             if (!array_key_exists('field', $criterion) || !is_numeric($criterion['field'])) {
                 continue;
             }
-            if (isset($criterion['itemtype'])) {
+            if (isset($criterion['itemtype']) && $criterion['itemtype'] !== $params['itemtype']) {
                 // In the criteria array, the search options are from the metatype POV (Agent Name for example is ID 1 in criteria array, but 900 from the POV of Computer)
                 $valid_meta_opts = SearchOption::getOptionsForItemtype($criterion['itemtype']);
                 if (!isset($valid_meta_opts[(int) $criterion['field']])) {
@@ -903,7 +903,7 @@ final class QueryBuilder implements SearchInputInterface
         if (count($invalid_criteria) > 0) {
             // There is probably no need to show more information about the invalid criteria
             Session::addMessageAfterRedirect(__s('Some search criteria were removed because they are invalid'), false, WARNING);
-            if (GLPI_ENVIRONMENT_TYPE === GLPI::ENV_DEVELOPMENT) {
+            if (GLPI_ENVIRONMENT_TYPE === GLPI::ENV_DEVELOPMENT || $_SESSION['glpi_use_mode'] === Session::DEBUG_MODE) {
                 trigger_error(
                     'Attempted to use invalid search options from itemtype: "' . $params['itemtype'] . '" with IDs ' . implode(', ', $invalid_criteria),
                     E_USER_WARNING

--- a/src/Glpi/Search/SearchEngine.php
+++ b/src/Glpi/Search/SearchEngine.php
@@ -284,6 +284,7 @@ final class SearchEngine
 
         // Default values of parameters
         $p = [
+            'itemtype'                  => $itemtype,
             'criteria'                  => [],
             'metacriteria'              => [],
             'sort'                      => [0],

--- a/src/Html.php
+++ b/src/Html.php
@@ -1795,6 +1795,7 @@ TWIG,
 
         $tpl_vars['debug_info'] = null;
 
+        self::displayMessageAfterRedirect();
         \Glpi\Debug\Profiler::getInstance()->stopAll();
         if ($_SESSION['glpi_use_mode'] === Session::DEBUG_MODE && !str_starts_with($_SERVER['PHP_SELF'], $CFG_GLPI['root_doc'] . '/install/')) {
             $tpl_vars['debug_info'] = \Glpi\Debug\Profile::getCurrent()->getDebugInfo();
@@ -2037,7 +2038,6 @@ TWIG,
 
         self::includeHeader($title, $sector, $item, $option); // Body
         echo "<body class='" . ($in_modal ? "in_modal" : "") . "'>";
-        self::displayMessageAfterRedirect();
         echo "<div id='page'>"; // Force legacy styles for now
     }
 
@@ -2071,7 +2071,6 @@ TWIG,
 
         self::includeHeader($title, $sector, $item, $option, true, true);
         echo "<body class='iframed'>";
-        self::displayMessageAfterRedirect();
         echo "<div id='page'>";
     }
 
@@ -2091,6 +2090,7 @@ TWIG,
 
        // Print foot
         self::loadJavascript();
+        self::displayMessageAfterRedirect();
         echo "</body></html>";
     }
 

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -470,6 +470,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
         $query_tab = [];
         parse_str($this->fields["query"], $query_tab);
         $query_tab['savedsearches_id'] = $ID;
+        $query_tab['reset'] = 'reset';
         return $query_tab;
     }
 

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -421,110 +421,6 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
     }
 
     /**
-     * Prepare query to use depending of the type
-     *
-     * @param integer $type      Saved search type (see SavedSearch constants)
-     * @param array   $query_tab Parameters array
-     * @param bool    $enable_partial_warnings display warning messages about partial loading
-     *
-     * @return array prepared query array
-     **/
-    public function prepareQueryToUse($type, $query_tab, $enable_partial_warnings = true)
-    {
-        switch ($type) {
-            case self::SEARCH:
-            case self::ALERT:
-                // Check if all data are valid
-                $query_tab_save = $query_tab;
-                $partial_load   = false;
-                // Standard search
-                if (isset($query_tab_save['criteria']) && count($query_tab_save['criteria'])) {
-                    unset($query_tab['criteria']);
-
-                    $itemtype_so = [
-                        $this->fields['itemtype'] => Search::getCleanedOptions($this->fields['itemtype'])
-                    ];
-                    $available_meta = Search::getMetaItemtypeAvailable($this->fields['itemtype']);
-
-                    $new_key = 0;
-                    foreach ($query_tab_save['criteria'] as $val) {
-                        // Get itemtype search options for current criterion
-                        $opt = [];
-                        if (!isset($val['meta'])) {
-                            $opt = $itemtype_so[$this->fields['itemtype']];
-                        } elseif (isset($val['itemtype'])) {
-                            if (!array_key_exists($val['itemtype'], $itemtype_so)) {
-                                $itemtype_so[$val['itemtype']] = Search::getCleanedOptions($val['itemtype']);
-                            }
-                            $opt = $itemtype_so[$val['itemtype']];
-                        }
-
-                        if (
-                            (
-                                // Check if search option is still available
-                                isset($val['field'])
-                                && $val['field'] != 'view'
-                                && $val['field'] != 'all'
-                                && (
-                                    !isset($opt[$val['field']])
-                                    || (isset($opt[$val['field']]['nosearch']) && $opt[$val['field']]['nosearch'])
-                                )
-                            )
-                            || (
-                                // Check if meta itemtype is still available
-                                isset($val['meta'])
-                                && (!isset($val['itemtype']) || !in_array($val['itemtype'], $available_meta))
-                            )
-                        ) {
-                            $partial_load = true;
-                        } else {
-                            $query_tab['criteria'][$new_key] = $val;
-                            $new_key++;
-                        }
-                    }
-                }
-                // Meta search
-                if (isset($query_tab_save['metacriteria']) && count($query_tab_save['metacriteria'])) {
-                    $meta_ok = Search::getMetaItemtypeAvailable($query_tab['itemtype']);
-                    unset($query_tab['metacriteria']);
-                    $new_key = 0;
-                    foreach ($query_tab_save['metacriteria'] as $val) {
-                        $opt = [];
-                        if (isset($val['itemtype'])) {
-                             $opt = Search::getCleanedOptions($val['itemtype']);
-                        }
-                       // Use if meta type is valid and option available
-                        if (
-                            !isset($val['itemtype']) || !in_array($val['itemtype'], $meta_ok)
-                            || !isset($opt[$val['field']])
-                        ) {
-                            $partial_load = true;
-                        } else {
-                            $query_tab['metacriteria'][$new_key] = $val;
-                            $new_key++;
-                        }
-                    }
-                }
-               // Display message
-                if (
-                    $enable_partial_warnings
-                    && $partial_load
-                    && Session::getCurrentInterface() != "helpdesk"
-                ) {
-                    Session::addMessageAfterRedirect(
-                        htmlescape(sprintf(__('Partial load of the saved search: %s'), $this->getName())),
-                        false,
-                        ERROR
-                    );
-                }
-               // add reset value
-                $query_tab['reset'] = 'reset';
-                break;
-        }
-        return $query_tab;
-    }
-
-    /**
      * Load a saved search
      *
      * @param integer $ID ID of the saved search
@@ -574,7 +470,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
         $query_tab = [];
         parse_str($this->fields["query"], $query_tab);
         $query_tab['savedsearches_id'] = $ID;
-        return $this->prepareQueryToUse($this->fields["type"], $query_tab);
+        return $query_tab;
     }
 
     /**
@@ -686,11 +582,10 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
      *
      * @param string $itemtype if given filter saved search by only this one
      * @param bool   $inverse if true, the `itemtype` params filter by "not" criteria
-     * @param bool   $enable_partial_warnings display warning messages about partial loading
      *
      * @return array
      */
-    public function getMine(?string $itemtype = null, bool $inverse = false, bool $enable_partial_warnings = true): array
+    public function getMine(?string $itemtype = null, bool $inverse = false): array
     {
         /** @var \DBmysql $DB */
         global $DB;
@@ -742,7 +637,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
                 $count = null;
                 $search_data = null;
                 try {
-                    $search_data = $this->execute(false, $enable_partial_warnings);
+                    $search_data = $this->execute();
                 } catch (\Throwable $e) {
                     ErrorHandler::getInstance()->handleException($e, false);
                     $error = true;
@@ -805,17 +700,16 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
     /**
      * return Html list of saved searches for a given itemtype
      *
-     * @param string $itemtype
+     * @param string|null $itemtype
      * @param bool   $inverse
-     * @param bool   $enable_partial_warnings display warning messages about partial loading
      *
      * @return void
      */
-    public function displayMine(?string $itemtype = null, bool $inverse = false, bool $enable_partial_warnings = true)
+    public function displayMine(?string $itemtype = null, bool $inverse = false)
     {
         TemplateRenderer::getInstance()->display('layout/parts/saved_searches_list.html.twig', [
             'active'         => $_SESSION['glpi_loaded_savedsearch'] ?? "",
-            'saved_searches' => $this->getMine($itemtype, $inverse, $enable_partial_warnings),
+            'saved_searches' => $this->getMine($itemtype, $inverse),
         ]);
     }
 
@@ -1122,13 +1016,12 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
      *
      * @param boolean $force Force query execution even if it should not be executed
      *                       (default false)
-     * @param boolean $enable_partial_warnings display warning messages about partial loading
      *
      * @throws RuntimeException
      *
      * @return array|null
      **/
-    public function execute($force = false, bool $enable_partial_warnings = true)
+    public function execute($force = false)
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
@@ -1145,18 +1038,12 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
             $query_tab = [];
             parse_str($this->getField('query'), $query_tab);
 
-            $params = null;
-            if (class_exists($this->getField('itemtype'))) {
-                $params = $this->prepareQueryToUse(
-                    $this->getField('type'),
-                    $query_tab,
-                    $enable_partial_warnings
-                );
-            }
+            $params = class_exists($this->getField('itemtype')) ? $query_tab : null;
 
             if (!$params) {
                 throw new \RuntimeException('Saved search #' . $this->getID() . ' seems to be broken!');
             } else {
+                $params['silent_validation'] = true;
                 $data                   = $search->prepareDatasForSearch(
                     $this->getField('itemtype'),
                     $params

--- a/tests/js/modules/Search/Table.test.js
+++ b/tests/js/modules/Search/Table.test.js
@@ -260,6 +260,9 @@ describe('Search Table', () => {
         window.AjaxMock.addMockResponse(new window.AjaxMockResponse('//ajax/search.php', 'GET', {}, () => {
             return $('div.ajax-container').html();
         }));
+        window.AjaxMock.addMockResponse(new window.AjaxMockResponse('//ajax/displayMessageAfterRedirect.php', 'GET', {}, () => {
+            return {};
+        }));
 
         real_table.getElement().find('th').eq(0).click();
         // Wait for mocked AJAX response to resolve
@@ -275,6 +278,9 @@ describe('Search Table', () => {
             glpilist_limit: '10',
         }, () => {
             return $('div.ajax-container').html();
+        }));
+        window.AjaxMock.addMockResponse(new window.AjaxMockResponse('//ajax/displayMessageAfterRedirect.php', 'GET', {}, () => {
+            return {};
         }));
         real_table.getElement().closest('form').find('select.search-limit-dropdown').first().val(10).trigger('change');
 
@@ -296,6 +302,9 @@ describe('Search Table', () => {
             'as_map': '0',
         }, () => {
             return $('div.ajax-container').html();
+        }));
+        window.AjaxMock.addMockResponse(new window.AjaxMockResponse('//ajax/displayMessageAfterRedirect.php', 'GET', {}, () => {
+            return {};
         }));
         real_table.getElement().closest('.search-container').find('form.search-form-container button[name="search"]').trigger('click');
         // Wait for mocked AJAX response to resolve
@@ -346,6 +355,9 @@ describe('Search Table', () => {
     test('Reload after refresh exception', async () => {
         window.AjaxMock.addMockResponse(new window.AjaxMockResponse('//ajax/search.php', 'GET', {}, () => {
             return $('div.ajax-container').html();
+        }));
+        window.AjaxMock.addMockResponse(new window.AjaxMockResponse('//ajax/displayMessageAfterRedirect.php', 'GET', {}, () => {
+            return {};
         }));
         const get_itemtype = jest.spyOn(real_table, 'getItemtype');
         get_itemtype.mockImplementation(() => {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | maybe
| New feature?  | -
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Adds a validation pass after the `QueryBuilder` is done building the search parameters array before it is sent to the data provider (`SQLProvider`). If a criterion refers to an invalid search option (typo in API request, missing plugin, bad saved search, etc), it is removed and a warning will be displayed to the user that states "Some search criteria were removed because they are invalid". Invalid sorts are silently discarded currently.

Since the legacy API uses the search engine as if it were a request from the web, but without the output, this PR adds validation to it too. Does not apply to High-Level API which doesn't use search option IDs and validates RSQL filters already.

This PR also changes how session messages are handled a little. Rather than calling for the display of the messages when the page begins to load, it is now done at the end so that messages generated during that page request can be displayed immediately rather than waiting for the next page load. Performing an AJAX search also now displays pending messages.