### PR TITLE
Fix condition that make ticket requesters invisible for simplified interface

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -791,7 +791,14 @@ class Search
        //// 3 - WHERE
 
        // default string
-        $COMMONWHERE = (Session::getCurrentInterface() != 'helpdesk') ? self::addDefaultWhere($data['itemtype']) : '';
+        if (
+            Session::getCurrentInterface() != 'helpdesk'
+            && $data['itemtype'] == Ticket::class
+        ) {
+            $COMMONWHERE = self::addDefaultWhere($data['itemtype']);
+        } else {
+            $COMMONWHERE = "";
+        }
         $first = empty($COMMONWHERE);
 
        // Add deleted if item have it

--- a/src/Search.php
+++ b/src/Search.php
@@ -791,14 +791,7 @@ class Search
        //// 3 - WHERE
 
        // default string
-        if (
-            Session::getCurrentInterface() != 'helpdesk'
-            && $data['itemtype'] == Ticket::class
-        ) {
-            $COMMONWHERE = self::addDefaultWhere($data['itemtype']);
-        } else {
-            $COMMONWHERE = "";
-        }
+        $COMMONWHERE = self::addDefaultWhere($data['itemtype']);
         $first = empty($COMMONWHERE);
 
        // Add deleted if item have it
@@ -4386,6 +4379,7 @@ JAVASCRIPT;
                 $condition = '';
                 if (
                     !Session::haveRight("ticket", Ticket::READALL)
+                    && Session::getCurrentInterface() != 'helpdesk'
                 ) {
                     $searchopt
                     = self::getOptions($itemtype);

--- a/src/Search.php
+++ b/src/Search.php
@@ -791,8 +791,8 @@ class Search
        //// 3 - WHERE
 
        // default string
-        $COMMONWHERE = self::addDefaultWhere($data['itemtype']);
-        $first       = empty($COMMONWHERE);
+        $COMMONWHERE = (Session::getCurrentInterface() != 'helpdesk') ? self::addDefaultWhere($data['itemtype']) : '';
+        $first = empty($COMMONWHERE);
 
        // Add deleted if item have it
         if ($data['item'] && $data['item']->maybeDeleted()) {
@@ -4379,7 +4379,6 @@ JAVASCRIPT;
                 $condition = '';
                 if (
                     !Session::haveRight("ticket", Ticket::READALL)
-                    && Session::getCurrentInterface() != 'helpdesk'
                 ) {
                     $searchopt
                     = self::getOptions($itemtype);

--- a/src/Search.php
+++ b/src/Search.php
@@ -4377,7 +4377,10 @@ JAVASCRIPT;
             case 'Ticket':
                // Same structure in addDefaultJoin
                 $condition = '';
-                if (!Session::haveRight("ticket", Ticket::READALL)) {
+                if (
+                    !Session::haveRight("ticket", Ticket::READALL)
+                    && Session::getCurrentInterface() != 'helpdesk'
+                ) {
                     $searchopt
                     = self::getOptions($itemtype);
                     $requester_table


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33657

With the simplified interface, if you are a requestor on a ticket and there are other requestors. Only one requester is shown in the list of tickets.

Standard interface : 
![image](https://github.com/glpi-project/glpi/assets/102067890/ee7e6200-68f1-4773-b7f9-a404a7d6dc7a)

Simplified interface : 
![image](https://github.com/glpi-project/glpi/assets/102067890/3647e151-973b-4edc-bc84-1d84a32fd34b)

After fix : 
![image](https://github.com/glpi-project/glpi/assets/102067890/5fdc2753-acb0-44aa-9833-6e4b3849f8a7)

