### PR TITLE
Fix helpdesk forms "child entities" checkbox

### DIFF
--- a/js/form_editor_controller.js
+++ b/js/form_editor_controller.js
@@ -635,7 +635,7 @@ class GlpiFormEditorController
      */
     #removeDraftStatus() {
         // Turn the "Add" button into "Save"
-        const add_button = $('#form-form button[name=update]');
+        const add_button = $('#main-form button[name=update]');
         add_button
             .find('.ti-plus')
             .removeClass('ti-plus')
@@ -644,7 +644,7 @@ class GlpiFormEditorController
         add_button.prop("title", __('Save'));
 
         // Show the delete button
-        const del_button = $('#form-form button[name=delete]');
+        const del_button = $('#main-form button[name=delete]');
         del_button.removeClass('d-none');
 
         // Mark as no longer a draft to avoid running this code again

--- a/templates/components/form/header.html.twig
+++ b/templates/components/form/header.html.twig
@@ -57,7 +57,7 @@
 {% set include_header_content = no_header == false and ((in_twig is defined or _get._in_modal|default(false)) or (in_twig is not defined and item.isNewID(item.fields['id']))) %}
 
 {% if open_form and item.canEdit(item.fields['id']) %}
-<form name="asset_form" method="post" action="{{ target }}" {{ formoptions|raw }} enctype="multipart/form-data" data-submit-once>
+<form id="main-form" name="asset_form" method="post" action="{{ target }}" {{ formoptions|raw }} enctype="multipart/form-data" data-submit-once>
    {% if item.isField("entities_id") %}
        <input type="hidden" name="entities_id" value="{{ entity_id }}" />
    {% endif %}
@@ -68,8 +68,6 @@
    <div id="mainformtable">
       {% if include_header_content %}
          {{ include('components/form/header_content.html.twig', {'inside_main': true}) }}
-      {% else %}
-         <input type="hidden" name="is_recursive" value="{{ item.fields['is_recursive']|default(1) }}" />
       {% endif %}
 
       {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::PRE_ITEM_FORM'), {'item': item, 'options': params}) }}

--- a/templates/components/form/header_content.html.twig
+++ b/templates/components/form/header_content.html.twig
@@ -153,13 +153,13 @@
                   {% set disabled = true %}
                {% endif %}
 
-               {% if not disabled %}<input type="hidden" name="is_recursive" value="0" />{% endif %}
-               <input class="form-check-input" type="checkbox" name="is_recursive" value="1"
+               {% if not disabled %}<input form="main-form" type="hidden" name="is_recursive" value="0" />{% endif %}
+               <input form="main-form" class="form-check-input" type="checkbox" name="is_recursive" value="1"
                   {% if item.isRecursive() %}checked="checked"{% endif %}
                   {% if disabled %}disabled="disabled"{% endif %} />
                {% if item is instanceof('CommonDBChild') and item.isNewItem() and item.isRecursive() %}
                   {# Send value on hidden field to ensure creation will use inherited recursivity on CommonDBChild #}
-                  <input type="hidden" name="is_recursive" value="1" />
+                  <input form="main-form" type="hidden" name="is_recursive" value="1" />
                {% endif %}
                <span class="form-check-label mb-0 mx-2">
                   {{ __('Child entities') }}
@@ -171,19 +171,4 @@
    {% endif %}
 
    {{ include('components/form/single-action.html.twig') }}
-
-   {% if inside_main is not defined %}
-      <script>
-         $("#header_{{ rand }} input[name='is_recursive']").on('change', function(e) {
-             const asset_form = $("form[name='asset_form']");
-             // If asset form has an is_recursive checkbox, we need set the value to the one in the header
-             if (asset_form.length) {
-                 const chk = asset_form.find("input[name='is_recursive']");
-                 if (chk.length) {
-                     chk.val(e.target.checked ? 1 : 0);
-                 }
-             }
-         });
-      </script>
-   {% endif %}
 </div>

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -48,7 +48,7 @@
 {% endfor %}
 
 <form
-    id="form-form"
+    id="main-form"
     data-glpi-form-editor-container
     class="
         form-editor-container
@@ -190,7 +190,7 @@
                 class="btn btn-secondary"
                 type="button"
                 name="preview"
-                form="form-form"
+                form="main-form"
                 title="{{ __("Preview") }}"
                 data-glpi-form-editor-preview-action
             >
@@ -201,7 +201,7 @@
                 class="btn btn-secondary d-none"
                 type="submit"
                 name="update"
-                form="form-form"
+                form="main-form"
                 title="{{ __("Save and preview") }}"
                 data-glpi-form-editor-save-and-preview-action
                 data-glpi-form-editor-preview-url="{{ path('front/form/form_renderer.php?id=' ~ item.fields.id) }}"
@@ -224,7 +224,7 @@
                 "
                 type="submit"
                 name="delete"
-                form="form-form"
+                form="main-form"
             >
                 <i class="ti ti-trash me-1"></i>{{ __("Put in trashbin") }}
             </button>
@@ -236,7 +236,7 @@
                 class="btn btn-ghost-danger me-2 {{ not item.fields.is_deleted ? "d-none" : "" }}"
                 type="submit"
                 name="purge"
-                form="form-form"
+                form="main-form"
             >
                 <i class="ti ti-trash me-1"></i>{{ __("Delete permanently") }}
             </button>
@@ -253,7 +253,7 @@
                 "
                 type="submit"
                 name="restore"
-                form="form-form"
+                form="main-form"
             >
                 <i class="ti ti-trash-off me-1"></i>{{ __("Restore") }}
             </button>
@@ -265,7 +265,7 @@
                 class="btn btn-primary"
                 type="submit"
                 name="update"
-                form="form-form"
+                form="main-form"
                 title="{{ __("Add") }}"
             >
                 <i class="ti ti-plus me-1"></i>
@@ -277,7 +277,7 @@
                 class="btn btn-primary"
                 type="submit"
                 name="update"
-                form="form-form"
+                form="main-form"
                 title="{{ __("Save") }}"
             >
                 <i class="ti ti-device-floppy me-1"></i>

--- a/tests/cypress/e2e/form/form_editor.cy.js
+++ b/tests/cypress/e2e/form/form_editor.cy.js
@@ -81,6 +81,17 @@ describe ('Form editor', () => {
         });
     });
 
+    it('can enable child entities', () => {
+        cy.createFormWithAPI().visitFormTab('Form');
+        cy.findByRole('checkbox', {"name": "Child entities"})
+            .should('be.not.checked')
+            .check()
+        ;
+        cy.findByRole('button', {"name": "Save"}).click();
+        cy.reload();
+        cy.findByRole('checkbox', {"name": "Child entities"}).should('be.checked');
+    }),
+
     it('can create and delete a question', () => {
         cy.createFormWithAPI().visitFormTab('Form');
 


### PR DESCRIPTION
The "child entities" checkbox didn't work on forms because it is situated outside of the html form.

For common assets, this is handled by running some javascript that bind the checkbox value to another hidden input found inside the form.
This mean any other items that want this checkbox to work have to copy the same script.

I've implemented a simpler fix, using the `form` property which allow an input outside of a form to be taken into account.
This require an id, which I've set to `main-form`.
Now, any item with the correct `main-form` id will work correctly.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
