### PR TITLE
Fix(ProjectTask): keep PojectTaskTeam when use a template

### DIFF
--- a/phpunit/functional/ProjectTaskTest.php
+++ b/phpunit/functional/ProjectTaskTest.php
@@ -372,6 +372,30 @@ class ProjectTaskTest extends DbTestCase
             'name'            => 'Subtask 2',
         ]);
 
+        // Create a user
+        $user_name = 'Project testClone - User' . random_int(0, 99999);
+        $this->createItems('User', [['name' => $user_name]]);
+        $users_id = getItemByTypeName("User", $user_name, true);
+
+       // Create a group
+        $group_name = 'Project testClone - Group' . random_int(0, 99999);
+        $this->createItems('Group', [['name' => $group_name]]);
+        $groups_id = getItemByTypeName("Group", $group_name, true);
+
+        // Add team to project
+        $this->createItems('ProjectTaskTeam', [
+            [
+                'projecttasks_id' => $task->fields['id'],
+                'itemtype'    => 'User',
+                'items_id'    => $users_id,
+            ],
+            [
+                'projecttasks_id' => $task->fields['id'],
+                'itemtype'    => 'Group',
+                'items_id'    => $groups_id,
+            ],
+        ]);
+
         // Clone the task
         $clonedTaskId = $task->clone();
         $clonedTask = \ProjectTask::getById($clonedTaskId);
@@ -379,6 +403,28 @@ class ProjectTaskTest extends DbTestCase
         // Check if the cloned task is in the same project with the same name
         $this->assertEquals($project->getID(), $clonedTask->fields['projects_id']);
         $this->assertEquals($task->fields['name'] . ' (copy)', $clonedTask->fields['name']);
+
+        // Load task team
+        $project_task_team = new \ProjectTaskTeam();
+        $team = [];
+        foreach ($project_task_team->find(['projecttasks_id' => $task->fields['id']]) as $row) {
+            $team[] = [
+                'itemtype' => $row['itemtype'],
+                'items_id' => $row['items_id'],
+            ];
+        }
+
+        // Load clone team
+        $team_clone = [];
+        foreach ($project_task_team->find(['projecttasks_id' => $clonedTaskId]) as $row) {
+            $team_clone[] = [
+                'itemtype' => $row['itemtype'],
+                'items_id' => $row['items_id'],
+            ];
+        }
+
+        // Compare teams
+        $this->assertEquals($team, $team_clone);
 
         // Check if the subtask has been cloned
         $clonedSubtask = new \ProjectTask();

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -72,6 +72,13 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
     const UPDATEMY    = 1024;
 
 
+    public function getCloneRelations(): array
+    {
+        return [
+            ProjectTaskTeam::class,
+        ];
+    }
+
     public static function getTypeName($nb = 0)
     {
         return _n('Project task', 'Project tasks', $nb);


### PR DESCRIPTION
When a project is created from a template containing tasks with assigned actors,

the created project does contain the tasks, but they no longer have actors.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !30072
