### PR TITLE
Add retries to a specific flaky test suite

### DIFF
--- a/tests/cypress/e2e/form/form_preview.cy.js
+++ b/tests/cypress/e2e/form/form_preview.cy.js
@@ -31,7 +31,15 @@
  * ---------------------------------------------------------------------
  */
 
-describe('Form preview', () => {
+// Tests from this file seems to randomly fail 1/20 times.
+// No one has been able to fix it yet, thus we are adding retries for now...
+const config = {
+    retries: {
+        runMode: 2,
+    },
+};
+
+describe('Form preview', config, () => {
     beforeEach(() => {
         cy.createWithAPI('Glpi\\Form\\Form', {
             'name': 'Test form preview',


### PR DESCRIPTION
Tests from the `form_preview` suite still fails from time to time for unknown reasons.
I suspect is able to click super fast on the `save` button while the ajax controller code is not yet loaded but I can't prove or fix it at this time.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
