### PR TITLE
feat(forms): use an answer formatted by the question type to handle other types than string

### DIFF
--- a/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeAssigneeTest.php
+++ b/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeAssigneeTest.php
@@ -1,0 +1,180 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\QuestionType;
+
+use DbTestCase;
+use Glpi\Form\Destination\FormDestinationTicket;
+use Glpi\Form\QuestionType\QuestionTypeAssignee;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+use Group;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Profile;
+use Profile_User;
+use Supplier;
+use User;
+
+final class QuestionTypeAssigneeTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public static function singleAssigneeAnswerIsDisplayedInTicketDescriptionProvider(): iterable
+    {
+        $glpi_id = getItemByTypeName(User::class, "glpi", true);
+        yield 'simple user' => [
+            'answer' => ["users_id-$glpi_id"],
+            'expected' => "glpi",
+        ];
+
+        $test_group_1_id = getItemByTypeName(Group::class, "_test_group_1", true);
+        yield 'simple group' => [
+            'answer' => ["groups_id-$test_group_1_id"],
+            'expected' => "_test_group_1",
+        ];
+
+        $supplier_01_id = getItemByTypeName(Supplier::class, "_suplier01_name", true);
+        yield 'simple supplier' => [
+            'answer' => ["suppliers_id-$supplier_01_id"],
+            'expected' => "_suplier01_name",
+        ];
+    }
+
+    #[DataProvider("singleAssigneeAnswerIsDisplayedInTicketDescriptionProvider")]
+    public function testSingleAssigneeAnswerIsDisplayedInTicketDescription(
+        array $answer,
+        string $expected
+    ): void {
+        $builder = new FormBuilder();
+        $builder->addQuestion("Assigned", QuestionTypeAssignee::class);
+        $builder->addDestination(FormDestinationTicket::class, "My ticket");
+        $form = $this->createForm($builder);
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Assigned" => $answer,
+        ]);
+
+        $this->assertStringContainsString(
+            "1) Assigned: $expected",
+            strip_tags($ticket->fields['content']),
+        );
+    }
+
+    public static function multipleAssigneeAnswerIsDisplayedInTicketDescriptionProvider(): iterable
+    {
+        $glpi_id = getItemByTypeName(User::class, "glpi", true);
+        $tech_id = getItemByTypeName(User::class, "tech", true);
+        yield 'multiple users' => [
+            'answer' => [
+                "users_id-$glpi_id",
+                "users_id-$tech_id",
+            ],
+            'expected' => "glpi, tech",
+        ];
+
+        $test_group_1_id = getItemByTypeName(Group::class, "_test_group_1", true);
+        $test_group_2_id = getItemByTypeName(Group::class, "_test_group_2", true);
+        yield 'multiple groups' => [
+            'answer' => [
+                "groups_id-$test_group_1_id",
+                "groups_id-$test_group_2_id",
+            ],
+            'expected' => "_test_group_1, _test_group_2",
+        ];
+
+        $supplier_01_id = getItemByTypeName(Supplier::class, "_suplier01_name", true);
+        $supplier_02_id = getItemByTypeName(Supplier::class, "_suplier02_name", true);
+        yield 'multiple suppliers' => [
+            'answer' => [
+                "suppliers_id-$supplier_01_id",
+                "suppliers_id-$supplier_02_id",
+            ],
+            'expected' => "_suplier01_name, _suplier02_name",
+        ];
+    }
+
+    #[DataProvider("multipleAssigneeAnswerIsDisplayedInTicketDescriptionProvider")]
+    public function testMultipleAssigneeAnswerIsDisplayedInTicketDescription(
+        array $answer,
+        string $expected
+    ): void {
+        $builder = new FormBuilder();
+        $builder->addQuestion("Assigned", QuestionTypeAssignee::class);
+        $builder->addDestination(FormDestinationTicket::class, "My ticket", ['is_multiple_actors' => true]);
+        $form = $this->createForm($builder);
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Assigned" => $answer,
+        ]);
+
+        $this->assertStringContainsString(
+            "1) Assigned: $expected",
+            strip_tags($ticket->fields['content']),
+        );
+    }
+
+    public function testAssignedUserWithFullNameIsDisplayedInTicketDescription(): void
+    {
+        // Create a user with a fully qualified name and allow him to be an assignee by making him super admin profile
+        $john_doe = $this->createItem(User::class, [
+            'name' => 'jdoe',
+            'firstname' => 'John',
+            'realname' => 'Doe',
+        ]);
+        $this->createItem(Profile_User::class, [
+            'users_id' => $john_doe->getID(),
+            'profiles_id' => getItemByTypeName(Profile::class, 'Super-Admin', true),
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+        ]);
+
+        $builder = new FormBuilder();
+        $builder->addQuestion("Assigned", QuestionTypeAssignee::class);
+        $builder->addDestination(FormDestinationTicket::class, "My ticket");
+        $form = $this->createForm($builder);
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Assigned" => ["users_id-{$john_doe->getID()}"],
+        ]);
+
+        $this->assertStringContainsString(
+            "1) Assigned: Doe John",
+            strip_tags($ticket->fields['content']),
+        );
+    }
+
+    // TODO: add a test to validate that invalid answers are refused:
+    // - users/groups/suppliers that does not have the right to be assignee
+    // - multiple values when the question is not configured to accept multiple answers
+}

--- a/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeAssigneeTest.php
+++ b/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeAssigneeTest.php
@@ -1,38 +1,5 @@
 <?php
 
-/**
- * ---------------------------------------------------------------------
- *
- * GLPI - Gestionnaire Libre de Parc Informatique
- *
- * http://glpi-project.org
- *
- * @copyright 2015-2024 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
- * @licence   https://www.gnu.org/licenses/gpl-3.0.html
- *
- * ---------------------------------------------------------------------
- *
- * LICENSE
- *
- * This file is part of GLPI.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
- * ---------------------------------------------------------------------
- */
-
 namespace tests\units\Glpi\Form\QuestionType;
 
 use DbTestCase;
@@ -51,88 +18,74 @@ final class QuestionTypeAssigneeTest extends DbTestCase
 {
     use FormTesterTrait;
 
-    public static function singleAssigneeAnswerIsDisplayedInTicketDescriptionProvider(): iterable
-    {
-        $glpi_id = getItemByTypeName(User::class, "glpi", true);
-        yield 'simple user' => [
-            'answer' => ["users_id-$glpi_id"],
-            'expected' => "glpi",
-        ];
-
-        $test_group_1_id = getItemByTypeName(Group::class, "_test_group_1", true);
-        yield 'simple group' => [
-            'answer' => ["groups_id-$test_group_1_id"],
-            'expected' => "_test_group_1",
-        ];
-
-        $supplier_01_id = getItemByTypeName(Supplier::class, "_suplier01_name", true);
-        yield 'simple supplier' => [
-            'answer' => ["suppliers_id-$supplier_01_id"],
-            'expected' => "_suplier01_name",
-        ];
-    }
-
-    #[DataProvider("singleAssigneeAnswerIsDisplayedInTicketDescriptionProvider")]
-    public function testSingleAssigneeAnswerIsDisplayedInTicketDescription(
-        array $answer,
-        string $expected
-    ): void {
-        $builder = new FormBuilder();
-        $builder->addQuestion("Assigned", QuestionTypeAssignee::class);
-        $builder->addDestination(FormDestinationTicket::class, "My ticket");
-        $form = $this->createForm($builder);
-
-        $ticket = $this->sendFormAndGetCreatedTicket($form, [
-            "Assigned" => $answer,
-        ]);
-
-        $this->assertStringContainsString(
-            "1) Assigned: $expected",
-            strip_tags($ticket->fields['content']),
-        );
-    }
-
-    public static function multipleAssigneeAnswerIsDisplayedInTicketDescriptionProvider(): iterable
+    public static function assigneeAnswerIsDisplayedInTicketDescriptionProvider(): iterable
     {
         $glpi_id = getItemByTypeName(User::class, "glpi", true);
         $tech_id = getItemByTypeName(User::class, "tech", true);
+        $test_group_1_id = getItemByTypeName(Group::class, "_test_group_1", true);
+        $test_group_2_id = getItemByTypeName(Group::class, "_test_group_2", true);
+        $supplier_01_id = getItemByTypeName(Supplier::class, "_suplier01_name", true);
+        $supplier_02_id = getItemByTypeName(Supplier::class, "_suplier02_name", true);
+
+        yield 'simple user' => [
+            'answer' => ["users_id-$glpi_id"],
+            'expected' => "glpi",
+            'is_multiple' => false,
+        ];
+
+        yield 'simple group' => [
+            'answer' => ["groups_id-$test_group_1_id"],
+            'expected' => "_test_group_1",
+            'is_multiple' => false,
+        ];
+
+        yield 'simple supplier' => [
+            'answer' => ["suppliers_id-$supplier_01_id"],
+            'expected' => "_suplier01_name",
+            'is_multiple' => false,
+        ];
+
         yield 'multiple users' => [
             'answer' => [
                 "users_id-$glpi_id",
                 "users_id-$tech_id",
             ],
             'expected' => "glpi, tech",
+            'is_multiple' => true,
         ];
 
-        $test_group_1_id = getItemByTypeName(Group::class, "_test_group_1", true);
-        $test_group_2_id = getItemByTypeName(Group::class, "_test_group_2", true);
         yield 'multiple groups' => [
             'answer' => [
                 "groups_id-$test_group_1_id",
                 "groups_id-$test_group_2_id",
             ],
             'expected' => "_test_group_1, _test_group_2",
+            'is_multiple' => true,
         ];
 
-        $supplier_01_id = getItemByTypeName(Supplier::class, "_suplier01_name", true);
-        $supplier_02_id = getItemByTypeName(Supplier::class, "_suplier02_name", true);
         yield 'multiple suppliers' => [
             'answer' => [
                 "suppliers_id-$supplier_01_id",
                 "suppliers_id-$supplier_02_id",
             ],
             'expected' => "_suplier01_name, _suplier02_name",
+            'is_multiple' => true,
         ];
     }
 
-    #[DataProvider("multipleAssigneeAnswerIsDisplayedInTicketDescriptionProvider")]
-    public function testMultipleAssigneeAnswerIsDisplayedInTicketDescription(
+    #[DataProvider("assigneeAnswerIsDisplayedInTicketDescriptionProvider")]
+    public function testAssigneeAnswerIsDisplayedInTicketDescription(
         array $answer,
-        string $expected
+        string $expected,
+        bool $is_multiple
     ): void {
         $builder = new FormBuilder();
         $builder->addQuestion("Assigned", QuestionTypeAssignee::class);
-        $builder->addDestination(FormDestinationTicket::class, "My ticket", ['is_multiple_actors' => true]);
+        $builder->addDestination(
+            FormDestinationTicket::class,
+            "My ticket",
+            ['is_multiple_actors' => $is_multiple]
+        );
         $form = $this->createForm($builder);
 
         $ticket = $this->sendFormAndGetCreatedTicket($form, [

--- a/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeAssigneeTest.php
+++ b/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeAssigneeTest.php
@@ -1,5 +1,37 @@
 <?php
 
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
 namespace tests\units\Glpi\Form\QuestionType;
 
 use DbTestCase;

--- a/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeCheckboxTest.php
+++ b/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeCheckboxTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\QuestionType;
+
+use DbTestCase;
+use Glpi\Form\Destination\FormDestinationTicket;
+use Glpi\Form\QuestionType\QuestionTypeCheckbox;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+
+final class QuestionTypeCheckboxTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public function testCheckboxAnswerIsDisplayedInTicketDescription(): void
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion(
+            name: "Shopping list",
+            type: QuestionTypeCheckbox::class,
+            extra_data: json_encode([
+                'options' => ['Bread', 'Milk', 'Cheese', 'Eggs', 'Butter'],
+            ])
+        );
+        $builder->addDestination(FormDestinationTicket::class, "My ticket");
+        $form = $this->createForm($builder);
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Shopping list" => ['Bread', 'Milk', 'Cheese'],
+        ]);
+
+        $this->assertStringContainsString(
+            "1) Shopping list: Bread, Milk, Cheese",
+            strip_tags($ticket->fields['content']),
+        );
+    }
+}

--- a/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeDateTimeTest.php
+++ b/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeDateTimeTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\QuestionType;
+
+use DbTestCase;
+use Glpi\Form\Destination\FormDestinationTicket;
+use Glpi\Form\QuestionType\QuestionTypeDateTime;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+
+final class QuestionTypeDateTimeTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public function testDateTimeAnswerIsDisplayedInTicketDescription(): void
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion(
+            name: "Date and time",
+            type: QuestionTypeDateTime::class,
+            extra_data: json_encode([
+                'is_date_enabled' => 1,
+                'is_time_enabled' => 0,
+            ])
+        );
+        $builder->addDestination(FormDestinationTicket::class, "My ticket");
+        $form = $this->createForm($builder);
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Date and time" => "2024-08-22T10:13",
+        ]);
+
+        $this->assertStringContainsString(
+            "1) Date and time: 2024-08-22 10:13",
+            strip_tags($ticket->fields['content']),
+        );
+    }
+
+    public function testDateAnswerIsDisplayedInTicketDescription(): void
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion(
+            name: "Date",
+            type: QuestionTypeDateTime::class,
+            extra_data: json_encode([
+                'is_date_enabled' => 1,
+                'is_time_enabled' => 0,
+            ])
+        );
+        $builder->addDestination(FormDestinationTicket::class, "My ticket");
+        $form = $this->createForm($builder);
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Date" => "2024-08-22",
+        ]);
+
+        $this->assertStringContainsString(
+            "1) Date: 2024-08-22",
+            strip_tags($ticket->fields['content']),
+        );
+    }
+
+    public function testTimeAnswerIsDisplayedInTicketDescription(): void
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion(
+            name: "Time",
+            type: QuestionTypeDateTime::class,
+            extra_data: json_encode([
+                'is_date_enabled' => 0,
+                'is_time_enabled' => 1,
+            ])
+        );
+        $builder->addDestination(FormDestinationTicket::class, "My ticket");
+        $form = $this->createForm($builder);
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Time" => "23:10",
+        ]);
+
+        $this->assertStringContainsString(
+            "1) Time: 23:10",
+            strip_tags($ticket->fields['content']),
+        );
+    }
+}

--- a/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeDateTimeTest.php
+++ b/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeDateTimeTest.php
@@ -53,7 +53,7 @@ final class QuestionTypeDateTimeTest extends DbTestCase
             type: QuestionTypeDateTime::class,
             extra_data: json_encode([
                 'is_date_enabled' => 1,
-                'is_time_enabled' => 0,
+                'is_time_enabled' => 1,
             ])
         );
         $builder->addDestination(FormDestinationTicket::class, "My ticket");

--- a/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeDropdownTest.php
+++ b/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeDropdownTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\QuestionType;
+
+use DbTestCase;
+use Glpi\Form\Destination\FormDestinationTicket;
+use Glpi\Form\QuestionType\QuestionTypeDropdown;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+
+final class QuestionTypeDropdownTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public function testSingleValueDropdownAnswerIsDisplayedInTicketDescription(): void
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion(
+            name: "Your favorite color",
+            type: QuestionTypeDropdown::class,
+            extra_data: json_encode([
+                'options' => ['Blue', 'Green', 'Red', 'Yellow', 'Black'],
+            ])
+        );
+        $builder->addDestination(FormDestinationTicket::class, "My ticket");
+        $form = $this->createForm($builder);
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Your favorite color" => ['Red'],
+        ]);
+
+        $this->assertStringContainsString(
+            "1) Your favorite color: Red",
+            strip_tags($ticket->fields['content']),
+        );
+    }
+
+    public function testMultipleValuesDropdownAnswerAreDisplayedInTicketDescription(): void
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion(
+            name: "Your favorite colors",
+            type: QuestionTypeDropdown::class,
+            extra_data: json_encode([
+                'options' => ['Blue', 'Green', 'Red', 'Yellow', 'Black'],
+                'is_multiple_dropdown' => 1,
+            ])
+        );
+        $builder->addDestination(FormDestinationTicket::class, "My ticket");
+        $form = $this->createForm($builder);
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Your favorite colors" => ['Red', 'Yellow'],
+        ]);
+
+        $this->assertStringContainsString(
+            "1) Your favorite colors: Red, Yellow",
+            strip_tags($ticket->fields['content']),
+        );
+    }
+}

--- a/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeEmailTest.php
+++ b/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeEmailTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\QuestionType;
+
+use DbTestCase;
+use Glpi\Form\Destination\FormDestinationTicket;
+use Glpi\Form\QuestionType\QuestionTypeEmail;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+
+final class QuestionTypeEmailTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public function testEmailAnswerIsDisplayedInTicketDescription(): void
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion("Email", QuestionTypeEmail::class);
+        $builder->addDestination(FormDestinationTicket::class, "My ticket");
+        $form = $this->createForm($builder);
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Email" => "iloveglpi@mail.com",
+        ]);
+
+        $this->assertStringContainsString(
+            "1) Email: iloveglpi@mail.com",
+            strip_tags($ticket->fields['content']),
+        );
+    }
+}

--- a/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeItemDropdownTest.php
+++ b/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeItemDropdownTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\QuestionType;
+
+use DbTestCase;
+use Glpi\Form\Destination\FormDestinationTicket;
+use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+use ITILCategory;
+
+final class QuestionTypeItemDropdownTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public function testItemDropdownAnswerIsDisplayedInTicketDescription(): void
+    {
+        $category = $this->createItem(ITILCategory::class, [
+            'name' => 'My category',
+        ]);
+
+        $builder = new FormBuilder();
+        $builder->addQuestion("Category", QuestionTypeItemDropdown::class);
+        $builder->addDestination(FormDestinationTicket::class, "My ticket");
+        $form = $this->createForm($builder);
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Category" => [
+                'itemtype' => ITILCategory::class,
+                'items_id' => $category->getID()
+            ],
+        ]);
+
+        $this->assertStringContainsString(
+            "1) Category: My category",
+            strip_tags($ticket->fields['content']),
+        );
+    }
+}

--- a/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeLongTextTest.php
+++ b/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeLongTextTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\QuestionType;
+
+use DbTestCase;
+use Glpi\Form\Destination\FormDestinationTicket;
+use Glpi\Form\QuestionType\QuestionTypeLongText;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+
+final class QuestionTypeLongTextTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public function testLongTextAnswerIsDisplayedInTicketDescription(): void
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion("Description", QuestionTypeLongText::class);
+        $builder->addDestination(FormDestinationTicket::class, "My ticket");
+        $form = $this->createForm($builder);
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Description" => "my description",
+        ]);
+
+        $this->assertStringContainsString(
+            "1) Description: my description",
+            strip_tags($ticket->fields['content']),
+        );
+    }
+}

--- a/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeNumberTest.php
+++ b/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeNumberTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\QuestionType;
+
+use DbTestCase;
+use Glpi\Form\Destination\FormDestinationTicket;
+use Glpi\Form\QuestionType\QuestionTypeNumber;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+
+final class QuestionTypeNumberTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public function testEmailAnswerIsDisplayedInTicketDescription(): void
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion("Age", QuestionTypeNumber::class);
+        $builder->addDestination(FormDestinationTicket::class, "My ticket");
+        $form = $this->createForm($builder);
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Age" => 41,
+        ]);
+
+        $this->assertStringContainsString(
+            "1) Age: 41",
+            strip_tags($ticket->fields['content']),
+        );
+    }
+}

--- a/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeObserverTest.php
+++ b/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeObserverTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\QuestionType;
+
+use DbTestCase;
+use Glpi\Form\Destination\FormDestinationTicket;
+use Glpi\Form\QuestionType\QuestionTypeObserver;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+use Group;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Profile;
+use Profile_User;
+use User;
+
+final class QuestionTypeObserverTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public static function singleObserverAnswerIsDisplayedInTicketDescriptionProvider(): iterable
+    {
+        $glpi_id = getItemByTypeName(User::class, "glpi", true);
+        yield 'simple user' => [
+            'answer' => ["users_id-$glpi_id"],
+            'expected' => "glpi",
+        ];
+
+        $test_group_1_id = getItemByTypeName(Group::class, "_test_group_1", true);
+        yield 'simple group' => [
+            'answer' => ["groups_id-$test_group_1_id"],
+            'expected' => "_test_group_1",
+        ];
+    }
+
+    #[DataProvider("singleObserverAnswerIsDisplayedInTicketDescriptionProvider")]
+    public function testSingleObserverAnswerIsDisplayedInTicketDescription(
+        array $answer,
+        string $expected
+    ): void {
+        $builder = new FormBuilder();
+        $builder->addQuestion("Observer", QuestionTypeObserver::class);
+        $builder->addDestination(FormDestinationTicket::class, "My ticket");
+        $form = $this->createForm($builder);
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Observer" => $answer,
+        ]);
+
+        $this->assertStringContainsString(
+            "1) Observer: $expected",
+            strip_tags($ticket->fields['content']),
+        );
+    }
+
+    public static function multipleObserverAnswerIsDisplayedInTicketDescriptionProvider(): iterable
+    {
+        $glpi_id = getItemByTypeName(User::class, "glpi", true);
+        $tech_id = getItemByTypeName(User::class, "tech", true);
+        yield 'multiple users' => [
+            'answer' => [
+                "users_id-$glpi_id",
+                "users_id-$tech_id",
+            ],
+            'expected' => "glpi, tech",
+        ];
+
+        $test_group_1_id = getItemByTypeName(Group::class, "_test_group_1", true);
+        $test_group_2_id = getItemByTypeName(Group::class, "_test_group_2", true);
+        yield 'multiple groups' => [
+            'answer' => [
+                "groups_id-$test_group_1_id",
+                "groups_id-$test_group_2_id",
+            ],
+            'expected' => "_test_group_1, _test_group_2",
+        ];
+    }
+
+    #[DataProvider("multipleObserverAnswerIsDisplayedInTicketDescriptionProvider")]
+    public function testMultipleObserverAnswerIsDisplayedInTicketDescription(
+        array $answer,
+        string $expected
+    ): void {
+        $builder = new FormBuilder();
+        $builder->addQuestion("Observer", QuestionTypeObserver::class);
+        $builder->addDestination(FormDestinationTicket::class, "My ticket", ['is_multiple_actors' => true]);
+        $form = $this->createForm($builder);
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Observer" => $answer,
+        ]);
+
+        $this->assertStringContainsString(
+            "1) Observer: $expected",
+            strip_tags($ticket->fields['content']),
+        );
+    }
+
+    public function testObserverUserWithFullNameIsDisplayedInTicketDescription(): void
+    {
+        // Create a user with a fully qualified name and allow him to be an Observer by making him super admin profile
+        $john_doe = $this->createItem(User::class, [
+            'name' => 'jdoe',
+            'firstname' => 'John',
+            'realname' => 'Doe',
+        ]);
+        $this->createItem(Profile_User::class, [
+            'users_id' => $john_doe->getID(),
+            'profiles_id' => getItemByTypeName(Profile::class, 'Super-Admin', true),
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+        ]);
+
+        $builder = new FormBuilder();
+        $builder->addQuestion("Observer", QuestionTypeObserver::class);
+        $builder->addDestination(FormDestinationTicket::class, "My ticket");
+        $form = $this->createForm($builder);
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Observer" => ["users_id-{$john_doe->getID()}"],
+        ]);
+
+        $this->assertStringContainsString(
+            "1) Observer: Doe John",
+            strip_tags($ticket->fields['content']),
+        );
+    }
+}

--- a/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeObserverTest.php
+++ b/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeObserverTest.php
@@ -50,72 +50,57 @@ final class QuestionTypeObserverTest extends DbTestCase
 {
     use FormTesterTrait;
 
-    public static function singleObserverAnswerIsDisplayedInTicketDescriptionProvider(): iterable
-    {
-        $glpi_id = getItemByTypeName(User::class, "glpi", true);
-        yield 'simple user' => [
-            'answer' => ["users_id-$glpi_id"],
-            'expected' => "glpi",
-        ];
-
-        $test_group_1_id = getItemByTypeName(Group::class, "_test_group_1", true);
-        yield 'simple group' => [
-            'answer' => ["groups_id-$test_group_1_id"],
-            'expected' => "_test_group_1",
-        ];
-    }
-
-    #[DataProvider("singleObserverAnswerIsDisplayedInTicketDescriptionProvider")]
-    public function testSingleObserverAnswerIsDisplayedInTicketDescription(
-        array $answer,
-        string $expected
-    ): void {
-        $builder = new FormBuilder();
-        $builder->addQuestion("Observer", QuestionTypeObserver::class);
-        $builder->addDestination(FormDestinationTicket::class, "My ticket");
-        $form = $this->createForm($builder);
-
-        $ticket = $this->sendFormAndGetCreatedTicket($form, [
-            "Observer" => $answer,
-        ]);
-
-        $this->assertStringContainsString(
-            "1) Observer: $expected",
-            strip_tags($ticket->fields['content']),
-        );
-    }
-
-    public static function multipleObserverAnswerIsDisplayedInTicketDescriptionProvider(): iterable
+    public static function observerAnswerIsDisplayedInTicketDescriptionProvider(): iterable
     {
         $glpi_id = getItemByTypeName(User::class, "glpi", true);
         $tech_id = getItemByTypeName(User::class, "tech", true);
+        $test_group_1_id = getItemByTypeName(Group::class, "_test_group_1", true);
+        $test_group_2_id = getItemByTypeName(Group::class, "_test_group_2", true);
+
+        yield 'simple user' => [
+            'answer' => ["users_id-$glpi_id"],
+            'expected' => "glpi",
+            'is_multiple' => false,
+        ];
+
+        yield 'simple group' => [
+            'answer' => ["groups_id-$test_group_1_id"],
+            'expected' => "_test_group_1",
+            'is_multiple' => false,
+        ];
+
         yield 'multiple users' => [
             'answer' => [
                 "users_id-$glpi_id",
                 "users_id-$tech_id",
             ],
             'expected' => "glpi, tech",
+            'is_multiple' => true,
         ];
 
-        $test_group_1_id = getItemByTypeName(Group::class, "_test_group_1", true);
-        $test_group_2_id = getItemByTypeName(Group::class, "_test_group_2", true);
         yield 'multiple groups' => [
             'answer' => [
                 "groups_id-$test_group_1_id",
                 "groups_id-$test_group_2_id",
             ],
             'expected' => "_test_group_1, _test_group_2",
+            'is_multiple' => true,
         ];
     }
 
-    #[DataProvider("multipleObserverAnswerIsDisplayedInTicketDescriptionProvider")]
-    public function testMultipleObserverAnswerIsDisplayedInTicketDescription(
+    #[DataProvider("observerAnswerIsDisplayedInTicketDescriptionProvider")]
+    public function testObserverAnswerIsDisplayedInTicketDescription(
         array $answer,
-        string $expected
+        string $expected,
+        bool $is_multiple
     ): void {
         $builder = new FormBuilder();
         $builder->addQuestion("Observer", QuestionTypeObserver::class);
-        $builder->addDestination(FormDestinationTicket::class, "My ticket", ['is_multiple_actors' => true]);
+        $builder->addDestination(
+            FormDestinationTicket::class,
+            "My ticket",
+            ['is_multiple_actors' => $is_multiple]
+        );
         $form = $this->createForm($builder);
 
         $ticket = $this->sendFormAndGetCreatedTicket($form, [

--- a/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeRadioTest.php
+++ b/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeRadioTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\QuestionType;
+
+use DbTestCase;
+use Glpi\Form\Destination\FormDestinationTicket;
+use Glpi\Form\QuestionType\QuestionTypeRadio;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+
+final class QuestionTypeRadioTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public function testRadioAnswerIsDisplayedInTicketDescription(): void
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion(
+            name: "Your favorite software",
+            type: QuestionTypeRadio::class,
+            extra_data: json_encode([
+                'options' => ['GLPI', 'GLPI again', 'Still GLPI'],
+            ])
+        );
+        $builder->addDestination(FormDestinationTicket::class, "My ticket");
+        $form = $this->createForm($builder);
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Your favorite software" => 'GLPI again',
+        ]);
+
+        $this->assertStringContainsString(
+            "1) Your favorite software: GLPI again",
+            strip_tags($ticket->fields['content']),
+        );
+    }
+}

--- a/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeRequestTypeTest.php
+++ b/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeRequestTypeTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\QuestionType;
+
+use DbTestCase;
+use Glpi\Form\Destination\FormDestinationTicket;
+use Glpi\Form\QuestionType\QuestionTypeRequestType;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+use Ticket;
+
+final class QuestionTypeRequestTypeTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public function testRequestTypeAnswerIsDisplayedInTicketDescription(): void
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion("Request type", QuestionTypeRequestType::class);
+        $builder->addDestination(FormDestinationTicket::class, "My ticket");
+        $form = $this->createForm($builder);
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Request type" => Ticket::DEMAND_TYPE,
+        ]);
+
+        $this->assertStringContainsString(
+            "1) Request type: Request",
+            strip_tags($ticket->fields['content']),
+        );
+    }
+}

--- a/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeRequesterTest.php
+++ b/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeRequesterTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\QuestionType;
+
+use DbTestCase;
+use Glpi\Form\Destination\FormDestinationTicket;
+use Glpi\Form\QuestionType\QuestionTypeRequester;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+use Group;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Profile;
+use Profile_User;
+use User;
+
+final class QuestionTypeRequesterTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public static function singleRequesterAnswerIsDisplayedInTicketDescriptionProvider(): iterable
+    {
+        $glpi_id = getItemByTypeName(User::class, "glpi", true);
+        yield 'simple user' => [
+            'answer' => ["users_id-$glpi_id"],
+            'expected' => "glpi",
+        ];
+
+        $test_group_1_id = getItemByTypeName(Group::class, "_test_group_1", true);
+        yield 'simple group' => [
+            'answer' => ["groups_id-$test_group_1_id"],
+            'expected' => "_test_group_1",
+        ];
+    }
+
+    #[DataProvider("singleRequesterAnswerIsDisplayedInTicketDescriptionProvider")]
+    public function testSingleRequesterAnswerIsDisplayedInTicketDescription(
+        array $answer,
+        string $expected
+    ): void {
+        $builder = new FormBuilder();
+        $builder->addQuestion("Requester", QuestionTypeRequester::class);
+        $builder->addDestination(FormDestinationTicket::class, "My ticket");
+        $form = $this->createForm($builder);
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Requester" => $answer,
+        ]);
+
+        $this->assertStringContainsString(
+            "1) Requester: $expected",
+            strip_tags($ticket->fields['content']),
+        );
+    }
+
+    public static function multipleRequesterAnswerIsDisplayedInTicketDescriptionProvider(): iterable
+    {
+        $glpi_id = getItemByTypeName(User::class, "glpi", true);
+        $tech_id = getItemByTypeName(User::class, "tech", true);
+        yield 'multiple users' => [
+            'answer' => [
+                "users_id-$glpi_id",
+                "users_id-$tech_id",
+            ],
+            'expected' => "glpi, tech",
+        ];
+
+        $test_group_1_id = getItemByTypeName(Group::class, "_test_group_1", true);
+        $test_group_2_id = getItemByTypeName(Group::class, "_test_group_2", true);
+        yield 'multiple groups' => [
+            'answer' => [
+                "groups_id-$test_group_1_id",
+                "groups_id-$test_group_2_id",
+            ],
+            'expected' => "_test_group_1, _test_group_2",
+        ];
+    }
+
+    #[DataProvider("multipleRequesterAnswerIsDisplayedInTicketDescriptionProvider")]
+    public function testMultipleRequesterAnswerIsDisplayedInTicketDescription(
+        array $answer,
+        string $expected
+    ): void {
+        $builder = new FormBuilder();
+        $builder->addQuestion("Requester", QuestionTypeRequester::class);
+        $builder->addDestination(FormDestinationTicket::class, "My ticket", ['is_multiple_actors' => true]);
+        $form = $this->createForm($builder);
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Requester" => $answer,
+        ]);
+
+        $this->assertStringContainsString(
+            "1) Requester: $expected",
+            strip_tags($ticket->fields['content']),
+        );
+    }
+
+    public function testRequesterUserWithFullNameIsDisplayedInTicketDescription(): void
+    {
+        // Create a user with a fully qualified name and allow him to be an Requester by making him super admin profile
+        $john_doe = $this->createItem(User::class, [
+            'name' => 'jdoe',
+            'firstname' => 'John',
+            'realname' => 'Doe',
+        ]);
+        $this->createItem(Profile_User::class, [
+            'users_id' => $john_doe->getID(),
+            'profiles_id' => getItemByTypeName(Profile::class, 'Super-Admin', true),
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+        ]);
+
+        $builder = new FormBuilder();
+        $builder->addQuestion("Requester", QuestionTypeRequester::class);
+        $builder->addDestination(FormDestinationTicket::class, "My ticket");
+        $form = $this->createForm($builder);
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Requester" => ["users_id-{$john_doe->getID()}"],
+        ]);
+
+        $this->assertStringContainsString(
+            "1) Requester: Doe John",
+            strip_tags($ticket->fields['content']),
+        );
+    }
+}

--- a/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeRequesterTest.php
+++ b/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeRequesterTest.php
@@ -50,45 +50,23 @@ final class QuestionTypeRequesterTest extends DbTestCase
 {
     use FormTesterTrait;
 
-    public static function singleRequesterAnswerIsDisplayedInTicketDescriptionProvider(): iterable
+    public static function requesterAnswerIsDisplayedInTicketDescriptionProvider(): iterable
     {
         $glpi_id = getItemByTypeName(User::class, "glpi", true);
+        $tech_id = getItemByTypeName(User::class, "tech", true);
+        $test_group_1_id = getItemByTypeName(Group::class, "_test_group_1", true);
+        $test_group_2_id = getItemByTypeName(Group::class, "_test_group_2", true);
+
         yield 'simple user' => [
             'answer' => ["users_id-$glpi_id"],
             'expected' => "glpi",
         ];
 
-        $test_group_1_id = getItemByTypeName(Group::class, "_test_group_1", true);
         yield 'simple group' => [
             'answer' => ["groups_id-$test_group_1_id"],
             'expected' => "_test_group_1",
         ];
-    }
 
-    #[DataProvider("singleRequesterAnswerIsDisplayedInTicketDescriptionProvider")]
-    public function testSingleRequesterAnswerIsDisplayedInTicketDescription(
-        array $answer,
-        string $expected
-    ): void {
-        $builder = new FormBuilder();
-        $builder->addQuestion("Requester", QuestionTypeRequester::class);
-        $builder->addDestination(FormDestinationTicket::class, "My ticket");
-        $form = $this->createForm($builder);
-
-        $ticket = $this->sendFormAndGetCreatedTicket($form, [
-            "Requester" => $answer,
-        ]);
-
-        $this->assertStringContainsString(
-            "1) Requester: $expected",
-            strip_tags($ticket->fields['content']),
-        );
-    }
-
-    public static function multipleRequesterAnswerIsDisplayedInTicketDescriptionProvider(): iterable
-    {
-        $glpi_id = getItemByTypeName(User::class, "glpi", true);
-        $tech_id = getItemByTypeName(User::class, "tech", true);
         yield 'multiple users' => [
             'answer' => [
                 "users_id-$glpi_id",
@@ -97,8 +75,6 @@ final class QuestionTypeRequesterTest extends DbTestCase
             'expected' => "glpi, tech",
         ];
 
-        $test_group_1_id = getItemByTypeName(Group::class, "_test_group_1", true);
-        $test_group_2_id = getItemByTypeName(Group::class, "_test_group_2", true);
         yield 'multiple groups' => [
             'answer' => [
                 "groups_id-$test_group_1_id",
@@ -108,14 +84,18 @@ final class QuestionTypeRequesterTest extends DbTestCase
         ];
     }
 
-    #[DataProvider("multipleRequesterAnswerIsDisplayedInTicketDescriptionProvider")]
-    public function testMultipleRequesterAnswerIsDisplayedInTicketDescription(
+    #[DataProvider("requesterAnswerIsDisplayedInTicketDescriptionProvider")]
+    public function testRequesterAnswerIsDisplayedInTicketDescription(
         array $answer,
         string $expected
     ): void {
         $builder = new FormBuilder();
         $builder->addQuestion("Requester", QuestionTypeRequester::class);
-        $builder->addDestination(FormDestinationTicket::class, "My ticket", ['is_multiple_actors' => true]);
+        $builder->addDestination(
+            FormDestinationTicket::class,
+            "My ticket",
+            ['is_multiple_actors' => count($answer) > 1]
+        );
         $form = $this->createForm($builder);
 
         $ticket = $this->sendFormAndGetCreatedTicket($form, [

--- a/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeShortTextTest.php
+++ b/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeShortTextTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\QuestionType;
+
+use DbTestCase;
+use Glpi\Form\Destination\FormDestinationTicket;
+use Glpi\Form\QuestionType\QuestionTypeShortText;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+
+final class QuestionTypeShortTextTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public function testShortTextAnswerIsDisplayedInTicketDescription(): void
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion("First name", QuestionTypeShortText::class);
+        $builder->addDestination(FormDestinationTicket::class, "My ticket");
+        $form = $this->createForm($builder);
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "First name" => "John",
+        ]);
+
+        $this->assertStringContainsString(
+            "1) First name: John",
+            strip_tags($ticket->fields['content']),
+        );
+    }
+}

--- a/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeUrgencyTest.php
+++ b/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeUrgencyTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\QuestionType;
+
+use DbTestCase;
+use Glpi\Form\Destination\FormDestinationTicket;
+use Glpi\Form\QuestionType\QuestionTypeUrgency;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+
+final class QuestionTypeUrgencyTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public function testUrgencyAnswerIsDisplayedInTicketDescription(): void
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion("What is the urgency", QuestionTypeUrgency::class);
+        $builder->addDestination(FormDestinationTicket::class, "My ticket");
+        $form = $this->createForm($builder);
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "What is the urgency" => 5, // Very high
+        ]);
+
+        $this->assertStringContainsString(
+            "1) What is the urgency: Very high",
+            strip_tags($ticket->fields['content']),
+        );
+    }
+}

--- a/src/Glpi/Form/Answer.php
+++ b/src/Glpi/Form/Answer.php
@@ -84,7 +84,7 @@ final readonly class Answer implements JsonSerializable
         return $this->raw_answer;
     }
 
-    public function getFormattedAnswer(): string
+    public function getFormattedAnswer(): ?string
     {
         $type = $this->getType();
         if ($type === null) {

--- a/src/Glpi/Form/Answer.php
+++ b/src/Glpi/Form/Answer.php
@@ -84,6 +84,16 @@ final readonly class Answer implements JsonSerializable
         return $this->raw_answer;
     }
 
+    public function getFormattedAnswer(): string
+    {
+        $type = $this->getType();
+        if ($type === null) {
+            return null;
+        }
+
+        return $type->formatRawAnswer($this->getRawAnswer());
+    }
+
     public function getQuestionLabel(): string
     {
         return $this->question_label;

--- a/src/Glpi/Form/QuestionType/AbstractQuestionType.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionType.php
@@ -35,6 +35,7 @@
 
 namespace Glpi\Form\QuestionType;
 
+use Glpi\Application\View\TemplateRenderer;
 use Glpi\Form\Question;
 use Override;
 
@@ -86,6 +87,28 @@ abstract class AbstractQuestionType implements QuestionTypeInterface
     public function renderAdministrationOptionsTemplate(?Question $question): string
     {
         return ''; // No options by default
+    }
+
+    #[Override]
+    public function renderAnswerTemplate($answer): string
+    {
+        return TemplateRenderer::getInstance()->renderFromStringTemplate(
+            '<div class="form-control-plaintext">{{ answer }}</div>',
+            ['answer' => $this->formatRawAnswer($answer)]
+        );
+    }
+
+    #[Override]
+    public function formatRawAnswer($answer): string
+    {
+        // By default only return the string ansswer
+        if (!is_string($answer) && !is_numeric($answer)) {
+            throw new \InvalidArgumentException(
+                'Raw answer must be a string or a method must be implemented to format the answer'
+            );
+        }
+
+        return (string) $answer;
     }
 
     #[Override]

--- a/src/Glpi/Form/QuestionType/AbstractQuestionType.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionType.php
@@ -101,7 +101,7 @@ abstract class AbstractQuestionType implements QuestionTypeInterface
     #[Override]
     public function formatRawAnswer($answer): string
     {
-        // By default only return the string ansswer
+        // By default only return the string answer
         if (!is_string($answer) && !is_numeric($answer)) {
             throw new \InvalidArgumentException(
                 'Raw answer must be a string or a method must be implemented to format the answer'

--- a/src/Glpi/Form/QuestionType/AbstractQuestionType.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionType.php
@@ -90,7 +90,7 @@ abstract class AbstractQuestionType implements QuestionTypeInterface
     }
 
     #[Override]
-    public function renderAnswerTemplate($answer): string
+    public function renderAnswerTemplate(mixed $answer): string
     {
         return TemplateRenderer::getInstance()->renderFromStringTemplate(
             '<div class="form-control-plaintext">{{ answer }}</div>',
@@ -99,7 +99,7 @@ abstract class AbstractQuestionType implements QuestionTypeInterface
     }
 
     #[Override]
-    public function formatRawAnswer($answer): string
+    public function formatRawAnswer(mixed $answer): string
     {
         // By default only return the string answer
         if (!is_string($answer) && !is_numeric($answer)) {

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
@@ -252,6 +252,26 @@ TWIG;
     }
 
     #[Override]
+    public function formatRawAnswer($answer): string
+    {
+        $formatted_actors = [];
+        foreach ($answer as $actor) {
+            foreach ($this->getAllowedActorTypes() as $type) {
+                if (strpos($actor, $type::getForeignKeyField()) === 0) {
+                    $items_id = (int)substr($actor, strlen($type::getForeignKeyField()) + 1);
+                    $item     = $type::getById($items_id);
+
+                    if ($item !== null) {
+                        $formatted_actors[] = $item->fields['name'];
+                    }
+                }
+            }
+        }
+
+        return implode(', ', $formatted_actors);
+    }
+
+    #[Override]
     public function renderEndUserTemplate(Question $question): string
     {
         $template = <<<TWIG

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
@@ -262,7 +262,7 @@ TWIG;
                     $item     = $type::getById($items_id);
 
                     if ($item !== null) {
-                        $formatted_actors[] = $item->fields['name'];
+                        $formatted_actors[] = $item->getName();
                     }
                 }
             }

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
@@ -223,7 +223,7 @@ TWIG;
     }
 
     #[Override]
-    public function renderAnswerTemplate($answer): string
+    public function renderAnswerTemplate(mixed $answer): string
     {
         $template = <<<TWIG
             <div class="form-control-plaintext">
@@ -252,7 +252,7 @@ TWIG;
     }
 
     #[Override]
-    public function formatRawAnswer($answer): string
+    public function formatRawAnswer(mixed $answer): string
     {
         $formatted_actors = [];
         foreach ($answer as $actor) {

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
@@ -292,7 +292,7 @@ TWIG;
                 <label class="form-check">
                     <input
                         type="{{ input_type }}"
-                        name="{{ question.getEndUserInputName() }}"
+                        name="{{ question.getEndUserInputName() }}[]"
                         value="{{ value.value }}"
                         class="form-check-input" {{ value.checked ? 'checked' : '' }}
                     >
@@ -307,6 +307,16 @@ TWIG;
             'values'     => $this->getValues($question),
             'input_type' => $this->getInputType($question),
         ]);
+    }
+
+    #[Override]
+    public function formatRawAnswer($answer): string
+    {
+        if (is_string($answer)) {
+            return $answer;
+        }
+
+        return implode(', ', $answer);
     }
 
     #[Override]

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
@@ -310,7 +310,7 @@ TWIG;
     }
 
     #[Override]
-    public function formatRawAnswer($answer): string
+    public function formatRawAnswer(mixed $answer): string
     {
         if (is_string($answer)) {
             return $answer;

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
@@ -138,19 +138,6 @@ TWIG;
     }
 
     #[Override]
-    public function renderAnswerTemplate($answer): string
-    {
-        $template = <<<TWIG
-            <div class="form-control-plaintext">{{ answer }}</div>
-TWIG;
-
-        $twig = TemplateRenderer::getInstance();
-        return $twig->renderFromStringTemplate($template, [
-            'answer' => $answer,
-        ]);
-    }
-
-    #[Override]
     public function getCategory(): QuestionTypeCategory
     {
         return QuestionTypeCategory::SHORT_ANSWER;

--- a/src/Glpi/Form/QuestionType/QuestionTypeDateTime.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeDateTime.php
@@ -337,16 +337,9 @@ TWIG;
     }
 
     #[Override]
-    public function renderAnswerTemplate($answer): string
+    public function formatRawAnswer($answer): string
     {
-        $template = <<<TWIG
-            <div class="form-control-plaintext">{{ answer }}</div>
-TWIG;
-
-        $twig = TemplateRenderer::getInstance();
-        return $twig->renderFromStringTemplate($template, [
-            'answer' => $this->formatAnswer($answer),
-        ]);
+        return $this->formatAnswer($answer);
     }
 
     #[Override]

--- a/src/Glpi/Form/QuestionType/QuestionTypeDateTime.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeDateTime.php
@@ -337,7 +337,7 @@ TWIG;
     }
 
     #[Override]
-    public function formatRawAnswer($answer): string
+    public function formatRawAnswer(mixed $answer): string
     {
         return $this->formatAnswer($answer);
     }

--- a/src/Glpi/Form/QuestionType/QuestionTypeFile.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeFile.php
@@ -133,6 +133,15 @@ TWIG;
     }
 
     #[Override]
+    public function formatRawAnswer($answer): string
+    {
+        return implode(', ', array_map(
+            fn($document_id) => (new Document())->getById($document_id)->fields['filename'],
+            $answer
+        ));
+    }
+
+    #[Override]
     public function getCategory(): QuestionTypeCategory
     {
         return QuestionTypeCategory::FILE;

--- a/src/Glpi/Form/QuestionType/QuestionTypeFile.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeFile.php
@@ -116,7 +116,7 @@ TWIG;
     }
 
     #[Override]
-    public function renderAnswerTemplate($answer): string
+    public function renderAnswerTemplate(mixed $answer): string
     {
         $template = <<<TWIG
             {% for document in documents %}
@@ -133,7 +133,7 @@ TWIG;
     }
 
     #[Override]
-    public function formatRawAnswer($answer): string
+    public function formatRawAnswer(mixed $answer): string
     {
         return implode(', ', array_map(
             fn($document_id) => (new Document())->getById($document_id)->fields['filename'],

--- a/src/Glpi/Form/QuestionType/QuestionTypeInterface.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeInterface.php
@@ -134,6 +134,16 @@ interface QuestionTypeInterface
     public function renderAnswerTemplate($answer): string;
 
     /**
+     * Format the given answer.
+     * This method is used to format the answer to display.
+     *
+     * @param mixed $answer Given raw answer data.
+     *
+     * @return string
+     */
+    public function formatRawAnswer($answer): string;
+
+    /**
      * Get the name of this questions type.
      *
      * @return string

--- a/src/Glpi/Form/QuestionType/QuestionTypeInterface.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeInterface.php
@@ -131,7 +131,7 @@ interface QuestionTypeInterface
      *
      * @return string
      */
-    public function renderAnswerTemplate($answer): string;
+    public function renderAnswerTemplate(mixed $answer): string;
 
     /**
      * Format the given answer.
@@ -141,7 +141,7 @@ interface QuestionTypeInterface
      *
      * @return string
      */
-    public function formatRawAnswer($answer): string;
+    public function formatRawAnswer(mixed $answer): string;
 
     /**
      * Get the name of this questions type.

--- a/src/Glpi/Form/QuestionType/QuestionTypeItem.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItem.php
@@ -39,6 +39,7 @@ use CartridgeItem;
 use ConsumableItem;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Form\Question;
+use Group;
 use Line;
 use Override;
 use PassiveDCEquipment;
@@ -235,6 +236,17 @@ TWIG;
             'itemtype' => $answer['itemtype'],
             'items_id' => $answer['items_id'],
         ]);
+    }
+
+    #[Override]
+    public function formatRawAnswer($answer): string
+    {
+        $item = $answer['itemtype']::getById($answer['items_id']);
+        if (!$item) {
+            return '';
+        }
+
+        return $item->fields['name'];
     }
 
     #[Override]

--- a/src/Glpi/Form/QuestionType/QuestionTypeItem.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItem.php
@@ -223,7 +223,7 @@ TWIG;
     }
 
     #[Override]
-    public function renderAnswerTemplate($answer): string
+    public function renderAnswerTemplate(mixed $answer): string
     {
         $template = <<<TWIG
             <div class="form-control-plaintext">
@@ -239,7 +239,7 @@ TWIG;
     }
 
     #[Override]
-    public function formatRawAnswer($answer): string
+    public function formatRawAnswer(mixed $answer): string
     {
         $item = $answer['itemtype']::getById($answer['items_id']);
         if (!$item) {

--- a/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
@@ -158,7 +158,7 @@ TWIG;
     }
 
     #[Override]
-    public function renderAnswerTemplate($answer): string
+    public function renderAnswerTemplate(mixed $answer): string
     {
         $template = <<<TWIG
             <div class="form-control-plaintext">{{ answer|safe_html }}</div>

--- a/src/Glpi/Form/QuestionType/QuestionTypeRequestType.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeRequestType.php
@@ -120,16 +120,9 @@ TWIG;
     }
 
     #[Override]
-    public function renderAnswerTemplate($answer): string
+    public function formatRawAnswer($answer): string
     {
-        $template = <<<TWIG
-            <div class="form-control-plaintext">{{ answer }}</div>
-TWIG;
-
-        $twig = TemplateRenderer::getInstance();
-        return $twig->renderFromStringTemplate($template, [
-            'answer' => Ticket::getTicketTypeName($answer)
-        ]);
+        return Ticket::getTicketTypeName($answer);
     }
 
     #[Override]

--- a/src/Glpi/Form/QuestionType/QuestionTypeRequestType.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeRequestType.php
@@ -120,7 +120,7 @@ TWIG;
     }
 
     #[Override]
-    public function formatRawAnswer($answer): string
+    public function formatRawAnswer(mixed $answer): string
     {
         return Ticket::getTicketTypeName($answer);
     }

--- a/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php
@@ -124,16 +124,9 @@ TWIG;
     }
 
     #[Override]
-    public function renderAnswerTemplate($answer): string
+    public function formatRawAnswer($answer): string
     {
-        $template = <<<TWIG
-            <div class="form-control-plaintext">{{ answer }}</div>
-TWIG;
-
-        $twig = TemplateRenderer::getInstance();
-        return $twig->renderFromStringTemplate($template, [
-            'answer' => CommonITILObject::getUrgencyName($answer)
-        ]);
+        return CommonITILObject::getUrgencyName($answer);
     }
 
     #[Override]

--- a/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php
@@ -124,7 +124,7 @@ TWIG;
     }
 
     #[Override]
-    public function formatRawAnswer($answer): string
+    public function formatRawAnswer(mixed $answer): string
     {
         return CommonITILObject::getUrgencyName($answer);
     }

--- a/src/Glpi/Form/Tag/AnswerTagProvider.php
+++ b/src/Glpi/Form/Tag/AnswerTagProvider.php
@@ -77,7 +77,7 @@ final class AnswerTagProvider implements TagProviderInterface
         }
 
         $answer = array_pop($answers);
-        return $answer->getRawAnswer();
+        return $answer->getFormattedAnswer();
     }
 
     public function getTagForQuestion(Question $question): Tag

--- a/tests/cypress/e2e/form/question_types/selectables.cy.js
+++ b/tests/cypress/e2e/form/question_types/selectables.cy.js
@@ -1,0 +1,206 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+describe('Selectable form question types', () => {
+    beforeEach(() => {
+        cy.createWithAPI('Glpi\\Form\\Form', {
+            'name': 'Tests form for the selectable form question types suite',
+        }).as('form_id');
+
+        cy.login();
+        cy.changeProfile('Super-Admin', true);
+
+        cy.get('@form_id').then((form_id) => {
+            const tab = 'Glpi\\Form\\Form$main';
+            cy.visit(`/front/form/form.form.php?id=${form_id}&forcetab=${tab}`);
+
+            // Add a new question
+            cy.findByRole("button", { name: "Add a new question" }).should('exist').click();
+
+            // Set the question name
+            cy.findByRole("textbox", { name: "Question name" }).should('exist').type("Test selectable question");
+        });
+    });
+
+    it('should configure a radio question type', () => {
+        describe('Configure question', () => {
+            // Change the question type
+            cy.getDropdownByLabelText('Question type').select('Radio');
+
+            // Add options
+            for (let index = 0; index < 3; index++) {
+                cy.findAllByRole('radio', { name: 'Default option' }).eq(index).should('exist').should('be.disabled');
+                cy.findAllByRole('textbox', { name: 'Selectable option' }).eq(index).type('Option ' + index);
+            }
+
+            // Save the form
+            cy.findByRole("button", { name: "Save" }).click();
+
+            // Reload the page
+            cy.reload();
+
+            // Check if options are still there
+            for (let index = 0; index < 3; index++) {
+                cy.findAllByRole('radio', { name: 'Default option' }).eq(index).should('exist').should('not.be.checked');
+                cy.findAllByRole('textbox', { name: 'Selectable option' }).eq(index).should('have.value', 'Option ' + index);
+            }
+
+            // Check the second option
+            cy.findAllByRole('radio', { name: 'Default option' }).eq(1).check();
+
+            // Save the form
+            cy.findByRole("button", { name: "Save" }).click();
+
+            // Reload the page
+            cy.reload();
+
+            // Check if the second option is still checked
+            cy.findAllByRole('radio', { name: 'Default option' }).eq(1).should('be.checked');
+        });
+
+
+        describe('Fill form', () => {
+            // Go to preview page (remove the target="_blank" attribute to stay in the same window)
+            cy.findByRole("link", { name: "Preview" })
+                .invoke('attr', 'target', '_self')
+                .click();
+
+            // Check if the question is displayed
+            cy.findByText('Test selectable question').should('exist');
+
+            // Check if the options are displayed
+            for (let index = 0; index < 3; index++) {
+                cy.findByRole('radio', { name: 'Option ' + index }).should('exist');
+            }
+
+            // Check if the second option is checked
+            cy.findByRole('radio', { name: 'Option 1' }).should('be.checked');
+
+            // Check the first option
+            cy.findByRole('radio', { name: 'Option 0' }).check();
+
+            // Check if the second option is not checked anymore
+            cy.findByRole('radio', { name: 'Option 1' }).should('not.be.checked');
+
+            // Submit the form
+            cy.findByRole("button", { name: "Send form" }).click();
+
+            // Check if the success message is displayed
+            cy.findByRole('alert').should('exist').should('contain.text', 'Item successfully created')
+                .find('a').should('exist').click();
+
+            // Check if the option is saved
+            cy.findByText('Option 0').should('exist');
+            cy.findByText('Option 1').should('not.exist');
+            cy.findByText('Option 2').should('not.exist');
+        });
+    });
+
+    it('should configure a checkbox question type', () => {
+        describe('Configure question', () => {
+            // Change the question type
+            cy.getDropdownByLabelText('Question type').select('Checkbox');
+
+            // Add options
+            for (let index = 0; index < 3; index++) {
+                cy.findAllByRole('checkbox', { name: 'Default option' }).eq(index).should('exist').should('be.disabled');
+                cy.findAllByRole('textbox', { name: 'Selectable option' }).eq(index).type('Option ' + index);
+            }
+
+            // Save the form
+            cy.findByRole("button", { name: "Save" }).click();
+
+            // Reload the page
+            cy.reload();
+
+            // Check if options are still there
+            for (let index = 0; index < 3; index++) {
+                cy.findAllByRole('checkbox', { name: 'Default option' }).eq(index).should('exist').should('not.be.checked');
+                cy.findAllByRole('textbox', { name: 'Selectable option' }).eq(index).should('have.value', 'Option ' + index);
+            }
+
+            // Check the second and third options
+            cy.findAllByRole('checkbox', { name: 'Default option' }).eq(1).check();
+            cy.findAllByRole('checkbox', { name: 'Default option' }).eq(2).check();
+
+            // Save the form
+            cy.findByRole("button", { name: "Save" }).click();
+
+            // Reload the page
+            cy.reload();
+
+            // Check if the second option is still checked
+            cy.findAllByRole('checkbox', { name: 'Default option' }).eq(1).should('be.checked');
+        });
+
+        describe('Fill form', () => {
+            // Go to preview page (remove the target="_blank" attribute to stay in the same window)
+            cy.findByRole("link", { name: "Preview" })
+                .invoke('attr', 'target', '_self')
+                .click();
+
+            // Check if the question is displayed
+            cy.findByText('Test selectable question').should('exist');
+
+            // Check if the options are displayed
+            for (let index = 0; index < 3; index++) {
+                cy.findByRole('checkbox', { name: 'Option ' + index }).should('exist');
+            }
+
+            // Check if the second and third options are checked
+            cy.findByRole('checkbox', { name: 'Option 1' }).should('be.checked');
+            cy.findByRole('checkbox', { name: 'Option 2' }).should('be.checked');
+
+            // Check the first option
+            cy.findByRole('checkbox', { name: 'Option 0' }).check();
+
+            // Uncheck the third option
+            cy.findByRole('checkbox', { name: 'Option 2' }).uncheck();
+
+            // Check if the second option is still checked
+            cy.findByRole('checkbox', { name: 'Option 1' }).should('be.checked');
+
+            // Submit the form
+            cy.findByRole("button", { name: "Send form" }).click();
+
+            // Check if the success message is displayed
+            cy.findByRole('alert').should('exist').should('contain.text', 'Item successfully created')
+                .find('a').should('exist').click();
+
+            // Check if the option is saved
+            cy.findByText('Option 0').should('exist');
+            cy.findByText('Option 1').should('exist');
+            cy.findByText('Option 2').should('not.exist');
+        });
+    });
+});

--- a/tests/src/FormTesterTrait.php
+++ b/tests/src/FormTesterTrait.php
@@ -347,8 +347,11 @@ trait FormTesterTrait
         $formatted_answers = [];
         foreach ($answers as $question => $answer) {
             $key = $this->getQuestionId($form, $question);
-            // Real answer will be decoded as string by default
-            $formatted_answers[$key] = (string) $answer;
+            if (is_numeric($answer)) {
+                // Real answer will be decoded as string by default
+                $answer = (string) $answer;
+            }
+            $formatted_answers[$key] = $answer;
         }
 
         // Submit form


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

Update `AnswerTagProvider` to return the formatted answer instead of the raw answer. This change improves the display of answers by formatting them based on their type. The `getFormattedAnswer()` method has been added to the `Answer` class, which formats the raw answer using the corresponding QuestionType's `formatRawAnswer()` method.