### PR TITLE
Forms: fix weird chrome only rendering issue

### DIFF
--- a/css/includes/components/form/_form-editor.scss
+++ b/css/includes/components/form/_form-editor.scss
@@ -66,6 +66,14 @@
     .card {
         border-bottom-left-radius: var(--tblr-border-radius) !important;
     }
+
+    [data-fix-dropdown-flex] {
+        .select2-selection__rendered {
+            // Weird chrome only css issue that break select2 dropdown for
+            // question type dropdowns...
+            display: flex !important;
+        }
+    }
 }
 
 .editor-footer {

--- a/templates/pages/admin/form/form_question.html.twig
+++ b/templates/pages/admin/form/form_question.html.twig
@@ -143,6 +143,7 @@
             <div
                 class="d-flex align-items-center mt-2"
                 data-glpi-form-editor-question-extra-details
+                data-fix-dropdown-flex
             >
                 {% set categories = {} %}
                 {% for category in question_types_manager.getCategories() %}


### PR DESCRIPTION
No idea why this only happens on chrome, I had to inject a `display: flex` instruction into a specific select2 span for it to work.
Super hacky but I don't understand the issue at all, probably some chrome / select2 conflict.

Before:
![image](https://github.com/user-attachments/assets/65552bca-d5fe-46cc-9f0d-b7ea9081aeca)

After:
![image](https://github.com/user-attachments/assets/9a3e0b72-494c-4fe6-8a15-ec8c0f216188)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
