### PR TITLE
Fix tinymce autoresize in forms

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -3662,7 +3662,7 @@ JS;
                     content_css: '{$content_css}',
                     content_style: '{$content_style}',
                     highlight_on_focus: false,
-                    autoresize_bottom_margin: 0, // Avoid excessive bottom padding
+                    autoresize_bottom_margin: 1, // Avoid excessive bottom padding
                     autoresize_overflow_padding: 0,
 
                     min_height: $editor_height,

--- a/tests/cypress/e2e/form/form_convert_default_values.cy.js
+++ b/tests/cypress/e2e/form/form_convert_default_values.cy.js
@@ -103,14 +103,9 @@ describe('Convert default value form', () => {
 
         // Set defaut value
         cy.findByRole('region', {'name': 'Question details'}).within(() => {
-            /**
-             * The force option should not be necessary,
-             * but it seems that when the test is executed on GitHub CI,
-             * the center of the element is hidden from view
-             */
             cy.findByLabelText("Default value")
                 .awaitTinyMCE()
-                .type(default_value, { force: true });
+                .type(default_value);
         });
 
         // Change type to "Text"


### PR DESCRIPTION
It seems like the `autoresize_bottom_margin: 0` option completely disabled tinymce resizing.
Using 1px instead works fine.

Before:
![image](https://github.com/user-attachments/assets/eb36b6ba-722a-4c5e-b983-effe34f6d16a)


After:
![image](https://github.com/user-attachments/assets/33c8c265-9272-47dc-8d60-3aa2552ca482)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
