### PR TITLE
Drop `CommonDevice::title()` and `Entity::title()` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,6 +243,7 @@ The present file will list all changes made to the project; according to the
 - `CommonDBTM::getCacheKeyForFriendlyName()`
 - `CommonDBTM::getSNMPCredential()`
 - `CommonDBTM::showDebugInfo()`
+- `CommonDevice::title()`
 - `CommonDropdown::displayHeader()`
 - `CommonGLPI::getAvailableDisplayOptions()`
 - `CommonGLPI::getDisplayOptions()`
@@ -278,6 +279,7 @@ The present file will list all changes made to the project; according to the
 - `DropdownTranslation::canBeTranslated()`. Translations are now always active.
 - `DropdownTranslation::isDropdownTranslationActive()`. Translations are now always active.
 - `Entity::getDefaultContractValues()`
+- `Entity::title()`
 - `FieldUnicity::showDebug()`
 - `GLPI::getErrorHandler()`
 - `GLPI::getLogLevel()`

--- a/src/CommonDevice.php
+++ b/src/CommonDevice.php
@@ -322,15 +322,6 @@ abstract class CommonDevice extends CommonDropdown
         return $tab;
     }
 
-    public function title()
-    {
-        Dropdown::showItemTypeMenu(
-            _n('Component', 'Components', Session::getPluralNumber()),
-            Dropdown::getDeviceItemTypes(),
-            self::getSearchURL()
-        );
-    }
-
     public static function getNameField()
     {
         return 'designation';

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -560,16 +560,6 @@ class Entity extends CommonTreeDropdown
     }
 
     /**
-     * Print a good title for entity pages
-     *
-     *@return void
-     **/
-    public function title()
-    {
-       // Empty title for entities
-    }
-
-    /**
      * Get the ID of entity assigned to the object
      *
      * simply return ID


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

These methods are not used anywhere.