### PR TITLE
Fix(Marketplace): retrieve 'changelog_url' from API

### DIFF
--- a/src/Marketplace/View.php
+++ b/src/Marketplace/View.php
@@ -235,17 +235,18 @@ class View extends CommonGLPI
             }
 
             $clean_plugin = [
-                'key'          => $key,
-                'name'         => $plugin['name'],
-                'logo_url'     => $apidata['logo_url'] ?? "",
-                'description'  => $apidata['descriptions'][0]['short_description'] ?? "",
-                'authors'      => $apidata['authors'] ?? [['id' => 'all', 'name' => $plugin['author'] ?? ""]],
-                'license'      => $apidata['license'] ?? $plugin['license'] ?? "",
-                'note'         => $apidata['note'] ?? -1,
-                'homepage_url' => $apidata['homepage_url'] ?? "",
-                'issues_url'   => $apidata['issues_url'] ?? "",
-                'readme_url'   => $apidata['readme_url'] ?? "",
-                'version'      => $plugin['version'] ?? "",
+                'key'           => $key,
+                'name'          => $plugin['name'],
+                'logo_url'      => $apidata['logo_url'] ?? "",
+                'description'   => $apidata['descriptions'][0]['short_description'] ?? "",
+                'authors'       => $apidata['authors'] ?? [['id' => 'all', 'name' => $plugin['author'] ?? ""]],
+                'license'       => $apidata['license'] ?? $plugin['license'] ?? "",
+                'note'          => $apidata['note'] ?? -1,
+                'homepage_url'  => $apidata['homepage_url'] ?? "",
+                'issues_url'    => $apidata['issues_url'] ?? "",
+                'readme_url'    => $apidata['readme_url'] ?? "",
+                'version'       => $plugin['version'] ?? "",
+                'changelog_url' => $apidata['changelog_url'] ?? "",
             ];
 
             $plugins[] = $clean_plugin;


### PR DESCRIPTION
Code exist to display a link to get plugin CHANGELOG

`View.php -> getPlugincard()`
```php
        $changelog_url = Html::entities_deep($plugin['changelog_url'] ?? "");
        $changelog_url = strlen($changelog_url)
            ? "<a href='{$changelog_url}' target='_blank' >
               <i class='ti ti-news add_tooltip' title='" . __s("Changelog") . "'></i>
               </a>"
             : "";
``` 

But when the plugin is loaded from the API, we don't retrieve the url.

This involves modifying all plugins that do not have the XML node `<changelog_url>` in the `plugin.xml` file

need : https://github.com/glpi-project/plugins/pull/85

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
