### PR TITLE
Form access control votes

### DIFF
--- a/phpunit/functional/Glpi/Form/AccessControl/ControlType/AllowListTest.php
+++ b/phpunit/functional/Glpi/Form/AccessControl/ControlType/AllowListTest.php
@@ -35,6 +35,7 @@
 
 namespace tests\units\Glpi\Form\AccessControl\ControlType;
 
+use Glpi\Form\AccessControl\AccessVote;
 use Glpi\Form\AccessControl\ControlType\AllowList;
 use Glpi\Form\AccessControl\FormAccessParameters;
 use JsonConfigInterface;
@@ -133,45 +134,45 @@ class AllowListTest extends \GLPITestCase
 
     public static function canAnswerProvider(): iterable
     {
-        yield 'Refuse all when allow list is empty' => [
+        yield 'Abstain if allow list is empty' => [
             'config'     => self::getEmptyAllowList(),
             'parameters' => self::getAuthenticatedUserParameters(),
-            'expected'   => false,
+            'expected'   => AccessVote::Abstain,
         ];
-        yield 'Refuse unauthenticated users' => [
+        yield 'Abstain if user is unauthenticated' => [
             'config'     => self::getFullyConfiguredAllowListConfig(),
             'parameters' => self::getUnauthenticatedUserParameters(),
-            'expected'   => false,
+            'expected'   => AccessVote::Abstain,
         ];
-        yield 'Allow directly allowed user' => [
+        yield 'Grant access to specifically allowed user' => [
             'config'     => self::getFullyConfiguredAllowListConfig(),
             'parameters' => self::getDirectlyAllowedUserParameters(),
-            'expected'   => true,
+            'expected'   => AccessVote::Grant,
         ];
-        yield 'Deny not directly allowed user' => [
+        yield 'Abstain if user is not specifically allowed' => [
             'config'     => self::getFullyConfiguredAllowListConfig(),
             'parameters' => self::getNotDirectlyAllowedUserParameters(),
-            'expected'   => false,
+            'expected'   => AccessVote::Abstain,
         ];
-        yield 'Allow user by group' => [
+        yield 'Grant access to specifically allowed group' => [
             'config'     => self::getFullyConfiguredAllowListConfig(),
             'parameters' => self::getAllowedUserByGroupParameters(),
-            'expected'   => true,
+            'expected'   => AccessVote::Grant,
         ];
-        yield 'Deny user by group' => [
+        yield 'Abstain if group is not specifically allowed' => [
             'config'     => self::getFullyConfiguredAllowListConfig(),
             'parameters' => self::getNotAllowedUserByGroupParameters(),
-            'expected'   => false,
+            'expected'   => AccessVote::Abstain,
         ];
-        yield 'Allow user by profile' => [
+        yield 'Grant access to specifically allowed profile' => [
             'config'     => self::getFullyConfiguredAllowListConfig(),
             'parameters' => self::getAllowedUserByProfileParameters(),
-            'expected'   => true,
+            'expected'   => AccessVote::Grant,
         ];
-        yield 'Deny user by profile' => [
+        yield 'Abstain if profile is not specifically allowed' => [
             'config'     => self::getFullyConfiguredAllowListConfig(),
             'parameters' => self::getNotAllowedUserByProfileParameters(),
-            'expected'   => false,
+            'expected'   => AccessVote::Abstain,
         ];
     }
 
@@ -179,7 +180,7 @@ class AllowListTest extends \GLPITestCase
     public function testCanAnswer(
         AllowListConfig $config,
         FormAccessParameters $parameters,
-        bool $expected
+        AccessVote $expected
     ): void {
         $allow_list = new AllowList();
         $this->assertEquals(

--- a/phpunit/functional/Glpi/Form/AccessControl/ControlType/DirectAccessTest.php
+++ b/phpunit/functional/Glpi/Form/AccessControl/ControlType/DirectAccessTest.php
@@ -35,6 +35,7 @@
 
 namespace tests\units\Glpi\Form\AccessControl\ControlType;
 
+use Glpi\Form\AccessControl\AccessVote;
 use Glpi\Form\AccessControl\ControlType\DirectAccess;
 use Glpi\Form\AccessControl\FormAccessParameters;
 use JsonConfigInterface;
@@ -134,47 +135,47 @@ class DirectAccessTest extends \GLPITestCase
                 session_info: self::getAuthenticatedSession(),
                 url_parameters: self::getValidTokenUrlParameters()
             ),
-            true
+            AccessVote::Grant
         ];
-        yield 'Authenticated form: deny authenticated user with wrong token' => [
+        yield 'Authenticated form: abstain for authenticated user with wrong token' => [
             $config_authenticated,
             new FormAccessParameters(
                 session_info: self::getUnauthenticatedSession(),
                 url_parameters: self::getInvalidTokenUrlParameters()
             ),
-            false
+            AccessVote::Abstain
         ];
-        yield 'Authenticated form: deny authenticated user with missing token' => [
+        yield 'Authenticated form: abstain for authenticated user with missing token' => [
             $config_authenticated,
             new FormAccessParameters(
                 session_info: self::getUnauthenticatedSession(),
                 url_parameters: self::getMissingTokenUrlParameters()
             ),
-            false
+            AccessVote::Abstain
         ];
-        yield 'Authenticated form: deny unauthenticated user with correct token' => [
+        yield 'Authenticated form: abstain for unauthenticated user with correct token' => [
             $config_authenticated,
             new FormAccessParameters(
                 session_info: self::getUnauthenticatedSession(),
                 url_parameters: self::getValidTokenUrlParameters()
             ),
-            false
+            AccessVote::Abstain
         ];
-        yield 'Authenticated form: deny unauthenticated user with wrong token' => [
+        yield 'Authenticated form: abstain for unauthenticated user with wrong token' => [
             $config_authenticated,
             new FormAccessParameters(
                 session_info: self::getUnauthenticatedSession(),
                 url_parameters: self::getInvalidTokenUrlParameters()
             ),
-            false
+            AccessVote::Abstain
         ];
-        yield 'Authenticated form: deny unauthenticated user with missing token' => [
+        yield 'Authenticated form: abstain for unauthenticated user with missing token' => [
             $config_authenticated,
             new FormAccessParameters(
                 session_info: self::getUnauthenticatedSession(),
                 url_parameters: self::getMissingTokenUrlParameters()
             ),
-            false
+            AccessVote::Abstain
         ];
 
         // Unauthenticated form
@@ -185,23 +186,23 @@ class DirectAccessTest extends \GLPITestCase
                 session_info: self::getAuthenticatedSession(),
                 url_parameters: self::getValidTokenUrlParameters()
             ),
-            true
+            AccessVote::Grant
         ];
-        yield 'Unauthenticated form: deny authenticated user with wrong token' => [
+        yield 'Unauthenticated form: abstain for authenticated user with wrong token' => [
             $config_unauthenticated,
             new FormAccessParameters(
                 session_info: self::getUnauthenticatedSession(),
                 url_parameters: self::getInvalidTokenUrlParameters()
             ),
-            false
+            AccessVote::Abstain
         ];
-        yield 'Unauthenticated form: deny authenticated user with missing token' => [
+        yield 'Unauthenticated form: abstain for authenticated user with missing token' => [
             $config_unauthenticated,
             new FormAccessParameters(
                 session_info: self::getUnauthenticatedSession(),
                 url_parameters: self::getMissingTokenUrlParameters()
             ),
-            false
+            AccessVote::Abstain
         ];
         yield 'Unauthenticated form: allow unauthenticated user with correct token' => [
             $config_unauthenticated,
@@ -209,7 +210,7 @@ class DirectAccessTest extends \GLPITestCase
                 session_info: self::getUnauthenticatedSession(),
                 url_parameters: self::getValidTokenUrlParameters()
             ),
-            true
+            AccessVote::Grant
         ];
         yield 'Unauthenticated form: deny unauthenticated user with wrong token' => [
             $config_unauthenticated,
@@ -217,7 +218,7 @@ class DirectAccessTest extends \GLPITestCase
                 session_info: self::getUnauthenticatedSession(),
                 url_parameters: self::getInvalidTokenUrlParameters()
             ),
-            false
+            AccessVote::Abstain
         ];
         yield 'Unauthenticated form: deny unauthenticated user with missing token' => [
             $config_unauthenticated,
@@ -225,7 +226,7 @@ class DirectAccessTest extends \GLPITestCase
                 session_info: self::getUnauthenticatedSession(),
                 url_parameters: self::getMissingTokenUrlParameters()
             ),
-            false
+            AccessVote::Abstain
         ];
     }
 
@@ -233,7 +234,7 @@ class DirectAccessTest extends \GLPITestCase
     public function testCanAnswer(
         DirectAccessConfig $config,
         FormAccessParameters $parameters,
-        bool $expected
+        AccessVote $expected
     ): void {
         $direct_access = new DirectAccess();
         $this->assertEquals(

--- a/src/Glpi/Form/AccessControl/AccessVote.php
+++ b/src/Glpi/Form/AccessControl/AccessVote.php
@@ -51,7 +51,21 @@ namespace Glpi\Form\AccessControl;
  */
 enum AccessVote
 {
+    /**
+      * Grant access.
+      * The access grant can still be denied if any other policy vote is `Deny`.
+      */
     case Grant;
+
+    /**
+      * Does not allow access, but does not deny it either.
+      * Access grant will depend on other policies vote.
+      */
     case Abstain;
+
+    /**
+      * Deny access.
+      * The access grant will be refused, whatever the other policies vote is.
+      */
     case Deny;
 }

--- a/src/Glpi/Form/AccessControl/AccessVote.php
+++ b/src/Glpi/Form/AccessControl/AccessVote.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\AccessControl;
+
+/**
+ * ControlTypeInterface::canAnwser require to return an AccessVote.
+ * Ideally, a control type will pick between two types depending on how it is
+ * labelled to end users.
+ *
+ * Here is an example for an hypothetical control type that would manager access
+ * according to the user IP.
+ * The control type could word its label in 3 different ways and for each labels
+ * there is a logical vote couple:
+ * vote couples:
+ * - "Allow access by specific IP": (Grant, Abstain)
+ * - "Restrict access by specific IP": (Grant, Deny)
+ * - "Block access to specific IP": (Abstain, Deny)
+ */
+enum AccessVote
+{
+    case Grant;
+    case Abstain;
+    case Deny;
+}

--- a/src/Glpi/Form/AccessControl/ControlType/AllowList.php
+++ b/src/Glpi/Form/AccessControl/ControlType/AllowList.php
@@ -35,6 +35,7 @@
 
 namespace Glpi\Form\AccessControl\ControlType;
 
+use Glpi\Form\AccessControl\AccessVote;
 use Glpi\Form\AccessControl\FormAccessParameters;
 use JsonConfigInterface;
 use Glpi\Application\View\TemplateRenderer;
@@ -98,16 +99,20 @@ final class AllowList implements ControlTypeInterface
     public function canAnswer(
         JsonConfigInterface $config,
         FormAccessParameters $parameters
-    ): bool {
+    ): AccessVote {
         if (!$config instanceof AllowListConfig) {
             throw new \InvalidArgumentException("Invalid config class");
         }
 
         if (!$parameters->isAuthenticated()) {
-            return false;
+            return AccessVote::Abstain;
         }
 
-        return $this->isUserAllowed($config, $parameters);
+        if (!$this->isUserAllowed($config, $parameters)) {
+            return AccessVote::Abstain;
+        }
+
+        return AccessVote::Grant;
     }
 
     private function isUserAllowed(

--- a/src/Glpi/Form/AccessControl/ControlType/ControlTypeInterface.php
+++ b/src/Glpi/Form/AccessControl/ControlType/ControlTypeInterface.php
@@ -35,6 +35,7 @@
 
 namespace Glpi\Form\AccessControl\ControlType;
 
+use Glpi\Form\AccessControl\AccessVote;
 use Glpi\Form\AccessControl\FormAccessParameters;
 use JsonConfigInterface;
 
@@ -93,10 +94,10 @@ interface ControlTypeInterface
      * @param JsonConfigInterface $config
      * @param FormAccessParameters $parameters
      *
-     * @return bool
+     * @return AccessVote
      */
     public function canAnswer(
         JsonConfigInterface $config,
         FormAccessParameters $parameters
-    ): bool;
+    ): AccessVote;
 }

--- a/src/Glpi/Form/AccessControl/ControlType/DirectAccess.php
+++ b/src/Glpi/Form/AccessControl/ControlType/DirectAccess.php
@@ -35,11 +35,11 @@
 
 namespace Glpi\Form\AccessControl\ControlType;
 
+use Glpi\Form\AccessControl\AccessVote;
 use Glpi\Form\AccessControl\FormAccessParameters;
 use JsonConfigInterface;
 use Glpi\Application\View\TemplateRenderer;
 use Override;
-use Glpi\Session\SessionInfo;
 
 final class DirectAccess implements ControlTypeInterface
 {
@@ -105,16 +105,20 @@ final class DirectAccess implements ControlTypeInterface
     public function canAnswer(
         JsonConfigInterface $config,
         FormAccessParameters $parameters
-    ): bool {
+    ): AccessVote {
         if (!$config instanceof DirectAccessConfig) {
             throw new \InvalidArgumentException("Invalid config class");
         }
 
         if (!$this->validateSession($config, $parameters)) {
-            return false;
+            return AccessVote::Abstain;
         }
 
-        return $this->validateToken($config, $parameters);
+        if (!$this->validateToken($config, $parameters)) {
+            return AccessVote::Abstain;
+        };
+
+        return AccessVote::Grant;
     }
 
     private function validateSession(


### PR DESCRIPTION
Discussed lengthy internally with @cedric-anne, replacement for https://github.com/glpi-project/glpi/pull/17117.

TLDR: We redefine the default behavior for our forms access controls policies while allowing future plugins to do things differently. No interface changes and no new configuration options.

----

As a reminder we have two possible policies:
* Allow specific users/groups/profiles
* Allow direct token access

Before this PR, enabling both these criteria would lead to an AND condition (user must have valid token AND be whitelisted) which is not intuitive for users because the names specify "Allow xxx" and not "Restrict xxx".
Thus, this has been changed to an OR condition.

Internally, we use a voting system with 3 choices (grant, abstain, deny).
Our default policies only use the grant/abstain vote but future plugins may want to add their own access policies and use the deny vote (for example, a "Restrict by IP" policy).

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
