### PR TITLE
fix browse view

### DIFF
--- a/ajax/treebrowse.php
+++ b/ajax/treebrowse.php
@@ -71,7 +71,7 @@ switch ($_REQUEST['action']) {
             'value'  => ($_REQUEST['cat_id'] > 0) ? $_REQUEST['cat_id'] : 0,
         ];
         Search::showList($itemtype, $params);
-        break;
+        return;
 }
 http_response_code(400);
 return;


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Avoid this error message in the browse mode display (with PHP 8.3):

![image](https://github.com/user-attachments/assets/c9abd18e-fc57-499c-9fa6-c42e7a394b78)

```
glpiphplog.WARNING:   *** PHP Warning (2): http_response_code(): Cannot set response code - headers already sent (output started at /home/ubuntu/Dev/GLPI/main/vendor/twig/twig/src/Template.php:328) in /home/ubuntu/Dev/GLPI/main/ajax/treebrowse.php at line 76
  Backtrace :
  ajax/treebrowse.php:76                             http_response_code()
  ...Glpi/Controller/LegacyFileLoadController.php:57 require()
  vendor/symfony/http-kernel/HttpKernel.php:101      Glpi\Controller\LegacyFileLoadController->Glpi\Controller\{closure}()
  ...ymfony/http-foundation/StreamedResponse.php:106 Symfony\Component\HttpKernel\HttpKernel::Symfony\Component\HttpKernel\{closure}()
  vendor/symfony/http-foundation/Response.php:423    Symfony\Component\HttpFoundation\StreamedResponse->sendContent()
  public/index.php:58                                Symfony\Component\HttpFoundation\Response->send()
```
