### PR TITLE
Fix Symfony base URL computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,7 @@ The present file will list all changes made to the project; according to the
 - The `inc/autoload.function.php`, `inc/based_config.php`, `inc/config.php`, `inc/db.function.php` and `inc/define.php` files have been removed and the `inc/includes.php` file has been almost emptied.
   The corresponding global functions, constants and variables are now loaded and initialized automatically and the corresponding GLPI boostraping logic is now executed automatically.
 - `Plugin::init()` and `Plugin::checkStates()` methods signature changed. It is not anymore possible to exclude specific plugins.
+- In a HTTP request context, `$_SERVER['PATH_INFO']`, `$_SERVER['SCRIPT_FILENAME'] and `$_SERVER['SCRIPT_NAME']` will no longer contain the path to the requested script, but will contain the path to the `public/index.php` script.
 
 #### Deprecated
 - Usage of `MAIL_SMTPSSL` and `MAIL_SMTPTLS` constants.

--- a/ajax/updatecurrenttab.php
+++ b/ajax/updatecurrenttab.php
@@ -33,10 +33,6 @@
  * ---------------------------------------------------------------------
  */
 
-if (!basename($_SERVER['SCRIPT_NAME']) == "helpdesk.faq.php") {
-    Session::checkLoginUser();
-}
-
 // Manage tabs
 if (isset($_GET['itemtype']) && isset($_GET['tab_key'])) {
     Session::setActiveTab($_GET['itemtype'], $_GET['tab_key']);

--- a/src/Glpi/Http/ExceptionListener.php
+++ b/src/Glpi/Http/ExceptionListener.php
@@ -52,6 +52,6 @@ final readonly class ExceptionListener implements EventSubscriberInterface
     {
         $handler = ErrorHandler::getInstance();
 
-        $handler->handleException($event->getThrowable());
+        $handler->handleException($event->getThrowable(), true);
     }
 }

--- a/src/Glpi/Http/ListenersPriority.php
+++ b/src/Glpi/Http/ListenersPriority.php
@@ -45,7 +45,7 @@ final class ListenersPriority
 
         LegacyRouterListener::class         => 400,
 
-        // Config providers are still expecting the `$_SERVER['SCRIPT_FILENAME']` to matches the legacy script path.
+        // Config providers may still expect some `$_SERVER` variables to be redefined.
         // They must therefore be executed after the `LegacyRouterListener`.
         LegacyConfigProviderListener::class => 350,
     ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The computation of the debug bar base URL is broken in legacy scripts because Symfony relies on `$_SERVER` variables that are overriden by GLPI. There is no need to override them anymore. Only a few plugins will be impacted, and fixing the corresponding legacy scripts will not be too difficult (they need to rely on `REQUEST_URI`).

![image](https://github.com/user-attachments/assets/299eaa99-f98a-4f37-b309-c3d02a20c889)
