### PR TITLE
Adding 'Processors number' in the computers overview list

### DIFF
--- a/src/DeviceProcessor.php
+++ b/src/DeviceProcessor.php
@@ -277,7 +277,7 @@ class DeviceProcessor extends CommonDevice
         ];
 
         $tab[] = [
-            'id'                 => '35', 
+            'id'                 => '35',
             'table'              => 'glpi_items_deviceprocessors',
             'field'              => 'id',
             'name'               => _x('quantity', 'Processors number'),

--- a/src/DeviceProcessor.php
+++ b/src/DeviceProcessor.php
@@ -277,6 +277,20 @@ class DeviceProcessor extends CommonDevice
         ];
 
         $tab[] = [
+            'id'                 => '35', 
+            'table'              => 'glpi_items_deviceprocessors',
+            'field'              => 'id',
+            'name'               => _x('quantity', 'Processors number'),
+            'forcegroupby'       => true,
+            'usehaving'          => true,
+            'datatype'           => 'number',
+            'massiveaction'      => false,
+            'joinparams'         => $main_joinparams,
+            'computation'        => 'COUNT(DISTINCT ' . $DB->quoteName('TABLE.id') . ')',
+            'nometa'             => true, // cannot GROUP_CONCAT a SUM
+        ];
+
+        $tab[] = [
             'id'                 => '36',
             'table'              => 'glpi_items_deviceprocessors',
             'field'              => 'frequency',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

In the computers list, computer.php, there is no possibility of showing the number of CPUs. If CPUs have the same name (as in nearly all computers) this is not visible anyhow in the list (while number of cores and threads can be displayed already). This would be important for various tasks and invoicing.

The translation of 'Processors number' is already present in GLPI, used for VMs.




