### PR TITLE
fix(clone): no date calculation

### DIFF
--- a/phpunit/functional/PrinterTest.php
+++ b/phpunit/functional/PrinterTest.php
@@ -169,7 +169,7 @@ class PrinterTest extends DbTestCase
 
     public function testCloneFromTemplateWithInfocoms()
     {
-        global $DB;
+        global $DB, $GLPI_CACHE;
 
         $entity_id = getItemByTypeName('Entity', '_test_root_entity', true);
 
@@ -219,6 +219,7 @@ class PrinterTest extends DbTestCase
         $this->assertTrue($infocom->getFromDB($infocom->getID()));
         $this->assertEquals(36, $infocom->getField('warranty_duration'));
         $this->assertEquals(null, $infocom->getField('delivery_date'));
+        $this->assertEquals(null, $infocom->getField('warranty_date'));
 
         // Update entity config
         $state_param = \Infocom::ON_STATUS_CHANGE . '_' . $state->getID();
@@ -232,7 +233,6 @@ class PrinterTest extends DbTestCase
             ],
             ['id' => $entity_id]
         );
-        global $GLPI_CACHE;
         $GLPI_CACHE->clear();
         $this->assertTrue($entity->getFromDB($entity_id));
         $this->assertEquals($state_param, $entity->getField('autofill_delivery_date'));

--- a/phpunit/functional/PrinterTest.php
+++ b/phpunit/functional/PrinterTest.php
@@ -226,13 +226,17 @@ class PrinterTest extends DbTestCase
         $entity = new \Entity();
         $DB->update(
             \Entity::getTable(),
-            ['autofill_delivery_date' => $state_param],
+            [
+                'autofill_delivery_date' => $state_param,
+                'autofill_warranty_date' => \Infocom::COPY_DELIVERY_DATE,
+            ],
             ['id' => $entity_id]
         );
         global $GLPI_CACHE;
         $GLPI_CACHE->clear();
         $this->assertTrue($entity->getFromDB($entity_id));
         $this->assertEquals($state_param, $entity->getField('autofill_delivery_date'));
+        $this->assertEquals(\Infocom::COPY_DELIVERY_DATE, $entity->getField('autofill_warranty_date'));
 
         // Create printer from template
         $printer = new \Printer();
@@ -250,5 +254,6 @@ class PrinterTest extends DbTestCase
         $this->assertTrue($infocom->getFromDB($infocom->getID()));
         $this->assertEquals(36, $infocom->getField('warranty_duration'));
         $this->assertEquals(date('Y-m-d'), $infocom->getField('delivery_date')); // = today
+        $this->assertEquals($infocom->getField('warranty_date'), $infocom->getField('warranty_date'));
     }
 }

--- a/phpunit/functional/PrinterTest.php
+++ b/phpunit/functional/PrinterTest.php
@@ -166,4 +166,89 @@ class PrinterTest extends DbTestCase
         $nb_after = (int)countElementsInTable('glpi_logs', ['itemtype' => 'Printer', 'items_id' => $id]);
         $this->assertSame($nb_before + 1, $nb_after);
     }
+
+    public function testCloneFromTemplateWithInfocoms()
+    {
+        global $DB;
+
+        $entity_id = getItemByTypeName('Entity', '_test_root_entity', true);
+
+        // Create Status
+        $state = new \State();
+        $state->add([
+            'name' => __METHOD__,
+            'entities_id' => $entity_id
+        ]);
+        $this->assertTrue($state->getFromDB($state->getID()));
+
+        // Create template
+        $template = new \Printer();
+        $template->add([
+            'name' => __METHOD__,
+            'entities_id' => $entity_id,
+            'states_id' => $state->getID(),
+            'is_template' => 1
+        ]);
+        $this->assertTrue($template->getFromDB($template->getID()));
+        $this->assertEquals(0, $template->getField('is_deleted'));
+        $this->assertEquals(0, $template->isDeleted());
+
+        // Add infocoms to template
+        $infocom = new \Infocom();
+        $infocom->add([
+            'items_id' => $template->getID(),
+            'itemtype' => 'Printer',
+            'warranty_duration' => 36,
+        ]);
+        $this->assertTrue($infocom->getFromDB($infocom->getID()));
+        $this->assertEquals(0, $infocom->isDeleted());
+
+        // Create printer from template
+        $printer = new \Printer();
+        $printer_id = $template->clone();
+        $this->assertTrue($printer->getFromDB($printer_id));
+        $this->assertEquals(0, $printer->getField('is_template'));
+        $this->assertEquals($state->getID(), $printer->getField('states_id'));
+
+        // Check infocoms
+        $infocom = new \Infocom();
+        $infocom->getFromDBByCrit([
+            'itemtype' => \Printer::getType(),
+            'items_id' => $printer_id,
+        ]);
+        $this->assertTrue($infocom->getFromDB($infocom->getID()));
+        $this->assertEquals(36, $infocom->getField('warranty_duration'));
+        $this->assertEquals(null, $infocom->getField('delivery_date'));
+
+        // Update entity config
+        $state_param = \Infocom::ON_STATUS_CHANGE . '_' . $state->getID();
+
+        $entity = new \Entity();
+        $DB->update(
+            \Entity::getTable(),
+            ['autofill_delivery_date' => $state_param],
+            ['id' => $entity_id]
+        );
+        global $GLPI_CACHE;
+        $GLPI_CACHE->clear();
+        $this->assertTrue($entity->getFromDB($entity_id));
+        $this->assertEquals($state_param, $entity->getField('autofill_delivery_date'));
+
+        // Create printer from template
+        $printer = new \Printer();
+        $printer_id = $template->clone();
+        $this->assertTrue($printer->getFromDB($printer_id));
+        $this->assertEquals(0, $printer->getField('is_template'));
+        $this->assertEquals($state->getID(), $printer->getField('states_id'));
+
+        // Check infocoms
+        $infocom = new \Infocom();
+        $infocom->getFromDBByCrit([
+            'itemtype' => \Printer::getType(),
+            'items_id' => $printer_id,
+        ]);
+        $this->assertTrue($infocom->getFromDB($infocom->getID()));
+        $this->assertEquals(36, $infocom->getField('warranty_duration'));
+        $this->assertEquals(date('Y-m-d'), $infocom->getField('delivery_date')); // = today
+    }
 }

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1380,8 +1380,9 @@ class CommonDBTM extends CommonGLPI
                     if (
                         Infocom::canApplyOn($this)
                         && isset($this->input['states_id'])
-                            && (!isset($this->input['is_template'])
-                                || !$this->input['is_template'])
+                        && (!isset($this->input['is_template'])
+                            || !$this->input['is_template'])
+                        && !($this->input['clone'] ?? false)
                     ) {
                         //Check if we have to automatically fill dates
                         Infocom::manageDateOnStatusChange($this);

--- a/src/Features/Clonable.php
+++ b/src/Features/Clonable.php
@@ -248,7 +248,7 @@ trait Clonable
             if (
                 \Infocom::canApplyOn($this)
                 && isset($new_item->input['states_id'])
-                && !($new_item->input['is_template'] && false)
+                && !($new_item->input['is_template'] ?? false)
             ) {
                 //Check if we have to automatically fill dates
                 \Infocom::manageDateOnStatusChange($new_item);

--- a/src/Features/Clonable.php
+++ b/src/Features/Clonable.php
@@ -244,6 +244,15 @@ trait Clonable
         if ($newID !== false) {
             $new_item->cloneRelations($this, $history);
             $new_item->post_clone($this, $history);
+
+            if (
+                \Infocom::canApplyOn($this)
+                && isset($new_item->input['states_id'])
+                && !($new_item->input['is_template'] && false)
+            ) {
+                //Check if we have to automatically fill dates
+                \Infocom::manageDateOnStatusChange($new_item);
+            }
         }
 
         return $newID;

--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -345,7 +345,7 @@ class Infocom extends CommonDBChild
     public static function autofillDates(&$infocoms = [], $field = '', $action = 0, $params = [])
     {
 
-        if (isset($infocoms[$field])) {
+        if (isset($infocoms[$field]) || is_null($infocoms[$field])) {
             switch ($action) {
                 default:
                 case 0:
@@ -400,15 +400,18 @@ class Infocom extends CommonDBChild
     public function prepareInputForUpdate($input)
     {
 
-       //Check if one or more dates needs to be updated
+        //Check if one or more dates needs to be updated
         foreach (self::getAutoManagemendDatesFields() as $key => $field) {
             $result = Entity::getUsedConfig($key, $this->fields['entities_id']);
 
-           //Only update date if it's empty in DB. Otherwise do nothing
+            //Only update date if it's empty in DB. Otherwise do nothing
             if (
                 ($result > 0)
                 && !isset($this->fields[$field])
             ) {
+                if (!isset($input[$field])) {
+                    $input[$field] = null;
+                }
                 self::autofillDates($input, $field, $result);
             }
         }


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !34062

When a printer is created from a template with infocoms, and date calculation rules have been activated on the entity. The asset's infocoms are missing.


