### PR TITLE
Fix modal appear for plugin installation

### DIFF
--- a/src/Glpi/Marketplace/View.php
+++ b/src/Glpi/Marketplace/View.php
@@ -845,26 +845,32 @@ HTML;
 
         if ($can_run_local_install) {
             $title = __s("Install");
-            $icon  = "ti ti-folder-plus";
+            $icon = "ti ti-folder-plus";
             if ($has_local_update) {
                 $title = __s("Update");
-                $icon  =  "far fa-caret-square-up";
+                $icon = "far fa-caret-square-up";
+                $buttons .= TemplateRenderer::getInstance()->render('components/plugin_update_modal.html.twig', [
+                    'plugin_name' => $plugin_inst->getField('name'),
+                    'to_version' => $plugin_inst->getField('version'),
+                    'modal_id' => 'updateModal' . $plugin_inst->getField('directory'),
+                    'open_btn' => '<button data-bs-toggle="modal"
+                                           data-bs-target="#updateModal' . $plugin_inst->getField('directory') . '"
+                                           title="' . $title . '">
+                                       <i class="' . $icon . '"></i>
+                                   </button>',
+                    'update_btn' => '<a href="#" class="btn btn-info w-100 modify_plugin"
+                                           data-action="install_plugin"
+                                           data-bs-dismiss="modal">
+                                           ' . _x("button", "Update") . '
+                                       </a>',
+                ]);
+            } else {
+                $buttons .= "<button class='modify_plugin'
+                                     data-action='install_plugin'
+                                     title='" . $title . "'>
+                        <i class='$icon'></i>
+                    </button>";
             }
-            $buttons .= TemplateRenderer::getInstance()->render('components/plugin_update_modal.html.twig', [
-                'plugin_name' => $plugin_inst->getField('name'),
-                'to_version' => $plugin_inst->getField('version'),
-                'modal_id' => 'updateModal' . $plugin_inst->getField('directory'),
-                'open_btn' => '<button data-bs-toggle="modal"
-                                       data-bs-target="#updateModal' . $plugin_inst->getField('directory') . '"
-                                       title="' . $title . '">
-                                   <i class="' . $icon . '"></i>
-                               </button>',
-                'update_btn' => '<a href="#" class="btn btn-info w-100 modify_plugin"
-                                       data-action="install_plugin"
-                                       data-bs-dismiss="modal">
-                                       ' . _x("button", "Update") . '
-                                   </a>',
-            ]);
         }
 
         if ($is_installed) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !32713

Fixed PR : #17148

The modal was only supposed to appear for plugin updates, but in plugin Marketplace mode, the modal would also appear when plugins were installed.