### PR TITLE
feat(rules): update reset rules modal and restrict button display

### DIFF
--- a/src/Glpi/Marketplace/View.php
+++ b/src/Glpi/Marketplace/View.php
@@ -899,8 +899,9 @@ HTML;
                                        data-bs-dismiss="modal">
                                        ' . _x("button", "Uninstall") . '
                                    </a>',
-                                __s('By uninstalling the "%s" plugin you will lose all the data of the plugin.'),
-                                htmlspecialchars($plugin_inst->getField('name'))
+                'content' => sprintf(
+                    __s('By uninstalling the "%s" plugin you will lose all the data of the plugin.'),
+                    htmlspecialchars($plugin_inst->getField('name'))
                 )
             ]);
 

--- a/src/Glpi/Marketplace/View.php
+++ b/src/Glpi/Marketplace/View.php
@@ -884,13 +884,16 @@ HTML;
                 }
             }
 
+            $uninstall_label = __s("Uninstall");
+            $buttons .= <<<HTML
+                <button data-bs-toggle="modal"
+                        data-bs-target="#uninstallModal{$plugin_inst->getField('directory')}"
+                        title="{$uninstall_label}">
+                    <i class="ti ti-folder-x"></i>
+                </button>
+            HTML;
             $buttons .= TemplateRenderer::getInstance()->render('components/danger_modal.html.twig', [
                 'modal_id' => 'uninstallModal' . $plugin_inst->getField('directory'),
-                'open_btn' => '<button data-bs-toggle="modal"
-                                       data-bs-target="#uninstallModal' . $plugin_inst->getField('directory') . '"
-                                       title="' . __s('Uninstall') . '">
-                                   <i class="ti ti-folder-x"></i>
-                               </button>',
                 'confirm_btn' => '<a href="#" class="btn btn-danger w-100 modify_plugin"
                                        data-action="uninstall_plugin"
                                        data-bs-dismiss="modal">

--- a/src/Glpi/Marketplace/View.php
+++ b/src/Glpi/Marketplace/View.php
@@ -884,19 +884,22 @@ HTML;
                 }
             }
 
-            $buttons .= TemplateRenderer::getInstance()->render('components/plugin_uninstall_modal.html.twig', [
-                'plugin_name' => $plugin_inst->getField('name'),
+            $buttons .= TemplateRenderer::getInstance()->render('components/danger_modal.html.twig', [
                 'modal_id' => 'uninstallModal' . $plugin_inst->getField('directory'),
                 'open_btn' => '<button data-bs-toggle="modal"
                                        data-bs-target="#uninstallModal' . $plugin_inst->getField('directory') . '"
                                        title="' . __s('Uninstall') . '">
                                    <i class="ti ti-folder-x"></i>
                                </button>',
-                'uninstall_btn' => '<a href="#" class="btn btn-danger w-100 modify_plugin"
+                'confirm_btn' => '<a href="#" class="btn btn-danger w-100 modify_plugin"
                                        data-action="uninstall_plugin"
                                        data-bs-dismiss="modal">
                                        ' . _x("button", "Uninstall") . '
                                    </a>',
+                'content' => sprintf(
+                    __('By uninstalling the "%s" plugin you will lose all the data of the plugin.'),
+                    $plugin_inst->getField('name')
+                )
             ]);
 
             if (!strlen($error) && $is_actived && $config_page) {

--- a/src/Glpi/Marketplace/View.php
+++ b/src/Glpi/Marketplace/View.php
@@ -891,7 +891,7 @@ HTML;
                         title="{$uninstall_label}">
                     <i class="ti ti-folder-x"></i>
                 </button>
-            HTML;
+HTML;
             $buttons .= TemplateRenderer::getInstance()->render('components/danger_modal.html.twig', [
                 'modal_id' => 'uninstallModal' . $plugin_inst->getField('directory'),
                 'confirm_btn' => '<a href="#" class="btn btn-danger w-100 modify_plugin"

--- a/src/Glpi/Marketplace/View.php
+++ b/src/Glpi/Marketplace/View.php
@@ -896,9 +896,8 @@ HTML;
                                        data-bs-dismiss="modal">
                                        ' . _x("button", "Uninstall") . '
                                    </a>',
-                'content' => sprintf(
-                    __('By uninstalling the "%s" plugin you will lose all the data of the plugin.'),
-                    $plugin_inst->getField('name')
+                                __s('By uninstalling the "%s" plugin you will lose all the data of the plugin.'),
+                                htmlspecialchars($plugin_inst->getField('name'))
                 )
             ]);
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2561,7 +2561,7 @@ class Plugin extends CommonDBTM
                                 title="{$uninstall_label}">
                                 <span class="sr-only">{$uninstall_label}</span>
                             </span></a>
-                        TWIG;
+TWIG;
 
                         $output .= TemplateRenderer::getInstance()->render('components/danger_modal.html.twig', [
                             'modal_id' => 'uninstallModal' . $plugin->getField('directory'),

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2553,14 +2553,18 @@ class Plugin extends CommonDBTM
                 if (in_array($state, [self::ACTIVATED, self::NOTUPDATED, self::TOBECONFIGURED, self::NOTACTIVATED], true)) {
                    // Uninstall button for installed plugins
                     if (function_exists("plugin_" . $directory . "_uninstall")) {
+                        $uninstall_label = __s("Uninstall");
+                        $output .= <<<TWIG
+                            <a class="pointer"><span class="fas fa-fw fa-folder-minus fa-2x me-1"
+                                data-bs-toggle="modal"
+                                data-bs-target="#uninstallModal{$plugin->getField('directory')}"
+                                title="{$uninstall_label}">
+                                <span class="sr-only">{$uninstall_label}</span>
+                            </span></a>
+                        TWIG;
+
                         $output .= TemplateRenderer::getInstance()->render('components/danger_modal.html.twig', [
                             'modal_id' => 'uninstallModal' . $plugin->getField('directory'),
-                            'open_btn' => '<a class="pointer"><span class="fas fa-fw fa-folder-minus fa-2x me-1"
-                                                  data-bs-toggle="modal"
-                                                  data-bs-target="#uninstallModal' . $plugin->getField('directory') . '"
-                                                  title="' . __s("Uninstall") . '">
-                                                  <span class="sr-only">' . __s("Uninstall") . '</span>
-                                              </span></a>',
                             'confirm_btn' => Html::getSimpleForm(
                                 static::getFormURL(),
                                 ['action' => 'uninstall'],

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2553,8 +2553,7 @@ class Plugin extends CommonDBTM
                 if (in_array($state, [self::ACTIVATED, self::NOTUPDATED, self::TOBECONFIGURED, self::NOTACTIVATED], true)) {
                    // Uninstall button for installed plugins
                     if (function_exists("plugin_" . $directory . "_uninstall")) {
-                        $output .= TemplateRenderer::getInstance()->render('components/plugin_uninstall_modal.html.twig', [
-                            'plugin_name' => $plugin->getField('name'),
+                        $output .= TemplateRenderer::getInstance()->render('components/danger_modal.html.twig', [
                             'modal_id' => 'uninstallModal' . $plugin->getField('directory'),
                             'open_btn' => '<a class="pointer"><span class="fas fa-fw fa-folder-minus fa-2x me-1"
                                                   data-bs-toggle="modal"
@@ -2562,7 +2561,7 @@ class Plugin extends CommonDBTM
                                                   title="' . __s("Uninstall") . '">
                                                   <span class="sr-only">' . __s("Uninstall") . '</span>
                                               </span></a>',
-                            'uninstall_btn' => Html::getSimpleForm(
+                            'confirm_btn' => Html::getSimpleForm(
                                 static::getFormURL(),
                                 ['action' => 'uninstall'],
                                 _x('button', 'Uninstall'),
@@ -2570,6 +2569,10 @@ class Plugin extends CommonDBTM
                                 '',
                                 'class="btn btn-danger w-100"'
                             ),
+                            'content' => sprintf(
+                                __('By uninstalling the "%s" plugin you will lose all the data of the plugin.'),
+                                $plugin->getField('name')
+                            )
                         ]);
                     } else {
                        //TRANS: %s is the list of missing functions

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2570,8 +2570,8 @@ class Plugin extends CommonDBTM
                                 'class="btn btn-danger w-100"'
                             ),
                             'content' => sprintf(
-                                __('By uninstalling the "%s" plugin you will lose all the data of the plugin.'),
-                                $plugin->getField('name')
+                                __s('By uninstalling the "%s" plugin you will lose all the data of the plugin.'),
+                                htmlspecialchars($plugin->getField('name'))
                             )
                         ]);
                     } else {

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -622,7 +622,6 @@ HTML;
                     {% endset %}
 
                     {{ include('components/danger_modal.html.twig', {
-                        'open_btn': open_btn,
                         'modal_id': 'reset_rules',
                         'confirm_btn': reset_btn,
                         'content': reset_warning

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -611,11 +611,9 @@ HTML;
         echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
             <div class="d-flex justify-content-center">
                 {% if can_reset %}
-                    {% set open_btn %}
-                        <button type="button" class="btn btn-ghost-danger mx-1" data-bs-toggle="modal" data-bs-target="#reset_rules">
-                            {{ reset_label }}
-                        </button>
-                    {% endset %}
+                    <button type="button" class="btn btn-ghost-danger mx-1" data-bs-toggle="modal" data-bs-target="#reset_rules">
+                        {{ reset_label }}
+                    </button>
 
                     {% set reset_btn %}
                         <a class="btn btn-danger w-100" role="button" href="{{ rule_class|itemtype_search_path }}?reinit=true&subtype={{ rule_class }}">
@@ -623,15 +621,11 @@ HTML;
                         </a>
                     {% endset %}
 
-                    {% set content %}
-                        <p>{{ reset_warning }}</p>
-                    {% endset %}
-
                     {{ include('components/danger_modal.html.twig', {
                         'open_btn': open_btn,
                         'modal_id': 'reset_rules',
                         'confirm_btn': reset_btn,
-                        'content': content
+                        'content': reset_warning
                     }) }}
                 {% endif %}
                 <button type="button" class="btn btn-primary mx-1" data-bs-toggle="modal" data-bs-target="#allruletest">{{ test_label }}</button>

--- a/templates/components/danger_modal.html.twig
+++ b/templates/components/danger_modal.html.twig
@@ -31,9 +31,6 @@
  # ---------------------------------------------------------------------
  #}
 
-<!-- Button trigger modal -->
-{{ open_btn|raw }}
-
 <!-- Modal -->
 <div class="modal fade" id="{{ modal_id }}" tabindex="-1" role="dialog" aria-hidden="true">
     <div class="modal-dialog" role="document">
@@ -45,7 +42,7 @@
                 <svg xmlns="http://www.w3.org/2000/svg" class="icon mb-2 text-danger icon-lg" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path d="M12 9v4"></path><path d="M10.363 3.591l-8.106 13.534a1.914 1.914 0 0 0 1.636 2.871h16.214a1.914 1.914 0 0 0 1.636 -2.87l-8.106 -13.536a1.914 1.914 0 0 0 -3.274 0z"></path><path d="M12 16h.01"></path></svg>
                 <h3>{{ title|default(_x('button', 'Are you sure?')) }}</h3>
                 <div class="text-muted">
-                    {{ content|raw }}
+                    {{ content }}
                 </div>
             </div>
             <div class="modal-footer">

--- a/templates/components/danger_modal.html.twig
+++ b/templates/components/danger_modal.html.twig
@@ -42,9 +42,11 @@
             <div class="modal-status bg-danger"></div>
             <div
                 class="modal-body text-center py-4">
-                <i class="fa-2x ti ti-alert-triangle mb-2 text-danger"></i>
-                <h3>{{ _x('button', 'Are you sure?') }}</h3>
-                <div class="text-muted">{{ __('By uninstalling the "%s" plugin you will lose all the data of the plugin.')|format(plugin_name) }}</div>
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon mb-2 text-danger icon-lg" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path d="M12 9v4"></path><path d="M10.363 3.591l-8.106 13.534a1.914 1.914 0 0 0 1.636 2.871h16.214a1.914 1.914 0 0 0 1.636 -2.87l-8.106 -13.536a1.914 1.914 0 0 0 -3.274 0z"></path><path d="M12 16h.01"></path></svg>
+                <h3>{{ title|default(_x('button', 'Are you sure?')) }}</h3>
+                <div class="text-muted">
+                    {{ content|raw }}
+                </div>
             </div>
             <div class="modal-footer">
                 <div class="w-100">
@@ -55,7 +57,7 @@
                             </a>
                         </div>
                         <div class="col">
-                            {{ uninstall_btn|raw }}
+                            {{ confirm_btn|raw }}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33542

Rules reset button changed to danger style.
Original neutral modal replaced by danger modal.
Button displayed only if user is on root entity and has configuration modification rights.

![image](https://github.com/glpi-project/glpi/assets/42278610/92339004-1a6a-4fe9-85fd-941db927ffaa)
