### PR TITLE
Use rootdn for User getFromLDAP during auth

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -3347,8 +3347,10 @@ TWIG, $twig_params);
         $auth->extauth       = 1;
 
         $infos  = $auth->connection_ldap($ldap_method, $login, $password, $error);
+        // Get another connection using the rootdn, in case the user doesn't have all the permissions required to see their own info
+        $rootdn_ldap_connection = self::tryToConnectToServer($ldap_method, $ldap_method['rootdn'], (new GLPIKey())->decrypt($ldap_method['rootdn_passwd']));
 
-        if ($infos === false) {
+        if ($infos === false || $rootdn_ldap_connection === false) {
             return $auth;
         }
 
@@ -3376,7 +3378,7 @@ TWIG, $twig_params);
                 $auth->user_present = false;
             }
             $auth->user->getFromLDAP(
-                $auth->ldap_connection,
+                $rootdn_ldap_connection,
                 $ldap_method,
                 $user_dn,
                 $login,

--- a/src/User.php
+++ b/src/User.php
@@ -1985,7 +1985,7 @@ class User extends CommonDBTM
     /**
      * Function that tries to load the user information from LDAP.
      *
-     * @param resource $ldap_connection LDAP connection
+     * @param resource|LDAP\Connection $ldap_connection LDAP connection
      * @param array    $ldap_method     LDAP method
      * @param string   $userdn          Basedn of the user
      * @param string   $login           User Login


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #17492

It seems that in some cases, depending on the LDAP implementation, a user could not have all the permissions required to see their own information which GLPI is trying to import. We should use the rootdn for `User::getFromLDAP` rather than the connection we make to validate the user's password during authentication. We use the rootdn for other calls to this method.