### PR TITLE
Fail js lint if e2e test is set as ".only"

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,6 +30,9 @@
     "parserOptions": {
         "ecmaVersion": 13
     },
+    "plugins": [
+        "no-only-tests"
+    ],
     "rules": {
         "eol-last": [
             "error",
@@ -68,7 +71,8 @@
         "semi": [
             "error",
             "always"
-        ]
+        ],
+        "no-only-tests/no-only-tests": "error"
     },
     "overrides": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
                 "cytoscape-grid-guide": "^2.3.0",
                 "diff-match-patch": "^1.0.4",
                 "echarts": "^5.5.1",
+                "eslint-plugin-no-only-tests": "^3.1.0",
                 "fittext.js": "^1.2.0",
                 "flatpickr": "^4.6.3",
                 "fuzzy": "^0.1.3",
@@ -6814,6 +6815,14 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint-plugin-no-only-tests": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.1.0.tgz",
+            "integrity": "sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==",
+            "engines": {
+                "node": ">=5.0.0"
             }
         },
         "node_modules/eslint-plugin-vue": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "cytoscape-grid-guide": "^2.3.0",
         "diff-match-patch": "^1.0.4",
         "echarts": "^5.5.1",
+        "eslint-plugin-no-only-tests": "^3.1.0",
         "fittext.js": "^1.2.0",
         "flatpickr": "^4.6.3",
         "fuzzy": "^0.1.3",


### PR DESCRIPTION
Cypress allow to use `.only` to force only a single test to be ran:

![image](https://github.com/user-attachments/assets/c9fcfc3e-7466-434c-9628-b2fbcc06f9b1)

This is very useful when working on a specific test but it can end up in the final PR if we don't remember to remove it before committing.
This is a huge issue because it lead to some tests not being executed anymore, which could hide failures.

To prevent this, I've added a new rule that will fail the javascript lint if `.only` is found:

![image](https://github.com/user-attachments/assets/e9f32aa0-87c4-4acc-bd41-bd4926df9bf0)

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
