### PR TITLE
Deprecate `Html::entities_deep()` and `Html::entity_decode_deep()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,8 @@ The present file will list all changes made to the project; according to the
 - `Html::cleanInputText()`
 - `Html::cleanPostForTextArea()`
 - `Html::createProgressBar()`
+- `Html::entities_deep()`
+- `Html::entity_decode_deep()`
 - `HookManager::enableCSRF()`
 - `Knowbase::getTreeCategoryList()`
 - `Knowbase::showBrowseView()`

--- a/phpunit/functional/HtmlTest.php
+++ b/phpunit/functional/HtmlTest.php
@@ -656,10 +656,10 @@ class HtmlTest extends \GLPITestCase
     {
         $value = 'Should be \' "escaped" éè!';
         $expected = 'Should be &#039; &quot;escaped&quot; &eacute;&egrave;!';
-        $result = \Html::entities_deep($value);
+        $result = @\Html::entities_deep($value);
         $this->assertSame($expected, $result);
 
-        $result = \Html::entities_deep([$value, $value, $value]);
+        $result = @\Html::entities_deep([$value, $value, $value]);
         $this->assertSame([$expected, $expected, $expected], $result);
     }
 

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -1453,7 +1453,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         }
 
         $html .= "<img src='" . $CFG_GLPI["root_doc"] . "/pics/rdv_interv.png' alt='' title=\"" .
-             Html::entities_deep($parent->getTypeName(1)) . "\">&nbsp;&nbsp;";
+             htmlspecialchars($parent->getTypeName(1)) . "\">&nbsp;&nbsp;";
         $html .= $parent->getStatusIcon($val['status']);
         $html .= "&nbsp;<a id='content_tracking_" . $val["id"] . $rand . "'
                    href='" . $parenttype::getFormURLWithID($val[$parenttype_fk]) . "'
@@ -1918,7 +1918,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
 
         $vcalendar = $this->getVCalendarForItem($this, $target_component);
 
-        $parent_fields = Html::entity_decode_deep($parent_item->fields);
+        $parent_fields = $parent_item->fields;
         $utc_tz = new \DateTimeZone('UTC');
 
         $vcomp = $vcalendar->getBaseComponent();

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -2191,8 +2191,6 @@ JAVASCRIPT;
             }
         }
 
-        $param['option_tooltips'] = Html::entities_deep($param['option_tooltips']);
-
         if ($param["display_emptychoice"] && !$param["multiple"]) {
             $elements = [ 0 => $param['emptylabel'] ] + $elements;
         }
@@ -2228,11 +2226,11 @@ JAVASCRIPT;
             }
 
             if ($param['tooltip']) {
-                $output .= ' title="' . Html::entities_deep($param['tooltip']) . '"';
+                $output .= ' title="' . htmlspecialchars($param['tooltip']) . '"';
             }
 
             if ($param['class']) {
-                $output .= ' class="' . Html::entities_deep($param['class']) . '"';
+                $output .= ' class="' . htmlspecialchars($param['class']) . '"';
             }
 
             if (!empty($param["on_change"])) {
@@ -2280,7 +2278,7 @@ JAVASCRIPT;
             foreach ($elements as $key => $val) {
                // optgroup management
                 if (is_array($val)) {
-                    $opt_goup = Html::entities_deep($key);
+                    $opt_goup = htmlspecialchars($key);
                     if ($max_option_size < strlen($opt_goup)) {
                         $max_option_size = strlen($opt_goup);
                     }
@@ -2290,11 +2288,11 @@ JAVASCRIPT;
                     if (isset($param['option_tooltips'][$key])) {
                         if (is_array($param['option_tooltips'][$key])) {
                             if (isset($param['option_tooltips'][$key]['__optgroup_label'])) {
-                                $output .= ' title="' . $param['option_tooltips'][$key]['__optgroup_label'] . '"';
+                                $output .= ' title="' . htmlspecialchars($param['option_tooltips'][$key]['__optgroup_label']) . '"';
                             }
                             $optgroup_tooltips = $param['option_tooltips'][$key];
                         } else {
-                            $output .= ' title="' . $param['option_tooltips'][$key] . '"';
+                            $output .= ' title="' . htmlspecialchars($param['option_tooltips'][$key]) . '"';
                         }
                     }
                     $output .= ">";
@@ -2310,9 +2308,9 @@ JAVASCRIPT;
                                 }
                             }
                             if ($optgroup_tooltips && isset($optgroup_tooltips[$key2])) {
-                                $output .= ' title="' . $optgroup_tooltips[$key2] . '"';
+                                $output .= ' title="' . htmlspecialchars($optgroup_tooltips[$key2]) . '"';
                             }
-                            $output .= ">" .  Html::entities_deep($val2) . "</option>";
+                            $output .= ">" .  htmlspecialchars($val2) . "</option>";
                             if ($max_option_size < strlen($val2)) {
                                 $max_option_size = strlen($val2);
                             }
@@ -2321,7 +2319,7 @@ JAVASCRIPT;
                     $output .= "</optgroup>";
                 } else {
                     if (!isset($param['used'][$key])) {
-                        $output .= "<option value='" . Html::entities_deep($key) . "'";
+                        $output .= "<option value='" . htmlspecialchars($key) . "'";
                        // Do not use in_array : trouble with 0 and empty value
                         foreach ($param['values'] as $value) {
                             if (strcmp($key, $value) === 0) {
@@ -2330,9 +2328,9 @@ JAVASCRIPT;
                             }
                         }
                         if (isset($param['option_tooltips'][$key])) {
-                            $output .= ' title="' . $param['option_tooltips'][$key] . '"';
+                            $output .= ' title="' . htmlspecialchars($param['option_tooltips'][$key]) . '"';
                         }
-                        $output .= ">" . Html::entities_deep($val) . "</option>";
+                        $output .= ">" . htmlspecialchars($val) . "</option>";
                         if (!is_null($val) && ($max_option_size < strlen($val))) {
                             $max_option_size = strlen($val);
                         }

--- a/src/Glpi/CalDAV/Traits/VobjectConverterTrait.php
+++ b/src/Glpi/CalDAV/Traits/VobjectConverterTrait.php
@@ -283,9 +283,9 @@ trait VobjectConverterTrait
 
         $content = $vcomponent->DESCRIPTION->getValue();
 
-       // Content is handled as plain text in CalDAV client and will be handled as rich text on GLPI side,
-       // so special chars have to be encoded in html entities.
-        $content = \Html::entities_deep($content);
+        // Content is handled as plain text in CalDAV client and will be handled as rich text on GLPI side,
+        // so special chars have to be encoded in html entities.
+        $content = htmlspecialchars($content);
 
         return $content;
     }

--- a/src/Glpi/Marketplace/View.php
+++ b/src/Glpi/Marketplace/View.php
@@ -531,7 +531,7 @@ JS;
         $description = Toolbox::stripTags($plugin['description']);
 
         $authors = Toolbox::stripTags(implode(', ', array_column($plugin['authors'] ?? [], 'name', 'id')));
-        $authors_title = Html::entities_deep($authors);
+        $authors_title = htmlspecialchars($authors);
         $authors = strlen($authors)
             ? "<i class='fa-fw ti ti-users'></i>{$authors}"
             : "";
@@ -550,28 +550,28 @@ JS;
             ? self::getStarsHtml($plugin['note'])
             : "";
 
-        $home_url = Html::entities_deep($plugin['homepage_url'] ?? "");
+        $home_url = htmlspecialchars($plugin['homepage_url'] ?? "");
         $home_url = strlen($home_url)
             ? "<a href='{$home_url}' target='_blank' >
                <i class='ti ti-home-2 add_tooltip' title='" . __s("Homepage") . "'></i>
                </a>"
             : "";
 
-        $issues_url = Html::entities_deep($plugin['issues_url'] ?? "");
+        $issues_url = htmlspecialchars($plugin['issues_url'] ?? "");
         $issues_url = strlen($issues_url)
             ? "<a href='{$issues_url}' target='_blank' >
                <i class='ti ti-bug add_tooltip' title='" . __s("Get help") . "'></i>
                </a>"
             : "";
 
-        $readme_url = Html::entities_deep($plugin['readme_url'] ?? "");
+        $readme_url = htmlspecialchars($plugin['readme_url'] ?? "");
         $readme_url = strlen($readme_url)
             ? "<a href='{$readme_url}' target='_blank' >
                <i class='ti ti-book add_tooltip' title='" . __s("Readme") . "'></i>
                </a>"
             : "";
 
-        $changelog_url = Html::entities_deep($plugin['changelog_url'] ?? "");
+        $changelog_url = htmlspecialchars($plugin['changelog_url'] ?? "");
         $changelog_url = strlen($changelog_url)
             ? "<a href='{$changelog_url}' target='_blank' >
                <i class='ti ti-news add_tooltip' title='" . __s("Changelog") . "'></i>
@@ -939,7 +939,7 @@ HTML;
     {
         $icon = "";
 
-        $logo_url = Html::entities_deep($plugin['logo_url'] ?? "");
+        $logo_url = htmlspecialchars($plugin['logo_url'] ?? "");
         if (strlen($logo_url)) {
             $icon = "<img src='{$logo_url}'>";
         } else {

--- a/src/Glpi/RichText/RichText.php
+++ b/src/Glpi/RichText/RichText.php
@@ -48,12 +48,12 @@ final class RichText
      *
      * @since 10.0.0
      *
-     * @param null|string   $content                HTML string to be made safe
-     * @param boolean       $encode_output_entities Indicates whether the output should be encoded (encoding of HTML special chars)
+     * @param null|string   $content        HTML string to be made safe
+     * @param boolean       $encode_output  Indicates whether the output should be encoded (encoding of HTML special chars)
      *
      * @return string
      */
-    public static function getSafeHtml(?string $content, bool $encode_output_entities = false): string
+    public static function getSafeHtml(?string $content, bool $encode_output = false): string
     {
 
         if (empty($content)) {
@@ -67,8 +67,8 @@ final class RichText
         // Remove extra lines
         $content = trim($content, "\r\n");
 
-        if ($encode_output_entities) {
-            $content = Html::entities_deep($content);
+        if ($encode_output) {
+            $content = htmlspecialchars($content);
         }
 
         return $content;
@@ -82,7 +82,7 @@ final class RichText
      * @param string  $content                HTML string to be made safe
      * @param boolean $keep_presentation      Indicates whether the presentation elements have to be replaced by plaintext equivalents
      * @param boolean $compact                Indicates whether the output should be compact (limited line length, no links URL, ...)
-     * @param boolean $encode_output_entities Indicates whether the output should be encoded (encoding of HTML special chars)
+     * @param boolean $encode_output          Indicates whether the output should be encoded (encoding of HTML special chars)
      * @param boolean $preserve_line_breaks   Indicates whether the line breaks should be preserved
      *
      * @return string
@@ -91,7 +91,7 @@ final class RichText
         string $content,
         bool $keep_presentation = true,
         bool $compact = false,
-        bool $encode_output_entities = false,
+        bool $encode_output = false,
         bool $preserve_case = false,
         bool $preserve_line_breaks = false
     ): string {
@@ -145,14 +145,14 @@ final class RichText
             }
 
             // Content is no more considered as HTML, decode its entities
-            $content = Html::entity_decode_deep($content);
+            $content = html_entity_decode($content);
         }
 
         // Remove extra lines
         $content = trim($content, "\r\n");
 
-        if ($encode_output_entities) {
-            $content = Html::entities_deep($content);
+        if ($encode_output) {
+            $content = htmlspecialchars($content);
         }
 
         return $content;
@@ -235,7 +235,7 @@ final class RichText
             if (preg_match('/(<|>)/', $content)) {
                 // Input was not HTML, and special chars were not saved as HTML entities.
                 // We have to encode them into HTML entities.
-                $content = Html::entities_deep($content);
+                $content = htmlspecialchars($content);
             }
 
             // Plain text line breaks have to be transformed into <br /> tags.

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -6052,7 +6052,7 @@ final class SQLProvider implements SearchProviderInterface
                         $count_display++;
                         if (!empty($data[$ID][$k]['name'])) {
                             $out .= (empty($out) ? '' : \Search::LBBR);
-                            $out .= "<a href='mailto:" . \Html::entities_deep($data[$ID][$k]['name']) . "'>" . $data[$ID][$k]['name'];
+                            $out .= "<a href='mailto:" . htmlspecialchars($data[$ID][$k]['name']) . "'>" . $data[$ID][$k]['name'];
                             $out .= "</a>";
                         }
                     }

--- a/src/Html.php
+++ b/src/Html.php
@@ -64,9 +64,13 @@ class Html
      * @param string|array $value
      *
      * @return string|array
+     *
+     * @deprecated 11.0.0
      **/
     public static function entity_decode_deep($value)
     {
+        Toolbox::deprecated();
+
         if (is_array($value)) {
             return array_map([__CLASS__, 'entity_decode_deep'], $value);
         }
@@ -83,9 +87,13 @@ class Html
      * @param string|array $value
      *
      * @return string|array
+     *
+     * @deprecated 11.0.0
      **/
     public static function entities_deep($value)
     {
+        Toolbox::deprecated();
+
         if (is_array($value)) {
             return array_map([__CLASS__, 'entities_deep'], $value);
         }

--- a/src/Item_RemoteManagement.php
+++ b/src/Item_RemoteManagement.php
@@ -209,7 +209,7 @@ class Item_RemoteManagement extends CommonDBChild
     public function getRemoteLink(): string
     {
         $link = '<a href="%s" target="_blank">%s</a>';
-        $id = Html::entities_deep($this->fields['remoteid']);
+        $id = htmlspecialchars($this->fields['remoteid'] ?? '');
         $href = null;
         switch ($this->fields['type']) {
             case self::TEAMVIEWER:

--- a/src/NotificationTemplate.php
+++ b/src/NotificationTemplate.php
@@ -273,7 +273,7 @@ class NotificationTemplate extends CommonDBTM
                      "<html>
                         <head>
                          <META http-equiv='Content-Type' content='text/html; charset=utf-8'>
-                         <title>" . Html::entities_deep($lang['subject']) . "</title>
+                         <title>" . htmlspecialchars($lang['subject']) . "</title>
                          <style type='text/css'>
                            {$css}
                          </style>
@@ -446,10 +446,10 @@ class NotificationTemplate extends CommonDBTM
                 } else { // check exact match
                     if (isset($data['##' . $if_field . '##'])) {
                       // Data value: the value for the field in the database
-                        $data_value = Html::entity_decode_deep($data['##' . $if_field . '##']);
+                        $data_value = $data['##' . $if_field . '##'];
 
                       // Condition value: the expected value needed to validate the condition
-                        $condition_value = Html::entity_decode_deep($out[2][$key]);
+                        $condition_value = $out[2][$key];
 
                       // Special case for data returned by Dropdown::getYesNo, we
                       // need to use the localized value in the comparison
@@ -495,8 +495,8 @@ class NotificationTemplate extends CommonDBTM
                 continue;
             }
             $data[$tag] = RichText::isRichTextHtmlContent($value)
-            ? RichText::getSafeHtml($value) // Value is rich text, make it safe
-            : nl2br(Html::entities_deep($value)); // Value is plain text, encode its entities
+                ? RichText::getSafeHtml($value) // Value is rich text, make it safe
+                : nl2br(htmlspecialchars($value)); // Value is plain text, encode its entities
         }
 
         return $data;

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2642,8 +2642,9 @@ TWIG;
                 return self::getState($state);
             break;
             case 'homepage':
-                $value = Html::entities_deep(Toolbox::formatOutputWebLink($values[$field]));
+                $value = Toolbox::formatOutputWebLink($values[$field]);
                 if (!empty($value)) {
+                    $value = htmlspecialchars($value);
                     return "<a href=\"" . $value . "\" target='_blank'>
                      <i class='fas fa-external-link-alt fa-2x'></i><span class='sr-only'>$value</span>
                   </a>";

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -2278,7 +2278,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
 
         $vcalendar = $this->getVCalendarForItem($this, $target_component);
 
-        $fields = Html::entity_decode_deep($this->fields);
+        $fields = $this->fields;
         $utc_tz = new \DateTimeZone('UTC');
 
         $vcomp = $vcalendar->getBaseComponent();

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -1123,7 +1123,6 @@ TWIG, $twig_params);
             ];
             // check entities
             if ($tmprule->isEntityAssign()) {
-                $rule['entities_id'] = $DB->escape(Html::entity_decode_deep($rule['entities_id']));
                 $entities_found = $entity->find(['completename' => $rule['entities_id']]);
                 if (empty($entities_found)) {
                     $refused_rule['reasons'][] = ['entity' => $rule['entities_id']];

--- a/src/UserEmail.php
+++ b/src/UserEmail.php
@@ -173,7 +173,7 @@ class UserEmail extends CommonDBChild
         if ($this->isNewID($this->getID())) {
             $value = '';
         } else {
-            $value = Html::entities_deep($this->fields['email']);
+            $value = htmlspecialchars($this->fields['email'] ?? '');
         }
         $result = "";
         $field_name = $field_name . "[$id]";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

These methods were initialy made to encode/decode entities in arrays, for instance to encode an array as it was done by the autosanitize logic, or to decode an item fields retrieved from the database.

Deprecating them will force people to either use the `htmlspeciachars` function in the HTML strinc concatenation context, either remove its usage that is no longer necessary due to removal of the autosanitize logic. It is exacly what I had to done in the GLPI code, and it permits me to see that we still had some pieces of code that were manually encoding/escaping stuffs that should not be encoded/escaped anymore.