### PR TITLE
fix(user): restores login in user's tooltip

### DIFF
--- a/templates/components/user/info_card.html.twig
+++ b/templates/components/user/info_card.html.twig
@@ -54,6 +54,12 @@
          </h4>
 
          <div class="text-muted">
+            {% if user['login'] is not empty %}
+                <div>
+                    <i class="fa-fw fas fa-id-badge"></i>
+                    {{ user['login'] }}
+                </div>
+            {% endif %}
             {% if user['email']|length > 0 %}
                <div>
                   <i class="fas fa-fw fa-envelope"></i>


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33820

Backport of #16974, because the login appeared in 9.5 in the tooltip