### PR TITLE
Forms destination: Use class name for config to avoid conflicts

### DIFF
--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/RequestTypeFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/RequestTypeFieldTest.php
@@ -207,6 +207,8 @@ final class RequestTypeFieldTest extends DbTestCase
         array $answers,
         int $expected_request_type,
     ): void {
+        $field = new RequestTypeField();
+
         // Insert config
         $destinations = $form->getDestinations();
         $this->assertCount(1, $destinations);
@@ -214,7 +216,7 @@ final class RequestTypeFieldTest extends DbTestCase
         $this->updateItem(
             $destination::getType(),
             $destination->getId(),
-            ['config' => ['request_type' => $config->jsonSerialize()]],
+            ['config' => [$field->getKey() => $config->jsonSerialize()]],
             ["config"],
         );
 

--- a/src/Glpi/Form/Destination/AbstractConfigField.php
+++ b/src/Glpi/Form/Destination/AbstractConfigField.php
@@ -43,6 +43,12 @@ use Override;
 abstract class AbstractConfigField implements ConfigFieldInterface
 {
     #[Override]
+    public function getKey(): string
+    {
+        return static::class;
+    }
+
+    #[Override]
     public function supportAutoConfiguration(): bool
     {
         return false;

--- a/src/Glpi/Form/Destination/AbstractConfigField.php
+++ b/src/Glpi/Form/Destination/AbstractConfigField.php
@@ -39,13 +39,14 @@ use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\Form;
 use LogicException;
 use Override;
+use Toolbox;
 
 abstract class AbstractConfigField implements ConfigFieldInterface
 {
     #[Override]
     public function getKey(): string
     {
-        return static::class;
+        return Toolbox::slugify(static::class);
     }
 
     #[Override]

--- a/src/Glpi/Form/Destination/CommonITILField/ContentField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ContentField.php
@@ -50,12 +50,6 @@ use Override;
 class ContentField extends AbstractConfigField
 {
     #[Override]
-    public function getKey(): string
-    {
-        return 'content';
-    }
-
-    #[Override]
     public function getLabel(): string
     {
         return __("Content");

--- a/src/Glpi/Form/Destination/CommonITILField/RequestTypeField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/RequestTypeField.php
@@ -48,12 +48,6 @@ use Ticket;
 class RequestTypeField extends AbstractConfigField
 {
     #[Override]
-    public function getKey(): string
-    {
-        return 'request_type';
-    }
-
-    #[Override]
     public function getLabel(): string
     {
         return __("Request type");

--- a/src/Glpi/Form/Destination/CommonITILField/TitleField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/TitleField.php
@@ -48,12 +48,6 @@ use Override;
 class TitleField extends AbstractConfigField
 {
     #[Override]
-    public function getKey(): string
-    {
-        return 'title';
-    }
-
-    #[Override]
     public function getLabel(): string
     {
         return __("Title");

--- a/tests/src/Form/Destination/AbstractFormDestinationType.php
+++ b/tests/src/Form/Destination/AbstractFormDestinationType.php
@@ -40,7 +40,9 @@ use CommonGLPI;
 use DbTestCase;
 use Glpi\Form\AnswersHandler\AnswersHandler;
 use Glpi\Form\AnswersSet;
+use Glpi\Form\Destination\CommonITILField\ContentField;
 use Glpi\Form\Destination\CommonITILField\SimpleValueConfig;
+use Glpi\Form\Destination\CommonITILField\TitleField;
 use Glpi\Form\Form;
 use Glpi\Form\QuestionType\QuestionTypeShortText;
 use Glpi\Tests\FormBuilder;
@@ -65,6 +67,9 @@ abstract class AbstractFormDestinationType extends DbTestCase
         $itemtype = $this->getTestedInstance()::getTargetItemtype();
         $link_itemtype = $itemtype::getItemLinkClass();
 
+        $title_field = new TitleField();
+        $content_field = new ContentField();
+
         // Create a form with a single FormDestinationTicket destination
         $form = $this->createForm(
             (new FormBuilder("Test form 1"))
@@ -73,10 +78,10 @@ abstract class AbstractFormDestinationType extends DbTestCase
                     $this->getTestedInstance()::class,
                     'test',
                     [
-                        'title'        => (new SimpleValueConfig("My title"))->jsonSerialize(),
-                        'title_auto'   => 0,
-                        'content'      => (new SimpleValueConfig("My content"))->jsonSerialize(),
-                        'content_auto' => 0,
+                        $title_field->getKey()             => (new SimpleValueConfig("My title"))->jsonSerialize(),
+                        $title_field->getAutoConfigKey()   => 0,
+                        $content_field->getKey()           => (new SimpleValueConfig("My content"))->jsonSerialize(),
+                        $content_field->getAutoConfigKey() => 0,
                     ]
                 )
         );


### PR DESCRIPTION
Suggested by @cedric-anne, avoid using specific keys name and use classes instead.
This reduce the risk on key conflicts if we allow plugins to define their own fields.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
