### PR TITLE
Move tabler/bootstrap scss compile to webpack

### DIFF
--- a/.webpack.config.js
+++ b/.webpack.config.js
@@ -25,6 +25,12 @@ let config = {
             entries[path.basename(file, '.js')] = file;
         }
 
+        // Handle SCSS files
+        const scssFiles = globSync(path.resolve(__dirname, 'lib/bundles') + '/!(*.min).scss');
+        for (const file of scssFiles) {
+            entries[path.basename(file, '.scss')] = file;
+        }
+
         return entries;
     },
     output: {
@@ -82,6 +88,11 @@ let config = {
                         return sanitizedPath;
                     },
                 },
+            },
+            {
+                // Build SCSS files
+                test: /\.scss$/,
+                use: [MiniCssExtractPlugin.loader, 'css-loader', 'sass-loader'],
             },
         ],
     },
@@ -163,23 +174,8 @@ var filesToCopy = [
     },
     // SCSS files
     {
-        package: '@fontsource/inter',
-        from: '{scss/mixins.scss,files/*all-[0-9]00*.woff,files/*[0-9]00*.woff2}',
-        to: scssOutputPath,
-    },
-    {
-        package: '@tabler/core',
-        from: 'src/scss/**/*.scss',
-        to: scssOutputPath,
-    },
-    {
-        package: '@tabler/icons-webfont',
-        from: 'dist/{fonts/*,tabler-icons.scss}',
-        to: scssOutputPath,
-    },
-    {
         package: 'bootstrap',
-        from: 'scss/**/*.scss',
+        from: 'scss/vendor/_rfs.scss',
         to: scssOutputPath,
     },
     {

--- a/.webpack.config.js
+++ b/.webpack.config.js
@@ -16,19 +16,19 @@ const scssOutputPath = 'css/lib';
  */
 let config = {
     entry: function () {
-        // Create an entry per *.js file in lib/bundle directory.
+        // Create an entry per file in lib/bundle directory.
         // Entry name will be name of the file (without ext).
         let entries = {};
 
-        const files = globSync(path.resolve(__dirname, 'lib/bundles') + '/!(*.min).js');
-        for (const file of files) {
-            entries[path.basename(file, '.js')] = file;
-        }
-
-        // Handle SCSS files
-        const scssFiles = globSync(path.resolve(__dirname, 'lib/bundles') + '/!(*.min).scss');
-        for (const file of scssFiles) {
-            entries[path.basename(file, '.scss')] = file;
+        for (const ext of ['.js', '.scss']) {
+            const files = globSync(path.resolve(__dirname, 'lib/bundles') + '/!(*.min)' + ext);
+            for (const file of files) {
+                const entry_name = path.basename(file, ext);
+                if (entry_name in entries) {
+                    throw new Error(`Duplicate bundle entry: '${entry_name}'.`);
+                }
+                entries[entry_name] = file;
+            }
         }
 
         return entries;

--- a/css/includes/_tabler_compat.scss
+++ b/css/includes/_tabler_compat.scss
@@ -131,4 +131,4 @@ $input-focus-border-color: color-mix(in srgb, var(--tblr-primary), white 50%);
 $input-focus-box-shadow: 0 0 1 .25rem color-mix(in srgb, var(--tblr-primary), transparent 75%);
 
 // RFS. Done as import because of complexity.
-@import "../lib/bootstrap/scss/vendor/rfs";
+@import "../lib/bootstrap/rfs";

--- a/install/install.php
+++ b/install/install.php
@@ -83,7 +83,7 @@ function header_html($etape)
     echo Html::script("js/glpi_dialog.js");
 
     // CSS
-    echo Html::scss("css/tabler", [], true);
+    echo Html::css('public/lib/tabler.css');
     echo Html::css('public/lib/base.css');
     echo Html::scss("css/install", [], true);
     echo "</head>";

--- a/install/update.php
+++ b/install/update.php
@@ -192,6 +192,7 @@ echo "<title>Setup GLPI</title>";
 echo Html::script("public/lib/base.js");
 echo Html::script("js/glpi_dialog.js");
 // CSS
+echo Html::css('public/lib/tabler.css');
 echo Html::css('public/lib/base.css');
 echo Html::scss("css/install", [], true);
 echo "</head>";

--- a/lib/bundles/tabler.scss
+++ b/lib/bundles/tabler.scss
@@ -6,7 +6,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2024 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -34,10 +33,10 @@
 $enable-negative-margins: true;
 $link-hover-decoration: none;
 
-@import "~@tabler/core/src/scss/core";
-@import "~@fontsource/inter/scss/mixins";
+@import "@tabler/core/src/scss/core";
+@import "@fontsource/inter/scss/mixins";
 
-$fontDir: "../css/lib/fontsource/inter/files";
+$fontDir: "@fontsource/inter/files";
 
 @include fontFace($weight: 100);
 @include fontFace($weight: 200);
@@ -53,6 +52,6 @@ $fontDir: "../css/lib/fontsource/inter/files";
     --tblr-font-sans-serif: inter, -apple-system, blinkmacsystemfont, san francisco, segoe ui, roboto, helvetica neue, sans-serif;
 }
 
-$ti-font-path: "../css/lib/tabler/icons-webfont/dist/fonts";
+$ti-font-path: "@tabler/icons-webfont/dist/fonts";
 
-@import "~@tabler/icons-webfont/dist/tabler-icons";
+@import "@tabler/icons-webfont/dist/tabler-icons";

--- a/src/Html.php
+++ b/src/Html.php
@@ -1211,7 +1211,7 @@ HTML;
         } else {
             $theme_path = $theme->getPath();
         }
-        $tpl_vars['css_files'][] = ['path' => 'css/tabler.scss'];
+        $tpl_vars['css_files'][] = ['path' => 'public/lib/tabler.css'];
         $tpl_vars['css_files'][] = ['path' => 'css/glpi.scss'];
         if ($theme->isCustomTheme()) {
             $tpl_vars['css_files'][] = ['path' => $theme_path];

--- a/src/Html.php
+++ b/src/Html.php
@@ -3549,7 +3549,7 @@ JS;
        // Apply all GLPI styles to editor content
         $theme = ThemeManager::getInstance()->getCurrentTheme();
         $content_css_paths = [
-            'css/tabler.scss',
+            'public/lib/tabler.css',
             'css/glpi.scss',
             'css/core_palettes.scss',
         ];

--- a/templates/layout/page_card_notlogged.html.twig
+++ b/templates/layout/page_card_notlogged.html.twig
@@ -35,7 +35,7 @@
 {% if css_files is not defined %}
    {% set css_files = [
        {'path': 'public/lib/base.css'},
-       {'path': 'css/tabler.scss'},
+       {'path': 'public/lib/tabler.css'},
        {'path': 'css/glpi.scss'},
        {'path': 'css/core_palettes.scss'}
    ] %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Currently, we copy the Tabler, Bootstrap, Fontsource, and Tabler icons styles/fonts to `css/lib` and compile the bootstrap/tabler styles using the scssphp compiler. This PR moves this compilation to webpack since we shouldn't be changing anything with it now that it has been separated from the core GLPI styles and palettes.

The only bootstrap scss file still copied to `css/lib` is used by `css/includes/_tabler_compat.scss` to make some Tabler/Bootstrap variables/functions available in the core GLPI styles.