### PR TITLE
chore(forms): Add tag color method in tag providers

### DIFF
--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/ContentFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/ContentFieldTest.php
@@ -95,7 +95,6 @@ final class ContentFieldTest extends DbTestCase
             label   : 'Dummy label',
             value   : self::FAKE_QUESTION_ID,
             provider: AnswerTagProvider::class,
-            color   : AnswerTagProvider::ACCENT_COLOR,
         );
     }
 

--- a/phpunit/functional/Glpi/Form/Tag/AnswerTagProviderTest.php
+++ b/phpunit/functional/Glpi/Form/Tag/AnswerTagProviderTest.php
@@ -63,13 +63,11 @@ final class AnswerTagProviderTest extends DbTestCase
                 label: 'Answer: First name',
                 value: $this->getQuestionId($form, 'First name'),
                 provider: AnswerTagProvider::class,
-                color: AnswerTagProvider::ACCENT_COLOR,
             ),
             new Tag(
                 label: 'Answer: Last name',
                 value: $this->getQuestionId($form, 'Last name'),
                 provider: AnswerTagProvider::class,
-                color: AnswerTagProvider::ACCENT_COLOR,
             ),
         ]);
     }

--- a/phpunit/functional/Glpi/Form/Tag/FormTagProviderTest.php
+++ b/phpunit/functional/Glpi/Form/Tag/FormTagProviderTest.php
@@ -55,7 +55,6 @@ final class FormTagProviderTest extends DbTestCase
                 label: 'Form name: Test form',
                 value: $form->getId(),
                 provider: FormTagProvider::class,
-                color: FormTagProvider::ACCENT_COLOR,
             )
         ]);
     }
@@ -68,7 +67,6 @@ final class FormTagProviderTest extends DbTestCase
                 label: 'Form name: My form',
                 value: $form->getId(),
                 provider: FormTagProvider::class,
-                color: FormTagProvider::ACCENT_COLOR,
             )
         ]);
     }

--- a/phpunit/functional/Glpi/Form/Tag/FormTagsManagerTest.php
+++ b/phpunit/functional/Glpi/Form/Tag/FormTagsManagerTest.php
@@ -61,37 +61,31 @@ final class FormTagsManagerTest extends DbTestCase
                 label: 'Form name: First and last name form',
                 value: $form->getId(),
                 provider: FormTagProvider::class,
-                color: FormTagProvider::ACCENT_COLOR,
             ),
             new Tag(
                 label: 'Section: Personal information',
                 value: $this->getSectionId($form, 'Personal information'),
                 provider: SectionTagProvider::class,
-                color: SectionTagProvider::ACCENT_COLOR,
             ),
             new Tag(
                 label: 'Question: First name',
                 value: $this->getQuestionId($form, 'First name'),
                 provider: QuestionTagProvider::class,
-                color: QuestionTagProvider::ACCENT_COLOR,
             ),
             new Tag(
                 label: 'Question: Last name',
                 value: $this->getQuestionId($form, 'Last name'),
                 provider: QuestionTagProvider::class,
-                color: QuestionTagProvider::ACCENT_COLOR,
             ),
             new Tag(
                 label: 'Answer: First name',
                 value: $this->getQuestionId($form, 'First name'),
                 provider: AnswerTagProvider::class,
-                color: AnswerTagProvider::ACCENT_COLOR,
             ),
             new Tag(
                 label: 'Answer: Last name',
                 value: $this->getQuestionId($form, 'Last name'),
                 provider: AnswerTagProvider::class,
-                color: AnswerTagProvider::ACCENT_COLOR,
             )
         ];
 

--- a/phpunit/functional/Glpi/Form/Tag/QuestionTagProviderTest.php
+++ b/phpunit/functional/Glpi/Form/Tag/QuestionTagProviderTest.php
@@ -61,13 +61,11 @@ final class QuestionTagProviderTest extends DbTestCase
                 label: 'Question: First name',
                 value: $this->getQuestionId($form, 'First name'),
                 provider: \Glpi\Form\Tag\QuestionTagProvider::class,
-                color: \Glpi\Form\Tag\QuestionTagProvider::ACCENT_COLOR,
             ),
             new Tag(
                 label: 'Question: Last name',
                 value: $this->getQuestionId($form, 'Last name'),
                 provider: \Glpi\Form\Tag\QuestionTagProvider::class,
-                color: \Glpi\Form\Tag\QuestionTagProvider::ACCENT_COLOR,
             ),
         ]);
     }

--- a/phpunit/functional/Glpi/Form/Tag/SectionTagProviderTest.php
+++ b/phpunit/functional/Glpi/Form/Tag/SectionTagProviderTest.php
@@ -61,13 +61,11 @@ final class SectionTagProviderTest extends DbTestCase
                 label: 'Section: Personal information',
                 value: $this->getSectionId($form, 'Personal information'),
                 provider: SectionTagProvider::class,
-                color: SectionTagProvider::ACCENT_COLOR,
             ),
             new Tag(
                 label: 'Section: Professional information',
                 value: $this->getSectionId($form, 'Professional information'),
                 provider: SectionTagProvider::class,
-                color: SectionTagProvider::ACCENT_COLOR,
             ),
         ]);
     }

--- a/phpunit/functional/Glpi/Form/Tag/TagTest.php
+++ b/phpunit/functional/Glpi/Form/Tag/TagTest.php
@@ -56,7 +56,7 @@ final class TagTest extends DbTestCase
         $tag = $this->getTagByName($tags, 'Question: First name');
         $question_id = $this->getQuestionId($form, 'First name');
         $provider = QuestionTagProvider::class;
-        $color = QuestionTagProvider::ACCENT_COLOR;
+        $color = (new $provider())->getTagColor();
 
         $expected = json_encode([
             'label' => 'Question: First name',

--- a/src/Glpi/Form/Tag/AnswerTagProvider.php
+++ b/src/Glpi/Form/Tag/AnswerTagProvider.php
@@ -43,7 +43,11 @@ use Override;
 
 final class AnswerTagProvider implements TagProviderInterface
 {
-    public const ACCENT_COLOR = "teal";
+    #[Override]
+    public function getTagColor(): string
+    {
+        return "teal";
+    }
 
     #[Override]
     public function getTags(Form $form): array
@@ -82,7 +86,6 @@ final class AnswerTagProvider implements TagProviderInterface
             label: sprintf(__('Answer: %s'), $question->fields['name']),
             value: $question->getId(),
             provider: self::class,
-            color: self::ACCENT_COLOR,
         );
     }
 }

--- a/src/Glpi/Form/Tag/FormTagProvider.php
+++ b/src/Glpi/Form/Tag/FormTagProvider.php
@@ -41,7 +41,11 @@ use Override;
 
 final class FormTagProvider implements TagProviderInterface
 {
-    public const ACCENT_COLOR = "yellow";
+    #[Override]
+    public function getTagColor(): string
+    {
+        return "yellow";
+    }
 
     #[Override]
     public function getTags(Form $form): array
@@ -69,7 +73,6 @@ final class FormTagProvider implements TagProviderInterface
             label: sprintf(__('Form name: %s'), $form->fields['name']),
             value: $form->getId(),
             provider: self::class,
-            color: self::ACCENT_COLOR,
         );
     }
 }

--- a/src/Glpi/Form/Tag/QuestionTagProvider.php
+++ b/src/Glpi/Form/Tag/QuestionTagProvider.php
@@ -42,7 +42,11 @@ use Override;
 
 final class QuestionTagProvider implements TagProviderInterface
 {
-    public const ACCENT_COLOR = "orange";
+    #[Override]
+    public function getTagColor(): string
+    {
+        return "orange";
+    }
 
     #[Override]
     public function getTags(Form $form): array
@@ -75,7 +79,6 @@ final class QuestionTagProvider implements TagProviderInterface
             label: sprintf(__('Question: %s'), $question->fields['name']),
             value: $question->getId(),
             provider: self::class,
-            color: self::ACCENT_COLOR,
         );
     }
 }

--- a/src/Glpi/Form/Tag/SectionTagProvider.php
+++ b/src/Glpi/Form/Tag/SectionTagProvider.php
@@ -42,7 +42,11 @@ use Override;
 
 final class SectionTagProvider implements TagProviderInterface
 {
-    public const ACCENT_COLOR = "cyan";
+    #[Override]
+    public function getTagColor(): string
+    {
+        return "cyan";
+    }
 
     #[Override]
     public function getTags(Form $form): array
@@ -75,7 +79,6 @@ final class SectionTagProvider implements TagProviderInterface
             label: sprintf(__('Section: %s'), $section->fields['name']),
             value: $section->getId(),
             provider: self::class,
-            color: self::ACCENT_COLOR,
         );
     }
 }

--- a/src/Glpi/Form/Tag/Tag.php
+++ b/src/Glpi/Form/Tag/Tag.php
@@ -48,9 +48,10 @@ final readonly class Tag
         string $label,
         string $value,
         string $provider,
-        string $color,
     ) {
         $this->label = $label;
+
+        $color = (new $provider())->getTagColor();
 
         // Build HTML representation of the tag.
         $properties = [

--- a/src/Glpi/Form/Tag/TagProviderInterface.php
+++ b/src/Glpi/Form/Tag/TagProviderInterface.php
@@ -41,6 +41,13 @@ use Glpi\Form\Form;
 interface TagProviderInterface
 {
     /**
+     * Get the color of the tag.
+     *
+     * @return string
+     */
+    public function getTagColor(): string;
+
+    /**
      * @return Tag[]
      */
     public function getTags(Form $form): array;

--- a/tests/functional/Glpi/RichText/RichText.php
+++ b/tests/functional/Glpi/RichText/RichText.php
@@ -399,7 +399,6 @@ HTML,
             label: __("My label"),
             value: 5, // Fake id
             provider: AnswerTagProvider::class,
-            color: AnswerTagProvider::ACCENT_COLOR,
         );
         yield 'Html content of form tags should not be modified' => [
             'content' => $tag->html,


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

Remove color constructor parameter, call method from provider instead.