### PR TITLE
Revert plugins PSR-4 autoloader changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,7 +153,6 @@ The present file will list all changes made to the project; according to the
 - Usage of `ajax/dropdownValidator.php` with the `users_id_validate` parameter is no longer supported. Use `items_id_target` instead.
 - `Glpi\Dashboard\Filters\AbstractFilter::field()` method has been made protected.
 - Usage of `CommonITILValidation::dropdownValidator()` with the `name` and `users_id_validate` options are no longer supported. Use `prefix` and `itemtype_target`/`items_id_target` respectively instead.
-- Namespaced plugins files must be placed in a subdirectory of the plugin `src` directory that corresponds to the second part of the plugin namespace (e.g. `src/Myplugin/` for a plugin called `myplugin`).
 - The `helper` property of form fields will not support anymore the presence of HTML code.
 - `Glpi\Application\ErrorHandler` constructor visibility has been changed to private.
 - `GLPI::initErrorHandler()` does not return any value anymore.

--- a/phpunit/functional/AutoloadTest.php
+++ b/phpunit/functional/AutoloadTest.php
@@ -80,4 +80,16 @@ class AutoloadTest extends DbTestCase
     {
         $this->assertTrue(class_exists('Glpi\\Event'));
     }
+
+    public function testPluginAutoloading()
+    {
+        // PSR4 autoloader (registered during plugins initialization)
+        $this->assertTrue(class_exists('GlpiPlugin\\Tester\\MyPsr4Class'));
+
+        // Pseudo-PSR4 class with no namespace
+        $this->assertTrue(class_exists('PluginTesterMyPseudoPsr4Class'));
+
+        // Legacy `inc/*.class.php` files
+        $this->assertTrue(class_exists('PluginTesterMyLegacyClass'));
+    }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -350,7 +350,7 @@ class Plugin extends CommonDBTM
                 $loaded = true;
                 if (!in_array($plugin_key, self::$loaded_plugins)) {
                     // Register PSR-4 autoloader
-                    $psr4_dir = $plugin_directory . '/src/' . ucfirst($plugin_key);
+                    $psr4_dir = $plugin_directory . '/src/';
                     if (is_dir($psr4_dir)) {
                         $psr4_autoloader = new \Composer\Autoload\ClassLoader();
                         $psr4_autoloader->addPsr4(NS_PLUG . ucfirst($plugin_key) . '\\', $psr4_dir);

--- a/src/autoload/legacy-autoloader.php
+++ b/src/autoload/legacy-autoloader.php
@@ -69,26 +69,14 @@ function glpi_autoload($classname)
         }
     }
 
-    // Legacy class path, e.g. `MyPluginFoo` -> `plugins/myplugin/inc/foo.class.php`
+    // Legacy class path, e.g. `PluginMyPluginFoo` -> `plugins/myplugin/inc/foo.class.php`
     $legacy_path          = sprintf('%s/inc/%s.class.php', $plugin_path, str_replace('\\', '/', strtolower($plugin_class)));
-    // PSR-4 styled path for class without namespace, e.g. `MyPluginFoo` -> `plugins/myplugin/src/MyPluginFoo.php`
+    // PSR-4 styled path for class without namespace, e.g. `PluginMyPluginFoo` -> `plugins/myplugin/src/PluginMyPluginFoo.php`
     $psr4_styled_path     = sprintf('%s/src/%s.php', $plugin_path, str_replace('\\', '/', $classname));
-    // PSR-4 unprefixed path for class with namespace, e.g. `GlpiPlugin\\MyPlugin\\Foo` -> `plugins/myplugin/src/Foo.php`
-    // deprecated in favor of `GlpiPlugin\\MyPlugin\\Foo` -> `plugins/myplugin/src/MyPlugin/Foo.php`.
-    $psr4_unprefixed_path = sprintf('%s/src/%s.php', $plugin_path, str_replace('\\', '/', $plugin_class));
     if (file_exists($legacy_path)) {
         include_once($legacy_path);
     } else if (strpos($classname, NS_PLUG) !== 0 && file_exists($psr4_styled_path)) {
         include_once($psr4_styled_path);
-    } else if (strpos($classname, NS_PLUG) !== 0 && file_exists($psr4_unprefixed_path)) {
-        Toolbox::deprecated(
-            sprintf(
-                'To PSR-4 autoloading of plugins classes now expects the class `%s` to be placed in `%s`',
-                $classname,
-                implode(DIRECTORY_SEPARATOR, [$plugin_key, 'src', $plugin_name, str_replace('\\', DIRECTORY_SEPARATOR, $plugin_class)])
-            )
-        );
-        include_once($psr4_unprefixed_path);
     }
 }
 

--- a/tests/fixtures/plugins/tester/inc/mylegacyclass.class.php
+++ b/tests/fixtures/plugins/tester/inc/mylegacyclass.class.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+final class PluginTesterMyLegacyClass
+{
+}

--- a/tests/fixtures/plugins/tester/src/MyPsr4Class.php
+++ b/tests/fixtures/plugins/tester/src/MyPsr4Class.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Tester;
+
+final class MyPsr4Class
+{
+}

--- a/tests/fixtures/plugins/tester/src/PluginTesterMyPseudoPsr4Class.php
+++ b/tests/fixtures/plugins/tester/src/PluginTesterMyPseudoPsr4Class.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+final class PluginTesterMyPseudoPsr4Class
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Revert changes made in #17233 for autoloading plugins. It introduces redundancy in classpaths that is not necessary.