### PR TITLE
Prevent the debug mode to be active during install/update

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -509,7 +509,7 @@ if (is_writable(GLPI_SESSION_DIR)) {
 
 Session::start();
 
-// Ensure that the debug mode is not used, and ensure that logs are written into tog files
+// Ensure that the debug mode is not used, and ensure that logs are written into log files
 Toolbox::setDebugMode(mode: Session::NORMAL_MODE, log_in_files: 1);
 
 if (isset($_POST["language"])) {

--- a/install/install.php
+++ b/install/install.php
@@ -74,7 +74,7 @@ function header_html($etape)
     // CSS
     echo Html::css('public/lib/tabler.css');
     echo Html::css('public/lib/base.css');
-    echo Html::scss("css/install", [], true);
+    echo Html::scss("css/install");
     echo "</head>";
     echo "<body>";
     echo "<div id='principal'>";
@@ -502,14 +502,15 @@ function update1($dbname)
 
 //------------Start of install script---------------------------
 
-
 // Use default session dir if not writable
 if (is_writable(GLPI_SESSION_DIR)) {
     Session::setPath();
 }
 
 Session::start();
-error_reporting(0); // we want to check system before affraid the user.
+
+// Ensure that the debug mode is not used, and ensure that logs are written into tog files
+Toolbox::setDebugMode(mode: Session::NORMAL_MODE, log_in_files: 1);
 
 if (isset($_POST["language"])) {
     $_SESSION["glpilanguage"] = $_POST["language"];
@@ -582,8 +583,6 @@ if (!isset($_SESSION['can_process_install']) || !isset($_POST["install"])) {
 
         case "Etape_1": // check ok, go import mysql settings.
             checkConfigFile();
-           // check system ok, we can use specific parameters for debug
-            Toolbox::setDebugMode(Session::DEBUG_MODE, 0, 0, 1);
 
             header_html(sprintf(__('Step %d'), 1));
             step2($_POST["update"]);

--- a/install/update.php
+++ b/install/update.php
@@ -96,10 +96,6 @@ function doUpdateDb()
      */
     global $migration, $update;
 
-    // Init debug variable
-    // Only show errors
-    Toolbox::setDebugMode(Session::DEBUG_MODE, 0, 0, 1);
-
     $currents            = $update->getCurrents();
     $current_version     = $currents['version'];
     $current_db_version  = $currents['dbversion'];
@@ -184,7 +180,7 @@ echo Html::script("js/glpi_dialog.js");
 // CSS
 echo Html::css('public/lib/tabler.css');
 echo Html::css('public/lib/base.css');
-echo Html::scss("css/install", [], true);
+echo Html::scss("css/install");
 echo "</head>";
 echo "<body>";
 echo "<div id='principal'>";

--- a/src/Glpi/Config/LegacyConfigurators/StandardIncludes.php
+++ b/src/Glpi/Config/LegacyConfigurators/StandardIncludes.php
@@ -164,7 +164,6 @@ TWIG, $twig_params);
                 $_SERVER['argc']--;
             }
         }
-        Toolbox::setDebugMode();
 
         if (isset($_SESSION["glpiroot"]) && $CFG_GLPI["root_doc"] != $_SESSION["glpiroot"]) {
             // When `$_SESSION["glpiroot"]` differs from `$CFG_GLPI["root_doc"]`, it means that

--- a/src/Html.php
+++ b/src/Html.php
@@ -5067,24 +5067,20 @@ HTML;
      *
      * @param string  $url      File to include (relative to GLPI_ROOT)
      * @param array   $options  Array of HTML attributes
-     * @param bool    $no_debug Ignore the debug mode of GLPI (usefull for install/update process)
      *
      * @return string CSS link tag
      **/
-    public static function scss($url, $options = [], bool $no_debug = false)
+    public static function scss($url, $options = [])
     {
         $prod_file = self::getScssCompilePath($url);
 
-        if (
-            file_exists($prod_file)
-            && ($no_debug || $_SESSION['glpi_use_mode'] != Session::DEBUG_MODE)
-        ) {
+        if ($_SESSION['glpi_use_mode'] != Session::DEBUG_MODE && file_exists($prod_file)) {
             $url = self::getPrefixedUrl(str_replace(GLPI_ROOT, '', $prod_file));
         } else {
             $file = $url;
             $url = self::getPrefixedUrl('/front/css.php');
             $url .= '?file=' . $file;
-            if (!$no_debug && $_SESSION['glpi_use_mode'] == Session::DEBUG_MODE) {
+            if ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE) {
                 $url .= '&debug';
             }
         }

--- a/src/Update.php
+++ b/src/Update.php
@@ -89,7 +89,7 @@ class Update
         }
         Session::start();
 
-        // Ensure that the debug mode is not used, and ensure that logs are written into tog files
+        // Ensure that the debug mode is not used, and ensure that logs are written into log files
         Toolbox::setDebugMode(mode: Session::NORMAL_MODE, log_in_files: 1);
 
         if (isCommandLine()) {

--- a/src/Update.php
+++ b/src/Update.php
@@ -89,6 +89,9 @@ class Update
         }
         Session::start();
 
+        // Ensure that the debug mode is not used, and ensure that logs are written into tog files
+        Toolbox::setDebugMode(mode: Session::NORMAL_MODE, log_in_files: 1);
+
         if (isCommandLine()) {
            // Init debug variable
             $_SESSION = ['glpilanguage' => (isset($this->args['lang']) ? $this->args['lang'] : 'en_GB')];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I think we should remove the forced debug mode on installation/update.

I guess the purpose of it was to be sure that any errors message is displayed, to not have issues with silent failures.

- For the update process, we now have a check that validates the database consistency when the update is finished. If something silently fails, it will probably be detected and people will be able to checks the logs to get any error trace.
- For the installation, we do not have this kind of check, but I guess that it is highly improbable that it silently fails in the midlle of the installation without being noticed by the administrator.

