### PR TITLE
disable language detection from browser when running tests

### DIFF
--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -48,7 +48,11 @@ Cypress.Commands.add('login', (username = 'e2e_tests', password = 'glpi') => {
         username,
         () => {
             cy.blockGLPIDashboards();
-            cy.visit('/');
+            cy.visit('/', {
+                headers: {
+                    'Accept-Language': 'en-GB,en;q=0.9',
+                }
+            });
             cy.title().should('eq', 'Authentication - GLPI');
             cy.findByRole('textbox', {'name': "Login"}).type(username);
             cy.findByLabelText("Password", {exact: false}).type(password);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

I wanted to run cypress on my local computer, but my system is in French.
So I can't pass the login test.
