### PR TITLE
feat(forms): Add ITILCategory field configuration for form destination

### DIFF
--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/ITILCategoryFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/ITILCategoryFieldTest.php
@@ -1,0 +1,305 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\Destination\CommonITILField;
+
+use DbTestCase;
+use Glpi\Form\AnswersHandler\AnswersHandler;
+use Glpi\Form\Destination\CommonITILField\ITILCategoryFieldConfig;
+use Glpi\Form\Destination\CommonITILField\ITILCategoryFieldStrategy;
+use Glpi\Form\Destination\FormDestinationTicket;
+use Glpi\Form\Form;
+use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+use ITILCategory;
+use Ticket;
+use TicketTemplate;
+
+final class ITILCategoryFieldTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public function testSpecificITILCategory(): void
+    {
+        $form = $this->createAndGetFormWithMultipleITILCategoryQuestions();
+        $itilcategory = $this->createItem(ITILCategory::getType(), [
+            'name' => 'Test ITILCategory for specific value',
+        ]);
+
+        // Specific value
+        $this->sendFormAndAssertTicketType(
+            form: $form,
+            config: new ITILCategoryFieldConfig(
+                strategy: ITILCategoryFieldStrategy::SPECIFIC_VALUE,
+                specific_itilcategory_id: $itilcategory->getID()
+            ),
+            answers: [],
+            expected_itilcategory: $itilcategory->getID()
+        );
+
+        // No specific value
+        $this->sendFormAndAssertTicketType(
+            form: $form,
+            config: new ITILCategoryFieldConfig(
+                strategy: ITILCategoryFieldStrategy::SPECIFIC_VALUE,
+                specific_itilcategory_id: 0
+            ),
+            answers: [],
+            expected_itilcategory: 0
+        );
+    }
+
+    public function testSpecificITILCategoryWithSpecificTemplate(): void
+    {
+        $form = $this->createAndGetFormWithMultipleITILCategoryQuestions();
+        $ticket_template = $this->createItem(TicketTemplate::getType(), [
+            'name' => 'Test TicketTemplate for specific value',
+        ]);
+        $itilcategory = $this->createItem(ITILCategory::getType(), [
+            'name'                        => 'Test ITILCategory for specific value',
+            'tickettemplates_id_incident' => $ticket_template->getID(),
+        ]);
+
+        $created_ticket = $this->sendFormAndAssertTicketType(
+            form: $form,
+            config: new ITILCategoryFieldConfig(
+                strategy: ITILCategoryFieldStrategy::SPECIFIC_VALUE,
+                specific_itilcategory_id: $itilcategory->getID()
+            ),
+            answers: [],
+            expected_itilcategory: $itilcategory->getID()
+        );
+
+        $this->assertEquals($ticket_template->getID(), $created_ticket->fields['tickettemplates_id']);
+    }
+
+    public function testSpecificITILCategoryWithoutSpecificTemplate(): void
+    {
+        $form = $this->createAndGetFormWithMultipleITILCategoryQuestions();
+        $default_template = (new Ticket())->getITILTemplateToUse(
+            entities_id: $_SESSION["glpiactive_entity"]
+        );
+        $itilcategory = $this->createItem(ITILCategory::getType(), [
+            'name' => 'Test ITILCategory for specific value',
+        ]);
+
+        $created_ticket = $this->sendFormAndAssertTicketType(
+            form: $form,
+            config: new ITILCategoryFieldConfig(
+                strategy: ITILCategoryFieldStrategy::SPECIFIC_VALUE,
+                specific_itilcategory_id: $itilcategory->getID()
+            ),
+            answers: [],
+            expected_itilcategory: $itilcategory->getID()
+        );
+
+        $this->assertEquals($default_template->getID(), $created_ticket->fields['tickettemplates_id']);
+    }
+
+    public function testITILCategoryFromSpecificQuestion(): void
+    {
+        $form = $this->createAndGetFormWithMultipleITILCategoryQuestions();
+        $itilcategories = $this->createItems(ITILCategory::getType(), [
+            ['name' => 'Test ITILCategory 1 for specific question'],
+            ['name' => 'Test ITILCategory 2 for specific question'],
+        ]);
+
+        // Using answer from first question
+        $this->sendFormAndAssertTicketType(
+            form: $form,
+            config: new ITILCategoryFieldConfig(
+                strategy: ITILCategoryFieldStrategy::SPECIFIC_ANSWER,
+                specific_question_id: $this->getQuestionId($form, "ITILCategory 1")
+            ),
+            answers: [
+                "ITILCategory 1" => [
+                    'itemtype' => ITILCategory::getType(),
+                    'items_id' => $itilcategories[0]->getID()
+                ],
+                "ITILCategory 2" => [
+                    'itemtype' => ITILCategory::getType(),
+                    'items_id' => $itilcategories[1]->getID()
+                ],
+            ],
+            expected_itilcategory: $itilcategories[0]->getID()
+        );
+
+        // Using answer from second question
+        $this->sendFormAndAssertTicketType(
+            form: $form,
+            config: new ITILCategoryFieldConfig(
+                strategy: ITILCategoryFieldStrategy::SPECIFIC_ANSWER,
+                specific_question_id: $this->getQuestionId($form, "ITILCategory 2")
+            ),
+            answers: [
+                "ITILCategory 1" => [
+                    'itemtype' => ITILCategory::getType(),
+                    'items_id' => $itilcategories[0]->getID()
+                ],
+                "ITILCategory 2" => [
+                    'itemtype' => ITILCategory::getType(),
+                    'items_id' => $itilcategories[1]->getID()
+                ],
+            ],
+            expected_itilcategory: $itilcategories[1]->getID()
+        );
+    }
+
+    public function testITILCategoryFromLastValidQuestion(): void
+    {
+        $form = $this->createAndGetFormWithMultipleITILCategoryQuestions();
+        $itilcategories = $this->createItems(ITILCategory::getType(), [
+            ['name' => 'Test ITILCategory 1 for last valid answer'],
+            ['name' => 'Test ITILCategory 2 for last valid answer'],
+            ['name' => 'Test ITILCategory 3 for last valid answer'],
+        ]);
+        $last_valid_answer_config = new ITILCategoryFieldConfig(
+            ITILCategoryFieldStrategy::LAST_VALID_ANSWER
+        );
+
+        // With multiple answers submitted
+        $this->sendFormAndAssertTicketType(
+            form: $form,
+            config: $last_valid_answer_config,
+            answers: [
+                "ITILCategory 1" => [
+                    'itemtype' => ITILCategory::getType(),
+                    'items_id' => $itilcategories[0]->getID()
+                ],
+                "ITILCategory 2" => [
+                    'itemtype' => ITILCategory::getType(),
+                    'items_id' => $itilcategories[1]->getID()
+                ],
+            ],
+            expected_itilcategory: $itilcategories[1]->getID()
+        );
+
+        // Only first answer was submitted
+        $this->sendFormAndAssertTicketType(
+            form: $form,
+            config: $last_valid_answer_config,
+            answers: [
+                "ITILCategory 1" => [
+                    'itemtype' => ITILCategory::getType(),
+                    'items_id' => $itilcategories[0]->getID()
+                ],
+            ],
+            expected_itilcategory: $itilcategories[0]->getID()
+        );
+
+        // Only second answer was submitted
+        $this->sendFormAndAssertTicketType(
+            form: $form,
+            config: $last_valid_answer_config,
+            answers: [
+                "ITILCategory 2" => [
+                    'itemtype' => ITILCategory::getType(),
+                    'items_id' => $itilcategories[1]->getID()
+                ],
+            ],
+            expected_itilcategory: $itilcategories[1]->getID()
+        );
+
+        // No answers, fallback to default value
+        $this->sendFormAndAssertTicketType(
+            form: $form,
+            config: $last_valid_answer_config,
+            answers: [],
+            expected_itilcategory: 0
+        );
+    }
+
+    private function sendFormAndAssertTicketType(
+        Form $form,
+        ITILCategoryFieldConfig $config,
+        array $answers,
+        int $expected_itilcategory,
+    ): Ticket {
+        // Insert config
+        $destinations = $form->getDestinations();
+        $this->assertCount(1, $destinations);
+        $destination = current($destinations);
+        $this->updateItem(
+            $destination::getType(),
+            $destination->getId(),
+            ['config' => ['itilcategory' => $config->jsonSerialize()]],
+            ["config"],
+        );
+
+        // The provider use a simplified answer format to be more readable.
+        // Rewrite answers into expected format.
+        $formatted_answers = [];
+        foreach ($answers as $question => $answer) {
+            $key = $this->getQuestionId($form, $question);
+            $formatted_answers[$key] = $answer;
+        }
+
+        // Submit form
+        $answers_handler = AnswersHandler::getInstance();
+        $answers = $answers_handler->saveAnswers(
+            $form,
+            $formatted_answers,
+            getItemByTypeName(\User::class, TU_USER, true)
+        );
+
+        // Get created ticket
+        $created_items = $answers->getCreatedItems();
+        $this->assertCount(1, $created_items);
+        $ticket = current($created_items);
+
+        // Check ITILCategory
+        $this->assertEquals($expected_itilcategory, $ticket->fields['itilcategories_id']);
+
+        // Return the created ticket to be able to check other fields
+        return $ticket;
+    }
+
+    private function createAndGetFormWithMultipleITILCategoryQuestions(): Form
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion("ITILCategory 1", QuestionTypeItemDropdown::class, [
+            'itemtype' => ITILCategory::class,
+        ]);
+        $builder->addQuestion("ITILCategory 2", QuestionTypeItemDropdown::class, [
+            'itemtype' => ITILCategory::class,
+        ]);
+        $builder->addDestination(
+            FormDestinationTicket::class,
+            "My ticket",
+        );
+        return $this->createForm($builder);
+    }
+}

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/ITILCategoryFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/ITILCategoryFieldTest.php
@@ -60,7 +60,7 @@ final class ITILCategoryFieldTest extends DbTestCase
         ]);
 
         // Specific value
-        $this->sendFormAndAssertTicketType(
+        $this->sendFormAndAssertTicketCategory(
             form: $form,
             config: new ITILCategoryFieldConfig(
                 strategy: ITILCategoryFieldStrategy::SPECIFIC_VALUE,
@@ -71,7 +71,7 @@ final class ITILCategoryFieldTest extends DbTestCase
         );
 
         // No specific value
-        $this->sendFormAndAssertTicketType(
+        $this->sendFormAndAssertTicketCategory(
             form: $form,
             config: new ITILCategoryFieldConfig(
                 strategy: ITILCategoryFieldStrategy::SPECIFIC_VALUE,
@@ -93,7 +93,7 @@ final class ITILCategoryFieldTest extends DbTestCase
             'tickettemplates_id_incident' => $ticket_template->getID(),
         ]);
 
-        $created_ticket = $this->sendFormAndAssertTicketType(
+        $created_ticket = $this->sendFormAndAssertTicketCategory(
             form: $form,
             config: new ITILCategoryFieldConfig(
                 strategy: ITILCategoryFieldStrategy::SPECIFIC_VALUE,
@@ -116,7 +116,7 @@ final class ITILCategoryFieldTest extends DbTestCase
             'name' => 'Test ITILCategory for specific value',
         ]);
 
-        $created_ticket = $this->sendFormAndAssertTicketType(
+        $created_ticket = $this->sendFormAndAssertTicketCategory(
             form: $form,
             config: new ITILCategoryFieldConfig(
                 strategy: ITILCategoryFieldStrategy::SPECIFIC_VALUE,
@@ -138,7 +138,7 @@ final class ITILCategoryFieldTest extends DbTestCase
         ]);
 
         // Using answer from first question
-        $this->sendFormAndAssertTicketType(
+        $this->sendFormAndAssertTicketCategory(
             form: $form,
             config: new ITILCategoryFieldConfig(
                 strategy: ITILCategoryFieldStrategy::SPECIFIC_ANSWER,
@@ -158,7 +158,7 @@ final class ITILCategoryFieldTest extends DbTestCase
         );
 
         // Using answer from second question
-        $this->sendFormAndAssertTicketType(
+        $this->sendFormAndAssertTicketCategory(
             form: $form,
             config: new ITILCategoryFieldConfig(
                 strategy: ITILCategoryFieldStrategy::SPECIFIC_ANSWER,
@@ -191,7 +191,7 @@ final class ITILCategoryFieldTest extends DbTestCase
         );
 
         // With multiple answers submitted
-        $this->sendFormAndAssertTicketType(
+        $this->sendFormAndAssertTicketCategory(
             form: $form,
             config: $last_valid_answer_config,
             answers: [
@@ -208,7 +208,7 @@ final class ITILCategoryFieldTest extends DbTestCase
         );
 
         // Only first answer was submitted
-        $this->sendFormAndAssertTicketType(
+        $this->sendFormAndAssertTicketCategory(
             form: $form,
             config: $last_valid_answer_config,
             answers: [
@@ -221,7 +221,7 @@ final class ITILCategoryFieldTest extends DbTestCase
         );
 
         // Only second answer was submitted
-        $this->sendFormAndAssertTicketType(
+        $this->sendFormAndAssertTicketCategory(
             form: $form,
             config: $last_valid_answer_config,
             answers: [
@@ -234,7 +234,7 @@ final class ITILCategoryFieldTest extends DbTestCase
         );
 
         // No answers, fallback to default value
-        $this->sendFormAndAssertTicketType(
+        $this->sendFormAndAssertTicketCategory(
             form: $form,
             config: $last_valid_answer_config,
             answers: [],
@@ -242,7 +242,7 @@ final class ITILCategoryFieldTest extends DbTestCase
         );
     }
 
-    private function sendFormAndAssertTicketType(
+    private function sendFormAndAssertTicketCategory(
         Form $form,
         ITILCategoryFieldConfig $config,
         array $answers,

--- a/src/Glpi/Form/Destination/CommonITILField/ITILCategoryField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILCategoryField.php
@@ -1,0 +1,177 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Destination\CommonITILField;
+
+use Glpi\Application\View\TemplateRenderer;
+use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\AnswersSet;
+use Glpi\Form\Destination\AbstractConfigField;
+use Glpi\Form\Form;
+use Glpi\Form\QuestionType\QuestionTypeItem;
+use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
+use Glpi\Form\QuestionType\QuestionTypeITILCategory;
+use InvalidArgumentException;
+use ITILCategory;
+use Override;
+
+class ITILCategoryField extends AbstractConfigField
+{
+    #[Override]
+    public function getKey(): string
+    {
+        return 'itilcategory';
+    }
+
+    #[Override]
+    public function getLabel(): string
+    {
+        return _n('ITIL category', 'ITIL categories', 1);
+    }
+
+    #[Override]
+    public function getConfigClass(): string
+    {
+        return ITILCategoryFieldConfig::class;
+    }
+
+    #[Override]
+    public function renderConfigForm(
+        Form $form,
+        JsonFieldInterface $config,
+        string $input_name,
+        array $display_options
+    ): string {
+        if (!$config instanceof ITILCategoryFieldConfig) {
+            throw new InvalidArgumentException("Unexpected config class");
+        }
+
+        $twig = TemplateRenderer::getInstance();
+        return $twig->render('pages/admin/form/itil_config_fields/itilcategory.html.twig', [
+            // Possible configuration constant that will be used to to hide/show additional fields
+            'CONFIG_SPECIFIC_VALUE'  => ITILCategoryFieldStrategy::SPECIFIC_VALUE->value,
+            'CONFIG_SPECIFIC_ANSWER' => ITILCategoryFieldStrategy::SPECIFIC_ANSWER->value,
+
+            // General display options
+            'options' => $display_options,
+
+            // Main config field
+            'main_config_field' => [
+                'label'           => $this->getLabel(),
+                'value'           => $config->getStrategy()->value,
+                'input_name'      => $input_name . "[" . ITILCategoryFieldConfig::STRATEGY . "]",
+                'possible_values' => $this->getMainConfigurationValuesforDropdown(),
+            ],
+
+            // Specific additional config for SPECIFIC_ANSWER strategy
+            'specific_value_extra_field' => [
+                'empty_label'     => __("Select an ITIL category..."),
+                'value'           => $config->getSpecificITILCategoryID() ?? 0,
+                'input_name'      => $input_name . "[" . ITILCategoryFieldConfig::ITILCATEGORY_ID . "]",
+            ],
+
+            // Specific additional config for SPECIFIC_VALUE strategy
+            'specific_answer_extra_field' => [
+                'empty_label'     => __("Select a question..."),
+                'value'           => $config->getSpecificQuestionId(),
+                'input_name'      => $input_name . "[" . ITILCategoryFieldConfig::QUESTION_ID . "]",
+                'possible_values' => $this->getITILCategoryQuestionsValuesForDropdown($form),
+            ],
+        ]);
+    }
+
+    #[Override]
+    public function applyConfiguratedValueToInputUsingAnswers(
+        JsonFieldInterface $config,
+        array $input,
+        AnswersSet $answers_set
+    ): array {
+        if (!$config instanceof ITILCategoryFieldConfig) {
+            throw new InvalidArgumentException("Unexpected config class");
+        }
+
+        // Compute value according to strategy
+        $itilcategory_id = $config->getStrategy()->getITILCategory($config, $answers_set);
+
+        // Do not edit input if invalid value was found
+        if (!ITILCategory::getById($itilcategory_id)) {
+            return $input;
+        }
+
+        // Apply value
+        $input['itilcategories_id'] = $itilcategory_id;
+        return $input;
+    }
+
+    #[Override]
+    public function getDefaultConfig(Form $form): ITILCategoryFieldConfig
+    {
+        return new ITILCategoryFieldConfig(
+            ITILCategoryFieldStrategy::LAST_VALID_ANSWER
+        );
+    }
+
+    private function getMainConfigurationValuesforDropdown(): array
+    {
+        $values = [];
+        foreach (ITILCategoryFieldStrategy::cases() as $strategies) {
+            $values[$strategies->value] = $strategies->getLabel();
+        }
+        return $values;
+    }
+
+    private function getITILCategoryQuestionsValuesForDropdown(Form $form): array
+    {
+        $values = [];
+        $questions = $form->getQuestionsByType(QuestionTypeItemDropdown::class);
+
+        foreach ($questions as $question) {
+            // Only keep questions that are ITIL categories
+            if ((new QuestionTypeItemDropdown())->getDefaultValueItemtype($question) !== ITILCategory::getType()) {
+                continue;
+            }
+
+            $values[$question->getId()] = $question->fields['name'];
+        }
+
+        return $values;
+    }
+
+    #[Override]
+    public function getWeight(): int
+    {
+        return 30;
+    }
+}

--- a/src/Glpi/Form/Destination/CommonITILField/ITILCategoryFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILCategoryFieldConfig.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Destination\CommonITILField;
+
+use Glpi\DBAL\JsonFieldInterface;
+use Override;
+
+final class ITILCategoryFieldConfig implements JsonFieldInterface
+{
+    // Unique reference to hardcoded names used for serialization and forms input names
+    public const STRATEGY = 'strategy';
+    public const QUESTION_ID = 'question_id';
+    public const ITILCATEGORY_ID = 'itilcategory_id';
+
+    public function __construct(
+        private ITILCategoryFieldStrategy $strategy,
+        private ?int $specific_question_id = null,
+        private ?int $specific_itilcategory_id = null,
+    ) {
+    }
+
+    #[Override]
+    public static function jsonDeserialize(array $data): self
+    {
+        $strategy = ITILCategoryFieldStrategy::tryFrom($data[self::STRATEGY] ?? "");
+        if ($strategy === null) {
+            $strategy = ITILCategoryFieldStrategy::LAST_VALID_ANSWER;
+        }
+
+        return new self(
+            strategy: $strategy,
+            specific_question_id: $data[self::QUESTION_ID],
+            specific_itilcategory_id: $data[self::ITILCATEGORY_ID],
+        );
+    }
+
+    #[Override]
+    public function jsonSerialize(): array
+    {
+        return [
+            self::STRATEGY => $this->strategy->value,
+            self::QUESTION_ID => $this->specific_question_id,
+            self::ITILCATEGORY_ID => $this->specific_itilcategory_id,
+        ];
+    }
+
+    public function getStrategy(): ITILCategoryFieldStrategy
+    {
+        return $this->strategy;
+    }
+
+    public function getSpecificQuestionId(): ?int
+    {
+        return $this->specific_question_id;
+    }
+
+    public function getSpecificITILCategoryID(): ?int
+    {
+        return $this->specific_itilcategory_id;
+    }
+}

--- a/src/Glpi/Form/Destination/CommonITILField/ITILCategoryFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILCategoryFieldStrategy.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Destination\CommonITILField;
+
+use atoum\atoum\php\tokenizer\iterator\value;
+use Glpi\Form\AnswersSet;
+use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
+use Glpi\Form\QuestionType\QuestionTypeITILCategory;
+use ITILCategory;
+
+enum ITILCategoryFieldStrategy: string
+{
+    case SPECIFIC_VALUE = 'specific_value';
+    case SPECIFIC_ANSWER = 'specific_answer';
+    case LAST_VALID_ANSWER = 'last_valid_answer';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::SPECIFIC_VALUE    => __("Specific ITIL category"),
+            self::SPECIFIC_ANSWER   => __("Answer from a specific question"),
+            self::LAST_VALID_ANSWER => __('Answer to last "ITIL Category" dropdown question'),
+        };
+    }
+
+    public function getITILCategory(
+        ITILCategoryFieldConfig $config,
+        AnswersSet $answers_set,
+    ): ?int {
+        return match ($this) {
+            self::SPECIFIC_VALUE => $config->getSpecificITILCategoryID(),
+            self::SPECIFIC_ANSWER => $this->getITILCategoryForSpecificAnswer(
+                $config->getSpecificQuestionId(),
+                $answers_set
+            ),
+            self::LAST_VALID_ANSWER => $this->getITILCategoryForLastValidAnswer($answers_set),
+        };
+    }
+
+    private function getITILCategoryForSpecificAnswer(
+        ?int $question_id,
+        AnswersSet $answers_set,
+    ): ?int {
+        if ($question_id === null) {
+            return null;
+        }
+
+        $answer = $answers_set->getAnswerByQuestionId($question_id);
+        if ($answer === null) {
+            return null;
+        }
+
+        $value = $answer->getRawAnswer();
+        if ($value['itemtype'] !== ITILCategory::getType() || !is_numeric($value['items_id'])) {
+            return null;
+        }
+
+        return (int) $value['items_id'];
+    }
+
+    private function getITILCategoryForLastValidAnswer(
+        AnswersSet $answers_set,
+    ): ?int {
+        $valid_answers = $answers_set->getAnswersByType(
+            QuestionTypeItemDropdown::class
+        );
+
+        if (count($valid_answers) == 0) {
+            return null;
+        }
+
+        $answer = end($valid_answers);
+        $value = $answer->getRawAnswer();
+        if ($value['itemtype'] !== ITILCategory::getType() || !is_numeric($value['items_id'])) {
+            return null;
+        }
+
+        return (int) $value['items_id'];
+    }
+}

--- a/templates/pages/admin/form/itil_config_fields/itilcategory.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/itilcategory.html.twig
@@ -1,0 +1,84 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
+{{ fields.dropdownArrayField(
+    main_config_field.input_name,
+    main_config_field.value,
+    main_config_field.possible_values,
+    main_config_field.label,
+    options
+) }}
+
+<div
+    {% if main_config_field.value != CONFIG_SPECIFIC_VALUE %}
+        class="d-none"
+    {% endif %}
+    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
+    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_VALUE }}"
+>
+    {{ fields.dropdownField(
+        'ITILCategory',
+        specific_value_extra_field.input_name,
+        specific_value_extra_field.value,
+        "",
+        options|merge({
+            no_label: true,
+            display_emptychoice: true,
+            emptylabel: specific_value_extra_field.empty_label,
+            aria_label: specific_value_extra_field.empty_label,
+        })
+    ) }}
+</div>
+
+<div
+    {% if main_config_field.value != CONFIG_SPECIFIC_ANSWER %}
+        class="d-none"
+    {% endif %}
+    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
+    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_ANSWER }}"
+>
+    {{ fields.dropdownArrayField(
+        specific_answer_extra_field.input_name,
+        specific_answer_extra_field.value,
+        specific_answer_extra_field.possible_values,
+        "",
+        options|merge({
+            no_label: true,
+            display_emptychoice: true,
+            emptylabel: specific_answer_extra_field.empty_label,
+            aria_label: specific_answer_extra_field.empty_label,
+        })
+    ) }}
+</div>

--- a/tests/cypress/e2e/form/destination_config_fields/itilcategory.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/itilcategory.cy.js
@@ -1,0 +1,130 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+describe('ITILCategory configuration', () => {
+    beforeEach(() => {
+        cy.login();
+        cy.changeProfile('Super-Admin', true);
+
+        // Create form with a single "request type" question
+        cy.createFormWithAPI().as('form_id').visitFormTab('Form');
+
+        // Create an ITIL category
+        cy.get('@form_id').then((form_id) => {
+            const itilcategory_name = 'Test ITIL Category for the ITILCategory configuration suite - ' + form_id;
+
+            cy.createWithAPI('ITILCategory', {
+                'name': itilcategory_name,
+            }).as('itilcategory_id');
+        });
+
+        cy.findByRole('button', {'name': "Add a new question"}).click();
+        cy.focused().type("My ITILCategory question");
+        cy.getDropdownByLabelText('Question type').selectDropdownValue('Item');
+        cy.getDropdownByLabelText('Question sub type').selectDropdownValue('Dropdowns');
+        cy.getDropdownByLabelText("Select a dropdown type").selectDropdownValue('ITIL categories');
+        cy.get('@form_id').then((form_id) => {
+            const itilcategory_name = 'Test ITIL Category for the ITILCategory configuration suite - ' + form_id;
+            cy.getDropdownByLabelText("Select a dropdown item").selectDropdownValue('»' + itilcategory_name);
+        });
+        cy.findByRole('button', {'name': 'Save'}).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+
+        // Go to destination tab
+        cy.findByRole('tab', {'name': "Items to create"}).click();
+        cy.findByRole('button', {'name': "Add ticket"}).click();
+        cy.checkAndCloseAlert('Item successfully added');
+    });
+
+    it('can use all possibles configuration options', () => {
+        cy.findByRole('region', {'name': "ITIL category configuration"}).as("config");
+        cy.get('@config').getDropdownByLabelText('ITIL category').as("itilcategory_dropdown");
+
+        // Default value
+        cy.get('@itilcategory_dropdown').should(
+            'have.text',
+            'Answer to last "ITIL Category" dropdown question'
+        );
+
+        // Make sure hidden dropdowns are not displayed
+        cy.get('@config').getDropdownByLabelText('Select an ITIL category...').should('not.exist');
+        cy.get('@config').getDropdownByLabelText('Select a question...').should('not.exist');
+
+        // Switch to "Specific ITIL category"
+        cy.get('@itilcategory_dropdown').selectDropdownValue('Specific ITIL category');
+        cy.get('@config').getDropdownByLabelText('Select an ITIL category...').as('specific_itilcategory_dropdown');
+        cy.get('@form_id').then((form_id) => {
+            const itilcategory_name = 'Test ITIL Category for the ITILCategory configuration suite - ' + form_id;
+            cy.get('@specific_itilcategory_dropdown').selectDropdownValue('»' + itilcategory_name);
+        });
+
+        cy.findByRole('button', {'name': 'Update item'}).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@itilcategory_dropdown').should('have.text', 'Specific ITIL category');
+        cy.get('@form_id').then((form_id) => {
+            const itilcategory_name = 'Test ITIL Category for the ITILCategory configuration suite - ' + form_id;
+            cy.get('@specific_itilcategory_dropdown').should('have.text', itilcategory_name);
+        });
+
+        // Switch to "Answer from a specific question"
+        cy.get('@itilcategory_dropdown').selectDropdownValue('Answer from a specific question');
+        cy.get('@config').getDropdownByLabelText('Select a question...').as('specific_answer_type_dropdown');
+        cy.get('@specific_answer_type_dropdown').selectDropdownValue('My ITILCategory question');
+
+        cy.findByRole('button', {'name': 'Update item'}).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@itilcategory_dropdown').should('have.text', 'Answer from a specific question');
+        cy.get('@specific_answer_type_dropdown').should('have.text', 'My ITILCategory question');
+    });
+
+    it('can create ticket using default configuration', () => {
+        // Go to preview
+        cy.findByRole('tab', {'name': "Form"}).click();
+        cy.findByRole('link', {'name': "Preview"})
+            .invoke('removeAttr', 'target') // Cypress can't handle tab changes
+            .click()
+        ;
+
+        // Fill the form
+        cy.findByRole('button', {'name': 'Send form'}).click();
+        cy.findByRole('link', {'name': 'My test form'}).click();
+
+        // Check ticket values
+        cy.get('@form_id').then((form_id) => {
+            const itilcategory_name = 'Test ITIL Category for the ITILCategory configuration suite - ' + form_id;
+            cy.getDropdownByLabelText('Category').should('have.text', itilcategory_name);
+        });
+
+        // Others possibles configurations are tested directly by the backend.
+    });
+});

--- a/tests/cypress/e2e/form/form_destination.cy.js
+++ b/tests/cypress/e2e/form/form_destination.cy.js
@@ -46,6 +46,7 @@ describe('Form destination', () => {
 
             // Create a ticket destination
             cy.findByRole('button', {name: "Add ticket"}).click();
+            cy.checkAndCloseAlert('Item successfully added');
         });
     });
 
@@ -59,6 +60,7 @@ describe('Form destination', () => {
 
         // Save form
         cy.findByRole("button", {name: "Update item"}).click();
+        cy.checkAndCloseAlert('Item successfully updated');
 
         // Check if the form destination name is updated
         cy.findByRole("textbox", {name: "Form destination name"}).should('exist').and('have.value', 'Updated ticket destination name');
@@ -103,6 +105,7 @@ describe('Form destination', () => {
 
             // Save changes (page reload)
             cy.findByRole('button', {'name': "Update item"}).click();
+            cy.checkAndCloseAlert('Item successfully updated');
         });
 
         describe('Validate manual values are kept after reload', () => {
@@ -122,6 +125,7 @@ describe('Form destination', () => {
 
             // Save changes (page reload)
             cy.findByRole('button', {'name': "Update item"}).click();
+            cy.checkAndCloseAlert('Item successfully updated');
         });
 
         describe('Validate manual values have been removed', () => {


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

![image](https://github.com/user-attachments/assets/ebbc4bc2-0295-442e-bee9-8882870fa5ac)

Possible configurations :
![image](https://github.com/user-attachments/assets/7a999bb6-2e3e-42db-bfd7-20a52c9760e8)

"Specific ITIL Category" display a secondary select to let the user pick the chosen itil category :
![image](https://github.com/user-attachments/assets/24c6d481-0f4a-4a75-8953-5125b66105c0)

"Answer from a specific question" display a secondary select to let the user pick the chosen question :
![image](https://github.com/user-attachments/assets/b92ccb0f-d21e-4935-aae3-464ac40400fa)
