### PR TITLE
Disable PHPUnit tests isolation

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     bootstrap="phpunit/bootstrap.php"
-    processIsolation="true"
     colors="true"
 >
   <testsuites>
@@ -15,4 +14,3 @@
     <ini name="memory_limit" value="256M" />
   </php>
 </phpunit>
-

--- a/phpunit/GLPITestCase.php
+++ b/phpunit/GLPITestCase.php
@@ -47,6 +47,7 @@ class GLPITestCase extends TestCase
     private $int;
     private $str;
     protected $has_failed = false;
+    private ?array $config_copy = null;
 
     /**
      * @var TestHandler
@@ -60,13 +61,15 @@ class GLPITestCase extends TestCase
 
     public function setUp(): void
     {
-       // By default, no session, not connected
+        $this->copyGlobals();
+
+        // By default, no session, not connected
         $this->resetSession();
 
         // By default, there shouldn't be any pictures in the test files
         $this->resetPictures();
 
-       // Ensure cache is clear
+        // Ensure cache is clear
         global $GLPI_CACHE;
         $GLPI_CACHE->clear();
 
@@ -83,6 +86,8 @@ class GLPITestCase extends TestCase
 
     public function tearDown(): void
     {
+        $this->resetGlobalsAndStaticValues();
+
         vfsStreamWrapper::unregister();
 
         if (isset($_SESSION['MESSAGE_AFTER_REDIRECT']) && !$this->has_failed) {
@@ -402,5 +407,24 @@ class GLPITestCase extends TestCase
     protected function getTestRootEntity(bool $only_id = false)
     {
         return getItemByTypeName('Entity', '_test_root_entity', $only_id);
+    }
+
+    protected function copyGlobals(): void
+    {
+        global $CFG_GLPI;
+
+        if ($this->config_copy === null) {
+            $this->config_copy = $CFG_GLPI;
+        }
+    }
+
+    protected function resetGlobalsAndStaticValues(): void
+    {
+        // Globals
+        global $CFG_GLPI;
+        $CFG_GLPI = $this->config_copy;
+
+        // Statics values
+        Log::$use_queue = false;
     }
 }

--- a/phpunit/GLPITestCase.php
+++ b/phpunit/GLPITestCase.php
@@ -61,7 +61,7 @@ class GLPITestCase extends TestCase
 
     public function setUp(): void
     {
-        $this->copyGlobals();
+        $this->storeGlobals();
 
         // By default, no session, not connected
         $this->resetSession();
@@ -409,7 +409,7 @@ class GLPITestCase extends TestCase
         return getItemByTypeName('Entity', '_test_root_entity', $only_id);
     }
 
-    protected function copyGlobals(): void
+    private function storeGlobals(): void
     {
         global $CFG_GLPI;
 
@@ -418,7 +418,7 @@ class GLPITestCase extends TestCase
         }
     }
 
-    protected function resetGlobalsAndStaticValues(): void
+    private function resetGlobalsAndStaticValues(): void
     {
         // Globals
         global $CFG_GLPI;

--- a/phpunit/functional/AutoloadTest.php
+++ b/phpunit/functional/AutoloadTest.php
@@ -37,6 +37,7 @@ namespace tests\units;
 
 use DbTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 require_once __DIR__ . '/../Autoload.php';
 
@@ -81,6 +82,7 @@ class AutoloadTest extends DbTestCase
         $this->assertTrue(class_exists('Glpi\\Event'));
     }
 
+    #[RunInSeparateProcess]
     public function testPluginAutoloading()
     {
         // PSR4 autoloader (registered during plugins initialization)

--- a/phpunit/functional/Glpi/Inventory/InventoryTest.php
+++ b/phpunit/functional/Glpi/Inventory/InventoryTest.php
@@ -44,6 +44,7 @@ use OperatingSystemArchitecture;
 use OperatingSystemServicePack;
 use OperatingSystemVersion;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use UserEmail;
 use wapmorgan\UnifiedArchive\UnifiedArchive;
 
@@ -6534,7 +6535,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         $this->assertSame($other_states_id, $computer->fields['states_id']);
     }
 
-
+    #[RunInSeparateProcess] // TODO: fix this test, it shouldn't need an individual process
     public function testOtherSerialFromTag()
     {
         global $DB;

--- a/tests/src/autoload/functions.php
+++ b/tests/src/autoload/functions.php
@@ -703,11 +703,7 @@ function loadDataset()
     $CFG_GLPI['caldav_supported_components']  = ['VEVENT', 'VJOURNAL', 'VTODO'];
 
     $conf = Config::getConfigurationValues('phpunit');
-    if (isset($conf['dataset']) && $conf['dataset'] == $data['_version']) {
-        printf("\nGLPI dataset version %s already loaded\n\n", $data['_version']);
-    } else {
-        printf("\nLoading GLPI dataset version %s\n", $data['_version']);
-
+    if (!(isset($conf['dataset']) && $conf['dataset'] == $data['_version'])) {
         $ids = [];
         foreach ($data as $type => $inputs) {
             if ($type[0] == '_') {
@@ -740,12 +736,10 @@ function loadDataset()
                 if (isset($input['name']) && $item = getItemByTypeName($type, $input['name'])) {
                     $input['id'] = $ids[$type][$input['name']] = $item->getField('id');
                     $item->update($input);
-                    echo ".";
                 } else {
                     // Not found, create it
                     $item = getItemForItemtype($type);
                     $id = $item->add($input);
-                    echo "+";
                     if (isset($input['name'])) {
                         $ids[$type][$input['name']] = $id;
                     }
@@ -753,7 +747,6 @@ function loadDataset()
             }
         }
         Search::$search = [];
-        echo "\nDone\n\n";
         Config::setConfigurationValues('phpunit', ['dataset' => $data['_version']]);
     }
     $DB->commit();


### PR DESCRIPTION
Disable tests isolations for PHPUnit.

There was 3 main issues:
* The `loadDataset()` script was outputting text, which meant that all tests that required authentification would fail because of the "headers already sent" state.
Fixed by deleting the output from the script as it is not very useful anyway. It can probably be re-added if the script is wrapped into another PHP process to prevent triggering headers inside the PHPUnit process.
* Shared static values like `Log::$use_queue`.
Inventory code would change this value which would make all assertions on logs by others tests fails.
Fixed by disabling the queue after each tests.
* Shared global config.
Fixed by restoring the default configuration after each tests.

With these change, only two tests needed the specific "run in separate process" instruction.
These tests could probably be fixed, I didn't look much it it.

Execution time is lowered from ~14 minutes to ~6 minutes on my laptop.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
