### PR TITLE
Force tab counters to respect user preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,7 @@ The present file will list all changes made to the project; according to the
 - `CommonDBTM::getSNMPCredential()`
 - `CommonDBTM::showDebugInfo()`
 - `CommonDropdown::displayHeader()`
+- `CommonGLPI::createTabEntry()` `nb` parameter no longer accepts integers. Pass a callable that returns a number instead or null. This will always respect the user's preferences for displaying the counter.
 - `CommonGLPI::getAvailableDisplayOptions()`
 - `CommonGLPI::getDisplayOptions()`
 - `CommonGLPI::getDisplayOptionsLink()`

--- a/phpunit/functional/ApplianceTest.php
+++ b/phpunit/functional/ApplianceTest.php
@@ -47,7 +47,7 @@ class ApplianceTest extends DbTestCase
             'ManualLink$1'       => "<span><i class='fas fa-link me-2'></i>Links</span>",
         ];
 
-        $appliance = new \Appliance();
+        $appliance = getItemByTypeName('Appliance', '_test_appliance01');
         $this->assertSame($expected, $appliance->defineTabs());
     }
 

--- a/src/Appliance_Item.php
+++ b/src/Appliance_Item.php
@@ -67,19 +67,10 @@ class Appliance_Item extends CommonDBRelation
             return '';
         }
 
-        $nb = 0;
-        if ($item->getType() == Appliance::class) {
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                if (!$item->isNewItem()) {
-                    $nb = self::countForMainItem($item);
-                }
-            }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType(), 'ti ti-package');
-        } else if (in_array($item->getType(), Appliance::getTypes(true))) {
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = self::countForItem($item);
-            }
-            return self::createTabEntry(Appliance::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+        if ($item::class === Appliance::class) {
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), static fn () => self::countForMainItem($item), $item::getType(), 'ti ti-package');
+        } else if (in_array($item->getType(), Appliance::getTypes(true), true)) {
+            return self::createTabEntry(Appliance::getTypeName(Session::getPluralNumber()), static fn () => self::countForItem($item), $item::getType());
         }
 
         return '';

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -1618,7 +1618,7 @@ class Auth extends CommonGLPI
             switch ($item::class) {
                 case User::class:
                     if (Session::haveRight("user", User::UPDATEAUTHENT)) {
-                        return self::createTabEntry(__('Synchronization'), 0, $item::class, 'ti ti-refresh');
+                        return self::createTabEntry(__('Synchronization'), null, $item::class, 'ti ti-refresh');
                     }
                     break;
             }

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -4418,9 +4418,9 @@ TWIG, $twig_params);
             && $item->can($item->getField('id'), READ)
         ) {
             $ong     = [];
-            $ong[1]  = self::createTabEntry(_sx('button', 'Test'), 0, $item::class, "ti ti-stethoscope"); // test connexion
-            $ong[2]  = self::createTabEntry(User::getTypeName(Session::getPluralNumber()), 0, $item::class, User::getIcon());
-            $ong[3]  = self::createTabEntry(Group::getTypeName(Session::getPluralNumber()), 0, $item::class, User::getIcon());
+            $ong[1]  = self::createTabEntry(_sx('button', 'Test'), null, $item::class, "ti ti-stethoscope"); // test connexion
+            $ong[2]  = self::createTabEntry(User::getTypeName(Session::getPluralNumber()), null, $item::class, User::getIcon());
+            $ong[3]  = self::createTabEntry(Group::getTypeName(Session::getPluralNumber()), null, $item::class, User::getIcon());
             $ong[5]  = self::createTabEntry(__('Advanced information'));   // params for entity advanced config
             $ong[6]  = self::createTabEntry(_n('Replicate', 'Replicates', Session::getPluralNumber()));
 

--- a/src/Budget.php
+++ b/src/Budget.php
@@ -87,7 +87,7 @@ class Budget extends CommonDropdown
             switch ($item->getType()) {
                 case __CLASS__:
                     return [1 => self::createTabEntry(__('Main')),
-                        2 => self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), 0, $item::getType(), 'ti ti-package')
+                        2 => self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), null, $item::getType(), 'ti ti-package')
                     ];
             }
         }

--- a/src/CableStrand.php
+++ b/src/CableStrand.php
@@ -66,18 +66,14 @@ class CableStrand extends CommonDropdown
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-
         if (!$withtemplate) {
-            $nb = 0;
-            switch ($item->getType()) {
-                case __CLASS__:
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = countElementsInTable(
-                            Cable::getTable(),
-                            ['cablestrands_id' => $item->getID()]
-                        );
-                    }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            switch ($item::class) {
+                case self::class:
+                    return self::createTabEntry(
+                        text: self::getTypeName(Session::getPluralNumber()),
+                        nb: static fn () => countElementsInTable(Cable::getTable(), ['cablestrands_id' => $item->getID()]),
+                        form_itemtype: $item::class
+                    );
             }
         }
         return '';

--- a/src/CalendarSegment.php
+++ b/src/CalendarSegment.php
@@ -426,12 +426,12 @@ class CalendarSegment extends CommonDBChild
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if (!$withtemplate) {
-            $nb = 0;
             if ($item instanceof Calendar) {
-                if ($_SESSION['glpishow_count_on_tabs']) {
-                    $nb = countElementsInTable(static::getTable(), ['calendars_id' => $item->getID()]);
-                }
-                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                return self::createTabEntry(
+                    text: self::getTypeName(Session::getPluralNumber()),
+                    nb: static fn () => countElementsInTable(static::getTable(), ['calendars_id' => $item->getID()]),
+                    form_itemtype: $item::getType()
+                );
             }
         }
         return '';

--- a/src/Calendar_Holiday.php
+++ b/src/Calendar_Holiday.php
@@ -161,15 +161,11 @@ class Calendar_Holiday extends CommonDBRelation
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if (!$withtemplate) {
-            $nb = 0;
             if ($item instanceof Calendar) {
-                if ($_SESSION['glpishow_count_on_tabs']) {
-                    $nb = countElementsInTable(self::getTable(), ['calendars_id' => $item->getID()]);
-                }
                 return self::createTabEntry(
-                    _n('Close time', 'Close times', Session::getPluralNumber()),
-                    $nb,
-                    $item::getType()
+                    text: _n('Close time', 'Close times', Session::getPluralNumber()),
+                    nb: static fn () => countElementsInTable(self::getTable(), ['calendars_id' => $item->getID()]),
+                    form_itemtype: $item::getType()
                 );
             }
         }

--- a/src/Cartridge.php
+++ b/src/Cartridge.php
@@ -1261,19 +1261,11 @@ TWIG, ['printer_id' => $printer->getID()]);
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if (!$withtemplate && self::canView()) {
-            $nb = 0;
             switch ($item::class) {
                 case Printer::class:
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = self::countForPrinter($item);
-                    }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
-
+                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), static fn () => self::showForPrinter($item));
                 case CartridgeItem::class:
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = self::countForCartridgeItem($item);
-                    }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), static fn () => self::showForCartridgeItem($item));
             }
         }
         return '';

--- a/src/CartridgeItem_PrinterModel.php
+++ b/src/CartridgeItem_PrinterModel.php
@@ -70,15 +70,14 @@ class CartridgeItem_PrinterModel extends CommonDBRelation
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-
         if (!$withtemplate && Printer::canView()) {
-            $nb = 0;
-            switch ($item->getType()) {
+            switch ($item::class) {
                 case 'CartridgeItem':
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = self::countForItem($item);
-                    }
-                    return self::createTabEntry(PrinterModel::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                    return self::createTabEntry(
+                        text: PrinterModel::getTypeName(Session::getPluralNumber()),
+                        nb: static fn () => self::countForItem($item),
+                        form_itemtype: $item::getType()
+                    );
             }
         }
         return '';

--- a/src/Central.php
+++ b/src/Central.php
@@ -68,15 +68,15 @@ class Central extends CommonGLPI
 
         if ($item->getType() == __CLASS__) {
             $tabs = [
-                1 => self::createTabEntry(__('Personal View'), 0, null, User::getIcon()),
-                2 => self::createTabEntry(__('Group View'), 0, null, Group::getIcon()),
-                3 => self::createTabEntry(__('Global View'), 0, null, 'ti ti-world'),
-                4 => self::createTabEntry(_n('RSS feed', 'RSS feeds', Session::getPluralNumber()), 0, null, RSSFeed::getIcon()),
+                1 => self::createTabEntry(__('Personal View'), null, null, User::getIcon()),
+                2 => self::createTabEntry(__('Group View'), null, null, Group::getIcon()),
+                3 => self::createTabEntry(__('Global View'), null, null, 'ti ti-world'),
+                4 => self::createTabEntry(_n('RSS feed', 'RSS feeds', Session::getPluralNumber()), null, null, RSSFeed::getIcon()),
             ];
 
             $grid = new Glpi\Dashboard\Grid('central');
             if ($grid::canViewOneDashboard()) {
-                array_unshift($tabs, self::createTabEntry(__('Dashboard'), 0, null, Dashboard::getIcon()));
+                array_unshift($tabs, self::createTabEntry(__('Dashboard'), null, null, Dashboard::getIcon()));
             }
 
             return $tabs;

--- a/src/Certificate_Item.php
+++ b/src/Certificate_Item.php
@@ -77,28 +77,19 @@ class Certificate_Item extends CommonDBRelation
      */
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-
         if (!$withtemplate) {
-            if (
-                $item->getType() == 'Certificate'
-                && count(Certificate::getTypes(false))
-            ) {
-                $nb = 0;
-                if ($_SESSION['glpishow_count_on_tabs']) {
-                    $nb = self::countForMainItem($item);
-                }
-                return self::createTabEntry(_n('Associated item', 'Associated items', Session::getPluralNumber()), $nb, $item::getType(), 'ti ti-package');
+            if ($item::class === Certificate::class && count(Certificate::getTypes(false))) {
+                return self::createTabEntry(
+                    text: _n('Associated item', 'Associated items', Session::getPluralNumber()),
+                    nb: static fn () => self::countForMainItem($item),
+                    form_itemtype: $item::getType(),
+                    icon: 'ti ti-package'
+                );
             } else if (
-                in_array($item->getType(), Certificate::getTypes(true))
+                in_array($item::class, Certificate::getTypes(true), true)
                 && Certificate::canView()
             ) {
-                if ($_SESSION['glpishow_count_on_tabs']) {
-                    return self::createTabEntry(
-                        Certificate::getTypeName(2),
-                        self::countForItem($item)
-                    );
-                }
-                return Certificate::getTypeName(2);
+                return self::createTabEntry(Certificate::getTypeName(2), static fn () => self::countForItem($item));
             }
         }
         return '';

--- a/src/Change.php
+++ b/src/Change.php
@@ -230,14 +230,14 @@ class Change extends CommonITILObject
                 case __CLASS__:
                     $ong = [];
                     if ($item->canUpdate()) {
-                         $ong[1] = static::createTabEntry(__('Statistics'), 0, null, 'ti ti-chart-pie');
+                         $ong[1] = static::createTabEntry(__('Statistics'), null, null, 'ti ti-chart-pie');
                     }
                     $satisfaction = new ChangeSatisfaction();
                     if (
                         $satisfaction->getFromDB($item->getID())
                         && in_array($item->fields['status'], self::getClosedStatusArray())
                     ) {
-                        $ong[3] = ChangeSatisfaction::createTabEntry(__('Satisfaction'), 0, static::getType());
+                        $ong[3] = ChangeSatisfaction::createTabEntry(__('Satisfaction'), null, static::getType());
                     }
 
                     return $ong;

--- a/src/Change_Problem.php
+++ b/src/Change_Problem.php
@@ -60,25 +60,19 @@ class Change_Problem extends CommonITILObject_CommonITILObject
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if (static::canView()) {
-            $nb = 0;
             switch ($item::class) {
                 case Change::class:
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = countElementsInTable(
-                            'glpi_changes_problems',
-                            ['changes_id' => $item->getID()]
-                        );
-                    }
-                    return self::createTabEntry(Problem::getTypeName(Session::getPluralNumber()), $nb, $item::class);
-
+                    return self::createTabEntry(
+                        text: Problem::getTypeName(Session::getPluralNumber()),
+                        nb: static fn () => countElementsInTable('glpi_changes_problems', ['changes_id' => $item->getID()]),
+                        form_itemtype: $item::class
+                    );
                 case Problem::class:
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = countElementsInTable(
-                            'glpi_changes_problems',
-                            ['problems_id' => $item->getID()]
-                        );
-                    }
-                    return self::createTabEntry(Change::getTypeName(Session::getPluralNumber()), $nb, $item::class);
+                    return self::createTabEntry(
+                        text: Change::getTypeName(Session::getPluralNumber()),
+                        nb: static fn () => countElementsInTable('glpi_changes_problems', ['problems_id' => $item->getID()]),
+                        form_itemtype: $item::class
+                    );
             }
         }
         return '';

--- a/src/Change_Ticket.php
+++ b/src/Change_Ticket.php
@@ -58,25 +58,19 @@ class Change_Ticket extends CommonITILObject_CommonITILObject
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if (static::canView()) {
-            $nb = 0;
             switch ($item::class) {
                 case Change::class:
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = countElementsInTable(
-                            'glpi_changes_tickets',
-                            ['changes_id' => $item->getID()]
-                        );
-                    }
-                    return self::createTabEntry(Ticket::getTypeName(Session::getPluralNumber()), $nb, $item::class);
-
+                    return self::createTabEntry(
+                        text: Ticket::getTypeName(Session::getPluralNumber()),
+                        nb: static fn () => countElementsInTable('glpi_changes_tickets', ['changes_id' => $item->getID()]),
+                        form_itemtype: $item::class
+                    );
                 case Ticket::class:
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = countElementsInTable(
-                            'glpi_changes_tickets',
-                            ['tickets_id' => $item->getID()]
-                        );
-                    }
-                    return self::createTabEntry(Change::getTypeName(Session::getPluralNumber()), $nb, $item::class);
+                    return self::createTabEntry(
+                        text: Change::getTypeName(Session::getPluralNumber()),
+                        nb: static fn () => countElementsInTable('glpi_changes_tickets', ['tickets_id' => $item->getID()]),
+                        form_itemtype: $item::class
+                    );
             }
         }
         return '';

--- a/src/CommonDBRelation.php
+++ b/src/CommonDBRelation.php
@@ -2105,6 +2105,33 @@ abstract class CommonDBRelation extends CommonDBConnexity
     }
 
     /**
+     * Count for item and linked items
+     *
+     * @param CommonDBTM $item
+     * @return int
+     * @see CommonDBTM::getLinkedItems()
+     */
+    public static function countForItemAndLinks(CommonDBTM $item): int
+    {
+        // Direct one
+        $count = static::countForItem($item);
+        // Linked items
+        $linkeditems = $item->getLinkedItems();
+
+        if (count($linkeditems)) {
+            foreach ($linkeditems as $type => $tab) {
+                $typeitem = new $type();
+                foreach ($tab as $ID) {
+                    if ($typeitem->getFromDB($ID)) {
+                        $count += static::countForItem($typeitem);
+                    }
+                }
+            }
+        }
+        return $count;
+    }
+
+    /**
      * Count items for main itemtype
      *
      * @param CommonDBTM $item              Item instance

--- a/src/CommonITILCost.php
+++ b/src/CommonITILCost.php
@@ -67,20 +67,16 @@ abstract class CommonITILCost extends CommonDBChild
      **/
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-
-        // can exists for template
-        if (
-            (get_class($item) == static::$itemtype)
-            && static::canView()
-        ) {
-            $nb = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = countElementsInTable(
+        // can exist for template
+        if ($item::class === static::$itemtype && static::canView()) {
+            return self::createTabEntry(
+                text: self::getTypeName(Session::getPluralNumber()),
+                nb: static fn () => countElementsInTable(
                     static::getTable(),
                     [$item::getForeignKeyField() => $item->getID()]
-                );
-            }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                ),
+                form_itemtype: $item::class
+            );
         }
         return '';
     }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8226,12 +8226,11 @@ abstract class CommonITILObject extends CommonDBTM
 
     public function addDefaultFormTab(array &$ong)
     {
-
-        $timeline    = $this->getTimelineItems(['with_logs' => false]);
-        $nb_elements = count($timeline);
-        $label = static::getTypeName(1);
-
-        $ong[static::getType() . '$main'] = static::createTabEntry($label, $nb_elements, static::getType());
+        $ong[static::class . '$main'] = static::createTabEntry(
+            text: static::getTypeName(1),
+            nb: fn () => count($this->getTimelineItems(['with_logs' => true])),
+            form_itemtype: static::class
+        );
         return $this;
     }
 

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -202,26 +202,16 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         /** @var CommonDBTM $item */
-        if (
-            ($item->getType() == static::getItilObjectItemType())
-            && $this->canView()
-        ) {
-            $nb = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $restrict = [$item->getForeignKeyField() => $item->getID()];
+        if ($item::class === static::getItilObjectItemType() && static::canView()) {
+            $restrict = [$item::getForeignKeyField() => $item->getID()];
 
-                if (
-                    $this->maybePrivate()
-                    && !$this->canViewPrivates()
-                ) {
-                    $restrict['OR'] = [
-                        'is_private'   => 0,
-                        'users_id'     => Session::getLoginUserID()
-                    ];
-                }
-                $nb = countElementsInTable($this->getTable(), $restrict);
+            if ($this->maybePrivate() && !$this->canViewPrivates()) {
+                $restrict['OR'] = [
+                    'is_private'   => 0,
+                    'users_id'     => Session::getLoginUserID()
+                ];
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), static fn () => countElementsInTable(static::getTable(), $restrict), $item::class);
         }
         return '';
     }

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -237,16 +237,16 @@ abstract class CommonITILValidation extends CommonDBChild
         }
 
         if (!$hidetab) {
-            $nb = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $restrict = [static::$items_id => $item->getID()];
-               // No rights for create only count asign ones
-                if (!Session::haveRightsOr(static::$rightname, static::getCreateRights())) {
-                    $restrict[] = static::getTargetCriteriaForUser(Session::getLoginUserID());
-                }
-                $nb = countElementsInTable(static::getTable(), $restrict);
+            $restrict = [static::$items_id => $item->getID()];
+            // No rights for create only count assigned ones
+            if (!Session::haveRightsOr(static::$rightname, static::getCreateRights())) {
+                $restrict[] = static::getTargetCriteriaForUser(Session::getLoginUserID());
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(
+                text: self::getTypeName(Session::getPluralNumber()),
+                nb: static fn () => countElementsInTable(static::getTable(), $restrict),
+                form_itemtype: $item::class
+            );
         }
         return '';
     }

--- a/src/CommonItilObject_Item.php
+++ b/src/CommonItilObject_Item.php
@@ -515,23 +515,23 @@ abstract class CommonItilObject_Item extends CommonDBRelation
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if (!$withtemplate) {
-            $nb = 0;
-            switch ($item->getType()) {
+            switch ($item::class) {
                 case static::$itemtype_1:
                     if (
                         ($_SESSION["glpiactiveprofile"]["helpdesk_hardware"] != 0)
                         && (count($_SESSION["glpiactiveprofile"]["helpdesk_item_type"]) > 0)
                     ) {
-                        if ($_SESSION['glpishow_count_on_tabs']) {
-                            $nb = countElementsInTable(
+                        return static::createTabEntry(
+                            text: _n('Item', 'Items', Session::getPluralNumber()),
+                            nb: static fn () => countElementsInTable(
                                 static::getTable(),
                                 [
                                     static::$items_id_1 => $item->getID(),
                                     'itemtype' => $_SESSION["glpiactiveprofile"]["helpdesk_item_type"]
                                 ]
-                            );
-                        }
-                        return static::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::getType());
+                            ),
+                            form_itemtype: $item::class
+                        );
                     }
             }
         }
@@ -1623,8 +1623,11 @@ abstract class CommonItilObject_Item extends CommonDBRelation
         return countElementsInTable(
             static::getTable(),
             [
-                'itemtype' => $asset::getType(),
-                'items_id' => $asset->getId(),
+                'WHERE' => [
+                    'itemtype' => $asset::class,
+                    'items_id' => $asset->getId(),
+                ],
+                'LIMIT' => 1
             ]
         ) > 0;
     }

--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -80,19 +80,12 @@ abstract class CommonTreeDropdown extends CommonDropdown
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-
-        if (
-            !$withtemplate
-            && ($item instanceof static)
-        ) {
-            $nb = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = countElementsInTable(
-                    $this->getTable(),
-                    [$this->getForeignKeyField() => $item->getID()]
-                );
-            }
-            return self::createTabEntry($this->getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+        if (!$withtemplate && ($item instanceof static)) {
+            return self::createTabEntry(
+                text: static::getTypeName(Session::getPluralNumber()),
+                nb: static fn () => countElementsInTable(static::getTable(), [static::getForeignKeyField() => $item->getID()]),
+                form_itemtype: $item::class
+            );
         }
         return '';
     }

--- a/src/Config.php
+++ b/src/Config.php
@@ -1336,29 +1336,29 @@ class Config extends CommonDBTM
                 $tabs = [
                     1 => self::createTabEntry(__('General setup')),  // Display
                     2 => self::createTabEntry(__('Default values')), // Prefs
-                    3 => self::createTabEntry(_n('Asset', 'Assets', Session::getPluralNumber()), 0, $item::getType(), 'ti ti-package'),
-                    4 => self::createTabEntry(__('Assistance'), 0, $item::getType(), 'ti ti-headset'),
-                    12 => self::createTabEntry(__('Management'), 0, $item::getType(), 'ti ti-wallet'),
+                    3 => self::createTabEntry(_n('Asset', 'Assets', Session::getPluralNumber()), null, $item::getType(), 'ti ti-package'),
+                    4 => self::createTabEntry(__('Assistance'), null, $item::getType(), 'ti ti-headset'),
+                    12 => self::createTabEntry(__('Management'), null, $item::getType(), 'ti ti-wallet'),
                 ];
                 if (Config::canUpdate()) {
-                    $tabs[9]  = self::createTabEntry(__('Logs purge'), 0, $item::getType(), Glpi\Event::getIcon());
+                    $tabs[9]  = self::createTabEntry(__('Logs purge'), null, $item::getType(), Glpi\Event::getIcon());
                     $tabs[5]  = self::createTabEntry(__('System'));
-                    $tabs[10] = self::createTabEntry(__('Security'), 0, $item::getType(), 'ti ti-shield-lock');
-                    $tabs[7]  = self::createTabEntry(__('Performance'), 0, $item::getType(), 'ti ti-dashboard');
-                    $tabs[8]  = self::createTabEntry(__('API'), 0, $item::getType(), 'ti ti-api-app');
-                    $tabs[11] = self::createTabEntry(Impact::getTypeName(), 0, $item::getType(), Impact::getIcon());
+                    $tabs[10] = self::createTabEntry(__('Security'), null, $item::getType(), 'ti ti-shield-lock');
+                    $tabs[7]  = self::createTabEntry(__('Performance'), null, $item::getType(), 'ti ti-dashboard');
+                    $tabs[8]  = self::createTabEntry(__('API'), null, $item::getType(), 'ti ti-api-app');
+                    $tabs[11] = self::createTabEntry(Impact::getTypeName(), null, $item::getType(), Impact::getIcon());
                 }
 
                 if (
                     DBConnection::isDBSlaveActive()
                     && Config::canUpdate()
                 ) {
-                    $tabs[6]  = self::createTabEntry(_n('SQL replica', 'SQL replicas', Session::getPluralNumber()), 0, $item::getType(), 'ti ti-database');  // Slave
+                    $tabs[6]  = self::createTabEntry(_n('SQL replica', 'SQL replicas', Session::getPluralNumber()), null, $item::getType(), 'ti ti-database');  // Slave
                 }
                 return $tabs;
 
             case 'GLPINetwork':
-                return self::createTabEntry(GLPINetwork::getTypeName(), 0, $item::getType(), GLPINetwork::getIcon());
+                return self::createTabEntry(GLPINetwork::getTypeName(), null, $item::getType(), GLPINetwork::getIcon());
 
             case Impact::getType():
                 return Impact::getTypeName();

--- a/src/Consumable.php
+++ b/src/Consumable.php
@@ -821,19 +821,12 @@ class Consumable extends CommonDBChild
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if (!$withtemplate && self::canView()) {
-            $nb = 0;
-            switch ($item::class) {
-                case ConsumableItem::class:
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb =  self::countForConsumableItem($item);
-                    }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
-                case User::class:
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = self::countForUser($item);
-                    }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
-            }
+            $nb = match ($item::class) {
+                ConsumableItem::class => static fn () => self::countForConsumableItem($item),
+                User::class => static fn () => self::countForUser($item),
+                default => null
+            };
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
         }
         return '';
     }

--- a/src/Contact_Supplier.php
+++ b/src/Contact_Supplier.php
@@ -62,19 +62,13 @@ class Contact_Supplier extends CommonDBRelation
     {
 
         if (!$withtemplate && Session::haveRight("contact_enterprise", READ)) {
-            $nb = 0;
-            switch ($item->getType()) {
-                case 'Supplier':
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb =  self::countForItem($item);
-                    }
-                    return self::createTabEntry(Contact::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
-
-                case 'Contact':
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = self::countForItem($item);
-                    }
-                    return self::createTabEntry(Supplier::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            $label = match ($item::class) {
+                Supplier::class => Contact::getTypeName(Session::getPluralNumber()),
+                Contact::class  => Supplier::getTypeName(Session::getPluralNumber()),
+                default         => null,
+            };
+            if ($label !== null) {
+                return self::createTabEntry($label, static fn () => self::countForItem($item), $item::class);
             }
         }
         return '';

--- a/src/ContractCost.php
+++ b/src/ContractCost.php
@@ -89,17 +89,13 @@ class ContractCost extends CommonDBChild
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-
         // can exist for template
-        if (
-            $item instanceof Contract
-            && Contract::canView()
-        ) {
-            $nb = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = countElementsInTable('glpi_contractcosts', ['contracts_id' => $item->getID()]);
-            }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
+        if ($item instanceof Contract && Contract::canView()) {
+            return self::createTabEntry(
+                text: self::getTypeName(Session::getPluralNumber()),
+                nb: static fn () => countElementsInTable('glpi_contractcosts', ['contracts_id' => $item->getID()]),
+                form_itemtype: $item::class
+            );
         }
         return '';
     }

--- a/src/Contract_Item.php
+++ b/src/Contract_Item.php
@@ -205,24 +205,22 @@ class Contract_Item extends CommonDBRelation
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-       // Can exists on template
+        // Can exist on template
         if (Contract::canView()) {
-            $nb = 0;
             switch ($item::class) {
                 case Contract::class:
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = self::countForMainItem($item);
-                    }
-                    return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::class, 'ti ti-package');
-
+                    return self::createTabEntry(
+                        text: _n('Item', 'Items', Session::getPluralNumber()),
+                        nb: static fn () => self::countForMainItem($item),
+                        form_itemtype: $item::class,
+                        icon: 'ti ti-package'
+                    );
                 default:
-                    if (
-                        $_SESSION['glpishow_count_on_tabs']
-                        && in_array($item::class, $CFG_GLPI["contract_types"], true)
-                    ) {
-                        $nb = self::countForItem($item);
-                    }
-                    return self::createTabEntry(Contract::getTypeName(Session::getPluralNumber()), $nb, $item::class);
+                    return self::createTabEntry(
+                        text: Contract::getTypeName(Session::getPluralNumber()),
+                        nb: in_array($item::class, $CFG_GLPI["contract_types"], true) ? (static fn () => self::countForItem($item)) : 0,
+                        form_itemtype: $item::class
+                    );
             }
         }
         return '';

--- a/src/Contract_Supplier.php
+++ b/src/Contract_Supplier.php
@@ -55,27 +55,23 @@ class Contract_Supplier extends CommonDBRelation
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if (!$withtemplate) {
-            $nb = 0;
             switch ($item::class) {
                 case Supplier::class:
                     if (Contract::canView()) {
-                        if ($_SESSION['glpishow_count_on_tabs']) {
-                            $nb =  self::countForItem($item);
-                        }
                         return self::createTabEntry(
-                            Contract::getTypeName(Session::getPluralNumber()),
-                            $nb,
-                            $item::class
+                            text: Contract::getTypeName(Session::getPluralNumber()),
+                            nb: static fn () => self::countForItem($item),
+                            form_itemtype: $item::class
                         );
                     }
                     break;
-
                 case Contract::class:
                     if (Session::haveRight("contact_enterprise", READ)) {
-                        if ($_SESSION['glpishow_count_on_tabs']) {
-                              $nb = self::countForItem($item);
-                        }
-                        return self::createTabEntry(Supplier::getTypeName(Session::getPluralNumber()), $nb, $item::class);
+                        return self::createTabEntry(
+                            text: Supplier::getTypeName(Session::getPluralNumber()),
+                            nb: static fn () => self::countForItem($item),
+                            form_itemtype: $item::class
+                        );
                     }
                     break;
             }

--- a/src/CronTaskLog.php
+++ b/src/CronTaskLog.php
@@ -84,22 +84,18 @@ class CronTaskLog extends CommonDBChild
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
 
-        if (!$withtemplate) {
-            $nb = 0;
-            if ($item instanceof CronTask) {
-                $ong    = [];
-                $ong[1] = self::createTabEntry(__('Statistics'), 0, $item::getType(), 'ti ti-report-analytics');
-                if ($_SESSION['glpishow_count_on_tabs']) {
-                    $nb =  countElementsInTable(
-                        $this->getTable(),
-                        ['crontasks_id' => $item->getID(),
-                            'state'        => self::STATE_STOP
-                        ]
-                    );
-                }
-                $ong[2] = self::createTabEntry(_n('Log', 'Logs', Session::getPluralNumber()), $nb, $item::getType());
-                return $ong;
-            }
+        if (!$withtemplate && $item instanceof CronTask) {
+            $ong    = [];
+            $ong[1] = self::createTabEntry(__('Statistics'), null, $item::class, 'ti ti-report-analytics');
+            $ong[2] = self::createTabEntry(
+                text: _n('Log', 'Logs', Session::getPluralNumber()),
+                nb: static fn () => countElementsInTable(static::getTable(), [
+                    'crontasks_id' => $item->getID(),
+                    'state'        => self::STATE_STOP
+                ]),
+                form_itemtype: $item::class
+            );
+            return $ong;
         }
         return '';
     }

--- a/src/DCRoom.php
+++ b/src/DCRoom.php
@@ -255,25 +255,16 @@ class DCRoom extends CommonDBTM
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-
         switch ($item::class) {
             case Datacenter::class:
-                $nb = 0;
-                if ($_SESSION['glpishow_count_on_tabs']) {
-                    $nb = countElementsInTable(
-                        self::getTable(),
-                        [
-                            'datacenters_id'  => $item->getID(),
-                            'is_deleted'      => 0
-                        ]
-                    );
-                }
                 return self::createTabEntry(
-                    self::getTypeName(Session::getPluralNumber()),
-                    $nb,
-                    $item::getType()
+                    text: self::getTypeName(Session::getPluralNumber()),
+                    nb: static fn () => countElementsInTable(self::getTable(), [
+                        'datacenters_id'  => $item->getID(),
+                        'is_deleted'      => 0
+                    ]),
+                    form_itemtype: $item::class
                 );
-             break;
         }
 
         return '';

--- a/src/Database.php
+++ b/src/Database.php
@@ -334,20 +334,17 @@ class Database extends CommonDBChild
     {
         if (
             !$withtemplate
-            && ($item::class === DatabaseInstance::class)
-            && $item->canView()
+            && $item::class === DatabaseInstance::class
+            && $item::canView()
         ) {
-            $nb = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = countElementsInTable(
-                    self::getTable(),
-                    [
-                        'databaseinstances_id' => $item->getID(),
-                        'is_deleted' => 0
-                    ]
-                );
-            }
-            return self::createTabEntry(self::getTypeName(), $nb, $item::class);
+            return self::createTabEntry(
+                text: self::getTypeName(),
+                nb: static fn () => countElementsInTable(self::getTable(), [
+                    'databaseinstances_id' => $item->getID(),
+                    'is_deleted' => 0
+                ]),
+                form_itemtype: $item::class
+            );
         }
         return '';
     }

--- a/src/DatabaseInstance.php
+++ b/src/DatabaseInstance.php
@@ -350,16 +350,12 @@ class DatabaseInstance extends CommonDBTM
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        if (!self::canView()) {
-            return '';
-        }
-
-        $nb = 0;
-        if (in_array($item->getType(), self::getTypes(true))) {
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = countElementsInTable(self::getTable(), ['itemtype' => $item->getType(), 'items_id' => $item->fields['id']]);
-            }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+        if (self::canView() && in_array($item::class, self::getTypes(true), true)) {
+            return self::createTabEntry(
+                text: self::getTypeName(Session::getPluralNumber()),
+                nb: static fn () => countElementsInTable(self::getTable(), ['itemtype' => $item::class, 'items_id' => $item->fields['id']]),
+                form_itemtype: $item::getType()
+            );
         }
         return '';
     }

--- a/src/DisplayPreference.php
+++ b/src/DisplayPreference.php
@@ -624,7 +624,7 @@ class DisplayPreference extends CommonDBTM
                 return $ong;
 
             case Config::class:
-                return self::createTabEntry(self::getTypeName(1), 0, __CLASS__, 'ti ti-columns-3');
+                return self::createTabEntry(self::getTypeName(1), null, __CLASS__, 'ti ti-columns-3');
         }
         return '';
     }

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -263,41 +263,32 @@ class Document_Item extends CommonDBRelation
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        $nbdoc = $nbitem = 0;
         switch ($item::class) {
             case Document::class:
                 $ong = [];
-                if ($_SESSION['glpishow_count_on_tabs'] && !$item->isNewItem()) {
-                    $nbdoc  = self::countForMainItem($item, ['NOT' => ['itemtype' => 'Document']]);
-                    $nbitem = self::countForMainItem($item, ['itemtype' => 'Document']);
-                }
-                $ong[1] = self::createTabEntry(_n(
-                    'Associated item',
-                    'Associated items',
-                    Session::getPluralNumber()
-                ), $nbdoc, $item::class, 'ti ti-package');
+                $ong[1] = self::createTabEntry(
+                    text: _n('Associated item', 'Associated items', Session::getPluralNumber()),
+                    nb: !$item->isNewItem() ? (static fn () => self::countForMainItem($item, ['NOT' => ['itemtype' => 'Document']])) : null,
+                    form_itemtype: $item::class,
+                    icon: 'ti ti-package'
+                );
                 $ong[2] = self::createTabEntry(
-                    Document::getTypeName(Session::getPluralNumber()),
-                    $nbitem,
-                    $item::class
+                    text: Document::getTypeName(Session::getPluralNumber()),
+                    nb: !$item->isNewItem() ? (static fn () => self::countForMainItem($item, ['itemtype' => 'Document'])) : null,
+                    form_itemtype: $item::class
                 );
                 return $ong;
 
             default:
                 // Can exist for template
                 if (
-                    Document::canView()
-                    || ($item::class === Ticket::class)
-                    || ($item::class === Reminder::class)
-                    || ($item::class === KnowbaseItem::class)
+                    in_array($item::class, [Ticket::class, Reminder::class, KnowbaseItem::class], true)
+                    || Document::canView()
                 ) {
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nbitem = self::countForItem($item);
-                    }
                     return self::createTabEntry(
-                        Document::getTypeName(Session::getPluralNumber()),
-                        $nbitem,
-                        $item::class
+                        text: Document::getTypeName(Session::getPluralNumber()),
+                        nb: static fn () => self::countForItem($item),
+                        form_itemtype: $item::class
                     );
                 }
         }

--- a/src/DomainRecord.php
+++ b/src/DomainRecord.php
@@ -53,10 +53,7 @@ class DomainRecord extends CommonDBChild
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if ($item::class === Domain::class) {
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                return self::createTabEntry(_n('Record', 'Records', Session::getPluralNumber()), self::countForDomain($item), $item::class);
-            }
-            return _n('Record', 'Records', Session::getPluralNumber());
+            return self::createTabEntry(_n('Record', 'Records', Session::getPluralNumber()), static fn () => self::countForDomain($item), $item::class);
         }
         return '';
     }

--- a/src/Domain_Item.php
+++ b/src/Domain_Item.php
@@ -64,22 +64,19 @@ class Domain_Item extends CommonDBRelation
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if ($item::class === Domain::class && count(Domain::getTypes(false))) {
-            $nb = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = self::countForDomain($item);
-            }
-            return self::createTabEntry(_n('Associated item', 'Associated items', Session::getPluralNumber()), $nb, $item::getType(), 'ti ti-package');
+            return self::createTabEntry(
+                text: _n('Associated item', 'Associated items', Session::getPluralNumber()),
+                nb: static fn () => self::countForDomain($item),
+                form_itemtype: $item::class,
+                icon: 'ti ti-package'
+            );
         }
 
         if (
             $item::class === DomainRelation::class || (in_array($item::class, Domain::getTypes(true), true)
                 && Session::haveRight('domain', READ))
         ) {
-            $nb = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = self::countForItem($item);
-            }
-            return self::createTabEntry(Domain::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(Domain::getTypeName(Session::getPluralNumber()), static fn () => self::countForItem($item), $item::class);
         }
         return '';
     }

--- a/src/DropdownTranslation.php
+++ b/src/DropdownTranslation.php
@@ -73,11 +73,11 @@ class DropdownTranslation extends CommonDBChild
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if ($item instanceof CommonDropdown && $item->maybeTranslated()) {
-            $nb = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = self::getNumberOfTranslationsForItem($item);
-            }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
+            return self::createTabEntry(
+                text: self::getTypeName(Session::getPluralNumber()),
+                nb: static fn () => self::getNumberOfTranslationsForItem($item),
+                form_itemtype: $item::class
+            );
         }
         return '';
     }

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -492,10 +492,10 @@ class Entity extends CommonTreeDropdown
                 case self::class:
                     $ong    = [];
                     $ong[1] = self::createTabEntry(self::getTypeName(Session::getPluralNumber()));
-                    $ong[2] = self::createTabEntry(__('Address'), 0, $item::class, Location::getIcon());
+                    $ong[2] = self::createTabEntry(__('Address'), null, $item::class, Location::getIcon());
                     $ong[3] = self::createTabEntry(__('Advanced information'));
                     if (Notification::canView()) {
-                        $ong[4] = self::createTabEntry(Notification::getTypeName(Session::getPluralNumber()), 0, $item::class, Notification::getIcon());
+                        $ong[4] = self::createTabEntry(Notification::getTypeName(Session::getPluralNumber()), null, $item::class, Notification::getIcon());
                     }
                     if (
                         Session::haveRightsOr(
@@ -503,13 +503,13 @@ class Entity extends CommonTreeDropdown
                             [self::READHELPDESK, self::UPDATEHELPDESK]
                         )
                     ) {
-                        $ong[5] = self::createTabEntry(__('Assistance'), 0, $item::class, 'ti ti-headset');
+                        $ong[5] = self::createTabEntry(__('Assistance'), null, $item::class, 'ti ti-headset');
                     }
-                    $ong[6] = self::createTabEntry(_n('Asset', 'Assets', Session::getPluralNumber()), 0, $item::class, 'ti ti-package');
+                    $ong[6] = self::createTabEntry(_n('Asset', 'Assets', Session::getPluralNumber()), null, $item::class, 'ti ti-package');
                     if (Session::haveRight(Config::$rightname, UPDATE)) {
-                        $ong[7] = self::createTabEntry(__('UI customization'), 0, $item::class, 'ti ti-palette');
+                        $ong[7] = self::createTabEntry(__('UI customization'), null, $item::class, 'ti ti-palette');
                     }
-                    $ong[8] = self::createTabEntry(__('Security'), 0, $item::class, 'ti ti-shield-lock');
+                    $ong[8] = self::createTabEntry(__('Security'), null, $item::class, 'ti ti-shield-lock');
 
                     return $ong;
             }

--- a/src/FieldUnicity.php
+++ b/src/FieldUnicity.php
@@ -110,7 +110,7 @@ class FieldUnicity extends CommonDropdown
     {
         if (!$withtemplate) {
             if ($item::class === static::class) {
-                return self::createTabEntry(__('Duplicates'), 0, $item::class, 'ti ti-copy');
+                return self::createTabEntry(__('Duplicates'), null, $item::class, 'ti ti-copy');
             }
         }
         return '';

--- a/src/Glpi/Asset/AssetDefinition.php
+++ b/src/Glpi/Asset/AssetDefinition.php
@@ -105,33 +105,25 @@ final class AssetDefinition extends CommonDBTM
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if ($item instanceof self) {
-            $capacities_count   = 0;
-            $profiles_count     = 0;
-            $translations_count = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $capacities_count   = count($item->getDecodedCapacitiesField());
-                $profiles_count     = count(array_filter($item->getDecodedProfilesField()));
-                $translations_count = count($item->getDecodedTranslationsField());
-            }
             return [
                 1 => self::createTabEntry(
-                    __('Capacities'),
-                    $capacities_count,
-                    self::class,
-                    'ti ti-adjustments'
+                    text: __('Capacities'),
+                    nb: static fn () => count($item->getDecodedCapacitiesField()),
+                    form_itemtype: self::class,
+                    icon: 'ti ti-adjustments'
                 ),
                 // 2 is reserved for "Fields"
                 3 => self::createTabEntry(
-                    _n('Profile', 'Profiles', Session::getPluralNumber()),
-                    $profiles_count,
-                    self::class,
-                    'ti ti-user-check'
+                    text: _n('Profile', 'Profiles', Session::getPluralNumber()),
+                    nb: static fn () => count(array_filter($item->getDecodedProfilesField())),
+                    form_itemtype: self::class,
+                    icon: 'ti ti-user-check'
                 ),
                 4 => self::createTabEntry(
-                    _n('Translation', 'Translations', Session::getPluralNumber()),
-                    $translations_count,
-                    self::class,
-                    'ti ti-language'
+                    text: _n('Translation', 'Translations', Session::getPluralNumber()),
+                    nb: static fn () => count($item->getDecodedTranslationsField()),
+                    form_itemtype: self::class,
+                    icon: 'ti ti-language'
                 ),
             ];
         }

--- a/src/Glpi/Asset/Asset_PeripheralAsset.php
+++ b/src/Glpi/Asset/Asset_PeripheralAsset.php
@@ -711,20 +711,20 @@ TWIG, $twig_params);
             if (in_array($item::class, $CFG_GLPI['directconnect_types'], true)) {
                 $canview = true;
                 if ($_SESSION['glpishow_count_on_tabs']) {
-                    $nb = self::countLinkedAssets($item);
+                    $nb = static fn () => self::countLinkedAssets($item);
                 }
             } else {
                 $canview = self::canViewPeripherals($item);
                 if ($canview && $_SESSION['glpishow_count_on_tabs']) {
-                    $nb = self::countPeripherals($item);
+                    $nb = static fn () => self::countPeripherals($item);
                 }
             }
 
             if ($canview) {
                 return self::createTabEntry(
-                    _n('Connection', 'Connections', Session::getPluralNumber()),
-                    $nb,
-                    $item::class
+                    text: _n('Connection', 'Connections', Session::getPluralNumber()),
+                    nb: $nb,
+                    form_itemtype: $item::class
                 );
             }
         }

--- a/src/Glpi/Form/AnswersSet.php
+++ b/src/Glpi/Form/AnswersSet.php
@@ -90,14 +90,9 @@ final class AnswersSet extends CommonDBChild
             return false;
         }
 
-        $count = 0;
-        if ($_SESSION['glpishow_count_on_tabs']) {
-            $count = $this->countAnswers($item);
-        }
-
         return self::createTabEntry(
-            self::getTypeName(),
-            $count,
+            text: self::getTypeName(),
+            nb: static fn () => self::countAnswers($item),
         );
     }
 
@@ -259,7 +254,7 @@ final class AnswersSet extends CommonDBChild
      *
      * @return int
      */
-    protected function countAnswers(Form $form): int
+    protected static function countAnswers(Form $form): int
     {
         return countElementsInTable(self::getTable(), [
             Form::getForeignKeyField() => $form->getID()

--- a/src/Glpi/Form/Destination/AbstractFormDestinationType.php
+++ b/src/Glpi/Form/Destination/AbstractFormDestinationType.php
@@ -50,12 +50,11 @@ abstract class AbstractFormDestinationType extends CommonGLPI implements FormDes
             return false;
         }
 
-        $count = 0;
-        if ($_SESSION['glpishow_count_on_tabs']) {
-            $count = $this->countCreatedItemsForAnswersSet($item);
-        }
-
-        return self::createTabEntry(static::getTypeName(), $count, icon: static::getTargetItemtype()::getIcon());
+        return self::createTabEntry(
+            text: static::getTypeName(),
+            nb: static fn () => self::countCreatedItemsForAnswersSet($item),
+            icon: static::getTargetItemtype()::getIcon()
+        );
     }
 
     #[Override]
@@ -93,7 +92,7 @@ abstract class AbstractFormDestinationType extends CommonGLPI implements FormDes
      *
      * @return int
      */
-    final protected function countCreatedItemsForAnswersSet(AnswersSet $answers): int
+    final protected static function countCreatedItemsForAnswersSet(AnswersSet $answers): int
     {
         return countElementsInTable(AnswersSet_FormDestinationItem::getTable(), [
             'forms_answerssets_id' => $answers->getID(),

--- a/src/Glpi/Form/Destination/FormDestination.php
+++ b/src/Glpi/Form/Destination/FormDestination.php
@@ -71,16 +71,10 @@ final class FormDestination extends CommonDBChild
             return false;
         }
 
-        $count = 0;
-        if ($_SESSION['glpishow_count_on_tabs']) {
-            $count = $this->countForForm($item);
-        }
-
         return self::createTabEntry(
-            self::getTypeName(),
-            $count,
-            null,
-            self::getIcon() // Must be passed manually for some reason
+            text: self::getTypeName(),
+            nb: static fn () => self::countForForm($item),
+            icon: self::getIcon() // Must be passed manually for some reason
         );
     }
 
@@ -302,7 +296,7 @@ final class FormDestination extends CommonDBChild
      *
      * @return int
      */
-    protected function countForForm(Form $form): int
+    protected static function countForForm(Form $form): int
     {
         return countElementsInTable(
             self::getTable(),

--- a/src/Glpi/Inventory/Conf.php
+++ b/src/Glpi/Inventory/Conf.php
@@ -299,7 +299,7 @@ class Conf extends CommonGLPI
             case __CLASS__:
                 $tabs = [];
                 if (Session::haveRight(self::$rightname, self::UPDATECONFIG)) {
-                    $tabs[1] = self::createTabEntry(__('Configuration'), 0, $item::getType());
+                    $tabs[1] = self::createTabEntry(__('Configuration'), null, $item::getType());
                 }
                 if ($item->enabled_inventory && Session::haveRight(self::$rightname, self::IMPORTFROMFILE)) {
                     $icon = "<i class='ti ti-upload me-2'></i>";
@@ -407,7 +407,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='import_volume'>";
-            echo \Item_Disk::createTabEntry(\Item_Disk::getTypeName(Session::getPluralNumber()), 0, \Item_Disk::getType());
+            echo \Item_Disk::createTabEntry(\Item_Disk::getTypeName(Session::getPluralNumber()), null, \Item_Disk::getType());
             echo "</label>";
             echo "</td>";
             echo "<td width='360'>";
@@ -420,7 +420,7 @@ class Conf extends CommonGLPI
 
             echo "<td>";
             echo "<label for='import_software'>";
-            echo \Software::createTabEntry(\Software::getTypeName(Session::getPluralNumber()), 0, \Software::getType());
+            echo \Software::createTabEntry(\Software::getTypeName(Session::getPluralNumber()), null, \Software::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -435,7 +435,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='import_monitor'>";
-            echo \Monitor::createTabEntry(\Monitor::getTypeName(Session::getPluralNumber()), 0, \Monitor::getType());
+            echo \Monitor::createTabEntry(\Monitor::getTypeName(Session::getPluralNumber()), null, \Monitor::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -449,7 +449,7 @@ class Conf extends CommonGLPI
             echo "</td>";
             echo "<td>";
             echo "<label for='import_printer'>";
-            echo \Printer::createTabEntry(\Printer::getTypeName(Session::getPluralNumber()), 0, \Printer::getType());
+            echo \Printer::createTabEntry(\Printer::getTypeName(Session::getPluralNumber()), null, \Printer::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -464,7 +464,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='import_peripheral'>";
-            echo \Peripheral::createTabEntry(\Peripheral::getTypeName(Session::getPluralNumber()), 0, \Peripheral::getType());
+            echo \Peripheral::createTabEntry(\Peripheral::getTypeName(Session::getPluralNumber()), null, \Peripheral::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -478,7 +478,7 @@ class Conf extends CommonGLPI
             echo "</td>";
             echo "<td>";
             echo "<label for='import_antivirus'>";
-            echo \ItemAntivirus::createTabEntry(\ItemAntivirus::getTypeName(Session::getPluralNumber()), 0, \ItemAntivirus::getType());
+            echo \ItemAntivirus::createTabEntry(\ItemAntivirus::getTypeName(Session::getPluralNumber()), null, \ItemAntivirus::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -493,7 +493,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='import_process'>";
-            echo \Item_Process::createTabEntry(\Item_Process::getTypeName(Session::getPluralNumber()), 0, \Item_Process::getType());
+            echo \Item_Process::createTabEntry(\Item_Process::getTypeName(Session::getPluralNumber()), null, \Item_Process::getType());
             echo "</label>";
             echo "</td>";
             echo "<td width='360'>";
@@ -505,7 +505,7 @@ class Conf extends CommonGLPI
             echo "</td>";
             echo "<td>";
             echo "<label for='import_env'>";
-            echo \Item_Environment::createTabEntry(\Item_Environment::getTypeName(Session::getPluralNumber()), 0, \Item_Environment::getType());
+            echo \Item_Environment::createTabEntry(\Item_Environment::getTypeName(Session::getPluralNumber()), null, \Item_Environment::getType());
             echo "</label>";
             echo "</td>";
             echo "<td width='360'>";
@@ -520,7 +520,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='import_unmanaged'>";
-            echo \Unmanaged::createTabEntry(\Unmanaged::getTypeName(Session::getPluralNumber()), 0, \Unmanaged::getType());
+            echo \Unmanaged::createTabEntry(\Unmanaged::getTypeName(Session::getPluralNumber()), null, \Unmanaged::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -539,7 +539,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='dropdown_states_id_default$rand'>";
-            echo \State::createTabEntry(__('Default status'), 0, \State::getType());
+            echo \State::createTabEntry(__('Default status'), null, \State::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -557,7 +557,7 @@ class Conf extends CommonGLPI
             echo "</td>";
 
             echo "<td><label for='dropdown_inventory_frequency$rand'>";
-            echo self::createTabEntry(__('Inventory frequency (in hours)'), 0, self::getType());
+            echo self::createTabEntry(__('Inventory frequency (in hours)'), null, self::getType());
             echo "</label></td><td>";
             \Dropdown::showNumber(
                 "inventory_frequency",
@@ -576,7 +576,7 @@ class Conf extends CommonGLPI
 
             echo "<td>";
             echo "<label for='dropdown_entities_id_id_default$rand'>";
-            echo \Entity::createTabEntry(__('Default entity'), 0, \Entity::getType());
+            echo \Entity::createTabEntry(__('Default entity'), null, \Entity::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -594,7 +594,7 @@ class Conf extends CommonGLPI
 
             echo "<td>";
             echo "<label for='import_monitor_on_partial_sn'>";
-            echo \Monitor::createTabEntry(__('Import monitor on serial partial match'), 0, \Monitor::getType());
+            echo \Monitor::createTabEntry(__('Import monitor on serial partial match'), null, \Monitor::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -648,7 +648,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='import_vm'>";
-            echo \ItemVirtualMachine::createTabEntry(__('Import virtual machines'), 0, \ItemVirtualMachine::getType());
+            echo \ItemVirtualMachine::createTabEntry(__('Import virtual machines'), null, \ItemVirtualMachine::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -660,7 +660,7 @@ class Conf extends CommonGLPI
             echo "</td>";
             echo "<td>";
             echo "<label for='dropdown_vm_type$rand'>";
-            echo \ComputerType::createTabEntry(\ComputerType::getTypeName(1), 0, \ComputerType::getType());
+            echo \ComputerType::createTabEntry(\ComputerType::getTypeName(1), null, \ComputerType::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -679,7 +679,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='vm_as_computer'>";
-            echo \Computer::createTabEntry(__('Create computer for virtual machines'), 0, \Computer::getType());
+            echo \Computer::createTabEntry(__('Create computer for virtual machines'), null, \Computer::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -691,7 +691,7 @@ class Conf extends CommonGLPI
             echo "</td>";
             echo "<td>";
             echo "<label for='vm_components'>";
-            echo \ItemVirtualMachine::createTabEntry(__('Create components for virtual machines'), 0, \ItemVirtualMachine::getType());
+            echo \ItemVirtualMachine::createTabEntry(__('Create components for virtual machines'), null, \ItemVirtualMachine::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -718,7 +718,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='component_processor'>";
-            echo \DeviceProcessor::createTabEntry(DeviceProcessor::getTypeName(Session::getPluralNumber()), 0, \DeviceProcessor::getType());
+            echo \DeviceProcessor::createTabEntry(DeviceProcessor::getTypeName(Session::getPluralNumber()), null, \DeviceProcessor::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -731,7 +731,7 @@ class Conf extends CommonGLPI
 
             echo "<td>";
             echo "<label for='component_harddrive'>";
-            echo \DeviceHardDrive::createTabEntry(DeviceHardDrive::getTypeName(Session::getPluralNumber()), 0, \DeviceHardDrive::getType());
+            echo \DeviceHardDrive::createTabEntry(DeviceHardDrive::getTypeName(Session::getPluralNumber()), null, \DeviceHardDrive::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -746,7 +746,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='component_memory'>";
-            echo \DeviceMemory::createTabEntry(DeviceMemory::getTypeName(Session::getPluralNumber()), 0, \DeviceMemory::getType());
+            echo \DeviceMemory::createTabEntry(DeviceMemory::getTypeName(Session::getPluralNumber()), null, \DeviceMemory::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -759,7 +759,7 @@ class Conf extends CommonGLPI
 
             echo "<td>";
             echo "<label for='component_soundcard'>";
-            echo \DeviceSoundCard::createTabEntry(DeviceSoundCard::getTypeName(Session::getPluralNumber()), 0, \DeviceSoundCard::getType());
+            echo \DeviceSoundCard::createTabEntry(DeviceSoundCard::getTypeName(Session::getPluralNumber()), null, \DeviceSoundCard::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -775,7 +775,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='component_networkcard'>";
-            echo \DeviceNetworkCard::createTabEntry(DeviceNetworkCard::getTypeName(Session::getPluralNumber()), 0, \DeviceNetworkCard::getType());
+            echo \DeviceNetworkCard::createTabEntry(DeviceNetworkCard::getTypeName(Session::getPluralNumber()), null, \DeviceNetworkCard::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -788,7 +788,7 @@ class Conf extends CommonGLPI
 
             echo "<td>";
             echo "<label for='component_networkcardvirtual'>";
-            echo \DeviceNetworkCard::createTabEntry(__('Virtual network cards'), 0, \DeviceNetworkCard::getType());
+            echo \DeviceNetworkCard::createTabEntry(__('Virtual network cards'), null, \DeviceNetworkCard::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -804,7 +804,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='component_graphiccard'>";
-            echo \DeviceGraphicCard::createTabEntry(DeviceGraphicCard::getTypeName(Session::getPluralNumber()), 0, \DeviceGraphicCard::getType());
+            echo \DeviceGraphicCard::createTabEntry(DeviceGraphicCard::getTypeName(Session::getPluralNumber()), null, \DeviceGraphicCard::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -817,7 +817,7 @@ class Conf extends CommonGLPI
 
             echo "<td>";
             echo "<label for='component_simcard'>";
-            echo \DeviceSimcard::createTabEntry(DeviceSimcard::getTypeName(Session::getPluralNumber()), 0, \DeviceSimcard::getType());
+            echo \DeviceSimcard::createTabEntry(DeviceSimcard::getTypeName(Session::getPluralNumber()), null, \DeviceSimcard::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -833,7 +833,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='component_drive'>";
-            echo \DeviceDrive::createTabEntry(DeviceDrive::getTypeName(Session::getPluralNumber()), 0, \DeviceDrive::getType());
+            echo \DeviceDrive::createTabEntry(DeviceDrive::getTypeName(Session::getPluralNumber()), null, \DeviceDrive::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -847,7 +847,7 @@ class Conf extends CommonGLPI
             echo "</td>";
             echo "<td>";
             echo "<label for='component_networkdrive'>";
-            echo \DeviceDrive::createTabEntry(__('Network drives'), 0, \DeviceDrive::getType());
+            echo \DeviceDrive::createTabEntry(__('Network drives'), null, \DeviceDrive::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -862,7 +862,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='component_drive'>";
-            echo \DeviceDrive::createTabEntry(__('Removable drives'), 0, \DeviceDrive::getType());
+            echo \DeviceDrive::createTabEntry(__('Removable drives'), null, \DeviceDrive::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -874,7 +874,7 @@ class Conf extends CommonGLPI
             echo "</td>";
             echo "<td>";
             echo "<label for='component_powersupply'>";
-            echo \DevicePowerSupply::createTabEntry(DevicePowerSupply::getTypeName(Session::getPluralNumber()), 0, \DevicePowerSupply::getType());
+            echo \DevicePowerSupply::createTabEntry(DevicePowerSupply::getTypeName(Session::getPluralNumber()), null, \DevicePowerSupply::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -890,7 +890,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='component_control'>";
-            echo \DeviceControl::createTabEntry(DeviceControl::getTypeName(Session::getPluralNumber()), 0, \DeviceControl::getType());
+            echo \DeviceControl::createTabEntry(DeviceControl::getTypeName(Session::getPluralNumber()), null, \DeviceControl::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -904,7 +904,7 @@ class Conf extends CommonGLPI
             echo "</td>";
             echo "<td>";
             echo "<label for='component_battery'>";
-            echo \DeviceBattery::createTabEntry(DeviceBattery::getTypeName(Session::getPluralNumber()), 0, \DeviceBattery::getType());
+            echo \DeviceBattery::createTabEntry(DeviceBattery::getTypeName(Session::getPluralNumber()), null, \DeviceBattery::getType());
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -919,7 +919,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<th colspan=4 >" . __('Agent cleanup') . "</th></tr>";
             echo "<tr class='tab_bg_1'><td>";
-            echo \Agent::createTabEntry(__('Update agents who have not contacted the server for (in days)'), 0, \Agent::getType());
+            echo \Agent::createTabEntry(__('Update agents who have not contacted the server for (in days)'), null, \Agent::getType());
             echo "</td><td width='20%'>";
             Dropdown::showNumber(
                 'stale_agents_delay',
@@ -931,7 +931,7 @@ class Conf extends CommonGLPI
                 ]
             );
             echo "</td><td>";
-            echo \Agent::createTabEntry(_n('Action', 'Actions', 1), 0, \Agent::getType());
+            echo \Agent::createTabEntry(_n('Action', 'Actions', 1), null, \Agent::getType());
             echo "</><td width='20%'>";
             //action
             $action = self::getDefaults()['stale_agents_action'];
@@ -961,7 +961,7 @@ class Conf extends CommonGLPI
             //blocaction with status
             echo "<tr class='tab_bg_1' style='display:none' id='bloc_status_action1'><td colspan=2></td>";
             echo "<td>";
-            echo \State::createTabEntry(__('If the asset status is'), 0, \State::getType());
+            echo \State::createTabEntry(__('If the asset status is'), null, \State::getType());
             echo "</td>";
             echo "<td width='20%'>";
             $condition = [];
@@ -988,7 +988,7 @@ class Conf extends CommonGLPI
 
             echo "<tr class='tab_bg_1' style='display:none' id='bloc_status_action2'><td colspan=2></td>";
             echo "<td>";
-            echo \State::createTabEntry(__('Status to apply'), 0, \State::getType());
+            echo \State::createTabEntry(__('Status to apply'), null, \State::getType());
             echo "</td>";
             echo "<td width='20%'>";
             State::dropdown(

--- a/src/Glpi/Search/CriteriaFilter.php
+++ b/src/Glpi/Search/CriteriaFilter.php
@@ -63,22 +63,25 @@ final class CriteriaFilter extends CommonDBChild
         }
 
         // Count number of filter criteria (with nested sub-criteria)
-        $nb = 0;
-        if (($filter = self::getForItem($item))) {
-            // important: array_walk_recursive iterates only over non-array values
-            // so we need to count only when we we found the 'field' key
-            array_walk_recursive($filter->fields['search_criteria'], function ($value, $key) use (&$nb) {
-                if ($key === 'field') {
-                    $nb++;
-                }
-            });
-        }
+        $nb = static function () use ($item) {
+            $count = 0;
+            if (($filter = self::getForItem($item))) {
+                // important: array_walk_recursive iterates only over non-array values
+                // so we need to count only when we we found the 'field' key
+                array_walk_recursive($filter->fields['search_criteria'], static function ($value, $key) use (&$count) {
+                    if ($key === 'field') {
+                        $count++;
+                    }
+                });
+            }
+            return $count;
+        };
 
         return self::createTabEntry(
-            self::getTypeName($nb),
-            $nb,
-            $item::getType(),
-            'ti ti-adjustments-horizontal'
+            text: self::getTypeName($nb),
+            nb: $nb,
+            form_itemtype: $item::class,
+            icon: 'ti ti-adjustments-horizontal'
         );
     }
 

--- a/src/Glpi/Socket.php
+++ b/src/Glpi/Socket.php
@@ -588,28 +588,24 @@ class Socket extends CommonDBChild
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
         if (!$withtemplate) {
-            $nb = 0;
-            switch (get_class($item)) {
+            switch ($item::class) {
                 case Location::class:
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb =  countElementsInTable(
-                            $this->getTable(),
-                            ['locations_id' => $item->getID()]
-                        );
-                    }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                    return self::createTabEntry(
+                        text: self::getTypeName(Session::getPluralNumber()),
+                        nb: static fn () => countElementsInTable(static::getTable(), ['locations_id' => $item->getID()]),
+                        form_itemtype: $item::class
+                    );
                 default:
                     /** @var CommonDBTM $item */
                     if (in_array($item->getType(), $CFG_GLPI['socket_types'])) {
-                        if ($_SESSION['glpishow_count_on_tabs']) {
-                              $nb =  countElementsInTable(
-                                  $this->getTable(),
-                                  ['itemtype' => $item->getType(),
-                                      'items_id' => $item->getID()
-                                  ]
-                              );
-                        }
-                        return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                        return self::createTabEntry(
+                            text: self::getTypeName(Session::getPluralNumber()),
+                            nb: static fn () => countElementsInTable(static::getTable(), [
+                                'itemtype' => $item::class,
+                                'items_id' => $item->getID()
+                            ]),
+                            form_itemtype: $item::class
+                        );
                     }
             }
         }

--- a/src/Group.php
+++ b/src/Group.php
@@ -116,23 +116,20 @@ class Group extends CommonTreeDropdown
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if (!$withtemplate && self::canView()) {
-            $nb = 0;
             switch ($item::class) {
                 case self::class:
                     $ong = [];
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = countElementsInTable(
-                            self::getTable(),
-                            ['groups_id' => $item->getID()]
-                        );
-                    }
-                    $ong[4] = self::createTabEntry(__('Child groups'), $nb, $item::class);
+                    $ong[4] = self::createTabEntry(
+                        text: __('Child groups'),
+                        nb: static fn () => countElementsInTable(self::getTable(), ['groups_id' => $item->getID()]),
+                        form_itemtype: $item::class
+                    );
 
                     if ($item->getField('is_itemgroup')) {
-                        $ong[1] = self::createTabEntry(__('Used items'), 0, $item::class, 'ti ti-package');
+                        $ong[1] = self::createTabEntry(__('Used items'), null, $item::class, 'ti ti-package');
                     }
                     if ($item->getField('is_assign')) {
-                        $ong[2] = self::createTabEntry(__('Managed items'), 0, $item::class, 'ti ti-package');
+                        $ong[2] = self::createTabEntry(__('Managed items'), null, $item::class, 'ti ti-package');
                     }
                     if (
                         $item->getField('is_usergroup')
@@ -140,9 +137,9 @@ class Group extends CommonTreeDropdown
                         && Session::haveRight("user", User::UPDATEAUTHENT)
                         && AuthLDAP::useAuthLdap()
                     ) {
-                        $ong[3] = self::createTabEntry(__('LDAP directory link'), 0, $item::class, 'ti ti-login');
+                        $ong[3] = self::createTabEntry(__('LDAP directory link'), null, $item::class, 'ti ti-login');
                     }
-                    $ong[5] = self::createTabEntry(__('Security'), 0, $item::class, 'ti ti-shield-lock');
+                    $ong[5] = self::createTabEntry(__('Security'), null, $item::class, 'ti ti-shield-lock');
                     return $ong;
             }
         }

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -643,23 +643,16 @@ class Group_User extends CommonDBRelation
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if (!$withtemplate) {
-            $nb = 0;
             switch ($item::class) {
                 case User::class:
                     if (Group::canView()) {
-                        if ($_SESSION['glpishow_count_on_tabs']) {
-                            $nb = self::countForItem($item);
-                        }
-                        return self::createTabEntry(Group::getTypeName(Session::getPluralNumber()), $nb, $item::class);
+                        return self::createTabEntry(Group::getTypeName(Session::getPluralNumber()), static fn () => self::countForItem($item), $item::class);
                     }
                     break;
 
                 case Group::class:
                     if (User::canView()) {
-                        if ($_SESSION['glpishow_count_on_tabs']) {
-                              $nb = self::countForItem($item);
-                        }
-                        return self::createTabEntry(User::getTypeName(Session::getPluralNumber()), $nb, $item::class);
+                        return self::createTabEntry(User::getTypeName(Session::getPluralNumber()), static fn () => self::countForItem($item), $item::class);
                     }
                     break;
             }

--- a/src/IPAddress.php
+++ b/src/IPAddress.php
@@ -342,8 +342,8 @@ class IPAddress extends CommonDBChild
         /** @var \DBmysql $DB */
         global $DB;
 
-        switch ($item->getType()) {
-            case 'IPNetwork':
+        switch ($item::class) {
+            case IPNetwork::class:
                 $result = $DB->request([
                     'COUNT'  => 'cpt',
                     'FROM'   => 'glpi_ipaddresses_ipnetworks',
@@ -363,16 +363,11 @@ class IPAddress extends CommonDBChild
      **/
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-
         if (
             $item->getID()
             && $item->can($item->getField('id'), READ)
         ) {
-            $nb = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = self::countForItem($item);
-            }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), static fn () => self::countForItem($item), $item::class);
         }
         return '';
     }

--- a/src/IPNetwork_Vlan.php
+++ b/src/IPNetwork_Vlan.php
@@ -232,18 +232,14 @@ class IPNetwork_Vlan extends CommonDBRelation
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-
         if (!$withtemplate) {
-            $nb = 0;
-            switch ($item->getType()) {
-                case 'IPNetwork':
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb =  countElementsInTable(
-                            $this->getTable(),
-                            ['ipnetworks_id' => $item->getID()]
-                        );
-                    }
-                    return self::createTabEntry(Vlan::getTypeName(), $nb, $item::getType());
+            switch ($item::class) {
+                case IPNetwork:: class:
+                    return self::createTabEntry(
+                        text: Vlan::getTypeName(),
+                        nb: static fn () => countElementsInTable(self::getTable(), ['ipnetworks_id' => $item->getID()]),
+                        form_itemtype: $item::class
+                    );
             }
         }
         return '';

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -60,16 +60,12 @@ class ITILSolution extends CommonDBChild
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        if ($item->isNewItem()) {
-            return '';
-        }
-        if ($item->maySolve()) {
-            $nb    = 0;
-            $title = self::getTypeName(Session::getPluralNumber());
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = self::countFor($item->getType(), $item->getID());
-            }
-            return self::createTabEntry($title, $nb, $item::getType());
+        if (!$item->isNewItem() && $item->maySolve()) {
+            return self::createTabEntry(
+                text: self::getTypeName(Session::getPluralNumber()),
+                nb: static fn () => self::countFor($item::class, $item->getID()),
+                form_itemtype: $item::class
+            );
         }
         return '';
     }

--- a/src/ITILTemplateField.php
+++ b/src/ITILTemplateField.php
@@ -92,6 +92,18 @@ abstract class ITILTemplateField extends CommonDBChild
         return '';
     }
 
+    public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
+    {
+        // can exist for template
+        if ($item instanceof ITILTemplate && Session::haveRight("itiltemplate", READ)) {
+            return static::createTabEntry(
+                text: static::getTypeName(Session::getPluralNumber()),
+                nb: static fn () => countElementsInTable(static::getTable(), [static::$items_id => $item->getID()]),
+                form_itemtype: $item::class
+            );
+        }
+        return '';
+    }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
     {

--- a/src/ITILTemplateHiddenField.php
+++ b/src/ITILTemplateHiddenField.php
@@ -49,28 +49,6 @@ abstract class ITILTemplateHiddenField extends ITILTemplateField
         return _n('Hidden field', 'Hidden fields', $nb);
     }
 
-
-    public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
-    {
-
-       // can exists for template
-        if (
-            $item instanceof ITILTemplate
-            && Session::haveRight("itiltemplate", READ)
-        ) {
-            $nb = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = countElementsInTable(
-                    $this->getTable(),
-                    [static::$items_id => $item->getID()]
-                );
-            }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
-        }
-        return '';
-    }
-
-
     public function post_purgeItem()
     {
         /** @var \DBmysql $DB */

--- a/src/ITILTemplateMandatoryField.php
+++ b/src/ITILTemplateMandatoryField.php
@@ -47,28 +47,6 @@ abstract class ITILTemplateMandatoryField extends ITILTemplateField
         return _n('Mandatory field', 'Mandatory fields', $nb);
     }
 
-
-    public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
-    {
-
-       // can exists for template
-        if (
-            $item instanceof ITILTemplate
-            && Session::haveRight("itiltemplate", READ)
-        ) {
-            $nb = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = countElementsInTable(
-                    $this->getTable(),
-                    [static::$items_id => $item->getID()]
-                );
-            }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
-        }
-        return '';
-    }
-
-
     public function post_purgeItem()
     {
         /** @var \DBmysql $DB */

--- a/src/ITILTemplatePredefinedField.php
+++ b/src/ITILTemplatePredefinedField.php
@@ -122,28 +122,6 @@ abstract class ITILTemplatePredefinedField extends ITILTemplateField
         }
     }
 
-
-    public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
-    {
-
-       // can exists for template
-        if (
-            $item instanceof ITILTemplate
-            && Session::haveRight("itiltemplate", READ)
-        ) {
-            $nb = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = countElementsInTable(
-                    $this->getTable(),
-                    [static::$items_id => $item->getID()]
-                );
-            }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
-        }
-        return '';
-    }
-
-
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
     {
 

--- a/src/ITILTemplateReadonlyField.php
+++ b/src/ITILTemplateReadonlyField.php
@@ -49,28 +49,6 @@ abstract class ITILTemplateReadonlyField extends ITILTemplateField
         return _n('Read only field', 'Read only fields', $nb);
     }
 
-
-    public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
-    {
-
-       // can exists for template
-        if (
-            $item instanceof ITILTemplate
-            && Session::haveRight("itiltemplate", READ)
-        ) {
-            $nb = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = countElementsInTable(
-                    $this->getTable(),
-                    [static::$items_id => $item->getID()]
-                );
-            }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
-        }
-        return '';
-    }
-
-
     public function post_purgeItem()
     {
         /** @var \DBmysql $DB */

--- a/src/Impact.php
+++ b/src/Impact.php
@@ -102,27 +102,21 @@ class Impact extends CommonGLPI
             );
         }
 
-        if (
-            !$_SESSION['glpishow_count_on_tabs']
-            || !isset($item->fields['id'])
-            || $is_itil_object
-        ) {
-            // Count is disabled in config OR no item loaded OR ITIL object -> no count
-            $total = 0;
-        } else if ($is_enabled_asset) {
+        $total = null;
+        if ($is_enabled_asset && !$is_itil_object && isset($item->fields['id'])) {
             // If on an asset, get the number of its direct dependencies
-            $total = count($DB->request([
+            $total = static fn () => count($DB->request([
                 'FROM'  => ImpactRelation::getTable(),
                 'WHERE' => [
                     'OR' => [
                         [
                             // Source item is our item
-                            'itemtype_source' => get_class($item),
+                            'itemtype_source' => $item::class,
                             'items_id_source' => $item->fields['id'],
                         ],
                         [
                             // Impacted item is our item AND source item is enabled
-                            'itemtype_impacted' => get_class($item),
+                            'itemtype_impacted' => $item::class,
                             'items_id_impacted' => $item->fields['id'],
                             'itemtype_source'   => self::getEnabledItemtypes()
                         ]
@@ -131,7 +125,7 @@ class Impact extends CommonGLPI
             ]));
         }
 
-        return self::createTabEntry(__("Impact analysis"), $total, $item::getType());
+        return self::createTabEntry(__("Impact analysis"), $total, $item::class);
     }
 
     public static function displayTabContentForItem(

--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -141,28 +141,23 @@ class Infocom extends CommonDBChild
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-
-       // Can exists on template
+        // Can exist on template
         if (Session::haveRight(self::$rightname, READ)) {
-            $nb = 0;
-            switch ($item->getType()) {
-                case 'Supplier':
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = self::countForSupplier($item);
-                    }
-                    return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::getType());
-
-                default:
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = countElementsInTable(
-                            'glpi_infocoms',
-                            ['itemtype' => $item->getType(),
-                                'items_id' => $item->getID()
-                            ]
-                        );
-                    }
-                    return self::createTabEntry(__('Management'), $nb, $item::getType());
-            }
+            return match ($item::class) {
+                Supplier::class => self::createTabEntry(
+                    text: _n('Item', 'Items', Session::getPluralNumber()),
+                    nb: static fn() => self::countForSupplier($item),
+                    form_itemtype: $item::class
+                ),
+                default => self::createTabEntry(
+                    text: __('Management'),
+                    nb: static fn() => countElementsInTable(self::getTable(), [
+                        'itemtype' => $item::class,
+                        'items_id' => $item->getID()
+                    ]),
+                    form_itemtype: $item::class
+                ),
+            };
         }
         return '';
     }

--- a/src/ItemAntivirus.php
+++ b/src/ItemAntivirus.php
@@ -55,17 +55,17 @@ class ItemAntivirus extends CommonDBChild
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-
-       // can exists for template
+        // can exist for template
         if ($item::canView()) {
-            $nb = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = countElementsInTable(
-                    self::getTable(),
-                    ['itemtype' => $item->getType(), 'items_id' => $item->getID(), 'is_deleted' => 0 ]
-                );
-            }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(
+                text: self::getTypeName(Session::getPluralNumber()),
+                nb: static fn () => countElementsInTable(self::getTable(), [
+                    'itemtype' => $item::class,
+                    'items_id' => $item->getID(),
+                    'is_deleted' => 0
+                ]),
+                form_itemtype: $item::class
+            );
         }
         return '';
     }

--- a/src/ItemVirtualMachine.php
+++ b/src/ItemVirtualMachine.php
@@ -76,21 +76,18 @@ class ItemVirtualMachine extends CommonDBChild
 
         if (
             !$withtemplate
-            && in_array($item::getType(), $CFG_GLPI['itemvirtualmachines_types'])
+            && in_array($item::class, $CFG_GLPI['itemvirtualmachines_types'], true)
             && $item::canView()
         ) {
-            $nb = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = countElementsInTable(
-                    self::getTable(),
-                    [
-                        'itemtype' => $item->getType(),
-                        'items_id' => $item->getID(),
-                        'is_deleted' => 0
-                    ]
-                );
-            }
-            return self::createTabEntry(self::getTypeName(), $nb, $item::getType());
+            return self::createTabEntry(
+                text: self::getTypeName(),
+                nb: static fn () => countElementsInTable(self::getTable(), [
+                    'itemtype' => $item::class,
+                    'items_id' => $item->getID(),
+                    'is_deleted' => 0
+                ]),
+                form_itemtype: $item::class
+            );
         }
         return '';
     }

--- a/src/Item_Cluster.php
+++ b/src/Item_Cluster.php
@@ -53,11 +53,12 @@ class Item_Cluster extends CommonDBRelation
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        $nb = 0;
-        if ($_SESSION['glpishow_count_on_tabs']) {
-            $nb = self::countForMainItem($item);
-        }
-        return self::createTabEntry(_n('Item', 'Items', $nb), $nb, $item::getType(), 'ti ti-package');
+        return self::createTabEntry(
+            text: _n('Item', 'Items', Session::getPluralNumber()),
+            nb: static fn () => self::countForMainItem($item),
+            form_itemtype: $item::class,
+            icon: 'ti ti-package'
+        );
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)

--- a/src/Item_DeviceCamera_ImageFormat.php
+++ b/src/Item_DeviceCamera_ImageFormat.php
@@ -50,20 +50,11 @@ class Item_DeviceCamera_ImageFormat extends CommonDBRelation
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        $nb = 0;
-        switch ($item->getType()) {
-            default:
-                if ($_SESSION['glpishow_count_on_tabs']) {
-                    $nb = countElementsInTable(
-                        self::getTable(),
-                        [
-                            'items_devicecameras_id' => $item->getID()
-                        ]
-                    );
-                }
-                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
-        }
-        return '';
+        return self::createTabEntry(
+            text: self::getTypeName(Session::getPluralNumber()),
+            nb: static fn () => countElementsInTable(self::getTable(), ['items_devicecameras_id' => $item->getID()]),
+            form_itemtype: $item::class
+        );
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)

--- a/src/Item_DeviceCamera_ImageResolution.php
+++ b/src/Item_DeviceCamera_ImageResolution.php
@@ -50,20 +50,11 @@ class Item_DeviceCamera_ImageResolution extends CommonDBRelation
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        $nb = 0;
-        switch ($item->getType()) {
-            default:
-                if ($_SESSION['glpishow_count_on_tabs']) {
-                    $nb = countElementsInTable(
-                        self::getTable(),
-                        [
-                            'items_devicecameras_id' => $item->getID()
-                        ]
-                    );
-                }
-                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
-        }
-        return '';
+        return self::createTabEntry(
+            text: self::getTypeName(Session::getPluralNumber()),
+            nb: static fn () => countElementsInTable(self::getTable(), ['items_devicecameras_id' => $item->getID()]),
+            form_itemtype: $item::class
+        );
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)

--- a/src/Item_Disk.php
+++ b/src/Item_Disk.php
@@ -75,20 +75,17 @@ class Item_Disk extends CommonDBChild
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        // can exists for template
+        // can exist for template
         if ($item::canView()) {
-            $nb = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = countElementsInTable(
-                    self::getTable(),
-                    [
-                        'items_id'     => $item->getID(),
-                        'itemtype'     => $item->getType(),
-                        'is_deleted'   => 0
-                    ]
-                );
-            }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(
+                text: self::getTypeName(Session::getPluralNumber()),
+                nb: static fn () => countElementsInTable(self::getTable(), [
+                    'itemtype'     => $item::class,
+                    'items_id'     => $item->getID(),
+                    'is_deleted'   => 0
+                ]),
+                form_itemtype: $item::class
+            );
         }
         return '';
     }

--- a/src/Item_Enclosure.php
+++ b/src/Item_Enclosure.php
@@ -53,11 +53,11 @@ class Item_Enclosure extends CommonDBRelation
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        $nb = 0;
-        if ($_SESSION['glpishow_count_on_tabs']) {
-            $nb = self::countForMainItem($item);
-        }
-        return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+        return self::createTabEntry(
+            text: self::getTypeName(Session::getPluralNumber()),
+            nb: static fn () => self::countForMainItem($item),
+            form_itemtype: $item::class
+        );
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)

--- a/src/Item_Environment.php
+++ b/src/Item_Environment.php
@@ -55,21 +55,23 @@ final class Item_Environment extends CommonDBChild
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if ($item::canView()) {
-            $nb = countElementsInTable(
-                self::getTable(),
-                [
-                    'items_id'     => $item->getID(),
-                    'itemtype'     => $item->getType(),
-                ]
-            );
-            if ($nb == 0) {
+            $criteria = [
+                'items_id' => $item->getID(),
+                'itemtype' => $item->getType(),
+            ];
+            // This tab only appears if there is at least one environment
+            $has_env = countElementsInTable(self::getTable(), [
+                'WHERE' => $criteria,
+                'LIMIT' => 1 // Only need to know if there is at least one
+            ]);
+            if ($has_env === 0) {
                 return '';
             }
-
-            if (!$_SESSION['glpishow_count_on_tabs']) {
-                $nb = 0;
-            }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(
+                text: self::getTypeName(Session::getPluralNumber()),
+                nb: static fn () => countElementsInTable(self::getTable(), $criteria),
+                form_itemtype: $item::class
+            );
         }
 
         return '';

--- a/src/Item_Line.php
+++ b/src/Item_Line.php
@@ -47,17 +47,19 @@ class Item_Line extends CommonDBRelation
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        $nb = 0;
         if ($item instanceof Line) {
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = self::countForMainItem($item) + self::countSimcardItemsForLine($item);
-            }
-            return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::getType(), 'ti ti-package');
+            return self::createTabEntry(
+                text: _n('Item', 'Items', Session::getPluralNumber()),
+                nb: static fn () => self::countForMainItem($item) + self::countSimcardItemsForLine($item),
+                form_itemtype: $item::class,
+                icon: 'ti ti-package'
+            );
         } else {
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = self::countForItem($item) + self::countSimcardLinesForItem($item);
-            }
-            return self::createTabEntry(Line::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(
+                text: Line::getTypeName(Session::getPluralNumber()),
+                nb: static fn () => self::countForItem($item) + self::countSimcardLinesForItem($item),
+                form_itemtype: $item::class
+            );
         }
     }
 

--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -54,15 +54,11 @@ class Item_OperatingSystem extends CommonDBRelation
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        $nb = 0;
-        switch ($item->getType()) {
-            default:
-                if ($_SESSION['glpishow_count_on_tabs']) {
-                    $nb = self::countForItem($item);
-                }
-                return self::createTabEntry(OperatingSystem::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
-        }
-        return '';
+        return self::createTabEntry(
+            text: OperatingSystem::getTypeName(Session::getPluralNumber()),
+            nb: static fn () => self::countForItem($item),
+            form_itemtype: $item::class
+        );
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)

--- a/src/Item_Plug.php
+++ b/src/Item_Plug.php
@@ -52,12 +52,9 @@ class Item_Plug extends CommonDBRelation
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        $nb = 0;
-        if ($_SESSION['glpishow_count_on_tabs']) {
-            $nb = $item::class === Plug::class
-                ? countElementsInTable(self::getTable(), ['plugs_id' => $item->getID()])
-                : countElementsInTable(self::getTable(), ['itemtype' => $item::class, 'items_id' => $item->getID()]);
-        }
+        $nb = $item::class === Plug::class
+            ? (static fn () => countElementsInTable(self::getTable(), ['plugs_id' => $item->getID()]))
+            : (static fn () => countElementsInTable(self::getTable(), ['itemtype' => $item::class, 'items_id' => $item->getID()]));
         return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
     }
 

--- a/src/Item_Process.php
+++ b/src/Item_Process.php
@@ -55,23 +55,24 @@ class Item_Process extends CommonDBChild
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if ($item::canView()) {
-            $nb = countElementsInTable(
-                self::getTable(),
-                [
-                    'items_id'     => $item->getID(),
-                    'itemtype'     => $item->getType(),
-                ]
-            );
-            if ($nb == 0) {
+            $criteria = [
+                'items_id' => $item->getID(),
+                'itemtype' => $item->getType(),
+            ];
+            // This tab only appears if there is at least one process
+            $has_env = countElementsInTable(self::getTable(), [
+                'WHERE' => $criteria,
+                'LIMIT' => 1 // Only need to know if there is at least one
+            ]);
+            if ($has_env === 0) {
                 return '';
             }
-
-            if (!$_SESSION['glpishow_count_on_tabs']) {
-                $nb = 0;
-            }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(
+                text: self::getTypeName(Session::getPluralNumber()),
+                nb: static fn () => countElementsInTable(self::getTable(), $criteria),
+                form_itemtype: $item::class
+            );
         }
-
         return '';
     }
 

--- a/src/Item_Project.php
+++ b/src/Item_Project.php
@@ -219,40 +219,25 @@ class Item_Project extends CommonDBRelation
         echo "</div>";
     }
 
-
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-
         if (!$withtemplate) {
-            $nb = 0;
-            switch ($item->getType()) {
-                case 'Project':
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = self::countForMainItem($item);
-                    }
-                    return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::getType(), 'ti ti-package');
-
+            switch ($item::class) {
+                case Project::class:
+                    return self::createTabEntry(
+                        text: _n('Item', 'Items', Session::getPluralNumber()),
+                        nb: static fn () => self::countForMainItem($item),
+                        form_itemtype: $item::class,
+                        icon: 'ti ti-package'
+                    );
                 default:
-                   // Not used now
+                    // Not used now
                     if (Session::haveRight("project", Project::READALL)) {
-                        if ($_SESSION['glpishow_count_on_tabs']) {
-                              // Direct one
-                              $nb = self::countForItem($item);
-
-                              // Linked items
-                              $linkeditems = $item->getLinkedItems();
-
-                            if (count($linkeditems)) {
-                                foreach ($linkeditems as $type => $tab) {
-                                    $typeitem = new $type();
-                                    foreach ($tab as $ID) {
-                                        $typeitem->getFromDB($ID);
-                                        $nb += self::countForItem($typeitem);
-                                    }
-                                }
-                            }
-                        }
-                        return self::createTabEntry(Project::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                        return self::createTabEntry(
+                            text: Project::getTypeName(Session::getPluralNumber()),
+                            nb: static fn () => self::countForItemAndLinks($item),
+                            form_itemtype: $item::class
+                        );
                     }
             }
         }

--- a/src/Item_Rack.php
+++ b/src/Item_Rack.php
@@ -53,22 +53,14 @@ class Item_Rack extends CommonDBRelation
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        $nb = 0;
-        switch ($item->getType()) {
-            default:
-                if ($_SESSION['glpishow_count_on_tabs']) {
-                    $nb = countElementsInTable(
-                        self::getTable(),
-                        ['racks_id'  => $item->getID()]
-                    );
-                    $nb += countElementsInTable(
-                        PDU_Rack::getTable(),
-                        ['racks_id'  => $item->getID()]
-                    );
-                }
-                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
-        }
-        return '';
+        return self::createTabEntry(
+            text: self::getTypeName(Session::getPluralNumber()),
+            nb: static function () use ($item) {
+                return countElementsInTable(self::getTable(), ['racks_id'  => $item->getID()])
+                    + countElementsInTable(PDU_Rack::getTable(), ['racks_id'  => $item->getID()]);
+            },
+            form_itemtype: $item::class
+        );
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)

--- a/src/Item_RemoteManagement.php
+++ b/src/Item_RemoteManagement.php
@@ -55,21 +55,14 @@ class Item_RemoteManagement extends CommonDBChild
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        $nb = 0;
-        switch ($item->getType()) {
-            default:
-                if ($_SESSION['glpishow_count_on_tabs']) {
-                    $nb = countElementsInTable(
-                        self::getTable(),
-                        [
-                            'items_id'     => $item->getID(),
-                            'itemtype'     => $item->getType()
-                        ]
-                    );
-                }
-                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
-        }
-        return '';
+        return self::createTabEntry(
+            text: self::getTypeName(Session::getPluralNumber()),
+            nb: static fn() => countElementsInTable(self::getTable(), [
+                'itemtype'     => $item::getType(),
+                'items_id'     => $item->getID()
+            ]),
+            form_itemtype: $item::getType()
+        );
     }
 
 

--- a/src/Item_SoftwareLicense.php
+++ b/src/Item_SoftwareLicense.php
@@ -968,19 +968,16 @@ JAVASCRIPT;
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        $nb = 0;
         switch ($item::class) {
             case SoftwareLicense::class:
                 if (!$withtemplate) {
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = self::countForLicense($item->getID());
-                    }
-                    return [1 => self::createTabEntry(__('Summary'), 0, $item::class),
+                    return [
+                        1 => self::createTabEntry(__('Summary'), null, $item::class),
                         2 => self::createTabEntry(
-                            _n('Item', 'Items', Session::getPluralNumber()),
-                            $nb,
-                            $item::class,
-                            'ti ti-package'
+                            text: _n('Item', 'Items', Session::getPluralNumber()),
+                            nb: static fn () => self::countForLicense($item->getID()),
+                            form_itemtype: $item::class,
+                            icon: 'ti ti-package'
                         )
                     ];
                 }

--- a/src/Item_SoftwareVersion.php
+++ b/src/Item_SoftwareVersion.php
@@ -1561,27 +1561,25 @@ class Item_SoftwareVersion extends CommonDBRelation
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        $nb = 0;
         switch ($item::class) {
-            case 'Software':
+            case Software::class:
                 if (!$withtemplate) {
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = self::countForSoftware($item->getID());
-                    }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
+                    return self::createTabEntry(
+                        text: self::getTypeName(Session::getPluralNumber()),
+                        nb: static fn () => self::countForSoftware($item->getID()),
+                        form_itemtype: $item::class
+                    );
                 }
                 break;
 
             case SoftwareVersion::class:
                 if (!$withtemplate) {
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = self::countForVersion($item->getID());
-                    }
-                    return [1 => __('Summary'),
+                    return [
+                        1 => __('Summary'),
                         2 => self::createTabEntry(
-                            self::getTypeName(Session::getPluralNumber()),
-                            $nb,
-                            $item::class
+                            text: self::getTypeName(Session::getPluralNumber()),
+                            nb: static fn () => self::countForVersion($item->getID()),
+                            form_itemtype: $item::class
                         )
                     ];
                 }
@@ -1590,10 +1588,11 @@ class Item_SoftwareVersion extends CommonDBRelation
             default:
                 // Installation allowed for template
                 if (Software::canView()) {
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = self::countForItem($item);
-                    }
-                    return self::createTabEntry(Software::getTypeName(Session::getPluralNumber()), $nb, $item::class);
+                    return self::createTabEntry(
+                        text: Software::getTypeName(Session::getPluralNumber()),
+                        nb: static fn () => self::countForItem($item),
+                        form_itemtype: $item::class
+                    );
                 }
                 break;
         }

--- a/src/Item_Ticket.php
+++ b/src/Item_Ticket.php
@@ -123,68 +123,19 @@ class Item_Ticket extends CommonItilObject_Item
         }
 
         // This tab might be hidden on assets
-        if (in_array($item::getType(), $CFG_GLPI['asset_types']) && !$this->shouldDisplayTabForAsset($item)) {
+        if (in_array($item::class, $CFG_GLPI['asset_types'], true) && !$this->shouldDisplayTabForAsset($item)) {
             return '';
         }
 
-        $nb = 0;
         if (!($item instanceof Ticket)) {
             $title = Ticket::getTypeName(Session::getPluralNumber());
-
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                // Direct one
-                $nb = countElementsInTable(
-                    'glpi_items_tickets',
-                    [
-                        'INNER JOIN' => [
-                            'glpi_tickets' => [
-                                'FKEY' => [
-                                    'glpi_items_tickets' => 'tickets_id',
-                                    'glpi_tickets'       => 'id'
-                                ]
-                            ]
-                        ],
-                        'WHERE' => [
-                            'itemtype' => $item->getType(),
-                            'items_id' => $item->getID(),
-                            'is_deleted' => 0
-                        ]
-                    ]
-                );
-
-                // Linked items
-                $linkeditems = $item->getLinkedItems();
-                if (count($linkeditems)) {
-                    foreach ($linkeditems as $type => $tab) {
-                        $nb += countElementsInTable(
-                            'glpi_items_tickets',
-                            [
-                                'INNER JOIN' => [
-                                    'glpi_tickets' => [
-                                        'FKEY' => [
-                                            'glpi_items_tickets' => 'tickets_id',
-                                            'glpi_tickets'       => 'id'
-                                        ]
-                                    ]
-                                ],
-                                'WHERE' => [
-                                    'itemtype' => $type,
-                                    'items_id' => $tab,
-                                    'is_deleted' => 0
-                                ]
-                            ]
-                        );
-                    }
-                }
-            }
+            $nb = static fn () => self::countForItemAndLinks($item);
         } else {
             $title = _n('Item', 'Items', Session::getPluralNumber());
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = self::countForMainItem($item);
-            }
+            $nb = static fn () => self::countForMainItem($item);
         }
 
-        return self::createTabEntry($title, $nb, $item::getType());
+        return self::createTabEntry($title, $nb, $item::class);
     }
 
     #[Override]

--- a/src/Itil_Project.php
+++ b/src/Itil_Project.php
@@ -64,32 +64,26 @@ class Itil_Project extends CommonDBRelation
         $label = '';
 
         if (static::canView()) {
-            $nb = 0;
             switch ($item::class) {
                 case Change::class:
                 case Problem::class:
                 case Ticket::class:
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = countElementsInTable(
-                            self::getTable(),
-                            [
-                                'itemtype' => $item->getType(),
-                                'items_id' => $item->getID(),
-                            ]
-                        );
-                    }
-                    $label = self::createTabEntry(Project::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                    $label = self::createTabEntry(
+                        text: Project::getTypeName(Session::getPluralNumber()),
+                        nb: countElementsInTable(self::getTable(), [
+                            'itemtype' => $item::class,
+                            'items_id' => $item->getID(),
+                        ]),
+                        form_itemtype: $item::class
+                    );
                     break;
 
                 case Project::class:
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = countElementsInTable(self::getTable(), ['projects_id' => $item->getID()]);
-                    }
                     $label = self::createTabEntry(
-                        _n('Itil item', 'Itil items', Session::getPluralNumber()),
-                        $nb,
-                        $item::getType(),
-                        Ticket::getIcon()
+                        text: _n('Itil item', 'Itil items', Session::getPluralNumber()),
+                        nb: static fn () => countElementsInTable(self::getTable(), ['projects_id' => $item->getID()]),
+                        form_itemtype: $item::class,
+                        icon: Ticket::getIcon()
                     );
                     break;
             }

--- a/src/Itil_Project.php
+++ b/src/Itil_Project.php
@@ -70,7 +70,7 @@ class Itil_Project extends CommonDBRelation
                 case Ticket::class:
                     $label = self::createTabEntry(
                         text: Project::getTypeName(Session::getPluralNumber()),
-                        nb: countElementsInTable(self::getTable(), [
+                        nb: static fn () => countElementsInTable(self::getTable(), [
                             'itemtype' => $item::class,
                             'items_id' => $item->getID(),
                         ]),

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -221,20 +221,16 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if (!$withtemplate) {
-            $nb = 0;
             switch ($item::class) {
                 case self::class:
                     $ong[1] = self::createTabEntry(self::getTypeName(1));
                     if ($item->canUpdateItem()) {
-                        if ($_SESSION['glpishow_count_on_tabs']) {
-                            $nb = $item->countVisibilities();
-                        }
                         $ong[2] = self::createTabEntry(
-                            _n('Target', 'Targets', Session::getPluralNumber()),
-                            $nb,
-                            $item::getType()
+                            text: _n('Target', 'Targets', Session::getPluralNumber()),
+                            nb: $item->countVisibilities(...),
+                            form_itemtype: $item::class
                         );
-                        $ong[3] = self::createTabEntry(__('Edit'), 0, $item::class, 'ti ti-pencil');
+                        $ong[3] = self::createTabEntry(__('Edit'), null, $item::class, 'ti ti-pencil');
                     }
                     return $ong;
             }

--- a/src/KnowbaseItemTranslation.php
+++ b/src/KnowbaseItemTranslation.php
@@ -83,22 +83,21 @@ class KnowbaseItemTranslation extends CommonDBChild
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if (!$withtemplate) {
-            switch ($item::class) {
-                case self::class:
-                    $ong[1] = self::getTypeName(1);
-                    if ($item->canUpdateItem()) {
-                        $ong[3] = __('Edit');
-                    }
-                    return $ong;
+            if ($item::class === self::class) {
+                $ong[1] = self::getTypeName(1);
+                if ($item->canUpdateItem()) {
+                    $ong[3] = __('Edit');
+                }
+                return $ong;
             }
         }
 
         if ($item instanceof KnowbaseItem) {
-            $nb = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = self::getNumberOfTranslationsForItem($item);
-            }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
+            return self::createTabEntry(
+                text: self::getTypeName(Session::getPluralNumber()),
+                nb: static fn () => self::getNumberOfTranslationsForItem($item),
+                form_itemtype: $item::class
+            );
         }
 
         return '';

--- a/src/KnowbaseItem_Comment.php
+++ b/src/KnowbaseItem_Comment.php
@@ -58,26 +58,23 @@ class KnowbaseItem_Comment extends CommonDBTM
             return '';
         }
 
-        $nb = 0;
-        if ($_SESSION['glpishow_count_on_tabs']) {
-            if ($item::class === KnowbaseItem::class) {
-                $where = [
-                    'knowbaseitems_id' => $item->getID(),
-                    'language'         => null
-                ];
-            } else {
-                $where = [
-                    'knowbaseitems_id' => $item->fields['knowbaseitems_id'],
-                    'language'         => $item->fields['language']
-                ];
-            }
-
-            $nb = countElementsInTable(
-                'glpi_knowbaseitems_comments',
-                $where
-            );
+        if ($item::class === KnowbaseItem::class) {
+            $where = [
+                'knowbaseitems_id' => $item->getID(),
+                'language'         => null
+            ];
+        } else {
+            $where = [
+                'knowbaseitems_id' => $item->fields['knowbaseitems_id'],
+                'language'         => $item->fields['language']
+            ];
         }
-        return self::createTabEntry(self::getTypeName($nb), $nb, $item::getType());
+
+        return self::createTabEntry(
+            text: self::getTypeName(Session::getPluralNumber()),
+            nb: static fn () => countElementsInTable(self::getTable(), $where),
+            form_itemtype: $item::class
+        );
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)

--- a/src/KnowbaseItem_Item.php
+++ b/src/KnowbaseItem_Item.php
@@ -62,18 +62,13 @@ class KnowbaseItem_Item extends CommonDBRelation
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if (static::canView()) {
-            $nb = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = self::getCountForItem($item);
-            }
-
             if ($item::class === KnowbaseItem::class) {
-                $type_name = _n('Associated element', 'Associated elements', $nb);
+                $type_name = _n('Associated element', 'Associated elements', Session::getPluralNumber());
             } else {
                 $type_name = __('Knowledge base');
             }
 
-            return self::createTabEntry($type_name, $nb, $item::class);
+            return self::createTabEntry($type_name, static fn () => self::getCountForItem($item), $item::class);
         }
         return '';
     }

--- a/src/KnowbaseItem_Revision.php
+++ b/src/KnowbaseItem_Revision.php
@@ -60,26 +60,22 @@ class KnowbaseItem_Revision extends CommonDBTM
             return '';
         }
 
-        $nb = 0;
-        if ($_SESSION['glpishow_count_on_tabs']) {
-            if ($item::class === KnowbaseItem::class) {
-                $where = [
-                    'knowbaseitems_id' => $item->getID(),
-                    'language'         => ''
-                ];
-            } else {
-                $where = [
-                    'knowbaseitems_id' => $item->fields['knowbaseitems_id'],
-                    'language'         => $item->fields['language']
-                ];
-            }
-
-            $nb = countElementsInTable(
-                'glpi_knowbaseitems_revisions',
-                $where
-            );
+        if ($item::class === KnowbaseItem::class) {
+            $where = [
+                'knowbaseitems_id' => $item->getID(),
+                'language'         => ''
+            ];
+        } else {
+            $where = [
+                'knowbaseitems_id' => $item->fields['knowbaseitems_id'],
+                'language'         => $item->fields['language']
+            ];
         }
-        return self::createTabEntry(self::getTypeName($nb), $nb, $item::class);
+        return self::createTabEntry(
+            text: self::getTypeName(Session::getPluralNumber()),
+            nb: static fn () => countElementsInTable(self::getTable(), $where),
+            form_itemtype: $item::class
+        );
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)

--- a/src/LevelAgreement.php
+++ b/src/LevelAgreement.php
@@ -485,16 +485,13 @@ TWIG, $twig_params);
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if (!$withtemplate) {
-            $nb = 0;
-            switch ($item->getType()) {
-                case 'SLM':
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = countElementsInTable(
-                            self::getTable(),
-                            ['slms_id' => $item->getField('id')]
-                        );
-                    }
-                    return self::createTabEntry(static::getTypeName($nb), $nb, $item::getType());
+            switch ($item::class) {
+                case SLM::class:
+                    return self::createTabEntry(
+                        text: static::getTypeName(Session::getPluralNumber()),
+                        nb: countElementsInTable(self::getTable(), ['slms_id' => $item->getField('id')]),
+                        form_itemtype: $item::class
+                    );
             }
         }
         return '';

--- a/src/LevelAgreementLevel.php
+++ b/src/LevelAgreementLevel.php
@@ -368,13 +368,13 @@ abstract class LevelAgreementLevel extends RuleTicket
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if (!$withtemplate) {
-            $nb = 0;
-            switch ($item->getType()) {
+            switch ($item::class) {
                 case static::$parentclass:
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb =  countElementsInTable(static::getTable(), [static::$fkparent => $item->getID()]);
-                    }
-                    return self::createTabEntry(static::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                    return self::createTabEntry(
+                        text: static::getTypeName(Session::getPluralNumber()),
+                        nb: static fn () => countElementsInTable(static::getTable(), [static::$fkparent => $item->getID()]),
+                        form_itemtype: $item::class
+                    );
             }
         }
         return '';

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -1050,7 +1050,7 @@ TWIG);
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if ($item->isDynamic() && $item->can($item->fields['id'], UPDATE)) {
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), 0, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), null, $item::getType());
         }
         return '';
     }

--- a/src/Log.php
+++ b/src/Log.php
@@ -98,16 +98,14 @@ class Log extends CommonDBTM
             return '';
         }
 
-        $nb = 0;
-        if ($_SESSION['glpishow_count_on_tabs']) {
-            $nb = countElementsInTable(
-                'glpi_logs',
-                ['itemtype' => $item->getType(),
-                    'items_id' => $item->getID()
-                ]
-            );
-        }
-        return self::createTabEntry(self::getTypeName(1), $nb, $item::getType());
+        return self::createTabEntry(
+            text: self::getTypeName(1),
+            nb: static fn () => countElementsInTable(self::getTable(), [
+                'itemtype' => $item::class,
+                'items_id' => $item->getID()
+            ]),
+            form_itemtype: $item::class
+        );
     }
 
 

--- a/src/NetworkAlias.php
+++ b/src/NetworkAlias.php
@@ -477,24 +477,14 @@ class NetworkAlias extends FQDNLabel
             $item->getID()
             && $item->can($item->getField('id'), READ)
         ) {
-            $nb = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                switch ($item::class) {
-                    case NetworkName::class:
-                        $nb = countElementsInTable(
-                            static::getTable(),
-                            ['networknames_id' => $item->getID()]
-                        );
-                        break;
-
-                    case FQDN::class:
-                        $nb = countElementsInTable(
-                            static::getTable(),
-                            ['fqdns_id' => $item->getID()]
-                        );
-                }
-            }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
+            $show_count = $item::class === NetworkName::class || $item::class === FQDN::class;
+            return self::createTabEntry(
+                text: self::getTypeName(Session::getPluralNumber()),
+                nb: $show_count ? (static fn () => countElementsInTable(static::getTable(), [
+                    $item::getForeignKeyField() => $item->getID()
+                ])) : 0,
+                form_itemtype: $item::class
+            );
         }
         return '';
     }

--- a/src/NetworkName.php
+++ b/src/NetworkName.php
@@ -882,11 +882,11 @@ TWIG, $twig_params);
             $item->getID()
             && $item->can($item->getField('id'), READ)
         ) {
-            $nb = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = self::countForItem($item);
-            }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
+            return self::createTabEntry(
+                text: self::getTypeName(Session::getPluralNumber()),
+                nb: static fn () => self::countForItem($item),
+                form_itemtype: $item::class
+            );
         }
         return '';
     }

--- a/src/NetworkPortConnectionLog.php
+++ b/src/NetworkPortConnectionLog.php
@@ -72,8 +72,11 @@ class NetworkPortConnectionLog extends CommonDBChild
         $array_ret = [];
 
         if ($item::class === NetworkPort::class) {
-            $cnt = countElementsInTable([static::getTable()], $this->getCriteria($item));
-            $array_ret[] = self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $cnt, $item::class);
+            $array_ret[] = self::createTabEntry(
+                text: self::getTypeName(Session::getPluralNumber()),
+                nb: fn () => countElementsInTable([static::getTable()], $this->getCriteria($item)),
+                form_itemtype: $item::class
+            );
         }
         return $array_ret;
     }

--- a/src/NetworkPortMetrics.php
+++ b/src/NetworkPortMetrics.php
@@ -54,8 +54,11 @@ class NetworkPortMetrics extends CommonDBChild
         $array_ret = [];
 
         if ($item::class === NetworkPort::class) {
-            $cnt = countElementsInTable([static::getTable()], [static::$items_id => $item->getField('id')]);
-            $array_ret[] = self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $cnt, $item::class);
+            $array_ret[] = self::createTabEntry(
+                text: self::getTypeName(Session::getPluralNumber()),
+                nb: static fn () => countElementsInTable([static::getTable()], [static::$items_id => $item->getField('id')]),
+                form_itemtype: $item::class
+            );
         }
         return $array_ret;
     }

--- a/src/NetworkPort_Vlan.php
+++ b/src/NetworkPort_Vlan.php
@@ -297,24 +297,19 @@ TWIG, $twig_params);
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if (!$withtemplate) {
-            $nb = 0;
             switch ($item::class) {
                 case NetworkPort::class:
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = countElementsInTable(
-                            static::getTable(),
-                            ["networkports_id" => $item->getID()]
-                        );
-                    }
-                    return self::createTabEntry(Vlan::getTypeName(), $nb, $item::class);
+                    return self::createTabEntry(
+                        text: Vlan::getTypeName(),
+                        nb: static fn () => countElementsInTable(static::getTable(), ['networkports_id' => $item->getID()]),
+                        form_itemtype: $item::class
+                    );
                 case Vlan::class:
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = countElementsInTable(
-                            static::getTable(),
-                            ["vlans_id" => $item->getID()]
-                        );
-                    }
-                    return self::createTabEntry(NetworkPort::getTypeName(), $nb, $item::class);
+                    return self::createTabEntry(
+                        text: NetworkPort::getTypeName(),
+                        nb: static fn () => countElementsInTable(static::getTable(), ['vlans_id' => $item->getID()]),
+                        form_itemtype: $item::class
+                    );
             }
         }
         return '';

--- a/src/Notepad.php
+++ b/src/Notepad.php
@@ -114,13 +114,8 @@ class Notepad extends CommonDBChild
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-
         if (Session::haveRight($item::$rightname, READNOTE)) {
-            $nb = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = self::countForItem($item);
-            }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), static fn () => self::countForItem($item), $item::class);
         }
         return '';
     }

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -1512,28 +1512,20 @@ class NotificationTarget extends CommonDBChild
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-
         if (!$withtemplate && Notification::canView()) {
-            $nb = 0;
-            switch ($item->getType()) {
-                case 'Group':
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = self::countForGroup($item);
-                    }
+            switch ($item::class) {
+                case Group::class:
                     return self::createTabEntry(
-                        Notification::getTypeName(Session::getPluralNumber()),
-                        $nb,
-                        $item::getType()
+                        text: Notification::getTypeName(Session::getPluralNumber()),
+                        nb: static fn () => self::countForGroup($item),
+                        form_itemtype: $item::class
                     );
-
-                case 'Notification':
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = countElementsInTable(
-                            $this->getTable(),
-                            ['notifications_id' => $item->getID()]
-                        );
-                    }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                case Notification::class:
+                    return self::createTabEntry(
+                        text: self::getTypeName(Session::getPluralNumber()),
+                        nb: static fn () => countElementsInTable(static::getTable(), ['notifications_id' => $item->getID()]),
+                        form_itemtype: $item::class
+                    );
             }
         }
         return '';

--- a/src/NotificationTemplateTranslation.php
+++ b/src/NotificationTemplateTranslation.php
@@ -383,21 +383,16 @@ TWIG, $twig_params);
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-
         if (!$withtemplate) {
-            $nb = 0;
             switch ($item::class) {
                 case self::class:
-                    return self::createTabEntry(__('Preview'), 0, $item::class, 'ti ti-template');
-                    break;
+                    return self::createTabEntry(__('Preview'), null, $item::class, 'ti ti-template');
                 case 'NotificationTemplate':
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = countElementsInTable(
-                            static::getTable(),
-                            ['notificationtemplates_id' => $item->getID()]
-                        );
-                    }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
+                    return self::createTabEntry(
+                        text: self::getTypeName(Session::getPluralNumber()),
+                        nb: countElementsInTable(static::getTable(), ['notificationtemplates_id' => $item->getID()]),
+                        form_itemtype: $item::class
+                    );
             }
         }
         return '';

--- a/src/Notification_NotificationTemplate.php
+++ b/src/Notification_NotificationTemplate.php
@@ -66,28 +66,20 @@ class Notification_NotificationTemplate extends CommonDBRelation
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-
         if (!$withtemplate && Notification::canView()) {
-            $nb = 0;
             switch ($item::class) {
                 case Notification::class:
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = countElementsInTable(
-                            static::getTable(),
-                            ['notifications_id' => $item->getID()]
-                        );
-                    }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
-                break;
+                    return self::createTabEntry(
+                        text: self::getTypeName(Session::getPluralNumber()),
+                        nb: static fn () => countElementsInTable(static::getTable(), ['notifications_id' => $item->getID()]),
+                        form_itemtype: $item::class
+                    );
                 case NotificationTemplate::class:
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = countElementsInTable(
-                            static::getTable(),
-                            ['notificationtemplates_id' => $item->getID()]
-                        );
-                    }
-                    return self::createTabEntry(Notification::getTypeName(Session::getPluralNumber()), $nb, $item::class);
-                break;
+                    return self::createTabEntry(
+                        text: Notification::getTypeName(Session::getPluralNumber()),
+                        nb: static fn () => countElementsInTable(static::getTable(), ['notificationtemplates_id' => $item->getID()]),
+                        form_itemtype: $item::class
+                    );
             }
         }
         return '';

--- a/src/PrinterLog.php
+++ b/src/PrinterLog.php
@@ -72,12 +72,14 @@ class PrinterLog extends CommonDBChild
      */
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-
         $array_ret = [];
 
-        if ($item->getType() == 'Printer') {
-            $cnt = countElementsInTable([static::getTable()], [static::$items_id => $item->getField('id')]);
-            $array_ret[] = self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $cnt, $item::getType());
+        if ($item::class === Printer::class) {
+            $array_ret[] = self::createTabEntry(
+                text: self::getTypeName(Session::getPluralNumber()),
+                nb: countElementsInTable([static::getTable()], [static::$items_id => $item->getField('id')]),
+                form_itemtype: $item::class
+            );
         }
         return $array_ret;
     }

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -179,7 +179,7 @@ class Problem extends CommonITILObject
                 case __CLASS__:
                     $ong = [];
                     if ($item->canUpdate()) {
-                        $ong[1] = static::createTabEntry(__('Statistics'), 0, null, 'ti ti-chart-pie');
+                        $ong[1] = static::createTabEntry(__('Statistics'), null, null, 'ti ti-chart-pie');
                     }
 
                     return $ong;

--- a/src/Problem_Ticket.php
+++ b/src/Problem_Ticket.php
@@ -52,21 +52,19 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if (static::canView()) {
-            $nb = 0;
             switch ($item::class) {
                 case Ticket::class:
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $problems = self::getTicketProblemsData($item->getID());
-                        $nb = count($problems);
-                    }
-                    return self::createTabEntry(Problem::getTypeName(Session::getPluralNumber()), $nb, $item::class);
-
+                    return self::createTabEntry(
+                        text: Problem::getTypeName(Session::getPluralNumber()),
+                        nb: static fn () => self::countForItem($item),
+                        form_itemtype: $item::class
+                    );
                 case Problem::class:
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $tickets = self::getProblemTicketsData($item->getID());
-                        $nb = count($tickets);
-                    }
-                    return self::createTabEntry(Ticket::getTypeName(Session::getPluralNumber()), $nb, $item::class);
+                    return self::createTabEntry(
+                        text: Ticket::getTypeName(Session::getPluralNumber()),
+                        nb: static fn () => self::countForItem($item),
+                        form_itemtype: $item::class
+                    );
             }
         }
         return '';

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -151,20 +151,20 @@ class Profile extends CommonDBTM
             switch ($item::class) {
                 case self::class:
                     if ($item->fields['interface'] === 'helpdesk') {
-                        $ong[3] = self::createTabEntry(__('Assistance'), 0, $item::class, 'ti ti-headset'); // Helpdesk
+                        $ong[3] = self::createTabEntry(__('Assistance'), null, $item::class, 'ti ti-headset'); // Helpdesk
                         $ong[4] = self::createTabEntry(__('Life cycles'));
-                        $ong[6] = self::createTabEntry(__('Tools'), 0, $item::class, 'ti ti-briefcase');
-                        $ong[8] = self::createTabEntry(__('Setup'), 0, $item::class, 'ti ti-cog');
-                        $ong[9] = self::createTabEntry(__('Security'), 0, $item::class, 'ti ti-shield-lock');
+                        $ong[6] = self::createTabEntry(__('Tools'), null, $item::class, 'ti ti-briefcase');
+                        $ong[8] = self::createTabEntry(__('Setup'), null, $item::class, 'ti ti-cog');
+                        $ong[9] = self::createTabEntry(__('Security'), null, $item::class, 'ti ti-shield-lock');
                     } else {
-                        $ong[2] = self::createTabEntry(_n('Asset', 'Assets', Session::getPluralNumber()), 0, $item::class, 'ti ti-package');
-                        $ong[3] = self::createTabEntry(__('Assistance'), 0, $item::class, 'ti ti-headset');
+                        $ong[2] = self::createTabEntry(_n('Asset', 'Assets', Session::getPluralNumber()), null, $item::class, 'ti ti-package');
+                        $ong[3] = self::createTabEntry(__('Assistance'), null, $item::class, 'ti ti-headset');
                         $ong[4] = self::createTabEntry(__('Life cycles'));
-                        $ong[5] = self::createTabEntry(__('Management'), 0, $item::class, 'ti ti-wallet');
-                        $ong[6] = self::createTabEntry(__('Tools'), 0, $item::class, 'ti ti-briefcase');
-                        $ong[7] = self::createTabEntry(__('Administration'), 0, $item::class, 'ti ti-shield-check');
-                        $ong[8] = self::createTabEntry(__('Setup'), 0, $item::class, 'ti ti-settings');
-                        $ong[9] = self::createTabEntry(__('Security'), 0, $item::class, 'ti ti-shield-lock');
+                        $ong[5] = self::createTabEntry(__('Management'), null, $item::class, 'ti ti-wallet');
+                        $ong[6] = self::createTabEntry(__('Tools'), null, $item::class, 'ti ti-briefcase');
+                        $ong[7] = self::createTabEntry(__('Administration'), null, $item::class, 'ti ti-shield-check');
+                        $ong[8] = self::createTabEntry(__('Setup'), null, $item::class, 'ti ti-settings');
+                        $ong[9] = self::createTabEntry(__('Security'), null, $item::class, 'ti ti-shield-lock');
                     }
                     return $ong;
             }

--- a/src/Project.php
+++ b/src/Project.php
@@ -139,22 +139,18 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if (static::canView() && !$withtemplate) {
-            $nb = 0;
-            switch ($item::class) {
-                case __CLASS__:
-                    $ong    = [];
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = countElementsInTable(
-                            static::getTable(),
-                            [
-                                static::getForeignKeyField() => $item->getID(),
-                                'is_deleted'                => 0
-                            ]
-                        );
-                    }
-                    $ong[1] = self::createTabEntry(static::getTypeName(Session::getPluralNumber()), $nb, $item::class);
-                    $ong[3] = self::createTabEntry(__('Kanban'));
-                    return $ong;
+            if ($item::class === self::class) {
+                $ong = [];
+                $ong[1] = self::createTabEntry(
+                    text: static::getTypeName(Session::getPluralNumber()),
+                    nb: countElementsInTable(static::getTable(), [
+                        static::getForeignKeyField() => $item->getID(),
+                        'is_deleted' => 0
+                    ]),
+                    form_itemtype: $item::class
+                );
+                $ong[3] = self::createTabEntry(__('Kanban'));
+                return $ong;
             }
         }
 

--- a/src/ProjectCost.php
+++ b/src/ProjectCost.php
@@ -83,11 +83,11 @@ class ProjectCost extends CommonDBChild
     {
         // can exist for template
         if (($item::class === Project::class) && Project::canView()) {
-            $nb = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = countElementsInTable('glpi_projectcosts', ['projects_id' => $item->getID()]);
-            }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
+            return self::createTabEntry(
+                text: self::getTypeName(Session::getPluralNumber()),
+                nb: static fn () => countElementsInTable('glpi_projectcosts', ['projects_id' => $item->getID()]),
+                form_itemtype: $item::class
+            );
         }
         return '';
     }

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -1438,27 +1438,19 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        $nb = 0;
-        switch ($item::class) {
-            case Project::class:
-                if ($_SESSION['glpishow_count_on_tabs']) {
-                    $nb = countElementsInTable(
-                        static::getTable(),
-                        ['projects_id' => $item->getID()]
-                    );
-                }
-                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
-
-            case self::class:
-                if ($_SESSION['glpishow_count_on_tabs']) {
-                    $nb = countElementsInTable(
-                        static::getTable(),
-                        ['projecttasks_id' => $item->getID()]
-                    );
-                }
-                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
-        }
-        return '';
+        return match ($item::class) {
+            Project::class => self::createTabEntry(
+                text: self::getTypeName(Session::getPluralNumber()),
+                nb: countElementsInTable(static::getTable(), ['projects_id' => $item->getID()]),
+                form_itemtype: $item::class
+            ),
+            self::class => self::createTabEntry(
+                text: self::getTypeName(Session::getPluralNumber()),
+                nb: countElementsInTable(static::getTable(), ['projecttasks_id' => $item->getID()]),
+                form_itemtype: $item::class
+            ),
+            default => '',
+        };
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)

--- a/src/ProjectTaskTeam.php
+++ b/src/ProjectTaskTeam.php
@@ -85,16 +85,8 @@ class ProjectTaskTeam extends CommonDBRelation
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-
-        if (!$withtemplate && static::canView()) {
-            $nb = 0;
-            switch ($item->getType()) {
-                case 'ProjectTask':
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = $item->getTeamCount();
-                    }
-                    return self::createTabEntry(self::getTypeName(1), $nb, $item::getType());
-            }
+        if (!$withtemplate && $item::class === ProjectTask::class && static::canView()) {
+            return self::createTabEntry(self::getTypeName(1), $item->getTeamCount(...), $item::class);
         }
         return '';
     }

--- a/src/ProjectTask_Ticket.php
+++ b/src/ProjectTask_Ticket.php
@@ -67,19 +67,19 @@ class ProjectTask_Ticket extends CommonDBRelation
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if (static::canView()) {
-            $nb = 0;
             switch ($item::class) {
                 case ProjectTask::class:
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = self::countForItem($item);
-                    }
-                    return self::createTabEntry(Ticket::getTypeName(Session::getPluralNumber()), $nb, $item::class);
-
+                    return self::createTabEntry(
+                        text: Ticket::getTypeName(Session::getPluralNumber()),
+                        nb: static fn () => self::countForItem($item),
+                        form_itemtype: $item::class
+                    );
                 case Ticket::class:
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = self::countForItem($item);
-                    }
-                    return self::createTabEntry(ProjectTask::getTypeName(Session::getPluralNumber()), $nb, $item::class);
+                    return self::createTabEntry(
+                        text: ProjectTask::getTypeName(Session::getPluralNumber()),
+                        nb: static fn () => self::countForItem($item),
+                        form_itemtype: $item::class
+                    );
             }
         }
         return '';

--- a/src/ProjectTeam.php
+++ b/src/ProjectTeam.php
@@ -94,16 +94,8 @@ class ProjectTeam extends CommonDBRelation
      **/
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-
-        if (self::canView()) {
-            $nb = 0;
-            switch ($item->getType()) {
-                case 'Project':
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = $item->getTeamCount();
-                    }
-                    return self::createTabEntry(self::getTypeName(1), $nb, $item::getType());
-            }
+        if ($item::class === Project::class && self::canView()) {
+            return self::createTabEntry(self::getTypeName(1), $item->getTeamCount(...), $item::class);
         }
         return '';
     }

--- a/src/RSSFeed.php
+++ b/src/RSSFeed.php
@@ -421,19 +421,15 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if (self::canView()) {
-            $nb = 0;
             switch ($item::class) {
-                case RSSFeed::class:
+                case self::class:
                     $showtab = [1 => self::createTabEntry(__('Content'))];
                     if (Session::haveRight('rssfeed_public', UPDATE)) {
-                        if ($_SESSION['glpishow_count_on_tabs']) {
-                            $nb = $item->countVisibilities();
-                        }
-                        $showtab[2] = self::createTabEntry(_n(
-                            'Target',
-                            'Targets',
-                            Session::getPluralNumber()
-                        ), $nb, $item::getType());
+                        $showtab[2] = self::createTabEntry(
+                            text: _n('Target', 'Targets', Session::getPluralNumber()),
+                            nb: $item->countVisibilities(...),
+                            form_itemtype: $item::class
+                        );
                     }
                     return $showtab;
             }

--- a/src/Rack.php
+++ b/src/Rack.php
@@ -330,27 +330,17 @@ class Rack extends CommonDBTM
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-
-        switch ($item->getType()) {
-            case DCRoom::getType():
-                $nb = 0;
-                if ($_SESSION['glpishow_count_on_tabs']) {
-                    $nb = countElementsInTable(
-                        self::getTable(),
-                        [
-                            'dcrooms_id'   => $item->getID(),
-                            'is_deleted'   => 0
-                        ]
-                    );
-                }
-                return self::createTabEntry(
-                    self::getTypeName(Session::getPluralNumber()),
-                    $nb,
-                    $item::getType()
-                );
-             break;
-        }
-        return '';
+        return match ($item::class) {
+            DCRoom::class => self::createTabEntry(
+                text: self::getTypeName(Session::getPluralNumber()),
+                nb: static fn() => countElementsInTable(self::getTable(), [
+                    'dcrooms_id' => $item->getID(),
+                    'is_deleted' => 0
+                ]),
+                form_itemtype: $item::class
+            ),
+            default => '',
+        };
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)

--- a/src/Reminder.php
+++ b/src/Reminder.php
@@ -461,18 +461,15 @@ class Reminder extends CommonDBVisible implements
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if (self::canView()) {
-            $nb = 0;
-            switch ($item->getType()) {
-                case 'Reminder':
+            switch ($item::class) {
+                case self::class:
                     if (Session::haveRight('reminder_public', CREATE)) {
-                        if ($_SESSION['glpishow_count_on_tabs']) {
-                            $nb = $item->countVisibilities();
-                        }
-                        return [1 => self::createTabEntry(_n(
-                            'Target',
-                            'Targets',
-                            Session::getPluralNumber()
-                        ), $nb, $item::getType())
+                        return [
+                            1 => self::createTabEntry(
+                                text: _n('Target', 'Targets', Session::getPluralNumber()),
+                                nb: $item->countVisibilities(...),
+                                form_itemtype: $item::class
+                            )
                         ];
                     }
             }

--- a/src/ReminderTranslation.php
+++ b/src/ReminderTranslation.php
@@ -79,13 +79,13 @@ class ReminderTranslation extends CommonDBChild
     {
         if (
             $item instanceof Reminder
-            && Session::getCurrentInterface() != "helpdesk"
+            && Session::getCurrentInterface() !== "helpdesk"
         ) {
-            $nb = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = self::getNumberOfTranslationsForItem($item);
-            }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(
+                text: self::getTypeName(Session::getPluralNumber()),
+                nb: static fn () => self::getNumberOfTranslationsForItem($item),
+                form_itemtype: $item::class
+            );
         }
 
         return '';

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -59,7 +59,7 @@ class Reservation extends CommonDBChild
             !$withtemplate
             && Session::haveRight("reservation", READ)
         ) {
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), 0, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), null, $item::getType());
         }
         return '';
     }

--- a/src/RuleMatchedLog.php
+++ b/src/RuleMatchedLog.php
@@ -90,18 +90,17 @@ class RuleMatchedLog extends CommonDBTM
         $array_ret = [];
 
         if ($item::class === Agent::class) {
-            $array_ret[0] = self::createTabEntry(__('Import information'), 0, $item::class);
+            $array_ret[0] = self::createTabEntry(__('Import information'), null, $item::class);
         } else {
             $continue = true;
 
             switch ($item::class) {
                 case Agent::class:
-                    $array_ret[0] = self::createTabEntry(__('Import information'), 0, $item::class);
+                    $array_ret[0] = self::createTabEntry(__('Import information'), null, $item::class);
                     break;
 
                 case Unmanaged::class:
-                    $cnt = self::countForItem($item);
-                    $array_ret[1] = self::createTabEntry(__('Import information'), $cnt, $item::class);
+                    $array_ret[1] = self::createTabEntry(__('Import information'), static fn () => self::countForItem($item), $item::class);
                     break;
 
                 case Computer::class:
@@ -118,8 +117,7 @@ class RuleMatchedLog extends CommonDBTM
             if (!$continue) {
                 return [];
             } else if (empty($array_ret)) {
-                $cnt = self::countForItem($item);
-                $array_ret[1] = self::createTabEntry(__('Import information'), $cnt, $item::class);
+                $array_ret[1] = self::createTabEntry(__('Import information'), static fn () => self::countForItem($item), $item::class);
             }
         }
         return $array_ret;

--- a/src/SavedSearch_Alert.php
+++ b/src/SavedSearch_Alert.php
@@ -70,18 +70,12 @@ class SavedSearch_Alert extends CommonDBChild
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         // can exists for template
-        if (
-            ($item instanceof SavedSearch)
-            && SavedSearch::canView()
-        ) {
-            $nb = 0;
-            if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = countElementsInTable(
-                    $this->getTable(),
-                    ['savedsearches_id' => $item->getID()]
-                );
-            }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+        if ($item instanceof SavedSearch && SavedSearch::canView()) {
+            return self::createTabEntry(
+                text: self::getTypeName(Session::getPluralNumber()),
+                nb: static fn () => countElementsInTable(static::getTable(), ['savedsearches_id' => $item->getID()]),
+                form_itemtype: $item::class
+            );
         }
         return '';
     }

--- a/src/SoftwareLicense.php
+++ b/src/SoftwareLicense.php
@@ -1114,35 +1114,25 @@ TWIG, $twig_params);
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if (!$withtemplate) {
-            $nb = 0;
-            switch (get_class($item)) {
+            switch ($item::class) {
                 case Software::class:
                     if (!self::canView()) {
                         return '';
                     }
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = self::countForSoftware($item->getID());
-                    }
                     return self::createTabEntry(
-                        self::getTypeName(Session::getPluralNumber()),
-                        (($nb >= 0) ? $nb : '&infin;'),
-                        $item::class
+                        text: self::getTypeName(Session::getPluralNumber()),
+                        nb: static fn () => self::countForSoftware($item->getID()),
+                        form_itemtype: $item::class
                     );
 
                 case self::class:
                     if (!self::canView()) {
                         return '';
                     }
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = countElementsInTable(
-                            static::getTable(),
-                            ['softwarelicenses_id' => $item->getID()]
-                        );
-                    }
                     return self::createTabEntry(
-                        self::getTypeName(Session::getPluralNumber()),
-                        (($nb >= 0) ? $nb : '&infin;'),
-                        $item::class
+                        text: self::getTypeName(Session::getPluralNumber()),
+                        nb: static fn () => countElementsInTable(static::getTable(), ['softwarelicenses_id' => $item->getID()]),
+                        form_itemtype: $item::class
                     );
             }
         }

--- a/src/SoftwareVersion.php
+++ b/src/SoftwareVersion.php
@@ -378,13 +378,13 @@ TWIG, $twig_params);
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if (!$withtemplate) {
-            $nb = 0;
             switch ($item::class) {
                 case Software::class:
-                    if ($_SESSION['glpishow_count_on_tabs']) {
-                        $nb = countElementsInTable(static::getTable(), ['softwares_id' => $item->getID()]);
-                    }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
+                    return self::createTabEntry(
+                        text: self::getTypeName(Session::getPluralNumber()),
+                        nb: countElementsInTable(static::getTable(), ['softwares_id' => $item->getID()]),
+                        form_itemtype: $item::class
+                    );
             }
         }
         return '';

--- a/src/Stencil.php
+++ b/src/Stencil.php
@@ -279,9 +279,11 @@ class Stencil extends CommonDBChild implements ZonableModelPicture
             return '';
         }
 
-        $nb = count(json_decode($this->getStencilFromItem($item)->fields['zones'] ?? '{}', true));
-
-        return self::createTabEntry($this->getTypeName(), $nb, $item::getType());
+        return self::createTabEntry(
+            text: static::getTypeName(),
+            nb: fn () => count(json_decode($this->getStencilFromItem($item)->fields['zones'] ?? '{}', true)),
+            form_itemtype: $item::class
+        );
     }
 
     public function displayStencil(): void

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -702,7 +702,7 @@ class Ticket extends CommonITILObject
             if ($_SESSION['glpishow_count_on_tabs']) {
                 switch (get_class($item)) {
                     case User::class:
-                        $nb = countElementsInTable(
+                        $nb = static fn () => countElementsInTable(
                             ['glpi_tickets', 'glpi_tickets_users'],
                             [
                                 'glpi_tickets_users.tickets_id'  => new QueryExpression(DBmysql::quoteName('glpi_tickets.id')),
@@ -711,11 +711,11 @@ class Ticket extends CommonITILObject
                                 'glpi_tickets.is_deleted'        => 0
                             ] + getEntitiesRestrictCriteria(self::getTable())
                         );
-                         $title = __('Created tickets');
+                        $title = __('Created tickets');
                         break;
 
                     case Supplier::class:
-                        $nb = countElementsInTable(
+                        $nb = static fn () => countElementsInTable(
                             ['glpi_tickets', 'glpi_suppliers_tickets'],
                             [
                                 'glpi_suppliers_tickets.tickets_id'    => new QueryExpression(DBmysql::quoteName('glpi_tickets.id')),
@@ -726,7 +726,7 @@ class Ticket extends CommonITILObject
                         break;
 
                     case SLA::class:
-                        $nb = countElementsInTable(
+                        $nb = static fn () => countElementsInTable(
                             'glpi_tickets',
                             [
                                 'OR'  => [
@@ -739,7 +739,7 @@ class Ticket extends CommonITILObject
                         break;
 
                     case OLA::class:
-                        $nb = countElementsInTable(
+                        $nb = static fn () => countElementsInTable(
                             'glpi_tickets',
                             [
                                 'OR'  => [
@@ -752,16 +752,16 @@ class Ticket extends CommonITILObject
                         break;
 
                     case Group::class:
-                          $nb = countElementsInTable(
-                              ['glpi_tickets', 'glpi_groups_tickets'],
-                              [
-                                  'glpi_groups_tickets.tickets_id' => new QueryExpression(DBmysql::quoteName('glpi_tickets.id')),
-                                  'glpi_groups_tickets.groups_id'  => $item->getID(),
-                                  'glpi_groups_tickets.type'       => CommonITILActor::REQUESTER,
-                                  'glpi_tickets.is_deleted'        => 0
-                              ] + getEntitiesRestrictCriteria(self::getTable())
-                          );
-                         $title = __('Created tickets');
+                        $nb = static fn () => countElementsInTable(
+                            ['glpi_tickets', 'glpi_groups_tickets'],
+                            [
+                                'glpi_groups_tickets.tickets_id' => new QueryExpression(DBmysql::quoteName('glpi_tickets.id')),
+                                'glpi_groups_tickets.groups_id'  => $item->getID(),
+                                'glpi_groups_tickets.type'       => CommonITILActor::REQUESTER,
+                                'glpi_tickets.is_deleted'        => 0
+                            ] + getEntitiesRestrictCriteria(self::getTable())
+                        );
+                        $title = __('Created tickets');
                         break;
 
                     default:
@@ -773,9 +773,9 @@ class Ticket extends CommonITILObject
                         break;
                 }
             }
-           // Not for Ticket class
-            if ($item->getType() != __CLASS__) {
-                return self::createTabEntry($title, $nb, $item::getType());
+            // Not for Ticket class
+            if ($item::class !== self::class) {
+                return self::createTabEntry($title, $nb, $item::class);
             }
         }
 
@@ -789,10 +789,10 @@ class Ticket extends CommonITILObject
                 $satisfaction->getFromDB($item->getID())
                 && $item->fields['status'] == self::CLOSED
             ) {
-                $ong[3] = TicketSatisfaction::createTabEntry(__('Satisfaction'), 0, static::getType());
+                $ong[3] = TicketSatisfaction::createTabEntry(__('Satisfaction'), null, static::getType());
             }
             if ($item->canView()) {
-                $ong[4] = static::createTabEntry(__('Statistics'), 0, null, 'ti ti-chart-pie');
+                $ong[4] = static::createTabEntry(__('Statistics'), null, null, 'ti ti-chart-pie');
             }
             return $ong;
         }

--- a/src/Ticket_Contract.php
+++ b/src/Ticket_Contract.php
@@ -53,17 +53,18 @@ class Ticket_Contract extends CommonDBRelation
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if (Contract::canView()) {
-            $nb = 0;
             if ($item::class === Ticket::class) {
-                if ($_SESSION['glpishow_count_on_tabs']) {
-                    $nb = count(self::getListForItem($item));
-                }
-                return self::createTabEntry(Contract::getTypeName(Session::getPluralNumber()), $nb, $item::class);
+                return self::createTabEntry(
+                    text: Contract::getTypeName(Session::getPluralNumber()),
+                    nb: self::countForItem($item),
+                    form_itemtype: $item::class
+                );
             } else if ($item::class === Contract::class) {
-                if ($_SESSION['glpishow_count_on_tabs']) {
-                    $nb = count(self::getListForItem($item));
-                }
-                return self::createTabEntry(Ticket::getTypeName(Session::getPluralNumber()), $nb, $item::class);
+                return self::createTabEntry(
+                    text: Ticket::getTypeName(Session::getPluralNumber()),
+                    nb: self::countForItem($item),
+                    form_itemtype: $item::class
+                );
             } else {
                 return '';
             }

--- a/src/Ticket_Contract.php
+++ b/src/Ticket_Contract.php
@@ -56,13 +56,13 @@ class Ticket_Contract extends CommonDBRelation
             if ($item::class === Ticket::class) {
                 return self::createTabEntry(
                     text: Contract::getTypeName(Session::getPluralNumber()),
-                    nb: self::countForItem($item),
+                    nb: static fn () => self::countForItem($item),
                     form_itemtype: $item::class
                 );
             } else if ($item::class === Contract::class) {
                 return self::createTabEntry(
                     text: Ticket::getTypeName(Session::getPluralNumber()),
-                    nb: self::countForItem($item),
+                    nb: static fn () => self::countForItem($item),
                     form_itemtype: $item::class
                 );
             } else {

--- a/src/User.php
+++ b/src/User.php
@@ -326,14 +326,14 @@ class User extends CommonDBTM
         switch ($item->getType()) {
             case __CLASS__:
                 $ong    = [];
-                $ong[1] = self::createTabEntry(__('Used items'), 0, $item::getType(), 'ti ti-package');
-                $ong[2] = self::createTabEntry(__('Managed items'), 0, $item::getType(), 'ti ti-package');
+                $ong[1] = self::createTabEntry(__('Used items'), null, $item::getType(), 'ti ti-package');
+                $ong[2] = self::createTabEntry(__('Managed items'), null, $item::getType(), 'ti ti-package');
 
                 if (
                     $item->fields['authtype'] === Auth::LDAP
                     && Session::haveRight(self::$rightname, self::READAUTHENT)
                 ) {
-                    $ong[3] = self::createTabEntry(__('LDAP information'), 0, $item::getType(), AuthLDAP::getIcon());
+                    $ong[3] = self::createTabEntry(__('LDAP information'), null, $item::getType(), AuthLDAP::getIcon());
                 }
                 return $ong;
 
@@ -7065,15 +7065,20 @@ JAVASCRIPT;
      */
     final public function getSubstitutes(): array
     {
+        /** @var DBmysql $DB */
+        global $DB;
+
         if ($this->isNewItem()) {
             return [];
         }
 
         $substitutes = [];
-        $rows = (new ValidatorSubstitute())->find([
-            'users_id' => $this->fields['id'],
+        $it = $DB->request([
+            'SELECT' => ['users_id_substitute'],
+            'FROM'   => ValidatorSubstitute::getTable(),
+            'WHERE'  => ['users_id' => $this->fields['id']]
         ]);
-        foreach ($rows as $row) {
+        foreach ($it as $row) {
             $substitutes[] = $row['users_id_substitute'];
         }
 

--- a/src/ValidatorSubstitute.php
+++ b/src/ValidatorSubstitute.php
@@ -44,14 +44,16 @@ final class ValidatorSubstitute extends CommonDBTM
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        switch ($item->getType()) {
-            case Preference::class:
-                $user = User::getById(Session::getLoginUserID());
-                $nb = $_SESSION['glpishow_count_on_tabs'] ? count($user->getSubstitutes()) : 0;
-                return self::createTabEntry(self::getTypeName($nb), $nb, $item::getType());
-        }
-
-        return '';
+        return match ($item::class) {
+            Preference::class => self::createTabEntry(
+                text: self::getTypeName(Session::getPluralNumber()),
+                nb: static fn() => countElementsInTable(ValidatorSubstitute::getTable(), [
+                    'users_id' => Session::getLoginUserID()
+                ]),
+                form_itemtype: $item::class
+            ),
+            default => '',
+        };
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -724,27 +724,26 @@ class Webhook extends CommonDBTM implements FilterableInterface
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        $headers_count = count($item->fields['custom_headers']);
-        if ($headers_count > 0) {
-            // If there are custom headers, we will include the static ones in the count.
-            // Otherwise, we won't show a count at all.
-            $headers_count += 2;
-        }
-
-        $queries_count = 0;
         $params = $item->getSentQueriesSearchParams();
         $params['export_all'] = true;
-        $data = Search::getDatas(QueuedWebhook::class, $params);
-        if (isset($data['data']['totalcount'])) {
-            $queries_count = $data['data']['totalcount'];
-        }
+        $params['only_count'] = true;
 
         return [
-            1 => self::createTabEntry(__('Security'), 0, $item::getType(), 'ti ti-shield-lock'),
-            2 => self::createTabEntry(__('Payload editor'), 0, $item::getType(), 'ti ti-code-dots'),
-            3 => self::createTabEntry(_n('Custom header', 'Custom headers', Session::getPluralNumber()), $headers_count, $item::getType(), 'ti ti-code-plus'),
-            4 => self::createTabEntry(_n('Query log', 'Queries log', Session::getPluralNumber()), $queries_count, $item::getType(), 'ti ti-mail-forward'),
-            5 => self::createTabEntry(__('Preview'), 0, $item::getType(), 'ti ti-eye-exclamation'),
+            1 => self::createTabEntry(__('Security'), null, $item::class, 'ti ti-shield-lock'),
+            2 => self::createTabEntry(__('Payload editor'), null, $item::class, 'ti ti-code-dots'),
+            3 => self::createTabEntry(
+                text: _n('Custom header', 'Custom headers', Session::getPluralNumber()),
+                nb: static fn () => count($item->fields['custom_headers']) + 2, // Add 2 for the static headers
+                form_itemtype: $item::class,
+                icon: 'ti ti-code-plus'
+            ),
+            4 => self::createTabEntry(
+                text: _n('Query log', 'Queries log', Session::getPluralNumber()),
+                nb: static fn () => (Search::getDatas(QueuedWebhook::class, $params)['data']['totalcount'] ?? 0),
+                form_itemtype: $item::class,
+                icon: 'ti ti-mail-forward'
+            ),
+            5 => self::createTabEntry(__('Preview'), null, $item::class, 'ti ti-eye-exclamation'),
         ];
     }
 

--- a/tests/functional/Item_SoftwareLicense.php
+++ b/tests/functional/Item_SoftwareLicense.php
@@ -236,7 +236,7 @@ class Item_SoftwareLicense extends DbTestCase
             1 => "<span><i class='ti ti-key me-2'></i>Summary</span>",
             2 => \Item_SoftwareLicense::createTabEntry(
                 _n('Item', 'Items', \Session::getPluralNumber()),
-                2,
+                static fn () => 2,
                 $license::getType(),
                 'ti ti-package'
             )

--- a/tests/functional/KnowbaseItem_Revision.php
+++ b/tests/functional/KnowbaseItem_Revision.php
@@ -180,7 +180,7 @@ class KnowbaseItem_Revision extends DbTestCase
 
         $_SESSION['glpishow_count_on_tabs'] = 1;
         $name = $kb_rev->getTabNameForItem($kb1);
-        $this->string($name)->isIdenticalTo("<span><i class='ti ti-history me-2'></i>Revision</span> <span class='badge glpi-badge'>1</span>");
+        $this->string($name)->isIdenticalTo("<span><i class='ti ti-history me-2'></i>Revisions</span> <span class='badge glpi-badge'>1</span>");
 
         $this->boolean(
             $kb1->update(

--- a/tests/functional/ValidatorSubstitute.php
+++ b/tests/functional/ValidatorSubstitute.php
@@ -75,7 +75,7 @@ class ValidatorSubstitute extends DbTestCase
 
         yield [
             'item' => new Preference(),
-            'expected' => "Authorized substitute <span class='badge glpi-badge'>1</span>",
+            'expected' => "Authorized substitutes <span class='badge glpi-badge'>1</span>",
         ];
 
         $_SESSION['glpishow_count_on_tabs'] = 0;

--- a/tests/src/autoload/functions.php
+++ b/tests/src/autoload/functions.php
@@ -678,6 +678,12 @@ function loadDataset()
                 'is_confidential' => 1,
                 'name' => 'Test OAuth Client',
             ]
+        ],
+        'Appliance' => [
+            [
+                'name'        => '_test_appliance01',
+                'entities_id' => '_test_root_entity',
+            ]
         ]
     ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Currently, the `createTabEntry` function that is used to build the HTML for tabs takes a number for a counter where 0 hides the counter. The issue is that the function doesn't check the `show_count_on_tabs` user preference, presumably this is because it's existence predates callables in GLPI so it wasn't possible before. This means that every usage of this function has to do their own check for this preference to determine if they need to count items or not. Looking through usages in plugins, it is clear that a lot of plugins don't respect the user preference at all. There are even some core GLPI tabs that always show the counter and it doesn't seem intentional.

The proposed solution is to allow passing a callable for the `$nb` parameter which is only called if the user preferences allows showing the counters. The only other value that will be accepted is 0 (maybe we can support null too). The function will no longer allow passing non-zero integers directly and therefore not allow bypassing the user preference.

This will force core GLPI code and plugins to always respect the user preference and make implementing code cleaner in most cases.

I also fixed a few cases where all list data was being retrieved just to count the results for the counter and some other performance issues.