### PR TITLE
Reduce locale json size

### DIFF
--- a/front/locale.php
+++ b/front/locale.php
@@ -128,4 +128,4 @@ if (count(array_diff($header_keys, array_keys($headers))) > 0) {
 // Output messages and headers
 $messages[''] = $headers;
 $messages->ksort();
-echo(json_encode($messages, JSON_PRETTY_PRINT));
+echo(json_encode($messages));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

From 371kb to 326kb for en_GB. Having pretty JSON formatting is just a waste of bytes. There is the option to format the JSON in the browser's developer tools (at least in Chrome) if anyone really needs it.