### PR TITLE
Fix phpunit warnings and wrong config dir

### DIFF
--- a/.github/actions/test_tests-phpunit.sh
+++ b/.github/actions/test_tests-phpunit.sh
@@ -10,11 +10,6 @@ else
   PHPUNIT_ADDITIONNAL_OPTIONS="--no-coverage";
 fi
 
-#temporary hack to prevent dual configuration
-if [[ ! -L "phpunit/config" ]]; then
-  ln -s ../tests/config phpunit/config
-fi
-
 vendor/bin/phpunit $PHPUNIT_ADDITIONNAL_OPTIONS
 
 unset COVERAGE_DIR

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -43,7 +43,7 @@ ini_set('display_errors', 'On');
 error_reporting(E_ALL);
 
 define('GLPI_ROOT', __DIR__ . '/../');
-define('GLPI_CONFIG_DIR', getenv('GLPI_CONFIG_DIR') ?: __DIR__ . '/config');
+define('GLPI_CONFIG_DIR', getenv('GLPI_CONFIG_DIR') ?: __DIR__ . '/../tests/config');
 define('GLPI_VAR_DIR', getenv('GLPI_VAR_DIR') ?: __DIR__ . '/files');
 define('GLPI_URI', getenv('GLPI_URI') ?: 'http://localhost:8088');
 define('GLPI_STRICT_DEPRECATED', true); //enable strict depreciations
@@ -110,3 +110,4 @@ loadDataset();
 // There is no need to pollute the output with error messages.
 ini_set('display_errors', 'Off');
 ErrorHandler::getInstance()->disableOutput();
+ErrorHandler::getInstance()->setForwardToInternalHandler(false);


### PR DESCRIPTION
"Expected" warnings are still being processed by PHP native handler, which display them.
It is only a visual issue on this branch, but on the `main` branch it makes the tests fails (due to process isolation being enabled, not sure why).

![image](https://github.com/glpi-project/glpi/assets/42734840/ac6c99ba-ba03-4a62-8554-a17756aba7be)

Note that this is the second time I get warnings that do not exist on the CI report (see #17455), there might be something wrong with it (I have confirmed with other developers that they have the same issue so it does not come from my setup).

Also the fallback for GLPI_CONFIG_DIR is wrong, it looks for a config file in the `phpunit` folder instead of `tests/config`.
This later part is a `10.0-bugfixes` only issue, it does not exist on `main`.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 