### PR TITLE
feat(forms): Blacklist dangerous questions types for anonymous forms

### DIFF
--- a/js/form_editor_controller.js
+++ b/js/form_editor_controller.js
@@ -51,12 +51,6 @@ class GlpiFormEditorController
     #is_draft;
 
     /**
-     * Is this form anonymous?
-     * @type {boolean}
-     */
-    #is_anonymous;
-
-    /**
      * Default question type to use when creating a new question
      * @type {string}
      */
@@ -80,14 +74,12 @@ class GlpiFormEditorController
      *
      * @param {string}  target
      * @param {boolean} is_draft
-     * @param {boolean} is_anonymous
      * @param {string} defaultQuestionType
      * @param {string} templates
      */
-    constructor(target, is_draft, is_anonymous, defaultQuestionType, templates) {
+    constructor(target, is_draft, defaultQuestionType, templates) {
         this.#target              = target;
         this.#is_draft            = is_draft;
-        this.#is_anonymous        = is_anonymous;
         this.#defaultQuestionType = defaultQuestionType;
         this.#templates           = templates;
         this.#options             = {};
@@ -1114,13 +1106,10 @@ class GlpiFormEditorController
         // Update the question type
         this.#setItemInput(question, "type", type);
 
-        // Check if the form is an anonymous form and if the question type allows it
-        const blacklisted_warning = question.find('[data-glpi-form-editor-blacklisted-question-type-warning]');
-        if (this.#is_anonymous && !this.#options[type].allowAnonymous) {
-            blacklisted_warning.removeClass('d-none');
-        } else {
-            blacklisted_warning.addClass('d-none');
-        }
+        // Handle blacklisted question type warning visibility
+        const allow_anonymous = this.#getQuestionTemplate(type).find("input[name=allow_anonymous]").val();
+        question.find("[data-glpi-form-editor-blacklisted-question-type-warning]")
+            .toggleClass("d-none", allow_anonymous == 1);
 
         // Convert the default value to match the new type
         this.#options[type].convertDefaultValue(

--- a/js/form_editor_controller.js
+++ b/js/form_editor_controller.js
@@ -949,6 +949,12 @@ class GlpiFormEditorController
             tooltip_trigger_el => new bootstrap.Tooltip(tooltip_trigger_el)
         );
 
+        // Init popovers
+        const popover_trigger_list = copy.find('[data-bs-toggle="popover"]');
+        [...popover_trigger_list].map(
+            popover_trigger_el => new bootstrap.Popover(popover_trigger_el)
+        );
+
         return copy;
     }
 
@@ -1107,7 +1113,7 @@ class GlpiFormEditorController
         this.#setItemInput(question, "type", type);
 
         // Handle blacklisted question type warning visibility
-        const allow_anonymous = this.#getQuestionTemplate(type).find("input[name=allow_anonymous]").val();
+        const allow_anonymous = this.#getQuestionTemplate(type).find("[data-glpi-form-editor-question-details]").data("glpi-form-editor-allow-anonymous");
         question.find("[data-glpi-form-editor-blacklisted-question-type-warning]")
             .toggleClass("d-none", allow_anonymous == 1);
 

--- a/js/form_editor_controller.js
+++ b/js/form_editor_controller.js
@@ -51,6 +51,12 @@ class GlpiFormEditorController
     #is_draft;
 
     /**
+     * Is this form anonymous?
+     * @type {boolean}
+     */
+    #is_anonymous;
+
+    /**
      * Default question type to use when creating a new question
      * @type {string}
      */
@@ -74,12 +80,14 @@ class GlpiFormEditorController
      *
      * @param {string}  target
      * @param {boolean} is_draft
+     * @param {boolean} is_anonymous
      * @param {string} defaultQuestionType
      * @param {string} templates
      */
-    constructor(target, is_draft, defaultQuestionType, templates) {
+    constructor(target, is_draft, is_anonymous, defaultQuestionType, templates) {
         this.#target              = target;
         this.#is_draft            = is_draft;
+        this.#is_anonymous        = is_anonymous;
         this.#defaultQuestionType = defaultQuestionType;
         this.#templates           = templates;
         this.#options             = {};
@@ -1105,6 +1113,14 @@ class GlpiFormEditorController
 
         // Update the question type
         this.#setItemInput(question, "type", type);
+
+        // Check if the form is an anonymous form and if the question type allows it
+        const blacklisted_warning = question.find('[data-glpi-form-editor-blacklisted-question-type-warning]');
+        if (this.#is_anonymous && !this.#options[type].allowAnonymous) {
+            blacklisted_warning.removeClass('d-none');
+        } else {
+            blacklisted_warning.addClass('d-none');
+        }
 
         // Convert the default value to match the new type
         this.#options[type].convertDefaultValue(

--- a/src/Glpi/Form/AccessControl/ControlType/AllowList.php
+++ b/src/Glpi/Form/AccessControl/ControlType/AllowList.php
@@ -41,6 +41,7 @@ use Glpi\Form\AccessControl\AccessVote;
 use Glpi\Form\AccessControl\FormAccessControl;
 use Glpi\Form\AccessControl\FormAccessParameters;
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Form\Form;
 use Group;
 use Override;
 use Profile;
@@ -65,6 +66,12 @@ final class AllowList implements ControlTypeInterface
     public function getConfigClass(): string
     {
         return AllowListConfig::class;
+    }
+
+    #[Override]
+    public function getWarnings(Form $form, array $warnings): array
+    {
+        return $warnings;
     }
 
     #[Override]

--- a/src/Glpi/Form/AccessControl/ControlType/AllowList.php
+++ b/src/Glpi/Form/AccessControl/ControlType/AllowList.php
@@ -181,7 +181,7 @@ final class AllowList implements ControlTypeInterface
         return in_array($session_info->getProfileId(), $config->getProfileIds());
     }
 
-    public function allowUnauthenticated(JsonConfigInterface $config): bool
+    public function allowUnauthenticated(JsonFieldInterface $config): bool
     {
         return false;
     }

--- a/src/Glpi/Form/AccessControl/ControlType/AllowList.php
+++ b/src/Glpi/Form/AccessControl/ControlType/AllowList.php
@@ -173,4 +173,9 @@ final class AllowList implements ControlTypeInterface
     ): bool {
         return in_array($session_info->getProfileId(), $config->getProfileIds());
     }
+
+    public function allowUnauthenticated(JsonConfigInterface $config): bool
+    {
+        return false;
+    }
 }

--- a/src/Glpi/Form/AccessControl/ControlType/ControlTypeInterface.php
+++ b/src/Glpi/Form/AccessControl/ControlType/ControlTypeInterface.php
@@ -101,4 +101,12 @@ interface ControlTypeInterface
         JsonFieldInterface $config,
         FormAccessParameters $parameters
     ): AccessVote;
+
+    /**
+     * Define if an unauthenticated user can view the form.
+     *
+     * @param JsonConfigInterface $config
+     * @return bool
+     */
+    public function allowUnauthenticated(JsonConfigInterface $config): bool;
 }

--- a/src/Glpi/Form/AccessControl/ControlType/ControlTypeInterface.php
+++ b/src/Glpi/Form/AccessControl/ControlType/ControlTypeInterface.php
@@ -39,6 +39,7 @@ use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\AccessControl\AccessVote;
 use Glpi\Form\AccessControl\FormAccessControl;
 use Glpi\Form\AccessControl\FormAccessParameters;
+use Glpi\Form\Form;
 
 interface ControlTypeInterface
 {
@@ -62,6 +63,15 @@ interface ControlTypeInterface
      * @return string Class name which implements JsonConfigInterface
      */
     public function getConfigClass(): string;
+
+    /**
+     * Get the warnings for the given form.
+     *
+     * @param  Form $form
+     * @param  string[] $warnings
+     * @return string[]
+     */
+    public function getWarnings(Form $form, array $warnings): array;
 
     /**
      * Render the configuration form of this control type.

--- a/src/Glpi/Form/AccessControl/ControlType/ControlTypeInterface.php
+++ b/src/Glpi/Form/AccessControl/ControlType/ControlTypeInterface.php
@@ -60,7 +60,7 @@ interface ControlTypeInterface
     /**
      * Get the free json config config class name for this object.
      *
-     * @return string Class name which implements JsonConfigInterface
+     * @return string Class name which implements JsonFieldInterface
      */
     public function getConfigClass(): string;
 
@@ -115,8 +115,8 @@ interface ControlTypeInterface
     /**
      * Define if an unauthenticated user can view the form.
      *
-     * @param JsonConfigInterface $config
+     * @param JsonFieldInterface $config
      * @return bool
      */
-    public function allowUnauthenticated(JsonConfigInterface $config): bool;
+    public function allowUnauthenticated(JsonFieldInterface $config): bool;
 }

--- a/src/Glpi/Form/AccessControl/ControlType/DirectAccess.php
+++ b/src/Glpi/Form/AccessControl/ControlType/DirectAccess.php
@@ -146,4 +146,13 @@ final class DirectAccess implements ControlTypeInterface
 
         return $config->getToken() === $token;
     }
+
+    public function allowUnauthenticated(JsonConfigInterface $config): bool
+    {
+        if (!$config instanceof DirectAccessConfig) {
+            throw new \InvalidArgumentException("Invalid config class");
+        }
+
+        return $config->allowUnauthenticated();
+    }
 }

--- a/src/Glpi/Form/AccessControl/ControlType/DirectAccess.php
+++ b/src/Glpi/Form/AccessControl/ControlType/DirectAccess.php
@@ -40,6 +40,8 @@ use Glpi\Form\AccessControl\AccessVote;
 use Glpi\Form\AccessControl\FormAccessControl;
 use Glpi\Form\AccessControl\FormAccessParameters;
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Form\AccessControl\FormAccessControlManager;
+use Glpi\Form\Form;
 use Override;
 
 final class DirectAccess implements ControlTypeInterface
@@ -60,6 +62,29 @@ final class DirectAccess implements ControlTypeInterface
     public function getConfigClass(): string
     {
         return DirectAccessConfig::class;
+    }
+
+    #[Override]
+    public function getWarnings(Form $form, array $warnings): array
+    {
+        return $this->addWarningIfFormHasBlacklistedQuestionTypes($form, $warnings);
+    }
+
+    private function addWarningIfFormHasBlacklistedQuestionTypes(
+        Form $form,
+        array $warnings
+    ): array {
+        if (
+            FormAccessControlManager::getInstance()->allowUnauthenticatedAccess($form)
+            && array_reduce(
+                $form->getQuestions(),
+                fn ($carry, $question) => $carry || !$question->getQuestionType()->isAllowedForUnauthenticatedAccess()
+            )
+        ) {
+            $warnings[] = __('This form contains question types that are not allowed for unauthenticated access. These questions will be hidden from unauthenticated users.');
+        }
+
+        return $warnings;
     }
 
     #[Override]

--- a/src/Glpi/Form/AccessControl/ControlType/DirectAccess.php
+++ b/src/Glpi/Form/AccessControl/ControlType/DirectAccess.php
@@ -172,7 +172,7 @@ final class DirectAccess implements ControlTypeInterface
         return $config->getToken() === $token;
     }
 
-    public function allowUnauthenticated(JsonConfigInterface $config): bool
+    public function allowUnauthenticated(JsonFieldInterface $config): bool
     {
         if (!$config instanceof DirectAccessConfig) {
             throw new \InvalidArgumentException("Invalid config class");

--- a/src/Glpi/Form/AccessControl/FormAccessControlManager.php
+++ b/src/Glpi/Form/AccessControl/FormAccessControlManager.php
@@ -92,7 +92,7 @@ final class FormAccessControlManager
         return array_values($controls);
     }
 
-    public function isAnonymousForm(Form $form): bool
+    public function allowUnauthenticatedAccess(Form $form): bool
     {
         $access_controls = $this->getActiveAccessControlsForForm($form);
         return array_reduce(
@@ -166,6 +166,12 @@ final class FormAccessControlManager
         $warnings = [];
         $warnings = $this->addWarningIfFormIsNotActive($form, $warnings);
         $warnings = $this->addWarningIfFormHasNoActivePolicies($form, $warnings);
+
+        // Add Access Control Strategy warnings
+        $access_controls = $this->getPossibleAccessControlsStrategies($form);
+        foreach ($access_controls as $access_control) {
+            $warnings = $access_control->getWarnings($form, $warnings);
+        }
 
         return $warnings;
     }

--- a/src/Glpi/Form/AccessControl/FormAccessControlManager.php
+++ b/src/Glpi/Form/AccessControl/FormAccessControlManager.php
@@ -98,11 +98,7 @@ final class FormAccessControlManager
         return array_reduce(
             $access_controls,
             function ($acc, $control) {
-                if ($control->getStrategy() instanceof DirectAccess) {
-                    return $acc || $control->getConfig()->allowUnauthenticated();
-                }
-
-                return $acc;
+                return $acc || $control->getStrategy()->allowUnauthenticated($control->getConfig());
             },
             false
         );

--- a/src/Glpi/Form/AccessControl/FormAccessControlManager.php
+++ b/src/Glpi/Form/AccessControl/FormAccessControlManager.php
@@ -92,6 +92,22 @@ final class FormAccessControlManager
         return array_values($controls);
     }
 
+    public function isAnonymousForm(Form $form): bool
+    {
+        $access_controls = $this->getActiveAccessControlsForForm($form);
+        return array_reduce(
+            $access_controls,
+            function ($acc, $control) {
+                if ($control->getStrategy() instanceof DirectAccess) {
+                    return $acc || $control->getConfig()->allowUnauthenticated();
+                }
+
+                return $acc;
+            },
+            false
+        );
+    }
+
     /**
      * Check if the current user can answer the given form.
      *

--- a/src/Glpi/Form/AccessControl/FormAccessControlManager.php
+++ b/src/Glpi/Form/AccessControl/FormAccessControlManager.php
@@ -168,7 +168,7 @@ final class FormAccessControlManager
         $warnings = $this->addWarningIfFormHasNoActivePolicies($form, $warnings);
 
         // Add Access Control Strategy warnings
-        $access_controls = $this->getPossibleAccessControlsStrategies($form);
+        $access_controls = $this->getPossibleAccessControlsStrategies();
         foreach ($access_controls as $access_control) {
             $warnings = $access_control->getWarnings($form, $warnings);
         }

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -45,6 +45,7 @@ use Glpi\Form\Destination\FormDestination;
 use Glpi\Form\QuestionType\QuestionTypeInterface;
 use Html;
 use Glpi\DBAL\QuerySubQuery;
+use Glpi\Form\AccessControl\FormAccessControlManager;
 use Glpi\Form\QuestionType\QuestionTypesManager;
 use Log;
 use Override;
@@ -124,6 +125,7 @@ final class Form extends CommonDBTM
             'params'                 => $options,
             'question_types_manager' => $types_manager,
             'js_files'               => $js_files,
+            'is_anonymous_form'      => FormAccessControlManager::getInstance()->isAnonymousForm($this),
         ]);
         return true;
     }

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -125,7 +125,7 @@ final class Form extends CommonDBTM
             'params'                 => $options,
             'question_types_manager' => $types_manager,
             'js_files'               => $js_files,
-            'is_anonymous_form'      => FormAccessControlManager::getInstance()->isAnonymousForm($this),
+            'allow_unauthenticated_access'      => FormAccessControlManager::getInstance()->allowUnauthenticatedAccess($this),
         ]);
         return true;
     }

--- a/src/Glpi/Form/Question.php
+++ b/src/Glpi/Form/Question.php
@@ -91,7 +91,7 @@ final class Question extends CommonDBChild implements BlockInterface
             'question_types_manager' => QuestionTypesManager::getInstance(),
             'section'                => $this->getItem(),
             'can_update'             => $this->getForm()->canUpdate(),
-            'is_anonymous'           => FormAccessControlManager::getInstance()->isAnonymousForm($this->getForm()),
+            'is_anonymous'           => FormAccessControlManager::getInstance()->allowUnauthenticatedAccess($this->getForm()),
         ]);
     }
 

--- a/src/Glpi/Form/Question.php
+++ b/src/Glpi/Form/Question.php
@@ -85,13 +85,13 @@ final class Question extends CommonDBChild implements BlockInterface
     public function displayBlockForEditor(): void
     {
         TemplateRenderer::getInstance()->display('pages/admin/form/form_question.html.twig', [
-            'form'                   => $this->getForm(),
-            'question'               => $this,
-            'question_type'          => $this->getQuestionType(),
-            'question_types_manager' => QuestionTypesManager::getInstance(),
-            'section'                => $this->getItem(),
-            'can_update'             => $this->getForm()->canUpdate(),
-            'is_anonymous'           => FormAccessControlManager::getInstance()->allowUnauthenticatedAccess($this->getForm()),
+            'form'                         => $this->getForm(),
+            'question'                     => $this,
+            'question_type'                => $this->getQuestionType(),
+            'question_types_manager'       => QuestionTypesManager::getInstance(),
+            'section'                      => $this->getItem(),
+            'can_update'                   => $this->getForm()->canUpdate(),
+            'allow_unauthenticated_access' => FormAccessControlManager::getInstance()->allowUnauthenticatedAccess($this->getForm()),
         ]);
     }
 

--- a/src/Glpi/Form/Question.php
+++ b/src/Glpi/Form/Question.php
@@ -43,6 +43,7 @@ use Glpi\Form\QuestionType\QuestionTypesManager;
 use Log;
 use Override;
 use ReflectionClass;
+use Session;
 
 /**
  * Question of a given helpdesk form's section
@@ -90,7 +91,7 @@ final class Question extends CommonDBChild implements BlockInterface
             'question_types_manager' => QuestionTypesManager::getInstance(),
             'section'                => $this->getItem(),
             'can_update'             => $this->getForm()->canUpdate(),
-            'is_anonymous_form'      => FormAccessControlManager::getInstance()->isAnonymousForm($this->getForm()),
+            'is_anonymous'           => FormAccessControlManager::getInstance()->isAnonymousForm($this->getForm()),
         ]);
     }
 

--- a/src/Glpi/Form/Question.php
+++ b/src/Glpi/Form/Question.php
@@ -37,6 +37,7 @@ namespace Glpi\Form;
 
 use CommonDBChild;
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Form\AccessControl\FormAccessControlManager;
 use Glpi\Form\QuestionType\QuestionTypeInterface;
 use Glpi\Form\QuestionType\QuestionTypesManager;
 use Log;
@@ -89,6 +90,7 @@ final class Question extends CommonDBChild implements BlockInterface
             'question_types_manager' => QuestionTypesManager::getInstance(),
             'section'                => $this->getItem(),
             'can_update'             => $this->getForm()->canUpdate(),
+            'is_anonymous_form'      => FormAccessControlManager::getInstance()->isAnonymousForm($this->getForm()),
         ]);
     }
 

--- a/src/Glpi/Form/QuestionType/AbstractQuestionType.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionType.php
@@ -113,7 +113,7 @@ abstract class AbstractQuestionType implements QuestionTypeInterface
     }
 
     #[Override]
-    public function isAllowedForAnonymousForm(): bool
+    public function isAllowedForUnauthenticatedAccess(): bool
     {
         return false;
     }

--- a/src/Glpi/Form/QuestionType/AbstractQuestionType.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionType.php
@@ -78,8 +78,11 @@ abstract class AbstractQuestionType implements QuestionTypeInterface
     #[Override]
     public function getFormEditorJsOptions(): string
     {
+        $is_allowed_for_anonymous_form = $this->isAllowedForAnonymousForm() ? 'true' : 'false';
+
         return <<<JS
             {
+                "allowAnonymous": $is_allowed_for_anonymous_form,
                 "extractDefaultValue": function (question) { return null; },
                 "convertDefaultValue": function (question, value) {
                     return value;
@@ -110,5 +113,11 @@ abstract class AbstractQuestionType implements QuestionTypeInterface
     public function getWeight(): int
     {
         return 10;
+    }
+
+    #[Override]
+    public function isAllowedForAnonymousForm(): bool
+    {
+        return false;
     }
 }

--- a/src/Glpi/Form/QuestionType/AbstractQuestionType.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionType.php
@@ -78,11 +78,8 @@ abstract class AbstractQuestionType implements QuestionTypeInterface
     #[Override]
     public function getFormEditorJsOptions(): string
     {
-        $is_allowed_for_anonymous_form = $this->isAllowedForAnonymousForm() ? 'true' : 'false';
-
         return <<<JS
             {
-                "allowAnonymous": $is_allowed_for_anonymous_form,
                 "extractDefaultValue": function (question) { return null; },
                 "convertDefaultValue": function (question, value) {
                     return value;

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
@@ -299,7 +299,7 @@ TWIG;
     }
 
     #[Override]
-    public function isAllowedForAnonymousForm(): bool
+    public function isAllowedForUnauthenticatedAccess(): bool
     {
         return false;
     }

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
@@ -297,4 +297,10 @@ TWIG;
     {
         return QuestionTypeCategory::ACTORS;
     }
+
+    #[Override]
+    public function isAllowedForAnonymousForm(): bool
+    {
+        return false;
+    }
 }

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
@@ -325,4 +325,10 @@ TWIG;
             'answers' => $answers,
         ]);
     }
+
+    #[Override]
+    public function isAllowedForAnonymousForm(): bool
+    {
+        return true;
+    }
 }

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
@@ -327,7 +327,7 @@ TWIG;
     }
 
     #[Override]
-    public function isAllowedForAnonymousForm(): bool
+    public function isAllowedForUnauthenticatedAccess(): bool
     {
         return true;
     }

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
@@ -56,6 +56,7 @@ abstract class AbstractQuestionTypeShortAnswer extends AbstractQuestionType
     {
         return <<<JS
             {
+                "allowAnonymous": true,
                 "extractDefaultValue": function (question) {
                     const input = question.find('[data-glpi-form-editor-question-type-specific]')
                         .find('[name="default_value"], [data-glpi-form-editor-original-name="default_value"]');
@@ -146,5 +147,11 @@ TWIG;
     public function getCategory(): QuestionTypeCategory
     {
         return QuestionTypeCategory::SHORT_ANSWER;
+    }
+
+    #[Override]
+    public function isAllowedForAnonymousForm(): bool
+    {
+        return true;
     }
 }

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
@@ -149,7 +149,7 @@ TWIG;
     }
 
     #[Override]
-    public function isAllowedForAnonymousForm(): bool
+    public function isAllowedForUnauthenticatedAccess(): bool
     {
         return true;
     }

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
@@ -56,7 +56,6 @@ abstract class AbstractQuestionTypeShortAnswer extends AbstractQuestionType
     {
         return <<<JS
             {
-                "allowAnonymous": true,
                 "extractDefaultValue": function (question) {
                     const input = question.find('[data-glpi-form-editor-question-type-specific]')
                         .find('[name="default_value"], [data-glpi-form-editor-original-name="default_value"]');

--- a/src/Glpi/Form/QuestionType/QuestionTypeDateTime.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeDateTime.php
@@ -348,4 +348,10 @@ TWIG;
             'answer' => $this->formatAnswer($answer),
         ]);
     }
+
+    #[Override]
+    public function isAllowedForAnonymousForm(): bool
+    {
+        return true;
+    }
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeDateTime.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeDateTime.php
@@ -350,7 +350,7 @@ TWIG;
     }
 
     #[Override]
-    public function isAllowedForAnonymousForm(): bool
+    public function isAllowedForUnauthenticatedAccess(): bool
     {
         return true;
     }

--- a/src/Glpi/Form/QuestionType/QuestionTypeFile.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeFile.php
@@ -137,4 +137,10 @@ TWIG;
     {
         return QuestionTypeCategory::FILE;
     }
+
+    #[Override]
+    public function isAllowedForAnonymousForm(): bool
+    {
+        return true;
+    }
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeFile.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeFile.php
@@ -139,7 +139,7 @@ TWIG;
     }
 
     #[Override]
-    public function isAllowedForAnonymousForm(): bool
+    public function isAllowedForUnauthenticatedAccess(): bool
     {
         return true;
     }

--- a/src/Glpi/Form/QuestionType/QuestionTypeInterface.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeInterface.php
@@ -94,7 +94,6 @@ interface QuestionTypeInterface
      * Get JS functions options for the form editor.
      *
      * The options must be a JSON object, accepting the following keys:
-     * The allowAnonymous key is used to allow or disallow the question type for anonymous forms.
      * The extractDefaultValue function is used to extract the default value from the form editor.
      * The convertDefaultValue function is used to convert the default value to the form editor.
      *

--- a/src/Glpi/Form/QuestionType/QuestionTypeInterface.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeInterface.php
@@ -93,7 +93,8 @@ interface QuestionTypeInterface
     /**
      * Get JS functions options for the form editor.
      *
-     * The options must be a JSON object, accepting two functions:
+     * The options must be a JSON object, accepting the following keys:
+     * The allowAnonymous key is used to allow or disallow the question type for anonymous forms.
      * The extractDefaultValue function is used to extract the default value from the form editor.
      * The convertDefaultValue function is used to convert the default value to the form editor.
      *
@@ -169,4 +170,12 @@ interface QuestionTypeInterface
      * @return int
      */
     public function getWeight(): int;
+
+    /**
+     * Check if this question type is allowed for anonymous forms.
+     * If this method returns false, the question type will not be displayed in the end user form.
+     *
+     * @return bool
+     */
+    public function isAllowedForAnonymousForm(): bool;
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeInterface.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeInterface.php
@@ -176,5 +176,5 @@ interface QuestionTypeInterface
      *
      * @return bool
      */
-    public function isAllowedForAnonymousForm(): bool;
+    public function isAllowedForUnauthenticatedAccess(): bool;
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
@@ -169,7 +169,7 @@ TWIG;
     }
 
     #[Override]
-    public function isAllowedForAnonymousForm(): bool
+    public function isAllowedForUnauthenticatedAccess(): bool
     {
         return true;
     }

--- a/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
@@ -49,7 +49,6 @@ final class QuestionTypeLongText extends AbstractQuestionType
     {
         return <<<JS
             {
-                "allowAnonymous": true,
                 "extractDefaultValue": function (question) {
                     const textarea = question.find('[data-glpi-form-editor-question-type-specific]')
                         .find('[name="default_value"], [data-glpi-form-editor-original-name="default_value"]');

--- a/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
@@ -49,6 +49,7 @@ final class QuestionTypeLongText extends AbstractQuestionType
     {
         return <<<JS
             {
+                "allowAnonymous": true,
                 "extractDefaultValue": function (question) {
                     const textarea = question.find('[data-glpi-form-editor-question-type-specific]')
                         .find('[name="default_value"], [data-glpi-form-editor-original-name="default_value"]');
@@ -166,5 +167,11 @@ TWIG;
     public function getCategory(): QuestionTypeCategory
     {
         return QuestionTypeCategory::LONG_ANSWER;
+    }
+
+    #[Override]
+    public function isAllowedForAnonymousForm(): bool
+    {
+        return true;
     }
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeRequestType.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeRequestType.php
@@ -139,7 +139,7 @@ TWIG;
     }
 
     #[Override]
-    public function isAllowedForAnonymousForm(): bool
+    public function isAllowedForUnauthenticatedAccess(): bool
     {
         return true;
     }

--- a/src/Glpi/Form/QuestionType/QuestionTypeRequestType.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeRequestType.php
@@ -137,4 +137,10 @@ TWIG;
     {
         return QuestionTypeCategory::REQUEST_TYPE;
     }
+
+    #[Override]
+    public function isAllowedForAnonymousForm(): bool
+    {
+        return true;
+    }
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php
@@ -141,4 +141,10 @@ TWIG;
     {
         return QuestionTypeCategory::URGENCY;
     }
+
+    #[Override]
+    public function isAllowedForAnonymousForm(): bool
+    {
+        return true;
+    }
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php
@@ -143,7 +143,7 @@ TWIG;
     }
 
     #[Override]
-    public function isAllowedForAnonymousForm(): bool
+    public function isAllowedForUnauthenticatedAccess(): bool
     {
         return true;
     }

--- a/src/Glpi/Form/Renderer/FormRenderer.php
+++ b/src/Glpi/Form/Renderer/FormRenderer.php
@@ -88,8 +88,7 @@ final class FormRenderer
         $twig = TemplateRenderer::getInstance();
         $html .= $twig->render('pages/form_renderer.html.twig', [
             'form'              => $form,
-            'is_anonymous_user' => FormAccessControlManager::getInstance()->isAnonymousForm($form)
-                && !Session::isAuthenticated(),
+            'is_anonymous_user' => !Session::isAuthenticated(),
         ]);
 
         return $html;

--- a/src/Glpi/Form/Renderer/FormRenderer.php
+++ b/src/Glpi/Form/Renderer/FormRenderer.php
@@ -39,6 +39,7 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\Form\AccessControl\FormAccessControlManager;
 use Glpi\Form\Form;
 use Html;
+use Session;
 
 /**
  * Utility class used to easily render a form
@@ -87,7 +88,8 @@ final class FormRenderer
         $twig = TemplateRenderer::getInstance();
         $html .= $twig->render('pages/form_renderer.html.twig', [
             'form'              => $form,
-            'is_anonymous_form' => FormAccessControlManager::getInstance()->isAnonymousForm($form),
+            'is_anonymous_user' => FormAccessControlManager::getInstance()->isAnonymousForm($form)
+                && !Session::isAuthenticated(),
         ]);
 
         return $html;

--- a/src/Glpi/Form/Renderer/FormRenderer.php
+++ b/src/Glpi/Form/Renderer/FormRenderer.php
@@ -36,6 +36,7 @@
 namespace Glpi\Form\Renderer;
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Form\AccessControl\FormAccessControlManager;
 use Glpi\Form\Form;
 use Html;
 
@@ -85,7 +86,8 @@ final class FormRenderer
         // Load template
         $twig = TemplateRenderer::getInstance();
         $html .= $twig->render('pages/form_renderer.html.twig', [
-            'form' => $form,
+            'form'              => $form,
+            'is_anonymous_form' => FormAccessControlManager::getInstance()->isAnonymousForm($form),
         ]);
 
         return $html;

--- a/src/Glpi/Form/Renderer/FormRenderer.php
+++ b/src/Glpi/Form/Renderer/FormRenderer.php
@@ -87,8 +87,8 @@ final class FormRenderer
         // Load template
         $twig = TemplateRenderer::getInstance();
         $html .= $twig->render('pages/form_renderer.html.twig', [
-            'form'              => $form,
-            'is_anonymous_user' => !Session::isAuthenticated(),
+            'form'                 => $form,
+            'unauthenticated_user' => !Session::isAuthenticated(),
         ]);
 
         return $html;

--- a/templates/layout/parts/user_header.html.twig
+++ b/templates/layout/parts/user_header.html.twig
@@ -38,7 +38,8 @@
       <div class="navbar-nav flex-row order-md-last user-menu">
          <div class="nav-item dropdown">
             <a href="#" class="nav-link d-flex lh-1 text-reset p-1 dropdown-toggle user-menu-dropdown-toggle {% if is_debug_active %}bg-red-lt{% endif %}"
-               data-bs-toggle="dropdown" data-bs-auto-close="outside">
+               data-bs-toggle="dropdown" data-bs-auto-close="outside"
+               aria-label="{{ __('User menu') }}">
                {% if not anonymous %}
                   <div class="pe-2 d-none d-xl-block">
                      <div>{{ (session('glpiactiveprofile')['name'] ?? '')|u.truncate(35, '...') }}</div>

--- a/templates/pages/admin/form/access_control/direct_access.html.twig
+++ b/templates/pages/admin/form/access_control/direct_access.html.twig
@@ -48,6 +48,7 @@
         class="form-control cursor-pointer"
         readonly=""
         value="{{ url }}"
+        aria-label="{{ __("Direct access URL") }}"
     >
     <span class="input-icon-addon">
         <i class="ti ti-files"></i>

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -318,13 +318,13 @@
             <div data-glpi-form-editor-question-template="{{ key }}">
                 {# Render admin template for the given question type #}
                 {{ include('pages/admin/form/form_question.html.twig', {
-                    'form'                   : item,
-                    'question_types_manager' : question_types_manager,
-                    'question_type'          : question_type,
-                    'question'               : null,
-                    'section'                : null,
-                    'can_update'             : true,
-                    'is_anonymous'      : allow_unauthenticated_access,
+                    'form'                        : item,
+                    'question_types_manager'      : question_types_manager,
+                    'question_type'               : question_type,
+                    'question'                    : null,
+                    'section'                     : null,
+                    'can_update'                  : true,
+                    'allow_unauthenticated_access': allow_unauthenticated_access,
                 }, with_context = false) }}
             </div>
         {% endfor %}

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -324,7 +324,7 @@
                     'question'               : null,
                     'section'                : null,
                     'can_update'             : true,
-                    'is_anonymous_form'      : is_anonymous_form,
+                    'is_anonymous'      : is_anonymous_form,
                 }, with_context = false) }}
             </div>
         {% endfor %}
@@ -371,7 +371,6 @@
     window.glpi_form_editor_controller = new GlpiFormEditorController(
         "[data-glpi-form-editor-container]",
         {{ item.fields.is_draft ? "true" : "false" }},
-        {{ is_anonymous_form ? "true" : "false" }},
         "{{ question_types_manager.getDefaultTypeClass()|escape('js') }}",
         "[data-glpi-form-editor-templates]"
     );

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -34,6 +34,7 @@
 {# @var item   Glpi\Form\Form #}
 {# @var params array #}
 {# @var question_types_manager Glpi\Form\QuestionType\QuestionTypesManager #}
+{# @var is_anonymous_form bool #}
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
@@ -323,6 +324,7 @@
                     'question'               : null,
                     'section'                : null,
                     'can_update'             : true,
+                    'is_anonymous_form'      : is_anonymous_form,
                 }, with_context = false) }}
             </div>
         {% endfor %}
@@ -369,6 +371,7 @@
     window.glpi_form_editor_controller = new GlpiFormEditorController(
         "[data-glpi-form-editor-container]",
         {{ item.fields.is_draft ? "true" : "false" }},
+        {{ is_anonymous_form ? "true" : "false" }},
         "{{ question_types_manager.getDefaultTypeClass()|escape('js') }}",
         "[data-glpi-form-editor-templates]"
     );

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -34,7 +34,7 @@
 {# @var item   Glpi\Form\Form #}
 {# @var params array #}
 {# @var question_types_manager Glpi\Form\QuestionType\QuestionTypesManager #}
-{# @var is_anonymous_form bool #}
+{# @var allow_unauthenticated_access bool #}
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
@@ -324,7 +324,7 @@
                     'question'               : null,
                     'section'                : null,
                     'can_update'             : true,
-                    'is_anonymous'      : is_anonymous_form,
+                    'is_anonymous'      : allow_unauthenticated_access,
                 }, with_context = false) }}
             </div>
         {% endfor %}

--- a/templates/pages/admin/form/form_question.html.twig
+++ b/templates/pages/admin/form/form_question.html.twig
@@ -37,6 +37,7 @@
 {# @var question               Glpi\Form\Question|null #}
 {# @var section                Glpi\Form\Section|null #}
 {# @var can_update             bool #}
+{# @var is_anonymous_form      bool #}
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
@@ -73,6 +74,14 @@
             </div>
             {# Display question's title #}
             <div class="d-flex mt-n1 align-items-center">
+                <i
+                    class="ti ti-alert-triangle text-warning me-2 {{ is_anonymous_form and not question_type.isAllowedForAnonymousForm() ? '' : 'd-none' }}"
+                    data-glpi-form-editor-blacklisted-question-type-warning
+                    data-bs-toggle="popover"
+                    data-bs-placement="top"
+                    data-bs-html="true"
+                    data-bs-content="{{ __("This question type cannot be used in a public form. User must be authenticated to view this question type. Check your access policy.") }}"
+                ></i>
                 <input
                     title="{{ __("Question name") }}"
                     class="form-control content-editable-h2 mb-0"

--- a/templates/pages/admin/form/form_question.html.twig
+++ b/templates/pages/admin/form/form_question.html.twig
@@ -37,7 +37,7 @@
 {# @var question               Glpi\Form\Question|null #}
 {# @var section                Glpi\Form\Section|null #}
 {# @var can_update             bool #}
-{# @var is_anonymous_form      bool #}
+{# @var is_anonymous           bool #}
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
@@ -75,7 +75,7 @@
             {# Display question's title #}
             <div class="d-flex mt-n1 align-items-center">
                 <i
-                    class="ti ti-alert-triangle text-warning me-2 {{ is_anonymous_form and not question_type.isAllowedForAnonymousForm() ? '' : 'd-none' }}"
+                    class="ti ti-alert-triangle text-warning me-2 {{ is_anonymous and not question_type.isAllowedForAnonymousForm() ? '' : 'd-none' }}"
                     data-glpi-form-editor-blacklisted-question-type-warning
                     data-bs-toggle="popover"
                     data-bs-placement="top"
@@ -254,6 +254,11 @@
             type="hidden"
             name="type"
             value="{{ constant('class', question_type) }}"
+        />
+        <input
+            type="hidden"
+            name="allow_anonymous"
+            value="{{ not is_anonymous or question_type.isAllowedForAnonymousForm() ? 1 : 0 }}"
         />
     </section>
     <div data-glpi-form-editor-question-extra-details>

--- a/templates/pages/admin/form/form_question.html.twig
+++ b/templates/pages/admin/form/form_question.html.twig
@@ -57,6 +57,7 @@
     <section
         data-glpi-form-editor-on-click="set-active"
         data-glpi-form-editor-question-details
+        data-glpi-form-editor-allow-anonymous="{{ not is_anonymous or question_type.isAllowedForAnonymousForm() ? 1 : 0 }}"
         class="card {{ question is not null and question.fields.is_mandatory ? 'mandatory-question' : '' }}"
         aria-label="{{ __("Question details") }}"
     >
@@ -78,6 +79,7 @@
                     class="ti ti-alert-triangle text-warning me-2 {{ is_anonymous and not question_type.isAllowedForAnonymousForm() ? '' : 'd-none' }}"
                     data-glpi-form-editor-blacklisted-question-type-warning
                     data-bs-toggle="popover"
+                    data-bs-trigger="hover"
                     data-bs-placement="top"
                     data-bs-html="true"
                     data-bs-content="{{ __("This question type cannot be used in a public form. User must be authenticated to view this question type. Check your access policy.") }}"
@@ -254,11 +256,6 @@
             type="hidden"
             name="type"
             value="{{ constant('class', question_type) }}"
-        />
-        <input
-            type="hidden"
-            name="allow_anonymous"
-            value="{{ not is_anonymous or question_type.isAllowedForAnonymousForm() ? 1 : 0 }}"
         />
     </section>
     <div data-glpi-form-editor-question-extra-details>

--- a/templates/pages/admin/form/form_question.html.twig
+++ b/templates/pages/admin/form/form_question.html.twig
@@ -31,13 +31,13 @@
  # ---------------------------------------------------------------------
  #}
 
-{# @var form                   Glpi\Form #}
-{# @var question_types_manager Glpi\Form\QuestionType\QuestionTypesManager #}
-{# @var question_type          Glpi\Form\QuestionType\QuestionTypeInterface #}
-{# @var question               Glpi\Form\Question|null #}
-{# @var section                Glpi\Form\Section|null #}
-{# @var can_update             bool #}
-{# @var is_anonymous           bool #}
+{# @var form                         Glpi\Form #}
+{# @var question_types_manager       Glpi\Form\QuestionType\QuestionTypesManager #}
+{# @var question_type                Glpi\Form\QuestionType\QuestionTypeInterface #}
+{# @var question                     Glpi\Form\Question|null #}
+{# @var section                      Glpi\Form\Section|null #}
+{# @var can_update                   bool #}
+{# @var allow_unauthenticated_access bool #}
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
@@ -57,7 +57,7 @@
     <section
         data-glpi-form-editor-on-click="set-active"
         data-glpi-form-editor-question-details
-        data-glpi-form-editor-allow-anonymous="{{ not is_anonymous or question_type.isAllowedForUnauthenticatedAccess() ? 1 : 0 }}"
+        data-glpi-form-editor-allow-anonymous="{{ not allow_unauthenticated_access or question_type.isAllowedForUnauthenticatedAccess() ? 1 : 0 }}"
         class="card {{ question is not null and question.fields.is_mandatory ? 'mandatory-question' : '' }}"
         aria-label="{{ __("Question details") }}"
     >
@@ -76,7 +76,7 @@
             {# Display question's title #}
             <div class="d-flex mt-n1 align-items-center">
                 <i
-                    class="ti ti-alert-triangle text-warning me-2 {{ is_anonymous and not question_type.isAllowedForUnauthenticatedAccess() ? '' : 'd-none' }}"
+                    class="ti ti-alert-triangle text-warning me-2 {{ allow_unauthenticated_access and not question_type.isAllowedForUnauthenticatedAccess() ? '' : 'd-none' }}"
                     data-glpi-form-editor-blacklisted-question-type-warning
                     data-bs-toggle="popover"
                     data-bs-trigger="hover"

--- a/templates/pages/admin/form/form_question.html.twig
+++ b/templates/pages/admin/form/form_question.html.twig
@@ -57,7 +57,7 @@
     <section
         data-glpi-form-editor-on-click="set-active"
         data-glpi-form-editor-question-details
-        data-glpi-form-editor-allow-anonymous="{{ not is_anonymous or question_type.isAllowedForAnonymousForm() ? 1 : 0 }}"
+        data-glpi-form-editor-allow-anonymous="{{ not is_anonymous or question_type.isAllowedForUnauthenticatedAccess() ? 1 : 0 }}"
         class="card {{ question is not null and question.fields.is_mandatory ? 'mandatory-question' : '' }}"
         aria-label="{{ __("Question details") }}"
     >
@@ -76,13 +76,13 @@
             {# Display question's title #}
             <div class="d-flex mt-n1 align-items-center">
                 <i
-                    class="ti ti-alert-triangle text-warning me-2 {{ is_anonymous and not question_type.isAllowedForAnonymousForm() ? '' : 'd-none' }}"
+                    class="ti ti-alert-triangle text-warning me-2 {{ is_anonymous and not question_type.isAllowedForUnauthenticatedAccess() ? '' : 'd-none' }}"
                     data-glpi-form-editor-blacklisted-question-type-warning
                     data-bs-toggle="popover"
                     data-bs-trigger="hover"
                     data-bs-placement="top"
                     data-bs-html="true"
-                    data-bs-content="{{ __("This question type cannot be used in a public form. User must be authenticated to view this question type. Check your access policy.") }}"
+                    data-bs-content="{{ __("The current access policy allows unauthenticated access to this form, but this question type will be hidden to unauthenticated users.") }}"
                 ></i>
                 <input
                     title="{{ __("Question name") }}"

--- a/templates/pages/form_renderer.html.twig
+++ b/templates/pages/form_renderer.html.twig
@@ -96,7 +96,7 @@
                 {% endif %}
 
                 {# Skip questions not allowed for anonymous forms #}
-                {% if not skip_question and form_block is instanceof('Glpi\\Form\\Question') and is_anonymous_user and not question_type.isAllowedForUnauthenticatedAccess() %}
+                {% if not skip_question and form_block is instanceof('Glpi\\Form\\Question') and unauthenticated_user and not question_type.isAllowedForUnauthenticatedAccess() %}
                     {% set skip_question = true %}
                 {% endif %}
 

--- a/templates/pages/form_renderer.html.twig
+++ b/templates/pages/form_renderer.html.twig
@@ -96,7 +96,7 @@
                 {% endif %}
 
                 {# Skip questions not allowed for anonymous forms #}
-                {% if not skip_question and form_block is instanceof('Glpi\\Form\\Question') and is_anonymous_user and not question_type.isAllowedForAnonymousForm() %}
+                {% if not skip_question and form_block is instanceof('Glpi\\Form\\Question') and is_anonymous_user and not question_type.isAllowedForUnauthenticatedAccess() %}
                     {% set skip_question = true %}
                 {% endif %}
 

--- a/templates/pages/form_renderer.html.twig
+++ b/templates/pages/form_renderer.html.twig
@@ -96,7 +96,7 @@
                 {% endif %}
 
                 {# Skip questions not allowed for anonymous forms #}
-                {% if not skip_question and form_block is instanceof('Glpi\\Form\\Question') and is_anonymous_form and not question_type.isAllowedForAnonymousForm() %}
+                {% if not skip_question and form_block is instanceof('Glpi\\Form\\Question') and is_anonymous_user and not question_type.isAllowedForAnonymousForm() %}
                     {% set skip_question = true %}
                 {% endif %}
 

--- a/templates/pages/form_renderer.html.twig
+++ b/templates/pages/form_renderer.html.twig
@@ -88,8 +88,19 @@
                     {% set question_type = form_block.getQuestionType() %}
                 {% endif %}
 
+                {% set skip_question = false %}
+
                 {# Skip unknown types (may be a disabled plugin) #}
-                {% if form_block is not instanceof('Glpi\\Form\\Question') or question_type is not null %}
+                {% if form_block is instanceof('Glpi\\Form\\Question') and question_type is null %}
+                    {% set skip_question = true %}
+                {% endif %}
+
+                {# Skip questions not allowed for anonymous forms #}
+                {% if not skip_question and form_block is instanceof('Glpi\\Form\\Question') and is_anonymous_form and not question_type.isAllowedForAnonymousForm() %}
+                    {% set skip_question = true %}
+                {% endif %}
+
+                {% if not skip_question %}
                     <section
                         aria-label="{{ form_block.fields.name }}"
                         class="card mb-3 {{ is_first_section ? "" : "d-none" }}"

--- a/tests/cypress/e2e/form/access_policies/direct_access.cy.js
+++ b/tests/cypress/e2e/form/access_policies/direct_access.cy.js
@@ -1,0 +1,211 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+describe('Form access policy', () => {
+    beforeEach(() => {
+        cy.createWithAPI('Glpi\\Form\\Form', {
+            'name': 'Test form for the access policy form suite',
+        }).as('form_id');
+
+        cy.login();
+        cy.changeProfile('Super-Admin', true);
+
+        cy.get('@form_id').then((form_id) => {
+            const tab = 'Glpi\\Form\\AccessControl\\FormAccessControl$1';
+            cy.visit(`/front/form/form.form.php?id=${form_id}&forcetab=${tab}`);
+        });
+    });
+
+    it('check if form direct access policy can be set', () => {
+        // Enable direct access policy
+        cy.findByRole('region', {
+            name: 'Allow direct access'
+        }).within(() => {
+            cy.findByRole('checkbox', {name: 'Active'})
+                .should('not.be.checked')
+                .click()
+            ;
+        });
+
+        // Check if "allow unauthenticated users" checkbox isn't checked
+        cy.findByRole('checkbox', { 'name': 'Allow unauthenticated users ?' }).should('not.be.checked');
+
+        // Save changes
+        cy.findByRole('button', { 'name': 'Save changes' }).click();
+
+        // Retrieve the direct access URL
+        cy.findByRole('textbox', { 'name': 'Direct access URL' }).should('exist').as('direct_access_url');
+
+        // Visit the direct access URL
+        cy.get('@direct_access_url').invoke('val').then((direct_access_url) => {
+            cy.visit('/front/' + direct_access_url.split('/front/')[1]);
+
+            // Check if the form title is displayed
+            cy.findByRole('heading', { 'name': 'Test form for the access policy form suite' }).should('exist');
+        });
+    });
+
+    it('check if form direct access policy can be set and direct access works with autenticated user', () => {
+        // Enable direct access policy
+        cy.findByRole('region', {
+            name: 'Allow direct access'
+        }).within(() => {
+            cy.findByRole('checkbox', {name: 'Active'})
+                .should('not.be.checked')
+                .click()
+            ;
+        });
+
+        // Check if "allow unauthenticated users" checkbox isn't checked
+        cy.findByRole('checkbox', { 'name': 'Allow unauthenticated users ?' }).should('not.be.checked');
+
+        // Save changes
+        cy.findByRole('button', { 'name': 'Save changes' }).click();
+
+        // Retrieve the direct access URL
+        cy.findByRole('textbox', { 'name': 'Direct access URL' }).should('exist').as('direct_access_url');
+
+        // Logout
+        cy.logout();
+
+        // Visit the direct access URL
+        cy.get('@direct_access_url').invoke('val').then((direct_access_url) => {
+            // Check if we can't access the form
+            cy.request({
+                url: '/front/' + direct_access_url.split('/front/')[1],
+                failOnStatusCode: false,
+            }).then((response) => {
+                expect( response.status).to.eq(403);
+            });
+        });
+    });
+
+    it('check if form direct access policy can be set and direct access works with unauthenticated user', () => {
+        // Enable direct access policy
+        cy.findByRole('region', {
+            name: 'Allow direct access'
+        }).within(() => {
+            cy.findByRole('checkbox', {name: 'Active'})
+                .should('not.be.checked')
+                .click()
+            ;
+        });
+
+        // Enable "allow unauthenticated users"
+        cy.findByRole('checkbox', { 'name': 'Allow unauthenticated users ?' }).check();
+
+        // Save changes
+        cy.findByRole('button', { 'name': 'Save changes' }).click();
+
+        // Retrieve the direct access URL
+        cy.findByRole('textbox', { 'name': 'Direct access URL' }).should('exist').as('direct_access_url');
+
+        // Logout
+        cy.logout();
+
+        // Visit the direct access URL
+        cy.get('@direct_access_url').invoke('val').then((direct_access_url) => {
+            cy.visit('/front/' + direct_access_url.split('/front/')[1]);
+
+            // Check if the form title is displayed
+            cy.findByRole('heading', { 'name': 'Test form for the access policy form suite' }).should('exist');
+        });
+    });
+
+    it('check if form direct access policy can be set and direct access works with unauthenticated user and hide blacklisted questions', () => {
+        // Enable direct access policy
+        cy.findByRole('region', {
+            name: 'Allow direct access'
+        }).within(() => {
+            cy.findByRole('checkbox', {name: 'Active'})
+                .should('not.be.checked')
+                .click()
+            ;
+        });
+
+        // Enable "allow unauthenticated users"
+        cy.findByRole('checkbox', { 'name': 'Allow unauthenticated users ?' }).check();
+
+        // Save changes
+        cy.findByRole('button', { 'name': 'Save changes' }).click();
+
+        // Retrieve the direct access URL
+        cy.findByRole('textbox', { 'name': 'Direct access URL' }).should('exist').as('direct_access_url');
+
+        // Add a new question
+        cy.get('@form_id').then((form_id) => {
+            const tab = 'Glpi\\Form\\Form$main';
+            cy.visit(`/front/form/form.form.php?id=${form_id}&forcetab=${tab}`);
+
+            // Add a new question
+            cy.findByRole('button', { 'name': 'Add a new question' }).click();
+
+            // Set the question title
+            cy.focused().type('Actor question title');
+
+            // Select the actor question type
+            cy.findByRole('combobox', { 'name': 'Short answer' }).select('Actors');
+
+            // Add a new question
+            cy.findByRole('button', { 'name': 'Add a new question' }).click();
+
+            // Set the question title
+            cy.focused().type('Short answer question title');
+
+            // Save form
+            cy.findByRole('button', { 'name': 'Save' }).click();
+
+            // Wait and close the save alert
+            cy.findByRole('alert', { timeout: 10000 }).should('exist').within(() => {
+                cy.findByRole('button', { 'name': 'Close' }).click();
+            });
+        });
+
+        // Logout
+        cy.logout();
+
+        // Visit the direct access URL
+        cy.get('@direct_access_url').invoke('val').then((direct_access_url) => {
+            cy.visit('/front/' + direct_access_url.split('/front/')[1]);
+
+            // Check if the form title is displayed
+            cy.findByRole('heading', { 'name': 'Test form for the access policy form suite' }).should('exist');
+
+            // Check if the actor question is hidden
+            cy.findByRole('heading', { 'name': 'Actor question title' }).should('not.exist');
+
+            // Check if the short answer question is displayed
+            cy.findByRole('heading', { 'name': 'Short answer question title' }).should('exist');
+        });
+    });
+});

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -81,6 +81,17 @@ Cypress.Commands.add('login', (username = 'e2e_tests', password = 'glpi') => {
 
 /**
  * @memberof Cypress.Chainable.prototype
+ * @method logout
+ * @description Logout of GLPI
+ * @returns Chainable
+ */
+Cypress.Commands.add('logout', () => {
+    cy.findByRole('link', {name: 'User menu'}).click();
+    cy.findByRole('link', {name: 'Logout'}).click();
+});
+
+/**
+ * @memberof Cypress.Chainable.prototype
  * @method changeProfile
  * @description Change the profile of the current user. Only supports the default GLPI profiles.
  * @param {string} profile - Profile to change to


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

The DirectAccess policy allow anonymous users to access a form.

This is dangerous because we don't want anonymous users to access specific features that could reveal database information like items dropdowns (for now only the actors type would be "dangerous").

![image](https://github.com/glpi-project/glpi/assets/42278610/675747f3-d319-46ac-82a6-06ce0fc6c824)
![image](https://github.com/glpi-project/glpi/assets/42278610/6bdc0579-4063-4a67-8d5b-89e532b069d4)
