### PR TITLE
Fix 17642

### DIFF
--- a/src/NetworkName.php
+++ b/src/NetworkName.php
@@ -186,14 +186,14 @@ class NetworkName extends FQDNLabel
     public static function rawSearchOptionsToAdd(array &$tab, array $joinparams)
     {
         $tab[] = [
-            'id'                 => '126',
-            'table'              => 'glpi_ipaddresses',
-            'field'              => 'name',
-            'name'               => __('IP'),
-            'forcegroupby'       => true,
-            'searchequalsonfield'=> true,
-            'massiveaction'      => false,
-            'joinparams'         => [
+            'id'                  => '126',
+            'table'               => 'glpi_ipaddresses',
+            'field'               => 'name',
+            'name'                => __('IP'),
+            'forcegroupby'        => true,
+            'searchequalsonfield' => true,
+            'massiveaction'       => false,
+            'joinparams'          => [
                 'jointype'  => 'mainitemtype_mainitem',
                 'condition' => ['NEWTABLE.is_deleted' => 0,
                     'NOT' => ['NEWTABLE.name' => '']
@@ -202,23 +202,23 @@ class NetworkName extends FQDNLabel
         ];
 
         $tab[] = [
-            'id'                 => '127',
-            'table'              => 'glpi_networknames',
-            'field'              => 'name',
-            'name'               => self::getTypeName(Session::getPluralNumber()),
-            'forcegroupby'       => true,
-            'massiveaction'      => false,
-            'joinparams'         => $joinparams
+            'id'                  => '127',
+            'table'               => 'glpi_networknames',
+            'field'               => 'name',
+            'name'                => self::getTypeName(Session::getPluralNumber()),
+            'forcegroupby'        => true,
+            'massiveaction'       => false,
+            'joinparams'          => $joinparams
         ];
 
         $tab[] = [
-            'id'                 => '128',
-            'table'              => 'glpi_networkaliases',
-            'field'              => 'name',
-            'name'               => NetworkAlias::getTypeName(Session::getPluralNumber()),
-            'forcegroupby'       => true,
-            'massiveaction'      => false,
-            'joinparams'         => [
+            'id'                  => '128',
+            'table'               => 'glpi_networkaliases',
+            'field'               => 'name',
+            'name'                => NetworkAlias::getTypeName(Session::getPluralNumber()),
+            'forcegroupby'        => true,
+            'massiveaction'       => false,
+            'joinparams'          => [
                 'jointype'   => 'child',
                 'beforejoin' => [
                     'table'      => 'glpi_networknames',

--- a/src/NetworkName.php
+++ b/src/NetworkName.php
@@ -191,6 +191,7 @@ class NetworkName extends FQDNLabel
             'field'              => 'name',
             'name'               => __('IP'),
             'forcegroupby'       => true,
+            'searchequalsonfield'=> true,
             'massiveaction'      => false,
             'joinparams'         => [
                 'jointype'  => 'mainitemtype_mainitem',


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Tests pass?   | I've used './tests/run_tests.sh --all' before and after modification and the same tests fails...
| Fixed tickets | #17642 

The only change is 'searchequalsonfield' for glpi_ipaddresses.name in 'NetworkName.php', so that the search doesn't try to use the "id" column when we use the selector "is" or "is not" in searchs but instead the correct column "name".
