### PR TITLE
Add user category search option (Requester, Observer, Technician)

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -4727,6 +4727,32 @@ abstract class CommonITILObject extends CommonDBTM
         $tab[] = $newtab;
 
         $newtab = [
+            'id'                 => '500',
+            'table'              => 'glpi_usercategories',
+            'field'              => 'name',
+            'datatype'           => 'dropdown',
+            'name'               => _n('Requester category', 'Requester categories', 1),
+            'forcegroupby'       => true,
+            'massiveaction'      => false,
+            'joinparams'         => [
+                'beforejoin'         => [
+                    'table'              => 'glpi_users',
+                    'joinparams'         => [
+                        'beforejoin'         => [
+                            'table'              => getTableForItemType($this->userlinkclass),
+                            'joinparams'         => [
+                                'jointype'           => 'child',
+                                'condition'          => ['NEWTABLE.type' => CommonITILActor::REQUESTER]
+                            ]
+                        ],
+                    ]
+                ]
+            ]
+        ];
+
+        $tab[] = $newtab;
+
+        $newtab = [
             'id'                 => '71',  // Also in Group_Ticket::post_addItem() and Log::getHistoryData()
             'table'              => 'glpi_groups',
             'field'              => 'completename',
@@ -4800,6 +4826,32 @@ abstract class CommonITILObject extends CommonDBTM
             ]
         ];
 
+        $newtab = [
+            'id'                 => '501',
+            'table'              => 'glpi_usercategories',
+            'field'              => 'name',
+            'datatype'           => 'dropdown',
+            'name'               => _n('Observer category', 'Observer categories', 1),
+            'forcegroupby'       => true,
+            'massiveaction'      => false,
+            'joinparams'         => [
+                'beforejoin'         => [
+                    'table'              => 'glpi_users',
+                    'joinparams'         => [
+                        'beforejoin'         => [
+                            'table'              => getTableForItemType($this->userlinkclass),
+                            'joinparams'         => [
+                                'jointype'           => 'child',
+                                'condition'          => ['NEWTABLE.type' => CommonITILActor::OBSERVER]
+                            ]
+                        ],
+                    ]
+                ]
+            ]
+        ];
+
+        $tab[] = $newtab;
+
         $tab[] = [
             'id'                 => '65', // Also in Group_Ticket::post_addItem() and Log::getHistoryData()
             'table'              => 'glpi_groups',
@@ -4863,6 +4915,32 @@ abstract class CommonITILObject extends CommonDBTM
                 ]
             ]
         ];
+
+        $newtab = [
+            'id'                 => '502',
+            'table'              => 'glpi_usercategories',
+            'field'              => 'name',
+            'datatype'           => 'dropdown',
+            'name'               => _n('Technician category', 'Technician categories', 1),
+            'forcegroupby'       => true,
+            'massiveaction'      => false,
+            'joinparams'         => [
+                'beforejoin'         => [
+                    'table'              => 'glpi_users',
+                    'joinparams'         => [
+                        'beforejoin'         => [
+                            'table'              => getTableForItemType($this->userlinkclass),
+                            'joinparams'         => [
+                                'jointype'           => 'child',
+                                'condition'          => ['NEWTABLE.type' => CommonITILActor::ASSIGN]
+                            ]
+                        ],
+                    ]
+                ]
+            ]
+        ];
+
+        $tab[] = $newtab;
 
         $tab[] = [
             'id'                 => '8', // Also in Group_Ticket::post_addItem() and Log::getHistoryData()

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -4824,7 +4824,7 @@ abstract class CommonITILObject extends CommonDBTM
             ]
         ];
 
-        $tab[]= [
+        $tab[] = [
             'id'                 => '501',
             'table'              => 'glpi_usercategories',
             'field'              => 'name',
@@ -4912,7 +4912,7 @@ abstract class CommonITILObject extends CommonDBTM
             ]
         ];
 
-        $tab[]= [
+        $tab[] = [
             'id'                 => '502',
             'table'              => 'glpi_usercategories',
             'field'              => 'name',

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -4726,7 +4726,7 @@ abstract class CommonITILObject extends CommonDBTM
         }
         $tab[] = $newtab;
 
-        $newtab = [
+        $tab[] = [
             'id'                 => '500',
             'table'              => 'glpi_usercategories',
             'field'              => 'name',
@@ -4749,8 +4749,6 @@ abstract class CommonITILObject extends CommonDBTM
                 ]
             ]
         ];
-
-        $tab[] = $newtab;
 
         $newtab = [
             'id'                 => '71',  // Also in Group_Ticket::post_addItem() and Log::getHistoryData()
@@ -4826,7 +4824,7 @@ abstract class CommonITILObject extends CommonDBTM
             ]
         ];
 
-        $newtab = [
+        $tab[]= [
             'id'                 => '501',
             'table'              => 'glpi_usercategories',
             'field'              => 'name',
@@ -4849,8 +4847,6 @@ abstract class CommonITILObject extends CommonDBTM
                 ]
             ]
         ];
-
-        $tab[] = $newtab;
 
         $tab[] = [
             'id'                 => '65', // Also in Group_Ticket::post_addItem() and Log::getHistoryData()
@@ -4916,7 +4912,7 @@ abstract class CommonITILObject extends CommonDBTM
             ]
         ];
 
-        $newtab = [
+        $tab[]= [
             'id'                 => '502',
             'table'              => 'glpi_usercategories',
             'field'              => 'name',
@@ -4939,8 +4935,6 @@ abstract class CommonITILObject extends CommonDBTM
                 ]
             ]
         ];
-
-        $tab[] = $newtab;
 
         $tab[] = [
             'id'                 => '8', // Also in Group_Ticket::post_addItem() and Log::getHistoryData()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33234

## Dev request

Related ticket : 33234

The customer wants to sort the "Support > Tickets" view by user category

![image](https://github.com/user-attachments/assets/d462e268-c992-4ffa-81a1-3fb36231ab56)

### Result : 
![image](https://github.com/user-attachments/assets/4075ba0b-5f12-406f-9e2b-aa55687583a2)

