### PR TITLE
Fix handling of project task team members after add

### DIFF
--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -295,7 +295,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
         global $CFG_GLPI;
 
         // Add team members
-        if (isset($this->input['teammember_list'])) {
+        if (!empty($this->input['teammember_list'])) {
             $taskteam = new ProjectTaskTeam();
             $members_types = self::getTeamMembersItemtypes();
             foreach ($members_types as $type) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In some cases, the `teammember_list` may be an empty string.