### PR TITLE
Planning - Fix external events resizing issue

### DIFF
--- a/js/planning.js
+++ b/js/planning.js
@@ -880,7 +880,7 @@ var GLPIPlanning  = {
             && recurringDef.typeData.origOptions.dtstart !== start
         ) {
             let startDate = new Date(start);
-            let dtstart = recurringDef.typeData._dtstart ?? recurringDef.typeData.origOptions.dtstart;
+            let dtstart = recurringDef.typeData._dtstart || recurringDef.typeData.origOptions.dtstart;
             let originDate = new Date(dtstart);
 
             let hours = startDate.getHours();

--- a/js/planning.js
+++ b/js/planning.js
@@ -849,6 +849,7 @@ var GLPIPlanning  = {
         var event      = info.event;
         var revertFunc = info.revert;
         var extProps   = event.extendedProps;
+        var recurringDef = event._def.recurringDef;
 
         var old_itemtype = null;
         var old_items_id = null;
@@ -871,6 +872,28 @@ var GLPIPlanning  = {
 
         var start = event.start;
         var end   = event.end;
+
+        if (
+            !move_instance
+            && recurringDef
+            && recurringDef.typeData
+            && recurringDef.typeData.origOptions.dtstart !== start
+        ) {
+            let startDate = new Date(start);
+            let dtstart = recurringDef.typeData._dtstart ?? recurringDef.typeData.origOptions.dtstart;
+            let originDate = new Date(dtstart);
+
+            let hours = startDate.getHours();
+            let minutes = startDate.getMinutes();
+
+            originDate.setHours(hours, minutes);
+
+            start = originDate;
+
+            let duration = end - event.start;
+            end = new Date(start.getTime() + duration);
+        }
+
         if (typeof end === 'undefined' || end === null) {
             end = new Date(start.getTime());
             if (event.allDay) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33543

We create an external event with repetition over 3 days, for example. You end up with 3 elements in the schedule.

![image](https://github.com/glpi-project/glpi/assets/102067890/f739728b-9584-40ae-8423-517b20f6949e)

If you extend the first element and choose to modify the whole series, everything works fine, but if you extend the 2nd or 3rd, all the previous elements will be deleted. 

![image](https://github.com/glpi-project/glpi/assets/102067890/ecb0cbec-5030-413b-a230-9566c9461506)
