### PR TITLE
 feat(forms): Add new configuration fields to forms destination - Request source

### DIFF
--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/RequestSourceFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/RequestSourceFieldTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\Destination\CommonITILField;
+
+use DbTestCase;
+use Glpi\Form\AnswersHandler\AnswersHandler;
+use Glpi\Form\Destination\CommonITILField\RequestSourceFieldConfig;
+use Glpi\Form\Destination\CommonITILField\RequestSourceFieldStrategy;
+use Glpi\Form\Destination\FormDestinationTicket;
+use Glpi\Form\Form;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+use RequestType;
+use Ticket;
+use TicketTemplate;
+use TicketTemplatePredefinedField;
+
+final class RequestSourceFieldTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public function testDefaultSourceWithPredefinedField(): void
+    {
+
+        $source = RequestType::getDefault('helpdesk');
+
+        $default_template = (new Ticket())->getITILTemplateToUse(
+            entities_id: $_SESSION["glpiactive_entity"]
+        );
+        $this->createItem(
+            TicketTemplatePredefinedField::class,
+            [
+                'tickettemplates_id' => $default_template->getID(),
+                'num' => 9,
+                'value' => $source,
+            ]
+        );
+
+        $created_ticket = $this->checkRequestSourceFieldConfiguration(
+            form: $this->createAndGetFormWithTicketDestination(),
+            config: new RequestSourceFieldConfig(
+                strategy: RequestSourceFieldStrategy::FROM_TEMPLATE,
+            ),
+        );
+
+        $this->assertEquals($source, $created_ticket->fields['requesttypes_id']);
+    }
+
+    public function testSpecificSourceWithPredefinedField(): void
+    {
+        $default_source = RequestType::getDefault('helpdesk');
+        $specified_source = RequestType::getDefault('followup');
+
+        $default_template = (new Ticket())->getITILTemplateToUse(
+            entities_id: $_SESSION["glpiactive_entity"]
+        );
+        $this->createItem(
+            TicketTemplatePredefinedField::class,
+            [
+                'tickettemplates_id' => $default_template->getID(),
+                'num' => 9,
+                'value' => $default_source,
+            ]
+        );
+
+        $created_ticket = $this->checkRequestSourceFieldConfiguration(
+            form: $this->createAndGetFormWithTicketDestination(),
+            config: new RequestSourceFieldConfig(
+                strategy: RequestSourceFieldStrategy::SPECIFIC_VALUE,
+                specific_request_source: $specified_source,
+            ),
+        );
+
+        $this->assertEquals($specified_source, $created_ticket->fields['requesttypes_id']);
+    }
+
+    private function checkRequestSourceFieldConfiguration(
+        Form $form,
+        RequestSourceFieldConfig $config,
+    ): Ticket {
+        // Insert config
+        $destinations = $form->getDestinations();
+        $this->assertCount(1, $destinations);
+        $destination = current($destinations);
+        $this->updateItem(
+            $destination::getType(),
+            $destination->getId(),
+            ['config' => ['request_source' => $config->jsonSerialize()]],
+            ["config"],
+        );
+
+        // Submit form
+        $answers_handler = AnswersHandler::getInstance();
+        $answers = $answers_handler->saveAnswers(
+            $form,
+            [],
+            getItemByTypeName(\User::class, TU_USER, true)
+        );
+
+        // Get created ticket
+        $created_items = $answers->getCreatedItems();
+        $this->assertCount(1, $created_items);
+        $ticket = current($created_items);
+
+        // Return the created ticket to be able to check other fields
+        return $ticket;
+    }
+
+    private function createAndGetFormWithTicketDestination(): Form
+    {
+        $builder = new FormBuilder();
+        $builder->addDestination(
+            FormDestinationTicket::class,
+            "My ticket",
+        );
+        return $this->createForm($builder);
+    }
+}

--- a/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
+++ b/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
@@ -40,11 +40,12 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\Form\AnswersSet;
 use Glpi\Form\Destination\CommonITILField\AssociatedItemsField;
 use Glpi\Form\Destination\CommonITILField\ContentField;
-use Glpi\Form\Destination\CommonITILField\TemplateField;
-use Glpi\Form\Destination\CommonITILField\ITILCategoryField;
 use Glpi\Form\Destination\CommonITILField\EntityField;
-use Glpi\Form\Destination\CommonITILField\LocationField;
+use Glpi\Form\Destination\CommonITILField\ITILCategoryField;
 use Glpi\Form\Destination\CommonITILField\ITILFollowupField;
+use Glpi\Form\Destination\CommonITILField\LocationField;
+use Glpi\Form\Destination\CommonITILField\RequestSourceField;
+use Glpi\Form\Destination\CommonITILField\TemplateField;
 use Glpi\Form\Destination\CommonITILField\TitleField;
 use Glpi\Form\Destination\CommonITILField\UrgencyField;
 use Glpi\Form\Form;
@@ -184,6 +185,7 @@ abstract class AbstractCommonITILFormDestination extends AbstractFormDestination
             new LocationField(),
             new AssociatedItemsField(),
             new ITILFollowupField(),
+            new RequestSourceField(),
         ];
     }
 

--- a/src/Glpi/Form/Destination/CommonITILField/RequestSourceField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/RequestSourceField.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Destination\CommonITILField;
+
+use Dropdown;
+use Glpi\Application\View\TemplateRenderer;
+use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\AnswersSet;
+use Glpi\Form\Destination\AbstractConfigField;
+use Glpi\Form\Form;
+use InvalidArgumentException;
+use Override;
+use RequestType;
+use Ticket;
+
+class RequestSourceField extends AbstractConfigField
+{
+    #[Override]
+    public function getKey(): string
+    {
+        return 'request_source';
+    }
+
+    #[Override]
+    public function getLabel(): string
+    {
+        return RequestType::getTypeName(1);
+    }
+
+    #[Override]
+    public function getConfigClass(): string
+    {
+        return RequestSourceFieldConfig::class;
+    }
+
+    #[Override]
+    public function renderConfigForm(
+        Form $form,
+        JsonFieldInterface $config,
+        string $input_name,
+        array $display_options
+    ): string {
+        if (!$config instanceof RequestSourceFieldConfig) {
+            throw new InvalidArgumentException("Unexpected config class");
+        }
+
+        $twig = TemplateRenderer::getInstance();
+        return $twig->render('pages/admin/form/itil_config_fields/request_source.html.twig', [
+            // Possible configuration constant that will be used to to hide/show additional fields
+            'CONFIG_SPECIFIC_VALUE'  => RequestSourceFieldStrategy::SPECIFIC_VALUE->value,
+
+            // General display options
+            'options' => $display_options,
+
+            // Main config field
+            'main_config_field' => [
+                'label'           => $this->getLabel(),
+                'value'           => $config->getStrategy()->value,
+                'input_name'      => $input_name . "[" . RequestSourceFieldConfig::STRATEGY . "]",
+                'possible_values' => $this->getMainConfigurationValuesforDropdown(),
+            ],
+
+            // Specific additional config for SPECIFIC_VALUE strategy
+            'specific_value_extra_field' => [
+                'empty_label'     => __("Select a request source..."),
+                'value'           => $config->getSpecificRequestSource(),
+                'input_name'      => $input_name . "[" . RequestSourceFieldConfig::REQUEST_SOURCE . "]",
+                'itemtype'        => RequestType::class,
+            ],
+        ]);
+    }
+
+    #[Override]
+    public function applyConfiguratedValueToInputUsingAnswers(
+        JsonFieldInterface $config,
+        array $input,
+        AnswersSet $answers_set
+    ): array {
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        if (!$config instanceof RequestSourceFieldConfig) {
+            throw new InvalidArgumentException("Unexpected config class");
+        }
+
+        // Compute value according to strategy
+        $request_source = $config->getStrategy()->getRequestSource($config, $answers_set);
+
+        // Do not edit input if invalid value was found
+
+        $db_values = $DB->request(['FROM' => 'glpi_requesttypes', 'WHERE' => ['is_active' => 1]]);
+        $valid_values = [];
+        foreach ($db_values as $data) {
+            $valid_values[] = $data['id'];
+        }
+
+        if (!array_search($request_source, $valid_values)) {
+            return $input;
+        }
+
+        // Apply value
+        $input['requesttypes_id'] = $request_source;
+        return $input;
+    }
+
+    #[Override]
+    public function getDefaultConfig(Form $form): RequestSourceFieldConfig
+    {
+        return new RequestSourceFieldConfig(
+            RequestSourceFieldStrategy::FROM_TEMPLATE
+        );
+    }
+
+    private function getMainConfigurationValuesforDropdown(): array
+    {
+        $values = [];
+        foreach (RequestSourceFieldStrategy::cases() as $strategies) {
+            $values[$strategies->value] = $strategies->getLabel();
+        }
+        return $values;
+    }
+
+    #[Override]
+    public function getWeight(): int
+    {
+        return 30;
+    }
+}

--- a/src/Glpi/Form/Destination/CommonITILField/RequestSourceFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/RequestSourceFieldConfig.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Destination\CommonITILField;
+
+use Glpi\DBAL\JsonFieldInterface;
+use Override;
+
+final class RequestSourceFieldConfig implements JsonFieldInterface
+{
+    // Unique reference to hardcoded names used for serialization and forms input names
+    public const STRATEGY = 'strategy';
+    public const REQUEST_SOURCE = 'request_source';
+
+    public function __construct(
+        private RequestSourceFieldStrategy $strategy,
+        private ?int $specific_request_source = null,
+    ) {
+    }
+
+    #[Override]
+    public static function jsonDeserialize(array $data): self
+    {
+        $strategy = RequestSourceFieldStrategy::tryFrom($data[self::STRATEGY] ?? "");
+        if ($strategy === null) {
+            $strategy = RequestSourceFieldStrategy::FROM_TEMPLATE;
+        }
+
+        return new self(
+            strategy: $strategy,
+            specific_request_source: $data[self::REQUEST_SOURCE],
+        );
+    }
+
+    #[Override]
+    public function jsonSerialize(): array
+    {
+        return [
+            self::STRATEGY => $this->strategy->value,
+            self::REQUEST_SOURCE => $this->specific_request_source,
+        ];
+    }
+
+    public function getStrategy(): RequestSourceFieldStrategy
+    {
+        return $this->strategy;
+    }
+
+    public function getSpecificRequestSource(): ?int
+    {
+        return $this->specific_request_source;
+    }
+}

--- a/src/Glpi/Form/Destination/CommonITILField/RequestSourceFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/RequestSourceFieldStrategy.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Destination\CommonITILField;
+
+use Glpi\Form\AnswersSet;
+
+enum RequestSourceFieldStrategy: string
+{
+    case FROM_TEMPLATE = 'from_template';
+    case SPECIFIC_VALUE = 'specific_value';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::FROM_TEMPLATE     => __("From template"),
+            self::SPECIFIC_VALUE    => __("Specific request source"),
+        };
+    }
+
+    public function getRequestSource(
+        RequestSourceFieldConfig $config,
+        AnswersSet $answers_set,
+    ): ?int {
+        return match ($this) {
+            self::FROM_TEMPLATE => null, // Let the template apply its default value by itself.
+            self::SPECIFIC_VALUE => $config->getSpecificRequestSource(),
+        };
+    }
+}

--- a/templates/pages/admin/form/itil_config_fields/request_source.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/request_source.html.twig
@@ -1,0 +1,62 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
+{{ fields.dropdownArrayField(
+    main_config_field.input_name,
+    main_config_field.value,
+    main_config_field.possible_values,
+    main_config_field.label,
+    options
+) }}
+
+<div
+    {% if main_config_field.value != CONFIG_SPECIFIC_VALUE %}
+        class="d-none"
+    {% endif %}
+    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
+    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_VALUE }}">
+    {{ fields.dropdownField(
+            specific_value_extra_field.itemtype,
+            specific_value_extra_field.input_name,
+            specific_value_extra_field.value ?? 0,
+            "",
+            options|merge({
+                no_label: true,
+                display_emptychoice: true,
+                emptylabel: specific_value_extra_field.empty_label,
+                aria_label: specific_value_extra_field.empty_label,
+            })
+    ) }}
+</div>

--- a/tests/cypress/e2e/form/destination_config_fields/request_source.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/request_source.cy.js
@@ -1,0 +1,96 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+describe('Request source configuration', () => {
+    beforeEach(() => {
+        cy.login();
+        cy.changeProfile('Super-Admin', true);
+
+        // Create form
+        cy.createFormWithAPI().visitFormTab('Form');
+
+        // Add a default question
+        cy.findByRole('button', { 'name': "Add a new question" }).click();
+        cy.findByRole('button', { 'name': 'Save' }).click();
+
+        // Go to destination tab
+        cy.findByRole('tab', { 'name': "Items to create" }).click();
+        cy.findByRole('button', { 'name': "Add ticket" }).click();
+        cy.checkAndCloseAlert('Item successfully added');
+    });
+
+    it('can use all possibles configuration options', () => {
+        cy.findByRole('region', { 'name': "Request source configuration" }).as("config");
+        cy.get('@config').getDropdownByLabelText('Request source').as("source_dropdown");
+
+        // Default value
+        cy.get('@source_dropdown').should(
+            'have.text',
+            'From template'
+        );
+
+        // Make sure hidden dropdowns are not displayed
+        cy.get('@config').getDropdownByLabelText('Select a request source...').should('not.exist');
+
+        // Switch to "Specific request source"
+        cy.get('@source_dropdown').selectDropdownValue('Specific request source');
+        cy.get('@config').getDropdownByLabelText('Select a request source...').as('specific_request_source_id_dropdown');
+        cy.get('@specific_request_source_id_dropdown').selectDropdownValue('E-Mail');
+
+        cy.findByRole('button', { 'name': 'Update item' }).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@source_dropdown').should('have.text', 'Specific request source');
+        cy.get('@specific_request_source_id_dropdown').should('have.text', 'E-Mail');
+    });
+
+    it('can create ticket using default configuration', () => {
+        cy.createWithAPI('TicketTemplatePredefinedField', {
+            'tickettemplates_id': 1, // Default template
+            'num': 9, // Request source
+            'value': 3, // Phone
+        });
+        // Go to preview
+        cy.findByRole('tab', { 'name': "Form" }).click();
+        cy.findByRole('link', { 'name': "Preview" })
+            .invoke('removeAttr', 'target') // Cypress can't handle tab changes
+            .click();
+
+        cy.findByRole('button', { 'name': 'Send form' }).click();
+        cy.findByRole('link', { 'name': 'My test form' }).click();
+
+        // Check ticket values
+        cy.getDropdownByLabelText('Request source').should('have.text', 'Phone');
+
+        // Others possibles configurations are tested directly by the backend.
+    });
+});


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |

![image](https://github.com/user-attachments/assets/21291d57-e295-4839-9b78-2b74297dcb38)

Possible configurations :

![image](https://github.com/user-attachments/assets/f61bff6c-dfd1-4c7a-ad8a-d4a92965ad43)

"Specific request source" display a secondary select to let the user pick the chosen source :

![image](https://github.com/user-attachments/assets/91757735-77f8-4de1-9dae-7b0fa11a0acd)

