### PR TITLE
Add PHPUnit test suite to the test runner script

### DIFF
--- a/.github/actions/test_tests-phpunit.sh
+++ b/.github/actions/test_tests-phpunit.sh
@@ -11,7 +11,9 @@ else
 fi
 
 #temporary hack to prevent dual configuration
-ln -s ../tests/config/ phpunit/
+if [[ ! -L "phpunit/config" ]]; then
+  ln -s ../tests/config phpunit/config
+fi
 
 vendor/bin/phpunit $PHPUNIT_ADDITIONNAL_OPTIONS
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -92,5 +92,5 @@ Running the test suite on containerized env
 -------------------------------------------
 
 If you want to execute tests in an environment similar to what is done by CI, you can use the `tests/run_tests.sh`.
-This scripts requires both "docker" and "docker-compose" utilities to be installed.
+This scripts requires the "docker" utility to be installed.
 Run `tests/run_tests.sh --help` for more information about its usage.

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -46,6 +46,7 @@ TESTS_SUITES=(
   "lint_twig"
   "install"
   "update"
+  "phpunit"
   "functional"
   "cache"
   "ldap"
@@ -146,6 +147,7 @@ Available tests suites:
  - lint_twig
  - install
  - update
+ - phpunit
  - functional
  - cache
  - ldap
@@ -158,8 +160,8 @@ EOF
 fi
 
 # Check for system dependencies
-if [[ ! -x "$(command -v docker)" || ! -x "$(command -v docker-compose)" ]]; then
-  echo "This scripts requires both \"docker\" and \"docker-compose\" utilities to be installed"
+if [[ ! -x "$(command -v docker)" ]]; then
+  echo "This scripts requires the \"docker\" utility to be installed"
   exit 1
 fi
 
@@ -177,14 +179,14 @@ fi
 # Define variables (some may be defined in .env file)
 APPLICATION_ROOT=$(readlink -f "$WORKING_DIR/..")
 [[ ! -z "$APP_CONTAINER_HOME" ]] || APP_CONTAINER_HOME=$(mktemp -d -t glpi-tests-home-XXXXXXXXXX)
-[[ ! -z "$DB_IMAGE" ]] || DB_IMAGE=githubactions-mysql:8.1
+[[ ! -z "$DB_IMAGE" ]] || DB_IMAGE=githubactions-mariadb:10.11
 [[ ! -z "$PHP_IMAGE" ]] || PHP_IMAGE=githubactions-php:7.4
 
 # Backup configuration files
 BACKUP_DIR=$(mktemp -d -t glpi-tests-backup-XXXXXXXXXX)
 find "$APPLICATION_ROOT/tests/config" -mindepth 1 ! -iname ".gitignore" -exec mv {} $BACKUP_DIR \;
 
-# Export variables to env (required for docker-compose) and start containers
+# Export variables to env (required for docker compose) and start containers
 export COMPOSE_FILE="$APPLICATION_ROOT/.github/actions/docker-compose-app.yml"
 if [[ "$USE_SERVICES_CONTAINERS" ]]; then
   export COMPOSE_FILE="$COMPOSE_FILE:$APPLICATION_ROOT/.github/actions/docker-compose-services.yml"
@@ -261,6 +263,10 @@ run_single_test () {
       && $APPLICATION_ROOT/.github/actions/init_initialize-9.5-db.sh \
       && docker compose exec -T app .github/actions/test_update-from-older-version.sh \
       && docker compose exec -T app .github/actions/test_update-from-9.5.sh \
+      || LAST_EXIT_CODE=$?
+      ;;
+    "phpunit")
+         docker compose exec -T app .github/actions/test_tests-phpunit.sh $TEST_ARGS \
       || LAST_EXIT_CODE=$?
       ;;
     "functional")


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I added the `phpunit` test suite support to the test runner script.

I also remove references to the obsolete `docker-compose` and change default DB image to `mariadb:10.11` to harmonize default test env with the `main` branch.