### PR TITLE
Form allow list: Add "All users" option

### DIFF
--- a/phpunit/functional/Glpi/Form/AccessControl/ControlType/AllowListTest.php
+++ b/phpunit/functional/Glpi/Form/AccessControl/ControlType/AllowListTest.php
@@ -35,6 +35,7 @@
 
 namespace tests\units\Glpi\Form\AccessControl\ControlType;
 
+use AbstractRightsDropdown;
 use Glpi\Form\AccessControl\AccessVote;
 use Glpi\Form\AccessControl\ControlType\AllowList;
 use Glpi\Form\AccessControl\FormAccessParameters;
@@ -182,6 +183,11 @@ class AllowListTest extends \DbTestCase
             'parameters' => self::getNotAllowedUserByProfileParameters(),
             'expected'   => AccessVote::Abstain,
         ];
+        yield 'Grant access if all users are allowed' => [
+            'config'     => self::getAllUsersAllowedConfig(),
+            'parameters' => self::getAuthenticatedUserParameters(),
+            'expected'   => AccessVote::Grant,
+        ];
     }
 
     #[DataProvider('canAnswerProvider')]
@@ -209,6 +215,15 @@ class AllowListTest extends \DbTestCase
             user_ids   : [1, 2, 3],
             group_ids  : [4, 5, 6],
             profile_ids: [7, 8, 9],
+        );
+    }
+
+    private static function getAllUsersAllowedConfig(): AllowListConfig
+    {
+        return new AllowListConfig(
+            user_ids   : [AbstractRightsDropdown::ALL_USERS],
+            group_ids  : [],
+            profile_ids: [],
         );
     }
 

--- a/src/Glpi/Form/AccessControl/ControlType/AllowList.php
+++ b/src/Glpi/Form/AccessControl/ControlType/AllowList.php
@@ -35,6 +35,7 @@
 
 namespace Glpi\Form\AccessControl\ControlType;
 
+use AbstractRightsDropdown;
 use Glpi\Form\AccessControl\AccessVote;
 use Glpi\Form\AccessControl\FormAccessControl;
 use Glpi\Form\AccessControl\FormAccessParameters;
@@ -78,6 +79,7 @@ final class AllowList implements ControlTypeInterface
         return $twig->render("pages/admin/form/access_control/allow_list.html.twig", [
             'access_control' => $access_control,
             'config' => $config,
+            'label' => $this->getLabel(),
         ]);
     }
 
@@ -140,6 +142,15 @@ final class AllowList implements ControlTypeInterface
         AllowListConfig $config,
         SessionInfo $session_info
     ): bool {
+        $all_users_are_allowed = in_array(
+            AbstractRightsDropdown::ALL_USERS,
+            $config->getUserIds()
+        );
+
+        if ($all_users_are_allowed) {
+            return true;
+        }
+
         return in_array($session_info->getUserId(), $config->getUserIds());
     }
 

--- a/src/Glpi/Form/AccessControl/ControlType/AllowListDropdown.php
+++ b/src/Glpi/Form/AccessControl/ControlType/AllowListDropdown.php
@@ -44,6 +44,12 @@ use User;
 
 final class AllowListDropdown extends AbstractRightsDropdown
 {
+    #[Override]
+    protected static function addAllUsersOption(): true
+    {
+        return true;
+    }
+
     /**
      * Count users for the given criteria.
      *
@@ -58,31 +64,35 @@ final class AllowListDropdown extends AbstractRightsDropdown
         array $profiles,
     ): array {
         $criteria = [];
-        foreach ($users as $user_id) {
-            $criteria[] = [
-                'link'       => 'OR',
-                'searchtype' => 'is',
-                'field'      => 2, // ID
-                'value'      => $user_id,
-            ];
-        }
+        $all_users_are_allowed = in_array(AbstractRightsDropdown::ALL_USERS, $users);
 
-        foreach ($groups as $group_id) {
-            $criteria[] = [
-                'link'       => 'OR',
-                'searchtype' => 'equals',
-                'field'      => 13, // Linked group,
-                'value'      => $group_id,
-            ];
-        }
+        if (!$all_users_are_allowed) {
+            foreach ($users as $user_id) {
+                $criteria[] = [
+                    'link'       => 'OR',
+                    'searchtype' => 'is',
+                    'field'      => 2, // ID
+                    'value'      => $user_id,
+                ];
+            }
 
-        foreach ($profiles as $profile_id) {
-            $criteria[] = [
-                'link'       => 'OR',
-                'searchtype' => 'equals',
-                'field'      => 20, // Profile
-                'value'      => $profile_id,
-            ];
+            foreach ($groups as $group_id) {
+                $criteria[] = [
+                    'link'       => 'OR',
+                    'searchtype' => 'equals',
+                    'field'      => 13, // Linked group,
+                    'value'      => $group_id,
+                ];
+            }
+
+            foreach ($profiles as $profile_id) {
+                $criteria[] = [
+                    'link'       => 'OR',
+                    'searchtype' => 'equals',
+                    'field'      => 20, // Profile
+                    'value'      => $profile_id,
+                ];
+            }
         }
 
         if (empty($criteria)) {

--- a/src/Html.php
+++ b/src/Html.php
@@ -4511,6 +4511,7 @@ JS;
             'parent_id_field'     => null,
             'templateResult'      => 'templateResult',
             'templateSelection'   => 'templateSelection',
+            'aria_label'          => '',
         ];
         $params = array_merge($default_options, $params);
 
@@ -4522,6 +4523,7 @@ JS;
         $multiple = $params['multiple'];
         $templateResult = $params['templateResult'];
         $templateSelection = $params['templateSelection'];
+        $aria_label = $params['aria_label'];
         unset($params["on_change"], $params["width"]);
 
         $allowclear =  "false";
@@ -4550,6 +4552,11 @@ JS;
         $parent_id_field = $params['parent_id_field'];
 
         unset($params['placeholder'], $params['value'], $params['valuename'], $params['parent_id_field']);
+
+        if (!empty($aria_label)) {
+            $params['specific_tags']['aria-label'] = $aria_label;
+        }
+        unset($params['aria_label']);
 
         foreach ($params['specific_tags'] as $tag => $val) {
             if (is_array($val)) {

--- a/templates/pages/admin/form/access_control/allow_list.html.twig
+++ b/templates/pages/admin/form/access_control/allow_list.html.twig
@@ -45,7 +45,7 @@
             'groups_id'  : config.getGroupIds(),
             'profiles_id': config.getProfileIds(),
         },
-        { 'aria_label': label }
+        {'aria_label': label}
     ]
 )|raw }}
 

--- a/templates/pages/admin/form/access_control/allow_list.html.twig
+++ b/templates/pages/admin/form/access_control/allow_list.html.twig
@@ -33,15 +33,20 @@
 
 {# @var \Glpi\Form\AccessControl\ControlType\FormAccessControl access_control #}
 {# @var \Glpi\Form\AccessControl\ControlType\AllowListConfig config #}
+{# @var string label #}
 
 {# Multi dropdown (User, Group and Profile) #}
 {{ call(
     "\\Glpi\\Form\\AccessControl\\ControlType\\AllowListDropdown::show",
-    [access_control.getNormalizedInputName("_allow_list_dropdown"), {
-        'users_id'   : config.getUserIds(),
-        'groups_id'  : config.getGroupIds(),
-        'profiles_id': config.getProfileIds(),
-    }]
+    [
+        access_control.getNormalizedInputName("_allow_list_dropdown"),
+        {
+            'users_id'   : config.getUserIds(),
+            'groups_id'  : config.getGroupIds(),
+            'profiles_id': config.getProfileIds(),
+        },
+        { 'aria_label': label }
+    ]
 )|raw }}
 
 {# Helper link that will be populated using a JS script #}

--- a/tests/cypress/e2e/form/access_control.cy.js
+++ b/tests/cypress/e2e/form/access_control.cy.js
@@ -50,6 +50,7 @@ describe('Access Control', () => {
         cy.findAllByRole('alert').eq(1).should('contain.text', "This form will not be visible to any users as there are currently no active access policies.");
     });
     it('can configure the allow list policy', () => {
+        // Change values
         cy.findByRole('region', {
             name: 'Allow specifics users, groups or profiles'
         }).within(() => {
@@ -58,18 +59,20 @@ describe('Access Control', () => {
                 .click()
             ;
         });
-
-        // TODO: modify the user/group/profile dropdown (unsure how to tests
-        // select2 ajax dropdown for now)
+        cy.getDropdownByLabelText('Allow specifics users, groups or profiles').selectDropdownValue('All users');
 
         // Save changes
         cy.findByRole('button', {name: 'Save changes'}).click();
 
+        // Check values are kept after update
         cy.findByRole('region', {
             name: 'Allow specifics users, groups or profiles'
         }).within(() => {
-            // Check values are kept after update
             cy.findByRole('checkbox', {name: 'Active'}).should('be.checked');
+            cy.getDropdownByLabelText('Allow specifics users, groups or profiles').should(
+                'contain.text',
+                'All users'
+            );
         });
     });
     it('can configure the direct access policy', () => {


### PR DESCRIPTION
Add a dedicated option that easily allow administrators to enable a form for all users.

![image](https://github.com/user-attachments/assets/845f1dae-01b4-4030-a96f-f920557cb5a3)

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
