### PR TITLE
Remove reference to moved file

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -85,7 +85,6 @@ include_once __DIR__ . '/CsvTestCase.php';
 include_once __DIR__ . '/FrontBaseClass.php';
 include_once __DIR__ . '/HLAPITestCase.php';
 include_once __DIR__ . '/RuleBuilder.php';
-include_once __DIR__ . '/InventoryTestCase.php';
 include_once __DIR__ . '/functional/CommonITILRecurrent.php';
 include_once __DIR__ . '/functional/Glpi/ContentTemplates/Parameters/AbstractParameters.php';
 include_once __DIR__ . '/functional/AbstractRightsDropdown.php';


### PR DESCRIPTION
`InventoryTestCase.php` has been moved to the `phpunit` folder.

We are still trying to include it from the atoum bootstrap file, which make all tests fails on my end (not sure why it does not trigger any error on the CI ?).

```
Error PHP WARNING in /localhost/glpi/main/tests/bootstrap.php on line 88:
include_once(/localhost/glpi/main/tests/InventoryTestCase.php): Failed to open stream: No such file or directory
```

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
