### PR TITLE
Fix Tiny description input size

### DIFF
--- a/src/ProjectTaskTemplate.php
+++ b/src/ProjectTaskTemplate.php
@@ -99,6 +99,10 @@ class ProjectTaskTemplate extends CommonDropdown
                 'label' => __('Effective duration'),
                 'type'  => 'actiontime'
             ],
+            ['name'  => 'comments',
+                'label' => __('Comments'),
+                'type'  => 'textarea'
+            ],
             ['name'  => 'description',
                 'label' => __('Description'),
                 'type'  => 'tinymce',
@@ -106,10 +110,7 @@ class ProjectTaskTemplate extends CommonDropdown
                 // When an element will be created from a template, tinymce will catch the base64 image and trigger the
                 // document upload process.
                 'convert_images_to_documents' => false,
-            ],
-            ['name'  => 'comments',
-                'label' => __('Comments'),
-                'type'  => 'textarea'
+
             ],
         ];
     }

--- a/templates/dropdown_form.html.twig
+++ b/templates/dropdown_form.html.twig
@@ -179,7 +179,7 @@
                 {% elseif type == 'password' %}
                     {{ fields.passwordField(field['name'], item.fields[field['name']], field['label'], fields_params) }}
                 {% elseif type == 'tinymce' %}
-                    {% set fields_params = fields_params|merge({'enable_richtext': true}) %}
+                    {% set fields_params = fields_params|merge({'enable_richtext': true, 'full_width': true, 'label_class': 'col-xxl-2', 'input_class': 'col-xxl-10'}) %}
                     {{ fields.textareaField(field['name'], item.fields[field['name']], field['label'], fields_params) }}
                 {% elseif type == 'duration' %}
                     {% set toadd = [] %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33651

In some forms, the rich text editor for descriptions is limited in size by the other inputs. This fix allows you to increase its size as much as possible to improve the user experience.

Before : 
![image](https://github.com/glpi-project/glpi/assets/102067890/48743a05-9450-4174-8453-4aac458c72b5)

After : 
![image](https://github.com/glpi-project/glpi/assets/102067890/1db596da-66eb-45ec-8402-8a5090362fb4)
