### PR TITLE
Fix loading of tabler CSS by TinyMCE editor

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -3559,17 +3559,17 @@ JS;
        // Apply all GLPI styles to editor content
         $theme = ThemeManager::getInstance()->getCurrentTheme();
         $content_css_paths = [
-            'public/lib/tabler.css',
             'css/glpi.scss',
             'css/core_palettes.scss',
         ];
         if ($theme->isCustomTheme()) {
             $content_css_paths[] = $theme->getPath();
         }
-        $content_css = implode(',', array_map(static function ($path) {
+        $content_css = preg_replace('/^.*href="([^"]+)".*$/', '$1', self::css('public/lib/base.css', ['force_no_version' => true]));
+        $content_css .= ',' . preg_replace('/^.*href="([^"]+)".*$/', '$1', self::css('public/lib/tabler.css', ['force_no_version' => true]));
+        $content_css .= ',' . implode(',', array_map(static function ($path) {
             return preg_replace('/^.*href="([^"]+)".*$/', '$1', self::scss($path, ['force_no_version' => true]));
         }, $content_css_paths));
-        $content_css .= ',' . preg_replace('/^.*href="([^"]+)".*$/', '$1', self::css('public/lib/base.css', ['force_no_version' => true]));
         $skin_url = preg_replace('/^.*href="([^"]+)".*$/', '$1', self::css('css/standalone/tinymce_empty_skin', ['force_no_version' => true]));
 
         // TODO: the recent changes to $skin_url above break tinyMCE's placeholders


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The `scss()` method was used for this CSS instead of the `css()` method. I also reorder the files to ensure that the GLPI theme is loaded after the base CSS.

Fixes the following error:
```
[2024-07-18 14:16:34] glpiphplog.WARNING:   *** PHP User Warning (512): Requested file /var/www/glpi/public/lib/tabler.css.scss does not exists. in /var/www/glpi/src/Html.php at line 6361
  Backtrace :
  src/Html.php:6361                                  trigger_error()
  front/css.php:61                                   Html::compileScss()
  ...Glpi/Controller/LegacyFileLoadController.php:57 require()
  vendor/symfony/http-kernel/HttpKernel.php:101      Glpi\Controller\LegacyFileLoadController->Glpi\Controller\{closure}()
  ...ymfony/http-foundation/StreamedResponse.php:106 Symfony\Component\HttpKernel\HttpKernel::Symfony\Component\HttpKernel\{closure}()
  vendor/symfony/http-foundation/Response.php:423    Symfony\Component\HttpFoundation\StreamedResponse->sendContent()
  public/index.php:58                                Symfony\Component\HttpFoundation\Response->send()
```