### PR TITLE
Fix handling of separator in dropdown import

### DIFF
--- a/phpunit/functional/LocationTest.php
+++ b/phpunit/functional/LocationTest.php
@@ -253,6 +253,46 @@ class LocationTest extends DbTestCase
         }
     }
 
+    public function testImportTree(): void
+    {
+        // Import a non existing tree
+        $instance = new \Location();
+        $imported_id = $instance->import(
+            Sanitizer::sanitize(
+                [
+                    'entities_id'   => 0,
+                    'name'          => 'location 1 > sub location A',
+                ]
+            )
+        );
+
+        $imported = \Location::getById($imported_id);
+        $this->assertInstanceOf(\Location::class, $imported);
+        $this->assertEquals('sub location A', $imported->fields['name']);
+        $this->assertGreaterThan(0, $imported->fields['locations_id']);
+
+        $imported_parent = \Location::getById($imported->fields['locations_id']);
+        $this->assertInstanceOf(\Location::class, $imported_parent);
+        $this->assertEquals('location 1', $imported_parent->fields['name']);
+        $this->assertEquals(0, $imported_parent->fields['locations_id']);
+
+        // Import a child of an existing location
+        $instance = new \Location();
+        $imported_id = $instance->import(
+            Sanitizer::sanitize(
+                [
+                    'entities_id'   => 0,
+                    'name'          => '_location01 > sub location B',
+                ]
+            )
+        );
+
+        $imported = \Location::getById($imported_id);
+        $this->assertInstanceOf(\Location::class, $imported);
+        $this->assertEquals('sub location B', $imported->fields['name']);
+        $this->assertEquals(getItemByTypeName(\Location::class, '_location01', true), $imported->fields['locations_id']);
+    }
+
     public function testImportSeparator(): void
     {
         $instance = new \Location();

--- a/phpunit/functional/LocationTest.php
+++ b/phpunit/functional/LocationTest.php
@@ -253,6 +253,31 @@ class LocationTest extends DbTestCase
         }
     }
 
+    public function testImportSeparator(): void
+    {
+        $instance = new \Location();
+        $imported_id = $instance->import(
+            Sanitizer::sanitize(
+                [
+                    'entities_id'   => 0,
+                    'name'          => '_location01 > _sublocation01',
+                ]
+            )
+        );
+        $this->assertEquals(getItemByTypeName(\Location::class, '_sublocation01', true), $imported_id);
+
+        $instance = new \Location();
+        $imported_id = $instance->import(
+            Sanitizer::sanitize(
+                [
+                    'entities_id'   => 0,
+                    'name'          => '_location02>_sublocation02', // no spaces around separator
+                ]
+            )
+        );
+        $this->assertEquals(getItemByTypeName(\Location::class, '_sublocation02', true), $imported_id);
+    }
+
     public function testImportParentVisibleEntity(): void
     {
         $instance = new \Location();

--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -1007,7 +1007,7 @@ abstract class CommonTreeDropdown extends CommonDropdown
         if (empty($completename)) {
             return $completename;
         }
-        $separator = ' > ';
+        $separator = '>';
         return implode(Sanitizer::sanitize($separator), explode($separator, $completename));
     }
 
@@ -1026,7 +1026,7 @@ abstract class CommonTreeDropdown extends CommonDropdown
         if (empty($completename)) {
             return $completename;
         }
-        $separator = ' > ';
+        $separator = '>';
         return implode($separator, explode(Sanitizer::sanitize($separator), $completename));
     }
 }

--- a/tests/functional/CommonTreeDropdown.php
+++ b/tests/functional/CommonTreeDropdown.php
@@ -42,26 +42,40 @@ class CommonTreeDropdown extends DbTestCase
     protected function completenameProvider(): iterable
     {
         yield [
-            'completename' => 'Root > Child 1 > Child 2', // "Root" > "Child 1" > "Child 2"
-            'expected'     => 'Root &#62; Child 1 &#62; Child 2',
+            'raw'       => 'Root > Child 1 > Child 2', // "Root" > "Child 1" > "Child 2"
+            'sanitized' => 'Root &#62; Child 1 &#62; Child 2',
         ];
 
         yield [
-            'completename' => 'Root > &#60;ext&#62; Child 1 > Child 2', // "Root" > "<ext> Child 1" > "Child 2"
-            'expected'     => 'Root &#62; &#60;ext&#62; Child 1 &#62; Child 2',
+            // "Root">"Child 1">"Child 2" (imported from external application that does not surround the separator by spaces)
+            'raw'       => 'Root>Child 1 > Child 2',
+            'sanitized' => 'Root&#62;Child 1 &#62; Child 2',
         ];
 
         yield [
-            'completename' => null,
-            'expected'     => null,
+            'raw'       => 'Root > R&#38;D > Team 1', // "Root" > "R&D" > "Team 1"
+            'sanitized' => 'Root &#62; R&#38;D &#62; Team 1',
+        ];
+
+        yield [
+            'raw'       => null,
+            'sanitized' => null,
         ];
     }
 
     /**
      * @dataProvider completenameProvider
      */
-    public function testSanitizeSeparatorInCompletename(?string $completename, ?string $expected)
+    public function testSanitizeSeparatorInCompletename(?string $raw, ?string $sanitized)
     {
-        $this->variable(\CommonTreeDropdown::sanitizeSeparatorInCompletename($completename))->isIdenticalTo($expected);
+        $this->variable(\CommonTreeDropdown::sanitizeSeparatorInCompletename($raw))->isIdenticalTo($sanitized);
+    }
+
+    /**
+     * @dataProvider completenameProvider
+     */
+    public function testUnsanitizeSeparatorInCompletename(?string $sanitized, ?string $raw)
+    {
+        $this->variable(\CommonTreeDropdown::unsanitizeSeparatorInCompletename($sanitized))->isIdenticalTo($raw);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #17514

It restores the behaviour that was present in GLPI 9.5 and in earlier versions. In these versions, it was possible to not surround the tree separator by spaces, for instance `Country>City>Address` should be splittedn into 3 locations.