### PR TITLE
ask for password if no value passed to database:install cli command

### DIFF
--- a/.github/actions/test_install.sh
+++ b/.github/actions/test_install.sh
@@ -8,7 +8,7 @@ mkdir -p $(dirname "$LOG_FILE")
 bin/console database:install \
   --ansi --no-interaction \
   --force \
-  --reconfigure --db-name=glpi --db-host=db --db-user=root \
+  --reconfigure --db-name=glpi --db-host=db --db-user=root --db-password="" \
   --strict-configuration \
   | tee $LOG_FILE
 if [[ -n $(grep "Warning" $LOG_FILE) ]];

--- a/.github/actions/test_update-from-9.5.sh
+++ b/.github/actions/test_update-from-9.5.sh
@@ -6,7 +6,7 @@ mkdir -p $(dirname "$LOG_FILE")
 
 bin/console database:configure \
   --no-interaction --ansi \
-  --reconfigure --db-name=glpitest-9.5 --db-host=db --db-user=root \
+  --reconfigure --db-name=glpitest-9.5 --db-host=db --db-user=root --db-password="" \
   --strict-configuration
 
 # Execute update
@@ -94,7 +94,7 @@ bin/console database:check_schema_integrity \
 # Check updated data
 bin/console database:configure \
   --no-interaction --ansi \
-  --reconfigure --db-name=glpi --db-host=db --db-user=root \
+  --reconfigure --db-name=glpi --db-host=db --db-user=root --db-password="" \
   --strict-configuration
 mkdir -p ./tests/files/_cache
 tests/bin/test-updated-data --host=db --user=root --fresh-db=glpi --updated-db=glpitest-9.5 --ansi --no-interaction

--- a/.github/actions/test_update-from-older-version.sh
+++ b/.github/actions/test_update-from-older-version.sh
@@ -7,7 +7,7 @@ mkdir -p $(dirname "$LOG_FILE")
 # Reconfigure DB
 bin/console database:configure \
   --ansi --no-interaction \
-  --reconfigure --db-name=glpitest085 --db-host=db --db-user=root
+  --reconfigure --db-name=glpitest085 --db-host=db --db-user=root --db-password=""
 
 # Execute update
 ## First run should do the migration (with no warnings/errors).
@@ -104,6 +104,6 @@ bin/console database:check_schema_integrity \
 # Check updated data
 bin/console database:configure \
   --no-interaction --ansi \
-  --reconfigure --db-name=glpi --db-host=db --db-user=root \
+  --reconfigure --db-name=glpi --db-host=db --db-user=root --db-password="" \
   --strict-configuration
 tests/bin/test-updated-data --host=db --user=root --fresh-db=glpi --updated-db=glpitest085 --ansi --no-interaction

--- a/src/Glpi/Console/Database/AbstractConfigureCommand.php
+++ b/src/Glpi/Console/Database/AbstractConfigureCommand.php
@@ -116,8 +116,7 @@ abstract class AbstractConfigureCommand extends AbstractCommand implements Force
             'db-password',
             'p',
             InputOption::VALUE_OPTIONAL,
-            __('Database password (will be prompted for value if option passed without value)'),
-            '' // Empty string by default (enable detection of null if passed without value)
+            __('Database password'),
         );
 
         $this->addOption(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

I found this while testing a new PR last Friday and I wanted to see new installations state.
The comment associated with the empty string value is very strange, it does the inverse of what it said
