### PR TITLE
Modularize Forms JS Code

### DIFF
--- a/css/includes/components/form/_form-editor.scss
+++ b/css/includes/components/form/_form-editor.scss
@@ -31,6 +31,12 @@
  * ---------------------------------------------------------------------
  */
 
+[data-glpi-form-editor-container]{
+    &:not(.initialized) {
+        pointer-events: none;
+    }
+}
+
 .form-editor {
     // Use all available parent space
     flex-grow: 1;

--- a/js/modules/DynamicDropdownController.js
+++ b/js/modules/DynamicDropdownController.js
@@ -41,7 +41,7 @@
  * - data-glpi-parent-dropdown-condition: the value that the parent dropdown
  *  must have for this dropdown to be displayed
  */
-class DynamicDropdownController
+export class DynamicDropdownController
 {
     constructor() {
         this.#watchForDropdownChanges();

--- a/js/modules/Forms/DestinationAutoConfigController.js
+++ b/js/modules/Forms/DestinationAutoConfigController.js
@@ -33,7 +33,7 @@
 
 /* global tinymce */
 
-class GlpiFormDestinationAutoConfigController
+export class GlpiFormDestinationAutoConfigController
 {
     constructor() {
         this.#watchForAutoConfigToggle();

--- a/js/modules/Forms/EditorController.js
+++ b/js/modules/Forms/EditorController.js
@@ -33,10 +33,12 @@
 
 /* global _, tinymce_editor_configs, getUUID, getRealInputWidth, sortable, tinymce, glpi_toast_error, bootstrap, setupAjaxDropdown, setupAdaptDropdown */
 
+import './QuestionDropdown.js';
+
 /**
  * Client code to handle users actions on the form_editor template
  */
-class GlpiFormEditorController
+export class GlpiFormEditorController
 {
     /**
      * Target form editor (jquery selector)

--- a/js/modules/Forms/EditorController.js
+++ b/js/modules/Forms/EditorController.js
@@ -33,8 +33,6 @@
 
 /* global _, tinymce_editor_configs, getUUID, getRealInputWidth, sortable, tinymce, glpi_toast_error, bootstrap, setupAjaxDropdown, setupAdaptDropdown */
 
-import './QuestionDropdown.js';
-
 /**
  * Client code to handle users actions on the form_editor template
  */

--- a/js/modules/Forms/EditorConvertedExtractedDefaultValue.js
+++ b/js/modules/Forms/EditorConvertedExtractedDefaultValue.js
@@ -31,7 +31,7 @@
  * ---------------------------------------------------------------------
  */
 
-class GlpiFormEditorConvertedExtractedDefaultValue
+export class GlpiFormEditorConvertedExtractedDefaultValue
 {
     /**
      * Enum for data types

--- a/js/modules/Forms/QuestionDropdown.js
+++ b/js/modules/Forms/QuestionDropdown.js
@@ -31,9 +31,11 @@
  * ---------------------------------------------------------------------
  */
 
-/* global sortable, GlpiFormQuestionTypeSelectable */
+/* global sortable */
 
-class GlpiFormQuestionTypeDropdown extends GlpiFormQuestionTypeSelectable {
+import { GlpiFormQuestionTypeSelectable } from './QuestionSelectable.js';
+
+export class GlpiFormQuestionTypeDropdown extends GlpiFormQuestionTypeSelectable {
 
     /**
      * Create a new GlpiFormQuestionTypeSelectable instance.

--- a/js/modules/Forms/QuestionSelectable.js
+++ b/js/modules/Forms/QuestionSelectable.js
@@ -33,7 +33,7 @@
 
 /* global sortable, getUUID */
 
-class GlpiFormQuestionTypeSelectable {
+export class GlpiFormQuestionTypeSelectable {
 
     /**
      * The selectable input type.
@@ -68,7 +68,7 @@ class GlpiFormQuestionTypeSelectable {
                 .each((index, option) => this._registerOptionListeners($(option)));
 
             // Compute the state to update the input names
-            window.glpi_form_editor_controller.computeState();
+            this.#getFormController().computeState();
 
             // Restore the checked state
             if (this._inputType === 'radio') {
@@ -79,6 +79,10 @@ class GlpiFormQuestionTypeSelectable {
 
             this.#enableOptionsSortable();
         }
+    }
+
+    #getFormController() {
+        return this._container.closest('form[data-glpi-form-editor-container]').data('controller');
     }
 
     /**
@@ -169,7 +173,7 @@ class GlpiFormQuestionTypeSelectable {
          * Required to link radio inputs between them in the same question
          * and unlink them between questions
          */
-        window.glpi_form_editor_controller.computeState();
+        this.#getFormController().computeState();
 
         // Call the onAddOption method
         this.onAddOption($(input).parent().next());
@@ -262,7 +266,7 @@ class GlpiFormQuestionTypeSelectable {
              * Required to link radio inputs between them in the same question
              * and unlink them between questions
              */
-            window.glpi_form_editor_controller.computeState();
+            this.#getFormController().computeState();
         }
     }
 

--- a/js/modules/Forms/QuestionSelectable.js
+++ b/js/modules/Forms/QuestionSelectable.js
@@ -67,7 +67,6 @@ export class GlpiFormQuestionTypeSelectable {
                 .siblings('div[data-glpi-form-editor-question-extra-details]')
                 .each((index, option) => this._registerOptionListeners($(option)));
 
-            // Compute the state to update the input names
             this.#getFormController().computeState();
 
             // Restore the checked state

--- a/js/modules/Forms/RendererController.js
+++ b/js/modules/Forms/RendererController.js
@@ -36,7 +36,7 @@
 /**
  * Client code to handle users actions on the form_renderer template
  */
-class GlpiFormRendererController
+export class GlpiFormRendererController
 {
     /**
      * Target form (jquery selector)

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -106,16 +106,6 @@ final class Form extends CommonDBTM
         $this->initForm($id, $options);
 
         $types_manager = QuestionTypesManager::getInstance();
-        $js_files = [
-            'js/form_editor_converted_extracted_default_value.js',
-        ];
-        foreach ($types_manager->getQuestionTypes() as $type) {
-            foreach ((new $type())->loadJavascriptFiles() as $file) {
-                if (!in_array($file, $js_files)) {
-                    $js_files[] = $file;
-                }
-            }
-        }
 
         // Render twig template
         $twig = TemplateRenderer::getInstance();
@@ -123,7 +113,6 @@ final class Form extends CommonDBTM
             'item'                   => $this,
             'params'                 => $options,
             'question_types_manager' => $types_manager,
-            'js_files'               => $js_files,
             'allow_unauthenticated_access'      => FormAccessControlManager::getInstance()->allowUnauthenticatedAccess($this),
         ]);
         return true;

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -107,7 +107,6 @@ final class Form extends CommonDBTM
 
         $types_manager = QuestionTypesManager::getInstance();
         $js_files = [
-            'js/form_editor_controller.js',
             'js/form_editor_converted_extracted_default_value.js',
         ];
         foreach ($types_manager->getQuestionTypes() as $type) {

--- a/src/Glpi/Form/QuestionType/AbstractQuestionType.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionType.php
@@ -46,12 +46,6 @@ abstract class AbstractQuestionType implements QuestionTypeInterface
     }
 
     #[Override]
-    public function loadJavascriptFiles(): array
-    {
-        return []; // No extra JS files by default
-    }
-
-    #[Override]
     public function formatDefaultValueForDB(mixed $value): ?string
     {
         return $value; // Default value is already formatted

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
@@ -70,16 +70,17 @@ abstract class AbstractQuestionTypeSelectable extends AbstractQuestionType
      */
     protected function getFormInlineScript(): string
     {
+        // language=Twig
         $js = <<<TWIG
-            $(document).ready(function() {
+            import("{{ js_path('js/modules/Forms/QuestionSelectable.js') }}").then((m) => {
                 {% if question is not null %}
                     const container = $('div[data-glpi-form-editor-selectable-question-options="{{ rand }}"]');
-                    new GlpiFormQuestionTypeSelectable('{{ input_type|escape('js') }}', container);
+                    new m.GlpiFormQuestionTypeSelectable('{{ input_type|escape('js') }}', container);
                 {% else %}
                     $(document).on('glpi-form-editor-question-type-changed', function(e, question, type) {
                         if (type === '{{ question_type|escape('js') }}') {
                             const container = question.find('div[data-glpi-form-editor-selectable-question-options]');
-                            new GlpiFormQuestionTypeSelectable('{{ input_type|escape('js') }}', container);
+                            new m.GlpiFormQuestionTypeSelectable('{{ input_type|escape('js') }}', container);
                         }
                     });
                 {% endif %}
@@ -92,7 +93,7 @@ TWIG;
     #[Override]
     public function loadJavascriptFiles(): array
     {
-        return ['js/form_question_selectable.js'];
+        return [];
     }
 
     #[Override]

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
@@ -91,12 +91,6 @@ TWIG;
     }
 
     #[Override]
-    public function loadJavascriptFiles(): array
-    {
-        return [];
-    }
-
-    #[Override]
     public function formatDefaultValueForDB(mixed $value): ?string
     {
         if (is_array($value)) {
@@ -261,9 +255,12 @@ TWIG;
             {{ _self.addOption(input_type, false, '', translations, null, true, true, hide_default_value_input) }}
         </div>
 
-
         <script>
-            {$this->getFormInlineScript()}
+            // TODO: avoid this, the script should probably run in a dedicated method that the framework can call at
+            // the right time.
+            $("[data-glpi-form-editor-container]").on('initialized', () => {
+                {$this->getFormInlineScript()}
+            });
         </script>
 TWIG;
 

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
@@ -57,6 +57,10 @@ abstract class AbstractQuestionTypeShortAnswer extends AbstractQuestionType
         return <<<JS
             {
                 "extractDefaultValue": function (question) {
+                    const GlpiFormEditorConvertedExtractedDefaultValue = $("[data-glpi-form-editor-container]")
+                        .data('EditorConvertedExtractedDefaultValue')
+                    ;
+
                     const input = question.find('[data-glpi-form-editor-question-type-specific]')
                         .find('[name="default_value"], [data-glpi-form-editor-original-name="default_value"]');
 
@@ -66,6 +70,10 @@ abstract class AbstractQuestionTypeShortAnswer extends AbstractQuestionType
                     );
                 },
                 "convertDefaultValue": function (question, value) {
+                    const GlpiFormEditorConvertedExtractedDefaultValue = $("[data-glpi-form-editor-container]")
+                        .data('EditorConvertedExtractedDefaultValue')
+                    ;
+
                     if (value == null) {
                         return '';
                     }

--- a/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
@@ -80,27 +80,19 @@ final class QuestionTypeDropdown extends AbstractQuestionTypeSelectable
     }
 
     #[Override]
-    public function loadJavascriptFiles(): array
-    {
-        return array_merge(
-            parent::loadJavascriptFiles(),
-            ['js/form_question_dropdown.js']
-        );
-    }
-
-    #[Override]
     protected function getFormInlineScript(): string
     {
+        // language=Twig
         $js = <<<TWIG
-            $(document).ready(function() {
+            import("{{ js_path('js/modules/Forms/QuestionDropdown.js') }}").then((m) => {
                 {% if question is not null %}
                     const container = $('div[data-glpi-form-editor-selectable-question-options="{{ rand }}"]');
-                    new GlpiFormQuestionTypeDropdown('{{ input_type|escape('js') }}', container);
+                    new m.GlpiFormQuestionTypeDropdown('{{ input_type|escape('js') }}', container);
                 {% else %}
                     $(document).on('glpi-form-editor-question-type-changed', function(e, question, type) {
                         if (type === '{{ question_type|escape('js') }}') {
                             const container = question.find('div[data-glpi-form-editor-selectable-question-options]');
-                            new GlpiFormQuestionTypeDropdown('{{ input_type|escape('js') }}', container);
+                            new m.GlpiFormQuestionTypeDropdown('{{ input_type|escape('js') }}', container);
                         }
                     });
                 {% endif %}

--- a/src/Glpi/Form/QuestionType/QuestionTypeInterface.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeInterface.php
@@ -45,14 +45,6 @@ interface QuestionTypeInterface
     public function __construct();
 
     /**
-     * Load the required JS files for this question type.
-     * This method is called when the form editor page is loaded.
-     *
-     * @return array List of JS files to load.
-     */
-    public function loadJavascriptFiles(): array;
-
-    /**
      * Format the default value for the database.
      * This method is called before saving the question.
      *

--- a/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
@@ -50,6 +50,10 @@ final class QuestionTypeLongText extends AbstractQuestionType
         return <<<JS
             {
                 "extractDefaultValue": function (question) {
+                    const GlpiFormEditorConvertedExtractedDefaultValue = $("[data-glpi-form-editor-container]")
+                        .data('EditorConvertedExtractedDefaultValue')
+                    ;
+
                     const textarea = question.find('[data-glpi-form-editor-question-type-specific]')
                         .find('[name="default_value"], [data-glpi-form-editor-original-name="default_value"]');
                     const inst = tinyMCE.get(textarea.attr('id'));
@@ -69,6 +73,10 @@ final class QuestionTypeLongText extends AbstractQuestionType
                     return '';
                 },
                 "convertDefaultValue": function (question, value) {
+                    const GlpiFormEditorConvertedExtractedDefaultValue = $("[data-glpi-form-editor-container]")
+                        .data('EditorConvertedExtractedDefaultValue')
+                    ;
+
                     if (value == null) {
                         return '';
                     }

--- a/src/Glpi/Form/Renderer/FormRenderer.php
+++ b/src/Glpi/Form/Renderer/FormRenderer.php
@@ -81,16 +81,9 @@ final class FormRenderer
      */
     public function render(Form $form): string
     {
-        // Load JS controller
-        $html = Html::script("js/form_renderer_controller.js");
-
-        // Load template
-        $twig = TemplateRenderer::getInstance();
-        $html .= $twig->render('pages/form_renderer.html.twig', [
-            'form'                 => $form,
+        return TemplateRenderer::getInstance()->render('pages/form_renderer.html.twig', [
+            'form' => $form,
             'unauthenticated_user' => !Session::isAuthenticated(),
         ]);
-
-        return $html;
     }
 }

--- a/templates/pages/admin/form/form_destination.html.twig
+++ b/templates/pages/admin/form/form_destination.html.twig
@@ -145,11 +145,13 @@
     </div>
 </div>
 
-<script src="{{ js_path("js/form_destination_auto_config_controller.js") }}"></script>
-<script src="{{ js_path("js/dynamic_dropdown_controller.js") }}"></script>
 <script>
-    new GlpiFormDestinationAutoConfigController();
-    new DynamicDropdownController();
+    import("{{ js_path('js/modules/Forms/DestinationAutoConfigController.js') }}").then((m) => {
+        new m.GlpiFormDestinationAutoConfigController();
+    });
+    import("{{ js_path('js/modules/DynamicDropdownController.js') }}").then((m) => {
+        new m.DynamicDropdownController();
+    });
 </script>
 
 

--- a/templates/pages/admin/form/form_destination_commonitil_config.html.twig
+++ b/templates/pages/admin/form/form_destination_commonitil_config.html.twig
@@ -89,9 +89,3 @@
         </section>
     {% endfor %}
 </div>
-
-<script>
-    import("{{ js_path('js/modules/Forms/DestinationAutoConfigController.js') }}").then((m) => {
-        new m.GlpiFormDestinationAutoConfigController();
-    });
-</script>

--- a/templates/pages/admin/form/form_destination_commonitil_config.html.twig
+++ b/templates/pages/admin/form/form_destination_commonitil_config.html.twig
@@ -89,3 +89,9 @@
         </section>
     {% endfor %}
 </div>
+
+<script>
+    import("{{ js_path('js/modules/Forms/DestinationAutoConfigController.js') }}").then((m) => {
+        new m.GlpiFormDestinationAutoConfigController();
+    });
+</script>

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -369,7 +369,7 @@
 
 <script defer type="module">
     import("{{ js_path('js/modules/Forms/EditorController.js') }}").then((m) => {
-        $('#form-form').data('controller', new m.GlpiFormEditorController(
+        $('[data-glpi-form-editor-container]').data('controller', new m.GlpiFormEditorController(
             "[data-glpi-form-editor-container]",
             {{ item.fields.is_draft ? "true" : "false" }},
             "{{ question_types_manager.getDefaultTypeClass()|escape('js') }}",

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -44,10 +44,6 @@
     'no_label'     : true,
 } %}
 
-{% for js_file in js_files %}
-    <script defer src="{{ js_path(js_file) }}"></script>
-{% endfor %}
-
 <form
     id="main-form"
     data-glpi-form-editor-container
@@ -368,14 +364,37 @@
 {% endif %}
 
 <script defer type="module">
-    import("{{ js_path('js/modules/Forms/EditorController.js') }}").then((m) => {
-        $('[data-glpi-form-editor-container]').data('controller', new m.GlpiFormEditorController(
-            "[data-glpi-form-editor-container]",
-            {{ item.fields.is_draft ? "true" : "false" }},
-            "{{ question_types_manager.getDefaultTypeClass()|escape('js') }}",
-            "[data-glpi-form-editor-templates]"
-        ));
-    });
+(async () => {
+    const modules = await Promise.all([
+        import("{{ js_path('js/modules/Forms/EditorController.js') }}"),
+        import("{{ js_path('js/modules/Forms/EditorConvertedExtractedDefaultValue.js') }}")
+    ]);
+    const GlpiFormEditorController = modules[0].GlpiFormEditorController;
+    const EditorConvertedExtractedDefaultValue = modules[1].GlpiFormEditorConvertedExtractedDefaultValue;
+
+    const container_selector = "[data-glpi-form-editor-container]";
+    const controller = new GlpiFormEditorController(
+        container_selector,
+        {{ item.fields.is_draft ? "true" : "false" }},
+        "{{ question_types_manager.getDefaultTypeClass()|escape('js') }}",
+        "[data-glpi-form-editor-templates]"
+    );
+
+    // Temporary solution, would be better to import it directly where it is needed but the current
+    // design doesn't allow it.
+    $(container_selector).data('EditorConvertedExtractedDefaultValue', EditorConvertedExtractedDefaultValue);
+
+    {% for question_type in question_types_manager.getQuestionTypes() %}
+        controller.registerQuestionTypeOptions(
+            '{{ get_class(question_type)|e('js') }}',
+            {{ question_type.getFormEditorJsOptions()|raw }}
+        );
+    {% endfor %}
+
+    $(container_selector).data('controller', controller);
+    $(container_selector).addClass("initialized");
+    $(container_selector).trigger("initialized");
+})();
 </script>
 
 <style>

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -45,7 +45,7 @@
 } %}
 
 {% for js_file in js_files %}
-    <script src="{{ js_path(js_file) }}"></script>
+    <script defer src="{{ js_path(js_file) }}"></script>
 {% endfor %}
 
 <form
@@ -367,20 +367,15 @@
     </div>
 {% endif %}
 
-<script>
-    window.glpi_form_editor_controller = new GlpiFormEditorController(
-        "[data-glpi-form-editor-container]",
-        {{ item.fields.is_draft ? "true" : "false" }},
-        "{{ question_types_manager.getDefaultTypeClass()|escape('js') }}",
-        "[data-glpi-form-editor-templates]"
-    );
-
-    {% for question_type in question_types_manager.getQuestionTypes() %}
-        window.glpi_form_editor_controller.registerQuestionTypeOptions(
-            '{{ get_class(question_type)|e('js') }}',
-            {{ question_type.getFormEditorJsOptions()|raw }}
-        );
-    {% endfor %}
+<script defer type="module">
+    import("{{ js_path('js/modules/Forms/EditorController.js') }}").then((m) => {
+        $('#form-form').data('controller', new m.GlpiFormEditorController(
+            "[data-glpi-form-editor-container]",
+            {{ item.fields.is_draft ? "true" : "false" }},
+            "{{ question_types_manager.getDefaultTypeClass()|escape('js') }}",
+            "[data-glpi-form-editor-templates]"
+        ));
+    });
 </script>
 
 <style>

--- a/templates/pages/form_renderer.html.twig
+++ b/templates/pages/form_renderer.html.twig
@@ -192,6 +192,8 @@
 </form>
 
 <script>
-    new GlpiFormRendererController($('#forms_form_answers'));
+    import("{{ js_path('js/modules/Forms/RendererController.js') }}").then((m) => {
+        new m.GlpiFormRendererController($('#forms_form_answers'));
+    });
 </script>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The Forms feature JS should be modularized and avoid adding even more to the `window` object. It makes it easier to move to a built script later rather than importing many smaller JS files.

Right now, it some cases the `QuestionSelectable.js` script can be imported twice because of the import in `QuestionDropdown.js` and the dynamic import for specific question types. Something I don't have time to spend more time on is making sure the JS files for specific question types are always loaded through imports in the EditorController and have them work without having to initialize new instances from inline scripts. That would avoid the duplicate import.