### PR TITLE
Forms destinations: add "request type" configuration

### DIFF
--- a/js/dynamic_dropdown_controller.js
+++ b/js/dynamic_dropdown_controller.js
@@ -1,0 +1,70 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * Helper class to easily manage sub dropdowns (i.e. you have a main dropdown
+ * and a few secondary dropdown that will only be displayed depending on the
+ * values of the main dropdown).
+ *
+ * The children dropdown must define two data attributes:
+ * - data-glpi-destination-parent: the name of the parent dropdown
+ * - data-glpi-destination-parent-value: the value that the parent dropdown
+ *  must have for this dropdown to be displayed
+ */
+class DynamicDropdownController
+{
+    constructor() {
+        this.#watchForDropdownChanges();
+    }
+
+    #watchForDropdownChanges() {
+        const dropdowns = $('select[data-select2-id]');
+
+        $(dropdowns).on('change', (e) => {
+            this.#updateChildrenDropdownsVisiblity($(e.target));
+        });
+    }
+
+    #updateChildrenDropdownsVisiblity(select) {
+        const name = $.escapeSelector(select.prop("name"));
+        const child_dropdowns = $(`[data-glpi-destination-parent='${name}']`);
+        const value = select.val();
+
+        child_dropdowns.each((i, dropdown) => {
+            const expected_value = $(dropdown).data(
+                'glpi-destination-parent-value'
+            );
+            $(dropdown).toggleClass('d-none', expected_value !== value);
+        });
+    }
+}

--- a/js/dynamic_dropdown_controller.js
+++ b/js/dynamic_dropdown_controller.js
@@ -37,8 +37,8 @@
  * values of the main dropdown).
  *
  * The children dropdown must define two data attributes:
- * - data-glpi-destination-parent: the name of the parent dropdown
- * - data-glpi-destination-parent-value: the value that the parent dropdown
+ * - data-glpi-parent-dropdown: the name of the parent dropdown
+ * - data-glpi-parent-dropdown-condition: the value that the parent dropdown
  *  must have for this dropdown to be displayed
  */
 class DynamicDropdownController
@@ -57,12 +57,12 @@ class DynamicDropdownController
 
     #updateChildrenDropdownsVisiblity(select) {
         const name = $.escapeSelector(select.prop("name"));
-        const child_dropdowns = $(`[data-glpi-destination-parent='${name}']`);
+        const child_dropdowns = $(`[data-glpi-parent-dropdown='${name}']`);
         const value = select.val();
 
         child_dropdowns.each((i, dropdown) => {
             const expected_value = $(dropdown).data(
-                'glpi-destination-parent-value'
+                'glpi-parent-dropdown-condition'
             );
             $(dropdown).toggleClass('d-none', expected_value !== value);
         });

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/RequestTypeFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/RequestTypeFieldTest.php
@@ -167,7 +167,7 @@ final class RequestTypeFieldTest extends DbTestCase
                 'value' => RequestTypeField::CONFIG_LAST_VALID_ANSWER,
             ],
             answers: [],
-            expected_request_type: Ticket::DEMAND_TYPE
+            expected_request_type: Ticket::INCIDENT_TYPE
         );
     }
 

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/RequestTypeFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/RequestTypeFieldTest.php
@@ -44,6 +44,8 @@ use Glpi\Form\QuestionType\QuestionTypeRequestType;
 use Glpi\Tests\FormBuilder;
 use Glpi\Tests\FormTesterTrait;
 use Ticket;
+use TicketTemplate;
+use TicketTemplatePredefinedField;
 
 final class RequestTypeFieldTest extends DbTestCase
 {
@@ -51,11 +53,25 @@ final class RequestTypeFieldTest extends DbTestCase
 
     public function testRequestTypeFromTemplate(): void
     {
+        // The default GLPI's template use "INCIDENT"
         $this->checkRequestTypeFieldConfiguration(
             form: $this->createAndGetFormWithMultipleRequestTypeQuestions(),
             config: ['value' => RequestTypeField::CONFIG_FROM_TEMPLATE],
             answers: [],
             expected_request_type: Ticket::INCIDENT_TYPE
+        );
+
+        // Set the default type as "Request" using predefined fields
+        $this->createItem(TicketTemplatePredefinedField::class, [
+            'tickettemplates_id' => getItemByTypeName(TicketTemplate::class, "Default", true),
+            'num' => 14, // Request type
+            'value' => Ticket::DEMAND_TYPE,
+        ]);
+        $this->checkRequestTypeFieldConfiguration(
+            form: $this->createAndGetFormWithMultipleRequestTypeQuestions(),
+            config: ['value' => RequestTypeField::CONFIG_FROM_TEMPLATE],
+            answers: [],
+            expected_request_type: Ticket::DEMAND_TYPE
         );
     }
 
@@ -168,6 +184,21 @@ final class RequestTypeFieldTest extends DbTestCase
             ],
             answers: [],
             expected_request_type: Ticket::INCIDENT_TYPE
+        );
+
+        // Try again with a different template value
+        $this->createItem(TicketTemplatePredefinedField::class, [
+            'tickettemplates_id' => getItemByTypeName(TicketTemplate::class, "Default", true),
+            'num' => 14, // Request type
+            'value' => Ticket::DEMAND_TYPE,
+        ]);
+        $this->checkRequestTypeFieldConfiguration(
+            form: $form,
+            config: [
+                'value' => RequestTypeField::CONFIG_LAST_VALID_ANSWER,
+            ],
+            answers: [],
+            expected_request_type: Ticket::DEMAND_TYPE
         );
     }
 

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/RequestTypeFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/RequestTypeFieldTest.php
@@ -1,0 +1,206 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\Destination\CommonITILField;
+
+use DbTestCase;
+use Glpi\Form\AnswersHandler\AnswersHandler;
+use Glpi\Form\Destination\FormDestinationTicket;
+use Glpi\Form\Form;
+use Glpi\Form\QuestionType\QuestionTypeRequestType;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+use Ticket;
+
+final class RequestTypeField extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public function requestTypeFieldConfigurationProvider(): iterable
+    {
+        $field = new \Glpi\Form\Destination\CommonITILField\RequestTypeField();
+
+        yield 'Using template/default value' => [
+            'form'    => $form = $this->getFormWithMultipleRequestTypeQuestions(),
+            'config'  => ['value' => $field::CONFIG_FROM_TEMPLATE],
+            'answers' => [],
+            'expected_request_type' => Ticket::INCIDENT_TYPE,
+        ];
+
+        yield 'Using specific value (DEMAND)' => [
+            'form'    => $form = $this->getFormWithMultipleRequestTypeQuestions(),
+            'config'  => [
+                'value' => $field::CONFIG_SPECIFIC_VALUE,
+                $field::EXTRA_CONFIG_REQUEST_TYPE => Ticket::DEMAND_TYPE,
+            ],
+            'answers' => [],
+            'expected_request_type' => Ticket::DEMAND_TYPE,
+        ];
+        yield 'Using specific value (INCIDENT)' => [
+            'form'    => $form = $this->getFormWithMultipleRequestTypeQuestions(),
+            'config'  => [
+                'value' => $field::CONFIG_SPECIFIC_VALUE,
+                $field::EXTRA_CONFIG_REQUEST_TYPE => Ticket::INCIDENT_TYPE,
+            ],
+            'answers' => [],
+            'expected_request_type' => Ticket::INCIDENT_TYPE,
+        ];
+
+        yield 'Using specific answer (DEMAND)' => [
+            'form'    => $form = $this->getFormWithMultipleRequestTypeQuestions(),
+            'config'  => [
+                'value' => $field::CONFIG_SPECIFIC_ANSWER,
+                $field::EXTRA_CONFIG_QUESTION_ID => $this->getQuestionId($form, "Request type 1"),
+            ],
+            'answers' => [
+                "Request type 1" => Ticket::DEMAND_TYPE,
+                "Request type 2" => Ticket::INCIDENT_TYPE,
+            ],
+            'expected_request_type' => Ticket::DEMAND_TYPE,
+        ];
+        yield 'Using specific answer (INCIDENT)' => [
+            'form'    => $form = $this->getFormWithMultipleRequestTypeQuestions(),
+            'config'  => [
+                'value' => $field::CONFIG_SPECIFIC_ANSWER,
+                $field::EXTRA_CONFIG_QUESTION_ID => $this->getQuestionId($form, "Request type 2"),
+            ],
+            'answers' => [
+                "Request type 1" => Ticket::DEMAND_TYPE,
+                "Request type 2" => Ticket::INCIDENT_TYPE,
+            ],
+            'expected_request_type' => Ticket::INCIDENT_TYPE,
+        ];
+
+        yield 'Using last valid answer (multiple answers submitted)' => [
+            'form'    => $form = $this->getFormWithMultipleRequestTypeQuestions(),
+            'config'  => [
+                'value' => $field::CONFIG_LAST_VALID_ANSWER,
+            ],
+            'answers' => [
+                "Request type 1" => Ticket::INCIDENT_TYPE,
+                "Request type 2" => Ticket::DEMAND_TYPE,
+            ],
+            'expected_request_type' => Ticket::DEMAND_TYPE,
+        ];
+        yield 'Using last valid answer (only first answer was submitted)' => [
+            'form'    => $form = $this->getFormWithMultipleRequestTypeQuestions(),
+            'config'  => [
+                'value' => $field::CONFIG_LAST_VALID_ANSWER,
+            ],
+            'answers' => [
+                "Request type 1" => Ticket::DEMAND_TYPE,
+            ],
+            'expected_request_type' => Ticket::DEMAND_TYPE,
+        ];
+        yield 'Using last valid answer (Only second answer was submitted)' => [
+            'form'    => $form = $this->getFormWithMultipleRequestTypeQuestions(),
+            'config'  => [
+                'value' => $field::CONFIG_LAST_VALID_ANSWER,
+            ],
+            'answers' => [
+                "Request type 2" => Ticket::DEMAND_TYPE,
+            ],
+            'expected_request_type' => Ticket::DEMAND_TYPE,
+        ];
+        yield 'Using last valid answer (no answers)' => [
+            'form'    => $form = $this->getFormWithMultipleRequestTypeQuestions(),
+            'config'  => [
+                'value' => $field::CONFIG_LAST_VALID_ANSWER,
+            ],
+            'answers' => [],
+            'expected_request_type' => Ticket::INCIDENT_TYPE, // Default value fallback
+        ];
+    }
+
+    /**
+     * @dataProvider requestTypeFieldConfigurationProvider
+     */
+    public function testRequestTypeFieldConfiguration(
+        Form $form,
+        array $config,
+        array $answers,
+        int $expected_request_type
+    ): void {
+        // Insert config
+        $destinations = $form->getDestinations();
+        $this->array($destinations)->hasSize(1);
+        $destination = current($destinations);
+        $this->updateItem(
+            $destination::getType(),
+            $destination->getId(),
+            ['config' => ['request_type' => $config]],
+            ["config"],
+        );
+
+        // The provider use a simplified answer format to be more readable.
+        // Rewrite answers into expected format.
+        $formatted_answers = [];
+        foreach ($answers as $question => $answer) {
+            $key = $this->getQuestionId($form, $question);
+            $formatted_answers[$key] = $answer;
+        }
+
+        // Submit form
+        $this->login();
+        $answers_handler = AnswersHandler::getInstance();
+        $answers = $answers_handler->saveAnswers(
+            $form,
+            $formatted_answers,
+            \Session::getLoginUserID()
+        );
+
+        // Get created ticket
+        $created_items = $answers->getCreatedItems();
+        $this->array($created_items)->hasSize(1);
+        $ticket = current($created_items);
+
+        // Check request type
+        $this->integer($ticket->fields['type'])
+            ->isEqualTo($expected_request_type)
+        ;
+    }
+
+    private function getFormWithMultipleRequestTypeQuestions(): Form
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion("Request type 1", QuestionTypeRequestType::class);
+        $builder->addQuestion("Request type 2", QuestionTypeRequestType::class);
+        $builder->addDestination(
+            FormDestinationTicket::class,
+            "My ticket",
+        );
+        return $this->createForm($builder);
+    }
+}

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/RequestTypeFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/RequestTypeFieldTest.php
@@ -197,12 +197,11 @@ final class RequestTypeFieldTest extends DbTestCase
         }
 
         // Submit form
-        $this->login();
         $answers_handler = AnswersHandler::getInstance();
         $answers = $answers_handler->saveAnswers(
             $form,
             $formatted_answers,
-            \Session::getLoginUserID()
+            getItemByTypeName(\User::class, TU_USER, true)
         );
 
         // Get created ticket

--- a/src/Glpi/Form/AnswersSet.php
+++ b/src/Glpi/Form/AnswersSet.php
@@ -145,6 +145,31 @@ final class AnswersSet extends CommonDBChild
         return $answers;
     }
 
+    public function getAnswerByQuestionId(int $id): ?Answer
+    {
+        $answers = $this->getAnswers();
+        $filtered_answers = array_filter(
+            $answers,
+            fn (Answer $answer) => $answer->getQuestionId() == $id
+        );
+
+        if (count($filtered_answers) == 1) {
+            return current($filtered_answers);
+        } else {
+            return null;
+        }
+    }
+
+    /** @return Answer[] */
+    public function getAnswersByType(string $type): array
+    {
+        $answers = $this->getAnswers();
+        return array_filter(
+            $answers,
+            fn (Answer $answer) => $answer->getRawType() == $type
+        );
+    }
+
     #[Override]
     public function rawSearchOptions()
     {

--- a/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
+++ b/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
@@ -156,7 +156,7 @@ abstract class AbstractCommonITILFormDestination extends AbstractFormDestination
         return "config[$field_key]";
     }
 
-    final private function applyPredefinedTemplateFields(array $input): array
+    private function applyPredefinedTemplateFields(array $input): array
     {
         $itemtype = static::getTargetItemtype();
 

--- a/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
+++ b/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
@@ -83,6 +83,9 @@ abstract class AbstractCommonITILFormDestination extends AbstractFormDestination
             'entities_id' => $form->fields['entities_id']
         ];
 
+        // Compute and apply template predefined template fields
+        $input = $this->applyPredefinedTemplateFields($input);
+
         // Compute input from fields configuration
         foreach ($this->getConfigurableFields() as $field) {
             $input = $field->applyConfiguratedValueToInputUsingAnswers(
@@ -151,5 +154,28 @@ abstract class AbstractCommonITILFormDestination extends AbstractFormDestination
         }
 
         return "config[$field_key]";
+    }
+
+    final private function applyPredefinedTemplateFields(array $input): array
+    {
+        $itemtype = static::getTargetItemtype();
+
+        /** @var \CommonITILObject $itil */
+        $itil = new $itemtype();
+        $template = $itil->getITILTemplateToUse(
+            entities_id: $_SESSION["glpiactive_entity"]
+        );
+
+        $predefined_fields_class = $itemtype . "TemplatePredefinedField";
+
+        /** @var \ITILTemplatePredefinedField $predefined_fields */
+        $predefined_fields = new $predefined_fields_class();
+
+        $fields = $predefined_fields->getPredefinedFields($template->fields['id']);
+        foreach ($fields as $field => $value) {
+            $input[$field] = $value;
+        }
+
+        return $input;
     }
 }

--- a/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
+++ b/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
@@ -79,6 +79,8 @@ abstract class AbstractCommonITILFormDestination extends AbstractFormDestination
         $input = [
             'name'    => '',
             'content' => '',
+            // Temporary as entity configuration is not yet available
+            'entities_id' => $form->fields['entities_id']
         ];
 
         // Compute input from fields configuration

--- a/src/Glpi/Form/Destination/AbstractConfigField.php
+++ b/src/Glpi/Form/Destination/AbstractConfigField.php
@@ -36,6 +36,7 @@
 namespace Glpi\Form\Destination;
 
 use Glpi\Form\Form;
+use ITILTemplate;
 use Override;
 
 abstract class AbstractConfigField implements ConfigFieldInterface

--- a/src/Glpi/Form/Destination/CommonITILField/RequestTypeField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/RequestTypeField.php
@@ -128,8 +128,8 @@ class RequestTypeField extends AbstractConfigField
                 {% if main_config_field.value != CONFIG_SPECIFIC_VALUE %}
                     class="d-none"
                 {% endif %}
-                data-glpi-destination-parent="{{ main_config_field.input_name }}"
-                data-glpi-destination-parent-value="{{ CONFIG_SPECIFIC_VALUE }}"
+                data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
+                data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_VALUE }}"
             >
                 {{ fields.dropdownArrayField(
                     specific_value_extra_field.input_name,
@@ -148,8 +148,8 @@ class RequestTypeField extends AbstractConfigField
                 {% if main_config_field.value != CONFIG_SPECIFIC_ANSWER %}
                     class="d-none"
                 {% endif %}
-                data-glpi-destination-parent="{{ main_config_field.input_name }}"
-                data-glpi-destination-parent-value="{{ CONFIG_SPECIFIC_ANSWER }}"
+                data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
+                data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_ANSWER }}"
             >
                 {{ fields.dropdownArrayField(
                     specific_answer_extra_field.input_name,

--- a/src/Glpi/Form/Destination/CommonITILField/RequestTypeField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/RequestTypeField.php
@@ -54,7 +54,7 @@ class RequestTypeField extends AbstractConfigField
     // Secondary config value that is used when the main value is CONFIG_SPECIFIC_VALUE
     public const EXTRA_CONFIG_REQUEST_TYPE = 'specific_request_type';
 
-    // Secondary config value that is used when the main value is CONFIG_LAST_VALID_ANSWER
+    // Secondary config value that is used when the main value is CONFIG_SPECIFIC_ANSWER
     public const EXTRA_CONFIG_QUESTION_ID = 'specific_question_id';
 
     #[Override]

--- a/src/Glpi/Form/Destination/CommonITILField/RequestTypeField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/RequestTypeField.php
@@ -265,9 +265,9 @@ TWIG;
     {
         return [
             self::CONFIG_FROM_TEMPLATE     => __("From template"),
-            self::CONFIG_SPECIFIC_VALUE    => __("Specific value"),
+            self::CONFIG_SPECIFIC_VALUE    => __("Specific request type"),
             self::CONFIG_SPECIFIC_ANSWER   => __("Answer from a specific question"),
-            self::CONFIG_LAST_VALID_ANSWER => __("Last valid answer"),
+            self::CONFIG_LAST_VALID_ANSWER => __('Answer to last "Request type" question'),
         ];
     }
 

--- a/src/Glpi/Form/Destination/CommonITILField/RequestTypeField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/RequestTypeField.php
@@ -1,0 +1,285 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Destination\CommonITILField;
+
+use Glpi\Application\View\TemplateRenderer;
+use Glpi\Form\AnswersSet;
+use Glpi\Form\Destination\AbstractConfigField;
+use Glpi\Form\Form;
+use Glpi\Form\QuestionType\QuestionTypeRequestType;
+use Override;
+use Ticket;
+
+class RequestTypeField extends AbstractConfigField
+{
+    // Main configuration main
+    public const CONFIG_FROM_TEMPLATE = 'from_template_or_default';
+    public const CONFIG_SPECIFIC_VALUE = 'specific_value';
+    public const CONFIG_SPECIFIC_ANSWER = 'specific_answer';
+    public const CONFIG_LAST_VALID_ANSWER = 'last_valid_answer';
+
+    // Secondary config value that is used when the main value is CONFIG_SPECIFIC_VALUE
+    public const EXTRA_CONFIG_REQUEST_TYPE = 'specific_request_type';
+
+    // Secondary config value that is used when the main value is CONFIG_LAST_VALID_ANSWER
+    public const EXTRA_CONFIG_QUESTION_ID = 'specific_question_id';
+
+    #[Override]
+    public function getKey(): string
+    {
+        return 'request_type';
+    }
+
+    #[Override]
+    public function getLabel(): string
+    {
+        return __("Request type");
+    }
+
+    #[Override]
+    public function renderConfigForm(
+        Form $form,
+        mixed $configurated_value,
+        string $input_name,
+        array $display_options
+    ): string {
+        if (!is_array($configurated_value)) {
+            $configurated_value = $this->getDefaultValue($form);
+        }
+
+        $parameters = [
+            // Possible configuration constant that will be used to to hide/show additional fields
+            'CONFIG_SPECIFIC_VALUE'  => self::CONFIG_SPECIFIC_VALUE,
+            'CONFIG_SPECIFIC_ANSWER' => self::CONFIG_SPECIFIC_ANSWER,
+
+            // General display options
+            'options' => $display_options,
+
+            // Main config field
+            'main_config_field' => [
+                'label'           => $this->getLabel(),
+                'value'           => $configurated_value['value'] ?? $this->getDefaultValue($form)['value'],
+                'input_name'      => $input_name . "[value]",
+                'possible_values' => $this->getMainConfigurationValuesforDropdown(),
+            ],
+
+            // Specific additional confog for CONFIG_SPECIFIC_VALUE
+            'specific_value_extra_field' => [
+                'empty_label'     => __("Select a request type..."),
+                'value'           => $this->getConfiguratedSpecificValue($configurated_value),
+                'input_name'      => $input_name . "[" . self::EXTRA_CONFIG_REQUEST_TYPE . "]",
+                'possible_values' => Ticket::getTypes(),
+            ],
+
+            // Specific additional confog for CONFIG_SPECIFIC_ANSWER
+            'specific_answer_extra_field' => [
+                'empty_label'     => __("Select a question..."),
+                'value'           => $this->getConfiguratedQuestionId($configurated_value),
+                'input_name'      => $input_name . "[" . self::EXTRA_CONFIG_QUESTION_ID . "]",
+                'possible_values' => $this->getRequestTypeQuestionsValuesForDropdown($form),
+            ],
+        ];
+
+        $template = <<<TWIG
+            {% import 'components/form/fields_macros.html.twig' as fields %}
+
+            {{ fields.dropdownArrayField(
+                main_config_field.input_name,
+                main_config_field.value,
+                main_config_field.possible_values,
+                main_config_field.label,
+                options
+            ) }}
+
+            <div
+                {% if main_config_field.value != CONFIG_SPECIFIC_VALUE %}
+                    class="d-none"
+                {% endif %}
+                data-glpi-destination-parent="{{ main_config_field.input_name }}"
+                data-glpi-destination-parent-value="{{ CONFIG_SPECIFIC_VALUE }}"
+            >
+                {{ fields.dropdownArrayField(
+                    specific_value_extra_field.input_name,
+                    specific_value_extra_field.value,
+                    specific_value_extra_field.possible_values,
+                    "",
+                    options|merge({
+                        no_label: true,
+                        display_emptychoice: true,
+                        emptylabel: specific_value_extra_field.empty_label,
+                    })
+                ) }}
+            </div>
+
+            <div
+                {% if main_config_field.value != CONFIG_SPECIFIC_ANSWER %}
+                    class="d-none"
+                {% endif %}
+                data-glpi-destination-parent="{{ main_config_field.input_name }}"
+                data-glpi-destination-parent-value="{{ CONFIG_SPECIFIC_ANSWER }}"
+            >
+                {{ fields.dropdownArrayField(
+                    specific_answer_extra_field.input_name,
+                    specific_answer_extra_field.value,
+                    specific_answer_extra_field.possible_values,
+                    "",
+                    options|merge({
+                        no_label: true,
+                        display_emptychoice: true,
+                        emptylabel: specific_answer_extra_field.empty_label,
+                    })
+                ) }}
+            </div>
+TWIG;
+
+        $twig = TemplateRenderer::getInstance();
+        return $twig->renderFromStringTemplate($template, $parameters);
+    }
+
+    #[Override]
+    public function applyConfiguratedValueToInputUsingAnswers(
+        mixed $configurated_value,
+        array $input,
+        AnswersSet $answers_set
+    ): array {
+        if (is_null($configurated_value)) {
+            return $input;
+        }
+
+        switch ($configurated_value['value']) {
+            default:
+            case self::CONFIG_FROM_TEMPLATE:
+                // Let the template apply its default value by itself.
+                $value = null;
+                break;
+
+            case self::CONFIG_SPECIFIC_VALUE:
+                $value = $this->getConfiguratedSpecificValue($configurated_value);
+                break;
+
+            case self::CONFIG_SPECIFIC_ANSWER:
+                $question_id = $this->getConfiguratedQuestionId($configurated_value);
+                if ($question_id === null) {
+                    $value = null;
+                    break;
+                }
+
+                $answer = $answers_set->getAnswerByQuestionId($question_id);
+                if ($answer === null) {
+                    $value = null;
+                    break;
+                }
+
+                $value = $answer->getRawAnswer();
+                break;
+
+            case self::CONFIG_LAST_VALID_ANSWER:
+                $valid_answers = $answers_set->getAnswersByType(
+                    QuestionTypeRequestType::class
+                );
+
+                if (count($valid_answers) == 0) {
+                    $value = null;
+                    break;
+                }
+
+                $answer = end($valid_answers);
+                $value = $answer->getRawAnswer();
+                break;
+        }
+
+        // Do not edit input if invalid value was found
+        $valid_values = [Ticket::INCIDENT_TYPE, Ticket::DEMAND_TYPE];
+        if (!array_search($value, $valid_values)) {
+            return $input;
+        }
+
+        // Apply value
+        $input['type'] = $value;
+        return $input;
+    }
+
+    #[Override]
+    public function getDefaultValue(Form $form): mixed
+    {
+        return ['value' => self::CONFIG_LAST_VALID_ANSWER];
+    }
+
+    private function getConfiguratedSpecificValue(array $config): ?int
+    {
+        $value = $config[self::EXTRA_CONFIG_REQUEST_TYPE] ?? null;
+
+        $valid_values = [Ticket::INCIDENT_TYPE, Ticket::DEMAND_TYPE];
+        if (!array_search($value, $valid_values)) {
+            return null;
+        }
+
+        return $value;
+    }
+
+    private function getConfiguratedQuestionId(array $config): ?int
+    {
+        $value = $config[self::EXTRA_CONFIG_QUESTION_ID] ?? null;
+
+        if (!is_numeric($value)) {
+            return null;
+        }
+
+        return (int) $value;
+    }
+
+    private function getMainConfigurationValuesforDropdown(): array
+    {
+        return [
+            self::CONFIG_FROM_TEMPLATE     => __("From template"),
+            self::CONFIG_SPECIFIC_VALUE    => __("Specific value"),
+            self::CONFIG_SPECIFIC_ANSWER   => __("Answer from a specific question"),
+            self::CONFIG_LAST_VALID_ANSWER => __("Last valid answer"),
+        ];
+    }
+
+    private function getRequestTypeQuestionsValuesForDropdown(Form $form): array
+    {
+        $values = [];
+        $questions = $form->getQuestionsByType(QuestionTypeRequestType::class);
+
+        foreach ($questions as $question) {
+            $values[$question->getId()] = $question->fields['name'];
+        }
+
+        return $values;
+    }
+}

--- a/src/Glpi/Form/Destination/CommonITILField/RequestTypeField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/RequestTypeField.php
@@ -140,6 +140,7 @@ class RequestTypeField extends AbstractConfigField
                         no_label: true,
                         display_emptychoice: true,
                         emptylabel: specific_value_extra_field.empty_label,
+                        aria_label: specific_value_extra_field.empty_label,
                     })
                 ) }}
             </div>
@@ -160,6 +161,7 @@ class RequestTypeField extends AbstractConfigField
                         no_label: true,
                         display_emptychoice: true,
                         emptylabel: specific_answer_extra_field.empty_label,
+                        aria_label: specific_answer_extra_field.empty_label,
                     })
                 ) }}
             </div>

--- a/src/Glpi/Form/Destination/FormDestinationTicket.php
+++ b/src/Glpi/Form/Destination/FormDestinationTicket.php
@@ -35,6 +35,7 @@
 
 namespace Glpi\Form\Destination;
 
+use Glpi\Form\Destination\CommonITILField\RequestTypeField;
 use Override;
 use Ticket;
 
@@ -44,5 +45,13 @@ final class FormDestinationTicket extends AbstractCommonITILFormDestination
     public static function getTargetItemtype(): string
     {
         return Ticket::class;
+    }
+
+    #[Override]
+    public function getConfigurableFields(): array
+    {
+        return array_merge(parent::getConfigurableFields(), [
+            new RequestTypeField(),
+        ]);
     }
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeRequestType.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeRequestType.php
@@ -87,7 +87,7 @@ TWIG;
         return $twig->renderFromStringTemplate($template, [
             'init'               => $question != null,
             'value'              => $this->getDefaultValue($question),
-            'request_types'     => Ticket::getTypes()
+            'request_types'      => Ticket::getTypes()
         ]);
     }
 
@@ -104,7 +104,8 @@ TWIG;
             '',
             {
                 'no_label'           : true,
-                'display_emptychoice': true
+                'display_emptychoice': false,
+                'aria_label'         : label
             }
         ) }}
 TWIG;
@@ -113,7 +114,8 @@ TWIG;
         return $twig->renderFromStringTemplate($template, [
             'value'              => $this->getDefaultValue($question),
             'question'           => $question,
-            'request_types'      => Ticket::getTypes()
+            'request_types'      => Ticket::getTypes(),
+            'label'              => $question->fields['name'],
         ]);
     }
 

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -467,7 +467,12 @@
       }|merge(options)]) %}
    {% endset %}
 
-   {{ _self.field(name, field, label, options|merge({'id': 'dropdown_' ~ name ~ options.rand})) }}
+   {# TODO: dropdown id did not match its label because the Dropdown class
+   does some additional processing on the ID (replacing "[" and "]" by underscore) #}
+   {# As a quick fix, this same replacement was manually done here but we should look
+   for a stronger solution (and apply for all dropdowns inputs) #}
+   {% set id = ('dropdown_' ~ name ~ options.rand)|replace({'[': '_', ']' : '_'}) %}
+   {{ _self.field(name, field, label, options|merge({'id': id})) }}
 {% endmacro %}
 
 {% macro dropdownTimestampField(name, value, label = '', options = {}) %}

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -37,6 +37,7 @@
    'fields_template': itiltemplate,
    'disabled': (not canupdate),
    'add_field_class': (is_expanded ? 'col-sm-6' : ''),
+   'rand': rand,
 } %}
 
 {% set itil_layout    = user_pref('itil_layout', true) %}
@@ -136,18 +137,22 @@
                {% set type_params = {
                   'value': item.fields['type'],
                   'width': '100%',
-                  'display': false
+                  'display': false,
+                  'rand': rand,
                }|merge(field_options) %}
                {% if item.isNewItem() %}
                   {% set type_params = type_params|merge({'on_change': 'this.form.submit()',}) %}
                {% else %}
                   {% set type_params = type_params|merge({'on_change': 'reloadCategory()',}) %}
                {% endif %}
+               {# Without passing a specific ID, the "dropdown" prefix is missing from the label's "for" property here (not sure why). TODO: investigate #}
                {{ fields.field(
                   'type',
                   item.dropdownType('type', type_params),
                   _n('Type', 'Types', 1),
-                  field_options
+                  field_options|merge({
+                     id: 'dropdown_type' ~ rand,
+                  })
                ) }}
             {% endif %}
 

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -56,7 +56,7 @@
             </span>
          </button>
       </h2>
-      <div id="item-main" class="accordion-collapse collapse {{ main_show ? "show" : "" }}" aria-labelledby="heading-main-item">
+      <section id="item-main" class="accordion-collapse collapse {{ main_show ? "show" : "" }}" aria-labelledby="heading-main-item">
          <div class="accordion-body row m-0 mt-n2">
 
             {{ call_plugin_hook('pre_item_form', {"item": item, 'options': params}) }}
@@ -251,7 +251,7 @@
 
             {{ call_plugin_hook('post_item_form', {"item": item, 'options': params}) }}
          </div>
-      </div>
+      </section>
    </div>
 
    {% set actors_show = headers_states['actors'] is not defined or headers_states['actors'] == "true" ? true : false %}

--- a/templates/pages/admin/form/form_destination.html.twig
+++ b/templates/pages/admin/form/form_destination.html.twig
@@ -145,6 +145,14 @@
     </div>
 </div>
 
+<script src="{{ js_path("js/form_destination_auto_config_controller.js") }}"></script>
+<script src="{{ js_path("js/dynamic_dropdown_controller.js") }}"></script>
+<script>
+    new GlpiFormDestinationAutoConfigController();
+    new DynamicDropdownController();
+</script>
+
+
 <style>
     /* Should be handled by tabler but it doesn't seem to be active */
     .accordion-header {

--- a/templates/pages/admin/form/form_destination_commonitil_config.html.twig
+++ b/templates/pages/admin/form/form_destination_commonitil_config.html.twig
@@ -78,10 +78,4 @@
             )|raw }}
         </section>
     {% endfor %}
-
 </div>
-
-<script src="{{ js_path("js/form_destination_auto_config_controller.js") }}"></script>
-<script>
-    new GlpiFormDestinationAutoConfigController();
-</script>

--- a/templates/pages/form_renderer.html.twig
+++ b/templates/pages/form_renderer.html.twig
@@ -90,7 +90,8 @@
 
                 {# Skip unknown types (may be a disabled plugin) #}
                 {% if form_block is not instanceof('Glpi\\Form\\Question') or question_type is not null %}
-                    <div
+                    <section
+                        aria-label="{{ form_block.fields.name }}"
                         class="card mb-3 {{ is_first_section ? "" : "d-none" }}"
                         data-glpi-form-renderer-parent-section="{{ section_index }}"
                     >
@@ -112,7 +113,7 @@
                                 {{ form_block.fields.description|safe_html }}
                             </div>
                         </div>
-                    </div>
+                    </section>
                 {% endif %}
             {% endfor %}
 

--- a/tests/cypress/e2e/form/destination_config_fields/request_type.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/request_type.cy.js
@@ -1,0 +1,121 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+describe('Request type configuration', () => {
+    beforeEach(() => {
+        cy.login();
+        cy.changeProfile('Super-Admin', true);
+
+        // Create form with a single "request type" question
+        cy.createFormWithAPI().visitFormTab('Form');
+        cy.findByRole('button', {'name': "Add a new question"}).click();
+        cy.focused().type("My request type question");
+        cy.getSelect2DropdownByValue('Short answer').setSelect2Value('Request type');
+        cy.findByRole('button', {'name': 'Save'}).click();
+        cy.findByRole('alert').should('contain.text', 'Item successfully updated');
+
+        // Go to destination tab
+        cy.findByRole('tab', {'name': "Items to create"}).click();
+        cy.findByRole('button', {'name': "Add ticket"}).click();
+        cy.findByRole('alert').should('contain.text', 'Item successfully added');
+    });
+
+    it('can use all possibles configuration options', () => {
+        cy.findByRole('region', {'name': "Request type configuration"}).as('config');
+
+        // Default value
+        cy.get("@config").select2ValueShouldBeSelected("Last valid answer");
+
+        // Make sure hidden dropdowns are not displayed
+        cy.get("@config").select2ValueShouldNotBeSelected('Select a question...');
+        cy.get("@config").select2ValueShouldNotBeSelected('Select a request type...');
+
+        // Switch to "From template"
+        cy.get("@config")
+            .getSelect2DropdownByValue('Last valid answer')
+            .setSelect2Value('From template')
+        ;
+        cy.findByRole('button', {'name': 'Update item'}).click();
+        cy.get("@config").select2ValueShouldBeSelected("From template");
+
+        // Switch to "Specific value"
+        cy.get("@config")
+            .getSelect2DropdownByValue('From template')
+            .setSelect2Value('Specific value')
+        ;
+        cy.get("@config")
+            .getSelect2DropdownByValue('Select a request type...')
+            .setSelect2Value('Request')
+        ;
+        cy.findByRole('button', {'name': 'Update item'}).click();
+        cy.get("@config").select2ValueShouldBeSelected("Specific value");
+        cy.get("@config").select2ValueShouldBeSelected("Request");
+
+        // Switch to "Answer from a specific question"
+        cy.get("@config")
+            .getSelect2DropdownByValue("Specific value")
+            .setSelect2Value("Answer from a specific question")
+        ;
+        cy.get("@config")
+            .getSelect2DropdownByValue('Select a question...')
+            .setSelect2Value('My request type question')
+        ;
+        cy.findByRole('button', {'name': 'Update item'}).click();
+        cy.get("@config").select2ValueShouldBeSelected("Answer from a specific question");
+        cy.get("@config").select2ValueShouldBeSelected("My request type question");
+    });
+
+    it('can create ticket using default configuration', () => {
+        // Go to preview
+        cy.findByRole('tab', {'name': "Form"}).click();
+        cy.findByRole('link', {'name': "Preview"})
+            .invoke('removeAttr', 'target') // Cypress can't handle tab changes
+            .click()
+        ;
+
+        // Fill form
+        cy.findByRole("region", {"name": "My request type question"})
+            .getSelect2DropdownByValue('-----')
+            .setSelect2Value('Request')
+        ;
+        cy.findByRole('button', {'name': 'Send form'}).click();
+        cy.findByRole('link', {'name': 'My test form'}).click();
+
+        // Check ticket values
+        cy.findByRole('region', {'name': 'Ticket'})
+            .select2ValueShouldBeSelected('Request')
+        ;
+
+        // Others possibles configurations are tested directly by the backend.
+    });
+});

--- a/tests/cypress/e2e/form/destination_config_fields/request_type.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/request_type.cy.js
@@ -50,7 +50,7 @@ describe('Request type configuration', () => {
         cy.findByRole('alert').should('contain.text', 'Item successfully added');
     });
 
-    it.only('can use all possibles configuration options', () => {
+    it('can use all possibles configuration options', () => {
         cy.findByRole('region', {'name': "Request type configuration"}).as("config");
         cy.get('@config').getDropdownByLabelText('Request type').as("request_type_dropdown");
 

--- a/tests/cypress/e2e/form/destination_config_fields/request_type.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/request_type.cy.js
@@ -40,7 +40,7 @@ describe('Request type configuration', () => {
         cy.createFormWithAPI().visitFormTab('Form');
         cy.findByRole('button', {'name': "Add a new question"}).click();
         cy.focused().type("My request type question");
-        cy.getSelect2DropdownByValue('Short answer').setSelect2Value('Request type');
+        cy.getDropdownByLabelText('Question type').selectDropdownValue('Request type');
         cy.findByRole('button', {'name': 'Save'}).click();
         cy.findByRole('alert').should('contain.text', 'Item successfully updated');
 
@@ -50,49 +50,42 @@ describe('Request type configuration', () => {
         cy.findByRole('alert').should('contain.text', 'Item successfully added');
     });
 
-    it('can use all possibles configuration options', () => {
-        cy.findByRole('region', {'name': "Request type configuration"}).as('config');
+    it.only('can use all possibles configuration options', () => {
+        cy.findByRole('region', {'name': "Request type configuration"}).as("config");
+        cy.get('@config').getDropdownByLabelText('Request type').as("request_type_dropdown");
 
         // Default value
-        cy.get("@config").select2ValueShouldBeSelected('Answer to last "Request type" question');
+        cy.get('@request_type_dropdown').should(
+            'have.text',
+            'Answer to last "Request type" question'
+        );
 
         // Make sure hidden dropdowns are not displayed
-        cy.get("@config").select2ValueShouldNotBeSelected('Select a question...');
-        cy.get("@config").select2ValueShouldNotBeSelected('Select a request type...');
+        cy.get('@config').getDropdownByLabelText('Select a request type...').should('not.exist');
+        cy.get('@config').getDropdownByLabelText('Select a question...').should('not.exist');
 
         // Switch to "From template"
-        cy.get("@config")
-            .getSelect2DropdownByValue('Answer to last "Request type" question')
-            .setSelect2Value('From template')
-        ;
+        cy.get('@request_type_dropdown').selectDropdownValue('From template');
         cy.findByRole('button', {'name': 'Update item'}).click();
-        cy.get("@config").select2ValueShouldBeSelected("From template");
+        cy.get('@request_type_dropdown').should('have.text', 'From template');
 
         // Switch to "Specific request type"
-        cy.get("@config")
-            .getSelect2DropdownByValue('From template')
-            .setSelect2Value('Specific request type')
-        ;
-        cy.get("@config")
-            .getSelect2DropdownByValue('Select a request type...')
-            .setSelect2Value('Request')
-        ;
+        cy.get('@request_type_dropdown').selectDropdownValue('Specific request type');
+        cy.get('@config').getDropdownByLabelText('Select a request type...').as('specific_request_type_dropdown');
+        cy.get('@specific_request_type_dropdown').selectDropdownValue('Request');
+
         cy.findByRole('button', {'name': 'Update item'}).click();
-        cy.get("@config").select2ValueShouldBeSelected("Specific request type");
-        cy.get("@config").select2ValueShouldBeSelected("Request");
+        cy.get('@request_type_dropdown').should('have.text', 'Specific request type');
+        cy.get('@specific_request_type_dropdown').should('have.text', 'Request');
 
         // Switch to "Answer from a specific question"
-        cy.get("@config")
-            .getSelect2DropdownByValue("Specific request type")
-            .setSelect2Value("Answer from a specific question")
-        ;
-        cy.get("@config")
-            .getSelect2DropdownByValue('Select a question...')
-            .setSelect2Value('My request type question')
-        ;
+        cy.get('@request_type_dropdown').selectDropdownValue('Answer from a specific question');
+        cy.get('@config').getDropdownByLabelText('Select a question...').as('specific_answer_type_dropdown');
+        cy.get('@specific_answer_type_dropdown').selectDropdownValue('My request type question');
+
         cy.findByRole('button', {'name': 'Update item'}).click();
-        cy.get("@config").select2ValueShouldBeSelected("Answer from a specific question");
-        cy.get("@config").select2ValueShouldBeSelected("My request type question");
+        cy.get('@request_type_dropdown').should('have.text', 'Answer from a specific question');
+        cy.get('@specific_answer_type_dropdown').should('have.text', 'My request type question');
     });
 
     it('can create ticket using default configuration', () => {

--- a/tests/cypress/e2e/form/destination_config_fields/request_type.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/request_type.cy.js
@@ -97,17 +97,13 @@ describe('Request type configuration', () => {
         ;
 
         // Fill form
-        cy.findByRole("region", {"name": "My request type question"})
-            .getSelect2DropdownByValue('-----')
-            .setSelect2Value('Request')
-        ;
+        cy.getDropdownByLabelText("My request type question").should('have.text', 'Incident');
+        cy.getDropdownByLabelText("My request type question").selectDropdownValue('Request');
         cy.findByRole('button', {'name': 'Send form'}).click();
         cy.findByRole('link', {'name': 'My test form'}).click();
 
         // Check ticket values
-        cy.findByRole('region', {'name': 'Ticket'})
-            .select2ValueShouldBeSelected('Request')
-        ;
+        cy.getDropdownByLabelText('Type').should('have.text', 'Request');
 
         // Others possibles configurations are tested directly by the backend.
     });

--- a/tests/cypress/e2e/form/destination_config_fields/request_type.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/request_type.cy.js
@@ -54,7 +54,7 @@ describe('Request type configuration', () => {
         cy.findByRole('region', {'name': "Request type configuration"}).as('config');
 
         // Default value
-        cy.get("@config").select2ValueShouldBeSelected("Last valid answer");
+        cy.get("@config").select2ValueShouldBeSelected('Answer to last "Request type" question');
 
         // Make sure hidden dropdowns are not displayed
         cy.get("@config").select2ValueShouldNotBeSelected('Select a question...');
@@ -62,28 +62,28 @@ describe('Request type configuration', () => {
 
         // Switch to "From template"
         cy.get("@config")
-            .getSelect2DropdownByValue('Last valid answer')
+            .getSelect2DropdownByValue('Answer to last "Request type" question')
             .setSelect2Value('From template')
         ;
         cy.findByRole('button', {'name': 'Update item'}).click();
         cy.get("@config").select2ValueShouldBeSelected("From template");
 
-        // Switch to "Specific value"
+        // Switch to "Specific request type"
         cy.get("@config")
             .getSelect2DropdownByValue('From template')
-            .setSelect2Value('Specific value')
+            .setSelect2Value('Specific request type')
         ;
         cy.get("@config")
             .getSelect2DropdownByValue('Select a request type...')
             .setSelect2Value('Request')
         ;
         cy.findByRole('button', {'name': 'Update item'}).click();
-        cy.get("@config").select2ValueShouldBeSelected("Specific value");
+        cy.get("@config").select2ValueShouldBeSelected("Specific request type");
         cy.get("@config").select2ValueShouldBeSelected("Request");
 
         // Switch to "Answer from a specific question"
         cy.get("@config")
-            .getSelect2DropdownByValue("Specific value")
+            .getSelect2DropdownByValue("Specific request type")
             .setSelect2Value("Answer from a specific question")
         ;
         cy.get("@config")

--- a/tests/cypress/support/commands/select2.d.ts
+++ b/tests/cypress/support/commands/select2.d.ts
@@ -31,25 +31,11 @@
  * ---------------------------------------------------------------------
  */
 
-Cypress.Commands.add('createFormWithAPI', (
-    fields = {
-        name: "My test form",
+declare namespace Cypress {
+    interface Chainable<Subject> {
+        getSelect2DropdownByValue(value: string): Chainable<any>
+        setSelect2Value(new_value: string): Chainable<any>
+        select2ValueShouldBeSelected(value: string): Chainable<any>
+        select2ValueShouldNotBeSelected(value: string): Chainable<any>
     }
-) => {
-    return cy.createWithAPI('Glpi\\Form\\Form', fields).then((form_id) => {
-        return form_id;
-    });
-});
-
-Cypress.Commands.add('visitFormTab', {prevSubject: true}, (
-    form_id,
-    tab_name
-) => {
-    const fully_qualified_tabs = new Map([
-        ['Form', 'Glpi\\Form\\Form\\Form$main'],
-        ['Destinations', 'Glpi\\Form\\Destination\\FormDestination$1'],
-    ]);
-    const tab = fully_qualified_tabs.get(tab_name);
-
-    return cy.visit(`/front/form/form.form.php?id=${form_id}&forcetab=${tab}`);
-});
+}

--- a/tests/cypress/support/commands/select2.d.ts
+++ b/tests/cypress/support/commands/select2.d.ts
@@ -33,9 +33,7 @@
 
 declare namespace Cypress {
     interface Chainable<Subject> {
-        getSelect2DropdownByValue(value: string): Chainable<any>
-        setSelect2Value(new_value: string): Chainable<any>
-        select2ValueShouldBeSelected(value: string): Chainable<any>
-        select2ValueShouldNotBeSelected(value: string): Chainable<any>
+        getDropdownByLabelText(value: string): Chainable<any>
+        selectDropdownValue(new_value: string): Chainable<any>
     }
 }

--- a/tests/cypress/support/commands/select2.js
+++ b/tests/cypress/support/commands/select2.js
@@ -69,6 +69,5 @@ Cypress.Commands.add('selectDropdownValue', {prevSubject: true}, (
     new_value
 ) => {
     cy.wrap(subject).click();
-    // cy.get(".select2-container--open").
     cy.findByRole('option', {name: new_value}).click();
 });

--- a/tests/cypress/support/commands/select2.js
+++ b/tests/cypress/support/commands/select2.js
@@ -31,25 +31,43 @@
  * ---------------------------------------------------------------------
  */
 
-Cypress.Commands.add('createFormWithAPI', (
-    fields = {
-        name: "My test form",
-    }
+Cypress.Commands.add('getSelect2DropdownByValue', {prevSubject: 'optional'}, (
+    subject,
+    value
 ) => {
-    return cy.createWithAPI('Glpi\\Form\\Form', fields).then((form_id) => {
-        return form_id;
-    });
+    if (subject) {
+        return cy.wrap(subject).findByRole('combobox', {name: value});
+    } else {
+        return cy.findByRole('combobox', {name: value});
+    }
 });
 
-Cypress.Commands.add('visitFormTab', {prevSubject: true}, (
-    form_id,
-    tab_name
+Cypress.Commands.add('setSelect2Value', {prevSubject: true}, (
+    subject,
+    new_value
 ) => {
-    const fully_qualified_tabs = new Map([
-        ['Form', 'Glpi\\Form\\Form\\Form$main'],
-        ['Destinations', 'Glpi\\Form\\Destination\\FormDestination$1'],
-    ]);
-    const tab = fully_qualified_tabs.get(tab_name);
+    cy.wrap(subject).click();
+    cy.findByRole('option', {name: new_value}).click();
+});
 
-    return cy.visit(`/front/form/form.form.php?id=${form_id}&forcetab=${tab}`);
+Cypress.Commands.add('select2ValueShouldBeSelected', {prevSubject: 'optional'}, (
+    subject,
+    value
+) => {
+    if (subject) {
+        cy.wrap(subject).getSelect2DropdownByValue(value).should('exist');
+    } else {
+        cy.getSelect2DropdownByValue(value).should('exist');
+    }
+});
+
+Cypress.Commands.add('select2ValueShouldNotBeSelected', {prevSubject: 'optional'}, (
+    subject,
+    value
+) => {
+    if (subject) {
+        cy.wrap(subject).getSelect2DropdownByValue(value).should('not.exist');
+    } else {
+        cy.getSelect2DropdownByValue(value).should('not.exist');
+    }
 });

--- a/tests/cypress/support/commands/select2.js
+++ b/tests/cypress/support/commands/select2.js
@@ -35,7 +35,7 @@ Cypress.Commands.addQuery('getDropdownByLabelText', (
     label_text
 ) => {
     return (previous_subject) => {
-        // Target might be the whole DOM or a specific exisint DOM node
+        // Target might be the whole DOM or a specific existing DOM node
         const getNode = (selector) => {
             return previous_subject ? previous_subject.find(selector) : Cypress.$(selector);
         };

--- a/tests/cypress/support/e2e.js
+++ b/tests/cypress/support/e2e.js
@@ -32,6 +32,7 @@
  */
 
 import './commands.js';
+import './commands/select2.js';
 import './commands/form.js';
 import '@testing-library/cypress/add-commands';
 import './cypress-axe.js';


### PR DESCRIPTION

![image](https://github.com/glpi-project/glpi/assets/42734840/0363a425-f48e-4064-9c74-3145eba713ab)

Possible configurations:

![image](https://github.com/glpi-project/glpi/assets/42734840/0030eccf-7dbe-4052-adc2-6e1af551294b)

"Specific value" and "Answer from a specific question" both display a secondary select to let the user pick the chosen type/question:

![image](https://github.com/glpi-project/glpi/assets/42734840/ebbbf912-d226-4fa6-8724-2038c998dc0b)

![image](https://github.com/glpi-project/glpi/assets/42734840/1566067f-63e0-411c-ade4-5dac70042781)

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
