### PR TITLE
Associate IP discovered through LLDP with NetworkPort

### DIFF
--- a/src/Inventory/Asset/NetworkPort.php
+++ b/src/Inventory/Asset/NetworkPort.php
@@ -170,7 +170,8 @@ class NetworkPort extends InventoryAsset
             'ifnumber'  => 'logical_number',
             'model'     => 'networkportmodels_id',
             'sysmac'    => 'mac',
-            'sysname'   => 'name'
+            'sysname'   => 'name',
+            'ip'        => 'ipaddress'
         ];
 
         foreach ($connections as $connection) {


### PR DESCRIPTION
LLDP is capable of IP discover of the client on a switch that contains an IP address on the same interface than the device connected to the port through the ARP table, and this info can be reported through GLPI Agent as ``<PORTS><PORT><CONNECTION><IP>`` can be seen on it's schema: https://documentation.fusioninventory.org/Advanced_topics/dev/spec/protocol/netinventory/ but GLPI seems to not associate the IP address to the NetworkPort of the device if this information comes from LLDP.

<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/glpi-project/glpi-agent/pull/712
