### PR TITLE
Code refactoring from #17117

### DIFF
--- a/front/form/access_control.form.php
+++ b/front/form/access_control.form.php
@@ -44,15 +44,15 @@ use Glpi\Form\AccessControl\FormAccessControl;
 
 try {
     $access_control = new FormAccessControl();
-
     if (isset($_POST["update"])) {
         // Update access control policies
-        foreach ($access_control->splitEncodedInputs($_POST) as $input) {
-            $id = $input['id'] ?? 0;
+        foreach ($_POST['_access_control'] as $id => $input) {
+            $input['id'] = $id;
 
             $access_control->check($id, UPDATE, $input);
             $access_control->getFromDB($id);
             $input['_config'] = $access_control->createConfigFromUserInput($input);
+
             if (!$access_control->update($input, true)) {
                 throw new RuntimeException(
                     "Failed to update access control item"

--- a/phpunit/functional/Glpi/Form/AccessControl/ControlType/AllowListTest.php
+++ b/phpunit/functional/Glpi/Form/AccessControl/ControlType/AllowListTest.php
@@ -38,13 +38,17 @@ namespace tests\units\Glpi\Form\AccessControl\ControlType;
 use Glpi\Form\AccessControl\AccessVote;
 use Glpi\Form\AccessControl\ControlType\AllowList;
 use Glpi\Form\AccessControl\FormAccessParameters;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
 use JsonConfigInterface;
 use Glpi\Form\AccessControl\ControlType\AllowListConfig;
 use Glpi\Session\SessionInfo;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-class AllowListTest extends \GLPITestCase
+class AllowListTest extends \DbTestCase
 {
+    use FormTesterTrait;
+
     public function testGetLabel(): void
     {
         $allow_list = new AllowList();
@@ -83,14 +87,19 @@ class AllowListTest extends \GLPITestCase
 
         // We only validate that the function run without errors.
         // The rendered content should be validated by an E2E test.
-        $this->assertNotEmpty($allow_list->renderConfigForm(new AllowListConfig()));
-        $this->assertNotEmpty($allow_list->renderConfigForm(new AllowListConfig(
-            user_ids   : [1, 2, 3],
-            group_ids  : [4, 5, 6],
-            profile_ids: [7, 8, 9],
-        )));
+        $form = $this->createForm(
+            (new FormBuilder())
+                ->addAccessControl(
+                    \Glpi\Form\AccessControl\ControlType\AllowList::class,
+                    $this->getFullyConfiguredAllowListConfig()
+                )
+        );
+        $access_control = $this->getAccessControl(
+            $form,
+            \Glpi\Form\AccessControl\ControlType\AllowList::class
+        );
+        $this->assertNotEmpty($allow_list->renderConfigForm($access_control));
     }
-
 
     public function testGetWeight(): void
     {
@@ -99,7 +108,6 @@ class AllowListTest extends \GLPITestCase
         // Not much to test here, just ensure the method run without errors
         $this->assertGreaterThan(0, $allow_list->getWeight());
     }
-
 
     public function testCreateConfigFromUserInput(): void
     {

--- a/phpunit/functional/Glpi/Form/AccessControl/ControlType/DirectAccessTest.php
+++ b/phpunit/functional/Glpi/Form/AccessControl/ControlType/DirectAccessTest.php
@@ -38,13 +38,17 @@ namespace tests\units\Glpi\Form\AccessControl\ControlType;
 use Glpi\Form\AccessControl\AccessVote;
 use Glpi\Form\AccessControl\ControlType\DirectAccess;
 use Glpi\Form\AccessControl\FormAccessParameters;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
 use JsonConfigInterface;
 use Glpi\Form\AccessControl\ControlType\DirectAccessConfig;
 use Glpi\Session\SessionInfo;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-class DirectAccessTest extends \GLPITestCase
+class DirectAccessTest extends \DBTestCase
 {
+    use FormTesterTrait;
+
     public function testGetLabel(): void
     {
         $direct_access = new DirectAccess();
@@ -88,13 +92,19 @@ class DirectAccessTest extends \GLPITestCase
 
         // We only validate that the function run without errors.
         // The rendered content should be validated by an E2E test.
-        $this->assertNotEmpty($direct_access->renderConfigForm(new DirectAccessConfig()));
-        $this->assertNotEmpty($direct_access->renderConfigForm(new DirectAccessConfig(
-            token: 'my token',
-            allow_unauthenticated: true,
-        )));
+        $form = $this->createForm(
+            (new FormBuilder())
+                ->addAccessControl(
+                    DirectAccess::class,
+                    new DirectAccessConfig(
+                        token: 'my token',
+                        allow_unauthenticated: true,
+                    )
+                )
+        );
+        $access_control = $this->getAccessControl($form, DirectAccess::class);
+        $this->assertNotEmpty($direct_access->renderConfigForm($access_control));
     }
-
 
     public function testGetWeight(): void
     {

--- a/phpunit/functional/Glpi/Form/AccessControl/FormAccessControlManagerTest.php
+++ b/phpunit/functional/Glpi/Form/AccessControl/FormAccessControlManagerTest.php
@@ -274,7 +274,8 @@ final class FormAccessControlManagerTest extends DbTestCase
 
     public function testGetWarningForInactiveFormWithoutAccessControlPolicies(): void
     {
-        $this->checkGetWarnings($this->getInactiveFormWithoutAccessControls(), [
+        $form = $this->createForm((new FormBuilder())->setIsActive(false));
+        $this->checkGetWarnings($form, [
             'This form is not visible to anyone because it is not active.',
             'This form will not be visible to any users as there are currently no active access policies.',
         ]);
@@ -282,7 +283,8 @@ final class FormAccessControlManagerTest extends DbTestCase
 
     public function testGetWarningForActiveFormWithoutAccessControlPolicies(): void
     {
-        $this->checkGetWarnings($this->getActiveFormWithoutAccessControls(), [
+        $form = $this->createForm((new FormBuilder())->setIsActive(true));
+        $this->checkGetWarnings($form, [
             'This form will not be visible to any users as there are currently no active access policies.',
         ]);
     }
@@ -334,16 +336,6 @@ final class FormAccessControlManagerTest extends DbTestCase
                     ],
                 ))
         );
-    }
-
-    private function getActiveFormWithoutAccessControls(): Form
-    {
-        return $this->createForm((new FormBuilder())->setIsActive(true));
-    }
-
-    private function getInactiveFormWithoutAccessControls(): Form
-    {
-        return $this->createForm((new FormBuilder())->setIsActive(false));
     }
 
     private function getActiveFormWithActiveAccessControls(): Form

--- a/phpunit/functional/Glpi/Form/AccessControl/FormAccessControlTest.php
+++ b/phpunit/functional/Glpi/Form/AccessControl/FormAccessControlTest.php
@@ -399,6 +399,35 @@ class FormAccessControlTest extends DbTestCase
         ]), json_encode($access_control_2->getConfig()));
     }
 
+    public function testEncodeInputName(): void
+    {
+        $form_access_control = new FormAccessControl();
+        $form_access_control->fields = ['id' => 1];
+
+        $this->assertEquals(
+            "_access_control_1_test",
+            $form_access_control->encodeInputName("test")
+        );
+    }
+
+    public function testSplitEncodedInputs(): void
+    {
+        $form_access_control = new FormAccessControl();
+        $inputs = $form_access_control->splitEncodedInputs([
+            'id'                                => 1,
+            'is_active'                         => false,
+            '_access_control_2_is_active'       => true,
+            '_access_control_2_users_id'        => 4,
+            '_access_control_33_is_active'       => true,
+            '_access_control_33_allow_anonymous' => true,
+        ]);
+
+        $this->assertEquals([
+            ['id' => 2, 'is_active' => true, 'users_id'  => 4],
+            ['id' => 33, 'is_active' => true, 'allow_anonymous'  => true],
+        ], $inputs);
+    }
+
     private function createAndGetAccessControl(): FormAccessControl
     {
         $form = $this->createForm(

--- a/phpunit/functional/Glpi/Form/AccessControl/FormAccessControlTest.php
+++ b/phpunit/functional/Glpi/Form/AccessControl/FormAccessControlTest.php
@@ -405,27 +405,9 @@ class FormAccessControlTest extends DbTestCase
         $form_access_control->fields = ['id' => 1];
 
         $this->assertEquals(
-            "_access_control_1_test",
+            "_access_control[1][test]",
             $form_access_control->getNormalizedInputName("test")
         );
-    }
-
-    public function testSplitEncodedInputs(): void
-    {
-        $form_access_control = new FormAccessControl();
-        $inputs = $form_access_control->splitEncodedInputs([
-            'id'                                => 1,
-            'is_active'                         => false,
-            '_access_control_2_is_active'       => true,
-            '_access_control_2_users_id'        => 4,
-            '_access_control_33_is_active'       => true,
-            '_access_control_33_allow_anonymous' => true,
-        ]);
-
-        $this->assertEquals([
-            ['id' => 2, 'is_active' => true, 'users_id'  => 4],
-            ['id' => 33, 'is_active' => true, 'allow_anonymous'  => true],
-        ], $inputs);
     }
 
     private function createAndGetAccessControl(): FormAccessControl

--- a/phpunit/functional/Glpi/Form/AccessControl/FormAccessControlTest.php
+++ b/phpunit/functional/Glpi/Form/AccessControl/FormAccessControlTest.php
@@ -399,14 +399,14 @@ class FormAccessControlTest extends DbTestCase
         ]), json_encode($access_control_2->getConfig()));
     }
 
-    public function testEncodeInputName(): void
+    public function testGetNormalizedInputName(): void
     {
         $form_access_control = new FormAccessControl();
         $form_access_control->fields = ['id' => 1];
 
         $this->assertEquals(
             "_access_control_1_test",
-            $form_access_control->encodeInputName("test")
+            $form_access_control->getNormalizedInputName("test")
         );
     }
 

--- a/src/Glpi/Form/AccessControl/ControlType/AllowList.php
+++ b/src/Glpi/Form/AccessControl/ControlType/AllowList.php
@@ -36,6 +36,7 @@
 namespace Glpi\Form\AccessControl\ControlType;
 
 use Glpi\Form\AccessControl\AccessVote;
+use Glpi\Form\AccessControl\FormAccessControl;
 use Glpi\Form\AccessControl\FormAccessParameters;
 use JsonConfigInterface;
 use Glpi\Application\View\TemplateRenderer;
@@ -66,14 +67,16 @@ final class AllowList implements ControlTypeInterface
     }
 
     #[Override]
-    public function renderConfigForm(JsonConfigInterface $config): string
+    public function renderConfigForm(FormAccessControl $access_control): string
     {
+        $config = $access_control->getConfig();
         if (!$config instanceof AllowListConfig) {
             throw new \InvalidArgumentException("Invalid config class");
         }
 
         $twig = TemplateRenderer::getInstance();
         return $twig->render("pages/admin/form/access_control/allow_list.html.twig", [
+            'access_control' => $access_control,
             'config' => $config,
         ]);
     }
@@ -88,6 +91,7 @@ final class AllowList implements ControlTypeInterface
     public function createConfigFromUserInput(array $input): AllowListConfig
     {
         $values = $input['_allow_list_dropdown'] ?? [];
+        $values = $values ?: []; // No selected values is sent by the html form as an empty string
         return AllowListConfig::createFromRawArray([
             'user_ids'    => AllowListDropdown::getPostedIds($values, User::class),
             'group_ids'   => AllowListDropdown::getPostedIds($values, Group::class),

--- a/src/Glpi/Form/AccessControl/ControlType/ControlTypeInterface.php
+++ b/src/Glpi/Form/AccessControl/ControlType/ControlTypeInterface.php
@@ -36,6 +36,7 @@
 namespace Glpi\Form\AccessControl\ControlType;
 
 use Glpi\Form\AccessControl\AccessVote;
+use Glpi\Form\AccessControl\FormAccessControl;
 use Glpi\Form\AccessControl\FormAccessParameters;
 use JsonConfigInterface;
 
@@ -65,11 +66,11 @@ interface ControlTypeInterface
     /**
      * Render the configuration form of this control type.
      *
-     * @param JsonConfigInterface $config
+     * @param FormAccessControl $access_control
      *
      * @return string Rendered content
      */
-    public function renderConfigForm(JsonConfigInterface $config): string;
+    public function renderConfigForm(FormAccessControl $access_control): string;
 
     /**
      * Get weight of this control type (used to sort controls types).

--- a/src/Glpi/Form/AccessControl/ControlType/DirectAccess.php
+++ b/src/Glpi/Form/AccessControl/ControlType/DirectAccess.php
@@ -36,6 +36,7 @@
 namespace Glpi\Form\AccessControl\ControlType;
 
 use Glpi\Form\AccessControl\AccessVote;
+use Glpi\Form\AccessControl\FormAccessControl;
 use Glpi\Form\AccessControl\FormAccessParameters;
 use JsonConfigInterface;
 use Glpi\Application\View\TemplateRenderer;
@@ -62,11 +63,12 @@ final class DirectAccess implements ControlTypeInterface
     }
 
     #[Override]
-    public function renderConfigForm(JsonConfigInterface $config): string
+    public function renderConfigForm(FormAccessControl $access_control): string
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
+        $config = $access_control->getConfig();
         if (!$config instanceof DirectAccessConfig) {
             throw new \InvalidArgumentException("Invalid config class");
         }
@@ -81,6 +83,7 @@ final class DirectAccess implements ControlTypeInterface
 
         $twig = TemplateRenderer::getInstance();
         return $twig->render("pages/admin/form/access_control/direct_access.html.twig", [
+            'access_control' => $access_control,
             'config' => $config,
             'url'    => $url,
         ]);

--- a/src/Glpi/Form/AccessControl/FormAccessControl.php
+++ b/src/Glpi/Form/AccessControl/FormAccessControl.php
@@ -92,6 +92,7 @@ final class FormAccessControl extends CommonDBChild
         $twig = TemplateRenderer::getInstance();
         echo $twig->render('pages/admin/form/access_control.html.twig', [
             'form'            => $item,
+            'warnings'        => $manager->getWarnings($item),
             'access_controls' => $sorted_access_controls,
         ]);
 
@@ -228,7 +229,7 @@ final class FormAccessControl extends CommonDBChild
     {
         $control_type = $this->fields['strategy'];
         if (!$this->isValidStrategy($control_type)) {
-            throw new \RuntimeException();
+            throw new \RuntimeException("Unknown strategy");
         }
 
         return new $control_type();
@@ -262,6 +263,48 @@ final class FormAccessControl extends CommonDBChild
         }
         $strategy = new $strategy_class();
         return $strategy->createConfigFromUserInput($input);
+    }
+
+    /**
+     * Encode the input name to make sure it is unique and multiple items
+     * can be updated using a single form.
+     *
+     * Content must be decoded using `splitEncodedInputs`.
+     *
+     * @param string $name
+     * @return string
+     */
+    public function encodeInputName(string $name): string
+    {
+        return "_access_control_{$this->getID()}_$name";
+    }
+
+    /**
+     * Split an input containing multiple encoded forms into individual inputs.
+     *
+     * @param array $input
+     * @return array
+     */
+    public function splitEncodedInputs(array $input): array
+    {
+        $inputs = [];
+
+        foreach ($input as $key => $value) {
+            $regex = "/_access_control_(\d+)_(.*)/";
+            if (!preg_match($regex, $key, $matches)) {
+                continue;
+            }
+
+            $id = $matches[1];
+            $name = $matches[2];
+
+            if (!isset($inputs[$id])) {
+                $inputs[$id] = ['id' => $id];
+            }
+            $inputs[$id][$name] = $value;
+        }
+
+        return array_values($inputs);
     }
 
     #[Override]

--- a/src/Glpi/Form/AccessControl/FormAccessControl.php
+++ b/src/Glpi/Form/AccessControl/FormAccessControl.php
@@ -269,42 +269,12 @@ final class FormAccessControl extends CommonDBChild
      * Encode the input name to make sure it is unique and multiple items
      * can be updated using a single form.
      *
-     * Content must be decoded using `splitEncodedInputs`.
-     *
      * @param string $name
      * @return string
      */
     public function getNormalizedInputName(string $name): string
     {
-        return "_access_control_{$this->getID()}_$name";
-    }
-
-    /**
-     * Split an input containing multiple encoded forms into individual inputs.
-     *
-     * @param array $input
-     * @return array
-     */
-    public function splitEncodedInputs(array $input): array
-    {
-        $inputs = [];
-
-        foreach ($input as $key => $value) {
-            $regex = "/_access_control_(\d+)_(.*)/";
-            if (!preg_match($regex, $key, $matches)) {
-                continue;
-            }
-
-            $id = $matches[1];
-            $name = $matches[2];
-
-            if (!isset($inputs[$id])) {
-                $inputs[$id] = ['id' => $id];
-            }
-            $inputs[$id][$name] = $value;
-        }
-
-        return array_values($inputs);
+        return "_access_control[{$this->getID()}][$name]";
     }
 
     #[Override]

--- a/src/Glpi/Form/AccessControl/FormAccessControl.php
+++ b/src/Glpi/Form/AccessControl/FormAccessControl.php
@@ -274,7 +274,7 @@ final class FormAccessControl extends CommonDBChild
      * @param string $name
      * @return string
      */
-    public function encodeInputName(string $name): string
+    public function getNormalizedInputName(string $name): string
     {
         return "_access_control_{$this->getID()}_$name";
     }

--- a/src/Glpi/Form/AccessControl/FormAccessControlManager.php
+++ b/src/Glpi/Form/AccessControl/FormAccessControlManager.php
@@ -142,6 +142,44 @@ final class FormAccessControlManager
         return $controls;
     }
 
+    /**
+     * Get an array access controls warnings messages (string) for a given
+     * form.
+     *
+     * @param Form $form
+     * @return string[]
+     */
+    public function getWarnings(Form $form): array
+    {
+        $warnings = [];
+        $warnings = $this->addWarningIfFormIsNotActive($form, $warnings);
+        $warnings = $this->addWarningIfFormHasNoActivePolicies($form, $warnings);
+
+        return $warnings;
+    }
+
+    private function addWarningIfFormIsNotActive(
+        Form $form,
+        array $warnings
+    ): array {
+        if ($form->fields['is_active'] == 0) {
+            $warnings[] = __('This form is not visible to anyone because it is not active.');
+        }
+
+        return $warnings;
+    }
+
+    private function addWarningIfFormHasNoActivePolicies(
+        Form $form,
+        array $warnings
+    ): array {
+        if (count($this->getActiveAccessControlsForForm($form)) == 0) {
+            $warnings[] = __('This form will not be visible to any users as there are currently no active access policies.');
+        }
+
+        return $warnings;
+    }
+
     private function validateAccessControlsPolicies(
         array $policies,
         FormAccessParameters $parameters

--- a/src/Glpi/Form/AccessControl/FormAccessControlManager.php
+++ b/src/Glpi/Form/AccessControl/FormAccessControlManager.php
@@ -162,7 +162,7 @@ final class FormAccessControlManager
         Form $form,
         array $warnings
     ): array {
-        if ($form->fields['is_active'] == 0) {
+        if ($form->isActive()) {
             $warnings[] = __('This form is not visible to anyone because it is not active.');
         }
 

--- a/src/Glpi/Form/AccessControl/FormAccessControlManager.php
+++ b/src/Glpi/Form/AccessControl/FormAccessControlManager.php
@@ -162,7 +162,7 @@ final class FormAccessControlManager
         Form $form,
         array $warnings
     ): array {
-        if ($form->isActive()) {
+        if (!$form->isActive()) {
             $warnings[] = __('This form is not visible to anyone because it is not active.');
         }
 
@@ -173,7 +173,7 @@ final class FormAccessControlManager
         Form $form,
         array $warnings
     ): array {
-        if (count($this->getActiveAccessControlsForForm($form)) == 0) {
+        if (count($this->getActiveAccessControlsForForm($form)) === 0) {
             $warnings[] = __('This form will not be visible to any users as there are currently no active access policies.');
         }
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -4785,7 +4785,8 @@ JS;
         }
         $select = '';
         if (isset($options['multiple']) && $options['multiple']) {
-            $original_field_name = htmlspecialchars(rtrim($name, '[]'));
+            $original_field_name = str_ends_with($name, '[]') ? substr($name, 0, -2) : $name;
+            $original_field_name = htmlspecialchars($original_field_name);
             $select .= "<input type='hidden' name='$original_field_name' value=''>";
         }
         $select .= sprintf(

--- a/templates/pages/admin/form/access_control.html.twig
+++ b/templates/pages/admin/form/access_control.html.twig
@@ -79,14 +79,14 @@
                             <input
                                 type="hidden"
                                 value="0"
-                                name="{{ access_control.encodeInputName("is_active") }}"
+                                name="{{ access_control.getNormalizedInputName("is_active") }}"
                             >
                             <input
                                 aria-label="{{ __("Active") }}"
                                 data-glpi-toggle-control
                                 class="form-check-input"
                                 type="checkbox"
-                                name="{{ access_control.encodeInputName("is_active") }}"
+                                name="{{ access_control.getNormalizedInputName("is_active") }}"
                                 value="1"
                                 {{ access_control.fields.is_active == true ? "checked" : "" }}
                             >

--- a/templates/pages/admin/form/access_control.html.twig
+++ b/templates/pages/admin/form/access_control.html.twig
@@ -33,80 +33,73 @@
 
 {# @var \Glpi\Form\Form form #}
 {# @var \Glpi\Form\AccessControl\FormAccessControl[] access_controls #}
+{# @var string[] warnings #}
 
 <div class="py-2 px-3">
     <div class="col-12 col-lg-6">
-        {% set is_form_disabled = not form.fields.is_active == true %}
-        {% set are_all_controls_disabled = access_controls|filter(control => control.fields.is_active == true)|length == 0 %}
-
-        {# Display warning/info if the form is disabled or has no active access control policies #}
-        <div class="{{ is_form_disabled or are_all_controls_disabled ? "mb-5" : "" }}">
-            {% if is_form_disabled %}
-                <div class="alert alert-warning d-flex align-items-center" role="alert">
-                    <i class="ti ti-alert-triangle me-2"></i>
-                    {{ __("This form is not visible to anyone because it is not active.") }}
-                </div>
-            {% endif %}
-            {% if are_all_controls_disabled %}
-                <div class="alert alert-warning d-flex align-items-center" role="alert">
-                    <i class="ti ti-alert-triangle me-2"></i>
-                    {{ __("This form will not be visible to any users as they are currently no active access policies.") }}
-                </div>
-            {% endif %}
-        </div>
-
-        {# Display each access control policies #}
-        {% for access_control in access_controls %}
-            {% set strategy = access_control.getStrategy() %}
-            {% set config = access_control.getConfig() %}
-
-            {# One form per policy as it is an individual item in the database #}
-            <form
-                method="POST"
-                action="{{ path('/ajax/form/access_control.form.php') }}"
-                data-glpi-acess-control-form
-                data-track-changes="true"
-                data-glpi-submitted-by="access-controls"
-                data-submit-once="true"
-            >
-                <div
-                    class="mb-5"
-                >
-                    <div
-                        {# Disabled item are showed with a lower opacity #}
-                        style="{{ access_control.fields.is_active == false ? "opacity: 0.5" : "" }}"
-                        data-glpi-toggle-control-target
-                    >
-                        <h3 class="d-flex align-items-center">
-                            <i class="{{ strategy.getIcon() }} me-2"></i>
-                            {{ strategy.getLabel() }}
-                            <label class="form-check mb-0 ms-auto form-switch">
-                                <input type="hidden" value="0" name="is_active">
-                                <input
-                                    data-glpi-toggle-control
-                                    class="form-check-input"
-                                    type="checkbox"
-                                    name="is_active"
-                                    value="1"
-                                    {{ access_control.fields.is_active == true ? "checked" : "" }}
-                                >
-                            </label>
-                        </h3>
-                        <div>
-                            {# Render custom config form #}
-                            {{ strategy.renderConfigForm(config)|raw }}
+        <form
+            method="POST"
+            action="{{ path('/front/form/access_control.form.php') }}"
+            data-track-changes="true"
+            data-submit-once="true"
+        >
+            {# Display warnings at the top of the tab #}
+            {% if warnings|length > 0 %}
+                <div class="mb-5">
+                    {% for warning in warnings %}
+                        <div
+                            class="alert alert-warning d-flex align-items-center"
+                            role="alert"
+                        >
+                            <i class="ti ti-alert-triangle me-2"></i>
+                            {{ warning }}
                         </div>
-                    </div>
-
-                    {# Hidden inputs #}
-                    <input type="hidden" name="id" value="{{ access_control.fields.id }}"/>
+                    {% endfor %}
                 </div>
-            </form>
-        {% endfor %}
+            {% endif %}
 
-        {% if form.canUpdate() and form.canUpdateItem() %}
-            {#  Dummy form wrapper to trigger the `data-submit-once` process #}
-            <form data-submit-once>
+            {# Display each access control policies #}
+            {# Display each access control policies #}
+            {% for access_control in access_controls %}
+                {% set strategy = access_control.getStrategy() %}
+                {% set config = access_control.getConfig() %}
+
+                <section
+                    class="mb-5"
+                    style="{{ access_control.fields.is_active == false ? "opacity: 0.5" : "" }}"
+                    {# Disabled item are showed with a lower opacity #}
+                    data-glpi-toggle-control-target
+                    data-glpi-access-control-form
+                    aria-label="{{ strategy.getLabel() }}"
+                >
+                    <h3 class="d-flex align-items-center">
+                        <i class="{{ strategy.getIcon() }} me-2"></i>
+                        {{ strategy.getLabel() }}
+                        <label class="form-check mb-0 ms-auto form-switch">
+                            <input
+                                type="hidden"
+                                value="0"
+                                name="{{ access_control.encodeInputName("is_active") }}"
+                            >
+                            <input
+                                aria-label="{{ __("Active") }}"
+                                data-glpi-toggle-control
+                                class="form-check-input"
+                                type="checkbox"
+                                name="{{ access_control.encodeInputName("is_active") }}"
+                                value="1"
+                                {{ access_control.fields.is_active == true ? "checked" : "" }}
+                            >
+                        </label>
+                    </h3>
+                    <div>
+                        {# Render custom config form #}
+                        {{ strategy.renderConfigForm(access_control)|raw }}
+                    </div>
+                </section>
+            {% endfor %}
+
+            {% if form.canUpdate() and form.canUpdateItem() %}
                 {# Submit button #}
                 <div class="d-flex flex-row-reverse">
                     {# This button will submit the others forms using a custom script #}
@@ -120,8 +113,11 @@
                         {{ __("Save changes") }}
                     </button>
                 </div>
-            </form>
-        {% endif %}
+            {% endif %}
+
+            <input type="hidden" name="id" value="{{ form.fields.id }}"/>
+            <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
+        </form>
     </div>
 </div>
 
@@ -134,44 +130,16 @@
     });
 
     // Toggle state if any input is modified
-    $("form[data-glpi-acess-control-form] :input").on("change", function(e) {
+    $("section[data-glpi-access-control-form] :input").on("change", function(e) {
         // Do not trigger on this is_active checkbox itself
-        if ($(this).prop("name") === "is_active") {
+        if ($(this).data("glpi-toggle-control") !== undefined) {
             return;
         }
 
-        $(this).closest("form").find("[data-glpi-toggle-control]").prop("checked", true);
-        $(this).closest("[data-glpi-toggle-control-target]")
-            .css("opacity", 1)
+        $(this).closest("section")
+            .find("[data-glpi-toggle-control]")
+            .prop("checked", true)
+            .trigger("change")
         ;
-    });
-
-    // Submit multiple forms.
-    // This is needed as each strategy is a dedicated item in the database.
-    $("[data-glpi-submit-id]").closest('form').on("submit", async function(e) {
-        e.preventDefault();
-
-        const submitted_forms = [];
-        const submit = $(this).find("[type=submit]");
-        const submit_id = submit.data("glpi-submit-id");
-
-        $(`[data-glpi-submitted-by="${submit_id}"]`).each(function() {
-            const form = $(this);
-
-            // Get form data with the submit button value manually set.
-            const data = form.serializeArray();
-            data.push({'name': submit.prop("name"), 'value': true});
-
-            submitted_forms.push(
-                $.post({
-                    url: form.prop("action"),
-                    data: $.param(data),
-                })
-            );
-        });
-
-        await Promise.all(submitted_forms);
-        window.glpiUnsavedFormChanges = false;
-        location.reload();
     });
 </script>

--- a/templates/pages/admin/form/access_control/allow_list.html.twig
+++ b/templates/pages/admin/form/access_control/allow_list.html.twig
@@ -31,12 +31,13 @@
  # ---------------------------------------------------------------------
  #}
 
+{# @var \Glpi\Form\AccessControl\ControlType\FormAccessControl access_control #}
 {# @var \Glpi\Form\AccessControl\ControlType\AllowListConfig config #}
 
 {# Multi dropdown (User, Group and Profile) #}
 {{ call(
     "\\Glpi\\Form\\AccessControl\\ControlType\\AllowListDropdown::show",
-    ["_allow_list_dropdown", {
+    [access_control.encodeInputName("_allow_list_dropdown"), {
         'users_id'   : config.getUserIds(),
         'groups_id'  : config.getGroupIds(),
         'profiles_id': config.getProfileIds(),

--- a/templates/pages/admin/form/access_control/allow_list.html.twig
+++ b/templates/pages/admin/form/access_control/allow_list.html.twig
@@ -37,7 +37,7 @@
 {# Multi dropdown (User, Group and Profile) #}
 {{ call(
     "\\Glpi\\Form\\AccessControl\\ControlType\\AllowListDropdown::show",
-    [access_control.encodeInputName("_allow_list_dropdown"), {
+    [access_control.getNormalizedInputName("_allow_list_dropdown"), {
         'users_id'   : config.getUserIds(),
         'groups_id'  : config.getGroupIds(),
         'profiles_id': config.getProfileIds(),

--- a/templates/pages/admin/form/access_control/direct_access.html.twig
+++ b/templates/pages/admin/form/access_control/direct_access.html.twig
@@ -31,6 +31,7 @@
  # ---------------------------------------------------------------------
  #}
 
+{# @var \Glpi\Form\AccessControl\ControlType\FormAccessControl access_control #}
 {# @var \Glpi\Form\AccessControl\ControlType\DirectAccessConfig config #}
 {# @var string                                                  url #}
 
@@ -57,13 +58,13 @@
 <label class="form-check form-switch">
     <input
         class="form-check-input"
-        name="_allow_unauthenticated"
+        name="{{ access_control.encodeInputName("_allow_unauthenticated") }}"
         type="hidden"
         value="0"
     >
     <input
         class="form-check-input"
-        name="_allow_unauthenticated"
+        name="{{ access_control.encodeInputName("_allow_unauthenticated") }}"
         type="checkbox"
         value="1"
         {{ config.allowUnauthenticated() ? 'checked' : '' }}
@@ -81,4 +82,8 @@
     </span>
 </label>
 
-<input type="hidden" name="_token" value="{{ config.getToken() }}">
+<input
+    type="hidden"
+    {{ access_control.encodeInputName("_token") }}
+    value="{{ config.getToken() }}"
+>

--- a/templates/pages/admin/form/access_control/direct_access.html.twig
+++ b/templates/pages/admin/form/access_control/direct_access.html.twig
@@ -58,13 +58,13 @@
 <label class="form-check form-switch">
     <input
         class="form-check-input"
-        name="{{ access_control.encodeInputName("_allow_unauthenticated") }}"
+        name="{{ access_control.getNormalizedInputName("_allow_unauthenticated") }}"
         type="hidden"
         value="0"
     >
     <input
         class="form-check-input"
-        name="{{ access_control.encodeInputName("_allow_unauthenticated") }}"
+        name="{{ access_control.getNormalizedInputName("_allow_unauthenticated") }}"
         type="checkbox"
         value="1"
         {{ config.allowUnauthenticated() ? 'checked' : '' }}
@@ -84,6 +84,6 @@
 
 <input
     type="hidden"
-    {{ access_control.encodeInputName("_token") }}
+    {{ access_control.getNormalizedInputName("_token") }}
     value="{{ config.getToken() }}"
 >

--- a/tests/cypress/e2e/form/access_control.cy.js
+++ b/tests/cypress/e2e/form/access_control.cy.js
@@ -46,7 +46,8 @@ describe('Access Control', () => {
     it('warnings are displayed', () => {
         // Quick tests to ensure that warnings are rendered correcly by twig.
         // We don't check their exact content as it is already validated by unit tests.
-        cy.findAllByRole('alert').should('have.length', 2);
+        cy.findAllByRole('alert').eq(0).should('contain.text', "This form is not visible to anyone because it is not active.");
+        cy.findAllByRole('alert').eq(1).should('contain.text', "This form will not be visible to any users as there are currently no active access policies.");
     });
     it('can configure the allow list policy', () => {
         cy.findByRole('region', {

--- a/tests/cypress/e2e/form/access_control.cy.js
+++ b/tests/cypress/e2e/form/access_control.cy.js
@@ -1,0 +1,125 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+describe('Access Control', () => {
+    beforeEach(() => {
+        cy.login();
+        cy.changeProfile('Super-Admin', true);
+
+        cy.createWithAPI('Glpi\\Form\\Form', {
+            'name': '[Tests] Access Control',
+        }).then((form_id) => {
+            const tab = 'Glpi\\Form\\AccessControl\\FormAccessControl$1';
+            cy.visit(`/front/form/form.form.php?id=${form_id}&forcetab=${tab}`);
+        });
+    });
+    it('warnings are displayed', () => {
+        // Quick tests to ensure that warnings are rendered correcly by twig.
+        // We don't check their exact content as it is already validated by unit tests.
+        cy.findAllByRole('alert').should('have.length', 2);
+    });
+    it('can configure the allow list policy', () => {
+        cy.findByRole('region', {
+            name: 'Allow specifics users, groups or profiles'
+        }).within(() => {
+            cy.findByRole('checkbox', {name: 'Active'})
+                .should('not.be.checked')
+                .click()
+            ;
+        });
+
+        // TODO: modify the user/group/profile dropdown (unsure how to tests
+        // select2 ajax dropdown for now)
+
+        // Save changes
+        cy.findByRole('button', {name: 'Save changes'}).click();
+
+        cy.findByRole('region', {
+            name: 'Allow specifics users, groups or profiles'
+        }).within(() => {
+            // Check values are kept after update
+            cy.findByRole('checkbox', {name: 'Active'}).should('be.checked');
+        });
+    });
+    it('can configure the direct access policy', () => {
+        cy.findByRole('region', {
+            name: 'Allow direct access'
+        }).within(() => {
+            cy.findByRole('checkbox', {name: 'Active'})
+                .should('not.be.checked')
+                .click()
+            ;
+            cy.findByRole('checkbox', {name: 'Allow unauthenticated users ?'})
+                .should('not.be.checked')
+                .click()
+            ;
+        });
+
+        // Save changes
+        cy.findByRole('button', {name: 'Save changes'}).click();
+
+        cy.findByRole('region', {
+            name: 'Allow direct access'
+        }).within(() => {
+            // Check values are kept after update
+            cy.findByRole('checkbox', {name: 'Active'}).should('be.checked');
+            cy.findByRole('checkbox', {
+                name: 'Allow unauthenticated users ?'
+            }).should('be.checked');
+
+            // Make sure link can be copied to clipboard
+            cy.findByLabelText("Click to copy to clipboard").click();
+            cy.window().then((win) => {
+                win.navigator.clipboard.readText().then((text) => {
+                    expect(text).to.contains('token=');
+                });
+            });
+        });
+    });
+    it('activate policy when any input is modified', () => {
+        cy.findByRole('region', {
+            name: 'Allow direct access'
+        }).within(() => {
+            cy.findByRole('checkbox', {name: 'Active'})
+                .should('not.be.checked')
+            ;
+            cy.findByRole('checkbox', {name: 'Allow unauthenticated users ?'})
+                .should('not.be.checked')
+                .click()
+            ;
+            cy.findByRole('checkbox', {name: 'Active'})
+                .should('be.checked')
+            ;
+        });
+    });
+});


### PR DESCRIPTION
Common code refactoring extracted from #17117.

This improve:
* Handling access control warnings. Previously computation were done directly in the twig template. Now the FormAccessManager compute the warning by itself and only send their text content to the template.
* Access policies html form. It was previously one form per policies that were sent one by one using ajax. Now merged into a simple form.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
