### PR TITLE
Fix(KnowbaseItem): fix the list of documents and their download

### DIFF
--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -562,7 +562,12 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
             }
         } else {
             $where = self::getVisibilityCriteriaKB();
-            $where['is_faq'] = 1;
+            $where[] = [
+                'OR' => [
+                    ['is_faq' => 1],
+                    ['is_token_url' => 1, 'token' => $_GET['token'] ?? '']
+                ]
+            ];
         }
 
         return $where;
@@ -919,7 +924,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
                 $downloadlink = NOT_AVAILABLE;
 
                 if ($document->getFromDB($docID)) {
-                    $downloadlink = $document->getDownloadLink();
+                    $downloadlink = $document->getDownloadLink($this);
                 }
 
                 if (!isset($heading_names[$data["documentcategories_id"]])) {


### PR DESCRIPTION
Since a knowledge base article can be shared with a single URL (and token)

GLPI no longer displays the list of documents.

```getVisibilityCriteriaFAQ()``` updates fix this issue.

Now that the document is visible it is not possible to download it.

GLPI returns the error _You do not have the required rights_.


```showFull()``` updates fix this issue by passing Item linked to the document, to check access rights


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30072
