### PR TITLE
Fix(Dashbaord): add missing browser tab title when dashboard embedded

### DIFF
--- a/front/central.php
+++ b/front/central.php
@@ -46,7 +46,7 @@ include('../inc/includes.php');
 if (isset($_GET["embed"]) && isset($_GET["dashboard"])) {
     $grid      = new Glpi\Dashboard\Grid($_GET["dashboard"]);
     $dashboard = $grid->getDashboard();
-    Html::zeroSecurityIframedHeader('central', 'central');
+    Html::zeroSecurityIframedHeader($grid->getDashboard()->getTitle(), 'central', 'central');
     echo $grid->embed($_REQUEST);
     Html::popFooter();
     exit;

--- a/src/Html.php
+++ b/src/Html.php
@@ -2132,6 +2132,7 @@ HTML;
      * @return void
      */
     public static function zeroSecurityIframedHeader(
+        string $title = "",
         string $sector = "none",
         string $item = "none",
         string $option = ""
@@ -2144,7 +2145,7 @@ HTML;
         }
         $HEADER_LOADED = true;
 
-        self::includeHeader('', $sector, $item, $option, true, true);
+        self::includeHeader($title, $sector, $item, $option, true, true);
         echo "<body class='iframed'>";
         self::displayMessageAfterRedirect();
         echo "<div id='page'>";


### PR DESCRIPTION
When dashboard is embedded 

![image](https://github.com/glpi-project/glpi/assets/7335054/009b2992-8c20-4f79-a58d-a1d1b42e3248)


browser tab ```title``` is missing

![image](https://github.com/glpi-project/glpi/assets/7335054/7b564621-abd3-4450-8996-b716be3ce20e)

This PR fix this

![image](https://github.com/glpi-project/glpi/assets/7335054/8221b46e-807f-4a8e-9038-0e58c944571b)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #33588
