### PR TITLE
Fix impact edit button escaping

### DIFF
--- a/js/impact.js
+++ b/js/impact.js
@@ -1381,8 +1381,8 @@ var GLPIImpact = {
             },
             {
                 id             : 'editEdge',
-                content        : '<i class="fas fa-edit me-2"></i>' + _.escape(__("Edge properties...")),
-                tooltipText    : _.escape(__("Set name for this edge")),
+                content        : '<i class="fas fa-edit me-2"></i>' + __("Edge properties..."),
+                tooltipText    : _.unescape(__("Set name for this edge")),
                 selector       : 'edge',
                 onClickFunction: this.menuOnEditEdge,
                 show           : !this.readonly,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`__()` alredy escapes strings. See other meu options that are using the same logic.