### PR TITLE
Make forms tags accent colors less flashy

### DIFF
--- a/phpunit/functional/Glpi/Form/Tag/TagTest.php
+++ b/phpunit/functional/Glpi/Form/Tag/TagTest.php
@@ -60,7 +60,7 @@ final class TagTest extends DbTestCase
 
         $expected = json_encode([
             'label' => 'Question: First name',
-            'html' => "<span contenteditable=\"false\" data-form-tag=\"true\" data-form-tag-value=\"$question_id\" data-form-tag-provider=\"$provider\" class=\"bg-$color-lt\">Question: First name</span>"
+            'html' => "<span contenteditable=\"false\" data-form-tag=\"true\" data-form-tag-value=\"$question_id\" data-form-tag-provider=\"$provider\" class=\"border-$color border-start border-3 bg-dark-lt\">Question: First name</span>"
         ]);
         $this->assertEquals($expected, json_encode($tag));
     }

--- a/src/Glpi/Form/Tag/Tag.php
+++ b/src/Glpi/Form/Tag/Tag.php
@@ -59,7 +59,7 @@ final readonly class Tag
             "data-form-tag"          => "true",
             "data-form-tag-value"    => $value,
             "data-form-tag-provider" => $provider,
-            "class"                  => "bg-$color-lt"
+            "class"                  => "border-$color border-start border-3 bg-dark-lt",
         ];
         $properties = implode(" ", array_map(
             fn($key, $value) => sprintf('%s="%s"', htmlspecialchars($key), htmlspecialchars($value)),


### PR DESCRIPTION
Tags accent colors were a good idea but the first iteration is too flashy and colorful.
I propose a second more "moderate" version.

Before:
![image](https://github.com/user-attachments/assets/cac66c78-22c4-4e9a-8de6-7e6a7687020b)

After:
![image](https://github.com/user-attachments/assets/4fc01e59-2a43-4b4c-b327-761c053a48df)


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
