### PR TITLE
Fix flaky tests

### DIFF
--- a/tests/cypress.config.js
+++ b/tests/cypress.config.js
@@ -34,8 +34,6 @@
 const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
-    defaultCommandTimeout: 10000,
-    retries: 2,
     viewportWidth: 1920,
     viewportHeight: 1080,
     experimentalStudio: true,

--- a/tests/cypress/e2e/form/form_preview.cy.js
+++ b/tests/cypress/e2e/form/form_preview.cy.js
@@ -48,15 +48,17 @@ describe('Form preview', () => {
 
     function checkPreviewButton() {
         // Check the preview button
+        cy.findByRole('button', { 'name': 'Preview' }).should('not.exist');
         cy.findByRole('button', { 'name': 'Save and preview' }).should('exist');
 
         // Save the form and check the preview button
-        cy.findByRole('button', { 'name': 'Save' }).click({ force: true });
+        cy.findByRole('button', { 'name': 'Save' }).click();
         cy.findByRole('alert')
             .should('contain.text', 'Item successfully updated')
             .within(() => {
                 cy.findByRole('button', { 'name': 'Close' }).click();
             });
+        cy.findByRole('link', { 'name': 'Save and preview' }).should('not.exist');
         cy.findByRole('link', { 'name': 'Preview' }).should('exist');
     }
 
@@ -85,14 +87,14 @@ describe('Form preview', () => {
     */
     it('Test form preview unsaved changes handling in sections', () => {
         // Add a new question
-        cy.findByRole('button', { 'name': 'Add a new question' }).click({ force: true });
+        cy.findByRole('button', { 'name': 'Add a new question' }).click();
         checkPreviewButton();
 
         // Focus question
         cy.findByRole('textbox', { 'name': 'Question name' }).click();
 
         // Add a new section
-        cy.findByRole('button', { 'name': 'Add a new section' }).click({ force: true });
+        cy.findByRole('button', { 'name': 'Add a new section' }).click();
         checkPreviewButton();
 
         cy.findAllByRole('region', { 'name': 'Form section' }).first().within(() => {
@@ -135,7 +137,7 @@ describe('Form preview', () => {
         };
 
         // Add a new question
-        cy.findByRole('button', { 'name': 'Add a new question' }).click({ force: true });
+        cy.findByRole('button', { 'name': 'Add a new question' }).click();
         check();
 
         // Edit the question name
@@ -185,7 +187,7 @@ describe('Form preview', () => {
         };
 
         // Add a new comment
-        cy.findByRole('button', { 'name': 'Add a new comment' }).click({ force: true });
+        cy.findByRole('button', { 'name': 'Add a new comment' }).click();
 
         // Edit the comment name
         cy.findByRole('textbox', { 'name': 'Comment title' }).type('Test comment');


### PR DESCRIPTION
Previous PR added a global retries for each failed E2E tests, which I think is not ideal as the "retry" feature is meant to help with external components that may fail (like an external API) and we have none yet.

The small changes I've made seems to be enough to prevent random failure (tests worked 10 times in a row yesterday when before it would fail 50% of the time).

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
