### PR TITLE
[HLAPI] Use static list of state types

### DIFF
--- a/src/Glpi/Api/HL/Controller/DropdownController.php
+++ b/src/Glpi/Api/HL/Controller/DropdownController.php
@@ -137,7 +137,20 @@ final class DropdownController extends AbstractController
                 'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
             ]
         ];
-        $visiblities = array_map('strtolower', $CFG_GLPI['state_types']);
+
+        // Uses static array for BC/stability. Plugins adding new types should use the related hook to modify the API schema
+        $state_types = [
+            'Computer', 'Monitor', 'NetworkEquipment',
+            'Peripheral', 'Phone', 'Printer', 'SoftwareLicense',
+            'Certificate', 'Enclosure', 'PDU', 'Line',
+            'Rack', 'SoftwareVersion', 'Cluster', 'Contract',
+            'Appliance', 'DatabaseInstance', 'Cable', 'Unmanaged', 'PassiveDCEquipment'
+        ];
+        $visiblities = [];
+        foreach ($state_types as $state_type) {
+            // Handle any cases where there may be a namespace and also make the property lowercase
+            $visiblities[$state_type] = strtolower(str_replace('\\', '_', $state_type));
+        }
 
         $schemas['State_Visibilities'] = [
             'type' => Doc\Schema::TYPE_OBJECT,
@@ -148,7 +161,7 @@ final class DropdownController extends AbstractController
             'x-full-schema' => 'State_Visibilities',
         ];
 
-        foreach ($visiblities as $visiblity) {
+        foreach ($visiblities as $state_type => $visiblity) {
             $schemas['State_Visibilities']['properties'][$visiblity] = [
                 'type' => Doc\Schema::TYPE_BOOLEAN,
                 'x-field' => 'is_visible',
@@ -159,7 +172,7 @@ final class DropdownController extends AbstractController
                     'field' => 'items_id',
                     'condition' => [
                         'itemtype' => 'State',
-                        'visible_itemtype' => $visiblity
+                        'visible_itemtype' => $state_type
                     ]
                 ]
             ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature? | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

For proper stability/versioning, we should use a static list of state types instead of the CFG_GLPI array. This PR also handles the conversion of class names to visibility property names. As seen when testing GraphQL locally previously when there is a custom asset defined, the GraphQL schema being generated was invalid because the slashes from the class name were being kept in property names.

If plugins add new state types, they should use the `REDEFINE_API_SCHEMAS` hook to add the new visibility properties to the schema.