### PR TITLE
Fix: Ensure attachments attached with private followups are handled correctly

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7893,10 +7893,10 @@ abstract class CommonITILObject extends CommonDBTM
 
     /**
      * Returns criteria that can be used to get documents related to current instance.
-     * 
+     *
      * @param integer $email
      * @param bool $bypass_rights
-     * 
+     *
      * @return array
      */
     public function getAssociatedDocumentsCriteria($bypass_rights = false, $email = false): array
@@ -7950,7 +7950,7 @@ abstract class CommonITILObject extends CommonDBTM
                 ];
             }
         }
-  
+
        // documents associated to solutions
         if ($bypass_rights || ITILSolution::canView()) {
             // Run the subquery separately. It's better for huge databases

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7893,10 +7893,13 @@ abstract class CommonITILObject extends CommonDBTM
 
     /**
      * Returns criteria that can be used to get documents related to current instance.
-     *
+     * 
+     * @param integer $email
+     * @param bool $bypass_rights
+     * 
      * @return array
      */
-    public function getAssociatedDocumentsCriteria($bypass_rights = false): array
+    public function getAssociatedDocumentsCriteria($bypass_rights = false, $email = false): array
     {
         $task_class = $this->getType() . 'Task';
         /** @var DBMysql $DB */
@@ -7909,8 +7912,7 @@ abstract class CommonITILObject extends CommonDBTM
                 Document_Item::getTableField('items_id') => $this->getID(),
             ],
         ];
-
-       // documents associated to followups
+        // documents associated to followups
         if ($bypass_rights || ITILFollowup::canView()) {
             $fup_crits = [
                 ITILFollowup::getTableField('itemtype') => $this->getType(),
@@ -7920,6 +7922,19 @@ abstract class CommonITILObject extends CommonDBTM
                 $fup_crits[] = [
                     'OR' => ['is_private' => 0, 'users_id' => Session::getLoginUserID()],
                 ];
+            } else if ($email) {
+                // Won't send documents associated with private followups unless the user has necessary rights.
+                $send_private_followups = false;
+                $user_id = User::getUsersIdByEmails($email);
+
+                if (count($user_id) > 0) {
+                    $send_private_followups = User::hasRightById($user_id[0], ITILFollowup::SEEPRIVATE);
+                }
+                if (!$send_private_followups) {
+                    $fup_crits[] = [
+                        'AND' => ['is_private' => 0],
+                    ];
+                }
             }
             // Run the subquery separately. It's better for huge databases
             $iterator_tmp = $DB->request([
@@ -7935,7 +7950,7 @@ abstract class CommonITILObject extends CommonDBTM
                 ];
             }
         }
-
+  
        // documents associated to solutions
         if ($bypass_rights || ITILSolution::canView()) {
             // Run the subquery separately. It's better for huge databases

--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -201,7 +201,7 @@ class NotificationEventMailing extends NotificationEventAbstract
                             'itemtype' => $current->fields['itemtype'],
                         ];
                         if ($item instanceof CommonITILObject) {
-                            $doc_crit = $item->getAssociatedDocumentsCriteria(true);
+                            $doc_crit = $item->getAssociatedDocumentsCriteria(true, $current->getField('recipient'));
                             if ($is_html) {
                                 // Remove documents having "NO_TIMELINE" position if mail is HTML, as
                                 // these documents corresponds to inlined images.

--- a/src/User.php
+++ b/src/User.php
@@ -6903,4 +6903,40 @@ HTML;
             'savedsearches_pinned' => exportArrayToDB($all_pinned),
         ]));
     }
+    
+    /**
+     * Returns if user has a specific right.
+     * 
+     * @param integer $userID  
+     * @param integer $right  Right value like(ITILFollowup::SEEPRIVATE)
+     * 
+     * @return boolean
+     */
+    public static function hasRightById(int $userID, int $right = 0): bool
+    {
+        /** @var DBMysql $DB */
+        global $DB;
+        
+        $user_profiles_ids = Profile_User::getUserProfiles($userID);
+        if (count($user_profiles_ids) > 0) { 
+            
+            foreach ($user_profiles_ids as $key => $profile_id) {
+                $iterator = $DB->request([
+                    'SELECT' => 'rights',
+                    'FROM'   => 'glpi_profilerights',
+                    'WHERE'  => [
+                        'name'   => 'followup',
+                        'rights' => ['&', $right],
+                        'profiles_id' => $profile_id
+                    ]
+                ]);
+
+                if (count($iterator) > 0) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }    
 }

--- a/src/User.php
+++ b/src/User.php
@@ -6903,23 +6903,22 @@ HTML;
             'savedsearches_pinned' => exportArrayToDB($all_pinned),
         ]));
     }
-    
+
     /**
      * Returns if user has a specific right.
-     * 
-     * @param integer $userID  
+     *
+     * @param integer $userID
      * @param integer $right  Right value like(ITILFollowup::SEEPRIVATE)
-     * 
+     *
      * @return boolean
      */
     public static function hasRightById(int $userID, int $right = 0): bool
     {
         /** @var DBMysql $DB */
         global $DB;
-        
+
         $user_profiles_ids = Profile_User::getUserProfiles($userID);
-        if (count($user_profiles_ids) > 0) { 
-            
+        if (count($user_profiles_ids) > 0) {
             foreach ($user_profiles_ids as $key => $profile_id) {
                 $iterator = $DB->request([
                     'SELECT' => 'rights',
@@ -6938,5 +6937,5 @@ HTML;
         }
 
         return false;
-    }    
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #16060

When sending a notification to a user's email, documents associated with private followups won't be sent unless the user has the right to view them.