### PR TITLE
fix(ticket): restores group's tooltip

### DIFF
--- a/ajax/comments.php
+++ b/ajax/comments.php
@@ -93,12 +93,10 @@ if (
             break;
 
         case Group::getType():
-            if ($_POST['value'] == 0) {
-                $tmpname = [
-                    'link'    => $CFG_GLPI['root_doc'] . "/front/group.php",
-                    'comment' => "",
-                ];
-            } else {
+            $tmpname = [
+                'comment' => "",
+            ];
+            if ($_POST['value'] != 0) {
                 $group = new \Group();
                 if (is_array($_POST["value"])) {
                     $comments = [];
@@ -135,12 +133,6 @@ if (
                 }
             }
             echo($tmpname["comment"] ?? '');
-
-            if (isset($_POST['withlink']) && isset($tmpname['link'])) {
-                echo "<script type='text/javascript' >\n";
-                echo Html::jsGetElementbyID($_POST['withlink']) . ".attr('href', '" . $tmpname['link'] . "');";
-                echo "</script>\n";
-            }
             break;
 
         default:

--- a/ajax/comments.php
+++ b/ajax/comments.php
@@ -98,20 +98,18 @@ if (
             ];
             if ($_POST['value'] != 0) {
                 $group = new \Group();
-                if (!is_array($_POST["value"])) {
-                    if ($group->getFromDB($_POST['value']) && $group->canView()) {
-                        $group_params = [
-                            'id' => $group->getID(),
-                            'group_name' => $group->fields['completename'],
-                            'comment' => $group->fields['comment'],
-                        ];
-                        $comment = TemplateRenderer::getInstance()->render('components/group/info_card.html.twig', [
-                            'group' => $group_params,
-                        ]);
-                        $tmpname = [
-                            'comment' => $comment,
-                        ];
-                    }
+                if (!is_array($_POST["value"]) && $group->getFromDB($_POST['value']) && $group->canView()) {
+                    $group_params = [
+                        'id' => $group->getID(),
+                        'group_name' => $group->fields['completename'],
+                        'comment' => $group->fields['comment'],
+                    ];
+                    $comment = TemplateRenderer::getInstance()->render('components/group/info_card.html.twig', [
+                        'group' => $group_params,
+                    ]);
+                    $tmpname = [
+                        'comment' => $comment,
+                    ];
                 }
             }
             echo($tmpname["comment"] ?? '');

--- a/ajax/comments.php
+++ b/ajax/comments.php
@@ -98,25 +98,7 @@ if (
             ];
             if ($_POST['value'] != 0) {
                 $group = new \Group();
-                if (is_array($_POST["value"])) {
-                    $comments = [];
-                    foreach ($_POST["value"] as $groups_id) {
-                        if ($group->getFromDB($groups_id) && $group->canView()) {
-                            $group_params = [
-                                'id' => $groups_id,
-                                'group_name' => $group->fields['completename'],
-                                'comment' => $group->fields['comment'],
-                            ];
-                            $comments[] = TemplateRenderer::getInstance()->render('components/group/info_card.html.twig', [
-                                'group' => $group_params,
-                            ]);
-                        }
-                    }
-                    $tmpname = [
-                        'comment' => implode("<br>", $comments),
-                    ];
-                    unset($_POST['withlink']);
-                } else {
+                if (!is_array($_POST["value"])) {
                     if ($group->getFromDB($_POST['value']) && $group->canView()) {
                         $group_params = [
                             'id' => $group->getID(),

--- a/ajax/comments.php
+++ b/ajax/comments.php
@@ -45,11 +45,13 @@ Html::header_nocache();
 
 Session::checkLoginUser();
 
+use Glpi\Application\View\TemplateRenderer;
+
 if (
     isset($_POST["itemtype"])
     && isset($_POST["value"])
 ) {
-   // Security
+    // Security
     if (!is_subclass_of($_POST["itemtype"], "CommonDBTM")) {
         exit();
     }
@@ -81,7 +83,58 @@ if (
                     }
                 }
             }
-            echo ($tmpname["comment"] ?? '');
+            echo($tmpname["comment"] ?? '');
+
+            if (isset($_POST['withlink']) && isset($tmpname['link'])) {
+                echo "<script type='text/javascript' >\n";
+                echo Html::jsGetElementbyID($_POST['withlink']) . ".attr('href', '" . $tmpname['link'] . "');";
+                echo "</script>\n";
+            }
+            break;
+
+        case Group::getType():
+            if ($_POST['value'] == 0) {
+                $tmpname = [
+                    'link'    => $CFG_GLPI['root_doc'] . "/front/group.php",
+                    'comment' => "",
+                ];
+            } else {
+                $group = new \Group();
+                if (is_array($_POST["value"])) {
+                    $comments = [];
+                    foreach ($_POST["value"] as $groups_id) {
+                        if ($group->getFromDB($groups_id) && $group->canView()) {
+                            $group_params = [
+                                'id' => $groups_id,
+                                'group_name' => $group->fields['completename'],
+                                'comment' => $group->fields['comment'],
+                            ];
+                            $comments[] = TemplateRenderer::getInstance()->render('components/group/info_card.html.twig', [
+                                'group' => $group_params,
+                            ]);
+                        }
+                    }
+                    $tmpname = [
+                        'comment' => implode("<br>", $comments),
+                    ];
+                    unset($_POST['withlink']);
+                } else {
+                    if ($group->getFromDB($_POST['value']) && $group->canView()) {
+                        $group_params = [
+                            'id' => $group->getID(),
+                            'group_name' => $group->fields['completename'],
+                            'comment' => $group->fields['comment'],
+                        ];
+                        $comment = TemplateRenderer::getInstance()->render('components/group/info_card.html.twig', [
+                            'group' => $group_params,
+                        ]);
+                        $tmpname = [
+                            'comment' => $comment,
+                        ];
+                    }
+                }
+            }
+            echo($tmpname["comment"] ?? '');
 
             if (isset($_POST['withlink']) && isset($tmpname['link'])) {
                 echo "<script type='text/javascript' >\n";
@@ -123,12 +176,12 @@ if (
                     $item = getItemForItemtype($_POST['itemtype']);
                     echo "<script type='text/javascript' >\n";
 
-                   //if item have a DC position (reload url to it's rack)
+                    //if item have a DC position (reload url to it's rack)
                     if ($rack = $item->isRackPart($_POST['itemtype'], $_POST["value"], true)) {
                         echo Html::jsGetElementbyID($_POST['with_dc_position']) . ".
                   html(\"&nbsp;<a class='fas fa-crosshairs' href='" . $rack->getLinkURL() . "'></a>\");";
                     } else {
-                       //remove old dc position
+                        //remove old dc position
                         echo Html::jsGetElementbyID($_POST['with_dc_position']) . ".empty();";
                     }
                     echo "</script>\n";

--- a/templates/components/group/info_card.html.twig
+++ b/templates/components/group/info_card.html.twig
@@ -50,13 +50,4 @@
          {% endif %}
       </div>
    </div>
-
-   {% if can_edit %}
-      <div class="col">
-         <a class="btn btn-icon btn-sm btn-outline-secondary" href="{{ path('front/preference.php') }}"
-            title="{{ __('Edit') }}" data-bs-toggle="tooltip" data-bs-placement="right">
-            <i class="fas fa-group-edit"></i>
-         </a>
-      </div>
-   {% endif %}
 </div>

--- a/templates/components/group/info_card.html.twig
+++ b/templates/components/group/info_card.html.twig
@@ -1,0 +1,62 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+<div class="p-0 group-info-card">
+   <div class="row">
+      <h4 class="card-title mb-1">
+         {% if group['id'] %}
+            <a href="{{ 'Group'|itemtype_form_path(group['id']) }}">{{ group['group_name'] }}</a>
+         {% else %}
+            {{ group['group_name'] }}
+         {% endif %}
+      </h4>
+
+      <div class="text-muted">
+         {% if group['comment']|length > 0 %}
+            <div>
+               <i class="ti ti-notes"></i>
+               {{ group['comment'] }}
+            </div>
+         {% endif %}
+      </div>
+   </div>
+
+   {% if can_edit %}
+      <div class="col">
+         <a class="btn btn-icon btn-sm btn-outline-secondary" href="{{ path('front/preference.php') }}"
+            title="{{ __('Edit') }}" data-bs-toggle="tooltip" data-bs-placement="right">
+            <i class="fas fa-group-edit"></i>
+         </a>
+      </div>
+   {% endif %}
+</div>

--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -174,6 +174,23 @@
               });
           }
 
+         if (is_selection && itemtype == "Group") {
+            const unique_id = "group_opt_" + actor_select.attr('data-actor-type') + "Group" + items_id;
+            $.ajax({
+               url: '{{ path('/ajax/comments.php') }}',
+               type: 'POST',
+               data: {
+                  'itemtype': 'Group',
+                  'value': items_id,
+               }
+            }).then((result) => {
+               if (result) {
+                  actor_select.parent().append('<' + `div id="content${unique_id}" style="display: none;">` + result + '<' + '/div>');
+                  option_element.attr('data-glpi-popover-source', `content${unique_id}`);
+               }
+            });
+         }
+
          // manage ticket information (number of assigned ticket for an actor)
          if (is_selection && itemtype != "Email") {
             var label = '';

--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -308,11 +308,22 @@
             if ($('.user-info-card:hover').length > 0) {
                return false;
             }
+            // prevent closing popover when group card is hover
+            if ($('.group-info-card:hover').length > 0) {
+               return false;
+            }
          });
       });
 
         // when the mouse leave the user card in the popover, close it
         $(document).on('mouseleave', '.user-info-card', function() {
+            setTimeout(() => {
+                $('.popover').popover('hide');
+            }, 300);
+        });
+
+        // when the mouse leave the group card in the popover, close it
+        $(document).on('mouseleave', '.group-info-card', function() {
             setTimeout(() => {
                 $('.popover').popover('hide');
             }, 300);


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33820

In 9.5, on tickets, groups had a tooltip allowing the complete name and comment to be displayed, but this was no longer present on 10.0.

Before:
![image](https://github.com/user-attachments/assets/848d5270-f7ff-4154-9c83-ad6f380ed471)

After:
![image](https://github.com/user-attachments/assets/6ba6cc9b-8a00-48a8-814e-15aa878ecacd)
