### PR TITLE
Fix(Inventory): uses the default status for computers created for VMs

### DIFF
--- a/phpunit/functional/Glpi/Inventory/Assets/VirtualMachine.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/VirtualMachine.php
@@ -803,6 +803,5 @@ class VirtualMachine extends AbstractInventoryAsset
             'uuid' => 'a1234567-89ab-cdef-0123-456789abcdef',
             'states_id' => $inv_states_id
         ]));
-
     }
 }

--- a/phpunit/functional/Glpi/Inventory/Assets/VirtualMachine.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/VirtualMachine.php
@@ -786,18 +786,18 @@ class VirtualMachine extends AbstractInventoryAsset
         $esx_id = $inventory->getItem()->fields['id'];
         $this->assertGreaterThan(0, $esx_id);
 
-        //get two VM
+        //get one VM
         $vm = new \ComputerVirtualMachine();
         $this->assertCount(1, $vm->find());
 
-        //get first ComputervirtualMachine
+        //get related ComputervirtualMachine
         $firlst_vm = new \ComputerVirtualMachine();
         $this->assertTrue($firlst_vm->getFromDBByCrit([
             'uuid' => 'a1234567-89ab-cdef-0123-456789abcdef',
             'computers_id' => $esx_id,
         ]));
 
-        //get related computer with fe040942-926a-e895-13f9-a37fc3607c14 with same state as default configured
+        //get related computer with a1234567-89ab-cdef-0123-456789abcdef with same state as default configured
         $first_computer_linked = new \Computer();
         $this->assertTrue($first_computer_linked->getFromDBByCrit([
             'uuid' => 'a1234567-89ab-cdef-0123-456789abcdef',

--- a/phpunit/functional/Glpi/Inventory/Assets/VirtualMachine.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/VirtualMachine.php
@@ -727,4 +727,82 @@ class VirtualMachine extends AbstractInventoryAsset
         $vm = new \ComputerVirtualMachine();
         $this->assertCount(0, $vm->find());
     }
+
+
+    public function testDefaultStatusForRelatedComputer()
+    {
+        $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+        <REQUEST>
+          <CONTENT>
+            <BIOS>
+              <ASSETTAG></ASSETTAG>
+              <BDATE>2018-02-08T00:00:00Z</BDATE>
+              <BVERSION>1.3.7</BVERSION>
+              <MSN>324DFG567</MSN>
+              <SMANUFACTURER>Dell Inc.</SMANUFACTURER>
+              <SMODEL>PowerEdge R640</SMODEL>
+              <SSN>324DFG567</SSN>
+            </BIOS>
+            <HARDWARE>
+              <DNS>10.100.230.2/10.100.230.4</DNS>
+              <MEMORY>130625</MEMORY>
+              <NAME>ESX-03-DMZ</NAME>
+              <UUID>8c8c8944-0074-5632-7452-b2c04f564712</UUID>
+              <VMSYSTEM>Physical</VMSYSTEM>
+              <WORKGROUP>teclib.fr</WORKGROUP>
+            </HARDWARE>
+            <VERSIONCLIENT>GLPI-Agent_v1.4-1</VERSIONCLIENT>
+            <VIRTUALMACHINES>
+              <COMMENT>Computer VM</COMMENT>
+              <MAC>00:50:56:90:43:42</MAC>
+              <MEMORY>1024</MEMORY>
+              <NAME>SRV-DMZ-EZ</NAME>
+              <STATUS>running</STATUS>
+              <UUID>a1234567-89ab-cdef-0123-456789abcdef</UUID>
+              <VCPU>1</VCPU>
+              <VMTYPE>VMware</VMTYPE>
+            </VIRTUALMACHINES>
+          </CONTENT>
+          <DEVICEID>ESX-03-DMZ.insep.fr-2023-02-02-11-34-53</DEVICEID>
+          <QUERY>INVENTORY</QUERY>
+        </REQUEST>
+        ";
+
+        //change config to import vms as computers
+        $this->login();
+
+        $state = new \State();
+        $inv_states_id = $state->add([
+            'name' => 'Has been inventoried'
+        ]);
+
+        $conf = new \Glpi\Inventory\Conf();
+        $this->assertTrue($conf->saveConf(['vm_as_computer' => 1, 'states_id_default' => $inv_states_id]));
+        $this->logout();
+
+        //computer inventory
+        $inventory = $this->doInventory($xml_source, true);
+
+        $esx_id = $inventory->getItem()->fields['id'];
+        $this->assertGreaterThan(0, $esx_id);
+
+        //get two VM
+        $vm = new \ComputerVirtualMachine();
+        $this->assertCount(1, $vm->find());
+
+        //get first ComputervirtualMachine
+        $firlst_vm = new \ComputerVirtualMachine();
+        $this->assertTrue($firlst_vm->getFromDBByCrit([
+            'uuid' => 'a1234567-89ab-cdef-0123-456789abcdef',
+            'computers_id' => $esx_id,
+        ]));
+
+        //get related computer with fe040942-926a-e895-13f9-a37fc3607c14 with same state as default configured
+        $first_computer_linked = new \Computer();
+        $this->assertTrue($first_computer_linked->getFromDBByCrit([
+            'uuid' => 'a1234567-89ab-cdef-0123-456789abcdef',
+            'states_id' => $inv_states_id
+        ]));
+
+    }
 }

--- a/src/Inventory/Asset/VirtualMachine.php
+++ b/src/Inventory/Asset/VirtualMachine.php
@@ -313,6 +313,7 @@ class VirtualMachine extends InventoryAsset
                     $rule->getCollectionPart();
                     $input = (array)$vm;
                     $input['itemtype'] = \Computer::class;
+                    $input['states_id'] = $this->conf->states_id_default > 0 ? $this->conf->states_id_default : 0;
                     $input['entities_id'] = $this->main_asset->getEntityID();
                     $input  = Sanitizer::sanitize($input);
                     $datarules = $rule->processAllRules($input);
@@ -330,6 +331,9 @@ class VirtualMachine extends InventoryAsset
                     $computervm->getFromDB($computers_vm_id);
                     $input = (array)$vm;
                     $input['id'] = $computers_vm_id;
+                    if ($this->conf->states_id_default != '-1') {
+                        $input['states_id'] = $this->conf->states_id_default;
+                    }
                     $computervm->update(Sanitizer::sanitize($input));
                 }
 


### PR DESCRIPTION
```Default status``` from inventory configuration is not used when GLPI creates/updates the virtual machine computer

if the ```Create computer for virtual machines``` option is enabled.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33628
