### PR TITLE
Fix generic assets groups definition

### DIFF
--- a/src/Glpi/Asset/Asset.php
+++ b/src/Glpi/Asset/Asset.php
@@ -396,14 +396,14 @@ abstract class Asset extends CommonDBTM
 
     public function prepareInputForAdd($input)
     {
-        $this->prepareGroupFields($input);
+        $input = $this->prepareGroupFields($input);
 
         return $this->prepareDefinitionInput($input);
     }
 
     public function prepareInputForUpdate($input)
     {
-        $this->prepareGroupFields($input);
+        $input = $this->prepareGroupFields($input);
 
         return $this->prepareDefinitionInput($input);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Follows #16760.
The groups were not saved when the generic asset creation/update form was submitted.