### PR TITLE
Replace `htmlentities()` usages by `htmlspecialchars()`

### DIFF
--- a/ajax/uemailUpdate.php
+++ b/ajax/uemailUpdate.php
@@ -125,7 +125,7 @@ if (
         );
     } else {
         $email_string = "<input type='mail' class='form-control' name='" . $_POST['field'] . "[alternative_email][]'
-                        value='" . htmlentities($default_email, ENT_QUOTES, 'utf-8') . "'>";
+                        value='" . htmlspecialchars($default_email) . "'>";
     }
 
     echo "$email_string";

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1410,7 +1410,7 @@ class CommonDBTM extends CommonGLPI
         if (!preg_match('/title=/', $p['linkoption'])) {
             $thename = $this->getName(['complete' => true]);
             if ($thename != NOT_AVAILABLE) {
-                $title = ' title="' . htmlentities($thename, ENT_QUOTES, 'utf-8') . '"';
+                $title = ' title="' . htmlspecialchars($thename) . '"';
             }
         }
 

--- a/src/Glpi/Api/HL/Middleware/DebugResponseMiddleware.php
+++ b/src/Glpi/Api/HL/Middleware/DebugResponseMiddleware.php
@@ -79,7 +79,7 @@ class DebugResponseMiddleware extends AbstractMiddleware implements ResponseMidd
             $header_value = '';
             foreach ($debug_messages as $debug_message) {
                 // escape quotes in the message, quote the message, and add it to the header value, and append a comma to the end
-                $msg = htmlentities($debug_message, ENT_QUOTES, 'UTF-8');
+                $msg = htmlspecialchars($debug_message);
                 $header_value .= '"' . $msg . '",';
             }
             // remove the last comma from the header value

--- a/src/Html.php
+++ b/src/Html.php
@@ -2584,7 +2584,7 @@ HTML;
             } else {
                 $out .= "onclick='modal_massiveaction_window$identifier.show();'";
             }
-            $out .= " href='#modal_massaction_content$identifier' title=\"" . htmlentities($p['title'], ENT_QUOTES, 'UTF-8') . "\">";
+            $out .= " href='#modal_massaction_content$identifier' title=\"" . htmlspecialchars($p['title']) . "\">";
             if ($p['display_arrow']) {
                 $out .= "<i class='ti ti-corner-left-" . ($p['ontop'] ? 'down' : 'up') . " mt-1' style='margin-left: -2px;'></i>";
             }
@@ -4014,7 +4014,7 @@ JAVASCRIPT
                                 echo "(object) " . get_class($val);
                             }
                         } else {
-                            echo htmlentities($val ?? "");
+                            echo htmlspecialchars($val ?? "");
                         }
                     }
                 }

--- a/src/autoload/i18n.php
+++ b/src/autoload/i18n.php
@@ -75,7 +75,7 @@ function __($str, $domain = 'glpi')
 
 
 /**
- * Translate a string and escape HTML entities
+ * Translate a string and escape HTML special chars.
  *
  * @since 0.84
  *
@@ -86,12 +86,12 @@ function __($str, $domain = 'glpi')
  */
 function __s($str, $domain = 'glpi')
 {
-    return htmlentities(__($str, $domain), ENT_QUOTES, 'UTF-8');
+    return htmlspecialchars(__($str, $domain));
 }
 
 
 /**
- * Translate a contextualized string and escape HTML entities
+ * Translate a contextualized string and escape HTML special chars.
  *
  * @since 0.84
  *
@@ -99,11 +99,11 @@ function __s($str, $domain = 'glpi')
  * @param string $str    to translate
  * @param string $domain domain used (default is glpi, may be plugin name)
  *
- * @return string protected string (with htmlentities)
+ * @return string
  */
 function _sx($ctx, $str, $domain = 'glpi')
 {
-    return htmlentities(_x($ctx, $str, $domain), ENT_QUOTES, 'UTF-8');
+    return htmlspecialchars(_x($ctx, $str, $domain));
 }
 
 
@@ -140,7 +140,7 @@ function _n($sing, $plural, $nb, $domain = 'glpi')
 
 
 /**
- * Pluralized translation with HTML entities escaped
+ * Pluralized translation with HTML special chars escaped
  *
  * @since 0.84
  *
@@ -149,11 +149,11 @@ function _n($sing, $plural, $nb, $domain = 'glpi')
  * @param integer $nb     to select singular or plural
  * @param string  $domain domain used (default is glpi, may be plugin name)
  *
- * @return string protected string (with htmlentities)
+ * @return string
  */
 function _sn($sing, $plural, $nb, $domain = 'glpi')
 {
-    return htmlentities(_n($sing, $plural, $nb, $domain), ENT_QUOTES, 'UTF-8');
+    return htmlspecialchars(_n($sing, $plural, $nb, $domain));
 }
 
 

--- a/tests/functional/Glpi/RichText/RichText.php
+++ b/tests/functional/Glpi/RichText/RichText.php
@@ -72,7 +72,7 @@ class RichText extends \GLPITestCase
   <url>http://www.glpi-project.org/void?test=1&amp;debug=1</url>
 </root>
 XML;
-        $content = '<h1>XML example</h1>' . "\n" . htmlentities($xml_sample);
+        $content = '<h1>XML example</h1>' . "\n" . htmlspecialchars($xml_sample);
         $result  = '<h1>XML example</h1>' . "\n" . str_replace(['&', '<', '>', '"', '='], ['&amp;', '&lt;', '&gt;', '&#34;', '&#61;'], $xml_sample);
         yield [
             'content'                => $content,
@@ -454,7 +454,7 @@ HTML,
   <url>http://www.glpi-project.org/void?test=1&amp;debug=1</url>
 </root>
 XML;
-        $content = '<h1>XML example</h1>' . "\n" . htmlentities($xml_sample);
+        $content = '<h1>XML example</h1>' . "\n" . htmlspecialchars($xml_sample);
         $result  = <<<PLAINTEXT
 XML example <?xml version="1.0" encoding="UTF-8"?> <root> <desc><![CDATA[Some CDATA content]]></desc> <url>http://www.glpi-project.org/void?test=1&amp;debug=1</url> </root>
 PLAINTEXT;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

There is no need to encode more chars than thosse encode by `htmlspecialchars()`.