### PR TITLE
 feat(forms) : Import form basic UI

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -2534,12 +2534,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Form/Destination/FormDestination.php',
 ];
 $ignoreErrors[] = [
-	// identifier: return.phpDocType
-	'message' => '#^PHPDoc tag @return with type array\\<Glpi\\\\Form\\\\Form\\> is incompatible with native type Glpi\\\\Form\\\\Export\\\\Result\\\\ImportResult\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Form/Export/Serializer/FormSerializer.php',
-];
-$ignoreErrors[] = [
 	// identifier: parameter.defaultValue
 	'message' => '#^Default value of the parameter \\#1 \\$history \\(int\\) of method Glpi\\\\Form\\\\Form\\:\\:post_updateItem\\(\\) is incompatible with type bool\\.$#',
 	'count' => 1,

--- a/phpunit/functional/Glpi/Form/Export/FormSerializerTest.php
+++ b/phpunit/functional/Glpi/Form/Export/FormSerializerTest.php
@@ -83,6 +83,32 @@ final class FormSerializerTest extends \DbTestCase
 
         // Assert: filename should reference the number of forms
         $this->assertEquals("export-of-7-forms.json", $result->getFileName());
+
+    }
+
+    // Minimal form import to be sure there are no failure when most properties are null or empty.
+    public function testExportAndImportFormWithoutValues(): void
+    {
+        // Arrange: create an empty form
+        $form = $this->createItem(Form::class, []);
+
+        // Act: export then reimport the form as a copy
+        $form_copy = $this->exportAndImportForm($form);
+
+        // Assert: validate each fields are equals between the original and the copy
+        $fields_to_check = [
+            'name',
+            'header',
+            'entities_id',
+            'is_recursive',
+        ];
+        foreach ($fields_to_check as $field) {
+            $this->assertEquals(
+                $form_copy->fields[$field],
+                $form->fields[$field],
+                "Failed $field:"
+            );
+        }
     }
 
     public function testExportAndImportFormBasicProperties(): void
@@ -193,6 +219,45 @@ final class FormSerializerTest extends \DbTestCase
                 'rank'        => 2,
             ],
         ], $sections_data);
+    }
+
+    public function testPreviewImportWithValidForm(): void
+    {
+        // Arrange: create a valid form
+        $form = $this->createAndGetFormWithBasicPropertiesFilled();
+
+        // Act: export the form and preview the import
+        $json = self::$serializer->exportFormsToJson([$form]);
+        $preview = self::$serializer->previewImport($json);
+
+        // Assert: the form should be valid
+        $this->assertEquals([$form->fields['name']], $preview->getValidForms());
+        $this->assertEquals([], $preview->getInvalidForms());
+    }
+
+    public function testPreviewImportWithInvalidForm(): void
+    {
+        // Need an active session to create entities
+        $this->login();
+
+        // Arrange: create an invalid form by setting it into a temporary entity
+        // that will be deleted later
+        $form = $this->createAndGetFormWithBasicPropertiesFilled();
+        $entity = $this->createItem(Entity::class, [
+            'name' => 'My entity',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+        $form->fields['entities_id'] = $entity->getID();
+
+        // Act: export the form; delete the temporary entity to make the form
+        // invalid; preview the import
+        $json = $this->exportForm($form);
+        $this->deleteItem(Entity::class, $entity->getID());
+        $preview = self::$serializer->previewImport($json);
+
+        // Assert: the form should be invalid
+        $this->assertEquals([], $preview->getValidForms());
+        $this->assertEquals([$form->fields['name']], $preview->getInvalidForms());
     }
 
     // TODO: add a test later to make sure that requirements for each forms do

--- a/phpunit/functional/Glpi/Form/Export/FormSerializerTest.php
+++ b/phpunit/functional/Glpi/Form/Export/FormSerializerTest.php
@@ -83,7 +83,6 @@ final class FormSerializerTest extends \DbTestCase
 
         // Assert: filename should reference the number of forms
         $this->assertEquals("export-of-7-forms.json", $result->getFileName());
-
     }
 
     // Minimal form import to be sure there are no failure when most properties are null or empty.
@@ -227,8 +226,8 @@ final class FormSerializerTest extends \DbTestCase
         $form = $this->createAndGetFormWithBasicPropertiesFilled();
 
         // Act: export the form and preview the import
-        $json = self::$serializer->exportFormsToJson([$form]);
-        $preview = self::$serializer->previewImport($json);
+        $results = self::$serializer->exportFormsToJson([$form]);
+        $preview = self::$serializer->previewImport($results->getJsonContent());
 
         // Assert: the form should be valid
         $this->assertEquals([$form->fields['name']], $preview->getValidForms());

--- a/src/Glpi/Controller/Form/Import/Step1IndexController.php
+++ b/src/Glpi/Controller/Form/Import/Step1IndexController.php
@@ -46,7 +46,7 @@ use Symfony\Component\Routing\Attribute\Route;
  */
 final class Step1IndexController extends AbstractController
 {
-    #[Route("/form/import", name: "glpi_form_import", methods: "GET")]
+    #[Route("/Form/Import", name: "glpi_form_import", methods: "GET")]
     public function __invoke(Request $request): Response
     {
         if (!Form::canCreate()) {

--- a/src/Glpi/Controller/Form/Import/Step1IndexController.php
+++ b/src/Glpi/Controller/Form/Import/Step1IndexController.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Controller\Form\Import;
+
+use Glpi\Controller\AbstractController;
+use Glpi\Form\Form;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Initial entry point of the import form process.
+ */
+final class Step1IndexController extends AbstractController
+{
+    #[Route("/form/import", name: "glpi_form_import", methods: "GET")]
+    public function __invoke(Request $request): Response
+    {
+        if (!Form::canCreate()) {
+            throw new AccessDeniedHttpException();
+        }
+
+        return $this->render("pages/admin/form/import/step1_index.html.twig", [
+            'title' => __("Import form"),
+            'menu'  => ['admin', Form::getType()],
+        ]);
+    }
+}

--- a/src/Glpi/Controller/Form/Import/Step2PreviewController.php
+++ b/src/Glpi/Controller/Form/Import/Step2PreviewController.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Controller\Form\Import;
+
+use Glpi\Controller\AbstractController;
+use Glpi\Form\Export\Serializer\FormSerializer;
+use Glpi\Form\Form;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class Step2PreviewController extends AbstractController
+{
+    #[Route("/form/import/preview", name: "glpi_form_import_preview", methods: "POST")]
+    public function __invoke(Request $request): Response
+    {
+        if (!Form::canCreate()) {
+            throw new AccessDeniedHttpException();
+        }
+
+        /** @var \Symfony\Component\HttpFoundation\File\UploadedFile $file */
+        $file = $request->files->get('import_file');
+        $json = $file->getContent();
+
+        $serializer = new FormSerializer();
+        return $this->render("pages/admin/form/import/step2_preview.html.twig", [
+            'title'   => __("Preview import"),
+            'menu'    => ['admin', Form::getType()],
+            'preview' => $serializer->previewImport($json),
+            'json'    => $json,
+        ]);
+    }
+}

--- a/src/Glpi/Controller/Form/Import/Step2PreviewController.php
+++ b/src/Glpi/Controller/Form/Import/Step2PreviewController.php
@@ -44,7 +44,7 @@ use Symfony\Component\Routing\Attribute\Route;
 
 final class Step2PreviewController extends AbstractController
 {
-    #[Route("/form/import/preview", name: "glpi_form_import_preview", methods: "POST")]
+    #[Route("/Form/Import/Preview", name: "glpi_form_import_preview", methods: "POST")]
     public function __invoke(Request $request): Response
     {
         if (!Form::canCreate()) {

--- a/src/Glpi/Controller/Form/Import/Step3ExecuteController.php
+++ b/src/Glpi/Controller/Form/Import/Step3ExecuteController.php
@@ -44,7 +44,7 @@ use Symfony\Component\Routing\Attribute\Route;
 
 final class Step3ExecuteController extends AbstractController
 {
-    #[Route("/form/import/execute", name: "glpi_form_import_execute", methods: "POST")]
+    #[Route("/Form/Import/Execute", name: "glpi_form_import_execute", methods: "POST")]
     public function __invoke(Request $request): Response
     {
         if (!Form::canCreate()) {

--- a/src/Glpi/Controller/Form/Import/Step3ExecuteController.php
+++ b/src/Glpi/Controller/Form/Import/Step3ExecuteController.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Controller\Form\Import;
+
+use Glpi\Controller\AbstractController;
+use Glpi\Form\Export\Serializer\FormSerializer;
+use Glpi\Form\Form;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class Step3ExecuteController extends AbstractController
+{
+    #[Route("/form/import/execute", name: "glpi_form_import_execute", methods: "POST")]
+    public function __invoke(Request $request): Response
+    {
+        if (!Form::canCreate()) {
+            throw new AccessDeniedHttpException();
+        }
+
+        // Get json from hidden input
+        $json = $request->request->get('json');
+
+        $serializer = new FormSerializer();
+        return $this->render("pages/admin/form/import/step3_execute.html.twig", [
+            'title'   => __("Import results"),
+            'menu'    => ['admin', Form::getType()],
+            'results' => $serializer->importFormsFromJson($json),
+        ]);
+    }
+}

--- a/src/Glpi/Form/Export/Context/DatabaseMapper.php
+++ b/src/Glpi/Form/Export/Context/DatabaseMapper.php
@@ -84,7 +84,7 @@ final class DatabaseMapper
     }
 
     /** @param DataRequirementSpecification[] $data_requirements */
-    public function loadExistingContextForRequirements(
+    public function mapExistingItemsForRequirements(
         array $data_requirements
     ): bool {
         foreach ($data_requirements as $requirement) {

--- a/src/Glpi/Form/Export/Result/ImportResultPreview.php
+++ b/src/Glpi/Form/Export/Result/ImportResultPreview.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Export\Result;
+
+use Glpi\Form\Form;
+
+final class ImportResultPreview
+{
+    /** @var string[] $valid_forms */
+    private array $valid_forms = [];
+
+    /** @var string[] $invalid_forms */
+    private array $invalid_forms = [];
+
+    public function addValidForm(string $form_name): void
+    {
+        $this->valid_forms[] = $form_name;
+    }
+
+    /** @return string[] */
+    public function getValidForms(): array
+    {
+        return $this->valid_forms;
+    }
+
+    public function addInvalidForm(string $form_name): void
+    {
+        $this->invalid_forms[] = $form_name;
+    }
+
+    /** @return string[] */
+    public function getInvalidForms(): array
+    {
+        return $this->invalid_forms;
+    }
+}

--- a/src/Glpi/Form/Export/Serializer/FormSerializer.php
+++ b/src/Glpi/Form/Export/Serializer/FormSerializer.php
@@ -40,6 +40,7 @@ use Glpi\Form\Export\Context\DatabaseMapper;
 use Glpi\Form\Export\Result\ExportResult;
 use Glpi\Form\Export\Result\ImportError;
 use Glpi\Form\Export\Result\ImportResult;
+use Glpi\Form\Export\Result\ImportResultPreview;
 use Glpi\Form\Export\Specification\ExportContentSpecification;
 use Glpi\Form\Export\Specification\FormContentSpecification;
 use Glpi\Form\Export\Specification\SectionContentSpecification;
@@ -72,10 +73,37 @@ final class FormSerializer extends AbstractFormSerializer
         );
     }
 
-    /** @return Form[] */
+    public function previewImport(
+        string $json,
+        DatabaseMapper $mapper = new DatabaseMapper(),
+    ): ImportResultPreview {
+        $export_specification = $this->deserialize($json);
+
+        // Validate version
+        if ($export_specification->version !== $this->getVersion()) {
+            throw new \InvalidArgumentException("Unsupported version");
+        }
+
+        // Validate each forms
+        $results = new ImportResultPreview();
+        foreach ($export_specification->forms as $form_spec) {
+            $requirements = $form_spec->data_requirements;
+            $mapper->mapExistingItemsForRequirements($requirements);
+
+            $form_name = $form_spec->name;
+            if ($mapper->validateRequirements($requirements)) {
+                $results->addValidForm($form_name);
+            } else {
+                $results->addInvalidForm($form_name);
+            }
+        }
+
+        return $results;
+    }
+
     public function importFormsFromJson(
         string $json,
-        DatabaseMapper $context = new DatabaseMapper(),
+        DatabaseMapper $mapper = new DatabaseMapper(),
     ): ImportResult {
         $export_specification = $this->deserialize($json);
 
@@ -88,9 +116,9 @@ final class FormSerializer extends AbstractFormSerializer
         $result = new ImportResult();
         foreach ($export_specification->forms as $form_spec) {
             $requirements = $form_spec->data_requirements;
-            $context->loadExistingContextForRequirements($requirements);
+            $mapper->mapExistingItemsForRequirements($requirements);
 
-            if (!$context->validateRequirements($requirements)) {
+            if (!$mapper->validateRequirements($requirements)) {
                 $result->addFailedFormImport(
                     $form_spec->name,
                     ImportError::MISSING_DATA_REQUIREMENT
@@ -98,7 +126,7 @@ final class FormSerializer extends AbstractFormSerializer
                 continue;
             }
 
-            $form = $this->importFormFromSpec($form_spec, $context);
+            $form = $this->importFormFromSpec($form_spec, $mapper);
             $result->addImportedForm($form);
         }
 

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -43,10 +43,10 @@ use Glpi\Form\AccessControl\ControlType\ControlTypeInterface;
 use Glpi\Form\AccessControl\FormAccessControl;
 use Glpi\Form\Destination\FormDestination;
 use Glpi\Form\QuestionType\QuestionTypeInterface;
-use Html;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\Form\AccessControl\FormAccessControlManager;
 use Glpi\Form\QuestionType\QuestionTypesManager;
+use Html;
 use Log;
 use MassiveAction;
 use Override;
@@ -263,6 +263,17 @@ final class Form extends CommonDBTM
         echo Html::scriptBlock("window.location.href = '$export_url';");
 
         return true;
+    }
+
+    public static function getAdditionalMenuLinks(): array
+    {
+        $links = [];
+
+        if (self::canCreate()) {
+            $links['import_forms'] = '/form/import';
+        }
+
+        return $links;
     }
 
     /**

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -270,7 +270,7 @@ final class Form extends CommonDBTM
         $links = [];
 
         if (self::canCreate()) {
-            $links['import_forms'] = '/form/import';
+            $links['import_forms'] = '/Form/Import';
         }
 
         return $links;

--- a/templates/layout/parts/context_links.html.twig
+++ b/templates/layout/parts/context_links.html.twig
@@ -97,6 +97,13 @@
             <span class="d-none d-xxl-block">{{ __('Setup') }}</span>
          </a>
       </li>
+   {% elseif type == 'import_forms' %}
+      <li class="nav-item">
+         <a href="{{ path(link) }}" role="button" class="btn btn-sm btn-ghost-secondary me-1 pe-2" title="{{ __('Import forms') }}">
+            <i class="ti ti-file-arrow-left"></i>
+            <span class="d-none d-xxl-block">{{ __('Import forms') }}</span>
+         </a>
+      </li>
    {% else %}
       <li class="nav-item">
          <a href="{{ path(link) }}" class="btn btn-sm btn-ghost-secondary me-1 pe-2">

--- a/templates/pages/admin/form/import/step1_index.html.twig
+++ b/templates/pages/admin/form/import/step1_index.html.twig
@@ -42,7 +42,7 @@
 {% block content_body %}
     <form
         method="POST"
-        action="{{ path('form/import/preview') }}"
+        action="{{ path('Form/Import/Preview') }}"
         enctype="multipart/form-data"
     >
         <div class="card">

--- a/templates/pages/admin/form/import/step1_index.html.twig
+++ b/templates/pages/admin/form/import/step1_index.html.twig
@@ -1,0 +1,76 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% extends "layout/page_without_tabs.html.twig" %}
+
+{% set tabler_container_size = "narrow" %}
+
+{% block content_title %}
+    {{ __('Import forms') }}
+{% endblock content_title %}
+
+{% block content_body %}
+    <form
+        method="POST"
+        action="{{ path('form/import/preview') }}"
+        enctype="multipart/form-data"
+    >
+        <div class="card">
+            <div class="card-body py-3 px-3">
+            <h3 id="select-files" class="card-title mb-3 mt-0">
+                {{ __('Select your file') }}
+            </h3>
+                <input
+                    accept=".json"
+                    aria-labelledby="select-files"
+                    class="form-control"
+                    type="file"
+                    name="import_file"
+                >
+            </div>
+        </div>
+
+        <div class="row mt-3">
+            <div class="col">
+                <div class="justify-content-end d-flex">
+                    <button type="submit" href="#" class="btn btn-primary">
+                        {{ __("Preview import") }}
+                    </button>
+                </div>
+            </div>
+        </div>
+
+        <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
+    </form>
+{% endblock content_body %}
+

--- a/templates/pages/admin/form/import/step2_preview.html.twig
+++ b/templates/pages/admin/form/import/step2_preview.html.twig
@@ -1,0 +1,99 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% extends "layout/page_without_tabs.html.twig" %}
+
+{% set tabler_container_size = "narrow" %}
+
+{% block content_title %}
+    {{ __('Import forms') }}
+{% endblock content_title %}
+
+{% block content_body %}
+    <form
+        method="POST"
+        action="{{ path('form/import/execute') }}"
+    >
+        <div class="card">
+            <div class="card-header py-3 px-4">
+                <h3 class="card-title">{{ __("Import preview") }}</h3>
+            </div>
+            <table class="table table-card mb-0">
+                <thead>
+                    <tr>
+                        <th class="w-70 px-4">{{ __("Form name") }}</th>
+                        <th class="w-30 px-4">{{ __("Status") }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for forms_name in preview.getValidForms() %}
+                        <tr>
+                            <td class="w-70 px-4">{{ forms_name }}</td>
+                            <td class="w-30 px-4">
+                                <div class="d-flex align-items-center">
+                                    <i class="ti ti-check text-success me-2"></i>
+                                    <span>{{ __("Ready to be imported") }}</span>
+                                </div>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    {% for forms_name in preview.getInvalidForms() %}
+                        <tr>
+                            <td class="w-70 px-4">{{ forms_name }}</td>
+                            <td class="w-30 px-4">
+                            <div class="d-flex align-items-center">
+                                    <i class="ti ti-x text-danger me-2"></i>
+                                    <span>{{ __("Can't be imported") }}</span>
+                                </div>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+
+        <div class="row mt-3">
+            <div class="col">
+                <div class="justify-content-end d-flex">
+                    <button type="submit" href="#" class="btn btn-primary">
+                        {{ __("Import") }}
+                    </button>
+                </div>
+            </div>
+        </div>
+
+        <input type="hidden" name="json" value="{{ json }}" />
+        <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
+    </form>
+{% endblock content_body %}
+

--- a/templates/pages/admin/form/import/step2_preview.html.twig
+++ b/templates/pages/admin/form/import/step2_preview.html.twig
@@ -42,7 +42,7 @@
 {% block content_body %}
     <form
         method="POST"
-        action="{{ path('form/import/execute') }}"
+        action="{{ path('Form/Import/Execute') }}"
     >
         <div class="card">
             <div class="card-header py-3 px-4">

--- a/templates/pages/admin/form/import/step3_execute.html.twig
+++ b/templates/pages/admin/form/import/step3_execute.html.twig
@@ -81,7 +81,7 @@
     <div class="row mt-3">
         <div class="col">
             <div class="justify-content-end d-flex">
-                <a href="{{ path('/form/import') }}" class="btn btn-outline-secondary">
+                <a href="{{ path('/Form/Import') }}" class="btn btn-outline-secondary">
                     {{ __("Import another file") }}
                 </a>
             </div>

--- a/templates/pages/admin/form/import/step3_execute.html.twig
+++ b/templates/pages/admin/form/import/step3_execute.html.twig
@@ -1,0 +1,91 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% extends "layout/page_without_tabs.html.twig" %}
+
+{% set tabler_container_size = "narrow" %}
+
+{% block content_title %}
+    {{ __('Import forms') }}
+{% endblock content_title %}
+
+{% block content_body %}
+    <div class="card">
+        <div class="card-header py-3 px-4">
+            <h3 class="card-title">{{ __("Import results") }}</h3>
+        </div>
+        <table class="table table-card mb-0">
+            <thead>
+                <tr>
+                    <th class="w-70 px-4">{{ "Glpi\\Form\\Form"|itemtype_name }}</th>
+                    <th class="w-30 px-4">{{ __("Status") }}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for form in results.getImportedForms() %}
+                    <tr>
+                        <td class="w-70 px-4">{{ form.getLink()|raw }}</td>
+                        <td class="w-30 px-4">
+                            <div class="d-flex align-items-center">
+                                <i class="ti ti-check text-success me-2"></i>
+                                <span>{{ __("Imported") }}</span>
+                            </div>
+                        </td>
+                    </tr>
+                {% endfor %}
+                {% for forms_name, error in results.getFailedFormImports() %}
+                    <tr>
+                        <td class="w-70 px-4">{{ forms_name }}</td>
+                        <td class="w-30 px-4">
+                        <div class="d-flex align-items-center">
+                                <i class="ti ti-x text-danger me-2"></i>
+                                <span>{{ __("Not imported") }}</span>
+                            </div>
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    <div class="row mt-3">
+        <div class="col">
+            <div class="justify-content-end d-flex">
+                <a href="{{ path('/form/import') }}" class="btn btn-outline-secondary">
+                    {{ __("Import another file") }}
+                </a>
+            </div>
+        </div>
+    </div>
+{% endblock content_body %}
+

--- a/templates/pages/admin/form/import/step3_execute.html.twig
+++ b/templates/pages/admin/form/import/step3_execute.html.twig
@@ -54,7 +54,7 @@
             <tbody>
                 {% for form in results.getImportedForms() %}
                     <tr>
-                        <td class="w-70 px-4">{{ form.getLink()|raw }}</td>
+                        <td class="w-70 px-4">{{ get_item_link(form) }}</td>
                         <td class="w-30 px-4">
                             <div class="d-flex align-items-center">
                                 <i class="ti ti-check text-success me-2"></i>

--- a/tests/cypress/e2e/form/serializer/import.cy.js
+++ b/tests/cypress/e2e/form/serializer/import.cy.js
@@ -1,0 +1,75 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+
+describe ('Import forms', () => {
+    beforeEach(() => {
+        cy.login();
+        cy.changeProfile('Super-Admin', true);
+    });
+
+    it('can import forms', () => {
+        // Step 1: file selection
+        cy.visit('/front/form/form.php');
+        cy.findByRole('button', {'name': "Import forms"}).click();
+        cy.findByLabelText("Select your file").selectFile("fixtures/export-of-2-forms.json");
+
+        // Step 2: preview
+        cy.findByRole('button', {'name': "Preview import"}).click();
+        cy.findAllByRole('row').as('preview');
+        cy.get("@preview").eq(1).within(() => {
+            cy.findByText("My valid form").should('exist');
+            cy.findByText("Ready to be imported").should('exist');
+        });
+        cy.get("@preview").eq(2).within(() => {
+            cy.findByText("My invalid form").should('exist');
+            cy.findByText("Can't be imported").should('exist');
+        });
+
+        // Step 3: import
+        cy.findByRole('button', {'name': "Import"}).click();
+        cy.findAllByRole('row').as('preview');
+        cy.get("@preview").eq(1).within(() => {
+            cy.findByRole("link", {'name': "My valid form"}).should('exist');
+            cy.findByText("Imported").should('exist');
+        });
+        cy.get("@preview").eq(2).within(() => {
+            cy.findByText("My invalid form").should('exist');
+            cy.findByText("Not imported").should('exist');
+        });
+
+        // Go back to first step
+        cy.findByRole('link', {'name': "Import another file"}).click();
+        cy.findByLabelText("Select your file").should('exist');
+    });
+});

--- a/tests/fixtures/export-of-2-forms.json
+++ b/tests/fixtures/export-of-2-forms.json
@@ -1,0 +1,29 @@
+{
+    "version": 1,
+    "forms": [
+        {
+            "name": "My valid form",
+            "header": "",
+            "entity_name": "E2ETestEntity",
+            "is_recursive": false,
+            "data_requirements": [
+                {
+                    "itemtype": "Entity",
+                    "name": "E2ETestEntity"
+                }
+            ]
+        },
+        {
+            "name": "My invalid form",
+            "header": "",
+            "entity_name": "Missing entity",
+            "is_recursive": false,
+            "data_requirements": [
+                {
+                    "itemtype": "Entity",
+                    "name": "Missing entity"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Minimal import UI.

Step 1:

![image](https://github.com/user-attachments/assets/10aadfba-9b35-4239-99a8-304b4a9bd336)

Step 2:

![image](https://github.com/user-attachments/assets/04f5bdba-d6d4-411c-b589-276dd4cf94b2)

Step 3:

![image](https://github.com/user-attachments/assets/b562bbfa-7e8f-4356-9b34-f09ee7e3e6c6)

Note that the second step isn't very interesting right now as it display something very similar to the third step.
This is temporary, in the future it will allow the user to pick replacements for missing items.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
