### PR TITLE
Fix(LifeCycle): ITILObject must be closed after the follow-up has been added (when validates solution)

### DIFF
--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -274,6 +274,7 @@ class ITILFollowup extends CommonDBChild
             $this->input["users_id"]
         );
 
+
         $donotif = !isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"];
 
         if ($donotif) {
@@ -282,8 +283,6 @@ class ITILFollowup extends CommonDBChild
             ];
             NotificationEvent::raiseEvent("add_followup", $parentitem, $options);
         }
-
-        PendingReason_Item::handlePendingReasonUpdateFromNewTimelineItem($this);
 
        // Add log entry in the ITILObject
         $changes = [
@@ -300,6 +299,7 @@ class ITILFollowup extends CommonDBChild
         );
 
         $this->updateParentStatus($this->input['_job'], $this->input);
+        PendingReason_Item::handlePendingReasonUpdateFromNewTimelineItem($this);
 
         parent::post_addItem();
     }

--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -274,8 +274,6 @@ class ITILFollowup extends CommonDBChild
             $this->input["users_id"]
         );
 
-        $this->updateParentStatus($this->input['_job'], $this->input);
-
         $donotif = !isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"];
 
         if ($donotif) {
@@ -300,6 +298,8 @@ class ITILFollowup extends CommonDBChild
             $this->getType(),
             Log::HISTORY_ADD_SUBITEM
         );
+
+        $this->updateParentStatus($this->input['_job'], $this->input);
 
         parent::post_addItem();
     }


### PR DESCRIPTION
When the requester validates the solution, the comment is added as a follow-up.

But the parent (Ticket) is closed before this action.

This can be seen in the ticket history

![image](https://github.com/user-attachments/assets/586da20f-52ce-439e-b714-3fa1dd814905)

This PR reverses the action order

![image](https://github.com/user-attachments/assets/31a90420-1ac9-4b92-b886-2031fb01851e)




| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33833
