### PR TITLE
Fix(Migration): fix bad column name

### DIFF
--- a/src/Migration.php
+++ b/src/Migration.php
@@ -1729,9 +1729,9 @@ class Migration
                             continue;
                         }
                         $DB->updateOrDie($table, [
-                            'field' => $new_search_opt
+                            'num' => $new_search_opt
                         ], [
-                            'field' => $old_search_opt
+                            'num' => $old_search_opt
                         ]);
                     }
                 }

--- a/tests/functional/Migration.php
+++ b/tests/functional/Migration.php
@@ -1166,9 +1166,9 @@ class Migration extends \GLPITestCase
             "DELETE `glpi_displaypreferences` FROM `glpi_displaypreferences` WHERE `id` IN ('12', '156', '421')",
             "UPDATE `glpi_displaypreferences` SET `num` = '10' WHERE `itemtype` = 'Printer' AND `num` = '20'",
             "UPDATE `glpi_displaypreferences` SET `num` = '1001' WHERE `itemtype` = 'Ticket' AND `num` = '1'",
-            "UPDATE `glpi_tickettemplatehiddenfields` SET `field` = '1001' WHERE `field` = '1'",
-            "UPDATE `glpi_tickettemplatemandatoryfields` SET `field` = '1001' WHERE `field` = '1'",
-            "UPDATE `glpi_tickettemplatepredefinedfields` SET `field` = '1001' WHERE `field` = '1'",
+            "UPDATE `glpi_tickettemplatehiddenfields` SET `num` = '1001' WHERE `num` = '1'",
+            "UPDATE `glpi_tickettemplatemandatoryfields` SET `num` = '1001' WHERE `num` = '1'",
+            "UPDATE `glpi_tickettemplatepredefinedfields` SET `num` = '1001' WHERE `num` = '1'",
             "UPDATE `glpi_savedsearches` SET `query` = 'is_deleted=0&as_map=0&criteria%5B0%5D%5Blink%5D=AND&criteria%5B0%5D%5Bfield%5D=100&criteria%5B0%5D%5Bsearchtype%5D=contains&criteria%5B0%5D%5Bvalue%5D=LT1&criteria%5B1%5D%5Blink%5D=AND&criteria%5B1%5D%5Bitemtype%5D=Budget&criteria%5B1%5D%5Bmeta%5D=1&criteria%5B1%5D%5Bfield%5D=4&criteria%5B1%5D%5Bsearchtype%5D=contains&criteria%5B1%5D%5Bvalue%5D=&search=Search&itemtype=Computer' WHERE `id` = '1'",
             "UPDATE `glpi_savedsearches` SET `query` = 'is_deleted=0&as_map=0&criteria%5B0%5D%5Blink%5D=AND&criteria%5B0%5D%5Bfield%5D=40&criteria%5B0%5D%5Bsearchtype%5D=contains&criteria%5B0%5D%5Bvalue%5D=LT1&criteria%5B1%5D%5Blink%5D=AND&criteria%5B1%5D%5Bitemtype%5D=Computer&criteria%5B1%5D%5Bmeta%5D=1&criteria%5B1%5D%5Bfield%5D=100&criteria%5B1%5D%5Bsearchtype%5D=contains&criteria%5B1%5D%5Bvalue%5D=&search=Search&itemtype=Computer' WHERE `id` = '2'",
         ]);


### PR DESCRIPTION
Fix bug introduced by https://github.com/glpi-project/glpi/pull/16966

Encountered during an update of the `fields` plugin with a migration of `searchoption` IDs

All tables concerning templates use the column `num` instead of `field` (to save the number of the searchoption -> the field).

Ex with `Ticket` (but same for `Change` and `Problem`)

```sql
MariaDB [10bugfixes]> explain glpi_tickettemplatehiddenfields;
+--------------------+------------------+------+-----+---------+----------------+
| Field              | Type             | Null | Key | Default | Extra          |
+--------------------+------------------+------+-----+---------+----------------+
| id                 | int(10) unsigned | NO   | PRI | NULL    | auto_increment |
| tickettemplates_id | int(10) unsigned | NO   | MUL | 0       |                |
| num                | int(11)          | NO   |     | 0       |                |
+--------------------+------------------+------+-----+---------+----------------+
3 rows in set (0,001 sec)

MariaDB [10bugfixes]> explain glpi_tickettemplatemandatoryfields;
+--------------------+------------------+------+-----+---------+----------------+
| Field              | Type             | Null | Key | Default | Extra          |
+--------------------+------------------+------+-----+---------+----------------+
| id                 | int(10) unsigned | NO   | PRI | NULL    | auto_increment |
| tickettemplates_id | int(10) unsigned | NO   | MUL | 0       |                |
| num                | int(11)          | NO   |     | 0       |                |
+--------------------+------------------+------+-----+---------+----------------+
3 rows in set (0,000 sec)

MariaDB [10bugfixes]> explain glpi_tickettemplatepredefinedfields;
+--------------------+------------------+------+-----+---------+----------------+
| Field              | Type             | Null | Key | Default | Extra          |
+--------------------+------------------+------+-----+---------+----------------+
| id                 | int(10) unsigned | NO   | PRI | NULL    | auto_increment |
| tickettemplates_id | int(10) unsigned | NO   | MUL | 0       |                |
| num                | int(11)          | NO   |     | 0       |                |
| value              | text             | YES  |     | NULL    |                |
+--------------------+------------------+------+-----+---------+----------------+
``` 

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
