### PR TITLE
fix: avoids creating a link within a link with img

### DIFF
--- a/phpunit/functional/ToolboxTest.php
+++ b/phpunit/functional/ToolboxTest.php
@@ -896,45 +896,77 @@ class ToolboxTest extends DbTestCase
 
     public function testConvertTagToImageAlreadyInLink()
     {
-        $img_tag = uniqid('', true);
+        $img_1_tag = uniqid('', true);
+        $img_2_tag = uniqid('', true);
 
         $item = new \Ticket();
         $item->fields['id'] = mt_rand(1, 50);
 
-        // Create document in DB
-        $document = new \Document();
-        $doc_id = $document->add([
-            'name'     => 'basic document',
-            'filename' => 'img.png',
-            'mime'     => 'image/png',
-            'tag'      => $img_tag,
-        ]);
-        $this->assertGreaterThan(0, (int)$doc_id);
+        $document_1 = $this->createItem(
+            \Document::class,
+            [
+                'name'     => 'basic document',
+                'filename' => 'img.png',
+                'mime'     => 'image/png',
+                'tag'      => $img_1_tag,
+            ]
+        );
+        $document_2 = $this->createItem(
+            \Document::class,
+            [
+                'name'     => 'another document',
+                'filename' => 'img2.png',
+                'mime'     => 'image/png',
+                'tag'      => $img_2_tag,
+            ]
+        );
 
-        $expected_url     = 'http://localhost';
-        $content_text     = '<a href="' . $expected_url . '" target="_blank" ><img id="' . $img_tag . '" width="10" height="10" /></a>';
-        $image_url        = '/front/document.send.php?docid=' . $doc_id;
-        $image_url       .= '&itemtype=' . $item->getType();
-        $image_url       .= '&items_id=' . $item->fields['id'];
+        $expected_url_1 = 'http://localhost/test/1';
+        $content_text   = <<<HTML
+            Some contents with <a href="http://example.org/">a link</a>
+            and a first image <a href="{$expected_url_1}" target="_blank"><img id="{$img_1_tag}" width="10" height="10" /></a> inside a link
+            then a second image surrounded by links <a href="http://www.example.org/">link1</a> <img id="{$img_2_tag}" width="10" height="10" /> <a href="http://www.example.org/2">link2</a>
+HTML;
 
-        $expected_result  = '<a href="' . $expected_url . '" target="_blank" ><img alt="' . $img_tag . '" width="10" src="' . $image_url . '" /></a>';
+        $image_1_src = sprintf(
+            '/front/document.send.php?docid=%d&itemtype=%s&items_id=%d',
+            $document_1->getID(),
+            $item->getType(),
+            $item->fields['id']
+        );
+        $image_2_src = sprintf(
+            '/front/document.send.php?docid=%d&itemtype=%s&items_id=%d',
+            $document_2->getID(),
+            $item->getType(),
+            $item->fields['id']
+        );
+        $expected_result  = <<<HTML
+            Some contents with <a href="http://example.org/">a link</a>
+            and a first image <a href="{$expected_url_1}" target="_blank"><img alt="{$img_1_tag}" width="10" src="{$image_1_src}" /></a> inside a link
+            then a second image surrounded by links <a href="http://www.example.org/">link1</a> <a href="{$image_2_src}" target="_blank" ><img alt="{$img_2_tag}" width="10" src="{$image_2_src}" /></a> <a href="http://www.example.org/2">link2</a>
+HTML;
+
+        $docs_data = [
+            $document_1->getID() => ['tag' => $img_1_tag],
+            $document_2->getID() => ['tag' => $img_2_tag]
+        ];
 
         // Processed data is expected to be sanitized, and expected result should remain sanitized
         $this->assertEquals(
             Sanitizer::sanitize($expected_result),
-            \Toolbox::convertTagToImage(Sanitizer::sanitize($content_text), $item, [$doc_id => ['tag' => $img_tag]])
+            \Toolbox::convertTagToImage(Sanitizer::sanitize($content_text), $item, $docs_data)
         );
 
         // Processed data may also be escaped using Toolbox::addslashes_deep(), and expected result should be escaped too
         $this->assertEquals(
             \Toolbox::addslashes_deep($expected_result),
-            \Toolbox::convertTagToImage(\Toolbox::addslashes_deep($content_text), $item, [$doc_id => ['tag' => $img_tag]])
+            \Toolbox::convertTagToImage(\Toolbox::addslashes_deep($content_text), $item, $docs_data)
         );
 
         // Processed data may also be not sanitized, and expected result should not be sanitized
         $this->assertEquals(
             $expected_result,
-            \Toolbox::convertTagToImage($content_text, $item, [$doc_id => ['tag' => $img_tag]])
+            \Toolbox::convertTagToImage($content_text, $item, $docs_data)
         );
     }
 

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2804,12 +2804,11 @@ class Toolbox
                             // Avoids creating a link within a link, when the image is already in an <a> tag
                             $add_link_tmp = $add_link;
                             if ($add_link) {
-                                $pattern = '/<a [^>]*>.*?' . preg_quote($image['tag'], '/') . '.*?<\/a>/s';
+                                $pattern = '/<a[^>]*>[^<>]*?<img[^>]+' . preg_quote($image['tag'], '/') . '[^<]+>[^<>]*?<\/a>/s';
                                 if (preg_match($pattern, $content_text)) {
                                     $add_link_tmp = false;
                                 }
                             }
-
                             // replace image
                             $new_image =  Html::getImageHtmlTagForDocument(
                                 $id,

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2801,12 +2801,21 @@ class Toolbox
                                 $height = $img_infos[1];
                             }
 
+                            // Avoids creating a link within a link, when the image is already in an <a> tag
+                            $add_link_tmp = $add_link;
+                            if ($add_link) {
+                                $pattern = '/<a [^>]*>.*?' . preg_quote($image['tag'], '/') . '.*?<\/a>/s';
+                                if (preg_match($pattern, $content_text)) {
+                                    $add_link_tmp = false;
+                                }
+                            }
+
                             // replace image
                             $new_image =  Html::getImageHtmlTagForDocument(
                                 $id,
                                 $width,
                                 $height,
-                                $add_link,
+                                $add_link_tmp,
                                 $object_url_param
                             );
                             if (empty($new_image)) {


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33829

In the content of a ticket, for example, when you add a link to an image. In the final rendering, the original link is not visible. The URL on the image is that of the document in GLPI.

