### PR TITLE
[HLAPI] Read document download

### DIFF
--- a/tests/functional/Glpi/Api/HL/Controller/ManagementController.php
+++ b/tests/functional/Glpi/Api/HL/Controller/ManagementController.php
@@ -35,6 +35,8 @@
 
 namespace tests\units\Glpi\Api\HL\Controller;
 
+use Glpi\Http\Request;
+
 class ManagementController extends \HLAPITestCase
 {
     public function testCreateGetUpdateDelete()
@@ -47,5 +49,12 @@ class ManagementController extends \HLAPITestCase
         foreach ($management_types as $m_name) {
             $this->api->autoTestCRUD('/Management/' . $m_name);
         }
+    }
+
+    public function testDocumentDownload()
+    {
+        $this->login();
+        // Not sure we can mock a file upload to actually test the download. At least we need to check the endpoint exists.
+        $this->api->hasMatch(new Request('GET', '/Management/Document/1/Download'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The ability to download document contents was accidentally removed when the route declarations in the controller were being de-duplicated. This adds it back with better OpenAPI documentation and also adds a test to check the endpoint exists so it doesn't get accidentally removed again. Not sure there is a good way to mock a file upload to actually test the download.
