### PR TITLE
Plan HLAPI versioning

### DIFF
--- a/resources/api_doc.MD
+++ b/resources/api_doc.MD
@@ -156,3 +156,19 @@ Alternatively, a REST API interface is available for the raw GraphQL type declar
 As is standard with GraphQL, you MUST specify each property that you want to be returned.
 
 For more information about GraphQL, see the [GraphQL documentation](https://graphql.org/learn/).
+
+
+## API Versioning
+
+The API is versioned by the URL path. If no version is specified, the latest version will be used.
+If you specify `v1`, your request will be routed to the legacy API while `v2` and later will be routed to the high-level API.
+Example: `/api.php/v2/...`
+
+### Version pinning strategy
+
+When you specify a version in the URL, the API will use the following rules when determining which version to use:
+- If only a major version is specified, the latest minor version will be used. For example `/api.php/v2/...` may use `v2.1` if it is the latest version.
+- If a major and minor version are specified, the latest patch version will be used. For example `/api.php/v2.1/...` may use `v2.1.3` if it is the latest version.
+- If a major, minor, and patch version are specified, that exact version will be used. For example `/api.php/v2.1.3/...` will use `v2.1.3`.
+
+In general, specifying only the major version is sufficient and shouldn't break your application when new versions are released as long as there is a supported version available.

--- a/src/Glpi/Api/HL/Controller/AdministrationController.php
+++ b/src/Glpi/Api/HL/Controller/AdministrationController.php
@@ -39,6 +39,8 @@ use Entity;
 use Glpi\Api\HL\Doc as Doc;
 use Glpi\Api\HL\Middleware\ResultFormatterMiddleware;
 use Glpi\Api\HL\Route;
+use Glpi\Api\HL\Router;
+use Glpi\Api\HL\RouteVersion;
 use Glpi\Api\HL\Search;
 use Glpi\Http\JSONResponse;
 use Glpi\Http\Request;
@@ -59,6 +61,7 @@ final class AdministrationController extends AbstractController
     {
         return [
             'User' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => User::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'x-rights-conditions' => [ // Object-level extra permissions
@@ -186,6 +189,7 @@ final class AdministrationController extends AbstractController
                 ]
             ],
             'Group' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => Group::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => [
@@ -237,6 +241,7 @@ final class AdministrationController extends AbstractController
                 ]
             ],
             'Entity' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => Entity::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => [
@@ -287,6 +292,7 @@ final class AdministrationController extends AbstractController
                 ]
             ],
             'Profile' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => Profile::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => [
@@ -307,6 +313,7 @@ final class AdministrationController extends AbstractController
                 ]
             ],
             'EmailAddress' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \UserEmail::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => [
@@ -333,6 +340,7 @@ final class AdministrationController extends AbstractController
     }
 
     #[Route(path: '/User', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List or search users',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -342,10 +350,11 @@ final class AdministrationController extends AbstractController
     )]
     public function searchUsers(Request $request): Response
     {
-        return Search::searchBySchema($this->getKnownSchema('User'), $request->getParameters());
+        return Search::searchBySchema($this->getKnownSchema('User', $this->getAPIVersion($request)), $request->getParameters());
     }
 
     #[Route(path: '/Group', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List or search groups',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -355,10 +364,11 @@ final class AdministrationController extends AbstractController
     )]
     public function searchGroups(Request $request): Response
     {
-        return Search::searchBySchema($this->getKnownSchema('Group'), $request->getParameters());
+        return Search::searchBySchema($this->getKnownSchema('Group', $this->getAPIVersion($request)), $request->getParameters());
     }
 
     #[Route(path: '/Entity', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List or search entities',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -368,10 +378,11 @@ final class AdministrationController extends AbstractController
     )]
     public function searchEntities(Request $request): Response
     {
-        return Search::searchBySchema($this->getKnownSchema('Entity'), $request->getParameters());
+        return Search::searchBySchema($this->getKnownSchema('Entity', $this->getAPIVersion($request)), $request->getParameters());
     }
 
     #[Route(path: '/Profile', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List or search profiles',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -381,7 +392,7 @@ final class AdministrationController extends AbstractController
     )]
     public function searchProfiles(Request $request): Response
     {
-        return Search::searchBySchema($this->getKnownSchema('Profile'), $request->getParameters());
+        return Search::searchBySchema($this->getKnownSchema('Profile', $this->getAPIVersion($request)), $request->getParameters());
     }
 
     /**
@@ -416,6 +427,7 @@ final class AdministrationController extends AbstractController
     }
 
     #[Route(path: '/User/Me', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get the current user',
         responses: [
@@ -425,10 +437,11 @@ final class AdministrationController extends AbstractController
     public function me(Request $request): Response
     {
         $my_user_id = $this->getMyUserID();
-        return Search::getOneBySchema($this->getKnownSchema('User'), ['id' => $my_user_id], $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema('User', $this->getAPIVersion($request)), ['id' => $my_user_id], $request->getParameters());
     }
 
     #[Route(path: '/User/Me/Email', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get the current user\'s email addresses',
         responses: [
@@ -441,6 +454,7 @@ final class AdministrationController extends AbstractController
     }
 
     #[Route(path: '/User/Me/Email', methods: ['POST'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Create a new email address for the current user',
         parameters: [
@@ -500,6 +514,7 @@ final class AdministrationController extends AbstractController
     }
 
     #[Route(path: '/User/Me/Email/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a specific email address for the current user',
         responses: [
@@ -518,6 +533,7 @@ final class AdministrationController extends AbstractController
     }
 
     #[Route(path: '/User/Me/Emails/Default', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get the default email address for the current user',
         responses: [
@@ -552,6 +568,7 @@ final class AdministrationController extends AbstractController
     }
 
     #[Route(path: '/User/Me/Picture', methods: ['GET'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get the picture for the current user'
     )]
@@ -571,6 +588,7 @@ final class AdministrationController extends AbstractController
     }
 
     #[Route(path: '/User', methods: ['POST'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(description: 'Create a new user', parameters: [
         [
             'name' => '_',
@@ -580,10 +598,11 @@ final class AdministrationController extends AbstractController
     ])]
     public function createUser(Request $request): Response
     {
-        return Search::createBySchema($this->getKnownSchema('User'), $request->getParameters(), [self::class, 'getUserByID']);
+        return Search::createBySchema($this->getKnownSchema('User', $this->getAPIVersion($request)), $request->getParameters(), [self::class, 'getUserByID']);
     }
 
     #[Route(path: '/User/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a user by ID',
         responses: [
@@ -592,10 +611,11 @@ final class AdministrationController extends AbstractController
     )]
     public function getUserByID(Request $request): Response
     {
-        return Search::getOneBySchema($this->getKnownSchema('User'), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema('User', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/User/username/{username}', methods: ['GET'], requirements: ['username' => '[a-zA-Z0-9_]+'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a user by username',
         responses: [
@@ -604,10 +624,11 @@ final class AdministrationController extends AbstractController
     )]
     public function getUserByUsername(Request $request): Response
     {
-        return Search::getOneBySchema($this->getKnownSchema('User'), $request->getAttributes(), $request->getParameters(), 'username');
+        return Search::getOneBySchema($this->getKnownSchema('User', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters(), 'username');
     }
 
     #[Route(path: '/User/{id}/Picture', methods: ['GET'], requirements: ['id' => '\d+'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get the picture for the current user'
     )]
@@ -627,6 +648,7 @@ final class AdministrationController extends AbstractController
     }
 
     #[Route(path: '/User/username/{username}/Picture', methods: ['GET'], requirements: ['username' => '[a-zA-Z0-9_]+'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get the picture for the current user'
     )]
@@ -646,6 +668,7 @@ final class AdministrationController extends AbstractController
     }
 
     #[Route(path: '/User/{id}', methods: ['PATCH'], requirements: ['id' => '\d+'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a user by ID',
         parameters: [
@@ -662,10 +685,11 @@ final class AdministrationController extends AbstractController
     )]
     public function updateUserByID(Request $request): Response
     {
-        return Search::updateBySchema($this->getKnownSchema('User'), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema('User', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/User/username/{username}', methods: ['PATCH'], requirements: ['username' => '[a-zA-Z0-9_]+'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a user by username',
         parameters: [
@@ -682,29 +706,31 @@ final class AdministrationController extends AbstractController
     )]
     public function updateUserByUsername(Request $request): Response
     {
-        return Search::updateBySchema($this->getKnownSchema('User'), $request->getAttributes(), $request->getParameters(), 'username');
+        return Search::updateBySchema($this->getKnownSchema('User', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters(), 'username');
     }
 
     #[Route(path: '/User/{id}', methods: ['DELETE'], requirements: ['id' => '\d+'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(description: 'Delete a user by ID')]
     public function deleteUserByID(Request $request): Response
     {
-        return Search::deleteBySchema($this->getKnownSchema('User'), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema('User', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/User/username/{username}', methods: ['DELETE'], requirements: ['username' => '[a-zA-Z0-9_]+'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(description: 'Delete a user by username')]
     public function deleteUserByUsername(Request $request): Response
     {
-        return Search::deleteBySchema($this->getKnownSchema('User'), $request->getAttributes(), $request->getParameters(), 'username');
+        return Search::deleteBySchema($this->getKnownSchema('User', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters(), 'username');
     }
 
-    private function getUsedOrManagedItems(int $users_id, bool $is_managed, array $request_params): Response
+    private function getUsedOrManagedItems(int $users_id, bool $is_managed, array $request_params, string $api_version): Response
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
         // Create a union schema with all relevant item types
-        $schema = Doc\Schema::getUnionSchemaForItemtypes($CFG_GLPI['assignable_types']);
+        $schema = Doc\Schema::getUnionSchemaForItemtypes($CFG_GLPI['assignable_types'], $api_version);
         $rsql_filter = $request_params['filter'] ?? '';
         if (!empty($rsql_filter)) {
             $rsql_filter = "($rsql_filter);";
@@ -716,68 +742,75 @@ final class AdministrationController extends AbstractController
     }
 
     #[Route(path: '/User/Me/UsedItem', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get the used items for the current user',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
     )]
     public function getMyUsedItems(Request $request): Response
     {
-        return $this->getUsedOrManagedItems($this->getMyUserID(), false, $request->getParameters());
+        return $this->getUsedOrManagedItems($this->getMyUserID(), false, $request->getParameters(), $this->getAPIVersion($request));
     }
 
     #[Route(path: '/User/{id}/UsedItem', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get the used items for a user by ID',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
     )]
     public function getUserUsedItemsByID(Request $request): Response
     {
-        return $this->getUsedOrManagedItems($request->getAttribute('id'), false, $request->getParameters());
+        return $this->getUsedOrManagedItems($request->getAttribute('id'), false, $request->getParameters(), $this->getAPIVersion($request));
     }
 
     #[Route(path: '/User/username/{username}/UsedItem', methods: ['GET'], requirements: ['username' => '[a-zA-Z0-9_]+'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get the used items for a user by username',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
     )]
     public function getUserUsedItemsByUsername(Request $request): Response
     {
-        $users_id = Search::getIDForOtherUniqueFieldBySchema($this->getKnownSchema('User'), 'username', $request->getAttribute('username'));
-        return $this->getUsedOrManagedItems($users_id, false, $request->getParameters());
+        $users_id = Search::getIDForOtherUniqueFieldBySchema($this->getKnownSchema('User', $this->getAPIVersion($request)), 'username', $request->getAttribute('username'));
+        return $this->getUsedOrManagedItems($users_id, false, $request->getParameters(), $this->getAPIVersion($request));
     }
 
     #[Route(path: '/User/Me/ManagedItem', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get the managed items for the current user',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
     )]
     public function getMyManagedItems(Request $request): Response
     {
-        return $this->getUsedOrManagedItems($this->getMyUserID(), true, $request->getParameters());
+        return $this->getUsedOrManagedItems($this->getMyUserID(), true, $request->getParameters(), $this->getAPIVersion($request));
     }
 
     #[Route(path: '/User/{id}/ManagedItem', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get the managed items for a user by ID',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
     )]
     public function getUserManagedItemsByID(Request $request): Response
     {
-        return $this->getUsedOrManagedItems($request->getAttribute('id'), true, $request->getParameters());
+        return $this->getUsedOrManagedItems($request->getAttribute('id'), true, $request->getParameters(), $this->getAPIVersion($request));
     }
 
     #[Route(path: '/User/username/{username}/ManagedItem', methods: ['GET'], requirements: ['username' => '[a-zA-Z0-9_]+'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get the managed items for a user by username',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
     )]
     public function getUserManagedItemsByUsername(Request $request): Response
     {
-        $users_id = Search::getIDForOtherUniqueFieldBySchema($this->getKnownSchema('User'), 'username', $request->getAttribute('username'));
-        return $this->getUsedOrManagedItems($users_id, true, $request->getParameters());
+        $users_id = Search::getIDForOtherUniqueFieldBySchema($this->getKnownSchema('User', $this->getAPIVersion($request)), 'username', $request->getAttribute('username'));
+        return $this->getUsedOrManagedItems($users_id, true, $request->getParameters(), $this->getAPIVersion($request));
     }
 
     #[Route(path: '/Group', methods: ['POST'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(description: 'Create a new group', parameters: [
         [
             'name' => '_',
@@ -787,10 +820,11 @@ final class AdministrationController extends AbstractController
     ])]
     public function createGroup(Request $request): Response
     {
-        return Search::createBySchema($this->getKnownSchema('Group'), $request->getParameters(), [self::class, 'getGroupByID']);
+        return Search::createBySchema($this->getKnownSchema('Group', $this->getAPIVersion($request)), $request->getParameters(), [self::class, 'getGroupByID']);
     }
 
     #[Route(path: '/Group/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a group by ID',
         responses: [
@@ -799,10 +833,11 @@ final class AdministrationController extends AbstractController
     )]
     public function getGroupByID(Request $request): Response
     {
-        return Search::getOneBySchema($this->getKnownSchema('Group'), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema('Group', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Group/{id}', methods: ['PATCH'], requirements: ['id' => '\d+'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a group by ID',
         parameters: [
@@ -819,17 +854,19 @@ final class AdministrationController extends AbstractController
     )]
     public function updateGroupByID(Request $request): Response
     {
-        return Search::updateBySchema($this->getKnownSchema('Group'), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema('Group', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Group/{id}', methods: ['DELETE'], requirements: ['id' => '\d+'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(description: 'Delete a group by ID')]
     public function deleteGroupByID(Request $request): Response
     {
-        return Search::deleteBySchema($this->getKnownSchema('Group'), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema('Group', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Entity', methods: ['POST'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(description: 'Create a new entity', parameters: [
         [
             'name' => '_',
@@ -839,10 +876,11 @@ final class AdministrationController extends AbstractController
     ])]
     public function createEntity(Request $request): Response
     {
-        return Search::createBySchema($this->getKnownSchema('Entity'), $request->getParameters(), [self::class, 'getEntityByID']);
+        return Search::createBySchema($this->getKnownSchema('Entity', $this->getAPIVersion($request)), $request->getParameters(), [self::class, 'getEntityByID']);
     }
 
     #[Route(path: '/Entity/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get an entity by ID',
         responses: [
@@ -851,10 +889,11 @@ final class AdministrationController extends AbstractController
     )]
     public function getEntityByID(Request $request): Response
     {
-        return Search::getOneBySchema($this->getKnownSchema('Entity'), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema('Entity', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Entity/{id}', methods: ['PATCH'], requirements: ['id' => '\d+'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update an entity by ID',
         parameters: [
@@ -871,17 +910,19 @@ final class AdministrationController extends AbstractController
     )]
     public function updateEntityByID(Request $request): Response
     {
-        return Search::updateBySchema($this->getKnownSchema('Entity'), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema('Entity', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Entity/{id}', methods: ['DELETE'], requirements: ['id' => '\d+'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(description: 'Delete an entity by ID')]
     public function deleteEntityByID(Request $request): Response
     {
-        return Search::deleteBySchema($this->getKnownSchema('Entity'), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema('Entity', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Profile', methods: ['POST'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(description: 'Create a new profile', parameters: [
         [
             'name' => '_',
@@ -891,10 +932,11 @@ final class AdministrationController extends AbstractController
     ])]
     public function createProfile(Request $request): Response
     {
-        return Search::createBySchema($this->getKnownSchema('Profile'), $request->getParameters(), [self::class, 'getProfileByID']);
+        return Search::createBySchema($this->getKnownSchema('Profile', $this->getAPIVersion($request)), $request->getParameters(), [self::class, 'getProfileByID']);
     }
 
     #[Route(path: '/Profile/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a profile by ID',
         responses: [
@@ -903,10 +945,11 @@ final class AdministrationController extends AbstractController
     )]
     public function getProfileByID(Request $request): Response
     {
-        return Search::getOneBySchema($this->getKnownSchema('Profile'), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema('Profile', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Profile/{id}', methods: ['PATCH'], requirements: ['id' => '\d+'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a profile by ID',
         parameters: [
@@ -923,13 +966,14 @@ final class AdministrationController extends AbstractController
     )]
     public function updateProfileByID(Request $request): Response
     {
-        return Search::updateBySchema($this->getKnownSchema('Profile'), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema('Profile', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Profile/{id}', methods: ['DELETE'], requirements: ['id' => '\d+'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(description: 'Delete a profile by ID')]
     public function deleteProfileByID(Request $request): Response
     {
-        return Search::deleteBySchema($this->getKnownSchema('Profile'), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema('Profile', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 }

--- a/src/Glpi/Api/HL/Controller/AssetController.php
+++ b/src/Glpi/Api/HL/Controller/AssetController.php
@@ -43,6 +43,7 @@ use Entity;
 use Glpi\Api\HL\Doc as Doc;
 use Glpi\Api\HL\Middleware\ResultFormatterMiddleware;
 use Glpi\Api\HL\Route;
+use Glpi\Api\HL\RouteVersion;
 use Glpi\Api\HL\Search;
 use Glpi\Http\JSONResponse;
 use Glpi\Http\Request;
@@ -107,6 +108,7 @@ final class AssetController extends AbstractController
         ];
 
         $schemas['PrinterModel'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \PrinterModel::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -124,6 +126,7 @@ final class AssetController extends AbstractController
         ];
 
         $schemas['SoftwareCategory'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \SoftwareCategory::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -141,6 +144,7 @@ final class AssetController extends AbstractController
         ];
 
         $schemas['OperatingSystem'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \OperatingSystem::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -157,6 +161,7 @@ final class AssetController extends AbstractController
         ];
 
         $schemas['RackModel'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \RackModel::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -174,6 +179,7 @@ final class AssetController extends AbstractController
         ];
 
         $schemas['RackType'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \RackType::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -192,6 +198,7 @@ final class AssetController extends AbstractController
         ];
 
         $schemas['PDUModel'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \PDUModel::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -216,6 +223,7 @@ final class AssetController extends AbstractController
         ];
 
         $schemas['PDUType'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \PDUType::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -234,6 +242,7 @@ final class AssetController extends AbstractController
         ];
 
         $schemas['PassiveDCEquipmentModel'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \PassiveDCEquipmentModel::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -258,6 +267,7 @@ final class AssetController extends AbstractController
         ];
 
         $schemas['PassiveDCEquipmentType'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \PassiveDCEquipmentType::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -274,6 +284,7 @@ final class AssetController extends AbstractController
         ];
 
         $schemas['SocketModel'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => SocketModel::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -290,6 +301,7 @@ final class AssetController extends AbstractController
         ];
 
         $schemas['NetworkPort'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \NetworkPort::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -326,6 +338,7 @@ final class AssetController extends AbstractController
         ];
 
         $schemas['DCRoom'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \DCRoom::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -356,6 +369,7 @@ final class AssetController extends AbstractController
             // Replace namespace separator with underscore
             $schema_name = str_replace('\\', '_', $asset_type);
             $schemas[$schema_name] = $schemas['_BaseAsset'];
+            $schemas[$schema_name]['x-version-introduced'] = '2.0';
             $schemas[$schema_name]['x-itemtype'] = $asset_type;
 
             // Need instance since some fields are not static even if they aren't related to instances
@@ -496,6 +510,7 @@ final class AssetController extends AbstractController
         }
 
         $schemas['Cartridge'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \Cartridge::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -536,6 +551,7 @@ final class AssetController extends AbstractController
         ];
 
         $schemas['CartridgeItem'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \CartridgeItem::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -605,6 +621,7 @@ final class AssetController extends AbstractController
         ];
 
         $schemas['Consumable'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \Consumable::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -641,6 +658,7 @@ final class AssetController extends AbstractController
         ];
 
         $schemas['ConsumableItem'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \ConsumableItem::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -683,6 +701,7 @@ final class AssetController extends AbstractController
         ];
 
         $schemas['Software'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => Software::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -769,6 +788,7 @@ final class AssetController extends AbstractController
         ];
 
         $schemas['SoftwareVersion'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \SoftwareVersion::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -791,6 +811,7 @@ final class AssetController extends AbstractController
         ];
 
         $schemas['Rack'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \Rack::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -915,6 +936,7 @@ final class AssetController extends AbstractController
         ];
 
         $schemas['RackItem'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \Item_Rack::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -946,6 +968,7 @@ final class AssetController extends AbstractController
         ];
 
         $schemas['Enclosure'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \Enclosure::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -1033,6 +1056,7 @@ final class AssetController extends AbstractController
         ];
 
         $schemas['PDU'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \PDU::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -1119,6 +1143,7 @@ final class AssetController extends AbstractController
         ];
 
         $schemas['PassiveDCEquipment'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \PassiveDCEquipment::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -1205,6 +1230,7 @@ final class AssetController extends AbstractController
         ];
 
         $schemas['Cable'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \Cable::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -1302,6 +1328,7 @@ final class AssetController extends AbstractController
         ];
 
         $schemas['Socket'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => Socket::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -1334,14 +1361,14 @@ final class AssetController extends AbstractController
      */
     public static function getAssetTypes(bool $classes_only = true): array
     {
-        /** @var array $CFG_GLPI */
-        global $CFG_GLPI;
-
         static $assets = null;
 
         if ($assets === null) {
             $assets = [];
-            $types = $CFG_GLPI["asset_types"];
+            $types = ['Computer', 'Monitor', 'NetworkEquipment',
+                'Peripheral', 'Phone', 'Printer', 'SoftwareLicense',
+                'Certificate', 'Unmanaged', 'Appliance'
+            ];
             /**
              * @var class-string<CommonDBTM> $type
              */
@@ -1392,6 +1419,7 @@ final class AssetController extends AbstractController
     }
 
     #[Route(path: '/', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get all available asset types',
         methods: ['GET'],
@@ -1432,10 +1460,13 @@ final class AssetController extends AbstractController
         $asset_schemas = array_filter($asset_schemas, static function ($key) use ($asset_types) {
             return !str_starts_with($key, '_') && in_array($key, $asset_types, true);
         }, ARRAY_FILTER_USE_KEY);
-        return Doc\Schema::getUnionSchema($asset_schemas);
+        $union_schema = Doc\Schema::getUnionSchema($asset_schemas);
+        $union_schema['x-version-introduced'] = '2.0';
+        return $union_schema;
     }
 
     #[Route(path: '/Global', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List or search assets of all types',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -1445,12 +1476,13 @@ final class AssetController extends AbstractController
     )]
     public function searchAll(Request $request): Response
     {
-        return Search::searchBySchema($this->getKnownSchema('CommonAsset'), $request->getParameters());
+        return Search::searchBySchema($this->getKnownSchema('CommonAsset', $this->getAPIVersion($request)), $request->getParameters());
     }
 
     #[Route(path: '/{itemtype}', methods: ['GET'], requirements: [
         'itemtype' => [self::class, 'getAssetTypes']
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List or search assets of a specific type',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -1461,13 +1493,14 @@ final class AssetController extends AbstractController
     public function search(Request $request): Response
     {
         $itemtype = $request->getAttribute('itemtype');
-        return Search::searchBySchema($this->getKnownSchema($itemtype), $request->getParameters());
+        return Search::searchBySchema($this->getKnownSchema($itemtype, $this->getAPIVersion($request)), $request->getParameters());
     }
 
     #[Route(path: '/{itemtype}/{id}', methods: ['GET'], requirements: [
         'itemtype' => [self::class, 'getAssetTypes'],
         'id' => '\d+'
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get an asset of a specific type by ID',
         responses: [
@@ -1477,13 +1510,14 @@ final class AssetController extends AbstractController
     public function getItem(Request $request): Response
     {
         $itemtype = $request->getAttribute('itemtype');
-        return Search::getOneBySchema($this->getKnownSchema($itemtype), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema($itemtype, $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/{itemtype}/{id}/Infocom', methods: ['GET'], requirements: [
         'itemtype' => [self::class, 'getAssetTypes'],
         'id' => '\d+'
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get the financial and administration information for a specific asset',
         responses: [
@@ -1501,7 +1535,7 @@ final class AssetController extends AbstractController
         $filter = 'itemtype==' . $itemtype . ';items_id==' . $items_id;
         $params['filter'] = $filter;
         $management_controller = new ManagementController();
-        $result = Search::searchBySchema($management_controller->getKnownSchema('Infocom'), $params);
+        $result = Search::searchBySchema($management_controller->getKnownSchema('Infocom', $this->getAPIVersion($request)), $params);
         if ($result->getStatusCode() !== 200) {
             return $result;
         }
@@ -1516,6 +1550,7 @@ final class AssetController extends AbstractController
     #[Route(path: '/{itemtype}', methods: ['POST'], requirements: [
         'itemtype' => [self::class, 'getAssetTypes'],
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Create an asset of a specific type',
         parameters: [
@@ -1529,13 +1564,14 @@ final class AssetController extends AbstractController
     public function createItem(Request $request): Response
     {
         $itemtype = $request->getAttribute('itemtype');
-        return Search::createBySchema($this->getKnownSchema($itemtype), $request->getParameters() + ['itemtype' => $itemtype], [self::class, 'getItem']);
+        return Search::createBySchema($this->getKnownSchema($itemtype, $this->getAPIVersion($request)), $request->getParameters() + ['itemtype' => $itemtype], [self::class, 'getItem']);
     }
 
     #[Route(path: '/{itemtype}/{id}', methods: ['PATCH'], requirements: [
         'itemtype' => [self::class, 'getAssetTypes'],
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update an asset of a specific type by ID',
         parameters: [
@@ -1549,23 +1585,25 @@ final class AssetController extends AbstractController
     public function updateItem(Request $request): Response
     {
         $itemtype = $request->getAttribute('itemtype');
-        return Search::updateBySchema($this->getKnownSchema($itemtype), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema($itemtype, $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/{itemtype}/{id}', methods: ['DELETE'], requirements: [
         'itemtype' => [self::class, 'getAssetTypes'],
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Delete an asset of a specific type by ID',
     )]
     public function deleteItem(Request $request): Response
     {
         $itemtype = $request->getAttribute('itemtype');
-        return Search::deleteBySchema($this->getKnownSchema($itemtype), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema($itemtype, $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Cartridge', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List or search cartridge models',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -1575,12 +1613,13 @@ final class AssetController extends AbstractController
     )]
     public function searchCartridgeItems(Request $request): Response
     {
-        return Search::searchBySchema($this->getKnownSchema('CartridgeItem'), $request->getParameters());
+        return Search::searchBySchema($this->getKnownSchema('CartridgeItem', $this->getAPIVersion($request)), $request->getParameters());
     }
 
     #[Route(path: '/Cartridge/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a cartridge model by ID',
         responses: [
@@ -1589,10 +1628,11 @@ final class AssetController extends AbstractController
     )]
     public function getCartridgeItem(Request $request): Response
     {
-        return Search::getOneBySchema($this->getKnownSchema('CartridgeItem'), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema('CartridgeItem', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Cartridge', methods: ['POST'], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Create a cartridge model',
         parameters: [
@@ -1605,12 +1645,13 @@ final class AssetController extends AbstractController
     )]
     public function createCartridgeItems(Request $request): Response
     {
-        return Search::createBySchema($this->getKnownSchema('CartridgeItem'), $request->getParameters(), [self::class, 'getCartridgeItem']);
+        return Search::createBySchema($this->getKnownSchema('CartridgeItem', $this->getAPIVersion($request)), $request->getParameters(), [self::class, 'getCartridgeItem']);
     }
 
     #[Route(path: '/Cartridge/{id}', methods: ['PATCH'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a cartridge model by ID',
         parameters: [
@@ -1623,23 +1664,25 @@ final class AssetController extends AbstractController
     )]
     public function updateCartridgeItems(Request $request): Response
     {
-        return Search::updateBySchema($this->getKnownSchema('CartridgeItem'), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema('CartridgeItem', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Cartridge/{id}', methods: ['DELETE'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Delete a cartridge model by ID',
     )]
     public function deleteCartridgeItems(Request $request): Response
     {
-        return Search::deleteBySchema($this->getKnownSchema('CartridgeItem'), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema('CartridgeItem', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Cartridge/{cartridgeitems_id}/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a cartridge by ID',
         responses: [
@@ -1648,10 +1691,11 @@ final class AssetController extends AbstractController
     )]
     public function getCartridge(Request $request): Response
     {
-        return Search::getOneBySchema($this->getKnownSchema('Cartridge'), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema('Cartridge', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Cartridge/{cartridgeitems_id}', methods: ['POST'], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Create a cartridge',
         parameters: [
@@ -1664,12 +1708,13 @@ final class AssetController extends AbstractController
     )]
     public function createCartridges(Request $request): Response
     {
-        return Search::createBySchema($this->getKnownSchema('Cartridge'), $request->getParameters(), [self::class, 'getCartridge']);
+        return Search::createBySchema($this->getKnownSchema('Cartridge', $this->getAPIVersion($request)), $request->getParameters(), [self::class, 'getCartridge']);
     }
 
     #[Route(path: '/Cartridge/{cartridgeitems_id}/{id}', methods: ['PATCH'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a cartridge by ID',
         parameters: [
@@ -1682,21 +1727,23 @@ final class AssetController extends AbstractController
     )]
     public function updateCartridges(Request $request): Response
     {
-        return Search::updateBySchema($this->getKnownSchema('Cartridge'), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema('Cartridge', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Cartridge/{cartridgeitems_id}/{id}', methods: ['DELETE'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Delete a cartridge by ID',
     )]
     public function deleteCartridges(Request $request): Response
     {
-        return Search::deleteBySchema($this->getKnownSchema('Cartridge'), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema('Cartridge', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Consumable', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List or search consumables models',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -1706,12 +1753,13 @@ final class AssetController extends AbstractController
     )]
     public function searchConsumableItems(Request $request): Response
     {
-        return Search::searchBySchema($this->getKnownSchema('ConsumableItem'), $request->getParameters());
+        return Search::searchBySchema($this->getKnownSchema('ConsumableItem', $this->getAPIVersion($request)), $request->getParameters());
     }
 
     #[Route(path: '/Consumable/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a consumable model by ID',
         responses: [
@@ -1720,10 +1768,11 @@ final class AssetController extends AbstractController
     )]
     public function getConsumableItem(Request $request): Response
     {
-        return Search::getOneBySchema($this->getKnownSchema('ConsumableItem'), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema('ConsumableItem', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Consumable', methods: ['POST'], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Create a consumable model',
         parameters: [
@@ -1736,12 +1785,13 @@ final class AssetController extends AbstractController
     )]
     public function createConsumableItems(Request $request): Response
     {
-        return Search::createBySchema($this->getKnownSchema('ConsumableItem'), $request->getParameters(), [self::class, 'getConsumableItem']);
+        return Search::createBySchema($this->getKnownSchema('ConsumableItem', $this->getAPIVersion($request)), $request->getParameters(), [self::class, 'getConsumableItem']);
     }
 
     #[Route(path: '/Consumable/{id}', methods: ['PATCH'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a consumable model by ID',
         parameters: [
@@ -1754,23 +1804,25 @@ final class AssetController extends AbstractController
     )]
     public function updateConsumableItems(Request $request): Response
     {
-        return Search::updateBySchema($this->getKnownSchema('ConsumableItem'), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema('ConsumableItem', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Consumable/{id}', methods: ['DELETE'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Delete a consumable model by ID',
     )]
     public function deleteConsumableItems(Request $request): Response
     {
-        return Search::deleteBySchema($this->getKnownSchema('ConsumableItem'), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema('ConsumableItem', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Consumable/{consumableitems_id}/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a consumable by ID',
         responses: [
@@ -1779,10 +1831,11 @@ final class AssetController extends AbstractController
     )]
     public function getConsumable(Request $request): Response
     {
-        return Search::getOneBySchema($this->getKnownSchema('Consumable'), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema('Consumable', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Consumable/{consumableitems_id}', methods: ['POST'], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Create a consumable',
         parameters: [
@@ -1795,12 +1848,13 @@ final class AssetController extends AbstractController
     )]
     public function createConsumables(Request $request): Response
     {
-        return Search::createBySchema($this->getKnownSchema('Consumable'), $request->getParameters(), [self::class, 'getConsumable']);
+        return Search::createBySchema($this->getKnownSchema('Consumable', $this->getAPIVersion($request)), $request->getParameters(), [self::class, 'getConsumable']);
     }
 
     #[Route(path: '/Consumable/{consumableitems_id}/{id}', methods: ['PATCH'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a consumable by ID',
         parameters: [
@@ -1813,21 +1867,23 @@ final class AssetController extends AbstractController
     )]
     public function updateConsumable(Request $request): Response
     {
-        return Search::updateBySchema($this->getKnownSchema('Consumable'), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema('Consumable', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Consumable/{consumableitems_id}/{id}', methods: ['DELETE'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Delete a consumable by ID',
     )]
     public function deleteConsumable(Request $request): Response
     {
-        return Search::deleteBySchema($this->getKnownSchema('Consumable'), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema('Consumable', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Software', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List or search software',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -1837,12 +1893,13 @@ final class AssetController extends AbstractController
     )]
     public function searchSoftware(Request $request): Response
     {
-        return Search::searchBySchema($this->getKnownSchema('Software'), $request->getParameters());
+        return Search::searchBySchema($this->getKnownSchema('Software', $this->getAPIVersion($request)), $request->getParameters());
     }
 
     #[Route(path: '/Software/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a software by ID',
         responses: [
@@ -1851,10 +1908,11 @@ final class AssetController extends AbstractController
     )]
     public function getSoftware(Request $request): Response
     {
-        return Search::getOneBySchema($this->getKnownSchema('Software'), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema('Software', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Software', methods: ['POST'], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Create a software',
         parameters: [
@@ -1867,12 +1925,13 @@ final class AssetController extends AbstractController
     )]
     public function createSoftware(Request $request): Response
     {
-        return Search::createBySchema($this->getKnownSchema('Software'), $request->getParameters(), [self::class, 'getSoftware']);
+        return Search::createBySchema($this->getKnownSchema('Software', $this->getAPIVersion($request)), $request->getParameters(), [self::class, 'getSoftware']);
     }
 
     #[Route(path: '/Software/{id}', methods: ['PATCH'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a software by ID',
         parameters: [
@@ -1885,21 +1944,23 @@ final class AssetController extends AbstractController
     )]
     public function updateSoftware(Request $request): Response
     {
-        return Search::updateBySchema($this->getKnownSchema('Software'), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema('Software', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Software/{id}', methods: ['DELETE'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Delete a software by ID',
     )]
     public function deleteSoftware(Request $request): Response
     {
-        return Search::deleteBySchema($this->getKnownSchema('Software'), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema('Software', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Rack', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List or search racks',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -1909,12 +1970,13 @@ final class AssetController extends AbstractController
     )]
     public function searchRack(Request $request): Response
     {
-        return Search::searchBySchema($this->getKnownSchema('Rack'), $request->getParameters());
+        return Search::searchBySchema($this->getKnownSchema('Rack', $this->getAPIVersion($request)), $request->getParameters());
     }
 
     #[Route(path: '/Rack/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a rack by ID',
         responses: [
@@ -1923,10 +1985,11 @@ final class AssetController extends AbstractController
     )]
     public function getRack(Request $request): Response
     {
-        return Search::getOneBySchema($this->getKnownSchema('Rack'), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema('Rack', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Rack', methods: ['POST'], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Create a rack',
         parameters: [
@@ -1939,12 +2002,13 @@ final class AssetController extends AbstractController
     )]
     public function createRack(Request $request): Response
     {
-        return Search::createBySchema($this->getKnownSchema('Rack'), $request->getParameters(), [self::class, 'getRack']);
+        return Search::createBySchema($this->getKnownSchema('Rack', $this->getAPIVersion($request)), $request->getParameters(), [self::class, 'getRack']);
     }
 
     #[Route(path: '/Rack/{id}', methods: ['PATCH'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a rack by ID',
         parameters: [
@@ -1957,23 +2021,25 @@ final class AssetController extends AbstractController
     )]
     public function updateRack(Request $request): Response
     {
-        return Search::updateBySchema($this->getKnownSchema('Rack'), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema('Rack', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Rack/{id}', methods: ['DELETE'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Delete a rack by ID',
     )]
     public function deleteRack(Request $request): Response
     {
-        return Search::deleteBySchema($this->getKnownSchema('Rack'), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema('Rack', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Rack/{rack_id}/Item', methods: ['GET'], requirements: [
         'rack_id' => '\d+'
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get items in a rack',
         responses: [
@@ -1985,13 +2051,14 @@ final class AssetController extends AbstractController
         $filters = $request->hasParameter('filter') ? $request->getParameter('filter') : '';
         $filters .= ';rack.id==' . $request->getAttribute('rack_id');
         $request->setParameter('filter', $filters);
-        return Search::searchBySchema($this->getKnownSchema('RackItem'), $request->getParameters());
+        return Search::searchBySchema($this->getKnownSchema('RackItem', $this->getAPIVersion($request)), $request->getParameters());
     }
 
     #[Route(path: '/Rack/{rack_id}/Item/{id}', methods: ['GET'], requirements: [
         'rack_id' => '\d+',
         'id' => '\d+'
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a rack item',
         responses: [
@@ -2003,13 +2070,14 @@ final class AssetController extends AbstractController
         $filters = $request->hasParameter('filter') ? $request->getParameter('filter') : '';
         $filters .= ';rack.id==' . $request->getAttribute('rack_id');
         $request->setParameter('filter', $filters);
-        return Search::getOneBySchema($this->getKnownSchema('RackItem'), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema('RackItem', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Rack/{rack_id}/Item/{id}', methods: ['PATCH'], requirements: [
         'rack_id' => '\d+',
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a rack item',
         parameters: [
@@ -2022,12 +2090,13 @@ final class AssetController extends AbstractController
     )]
     public function updateRackItem(Request $request): Response
     {
-        return Search::updateBySchema($this->getKnownSchema('RackItem'), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema('RackItem', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Rack/{rack_id}/Item', methods: ['POST'], requirements: [
         'rack_id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Add an item to a rack',
         parameters: [
@@ -2050,7 +2119,7 @@ final class AssetController extends AbstractController
         }
 
         $request->setParameter('rack', $request->getAttribute('rack_id'));
-        return Search::createBySchema($this->getKnownSchema('RackItem'), $request->getParameters(), [
+        return Search::createBySchema($this->getKnownSchema('RackItem', $this->getAPIVersion($request)), $request->getParameters(), [
             self::class, 'getRackItem'
         ], [
             'mapped' => [
@@ -2063,15 +2132,17 @@ final class AssetController extends AbstractController
         'rack_id' => '\d+',
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Remove an item from a rack'
     )]
     public function deleteRackItem(Request $request): Response
     {
-        return Search::deleteBySchema($this->getKnownSchema('RackItem'), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema('RackItem', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Enclosure', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List or search enclosure',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -2081,12 +2152,13 @@ final class AssetController extends AbstractController
     )]
     public function searchEnclosure(Request $request): Response
     {
-        return Search::searchBySchema($this->getKnownSchema('Enclosure'), $request->getParameters());
+        return Search::searchBySchema($this->getKnownSchema('Enclosure', $this->getAPIVersion($request)), $request->getParameters());
     }
 
     #[Route(path: '/Enclosure/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a enclosure by ID',
         responses: [
@@ -2095,10 +2167,11 @@ final class AssetController extends AbstractController
     )]
     public function getEnclosure(Request $request): Response
     {
-        return Search::getOneBySchema($this->getKnownSchema('Enclosure'), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema('Enclosure', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Enclosure', methods: ['POST'], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Create a enclosure',
         parameters: [
@@ -2111,12 +2184,13 @@ final class AssetController extends AbstractController
     )]
     public function createEnclosure(Request $request): Response
     {
-        return Search::createBySchema($this->getKnownSchema('Enclosure'), $request->getParameters(), [self::class, 'getEnclosure']);
+        return Search::createBySchema($this->getKnownSchema('Enclosure', $this->getAPIVersion($request)), $request->getParameters(), [self::class, 'getEnclosure']);
     }
 
     #[Route(path: '/Enclosure/{id}', methods: ['PATCH'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a enclosure by ID',
         parameters: [
@@ -2129,21 +2203,23 @@ final class AssetController extends AbstractController
     )]
     public function updateEnclosure(Request $request): Response
     {
-        return Search::updateBySchema($this->getKnownSchema('Enclosure'), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema('Enclosure', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Enclosure/{id}', methods: ['DELETE'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Delete a enclosure by ID',
     )]
     public function deleteEnclosure(Request $request): Response
     {
-        return Search::deleteBySchema($this->getKnownSchema('Enclosure'), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema('Enclosure', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/PDU', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List or search PDUs',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -2153,12 +2229,13 @@ final class AssetController extends AbstractController
     )]
     public function searchPDU(Request $request): Response
     {
-        return Search::searchBySchema($this->getKnownSchema('PDU'), $request->getParameters());
+        return Search::searchBySchema($this->getKnownSchema('PDU', $this->getAPIVersion($request)), $request->getParameters());
     }
 
     #[Route(path: '/PDU/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a PDU by ID',
         responses: [
@@ -2167,10 +2244,11 @@ final class AssetController extends AbstractController
     )]
     public function getPDU(Request $request): Response
     {
-        return Search::getOneBySchema($this->getKnownSchema('PDU'), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema('PDU', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/PDU', methods: ['POST'], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Create a PDU',
         parameters: [
@@ -2183,12 +2261,13 @@ final class AssetController extends AbstractController
     )]
     public function createPDU(Request $request): Response
     {
-        return Search::createBySchema($this->getKnownSchema('PDU'), $request->getParameters(), [self::class, 'getPDU']);
+        return Search::createBySchema($this->getKnownSchema('PDU', $this->getAPIVersion($request)), $request->getParameters(), [self::class, 'getPDU']);
     }
 
     #[Route(path: '/PDU/{id}', methods: ['PATCH'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a PDU by ID',
         parameters: [
@@ -2201,21 +2280,23 @@ final class AssetController extends AbstractController
     )]
     public function updatePDU(Request $request): Response
     {
-        return Search::updateBySchema($this->getKnownSchema('PDU'), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema('PDU', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/PDU/{id}', methods: ['DELETE'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Delete a PDU by ID',
     )]
     public function deletePDU(Request $request): Response
     {
-        return Search::deleteBySchema($this->getKnownSchema('PDU'), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema('PDU', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/PassiveDCEquipment', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List or search passive DC equipment',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -2225,12 +2306,13 @@ final class AssetController extends AbstractController
     )]
     public function searchPassiveDCEquipment(Request $request): Response
     {
-        return Search::searchBySchema($this->getKnownSchema('PassiveDCEquipment'), $request->getParameters());
+        return Search::searchBySchema($this->getKnownSchema('PassiveDCEquipment', $this->getAPIVersion($request)), $request->getParameters());
     }
 
     #[Route(path: '/PassiveDCEquipment/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a passive DC equipment by ID',
         responses: [
@@ -2239,10 +2321,11 @@ final class AssetController extends AbstractController
     )]
     public function getPassiveDCEquipment(Request $request): Response
     {
-        return Search::getOneBySchema($this->getKnownSchema('PassiveDCEquipment'), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema('PassiveDCEquipment', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/PassiveDCEquipment', methods: ['POST'], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Create a passive DC equipment',
         parameters: [
@@ -2255,12 +2338,13 @@ final class AssetController extends AbstractController
     )]
     public function createPassiveDCEquipment(Request $request): Response
     {
-        return Search::createBySchema($this->getKnownSchema('PassiveDCEquipment'), $request->getParameters(), [self::class, 'getPassiveDCEquipment']);
+        return Search::createBySchema($this->getKnownSchema('PassiveDCEquipment', $this->getAPIVersion($request)), $request->getParameters(), [self::class, 'getPassiveDCEquipment']);
     }
 
     #[Route(path: '/PassiveDCEquipment/{id}', methods: ['PATCH'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a passive DC equipment by ID',
         parameters: [
@@ -2273,21 +2357,23 @@ final class AssetController extends AbstractController
     )]
     public function updatePassiveDCEquipment(Request $request): Response
     {
-        return Search::updateBySchema($this->getKnownSchema('PassiveDCEquipment'), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema('PassiveDCEquipment', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/PassiveDCEquipment/{id}', methods: ['DELETE'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Delete a passive DC equipment by ID',
     )]
     public function deletePassiveDCEquipment(Request $request): Response
     {
-        return Search::deleteBySchema($this->getKnownSchema('PassiveDCEquipment'), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema('PassiveDCEquipment', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Cable', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List or search cables',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -2297,12 +2383,13 @@ final class AssetController extends AbstractController
     )]
     public function searchCables(Request $request): Response
     {
-        return Search::searchBySchema($this->getKnownSchema('Cable'), $request->getParameters());
+        return Search::searchBySchema($this->getKnownSchema('Cable', $this->getAPIVersion($request)), $request->getParameters());
     }
 
     #[Route(path: '/Cable/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a cable by ID',
         responses: [
@@ -2311,10 +2398,11 @@ final class AssetController extends AbstractController
     )]
     public function getCable(Request $request): Response
     {
-        return Search::getOneBySchema($this->getKnownSchema('Cable'), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema('Cable', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Cable', methods: ['POST'], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Create a cable',
         parameters: [
@@ -2327,12 +2415,13 @@ final class AssetController extends AbstractController
     )]
     public function createCable(Request $request): Response
     {
-        return Search::createBySchema($this->getKnownSchema('Cable'), $request->getParameters(), [self::class, 'getCable']);
+        return Search::createBySchema($this->getKnownSchema('Cable', $this->getAPIVersion($request)), $request->getParameters(), [self::class, 'getCable']);
     }
 
     #[Route(path: '/Cable/{id}', methods: ['PATCH'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a cable by ID',
         parameters: [
@@ -2345,21 +2434,23 @@ final class AssetController extends AbstractController
     )]
     public function updateCable(Request $request): Response
     {
-        return Search::updateBySchema($this->getKnownSchema('Cable'), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema('Cable', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Cable/{id}', methods: ['DELETE'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Delete a cable by ID',
     )]
     public function deleteCable(Request $request): Response
     {
-        return Search::deleteBySchema($this->getKnownSchema('Cable'), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema('Cable', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Socket', methods: ['GET'], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List or search sockets',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -2369,12 +2460,13 @@ final class AssetController extends AbstractController
     )]
     public function searchSockets(Request $request): Response
     {
-        return Search::searchBySchema($this->getKnownSchema('Socket'), $request->getParameters());
+        return Search::searchBySchema($this->getKnownSchema('Socket', $this->getAPIVersion($request)), $request->getParameters());
     }
 
     #[Route(path: '/Socket/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a socket by ID',
         responses: [
@@ -2383,10 +2475,11 @@ final class AssetController extends AbstractController
     )]
     public function getSocket(Request $request): Response
     {
-        return Search::getOneBySchema($this->getKnownSchema('Socket'), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema('Socket', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Socket', methods: ['POST'], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Create a socket',
         parameters: [
@@ -2399,12 +2492,13 @@ final class AssetController extends AbstractController
     )]
     public function createSocket(Request $request): Response
     {
-        return Search::createBySchema($this->getKnownSchema('Socket'), $request->getParameters(), [self::class, 'getSocket']);
+        return Search::createBySchema($this->getKnownSchema('Socket', $this->getAPIVersion($request)), $request->getParameters(), [self::class, 'getSocket']);
     }
 
     #[Route(path: '/Socket/{id}', methods: ['PATCH'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a socket by ID',
         parameters: [
@@ -2417,23 +2511,25 @@ final class AssetController extends AbstractController
     )]
     public function updateSocket(Request $request): Response
     {
-        return Search::updateBySchema($this->getKnownSchema('Socket'), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema('Socket', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Socket/{id}', methods: ['DELETE'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Delete a socket by ID',
     )]
     public function deleteSocket(Request $request): Response
     {
-        return Search::deleteBySchema($this->getKnownSchema('Socket'), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema('Socket', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Software/{software_id}/Version', methods: ['GET'], requirements: [
         'software_id' => '\d+',
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List or search software versions',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -2446,12 +2542,13 @@ final class AssetController extends AbstractController
         $filters = $request->hasParameter('filter') ? $request->getParameter('filter') : '';
         $filters .= ';software.id==' . $request->getAttribute('software_id');
         $request->setParameter('filter', $filters);
-        return Search::searchBySchema($this->getKnownSchema('SoftwareVersion'), $request->getParameters());
+        return Search::searchBySchema($this->getKnownSchema('SoftwareVersion', $this->getAPIVersion($request)), $request->getParameters());
     }
 
     #[Route(path: '/Software/{software_id}/Version/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a software version by ID',
         responses: [
@@ -2463,12 +2560,13 @@ final class AssetController extends AbstractController
         $filters = $request->hasParameter('filter') ? $request->getParameter('filter') : '';
         $filters .= ';software.id==' . $request->getAttribute('software_id');
         $request->setParameter('filter', $filters);
-        return Search::getOneBySchema($this->getKnownSchema('SoftwareVersion'), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema('SoftwareVersion', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Software/{software_id}/Version', methods: ['POST'], requirements: [
         'software_id' => '\d+',
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Create a software version',
         parameters: [
@@ -2482,7 +2580,7 @@ final class AssetController extends AbstractController
     public function createSoftwareVersion(Request $request): Response
     {
         $request->setParameter('software', $request->getAttribute('software_id'));
-        return Search::createBySchema($this->getKnownSchema('SoftwareVersion'), $request->getParameters(), [
+        return Search::createBySchema($this->getKnownSchema('SoftwareVersion', $this->getAPIVersion($request)), $request->getParameters(), [
             self::class, 'getSoftwareVersion'
         ], [
             'mapped' => [
@@ -2494,6 +2592,7 @@ final class AssetController extends AbstractController
     #[Route(path: '/Software/{software_id}/Version/{id}', methods: ['PATCH'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a software version by ID',
         parameters: [
@@ -2506,17 +2605,18 @@ final class AssetController extends AbstractController
     )]
     public function updateSoftwareVersion(Request $request): Response
     {
-        return Search::updateBySchema($this->getKnownSchema('SoftwareVersion'), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema('SoftwareVersion', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Software/{software_id}/Version/{id}', methods: ['DELETE'], requirements: [
         'id' => '\d+'
     ], tags: ['Assets'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Delete a software version by ID',
     )]
     public function deleteSoftwareVersion(Request $request): Response
     {
-        return Search::deleteBySchema($this->getKnownSchema('SoftwareVersion'), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema('SoftwareVersion', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 }

--- a/src/Glpi/Api/HL/Controller/ComponentController.php
+++ b/src/Glpi/Api/HL/Controller/ComponentController.php
@@ -38,6 +38,7 @@ namespace Glpi\Api\HL\Controller;
 use Glpi\Api\HL\Doc as Doc;
 use Glpi\Api\HL\Middleware\ResultFormatterMiddleware;
 use Glpi\Api\HL\Route;
+use Glpi\Api\HL\RouteVersion;
 use Glpi\Api\HL\Search;
 use Glpi\Http\JSONResponse;
 use Glpi\Http\Request;
@@ -120,16 +121,19 @@ class ComponentController extends AbstractController
 
         return [
             'BatteryType' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceBatteryType::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_type_properties
             ],
             'BatteryModel' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceBatteryModel::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_model_properties
             ],
             'Battery' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceBattery::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
@@ -140,11 +144,13 @@ class ComponentController extends AbstractController
                 ]
             ],
             'CameraModel' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceCameraModel::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_model_properties
             ],
             'Camera' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceCamera::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
@@ -158,16 +164,19 @@ class ComponentController extends AbstractController
                 ]
             ],
             'CaseType' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceCaseType::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_type_properties
             ],
             'CaseModel' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceCaseModel::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_model_properties
             ],
             'Case' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceCase::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
@@ -176,11 +185,13 @@ class ComponentController extends AbstractController
                 ]
             ],
             'ControllerModel' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceControlModel::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_model_properties
             ],
             'Controller' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceControl::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
@@ -190,11 +201,13 @@ class ComponentController extends AbstractController
                 ]
             ],
             'DriveModel' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceDriveModel::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_model_properties
             ],
             'Drive' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceDrive::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
@@ -205,16 +218,19 @@ class ComponentController extends AbstractController
                 ]
             ],
             'FirmwareType' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceFirmwareType::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_type_properties
             ],
             'FirmwareModel' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceFirmwareModel::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_model_properties
             ],
             'Firmware' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceFirmware::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
@@ -225,16 +241,19 @@ class ComponentController extends AbstractController
                 ]
             ],
             'GenericDeviceType' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceGenericType::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_type_properties
             ],
             'GenericDeviceModel' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceGenericModel::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_model_properties
             ],
             'GenericDevice' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceGeneric::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
@@ -244,11 +263,13 @@ class ComponentController extends AbstractController
                 ]
             ],
             'GraphicCardModel' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceGraphicCardModel::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_model_properties
             ],
             'GraphicCard' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceGraphicCard::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
@@ -259,11 +280,13 @@ class ComponentController extends AbstractController
                 ]
             ],
             'HardDriveModel' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceHardDriveModel::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_model_properties
             ],
             'HardDrive' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceHardDrive::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
@@ -275,21 +298,25 @@ class ComponentController extends AbstractController
                 ]
             ],
             'InterfaceType' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \InterfaceType::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_type_properties
             ],
             'MemoryType' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceMemoryType::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_type_properties
             ],
             'MemoryModel' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceMemoryModel::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_model_properties
             ],
             'Memory' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceMemory::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
@@ -300,11 +327,13 @@ class ComponentController extends AbstractController
                 ]
             ],
             'NetworkCardModel' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceNetworkCardModel::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_model_properties
             ],
             'NetworkCard' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceNetworkCard::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
@@ -314,11 +343,13 @@ class ComponentController extends AbstractController
                 ]
             ],
             'PCIModel' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DevicePciModel::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_model_properties
             ],
             'PCIDevice' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DevicePci::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
@@ -326,11 +357,13 @@ class ComponentController extends AbstractController
                 ]
             ],
             'PowerSupplyModel' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DevicePowerSupplyModel::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_model_properties
             ],
             'PowerSupply' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DevicePowerSupply::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
@@ -340,11 +373,13 @@ class ComponentController extends AbstractController
                 ]
             ],
             'ProcessorModel' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceProcessorModel::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_model_properties
             ],
             'Processor' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceProcessor::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
@@ -356,16 +391,19 @@ class ComponentController extends AbstractController
                 ]
             ],
             'SensorType' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceSensorType::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_type_properties
             ],
             'SensorModel' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceSensorModel::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_model_properties
             ],
             'Sensor' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceSensor::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
@@ -375,11 +413,13 @@ class ComponentController extends AbstractController
                 ]
             ],
             'SIMCardType' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceSimcardType::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_type_properties
             ],
             'SIMCard' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceSimcard::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
@@ -389,11 +429,13 @@ class ComponentController extends AbstractController
                 ]
             ],
             'SoundCardModel' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceSoundCardModel::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_model_properties
             ],
             'SoundCard' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceSoundCard::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
@@ -401,6 +443,7 @@ class ComponentController extends AbstractController
                 ]
             ],
             'SystemboardModel' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceMotherboardModel::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_model_properties + [
@@ -408,6 +451,7 @@ class ComponentController extends AbstractController
                 ]
             ],
             'Systemboard' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \DeviceMotherboard::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_device_properties + [
@@ -416,6 +460,7 @@ class ComponentController extends AbstractController
                 ]
             ],
             'BatteryItem' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \Item_DeviceBattery::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
@@ -429,6 +474,7 @@ class ComponentController extends AbstractController
                 ]
             ],
             'CameraItem' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \Item_DeviceCamera::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => array_filter($common_item_device_properties + [
@@ -436,6 +482,7 @@ class ComponentController extends AbstractController
                 ], static fn($key) => !in_array($key, ['status', 'location', 'serial', 'otherserial']), ARRAY_FILTER_USE_KEY) // Cameras don't follow the general schema of the others
             ],
             'CaseItem' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \Item_DeviceCase::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
@@ -443,6 +490,7 @@ class ComponentController extends AbstractController
                 ]
             ],
             'ControllerItem' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \Item_DeviceControl::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
@@ -451,6 +499,7 @@ class ComponentController extends AbstractController
                 ]
             ],
             'DriveItem' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \Item_DeviceDrive::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
@@ -459,6 +508,7 @@ class ComponentController extends AbstractController
                 ]
             ],
             'FirmwareItem' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \Item_DeviceFirmware::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
@@ -466,6 +516,7 @@ class ComponentController extends AbstractController
                 ]
             ],
             'GenericDeviceItem' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \Item_DeviceGeneric::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
@@ -473,6 +524,7 @@ class ComponentController extends AbstractController
                 ]
             ],
             'GraphicCardItem' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \Item_DeviceGraphicCard::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
@@ -482,6 +534,7 @@ class ComponentController extends AbstractController
                 ]
             ],
             'HardDriveItem' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \Item_DeviceHardDrive::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
@@ -491,6 +544,7 @@ class ComponentController extends AbstractController
                 ]
             ],
             'MemoryItem' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \Item_DeviceMemory::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
@@ -500,6 +554,7 @@ class ComponentController extends AbstractController
                 ]
             ],
             'NetworkCardItem' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \Item_DeviceNetworkCard::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
@@ -509,6 +564,7 @@ class ComponentController extends AbstractController
                 ]
             ],
             'PCIDeviceItem' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \Item_DevicePci::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
@@ -517,6 +573,7 @@ class ComponentController extends AbstractController
                 ]
             ],
             'PowerSupplyItem' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \Item_DevicePowerSupply::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
@@ -524,6 +581,7 @@ class ComponentController extends AbstractController
                 ]
             ],
             'ProcessorItem' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \Item_DeviceProcessor::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
@@ -535,6 +593,7 @@ class ComponentController extends AbstractController
                 ]
             ],
             'SensorItem' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \Item_DeviceSensor::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
@@ -542,6 +601,7 @@ class ComponentController extends AbstractController
                 ]
             ],
             'SIMCardItem' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \Item_DeviceSimcard::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
@@ -557,6 +617,7 @@ class ComponentController extends AbstractController
                 ]
             ],
             'SoundCardItem' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \Item_DeviceSoundCard::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
@@ -565,6 +626,7 @@ class ComponentController extends AbstractController
                 ]
             ],
             'SystemboardItem' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => \Item_DeviceMotherboard::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => $common_item_device_properties + [
@@ -575,6 +637,7 @@ class ComponentController extends AbstractController
     }
 
     #[Route(path: '/Components', methods: ['GET'], tags: ['Components'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get all available component types',
         methods: ['GET'],
@@ -622,6 +685,7 @@ class ComponentController extends AbstractController
     #[Route(path: '/Components/{component_type}', methods: ['GET'], requirements: [
         'component_type' => '\w*'
     ], tags: ['Components'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get the component definitions of the specified type',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -632,13 +696,14 @@ class ComponentController extends AbstractController
     public function getComponentTypes(Request $request): Response
     {
         $component_type = $request->getAttribute('component_type');
-        return Search::searchBySchema($this->getKnownSchema($component_type), $request->getParameters());
+        return Search::searchBySchema($this->getKnownSchema($component_type, $this->getAPIVersion($request)), $request->getParameters());
     }
 
     #[Route(path: '/Components/{component_type}/{id}', methods: ['GET'], requirements: [
         'component_type' => '\w*',
         'id' => '\d+'
     ], tags: ['Components'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a specific component definition',
         responses: [
@@ -648,12 +713,13 @@ class ComponentController extends AbstractController
     public function getComponentType(Request $request): Response
     {
         $component_type = $request->getAttribute('component_type');
-        return Search::getOneBySchema($this->getKnownSchema($component_type), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema($component_type, $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Components/{component_type}', methods: ['POST'], requirements: [
         'component_type' => '\w*'
     ], tags: ['Components'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Create a component definition of the specified type',
         parameters: [
@@ -669,13 +735,14 @@ class ComponentController extends AbstractController
         $component_type = $request->getAttribute('component_type');
         // Needed to determine the correct URL for getComponentsOfType route
         $request->setParameter('component_type', $component_type);
-        return Search::createBySchema($this->getKnownSchema($component_type), $request->getParameters(), [self::class, 'getComponentType']);
+        return Search::createBySchema($this->getKnownSchema($component_type, $this->getAPIVersion($request)), $request->getParameters(), [self::class, 'getComponentType']);
     }
 
     #[Route(path: '/Components/{component_type}/{id}/Items', methods: ['GET'], requirements: [
         'component_type' => '\w*',
         'id' => '\d+'
     ], tags: ['Components'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get the components of a specific component definition',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -687,11 +754,11 @@ class ComponentController extends AbstractController
     {
         $component_type = $request->getAttribute('component_type');
         $component_id = $request->getAttribute('id');
-        $item_schema = $this->getKnownSchema($component_type . 'Item');
+        $item_schema = $this->getKnownSchema($component_type . 'Item', $this->getAPIVersion($request));
         // Find property that links to the component type
         $component_property = null;
 
-        $component_table = ($this->getKnownSchema($component_type)['x-itemtype'])::getTable();
+        $component_table = ($this->getKnownSchema($component_type, $this->getAPIVersion($request))['x-itemtype'])::getTable();
         foreach ($item_schema['properties'] as $property => $property_schema) {
             if (isset($property_schema['x-join']) && $property_schema['x-join']['table'] === $component_table) {
                 $component_property = $property;
@@ -711,6 +778,7 @@ class ComponentController extends AbstractController
         'component_type' => '\w*',
         'id' => '\d+'
     ], tags: ['Components'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a component definition of the specified type',
         parameters: [
@@ -724,26 +792,28 @@ class ComponentController extends AbstractController
     public function updateComponentType(Request $request): Response
     {
         $component_type = $request->getAttribute('component_type');
-        return Search::updateBySchema($this->getKnownSchema($component_type), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema($component_type, $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Components/{component_type}/{id}', methods: ['DELETE'], requirements: [
         'component_type' => '\w*',
         'id' => '\d+'
     ], tags: ['Components'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Delete a component definition of the specified type',
     )]
     public function deleteComponentType(Request $request): Response
     {
         $component_type = $request->getAttribute('component_type');
-        return Search::deleteBySchema($this->getKnownSchema($component_type), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema($component_type, $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Components/{component_type}/Items/{id}', methods: ['GET'], requirements: [
         'component_type' => '\w*',
         'id' => '\d+'
     ], tags: ['Components'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a specific component',
         responses: [
@@ -753,7 +823,7 @@ class ComponentController extends AbstractController
     public function getComponent(Request $request): Response
     {
         $component_type = $request->getAttribute('component_type');
-        $item_schema = $this->getKnownSchema($component_type . 'Item');
+        $item_schema = $this->getKnownSchema($component_type . 'Item', $this->getAPIVersion($request));
 
         return Search::getOneBySchema($item_schema, $request->getAttributes(), $request->getParameters());
     }
@@ -763,6 +833,7 @@ class ComponentController extends AbstractController
         'component_type' => '\w*',
         'id' => '\d+'
     ], tags: ['Assets', 'Components'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get all components for an asset',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -779,7 +850,7 @@ class ComponentController extends AbstractController
         $request->setParameter('filter', $filters);
 
         $component_type = $request->getAttribute('component_type');
-        $item_schema = $this->getKnownSchema($component_type . 'Item');
+        $item_schema = $this->getKnownSchema($component_type . 'Item', $this->getAPIVersion($request));
 
         return Search::searchBySchema($item_schema, $request->getParameters());
     }

--- a/src/Glpi/Api/HL/Controller/CoreController.php
+++ b/src/Glpi/Api/HL/Controller/CoreController.php
@@ -40,6 +40,7 @@ use Glpi\Api\HL\OpenAPIGenerator;
 use Glpi\Api\HL\Route;
 use Glpi\Api\HL\Router;
 use Glpi\Api\HL\Doc as Doc;
+use Glpi\Api\HL\RouteVersion;
 use Glpi\Application\ErrorHandler;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Http\JSONResponse;
@@ -58,6 +59,7 @@ final class CoreController extends AbstractController
     {
         return [
             'Session' => [
+                'x-version-introduced' => '2.0',
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => [
                     'current_time' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
@@ -90,6 +92,7 @@ final class CoreController extends AbstractController
                 ]
             ],
             'EntityTransferRecord' => [
+                'x-version-introduced' => '2.0',
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => [
                     'itemtype' => ['type' => Doc\Schema::TYPE_STRING],
@@ -102,6 +105,7 @@ final class CoreController extends AbstractController
     }
 
     #[Route(path: '/', methods: ['GET'], security_level: Route::SECURITY_NONE, middlewares: [CookieAuthMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'API Homepage. Displays the available API versions and a list of available routes. When logged in, more routes are displayed.',
         responses: [
@@ -151,6 +155,7 @@ final class CoreController extends AbstractController
     }
 
     #[Route(path: '/doc{ext}', methods: ['GET'], requirements: ['ext' => '(.json)?'], security_level: Route::SECURITY_NONE, middlewares: [CookieAuthMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Displays the API documentation as a Swagger UI HTML page or as the raw JSON schema.',
         parameters: [
@@ -167,13 +172,13 @@ final class CoreController extends AbstractController
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $generator = new OpenAPIGenerator(Router::getInstance());
+        $generator = new OpenAPIGenerator(Router::getInstance(), $this->getAPIVersion($request));
 
         $requested_types = $request->getHeader('Accept');
         $requested_json = in_array('application/json', $requested_types, true) ||
             str_ends_with($request->getUri()->getPath(), '.json');
         if (!$requested_json) {
-            $swagger_content = '<!DOCTYPE html><html><head><meta charset="UTF-8"><title>GLPI API Documentation</title>';
+            $swagger_content = '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>GLPI API Documentation</title>';
             $swagger_content .= \Html::script('/public/lib/swagger-ui.js');
             $swagger_content .= \Html::css('/public/lib/swagger-ui.css');
             $favicon = \Html::getPrefixedUrl('/pics/favicon.ico');
@@ -217,6 +222,7 @@ HTML;
     }
 
     #[Route(path: '/getting-started{ext}', methods: ['GET'], requirements: ['ext' => '(.md)?'], security_level: Route::SECURITY_NONE, middlewares: [CookieAuthMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Displays the general API documentation to get started.',
         parameters: [
@@ -282,6 +288,7 @@ HTML;
     }
 
     #[Route('/{req}', ['GET', 'POST', 'PATCH', 'PUT', 'DELETE'], ['req' => '.*'], -1)]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'A fallback for when no other endpoint matches the request. A 404 error will be shown.',
         methods: ['GET', 'POST', 'PATCH', 'PUT', "DELETE"],
@@ -300,6 +307,7 @@ HTML;
     }
 
     #[Route(path: '/{req}', methods: ['OPTIONS'], requirements: ['req' => '.*'], priority: -1, security_level: Route::SECURITY_NONE)]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'A global route that enables the OPTIONS method on all endpoints. This responds with an Accept header indicating which methods are allowed.',
         methods: ['OPTIONS']
@@ -327,6 +335,7 @@ HTML;
     }
 
     #[Route(path: '/session', methods: ['GET'], tags: ['Session'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get information about the session',
         responses: [
@@ -403,6 +412,7 @@ HTML;
     }
 
     #[Route(path: '/authorize', methods: ['GET', 'POST'], security_level: Route::SECURITY_NONE, tags: ['Session'], middlewares: [CookieAuthMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Authorize the API client using the authorization code grant type.',
     )]
@@ -451,6 +461,7 @@ HTML;
     }
 
     #[Route(path: '/token', methods: ['POST'], security_level: Route::SECURITY_NONE, tags: ['Session'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get an OAuth 2.0 token'
     )]
@@ -469,6 +480,7 @@ HTML;
     }
 
     #[Route(path: '/swagger-oauth-redirect', methods: ['GET'], security_level: Route::SECURITY_NONE, tags: ['Session'])]
+    #[RouteVersion(introduced: '2.0')]
     public function swaggerOAuthRedirect(Request $request): Response
     {
         $content = file_get_contents(GLPI_ROOT . '/public/lib/swagger-ui-dist/oauth2-redirect.html');
@@ -476,6 +488,7 @@ HTML;
     }
 
     #[Route(path: '/status', methods: ['GET'], tags: ['Status'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a list of all GLPI system status checker services.',
     )]
@@ -496,6 +509,7 @@ HTML;
     }
 
     #[Route(path: '/status/all', methods: ['GET'], security_level: Route::SECURITY_NONE, tags: ['Status'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get the the status of all GLPI system status checker services',
         responses: [
@@ -525,6 +539,7 @@ HTML;
     #[Route(path: '/status/{service}', methods: ['GET'], requirements: [
         'service' => '[a-zA-Z0-9_]+'
     ], priority: 9, tags: ['Status'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get the status of a GLPI system status checker service. Use "all" as the service to get the full system status.',
         responses: [
@@ -552,6 +567,7 @@ HTML;
     }
 
     #[Route(path: '/Transfer', methods: ['POST'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Transfer one or more items to another entity',
         parameters: [
@@ -581,7 +597,7 @@ HTML;
         $controllers = Router::getInstance()->getControllers();
         $schema_mappings = [];
         foreach ($controllers as $controller) {
-            $schemas = $controller::getKnownSchemas();
+            $schemas = $controller::getKnownSchemas($this->getAPIVersion($request));
             foreach ($schemas as $schema_name => $schema) {
                 if (isset($schema['x-itemtype'])) {
                     $schema_mappings[$schema_name] = $schema['x-itemtype'];

--- a/src/Glpi/Api/HL/Controller/DropdownController.php
+++ b/src/Glpi/Api/HL/Controller/DropdownController.php
@@ -82,6 +82,7 @@ final class DropdownController extends AbstractController
         $schemas = [];
 
         $schemas['Location'] = [
+            'x-version-introduced' => '2.0',
             'type' => Doc\Schema::TYPE_OBJECT,
             'x-itemtype' => Location::class,
             'description' => Location::getTypeName(1),
@@ -116,6 +117,7 @@ final class DropdownController extends AbstractController
         ];
 
         $schemas['State'] = [
+            'x-version-introduced' => '2.0',
             'type' => Doc\Schema::TYPE_OBJECT,
             'x-itemtype' => State::class,
             'description' => State::getTypeName(1),
@@ -153,6 +155,7 @@ final class DropdownController extends AbstractController
         }
 
         $schemas['State_Visibilities'] = [
+            'x-version-introduced' => '2.0',
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => []
         ];
@@ -180,6 +183,7 @@ final class DropdownController extends AbstractController
         $schemas['State']['properties']['visibilities']['properties'] = $schemas['State_Visibilities']['properties'];
 
         $schemas['Manufacturer'] = [
+            'x-version-introduced' => '2.0',
             'type' => Doc\Schema::TYPE_OBJECT,
             'x-itemtype' => Manufacturer::class,
             'description' => Manufacturer::getTypeName(1),
@@ -197,6 +201,7 @@ final class DropdownController extends AbstractController
         ];
 
         $schemas['Calendar'] = [
+            'x-version-introduced' => '2.0',
             'type' => Doc\Schema::TYPE_OBJECT,
             'x-itemtype' => Calendar::class,
             'description' => Calendar::getTypeName(1),

--- a/src/Glpi/Api/HL/Controller/GraphQLController.php
+++ b/src/Glpi/Api/HL/Controller/GraphQLController.php
@@ -41,6 +41,7 @@ use Glpi\Api\HL\GraphQLGenerator;
 use Glpi\Api\HL\Middleware\CookieAuthMiddleware;
 use Glpi\Api\HL\Route;
 use Glpi\Api\HL\Router;
+use Glpi\Api\HL\RouteVersion;
 use Glpi\Http\JSONResponse;
 use Glpi\Http\Request;
 use Glpi\Http\Response;
@@ -49,6 +50,7 @@ use Glpi\Http\Response;
 final class GraphQLController extends AbstractController
 {
     #[Route(path: '/', methods: ['POST'], security_level: Route::SECURITY_AUTHENTICATED)]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'GraphQL API',
     )]
@@ -58,12 +60,13 @@ final class GraphQLController extends AbstractController
     }
 
     #[Route(path: '/Schema', methods: ['GET'], security_level: Route::SECURITY_AUTHENTICATED)]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'GraphQL API Schema',
     )]
     public function getSchema(Request $request): Response
     {
-        $graphql_generator = new GraphQLGenerator();
+        $graphql_generator = new GraphQLGenerator($this->getAPIVersion($request));
         return new Response(200, [], $graphql_generator->getSchema());
     }
 }

--- a/src/Glpi/Api/HL/Controller/ITILController.php
+++ b/src/Glpi/Api/HL/Controller/ITILController.php
@@ -44,6 +44,7 @@ use Entity;
 use Glpi\Api\HL\Doc as Doc;
 use Glpi\Api\HL\Middleware\ResultFormatterMiddleware;
 use Glpi\Api\HL\Route;
+use Glpi\Api\HL\RouteVersion;
 use Glpi\Api\HL\Search;
 use Glpi\Http\JSONResponse;
 use Glpi\Http\Request;
@@ -81,6 +82,7 @@ final class ITILController extends AbstractController
         $schemas = [];
 
         $schemas['ITILCategory'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => 'ITILCategory',
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -113,16 +115,19 @@ final class ITILController extends AbstractController
             'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
         ];
         $schemas['TicketTemplate'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => 'TicketTemplate',
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => $common_itiltemplate_properties
         ];
         $schemas['ChangeTemplate'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => 'ChangeTemplate',
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => $common_itiltemplate_properties
         ];
         $schemas['ProblemTemplate'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => 'ProblemTemplate',
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => $common_itiltemplate_properties
@@ -168,6 +173,7 @@ final class ITILController extends AbstractController
         /** @var class-string<CommonITILObject> $itil_type */
         foreach ($itil_types as $itil_type) {
             $schemas[$itil_type] = $base_schema;
+            $schemas[$itil_type]['x-version-introduced'] = '2.0';
             if ($itil_type === Ticket::class) {
                 $schemas[$itil_type]['properties']['type'] = [
                     'type' => Doc\Schema::TYPE_INTEGER,
@@ -260,18 +266,22 @@ final class ITILController extends AbstractController
         ];
 
         $schemas['TicketTask'] = $base_task_schema;
+        $schemas['TicketTask']['x-version-introduced'] = '2.0';
         $schemas['TicketTask']['x-itemtype'] = \TicketTask::class;
         $schemas['TicketTask']['properties'][Ticket::getForeignKeyField()] = ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64];
 
         $schemas['ChangeTask'] = $base_task_schema;
+        $schemas['ChangeTask']['x-version-introduced'] = '2.0';
         $schemas['ChangeTask']['x-itemtype'] = \ChangeTask::class;
         $schemas['ChangeTask']['properties'][Change::getForeignKeyField()] = ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64];
 
         $schemas['ProblemTask'] = $base_task_schema;
+        $schemas['ProblemTask']['x-version-introduced'] = '2.0';
         $schemas['ProblemTask']['x-itemtype'] = \ProblemTask::class;
         $schemas['ProblemTask']['properties'][Problem::getForeignKeyField()] = ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64];
 
         $schemas['TaskCategory'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \TaskCategory::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -286,6 +296,7 @@ final class ITILController extends AbstractController
         ];
 
         $schemas['RequestType'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \RequestType::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'properties' => [
@@ -315,6 +326,7 @@ final class ITILController extends AbstractController
         ];
 
         $schemas['Followup'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \ITILFollowup::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'x-rights-conditions' => [ // Object-level extra permissions
@@ -349,6 +361,7 @@ final class ITILController extends AbstractController
         ];
 
         $schemas['Solution'] = [
+            'x-version-introduced' => '2.0',
             'type' => Doc\Schema::TYPE_OBJECT,
             'x-itemtype' => \ITILSolution::class,
             'properties' => [
@@ -403,14 +416,17 @@ final class ITILController extends AbstractController
         ];
 
         $schemas['TicketValidation'] = $base_validation_schema;
+        $schemas['TicketValidation']['x-version-introduced'] = '2.0';
         $schemas['TicketValidation']['x-itemtype'] = \TicketValidation::class;
         $schemas['TicketValidation']['properties'][Ticket::getForeignKeyField()] = ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64];
 
         $schemas['ChangeValidation'] = $base_validation_schema;
+        $schemas['ChangeValidation']['x-version-introduced'] = '2.0';
         $schemas['ChangeValidation']['x-itemtype'] = \ChangeValidation::class;
         $schemas['ChangeValidation']['properties'][Change::getForeignKeyField()] = ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64];
 
         $schemas['TeamMember'] = [
+            'x-version-introduced' => '2.0',
             'type' => Doc\Schema::TYPE_OBJECT,
             'description' => 'The valid types and roles depend on the type of the item they are being added to',
             'properties' => [
@@ -426,6 +442,7 @@ final class ITILController extends AbstractController
         ];
 
         $schemas['RecurringTicket'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \TicketRecurrent::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'description' => 'Recurring ticket',
@@ -464,6 +481,7 @@ final class ITILController extends AbstractController
         ];
 
         $schemas['RecurringChange'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \RecurrentChange::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'description' => 'Recurring change',
@@ -501,6 +519,7 @@ final class ITILController extends AbstractController
         ];
 
         $schemas['ExternalEventTemplate'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \PlanningExternalEventTemplate::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'description' => \PlanningExternalEventTemplate::getTypeName(1),
@@ -528,6 +547,7 @@ final class ITILController extends AbstractController
         ];
 
         $schemas['EventCategory'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \PlanningEventCategory::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'description' => \PlanningEventCategory::getTypeName(1),
@@ -546,6 +566,7 @@ final class ITILController extends AbstractController
         ];
 
         $schemas['ExternalEvent'] = [
+            'x-version-introduced' => '2.0',
             'x-itemtype' => \PlanningExternalEvent::class,
             'type' => Doc\Schema::TYPE_OBJECT,
             'description' => \PlanningExternalEvent::getTypeName(1),
@@ -610,9 +631,9 @@ final class ITILController extends AbstractController
      * @param class-string<CommonITILObject> $itemtype
      * @return array
      */
-    private function getSubitemSchemaFor(string $subitem_schema_name, string $itemtype): array
+    private function getSubitemSchemaFor(string $subitem_schema_name, string $itemtype, string $api_version): array
     {
-        $subitem_schema = $this->getKnownSchema($subitem_schema_name);
+        $subitem_schema = $this->getKnownSchema($subitem_schema_name, $api_version);
         $subitem_schema['x-itemtype'] = match ($subitem_schema_name) {
             'Task' => $itemtype::getTaskClass(),
             'Followup' => 'ITILFollowup',
@@ -626,6 +647,7 @@ final class ITILController extends AbstractController
     }
 
     #[Route(path: '/{itemtype}', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List or search Tickets, Changes or Problems',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -636,10 +658,11 @@ final class ITILController extends AbstractController
     public function search(Request $request): Response
     {
         $itemtype = $request->getAttribute('itemtype');
-        return Search::searchBySchema($this->getKnownSchema($itemtype), $request->getParameters());
+        return Search::searchBySchema($this->getKnownSchema($itemtype, $this->getAPIVersion($request)), $request->getParameters());
     }
 
     #[Route(path: '/{itemtype}/{id}', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a Ticket, Change or Problem by ID',
         parameters: [
@@ -657,10 +680,11 @@ final class ITILController extends AbstractController
     public function getItem(Request $request): Response
     {
         $itemtype = $request->getAttribute('itemtype');
-        return Search::getOneBySchema($this->getKnownSchema($itemtype), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema($itemtype, $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/{itemtype}', methods: ['POST'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Create a new Ticket, Change or Problem',
         parameters: [
@@ -674,10 +698,11 @@ final class ITILController extends AbstractController
     public function createItem(Request $request): Response
     {
         $itemtype = $request->getAttribute('itemtype');
-        return Search::createBySchema($this->getKnownSchema($itemtype), $request->getParameters() + ['itemtype' => $itemtype], [self::class, 'getItem']);
+        return Search::createBySchema($this->getKnownSchema($itemtype, $this->getAPIVersion($request)), $request->getParameters() + ['itemtype' => $itemtype], [self::class, 'getItem']);
     }
 
     #[Route(path: '/{itemtype}/{id}', methods: ['PATCH'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a Ticket, Change or Problem by ID',
         parameters: [
@@ -697,10 +722,11 @@ final class ITILController extends AbstractController
     public function updateItem(Request $request): Response
     {
         $itemtype = $request->getAttribute('itemtype');
-        return Search::updateBySchema($this->getKnownSchema($itemtype), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema($itemtype, $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/{itemtype}/{id}', methods: ['DELETE'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Delete a Ticket, Change or Problem by ID',
         parameters: [
@@ -715,7 +741,7 @@ final class ITILController extends AbstractController
     public function deleteItem(Request $request): Response
     {
         $itemtype = $request->getAttribute('itemtype');
-        return Search::deleteBySchema($this->getKnownSchema($itemtype), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema($itemtype, $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     private function getRequiredTimelineItemFields(CommonITILObject $item, Request $request, string $subitem_type): array
@@ -743,16 +769,16 @@ final class ITILController extends AbstractController
         return $filters;
     }
 
-    private function getKnownSubitemSchema(CommonITILObject $item, string $subitem_type): ?array
+    private function getKnownSubitemSchema(CommonITILObject $item, string $subitem_type, string $api_version): ?array
     {
         if ($subitem_type === 'Document') {
-            $schema = (new ManagementController())->getKnownSchema('Document_Item');
+            $schema = (new ManagementController())->getKnownSchema('Document_Item', $api_version);
         } else if ($subitem_type === 'Task') {
-            $schema = $this->getKnownSchema($item::getTaskClass());
+            $schema = $this->getKnownSchema($item::getTaskClass(), $api_version);
         } else if ($subitem_type === 'Validation' && class_exists($item::getType() . 'Validation')) {
-            $schema = $this->getKnownSchema($item::getType() . 'Validation');
+            $schema = $this->getKnownSchema($item::getType() . 'Validation', $api_version);
         } else {
-            $schema = $this->getKnownSchema($subitem_type);
+            $schema = $this->getKnownSchema($subitem_type, $api_version);
         }
         return $schema;
     }
@@ -770,7 +796,7 @@ final class ITILController extends AbstractController
         $results = [];
         foreach ($subitem_types as $subitem_type) {
             $filters = $this->getTimelineItemFilters($item, $request, $subitem_type);
-            $schema = $this->getKnownSubitemSchema($item, $subitem_type);
+            $schema = $this->getKnownSubitemSchema($item, $subitem_type, $this->getAPIVersion($request));
             if ($schema === null) {
                 continue;
             }
@@ -806,6 +832,7 @@ final class ITILController extends AbstractController
     }
 
     #[Route(path: '/{itemtype}/{id}/Timeline', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get all timeline items for a Ticket, Change or Problem by ID',
         parameters: [
@@ -828,6 +855,7 @@ final class ITILController extends AbstractController
     #[Route(path: '/{itemtype}/{id}/Timeline/{subitem_type}', methods: ['GET'], requirements: [
         'subitem_type' => 'Followup|Document|Solution|Validation'
     ], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get all timeline items of a specific type for a Ticket, Change or Problem by ID',
         parameters: [
@@ -857,6 +885,7 @@ final class ITILController extends AbstractController
     }
 
     #[Route(path: '/{itemtype}/{id}/Timeline/Task', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get all tasks for a Ticket, Change or Problem by ID',
         parameters: [
@@ -933,6 +962,7 @@ final class ITILController extends AbstractController
         'subitem_type' => 'Followup|Document|Solution|Validation',
         'subitem_id' => '\d+'
     ], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a specific timeline item by type and ID for a Ticket, Change or Problem by ID',
         parameters: [
@@ -959,6 +989,7 @@ final class ITILController extends AbstractController
     #[Route(path: '/{itemtype}/{id}/Timeline/Task/{subitem_id}', methods: ['GET'], requirements: [
         'subitem_id' => '\d+'
     ], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a task for a Ticket, Change or Problem by ID',
         parameters: [
@@ -986,6 +1017,7 @@ final class ITILController extends AbstractController
     #[Route(path: '/{itemtype}/{id}/Timeline/{subitem_type}', methods: ['POST'], requirements: [
         'subitem_type' => 'Followup|Document|Solution|Validation'
     ])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Create a timeline item for a Ticket, Change or Problem by ID',
         parameters: [
@@ -1010,7 +1042,7 @@ final class ITILController extends AbstractController
 
         $parameters = $request->getParameters();
         $parameters = array_merge($parameters, $this->getRequiredTimelineItemFields($item, $request, $subitem_type));
-        $schema = $this->getKnownSubitemSchema($item, $subitem_type);
+        $schema = $this->getKnownSubitemSchema($item, $subitem_type, $this->getAPIVersion($request));
         return Search::createBySchema($schema, $parameters, [self::class, 'getTimelineItem'], [
             'mapped' => [
                 'itemtype' => $item::getType(),
@@ -1022,6 +1054,7 @@ final class ITILController extends AbstractController
     }
 
     #[Route(path: '/{itemtype}/{id}/Timeline/Task', methods: ['POST'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Create a task for a Ticket, Change or Problem by ID',
         parameters: [
@@ -1045,7 +1078,7 @@ final class ITILController extends AbstractController
 
         $parameters = $request->getParameters();
         $parameters = array_merge($parameters, $this->getRequiredTimelineItemFields($item, $request, 'Task'));
-        $schema = $this->getKnownSubitemSchema($item, 'Task');
+        $schema = $this->getKnownSubitemSchema($item, 'Task', $this->getAPIVersion($request));
         return Search::createBySchema($schema, $parameters, [self::class, 'getTimelineTask'], [
             'mapped' => [
                 'itemtype' => $item::getType(),
@@ -1060,6 +1093,7 @@ final class ITILController extends AbstractController
         'subitem_type' => 'Followup|Document|Solution|Validation',
         'subitem_id' => '\d+'
     ])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a timeline item by ID for a Ticket, Change or Problem by ID',
         parameters: [
@@ -1090,12 +1124,13 @@ final class ITILController extends AbstractController
         }
         $attributes = $request->getAttributes();
         $attributes['id'] = $request->getAttribute('subitem_id');
-        return Search::updateBySchema($this->getKnownSubitemSchema($item, $subitem_type), $attributes, $parameters);
+        return Search::updateBySchema($this->getKnownSubitemSchema($item, $subitem_type, $this->getAPIVersion($request)), $attributes, $parameters);
     }
 
     #[Route(path: '/{itemtype}/{id}/Timeline/Task/{subitem_id}', methods: ['PATCH'], requirements: [
         'subitem_id' => '\d+'
     ])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a task for a Ticket, Change or Problem by ID',
         parameters: [
@@ -1125,13 +1160,14 @@ final class ITILController extends AbstractController
         }
         $attributes = $request->getAttributes();
         $attributes['id'] = $request->getAttribute('subitem_id');
-        return Search::updateBySchema($this->getKnownSubitemSchema($item, 'Task'), $attributes, $parameters);
+        return Search::updateBySchema($this->getKnownSubitemSchema($item, 'Task', $this->getAPIVersion($request)), $attributes, $parameters);
     }
 
     #[Route(path: '/{itemtype}/{id}/Timeline/{subitem_type}/{subitem_id}', methods: ['DELETE'], requirements: [
         'subitem_type' => 'Followup|Document|Solution|Validation',
         'subitem_id' => '\d+'
     ])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Delete a timeline item by ID for a Ticket, Change or Problem by ID',
         parameters: [
@@ -1150,12 +1186,13 @@ final class ITILController extends AbstractController
         $subitem_type = $request->getAttribute('subitem_type');
         $attributes = $request->getAttributes();
         $attributes['id'] = $request->getAttribute('subitem_id');
-        return Search::deleteBySchema($this->getKnownSubitemSchema($item, $subitem_type), $attributes, $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSubitemSchema($item, $subitem_type, $this->getAPIVersion($request)), $attributes, $request->getParameters());
     }
 
     #[Route(path: '/{itemtype}/{id}/Timeline/Task/{subitem_id}', methods: ['DELETE'], requirements: [
         'subitem_id' => '\d+'
     ])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Delete a task for a Ticket, Change or Problem by ID',
         parameters: [
@@ -1173,7 +1210,7 @@ final class ITILController extends AbstractController
         $item = $request->getParameter('_item');
         $attributes = $request->getAttributes();
         $attributes['id'] = $request->getAttribute('subitem_id');
-        return Search::deleteBySchema($this->getKnownSubitemSchema($item, 'Task'), $attributes, $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSubitemSchema($item, 'Task', $this->getAPIVersion($request)), $attributes, $request->getParameters());
     }
 
     /**
@@ -1245,6 +1282,7 @@ final class ITILController extends AbstractController
     }
 
     #[Route(path: '/{itemtype}/{id}/TeamMember', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get the team members for a specific Ticket, Change or Problem by ID',
         responses: [
@@ -1264,6 +1302,7 @@ final class ITILController extends AbstractController
     }
 
     #[Route(path: '/{itemtype}/{id}/TeamMember/{role}', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get the team members by role for specific Ticket, Change, Problem by ID',
         parameters: [
@@ -1300,6 +1339,7 @@ final class ITILController extends AbstractController
     }
 
     #[Route(path: '/{itemtype}/{id}/TeamMember', methods: ['POST'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Add a team member to a specific Ticket, Change or Problem',
         parameters: [
@@ -1340,6 +1380,7 @@ final class ITILController extends AbstractController
     }
 
     #[Route(path: '/{itemtype}/{id}/TeamMember', methods: ['DELETE'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Remove a team member from a specific Ticket, Change or Problem',
         parameters: [
@@ -1380,6 +1421,7 @@ final class ITILController extends AbstractController
     }
 
     #[Route(path: '/RecurringTicket', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List or search recurring tickets',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -1389,12 +1431,13 @@ final class ITILController extends AbstractController
     )]
     public function searchRecurringTickets(Request $request): Response
     {
-        return Search::searchBySchema($this->getKnownSchema('RecurringTicket'), $request->getParameters());
+        return Search::searchBySchema($this->getKnownSchema('RecurringTicket', $this->getAPIVersion($request)), $request->getParameters());
     }
 
     #[Route(path: '/RecurringTicket/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
     ], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a recurring ticket by ID',
         responses: [
@@ -1403,10 +1446,11 @@ final class ITILController extends AbstractController
     )]
     public function getRecurringTicket(Request $request): Response
     {
-        return Search::getOneBySchema($this->getKnownSchema('RecurringTicket'), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema('RecurringTicket', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/RecurringTicket', methods: ['POST'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Create a recurring ticket',
         parameters: [
@@ -1419,12 +1463,13 @@ final class ITILController extends AbstractController
     )]
     public function createRecurringTicket(Request $request): Response
     {
-        return Search::createBySchema($this->getKnownSchema('RecurringTicket'), $request->getParameters(), [self::class, 'getRecurringTicket']);
+        return Search::createBySchema($this->getKnownSchema('RecurringTicket', $this->getAPIVersion($request)), $request->getParameters(), [self::class, 'getRecurringTicket']);
     }
 
     #[Route(path: '/RecurringTicket/{id}', methods: ['PATCH'], requirements: [
         'id' => '\d+'
     ])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a recurring ticket by ID',
         parameters: [
@@ -1437,21 +1482,23 @@ final class ITILController extends AbstractController
     )]
     public function updateRecurringTicket(Request $request): Response
     {
-        return Search::updateBySchema($this->getKnownSchema('RecurringTicket'), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema('RecurringTicket', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/RecurringTicket/{id}', methods: ['DELETE'], requirements: [
         'id' => '\d+'
     ])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Delete a recurring ticket by ID',
     )]
     public function deleteRecurringTicket(Request $request): Response
     {
-        return Search::deleteBySchema($this->getKnownSchema('RecurringTicket'), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema('RecurringTicket', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/RecurringChange', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List or search recurring changes',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -1461,12 +1508,13 @@ final class ITILController extends AbstractController
     )]
     public function searchRecurringChanges(Request $request): Response
     {
-        return Search::searchBySchema($this->getKnownSchema('RecurringChange'), $request->getParameters());
+        return Search::searchBySchema($this->getKnownSchema('RecurringChange', $this->getAPIVersion($request)), $request->getParameters());
     }
 
     #[Route(path: '/RecurringChange/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
     ], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a recurring change by ID',
         responses: [
@@ -1475,10 +1523,11 @@ final class ITILController extends AbstractController
     )]
     public function getRecurringChange(Request $request): Response
     {
-        return Search::getOneBySchema($this->getKnownSchema('RecurringChange'), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema('RecurringChange', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/RecurringChange', methods: ['POST'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Create a recurring change',
         parameters: [
@@ -1491,12 +1540,13 @@ final class ITILController extends AbstractController
     )]
     public function createRecurringChange(Request $request): Response
     {
-        return Search::createBySchema($this->getKnownSchema('RecurringChange'), $request->getParameters(), [self::class, 'getRecurringChange']);
+        return Search::createBySchema($this->getKnownSchema('RecurringChange', $this->getAPIVersion($request)), $request->getParameters(), [self::class, 'getRecurringChange']);
     }
 
     #[Route(path: '/RecurringChange/{id}', methods: ['PATCH'], requirements: [
         'id' => '\d+'
     ])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a recurring change by ID',
         parameters: [
@@ -1509,21 +1559,23 @@ final class ITILController extends AbstractController
     )]
     public function updateRecurringChange(Request $request): Response
     {
-        return Search::updateBySchema($this->getKnownSchema('RecurringChange'), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema('RecurringChange', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/RecurringChange/{id}', methods: ['DELETE'], requirements: [
         'id' => '\d+'
     ])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Delete a recurring change by ID',
     )]
     public function deleteRecurringChange(Request $request): Response
     {
-        return Search::deleteBySchema($this->getKnownSchema('RecurringChange'), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema('RecurringChange', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/ExternalEvent', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List or search external events',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -1533,12 +1585,13 @@ final class ITILController extends AbstractController
     )]
     public function searchExternalEvent(Request $request): Response
     {
-        return Search::searchBySchema($this->getKnownSchema('ExternalEvent'), $request->getParameters());
+        return Search::searchBySchema($this->getKnownSchema('ExternalEvent', $this->getAPIVersion($request)), $request->getParameters());
     }
 
     #[Route(path: '/ExternalEvent/{id}', methods: ['GET'], requirements: [
         'id' => '\d+'
     ], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get an external event by ID',
         responses: [
@@ -1547,10 +1600,11 @@ final class ITILController extends AbstractController
     )]
     public function getExternalEvent(Request $request): Response
     {
-        return Search::getOneBySchema($this->getKnownSchema('ExternalEvent'), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema('ExternalEvent', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/ExternalEvent', methods: ['POST'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Create an external event',
         parameters: [
@@ -1563,12 +1617,13 @@ final class ITILController extends AbstractController
     )]
     public function createExternalEvent(Request $request): Response
     {
-        return Search::createBySchema($this->getKnownSchema('ExternalEvent'), $request->getParameters(), [self::class, 'getExternalEvent']);
+        return Search::createBySchema($this->getKnownSchema('ExternalEvent', $this->getAPIVersion($request)), $request->getParameters(), [self::class, 'getExternalEvent']);
     }
 
     #[Route(path: '/ExternalEvent/{id}', methods: ['PATCH'], requirements: [
         'id' => '\d+'
     ])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update an external event by ID',
         parameters: [
@@ -1581,17 +1636,18 @@ final class ITILController extends AbstractController
     )]
     public function updateExternalEvent(Request $request): Response
     {
-        return Search::updateBySchema($this->getKnownSchema('ExternalEvent'), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema('ExternalEvent', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/ExternalEvent/{id}', methods: ['DELETE'], requirements: [
         'id' => '\d+'
     ])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Delete an external event by ID',
     )]
     public function deleteExternalEvent(Request $request): Response
     {
-        return Search::deleteBySchema($this->getKnownSchema('ExternalEvent'), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema('ExternalEvent', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 }

--- a/src/Glpi/Api/HL/Controller/ManagementController.php
+++ b/src/Glpi/Api/HL/Controller/ManagementController.php
@@ -51,6 +51,7 @@ use Entity;
 use Glpi\Api\HL\Doc as Doc;
 use Glpi\Api\HL\Middleware\ResultFormatterMiddleware;
 use Glpi\Api\HL\Route;
+use Glpi\Api\HL\RouteVersion;
 use Glpi\Api\HL\Search;
 use Glpi\Http\JSONResponse;
 use Glpi\Http\Request;
@@ -82,55 +83,68 @@ final class ManagementController extends AbstractController
             $management_types = [
                 Appliance::class => [
                     'schema_name' => 'Appliance',
-                    'label' => Appliance::getTypeName(1)
+                    'label' => Appliance::getTypeName(1),
+                    'version_introduced' => '2.0'
                 ],
                 Budget::class => [
                     'schema_name' => 'Budget',
-                    'label' => Budget::getTypeName(1)
+                    'label' => Budget::getTypeName(1),
+                    'version_introduced' => '2.0'
                 ],
                 Certificate::class => [
                     'schema_name' => 'Certificate',
-                    'label' => Certificate::getTypeName(1)
+                    'label' => Certificate::getTypeName(1),
+                    'version_introduced' => '2.0'
                 ],
                 Cluster::class => [
                     'schema_name' => 'Cluster',
-                    'label' => Cluster::getTypeName(1)
+                    'label' => Cluster::getTypeName(1),
+                    'version_introduced' => '2.0'
                 ],
                 Contact::class => [
                     'schema_name' => 'Contact',
-                    'label' => Contact::getTypeName(1)
+                    'label' => Contact::getTypeName(1),
+                    'version_introduced' => '2.0'
                 ],
                 Contract::class => [
                     'schema_name' => 'Contract',
-                    'label' => Contract::getTypeName(1)
+                    'label' => Contract::getTypeName(1),
+                    'version_introduced' => '2.0'
                 ],
                 Database::class => [
                     'schema_name' => 'Database',
-                    'label' => Database::getTypeName(1)
+                    'label' => Database::getTypeName(1),
+                    'version_introduced' => '2.0'
                 ],
                 Datacenter::class => [
                     'schema_name' => 'DataCenter',
-                    'label' => Datacenter::getTypeName(1)
+                    'label' => Datacenter::getTypeName(1),
+                    'version_introduced' => '2.0'
                 ],
                 Document::class => [
                     'schema_name' => 'Document',
-                    'label' => Document::getTypeName(1)
+                    'label' => Document::getTypeName(1),
+                    'version_introduced' => '2.0'
                 ],
                 Domain::class => [
                     'schema_name' => 'Domain',
-                    'label' => Domain::getTypeName(1)
+                    'label' => Domain::getTypeName(1),
+                    'version_introduced' => '2.0'
                 ],
                 SoftwareLicense::class => [
                     'schema_name' => 'License',
-                    'label' => SoftwareLicense::getTypeName(1)
+                    'label' => SoftwareLicense::getTypeName(1),
+                    'version_introduced' => '2.0'
                 ],
                 Line::class => [
                     'schema_name' => 'Line',
-                    'label' => Line::getTypeName(1)
+                    'label' => Line::getTypeName(1),
+                    'version_introduced' => '2.0'
                 ],
                 Supplier::class => [
                     'schema_name' => 'Supplier',
-                    'label' => Supplier::getTypeName(1)
+                    'label' => Supplier::getTypeName(1),
+                    'version_introduced' => '2.0'
                 ],
             ];
         }
@@ -148,6 +162,7 @@ final class ManagementController extends AbstractController
         foreach ($management_types as $m_class => $m_data) {
             $m_name = $m_data['schema_name'];
             $schemas[$m_name] = [
+                'x-version-introduced' => $m_data['version_introduced'],
                 'x-itemtype' => $m_class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => [
@@ -316,6 +331,7 @@ final class ManagementController extends AbstractController
         $schemas['Document']['properties']['mime'] = ['type' => Doc\Schema::TYPE_STRING];
         $schemas['Document']['properties']['sha1sum'] = ['type' => Doc\Schema::TYPE_STRING];
         $schemas['Document_Item'] = [
+            'x-version-introduced' => '2.0',
             'type' => Doc\Schema::TYPE_OBJECT,
             'x-itemtype' => Document_Item::class,
             'properties' => [
@@ -349,6 +365,7 @@ final class ManagementController extends AbstractController
         ];
 
         $schemas['Infocom'] = [
+            'x-version-introduced' => '2.0',
             'type' => Doc\Schema::TYPE_OBJECT,
             'x-itemtype' => 'Infocom',
             'properties' => [
@@ -443,6 +460,7 @@ final class ManagementController extends AbstractController
     }
 
     #[Route(path: '/', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get all available management types',
         methods: ['GET'],
@@ -480,6 +498,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/{itemtype}', methods: ['GET'], requirements: [
         'itemtype' => [self::class, 'getManagementTypes']
     ], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List or search management items',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -490,13 +509,14 @@ final class ManagementController extends AbstractController
     public function searchItems(Request $request): Response
     {
         $itemtype = $request->getAttribute('itemtype');
-        return Search::searchBySchema($this->getKnownSchema($itemtype), $request->getParameters());
+        return Search::searchBySchema($this->getKnownSchema($itemtype, $this->getAPIVersion($request)), $request->getParameters());
     }
 
     #[Route(path: '/{itemtype}/{id}', methods: ['GET'], requirements: [
         'itemtype' => [self::class, 'getManagementTypes'],
         'id' => '\d+'
     ], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a management item by ID',
         responses: [
@@ -506,10 +526,11 @@ final class ManagementController extends AbstractController
     public function getItem(Request $request): Response
     {
         $itemtype = $request->getAttribute('itemtype');
-        return Search::getOneBySchema($this->getKnownSchema($itemtype), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema($itemtype, $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Document/{id}/Download', methods: ['GET'], requirements: ['id' => '\d+'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Download a document by ID',
         parameters: [
@@ -541,6 +562,7 @@ final class ManagementController extends AbstractController
     #[Route(path: '/{itemtype}', methods: ['POST'], requirements: [
         'itemtype' => [self::class, 'getManagementTypes']
     ])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(description: 'Create a new management item', parameters: [
         [
             'name' => '_',
@@ -551,13 +573,14 @@ final class ManagementController extends AbstractController
     public function createItem(Request $request): Response
     {
         $itemtype = $request->getAttribute('itemtype');
-        return Search::createBySchema($this->getKnownSchema($itemtype), $request->getParameters() + ['itemtype' => $itemtype], [self::class, 'getItem']);
+        return Search::createBySchema($this->getKnownSchema($itemtype, $this->getAPIVersion($request)), $request->getParameters() + ['itemtype' => $itemtype], [self::class, 'getItem']);
     }
 
     #[Route(path: '/{itemtype}/{id}', methods: ['PATCH'], requirements: [
         'itemtype' => [self::class, 'getManagementTypes'],
         'id' => '\d+'
     ])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a management item by ID',
         parameters: [
@@ -574,17 +597,18 @@ final class ManagementController extends AbstractController
     public function updateItem(Request $request): Response
     {
         $itemtype = $request->getAttribute('itemtype');
-        return Search::updateBySchema($this->getKnownSchema($itemtype), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema($itemtype, $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/{itemtype}/{id}', methods: ['DELETE'], requirements: [
         'itemtype' => [self::class, 'getManagementTypes'],
         'id' => '\d+'
     ])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(description: 'Delete a management item by ID')]
     public function deleteItem(Request $request): Response
     {
         $itemtype = $request->getAttribute('itemtype');
-        return Search::deleteBySchema($this->getKnownSchema($itemtype), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema($itemtype, $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 }

--- a/src/Glpi/Api/HL/Controller/ProjectController.php
+++ b/src/Glpi/Api/HL/Controller/ProjectController.php
@@ -37,6 +37,7 @@ namespace Glpi\Api\HL\Controller;
 
 use Glpi\Api\HL\Middleware\ResultFormatterMiddleware;
 use Glpi\Api\HL\Route;
+use Glpi\Api\HL\RouteVersion;
 use Glpi\Api\HL\Search;
 use Glpi\Http\Request;
 use Glpi\Http\Response;
@@ -51,6 +52,7 @@ final class ProjectController extends AbstractController
     {
         return [
             'Project' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => Project::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'x-rights-conditions' => [ // Object-level extra permissions
@@ -133,6 +135,7 @@ final class ProjectController extends AbstractController
                 ]
             ],
             'ProjectTask' => [
+                'x-version-introduced' => '2.0',
                 'x-itemtype' => ProjectTask::class,
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'x-rights-conditions' => [ // Object-level extra permissions
@@ -218,6 +221,7 @@ final class ProjectController extends AbstractController
     }
 
     #[Route(path: '/', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List or search projects',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -227,10 +231,11 @@ final class ProjectController extends AbstractController
     )]
     public function searchProjects(Request $request): Response
     {
-        return Search::searchBySchema($this->getKnownSchema('Project'), $request->getParameters());
+        return Search::searchBySchema($this->getKnownSchema('Project', $this->getAPIVersion($request)), $request->getParameters());
     }
 
     #[Route(path: '/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a project by ID',
         responses: [
@@ -239,10 +244,11 @@ final class ProjectController extends AbstractController
     )]
     public function getProject(Request $request): Response
     {
-        return Search::getOneBySchema($this->getKnownSchema('Project'), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema('Project', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/', methods: ['POST'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(description: 'Create a new project', parameters: [
         [
             'name' => '_',
@@ -252,10 +258,11 @@ final class ProjectController extends AbstractController
     ])]
     public function createProject(Request $request): Response
     {
-        return Search::createBySchema($this->getKnownSchema('Project'), $request->getParameters(), [self::class, 'getProject']);
+        return Search::createBySchema($this->getKnownSchema('Project', $this->getAPIVersion($request)), $request->getParameters(), [self::class, 'getProject']);
     }
 
     #[Route(path: '/{id}', methods: ['PATCH'], requirements: ['id' => '\d+'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a project by ID',
         parameters: [
@@ -271,17 +278,19 @@ final class ProjectController extends AbstractController
     )]
     public function updateProject(Request $request): Response
     {
-        return Search::updateBySchema($this->getKnownSchema('Project'), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema('Project', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/{id}', methods: ['DELETE'], requirements: ['id' => '\d+'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(description: 'Delete a project by ID')]
     public function deleteProject(Request $request): Response
     {
-        return Search::deleteBySchema($this->getKnownSchema('Project'), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema('Project', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Task', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List or search project tasks',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -291,10 +300,11 @@ final class ProjectController extends AbstractController
     )]
     public function searchTasks(Request $request): Response
     {
-        return Search::searchBySchema($this->getKnownSchema('ProjectTask'), $request->getParameters());
+        return Search::searchBySchema($this->getKnownSchema('ProjectTask', $this->getAPIVersion($request)), $request->getParameters());
     }
 
     #[Route(path: '/Task/{id}', methods: ['GET'], requirements: ['id' => '\d+'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a task by ID',
         responses: [
@@ -303,10 +313,11 @@ final class ProjectController extends AbstractController
     )]
     public function getTask(Request $request): Response
     {
-        return Search::getOneBySchema($this->getKnownSchema('ProjectTask'), $request->getAttributes(), $request->getParameters());
+        return Search::getOneBySchema($this->getKnownSchema('ProjectTask', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Task', methods: ['POST'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(description: 'Create a new task', parameters: [
         [
             'name' => '_',
@@ -316,10 +327,11 @@ final class ProjectController extends AbstractController
     ])]
     public function createTask(Request $request): Response
     {
-        return Search::createBySchema($this->getKnownSchema('ProjectTask'), $request->getParameters(), [self::class, 'getTask']);
+        return Search::createBySchema($this->getKnownSchema('ProjectTask', $this->getAPIVersion($request)), $request->getParameters(), [self::class, 'getTask']);
     }
 
     #[Route(path: '/Task/{id}', methods: ['PATCH'], requirements: ['id' => '\d+'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a task by ID',
         responses: [
@@ -328,17 +340,19 @@ final class ProjectController extends AbstractController
     )]
     public function updateTask(Request $request): Response
     {
-        return Search::updateBySchema($this->getKnownSchema('ProjectTask'), $request->getAttributes(), $request->getParameters());
+        return Search::updateBySchema($this->getKnownSchema('ProjectTask', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Task/{id}', methods: ['DELETE'], requirements: ['id' => '\d+'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(description: 'Delete a task by ID')]
     public function deleteTask(Request $request): Response
     {
-        return Search::deleteBySchema($this->getKnownSchema('ProjectTask'), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema('ProjectTask', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/{project_id}/Task', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List or search project tasks',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -353,10 +367,11 @@ final class ProjectController extends AbstractController
             $params['filter'] = [];
         }
         $params['filter']['project'] = $request->getAttributes()['project_id'];
-        return Search::searchBySchema($this->getKnownSchema('ProjectTask'), $params);
+        return Search::searchBySchema($this->getKnownSchema('ProjectTask', $this->getAPIVersion($request)), $params);
     }
 
     #[Route(path: '/{project_id}/Task', methods: ['POST'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(description: 'Create a new task', parameters: [
         [
             'name' => '_',
@@ -368,6 +383,6 @@ final class ProjectController extends AbstractController
     {
         $params = $request->getParameters();
         $params['project'] = $request->getAttributes()['project_id'];
-        return Search::createBySchema($this->getKnownSchema('ProjectTask'), $params, [self::class, 'getTask']);
+        return Search::createBySchema($this->getKnownSchema('ProjectTask', $this->getAPIVersion($request)), $params, [self::class, 'getTask']);
     }
 }

--- a/src/Glpi/Api/HL/Controller/ReportController.php
+++ b/src/Glpi/Api/HL/Controller/ReportController.php
@@ -37,6 +37,7 @@ namespace Glpi\Api\HL\Controller;
 
 use Glpi\Api\HL\Middleware\ResultFormatterMiddleware;
 use Glpi\Api\HL\Route;
+use Glpi\Api\HL\RouteVersion;
 use Glpi\Api\HL\Search;
 use Glpi\Http\JSONResponse;
 use Glpi\Http\Request;
@@ -49,6 +50,7 @@ class ReportController extends AbstractController
     {
         return [
             'StatReport' => [
+                'x-version-introduced' => '2.0',
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => [
                     'assistance_type' => [
@@ -73,6 +75,7 @@ class ReportController extends AbstractController
                 ]
             ],
             'GlobalStats' => [
+                'x-version-introduced' => '2.0',
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => [
                     'sample_dates' => [
@@ -157,6 +160,7 @@ class ReportController extends AbstractController
                 ]
             ],
             'ITILStats' => [
+                'x-version-introduced' => '2.0',
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => [
                     'item' => [
@@ -224,6 +228,7 @@ class ReportController extends AbstractController
                 ]
             ],
             'AssetStats' => [
+                'x-version-introduced' => '2.0',
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => [
                     'item' => [
@@ -257,6 +262,7 @@ class ReportController extends AbstractController
                 ]
             ],
             'AssetCharacteristicsStats' => [
+                'x-version-introduced' => '2.0',
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'properties' => [
                     'characteristic' => [
@@ -318,6 +324,7 @@ class ReportController extends AbstractController
     }
 
     #[Route(path: '/Assistance/Stat', methods: ['GET'], tags: ['Statistics', 'Assistance'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List available assistance statistics',
         responses: [
@@ -384,6 +391,7 @@ class ReportController extends AbstractController
     #[Route(path: '/Assistance/Stat/{assistance_type}/Global', methods: ['GET'], requirements: [
         'assistance_type' => 'Ticket|Change|Problem'
     ], tags: ['Statistics', 'Assistance'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get global assistance statistics',
         parameters: [
@@ -448,6 +456,7 @@ class ReportController extends AbstractController
     #[Route(path: '/Assistance/Stat/{assistance_type}/Characteristics', methods: ['GET'], requirements: [
         'assistance_type' => 'Ticket|Change|Problem'
     ], tags: ['Statistics', 'Assistance'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get assistance statistics',
         parameters: [
@@ -568,6 +577,7 @@ class ReportController extends AbstractController
     #[Route(path: '/Assistance/Stat/{assistance_type}/Characteristics/Export', methods: ['GET'], requirements: [
         'assistance_type' => 'Ticket|Change|Problem'
     ], tags: ['Statistics', 'Assistance'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Export assistance statistics',
         parameters: [
@@ -661,6 +671,7 @@ class ReportController extends AbstractController
     #[Route(path: '/Assistance/Stat/{assistance_type}/Asset', methods: ['GET'], requirements: [
         'assistance_type' => 'Ticket|Change|Problem'
     ], tags: ['Statistics', 'Assistance'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get assistance statistics by asset',
         parameters: [
@@ -726,6 +737,7 @@ class ReportController extends AbstractController
     #[Route(path: '/Assistance/Stat/{assistance_type}/Asset/Export', methods: ['GET'], requirements: [
         'assistance_type' => 'Ticket|Change|Problem'
     ], tags: ['Statistics', 'Assistance'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Export assistance statistics by asset',
         parameters: [
@@ -809,6 +821,7 @@ class ReportController extends AbstractController
     #[Route(path: '/Assistance/Stat/{assistance_type}/AssetCharacteristics', methods: ['GET'], requirements: [
         'assistance_type' => 'Ticket|Change|Problem'
     ], tags: ['Statistics', 'Assistance'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get assistance statistics by asset characteristics',
         parameters: [
@@ -940,6 +953,7 @@ class ReportController extends AbstractController
     #[Route(path: '/Assistance/Stat/{assistance_type}/AssetCharacteristics/Export', methods: ['GET'], requirements: [
         'assistance_type' => 'Ticket|Change|Problem'
     ], tags: ['Statistics', 'Assistance'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Export assistance statistics by asset characteristics',
         parameters: [

--- a/src/Glpi/Api/HL/Controller/RuleController.php
+++ b/src/Glpi/Api/HL/Controller/RuleController.php
@@ -39,6 +39,7 @@ use Glpi\Api\HL\Doc as Doc;
 use Glpi\Api\HL\Middleware\ResultFormatterMiddleware;
 use Glpi\Api\HL\Route;
 use Glpi\Api\HL\Router;
+use Glpi\Api\HL\RouteVersion;
 use Glpi\Api\HL\Search;
 use Glpi\Http\JSONResponse;
 use Glpi\Http\Request;
@@ -51,6 +52,7 @@ final class RuleController extends AbstractController
     {
         $schemas = [
             'RuleCriteria' => [
+                'x-version-introduced' => '2.0',
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'x-itemtype' => 'RuleCriteria',
                 'properties' => [
@@ -75,6 +77,7 @@ final class RuleController extends AbstractController
                 ]
             ],
             'RuleCriteriaCondition' => [
+                'x-version-introduced' => '2.0',
                 'type' => Doc\Schema::TYPE_OBJECT,
                 // No x-itemtype because it isn't in the DB. It cannot be searched.
                 'properties' => [
@@ -93,6 +96,7 @@ final class RuleController extends AbstractController
                 ]
             ],
             'RuleCriteriaCriteria' => [
+                'x-version-introduced' => '2.0',
                 'type' => Doc\Schema::TYPE_OBJECT,
                 // No x-itemtype because it isn't in the DB. It cannot be searched.
                 'properties' => [
@@ -101,6 +105,7 @@ final class RuleController extends AbstractController
                 ]
             ],
             'RuleActionType' => [
+                'x-version-introduced' => '2.0',
                 'type' => Doc\Schema::TYPE_OBJECT,
                 // No x-itemtype because it isn't in the DB. It cannot be searched.
                 'properties' => [
@@ -116,6 +121,7 @@ final class RuleController extends AbstractController
                 ]
             ],
             'RuleActionField' => [
+                'x-version-introduced' => '2.0',
                 'type' => Doc\Schema::TYPE_OBJECT,
                 // No x-itemtype because it isn't in the DB. It cannot be searched.
                 'properties' => [
@@ -131,6 +137,7 @@ final class RuleController extends AbstractController
                 ]
             ],
             'RuleAction' => [
+                'x-version-introduced' => '2.0',
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'x-itemtype' => 'RuleAction',
                 'properties' => [
@@ -156,6 +163,7 @@ final class RuleController extends AbstractController
             ],
         ];
         $schemas['Rule'] = [
+            'x-version-introduced' => '2.0',
             'type' => Doc\Schema::TYPE_OBJECT,
             'x-itemtype' => 'Rule',
             'properties' => [
@@ -256,7 +264,7 @@ final class RuleController extends AbstractController
     {
         $params = $request->getParameters();
         // Only allow updating if the criterion exists in the rule
-        $result = Search::getOneBySchema($this->getKnownSchema($schema), $request->getAttributes(), $params);
+        $result = Search::getOneBySchema($this->getKnownSchema($schema, $this->getAPIVersion($request)), $request->getAttributes(), $params);
         try {
             $decoded = json_decode((string)$result->getBody(), true, 512, JSON_THROW_ON_ERROR);
             return isset($decoded['rule']['id']) && $decoded['rule']['id'] === (int) $request->getAttribute('rule_id');
@@ -266,6 +274,7 @@ final class RuleController extends AbstractController
     }
 
     #[Route(path: '/Collection', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List all rule collections',
         responses: [
@@ -316,6 +325,7 @@ final class RuleController extends AbstractController
     }
 
     #[Route(path: '/Collection/{collection}/CriteriaCondition', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List accepted "condition" values for criteria for rules in a collection',
         responses: [
@@ -353,6 +363,7 @@ final class RuleController extends AbstractController
     }
 
     #[Route(path: '/Collection/{collection}/CriteriaCriteria', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List accepted "criteria" values for criteria for rules in a collection',
         responses: [
@@ -382,6 +393,7 @@ final class RuleController extends AbstractController
     }
 
     #[Route(path: '/Collection/{collection}/ActionType', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List accepted "action_type" values for actions for rules in a collection',
         responses: [
@@ -419,6 +431,7 @@ final class RuleController extends AbstractController
     }
 
     #[Route(path: '/Collection/{collection}/ActionField', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List accepted "field" values for actions for rules in a collection',
         responses: [
@@ -449,6 +462,7 @@ final class RuleController extends AbstractController
     }
 
     #[Route(path: '/Collection/{collection}/Rule', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'List or search rules in a collection',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -469,10 +483,11 @@ final class RuleController extends AbstractController
         $filter .= ';sub_type==Rule' . $request->getAttribute('collection');
         $params['filter'] = $filter;
 
-        return Search::searchBySchema($this->getKnownSchema('Rule'), $params);
+        return Search::searchBySchema($this->getKnownSchema('Rule', $this->getAPIVersion($request)), $params);
     }
 
     #[Route(path: '/Collection/{collection}/Rule/{id}', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a rule from a collection',
         parameters: [self::PARAMETER_RSQL_FILTER, self::PARAMETER_START, self::PARAMETER_LIMIT, self::PARAMETER_SORT],
@@ -493,10 +508,11 @@ final class RuleController extends AbstractController
         $filter .= ';sub_type==Rule' . $request->getAttribute('collection');
         $params['filter'] = $filter;
 
-        return Search::getOneBySchema($this->getKnownSchema('Rule'), $request->getAttributes(), $params);
+        return Search::getOneBySchema($this->getKnownSchema('Rule', $this->getAPIVersion($request)), $request->getAttributes(), $params);
     }
 
     #[Route(path: '/Collection/{collection}/Rule/{id}/Criteria', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get criteria for a rule from a collection',
         responses: [
@@ -517,10 +533,11 @@ final class RuleController extends AbstractController
         $filter .= ';rule==' . $request->getAttribute('id');
         $params['filter'] = $filter;
 
-        return Search::searchBySchema($this->getKnownSchema('RuleCriteria'), $params);
+        return Search::searchBySchema($this->getKnownSchema('RuleCriteria', $this->getAPIVersion($request)), $params);
     }
 
     #[Route(path: '/Collection/{collection}/Rule/{rule_id}/Criteria/{id}', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a specific criterion for a rule from a collection',
         responses: [
@@ -541,10 +558,11 @@ final class RuleController extends AbstractController
         $filter .= ';rule==' . $request->getAttribute('rule_id');
         $params['filter'] = $filter;
 
-        return Search::getOneBySchema($this->getKnownSchema('RuleCriteria'), $request->getAttributes(), $params);
+        return Search::getOneBySchema($this->getKnownSchema('RuleCriteria', $this->getAPIVersion($request)), $request->getAttributes(), $params);
     }
 
     #[Route(path: '/Collection/{collection}/Rule/{id}/Action', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get actions for a rule from a collection',
         responses: [
@@ -565,10 +583,11 @@ final class RuleController extends AbstractController
         $filter .= ';rule==' . $request->getAttribute('rule_id');
         $params['filter'] = $filter;
 
-        return Search::searchBySchema($this->getKnownSchema('RuleAction'), $params);
+        return Search::searchBySchema($this->getKnownSchema('RuleAction', $this->getAPIVersion($request)), $params);
     }
 
     #[Route(path: '/Collection/{collection}/Rule/{rule_id}/Action/{id}', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Get a specific action for a rule from a collection',
         responses: [
@@ -589,10 +608,11 @@ final class RuleController extends AbstractController
         $filter .= ';rule==' . $request->getAttribute('rule_id');
         $params['filter'] = $filter;
 
-        return Search::getOneBySchema($this->getKnownSchema('RuleAction'), $request->getAttributes(), $params);
+        return Search::getOneBySchema($this->getKnownSchema('RuleAction', $this->getAPIVersion($request)), $request->getAttributes(), $params);
     }
 
     #[Route(path: '/Collection/{collection}/Rule', methods: ['POST'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Create a rule in a collection',
         parameters: [
@@ -612,7 +632,7 @@ final class RuleController extends AbstractController
         $params = $request->getParameters();
         $params['sub_type'] = 'Rule' . $request->getAttribute('collection');
 
-        return Search::createBySchema($this->getKnownSchema('Rule'), $params, [self::class, 'getRule'], [
+        return Search::createBySchema($this->getKnownSchema('Rule', $this->getAPIVersion($request)), $params, [self::class, 'getRule'], [
             'mapped' => [
                 'collection' => $request->getAttribute('collection')
             ]
@@ -620,6 +640,7 @@ final class RuleController extends AbstractController
     }
 
     #[Route(path: '/Collection/{collection}/Rule/{id}', methods: ['PATCH'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a rule in a collection',
         parameters: [
@@ -639,10 +660,11 @@ final class RuleController extends AbstractController
         $params = $request->getParameters();
         $params['sub_type'] = 'Rule' . $request->getAttribute('collection');
 
-        return Search::updateBySchema($this->getKnownSchema('Rule'), $request->getAttributes(), $params);
+        return Search::updateBySchema($this->getKnownSchema('Rule', $this->getAPIVersion($request)), $request->getAttributes(), $params);
     }
 
     #[Route(path: '/Collection/{collection}/Rule/{id}', methods: ['DELETE'])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Delete a rule in a collection'
     )]
@@ -651,10 +673,11 @@ final class RuleController extends AbstractController
         if ($response = $this->checkCollectionAccess($request, PURGE)) {
             return $response;
         }
-        return Search::deleteBySchema($this->getKnownSchema('Rule'), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema('Rule', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Collection/{collection}/Rule/{rule_id}/Criteria', methods: ['POST'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Create a criterion for a rule in a collection',
         parameters: [
@@ -674,7 +697,7 @@ final class RuleController extends AbstractController
         $params = $request->getParameters();
         $params['rule'] = $request->getAttribute('rule_id');
 
-        return Search::createBySchema($this->getKnownSchema('RuleCriteria'), $params, [self::class, 'getRuleCriterion'], [
+        return Search::createBySchema($this->getKnownSchema('RuleCriteria', $this->getAPIVersion($request)), $params, [self::class, 'getRuleCriterion'], [
             'mapped' => [
                 'rule_id' => $request->getAttribute('rule_id'),
                 'collection' => $request->getAttribute('collection')
@@ -683,6 +706,7 @@ final class RuleController extends AbstractController
     }
 
     #[Route(path: '/Collection/{collection}/Rule/{rule_id}/Criteria/{id}', methods: ['PATCH'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update a criterion for a rule in a collection',
         parameters: [
@@ -707,10 +731,11 @@ final class RuleController extends AbstractController
         $params['id'] = $request->getAttribute('id');
         $params['rule.id'] = $request->getAttribute('rule_id');
 
-        return Search::updateBySchema($this->getKnownSchema('RuleCriteria'), $request->getAttributes(), $params);
+        return Search::updateBySchema($this->getKnownSchema('RuleCriteria', $this->getAPIVersion($request)), $request->getAttributes(), $params);
     }
 
     #[Route(path: '/Collection/{collection}/Rule/{rule_id}/Criteria/{id}', methods: ['DELETE'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Delete a criterion for a rule in a collection',
         parameters: [
@@ -730,10 +755,11 @@ final class RuleController extends AbstractController
             return self::getNotFoundErrorResponse();
         }
 
-        return Search::deleteBySchema($this->getKnownSchema('RuleCriteria'), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema('RuleCriteria', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 
     #[Route(path: '/Collection/{collection}/Rule/{rule_id}/Action', methods: ['POST'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Create an action for a rule in a collection',
         parameters: [
@@ -753,7 +779,7 @@ final class RuleController extends AbstractController
         $params = $request->getParameters();
         $params['rule'] = $request->getAttribute('rule_id');
 
-        return Search::createBySchema($this->getKnownSchema('RuleAction'), $params, [self::class, 'getRuleAction'], [
+        return Search::createBySchema($this->getKnownSchema('RuleAction', $this->getAPIVersion($request)), $params, [self::class, 'getRuleAction'], [
             'mapped' => [
                 'rule_id' => $request->getAttribute('rule_id'),
                 'collection' => $request->getAttribute('collection')
@@ -762,6 +788,7 @@ final class RuleController extends AbstractController
     }
 
     #[Route(path: '/Collection/{collection}/Rule/{rule_id}/Action/{id}', methods: ['PATCH'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Update an action for a rule in a collection',
         parameters: [
@@ -786,10 +813,11 @@ final class RuleController extends AbstractController
         $params['id'] = $request->getAttribute('id');
         $params['rule.id'] = $request->getAttribute('rule_id');
 
-        return Search::updateBySchema($this->getKnownSchema('RuleAction'), $request->getAttributes(), $params);
+        return Search::updateBySchema($this->getKnownSchema('RuleAction', $this->getAPIVersion($request)), $request->getAttributes(), $params);
     }
 
     #[Route(path: '/Collection/{collection}/Rule/{rule_id}/Action/{id}', methods: ['DELETE'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.0')]
     #[Doc\Route(
         description: 'Delete an action for a rule in a collection',
         parameters: [
@@ -809,6 +837,6 @@ final class RuleController extends AbstractController
             return self::getNotFoundErrorResponse();
         }
 
-        return Search::deleteBySchema($this->getKnownSchema('RuleAction'), $request->getAttributes(), $request->getParameters());
+        return Search::deleteBySchema($this->getKnownSchema('RuleAction', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
     }
 }

--- a/src/Glpi/Api/HL/Doc/SchemaReference.php
+++ b/src/Glpi/Api/HL/Doc/SchemaReference.php
@@ -54,11 +54,12 @@ final class SchemaReference implements \ArrayAccess
      * @param string $controller The controller that is calling this method
      * @param array $attributes Attributes from the request, if we know them to help resolve placeholders in the ref.
      *                          For example: /Assets/{itemtype} when the ref is "{itemtype}". The attributes array should contain an "itemtype" key.
+     * @param string $api_version The API version
      * @return array|null
      */
-    public static function resolveRef($ref, string $controller, array $attributes = []): ?array
+    public static function resolveRef($ref, string $controller, array $attributes, string $api_version): ?array
     {
-        $known_schemas = OpenAPIGenerator::getComponentSchemas();
+        $known_schemas = OpenAPIGenerator::getComponentSchemas($api_version);
         if (!is_string($ref) && $ref !== null) {
             $ref = $ref['ref'];
         }

--- a/src/Glpi/Api/HL/GraphQLGenerator.php
+++ b/src/Glpi/Api/HL/GraphQLGenerator.php
@@ -42,6 +42,13 @@ final class GraphQLGenerator
 {
     private array $types = [];
 
+    private string $api_version;
+
+    public function __construct(string $api_version)
+    {
+        $this->api_version = $api_version;
+    }
+
     private function normalizeTypeName(string $type_name): string
     {
         return str_replace(array(' ', '-'), array('', '_'), $type_name);
@@ -91,7 +98,7 @@ final class GraphQLGenerator
 
     private function loadTypes()
     {
-        $component_schemas = OpenAPIGenerator::getComponentSchemas();
+        $component_schemas = OpenAPIGenerator::getComponentSchemas($this->api_version);
         foreach ($component_schemas as $schema_name => $schema) {
             $new_types = $this->getTypesForSchema($schema_name, $schema);
             foreach ($new_types as $type_name => $type) {
@@ -107,8 +114,8 @@ final class GraphQLGenerator
             return [];
         }
         //Names cannot have spaces or dashes
-        $schema_name = self::normalizeTypeName($schema_name);
-        $types[$schema_name] = self::convertRESTSchemaToGraphQLSchema($schema_name, $schema);
+        $schema_name = $this->normalizeTypeName($schema_name);
+        $types[$schema_name] = $this->convertRESTSchemaToGraphQLSchema($schema_name, $schema);
 
         // Handle "internal" types that are used for object properties
         foreach ($schema['properties'] as $prop_name => $prop) {

--- a/src/Glpi/Api/HL/OpenAPIGenerator.php
+++ b/src/Glpi/Api/HL/OpenAPIGenerator.php
@@ -73,9 +73,12 @@ final class OpenAPIGenerator
 
     private Router $router;
 
-    public function __construct(Router $router)
+    private string $api_version;
+
+    public function __construct(Router $router, string $api_version)
     {
         $this->router = $router;
+        $this->api_version = $api_version;
     }
 
     private function getPublicVendorExtensions(): array
@@ -132,7 +135,7 @@ EOT;
         ];
     }
 
-    public static function getComponentSchemas(): array
+    public static function getComponentSchemas(string $api_version): array
     {
         static $schemas = null;
 
@@ -141,7 +144,7 @@ EOT;
 
             $controllers = Router::getInstance()->getControllers();
             foreach ($controllers as $controller) {
-                $known_schemas = $controller::getKnownSchemas();
+                $known_schemas = $controller::getKnownSchemas($api_version);
                 $short_name = (new \ReflectionClass($controller))->getShortName();
                 $controller_name = str_replace('Controller', '', $short_name);
                 foreach ($known_schemas as $schema_name => $known_schema) {
@@ -175,7 +178,7 @@ EOT;
 
     private function getComponentReference(string $name, string $controller): ?array
     {
-        $components = self::getComponentSchemas();
+        $components = self::getComponentSchemas($this->api_version);
         // Try matching by name and controller first
         $match = null;
         $is_ref_array = str_ends_with($name, '[]');
@@ -227,7 +230,7 @@ EOT;
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $component_schemas = self::getComponentSchemas();
+        $component_schemas = self::getComponentSchemas($this->api_version);
         ksort($component_schemas);
         $schema = [
             'openapi' => self::OPENAPI_VERSION,

--- a/src/Glpi/Api/HL/OpenAPIGenerator.php
+++ b/src/Glpi/Api/HL/OpenAPIGenerator.php
@@ -83,7 +83,7 @@ final class OpenAPIGenerator
 
     private function getPublicVendorExtensions(): array
     {
-        return ['x-writeonly', 'x-readonly', 'x-full-schema'];
+        return ['x-writeonly', 'x-readonly', 'x-full-schema', 'x-introduced', 'x-deprecated', 'x-removed'];
     }
 
     private function cleanVendorExtensions(array $schema, ?string $parent_key = null): array

--- a/src/Glpi/Api/HL/RoutePath.php
+++ b/src/Glpi/Api/HL/RoutePath.php
@@ -337,6 +337,22 @@ final class RoutePath
         return $result;
     }
 
+    public function getRouteVersion(): RouteVersion
+    {
+        return $this->getMethod()->getAttributes(RouteVersion::class)[0]->newInstance();
+    }
+
+    /**
+     * Returns true if the route is valid for the given API version
+     * @param string $api_version
+     * @return bool
+     */
+    public function matchesAPIVersion(string $api_version): bool
+    {
+        $version = $this->getRouteVersion();
+        return (version_compare($api_version, $version->introduced, '>=') && (empty($version->removed) || version_compare($api_version, $version->removed, '<')));
+    }
+
     private function setPath(string $path)
     {
         $this->path = $path;

--- a/src/Glpi/Api/HL/RouteVersion.php
+++ b/src/Glpi/Api/HL/RouteVersion.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Api\HL;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class RouteVersion
+{
+    public function __construct(
+        /** @var string $introduced The first API version this route is available in */
+        public string $introduced,
+        /** @var string $deprecated The API version this route is deprecated in */
+        public string $deprecated = '',
+        /** @var string $removed The API version this route is removed in */
+        public string $removed = ''
+    ) {
+    }
+}

--- a/src/Glpi/Api/HL/Router.php
+++ b/src/Glpi/Api/HL/Router.php
@@ -157,6 +157,33 @@ EOT;
     }
 
     /**
+     * Normalize the requested API version based on the available versions.
+     *
+     * If only a major version is specified, the latest minor version will be used.
+     * If a major and minor version is specified, the latest patch version will be used.
+     * If a complete version is specified, it will be used as is.
+     * If no version is specified, the latest version will be used.
+     * @param string $version
+     * @return string
+     */
+    public static function normalizeAPIVersion(string $version): string
+    {
+        $versions = array_column(static::getAPIVersions(), 'version');
+        $best_match = null;
+        if (in_array($version, $versions, true)) {
+            // Exact match
+            return $version;
+        }
+
+        foreach ($versions as $available_version) {
+            if (str_starts_with($available_version, $version . '.') && version_compare($available_version, $best_match ?? '0.0.0', '>')) {
+                $best_match = $available_version;
+            }
+        }
+        return $best_match;
+    }
+
+    /**
      * Get the singleton instance of the router
      *
      * @return Router
@@ -447,10 +474,12 @@ EOT;
      */
     public function matchAll(Request $request): array
     {
-        /** @var RoutePath[] $routes */
         $routes = $this->getRoutesFromCache();
-        $routes = array_filter($routes, static function ($route) use ($request) {
-            if (in_array($request->getMethod(), $route->getRouteMethods(), true)) {
+
+        $api_version = $request->getHeaderLine('GLPI-API-Version') ?: static::API_VERSION;
+        // Filter routes by the requested API version and method
+        $routes = array_filter($routes, static function ($route) use ($request, $api_version) {
+            if ($route->matchesAPIVersion($api_version) && in_array($request->getMethod(), $route->getRouteMethods(), true)) {
                 // Verify the request uri path matches the compiled path
                 return (bool) preg_match('#^' . $route->getCompiledPath() . '$#i', $request->getUri()->getPath());
             }

--- a/src/Glpi/Controller/ApiController.php
+++ b/src/Glpi/Controller/ApiController.php
@@ -86,16 +86,18 @@ final readonly class ApiController implements Controller
         }
 
         $supported_versions = Router::getAPIVersions();
-        if (preg_match('/^\/v\d+(\/|$)/', $relative_uri)) {
-            // A specific API version has been requested
-            //TODO Plan handling endpoints with specific versions
-            // For now, just remove the version prefix from the URI
-            $relative_uri = preg_replace('/^\/v\d+(\/|$)/', '/', $relative_uri);
+        // Extract the requested API version (if any) and then remove it from the URI
+        $version = Router::API_VERSION;
+        if (preg_match('/^\/v\d+(\.\d+)*\//', $relative_uri, $matches)) {
+            $version = $matches[0];
+            $relative_uri = preg_replace('/^\/v\d+(\.\d+)*\//', '/', $relative_uri);
         }
+        $version = Router::normalizeAPIVersion($version);
 
         $body = file_get_contents('php://input') ?? null;
 
         $headers = getallheaders() ?? [];
+        $headers['GLPI-API-Version'] = $version;
         $request = new Request($method, $relative_uri, $headers, $body);
 
         $router = Router::getInstance();

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -389,7 +389,8 @@ class Webhook extends CommonDBTM implements FilterableInterface
              * @var array $categories
              */
             foreach ($supported as $controller => $categories) {
-                $schemas = $controller::getKnownSchemas();
+                // TODO Allow pinning webhooks to specific API versions
+                $schemas = $controller::getKnownSchemas(Router::API_VERSION);
                 foreach ($categories as $category => $itemtypes) {
                     if ($category === 'main') {
                         foreach ($itemtypes as $i => $supported_itemtype) {
@@ -895,7 +896,8 @@ class Webhook extends CommonDBTM implements FilterableInterface
             echo __('This itemtype is not supported by the API. Maybe a plugin is missing/disabled?');
             return null;
         }
-        return $controller_class::getKnownSchemas()[$schema_name] ?? null;
+        // TODO Allow pinning webhooks to specific API versions
+        return $controller_class::getKnownSchemas(Router::API_VERSION)[$schema_name] ?? null;
     }
 
     public static function getMonacoSuggestions(string|null $itemtype): array

--- a/tests/functional/Glpi/Api/HL/Controller/ComponentController.php
+++ b/tests/functional/Glpi/Api/HL/Controller/ComponentController.php
@@ -35,6 +35,7 @@
 
 namespace tests\units\Glpi\Api\HL\Controller;
 
+use Glpi\Api\HL\Router;
 use Glpi\Http\Request;
 
 class ComponentController extends \HLAPITestCase
@@ -129,7 +130,7 @@ class ComponentController extends \HLAPITestCase
         });
 
         // Find the itemtype of the component
-        $schema = \Glpi\Api\HL\Controller\ComponentController::getKnownSchemas()[$type];
+        $schema = \Glpi\Api\HL\Controller\ComponentController::getKnownSchemas(Router::API_VERSION)[$type];
         $device_fk = $schema['x-itemtype']::getForeignKeyField();
         $itemtype = 'Item_' . $schema['x-itemtype'];
         $item = new $itemtype();

--- a/tests/functional/Glpi/Api/HL/OpenAPIGenerator.php
+++ b/tests/functional/Glpi/Api/HL/OpenAPIGenerator.php
@@ -52,7 +52,7 @@ class OpenAPIGenerator extends HLAPITestCase
             '/Assets/Computer/{id}',
             '/Assets/Monitor/{id}',
         ];
-        $generator = new \Glpi\Api\HL\OpenAPIGenerator(\Glpi\Api\HL\Router::getInstance());
+        $generator = new \Glpi\Api\HL\OpenAPIGenerator(\Glpi\Api\HL\Router::getInstance(), \Glpi\Api\HL\Router::API_VERSION);
         $openapi = $generator->getSchema();
 
         foreach ($to_check as $path) {
@@ -87,7 +87,7 @@ class OpenAPIGenerator extends HLAPITestCase
             ['path' => '/Assistance/Problem/{id}', 'placeholder' => 'itemtype'],
         ];
 
-        $generator = new \Glpi\Api\HL\OpenAPIGenerator(\Glpi\Api\HL\Router::getInstance());
+        $generator = new \Glpi\Api\HL\OpenAPIGenerator(\Glpi\Api\HL\Router::getInstance(), \Glpi\Api\HL\Router::API_VERSION);
         $openapi = $generator->getSchema();
 
         foreach ($to_check as $endpoint) {

--- a/tests/functional/Glpi/Api/HL/Router.php
+++ b/tests/functional/Glpi/Api/HL/Router.php
@@ -36,6 +36,7 @@
 namespace tests\units\Glpi\Api\HL;
 
 use Glpi\Api\HL\Route;
+use Glpi\Api\HL\RouteVersion;
 use Glpi\Http\JSONResponse;
 use Glpi\Http\Request;
 use Glpi\Http\Response;
@@ -48,6 +49,50 @@ class Router extends GLPITestCase
     {
         $router = TestRouter::getInstance();
         $this->variable($router->match(new Request('GET', '/test')))->isNotNull();
+    }
+
+    public function testAllRoutesHaveVersioningInfo()
+    {
+        $router = \Glpi\Api\HL\Router::getInstance();
+        $all_routes = $router->getAllRoutes();
+
+        $routes_missing_versions = [];
+        foreach ($all_routes as $route) {
+            $version_attrs = $route->getMethod()->getAttributes(RouteVersion::class);
+            if (empty($version_attrs)) {
+                $routes_missing_versions[] = $route->getRoutePath();
+            }
+        }
+        $this->array($routes_missing_versions)->isEmpty('Routes missing versioning info: ' . implode(', ', $routes_missing_versions));
+    }
+
+    public function testAllSchemasHaveVersioningInfo()
+    {
+        $router = \Glpi\Api\HL\Router::getInstance();
+        $controllers = $router->getControllers();
+
+        $schemas_missing_versions = [];
+        foreach ($controllers as $controller) {
+            $schemas = $controller::getKnownSchemas(null);
+            foreach ($schemas as $schema_name => $schema) {
+                if (str_starts_with($schema_name, '_')) {
+                    continue;
+                }
+                if (!isset($schema['x-version-introduced'])) {
+                    $schemas_missing_versions[] = $schema_name . ' in ' . $controller::class;
+                }
+            }
+        }
+
+        $this->array($schemas_missing_versions)->isEmpty('Schemas missing versioning info: ' . implode(', ', $schemas_missing_versions));
+    }
+
+    public function testNormalizeAPIVersion()
+    {
+        $this->string(TestRouter::normalizeAPIVersion('50'))->isEqualTo('50.2.0');
+        $this->string(TestRouter::normalizeAPIVersion('50.1.1'))->isEqualTo('50.1.1');
+        $this->string(TestRouter::normalizeAPIVersion('50.1'))->isEqualTo('50.1.2');
+        $this->string(TestRouter::normalizeAPIVersion('50.2'))->isEqualTo('50.2.0');
     }
 }
 
@@ -64,6 +109,48 @@ class TestRouter extends \Glpi\Api\HL\Router
         }
         return $router;
     }
+
+    public static function getAPIVersions(): array
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        $versions = parent::getAPIVersions();
+
+        // Add fake versions we will probably never use
+        $versions[] = [
+            'api_version' => '50',
+            'version' => '50.0.0',
+            'endpoint' => $CFG_GLPI['url_base'] . '/api.php/v50',
+        ];
+        $versions[] = [
+            'api_version' => '50',
+            'version' => '50.1.0',
+            'endpoint' => $CFG_GLPI['url_base'] . '/api.php/v50.1',
+        ];
+        $versions[] = [
+            'api_version' => '50',
+            'version' => '50.1.1',
+            'endpoint' => $CFG_GLPI['url_base'] . '/api.php/v50.1.1',
+        ];
+        $versions[] = [
+            'api_version' => '50',
+            'version' => '50.1.2',
+            'endpoint' => $CFG_GLPI['url_base'] . '/api.php/v50.1.2',
+        ];
+        $versions[] = [
+            'api_version' => '50',
+            'version' => '50.2.0',
+            'endpoint' => $CFG_GLPI['url_base'] . '/api.php/v50.2',
+        ];
+        $versions[] = [
+            'api_version' => '51',
+            'version' => '51.0.0',
+            'endpoint' => $CFG_GLPI['url_base'] . '/api.php/v51',
+        ];
+
+        return $versions;
+    }
 }
 
 // @codingStandardsIgnoreStart
@@ -75,6 +162,7 @@ class TestController extends \Glpi\Api\HL\Controller\AbstractController
      * @return Response
      */
     #[Route('/{req}', ['GET', 'POST', 'PATCH', 'PUT', 'DELETE', 'OPTIONS'], ['req' => '.*'], -1)]
+    #[RouteVersion(introduced: TestRouter::API_VERSION)]
     public function defaultRoute(RequestInterface $request): Response
     {
         return new Response(200, [], __FUNCTION__);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This was an important feature that drove the creation of a new API. The initial PR for it already planned to handle specifying the version in the URL (or default to the current version). However, it currently just handles redirecting v1 to the legacy API. Beyond that, the version is removed from the URL and not handled.

This PR will add the framework for versioning HLAPI routes and schemas and handling the generation of the OpenAPI documentation for the requested version. I've put this off for a while but makes sense to add this functionality now before anything needs to be done for the next API version.

The current plan:
- Add RouteVersion attribute that is required to be present on all route methods (enforced by unit test). This attribute will have a required param for an `introduced` version and optional params for `deprecated` and `removed`. This filtering will be handled in the router during route matching.
- Add new "extension attributes for the schemas" `x-version-introduced`, `x-version-deprecated`, and `x-version-removed` and their properties. The introduction version at the schema level will be required (enforced by unit test). For example the schema "Computer" may have the introduction version of "2.0" while a property inside the schema can have an introduction version of "2.1". If the user requests version 2.0 of the API, the property added in 2.1 will be removed. This filtering will be handled in the `getKnownSchemas` method in the controller's abstract class. This should cover all uses including inside controller methods, OpenAPI documentation generation, and GraphQL schema creation.
- For tracking the API version, a header can be set internally in the request based on the URL so that it can be referenced anywhere the request is available. Doesn't really matter what header name is chosen if we don't intend for it to be used by users "GLPI-API-Version" may make the most sense since there is no standard header for it.