### PR TITLE
Remove ProjectTask search restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ The present file will list all changes made to the project; according to the
 - Warranty expiration alerts no longer trigger for deleted items.
 - New UI for searching for Ticket/Change/Problem solutions from the Knowledgebase.
 - Validations are only allowed on Tickets and Changes that are not solved or closed.
+- Searching project tasks in the legacy API is no longer restricted to only tasks the user is assigned to.
 
 ### Deprecated
 - Survey URL tags `TICKETCATEGORY_ID` and `TICKETCATEGORY_NAME` are deprecated and replaced by `ITILCATEGORY_ID` and `ITILCATEGORY_NAME` respectively.

--- a/phpunit/functional/ProjectTest.php
+++ b/phpunit/functional/ProjectTest.php
@@ -645,4 +645,22 @@ PLAINTEXT;
         // Check if a group with a project, assigned to a group project team, returns an empty array when $search_in_team is false
         $this->assertEmpty(\Project::getActiveProjectIDsForGroup([$group->getID()], false));
     }
+
+    public function testMyTasksURL()
+    {
+        $this->login('post-only', 'postonly');
+        $_SESSION['glpiactiveprofile']['projecttask'] = \ProjectTask::READMY;
+        $this->string(\Project::getAdditionalMenuContent()['project']['page'])->isIdenticalTo(\ProjectTask::getMyTasksURL(false));
+
+        $this->login();
+        $this->boolean(\Project::getAdditionalMenuContent())->isFalse();
+
+        $menu_options = \Project::getAdditionalMenuOptions();
+        $this->string($menu_options['task']['page'])->isIdenticalTo(\ProjectTask::getMyTasksURL(false));
+        $this->string($menu_options['task']['links']['search'])->isIdenticalTo(\ProjectTask::getMyTasksURL(false));
+
+        $menu_links = \Project::getAdditionalMenuLinks();
+        $has_my_tasks_link = in_array(\ProjectTask::getMyTasksURL(false), $menu_links, true);
+        $this->boolean($has_my_tasks_link)->isTrue();
+    }
 }

--- a/phpunit/functional/ProjectTest.php
+++ b/phpunit/functional/ProjectTest.php
@@ -648,19 +648,24 @@ PLAINTEXT;
 
     public function testMyTasksURL()
     {
-        $this->login('post-only', 'postonly');
-        $_SESSION['glpiactiveprofile']['projecttask'] = \ProjectTask::READMY;
-        $this->string(\Project::getAdditionalMenuContent()['project']['page'])->isIdenticalTo(\ProjectTask::getMyTasksURL(false));
-
+        // Allowed to read all projects -> no specific additional menu content
         $this->login();
-        $this->boolean(\Project::getAdditionalMenuContent())->isFalse();
+        $this->assertFalse(\Project::getAdditionalMenuContent());
+
+        // Only allowed to read own tasks -> specific additional menu content
+        $this->login();
+        $_SESSION['glpiactiveprofile']['project'] = 0;
+        $_SESSION['glpiactiveprofile']['projecttask'] = \ProjectTask::READMY;
+
+        $this->assertEquals(\ProjectTask::getMyTasksURL(false), \Project::getAdditionalMenuContent()['project']['page']);
 
         $menu_options = \Project::getAdditionalMenuOptions();
-        $this->string($menu_options['task']['page'])->isIdenticalTo(\ProjectTask::getMyTasksURL(false));
-        $this->string($menu_options['task']['links']['search'])->isIdenticalTo(\ProjectTask::getMyTasksURL(false));
+
+        $this->assertEquals(\ProjectTask::getMyTasksURL(false), $menu_options['ProjectTask']['page']);
+        $this->assertEquals(\ProjectTask::getMyTasksURL(false), $menu_options['ProjectTask']['links']['search']);
 
         $menu_links = \Project::getAdditionalMenuLinks();
         $has_my_tasks_link = in_array(\ProjectTask::getMyTasksURL(false), $menu_links, true);
-        $this->boolean($has_my_tasks_link)->isTrue();
+        $this->assertTrue($has_my_tasks_link);
     }
 }

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -665,26 +665,52 @@ final class SQLProvider implements SearchProviderInterface
                 break;
 
             case 'ProjectTask':
-                $teamtable  = 'glpi_projecttaskteams';
-                $group_criteria = [];
-                if (count($_SESSION['glpigroups'])) {
-                    $group_criteria = [
-                        "$teamtable.itemtype" => Group::class,
-                        "$teamtable.items_id" => $_SESSION['glpigroups']
+                if (!Session::haveRightsOr('project', [\Project::READALL, \Project::READMY])) {
+                    // Can only see the tasks assigned to the user or one of his groups
+                    $teamtable = 'glpi_projecttaskteams';
+                    $group_criteria = [];
+                    if (count($_SESSION['glpigroups'])) {
+                        $group_criteria = [
+                            "$teamtable.itemtype" => Group::class,
+                            "$teamtable.items_id" => $_SESSION['glpigroups']
+                        ];
+                    }
+                    $user_criteria = [
+                        "$teamtable.itemtype" => User::class,
+                        "$teamtable.items_id" => Session::getLoginUserID()
                     ];
-                }
-                $user_criteria = [
-                    "$teamtable.itemtype" => User::class,
-                    "$teamtable.items_id" => Session::getLoginUserID()
-                ];
-                $criteria = [
-                    "glpi_projects.is_template" => 0,
-                    'OR' => [
-                        $user_criteria
-                    ]
-                ];
-                if (!empty($group_criteria)) {
-                    $criteria['OR'][] = $group_criteria;
+                    $criteria = [
+                        "glpi_projects.is_template" => 0,
+                        'OR' => [
+                            $user_criteria
+                        ]
+                    ];
+                    if (!empty($group_criteria)) {
+                        $criteria['OR'][] = $group_criteria;
+                    }
+                } else if (Session::haveRight('project', \Project::READMY)) {
+                    // User must be the manager, in the manager group or in the project team
+                    $teamtable = 'glpi_projectteams';
+                    $group_criteria = [];
+                    if (count($_SESSION['glpigroups'])) {
+                        $group_criteria = [
+                            "$teamtable.itemtype" => Group::class,
+                            "$teamtable.items_id" => $_SESSION['glpigroups']
+                        ];
+                    }
+                    $user_criteria = [
+                        "$teamtable.itemtype" => User::class,
+                        "$teamtable.items_id" => Session::getLoginUserID()
+                    ];
+                    $criteria = [
+                        'OR' => [
+                            $user_criteria,
+                            'glpi_projects.users_id' => Session::getLoginUserID()
+                        ]
+                    ];
+                    if (!empty($group_criteria)) {
+                        $criteria['OR'][] = $group_criteria;
+                    }
                 }
                 break;
 
@@ -1986,6 +2012,16 @@ final class SQLProvider implements SearchProviderInterface
                     $already_link_tables,
                     "glpi_projecttaskteams",
                     "projecttaskteams_id",
+                    0,
+                    0,
+                    ['jointype' => 'child']
+                ));
+                $out = array_merge_recursive($out, self::getLeftJoinCriteria(
+                    $itemtype,
+                    'glpi_projects',
+                    $already_link_tables,
+                    "glpi_projectteams",
+                    "projectteams_id",
                     0,
                     0,
                     ['jointype' => 'child']

--- a/src/Project.php
+++ b/src/Project.php
@@ -212,7 +212,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
             && Session::haveRight('projecttask', ProjectTask::READMY)
         ) {
             $menu['project']['title'] = self::getTypeName(Session::getPluralNumber());
-            $menu['project']['page']  = ProjectTask::getSearchURL(false);
+            $menu['project']['page']  = ProjectTask::getMyTasksURL(false);
 
             return $menu;
         }
@@ -224,9 +224,9 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
         return [
             ProjectTask::class => [
                 'title' => __('My tasks'),
-                'page'  => ProjectTask::getSearchURL(false),
+                'page'  => ProjectTask::getMyTasksURL(false),
                 'links' => [
-                    'search' => ProjectTask::getSearchURL(false),
+                    'search' => ProjectTask::getMyTasksURL(false),
                 ]
             ]
         ];
@@ -246,7 +246,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
             </span>
          ';
 
-            $links[$pic_validate] = ProjectTask::getSearchURL(false);
+            $links[$pic_validate] = ProjectTask::getMyTasksURL(false);
 
             $links['summary_kanban'] = self::getFormURL(false) . '?showglobalkanban=1';
         }

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -155,6 +155,25 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
         return false;
     }
 
+    public static function getMyTasksURL(bool $full)
+    {
+        return self::getSearchURL($full) . '?' . Toolbox::append_params([
+            'criteria' => [
+                [
+                    'field' => 87,
+                    'searchtype' => 'equals',
+                    'value' => 'myself'
+                ],
+                [
+                    'link' => 'OR',
+                    'field' => 88,
+                    'searchtype' => 'equals',
+                    'value' => 'mygroups'
+                ]
+            ]
+        ]);
+    }
+
     public function cleanDBonPurge()
     {
         $this->deleteChildrenAndRelationsFromDb(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

Remove hidden restriction when searching project tasks that only allowed assigned tasks to be visible. Now, it can show all tasks that the user has access to see.

The "My tasks" button shown on project pages now explicitly loads the search results with the task team criteria that used to be hidden.

This PR also means that the legacy API will now allow searching all project tasks, not just the assigned ones.