### PR TITLE
Fix(Rule): remove useless 'search' entry

### DIFF
--- a/src/Rule.php
+++ b/src/Rule.php
@@ -240,8 +240,6 @@ class Rule extends CommonDBTM
                               = $rulecollection->getRuleClass()->getTitle();
                     $menu['rule']['options'][$rulecollection->menu_option]['page']
                               = $ruleclassname::getSearchURL(false);
-                    $menu['rule']['options'][$rulecollection->menu_option]['links']['search']
-                              = $ruleclassname::getSearchURL(false);
                     if ($rulecollection->canCreate()) {
                         $menu['rule']['options'][$rulecollection->menu_option]['links']['add']
                               = $ruleclassname::getFormURL(false);


### PR DESCRIPTION
Remove useless `search` entry

![image](https://github.com/user-attachments/assets/07d3804d-2997-4052-8a7a-8d5a1f2ad490)

There is simply no search filter here or for the rules in general.

Apply on : 

- ```rule_ldap```
- ```rule_import```
-  ```rule_location```
-  ```rule_ticket```
-  ```rule_softwarecategories```
-  ```rule_mailcollector```


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #17500 
