### PR TITLE
Fix ambiguous status column in query

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -5333,7 +5333,7 @@ JAVASCRIPT;
 
         $criteria = self::getCommonCriteria();
         $criteria['WHERE'] = [
-            'status'       => self::INCOMING,
+            self::getTable() . '.status'       => self::INCOMING,
             'is_deleted'   => 0
         ] + getEntitiesRestrictCriteria(self::getTable());
         $criteria['LIMIT'] = (int)$_SESSION['glpilist_limit'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #17422

The addition of validations to the ticket common criteria made the status column ambiguous for the new ticket list which is shown when the "Show new tickets on the home page" preference is enabled.