### PR TITLE
 feat(forms): Forms destinations - config urgency

### DIFF
--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/UrgencyFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/UrgencyFieldTest.php
@@ -1,0 +1,267 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\Destination\CommonITILField;
+
+use DbTestCase;
+use Glpi\Form\Destination\CommonITILField\UrgencyField;
+use Glpi\Form\Destination\CommonITILField\UrgencyFieldConfig;
+use Glpi\Form\Destination\CommonITILField\UrgencyFieldStrategy;
+use Glpi\Form\Destination\FormDestinationTicket;
+use Glpi\Form\Form;
+use Glpi\Form\QuestionType\QuestionTypeUrgency;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+use TicketTemplate;
+use TicketTemplatePredefinedField;
+
+final class UrgencyFieldTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public function testUrgencyFromTemplateDefault(): void
+    {
+        $default_urgency = 3; // (medium)
+
+        $form = $this->createAndGetFormWithTwoUrgencyQuestions();
+        $this->setUrgencyConfig($form, new UrgencyFieldConfig(
+            UrgencyFieldStrategy::FROM_TEMPLATE
+        ));
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form);
+
+        // The default template does not define an urgency, it should
+        // thus be GLPI's default value: 3 (medium)
+        $this->assertEquals($default_urgency, $ticket->fields['urgency']);
+    }
+
+    public function testUrgencyFromTemplateSpecific(): void
+    {
+        $very_high_urgency = 5;
+
+        $form = $this->createAndGetFormWithTwoUrgencyQuestions();
+        $this->setTemplatePredefinedUrgency($very_high_urgency);
+        $this->setUrgencyConfig($form, new UrgencyFieldConfig(
+            UrgencyFieldStrategy::FROM_TEMPLATE
+        ));
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form);
+
+        $this->assertEquals($very_high_urgency, $ticket->fields['urgency']);
+    }
+
+    public function testSpecificUrgency(): void
+    {
+        $high_urgency = 4;
+
+        $form = $this->createAndGetFormWithTwoUrgencyQuestions();
+        $this->setUrgencyConfig($form, new UrgencyFieldConfig(
+            strategy: UrgencyFieldStrategy::SPECIFIC_VALUE,
+            specific_urgency_value: $high_urgency,
+        ));
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form);
+
+        $this->assertEquals($high_urgency, $ticket->fields['urgency']);
+    }
+
+    public function testUrgencyFromFirstQuestion(): void
+    {
+        $low_urgency = 2;
+
+        $form = $this->createAndGetFormWithTwoUrgencyQuestions();
+        $this->setUrgencyConfig($form, new UrgencyFieldConfig(
+            strategy: UrgencyFieldStrategy::SPECIFIC_ANSWER,
+            specific_question_id: $this->getQuestionId($form, "Urgency 1"),
+        ));
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Urgency 1" => $low_urgency,
+            "Urgency 2" => 4, // Another urgency in another question as a "control" subject
+        ]);
+
+        $this->assertEquals($low_urgency, $ticket->fields['urgency']);
+    }
+
+    public function testUrgencyFromSecondQuestion(): void
+    {
+        $very_low_urgency = 1;
+
+        $form = $this->createAndGetFormWithTwoUrgencyQuestions();
+        $this->setUrgencyConfig($form, new UrgencyFieldConfig(
+            strategy: UrgencyFieldStrategy::SPECIFIC_ANSWER,
+            specific_question_id: $this->getQuestionId($form, "Urgency 2"),
+        ));
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Urgency 1" => 4, // Another urgency in another question as a "control" subject
+            "Urgency 2" => $very_low_urgency,
+        ]);
+
+        $this->assertEquals($very_low_urgency, $ticket->fields['urgency']);
+    }
+
+    public function testUrgencyFromLastValidQuestion(): void
+    {
+        $very_high_urgency = 5;
+
+        $form = $this->createAndGetFormWithTwoUrgencyQuestions();
+        $this->setUrgencyConfig($form, new UrgencyFieldConfig(
+            UrgencyFieldStrategy::LAST_VALID_ANSWER,
+        ));
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Urgency 1" => 4, // Another urgency in another question as a "control" subject
+            "Urgency 2" => $very_high_urgency,
+        ]);
+
+        $this->assertEquals($very_high_urgency, $ticket->fields['urgency']);
+    }
+
+    public function testUrgencyFromLastValidQuestionWithOnlyFirstAnswer(): void
+    {
+        $very_high_urgency = 5;
+
+        $form = $this->createAndGetFormWithTwoUrgencyQuestions();
+        $this->setUrgencyConfig($form, new UrgencyFieldConfig(
+            UrgencyFieldStrategy::LAST_VALID_ANSWER,
+        ));
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Urgency 1" => $very_high_urgency,
+        ]);
+
+        $this->assertEquals($very_high_urgency, $ticket->fields['urgency']);
+    }
+
+    public function testUrgencyFromLastValidQuestionWithOnlySecondtAnswer(): void
+    {
+        $very_high_urgency = 5;
+
+        $form = $this->createAndGetFormWithTwoUrgencyQuestions();
+        $this->setUrgencyConfig($form, new UrgencyFieldConfig(
+            UrgencyFieldStrategy::LAST_VALID_ANSWER,
+        ));
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Urgency 2" => $very_high_urgency,
+        ]);
+
+        $this->assertEquals($very_high_urgency, $ticket->fields['urgency']);
+    }
+
+    public function testUrgencyFromLastValidQuestionWithoutAnswers(): void
+    {
+        $default_urgency = 3; // (medium)
+
+        $form = $this->createAndGetFormWithTwoUrgencyQuestions();
+        $this->setUrgencyConfig($form, new UrgencyFieldConfig(
+            UrgencyFieldStrategy::LAST_VALID_ANSWER,
+        ));
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form);
+
+        $this->assertEquals($default_urgency, $ticket->fields['urgency']);
+    }
+
+    public function testUrgencyFromLastValidQuestionWithoutAnswersUsingTemplate(): void
+    {
+        $high_urgency = 4; // (medium)
+
+        $form = $this->createAndGetFormWithTwoUrgencyQuestions();
+        $this->setTemplatePredefinedUrgency($high_urgency);
+        $this->setUrgencyConfig($form, new UrgencyFieldConfig(
+            UrgencyFieldStrategy::LAST_VALID_ANSWER,
+        ));
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form);
+
+        $this->assertEquals($high_urgency, $ticket->fields['urgency']);
+    }
+
+    public function testDefaultConfigIsLastAnswer(): void
+    {
+        $low_urgency = 2;
+
+        $form = $this->createAndGetFormWithTwoUrgencyQuestions();
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Urgency 1" => 4, // Another urgency in another question as a "control" subject
+            "Urgency 2" => $low_urgency,
+        ]);
+
+        $this->assertEquals($low_urgency, $ticket->fields['urgency']);
+    }
+
+    private function setUrgencyConfig(
+        Form $form,
+        UrgencyFieldConfig $config,
+    ): void {
+        $field = new UrgencyField();
+
+        // Insert config
+        $destinations = $form->getDestinations();
+        $this->assertCount(1, $destinations);
+        $destination = current($destinations);
+        $this->updateItem(
+            $destination::getType(),
+            $destination->getId(),
+            ['config' => [$field->getKey() => $config->jsonSerialize()]],
+            ["config"],
+        );
+    }
+
+    private function setTemplatePredefinedUrgency(int $urgency): void
+    {
+        $template = getItemByTypeName(TicketTemplate::class, "Default");
+        $this->createItem(TicketTemplatePredefinedField::class, [
+            'tickettemplates_id' => $template->getId(),
+            'num' => 10, // Urgency
+            'value' => $urgency,
+        ]);
+    }
+
+    private function createAndGetFormWithTwoUrgencyQuestions(): Form
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion("Urgency 1", QuestionTypeUrgency::class);
+        $builder->addQuestion("Urgency 2", QuestionTypeUrgency::class);
+        $builder->addDestination(
+            FormDestinationTicket::class,
+            "My ticket",
+        );
+        return $this->createForm($builder);
+    }
+}

--- a/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
+++ b/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
@@ -40,6 +40,7 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\Form\AnswersSet;
 use Glpi\Form\Destination\CommonITILField\ContentField;
 use Glpi\Form\Destination\CommonITILField\TitleField;
+use Glpi\Form\Destination\CommonITILField\UrgencyField;
 use Glpi\Form\Form;
 use Override;
 
@@ -143,6 +144,7 @@ abstract class AbstractCommonITILFormDestination extends AbstractFormDestination
         return [
             new TitleField(),
             new ContentField(),
+            new UrgencyField(),
         ];
     }
 

--- a/src/Glpi/Form/Destination/CommonITILField/UrgencyFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/UrgencyFieldConfig.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Destination\CommonITILField;
+
+use Glpi\DBAL\JsonFieldInterface;
+use Override;
+
+final class UrgencyFieldConfig implements JsonFieldInterface
+{
+    // Unique reference to hardcoded names used for serialization and forms input names
+    public const STRATEGY = 'strategy';
+    public const SPECIFIC_QUESTION_ID = 'specific_question_id';
+    public const SPECIFIC_URGENCY_VALUE = 'specific_urgency_value';
+
+    public function __construct(
+        private UrgencyFieldStrategy $strategy,
+        private ?int $specific_question_id = null,
+        private ?int $specific_urgency_value = null,
+    ) {
+    }
+
+    #[Override]
+    public static function jsonDeserialize(array $data): self
+    {
+        $strategy = UrgencyFieldStrategy::tryFrom($data[self::STRATEGY] ?? "");
+        if ($strategy === null) {
+            $strategy = UrgencyFieldStrategy::LAST_VALID_ANSWER;
+        }
+
+        return new self(
+            strategy: $strategy,
+            specific_question_id: $data[self::SPECIFIC_QUESTION_ID],
+            specific_urgency_value: $data[self::SPECIFIC_URGENCY_VALUE],
+        );
+    }
+
+    #[Override]
+    public function jsonSerialize(): array
+    {
+        return [
+            self::STRATEGY => $this->strategy->value,
+            self::SPECIFIC_QUESTION_ID => $this->specific_question_id,
+            self::SPECIFIC_URGENCY_VALUE => $this->specific_urgency_value,
+        ];
+    }
+
+    public function getStrategy(): UrgencyFieldStrategy
+    {
+        return $this->strategy;
+    }
+
+    public function getSpecificUrgency(): ?int
+    {
+        return $this->specific_urgency_value;
+    }
+
+    public function getSpecificQuestionId(): ?int
+    {
+        return $this->specific_question_id;
+    }
+}

--- a/src/Glpi/Form/Destination/CommonITILField/UrgencyFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/UrgencyFieldStrategy.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Destination\CommonITILField;
+
+use Glpi\Form\AnswersSet;
+use Glpi\Form\QuestionType\QuestionTypeUrgency;
+
+enum UrgencyFieldStrategy: string
+{
+    case FROM_TEMPLATE = 'from_template';
+    case SPECIFIC_VALUE = 'specific_value';
+    case SPECIFIC_ANSWER = 'specific_answer';
+    case LAST_VALID_ANSWER = 'last_valid_answer';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::FROM_TEMPLATE     => __("From template"),
+            self::SPECIFIC_VALUE    => __("Specific urgency"),
+            self::SPECIFIC_ANSWER   => __("Answer from a specific question"),
+            self::LAST_VALID_ANSWER => __('Answer to last "Urgency" question'),
+        };
+    }
+
+    public function computeUrgency(
+        UrgencyFieldConfig $config,
+        AnswersSet $answers_set,
+    ): ?int {
+        return match ($this) {
+            self::FROM_TEMPLATE => null, // Let the template apply its default value
+            self::SPECIFIC_VALUE => $config->getSpecificUrgency(),
+            self::SPECIFIC_ANSWER => $this->getUrgencyFromSpecificAnswer(
+                $config->getSpecificQuestionId(),
+                $answers_set
+            ),
+            self::LAST_VALID_ANSWER => $this->getUrgencyFromLastValidAnswer($answers_set),
+        };
+    }
+
+    private function getUrgencyFromSpecificAnswer(
+        ?int $question_id,
+        AnswersSet $answers_set,
+    ): ?int {
+        if ($question_id === null) {
+            return null;
+        }
+
+        $answer = $answers_set->getAnswerByQuestionId($question_id);
+        if ($answer === null) {
+            return null;
+        }
+
+        $value = $answer->getRawAnswer();
+        if (!is_numeric($value)) {
+            return null;
+        }
+
+        return (int) $value;
+    }
+
+    private function getUrgencyFromLastValidAnswer(
+        AnswersSet $answers_set,
+    ): ?int {
+        $valid_answers = $answers_set->getAnswersByType(
+            QuestionTypeUrgency::class
+        );
+
+        if (count($valid_answers) == 0) {
+            return null;
+        }
+
+        $answer = end($valid_answers);
+        $value = $answer->getRawAnswer();
+        if (!is_numeric($value)) {
+            return null;
+        }
+
+        return (int) $value;
+    }
+}

--- a/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php
@@ -108,6 +108,7 @@ TWIG;
             {
                 'no_label'            : true,
                 'display_emptychoice' : true,
+                'aria_label'          : label
             }
         ) }}
 TWIG;
@@ -120,6 +121,7 @@ TWIG;
                 range(1, 5),
                 array_map(fn ($urgency) => CommonITILObject::getUrgencyName($urgency), range(1, 5))
             ),
+            'label' => $question->fields['name'],
         ]);
     }
 

--- a/templates/components/itilobject/fields/priority_matrix.html.twig
+++ b/templates/components/itilobject/fields/priority_matrix.html.twig
@@ -57,7 +57,9 @@
       'rand': rand,
    }|merge(urgency_options)),
    __('Urgency'),
-   field_options
+   field_options|merge({
+      'id': 'dropdown_urgency' ~ field_options.rand,
+   })
 ) }}
 
 {% set impact_options = field_options %}

--- a/templates/pages/admin/form/itil_config_fields/urgency.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/urgency.html.twig
@@ -1,0 +1,84 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
+{{ fields.dropdownArrayField(
+    main_config_field.input_name,
+    main_config_field.value,
+    main_config_field.possible_values,
+    main_config_field.label,
+    options
+) }}
+
+<div
+    {% if main_config_field.value != CONFIG_SPECIFIC_VALUE %}
+        class="d-none"
+    {% endif %}
+    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
+    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_VALUE }}"
+>
+    {{ fields.dropdownArrayField(
+        specific_value_extra_field.input_name,
+        specific_value_extra_field.value,
+        specific_value_extra_field.possible_values,
+        "",
+        options|merge({
+            no_label: true,
+            display_emptychoice: true,
+            emptylabel: specific_value_extra_field.empty_label,
+            aria_label: specific_value_extra_field.empty_label,
+        })
+    ) }}
+</div>
+
+<div
+    {% if main_config_field.value != CONFIG_SPECIFIC_ANSWER %}
+        class="d-none"
+    {% endif %}
+    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
+    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_ANSWER }}"
+>
+    {{ fields.dropdownArrayField(
+        specific_answer_extra_field.input_name,
+        specific_answer_extra_field.value,
+        specific_answer_extra_field.possible_values,
+        "",
+        options|merge({
+            no_label: true,
+            display_emptychoice: true,
+            emptylabel: specific_answer_extra_field.empty_label,
+            aria_label: specific_answer_extra_field.empty_label,
+        })
+    ) }}
+</div>

--- a/tests/cypress/e2e/form/destination_config_fields/urgency.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/urgency.cy.js
@@ -1,0 +1,109 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+describe('Urgency configuration', () => {
+    beforeEach(() => {
+        cy.login();
+        cy.changeProfile('Super-Admin', true);
+
+        // Create form with a single "urgency" question
+        cy.createFormWithAPI().visitFormTab('Form');
+        cy.findByRole('button', {'name': "Add a new question"}).click();
+        cy.focused().type("My urgency question");
+        cy.getDropdownByLabelText('Question type').selectDropdownValue('Urgency');
+        cy.findByRole('button', {'name': 'Save'}).click();
+        cy.findByRole('alert').should('contain.text', 'Item successfully updated');
+
+        // Go to destination tab
+        cy.findByRole('tab', {'name': "Items to create"}).click();
+        cy.findByRole('button', {'name': "Add ticket"}).click();
+        cy.findByRole('alert').should('contain.text', 'Item successfully added');
+    });
+
+    it('can use all possibles configuration options', () => {
+        cy.findByRole('region', {'name': "Urgency configuration"}).as("config");
+        cy.get('@config').getDropdownByLabelText('Urgency').as("urgency_dropdown");
+
+        // Default value
+        cy.get('@urgency_dropdown').should(
+            'have.text',
+            'Answer to last "Urgency" question'
+        );
+
+        // Make sure hidden dropdowns are not displayed
+        cy.get('@config').getDropdownByLabelText('Select an urgency level...').should('not.exist');
+        cy.get('@config').getDropdownByLabelText('Select a question...').should('not.exist');
+
+        // Switch to "From template"
+        cy.get('@urgency_dropdown').selectDropdownValue('From template');
+        cy.findByRole('button', {'name': 'Update item'}).click();
+        cy.get('@urgency_dropdown').should('have.text', 'From template');
+
+        // Switch to "Specific type"
+        cy.get('@urgency_dropdown').selectDropdownValue('Specific urgency');
+        cy.get('@config').getDropdownByLabelText('Select an urgency level...').as('specific_urgency_dropdown');
+        cy.get('@specific_urgency_dropdown').selectDropdownValue('High');
+
+        cy.findByRole('button', {'name': 'Update item'}).click();
+        cy.get('@urgency_dropdown').should('have.text', 'Specific urgency');
+        cy.get('@specific_urgency_dropdown').should('have.text', 'High');
+
+        // Switch to "Answer from a specific question"
+        cy.get('@urgency_dropdown').selectDropdownValue('Answer from a specific question');
+        cy.get('@config').getDropdownByLabelText('Select a question...').as('specific_answer_type_dropdown');
+        cy.get('@specific_answer_type_dropdown').selectDropdownValue('My urgency question');
+
+        cy.findByRole('button', {'name': 'Update item'}).click();
+        cy.get('@urgency_dropdown').should('have.text', 'Answer from a specific question');
+        cy.get('@specific_answer_type_dropdown').should('have.text', 'My urgency question');
+    });
+
+    it('can create ticket using default configuration', () => {
+        // Go to preview
+        cy.findByRole('tab', {'name': "Form"}).click();
+        cy.findByRole('link', {'name': "Preview"})
+            .invoke('removeAttr', 'target') // Cypress can't handle tab changes
+            .click()
+        ;
+
+        // Fill form
+        cy.getDropdownByLabelText("My urgency question").selectDropdownValue('Very high');
+        cy.findByRole('button', {'name': 'Send form'}).click();
+        cy.findByRole('link', {'name': 'My test form'}).click();
+
+        // Check ticket values
+        cy.getDropdownByLabelText('Urgency').should('have.text', 'Very high');
+
+        // Others possibles configurations are tested directly by the backend.
+    });
+});


### PR DESCRIPTION
Credit to @ccailly, we both ended up working on this feature by accident so I've merged both work into one (there was good things to keep on both sides).

![image](https://github.com/user-attachments/assets/8e69def9-12f2-41ba-9ae9-1265c197f1d2)

Note that I've noticed this does not take into account that urgency levels can be disabled in the general config (the urgency question type also missed this "feature").
I've added it to the backlog and will fix it in another PR (I'll probably add a proper Urgency backed enum because we don't even have constants for urgency values right now).

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
