### PR TITLE
Form import: map only items visible in the current entity

### DIFF
--- a/src/Glpi/Controller/Form/Import/Step2PreviewController.php
+++ b/src/Glpi/Controller/Form/Import/Step2PreviewController.php
@@ -35,8 +35,10 @@
 namespace Glpi\Controller\Form\Import;
 
 use Glpi\Controller\AbstractController;
+use Glpi\Form\Export\Context\DatabaseMapper;
 use Glpi\Form\Export\Serializer\FormSerializer;
 use Glpi\Form\Form;
+use Session;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -56,10 +58,12 @@ final class Step2PreviewController extends AbstractController
         $json = $file->getContent();
 
         $serializer = new FormSerializer();
+        $mapper = new DatabaseMapper(Session::getActiveEntities());
+
         return $this->render("pages/admin/form/import/step2_preview.html.twig", [
             'title'   => __("Preview import"),
             'menu'    => ['admin', Form::getType()],
-            'preview' => $serializer->previewImport($json),
+            'preview' => $serializer->previewImport($json, $mapper),
             'json'    => $json,
         ]);
     }

--- a/src/Glpi/Controller/Form/Import/Step3ExecuteController.php
+++ b/src/Glpi/Controller/Form/Import/Step3ExecuteController.php
@@ -35,8 +35,10 @@
 namespace Glpi\Controller\Form\Import;
 
 use Glpi\Controller\AbstractController;
+use Glpi\Form\Export\Context\DatabaseMapper;
 use Glpi\Form\Export\Serializer\FormSerializer;
 use Glpi\Form\Form;
+use Session;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -55,10 +57,12 @@ final class Step3ExecuteController extends AbstractController
         $json = $request->request->get('json');
 
         $serializer = new FormSerializer();
+        $mapper = new DatabaseMapper(Session::getActiveEntities());
+
         return $this->render("pages/admin/form/import/step3_execute.html.twig", [
             'title'   => __("Import results"),
             'menu'    => ['admin', Form::getType()],
-            'results' => $serializer->importFormsFromJson($json),
+            'results' => $serializer->importFormsFromJson($json, $mapper),
         ]);
     }
 }

--- a/src/Glpi/Form/Export/Context/DatabaseMapper.php
+++ b/src/Glpi/Form/Export/Context/DatabaseMapper.php
@@ -44,7 +44,20 @@ use Search;
 final class DatabaseMapper
 {
     // Store itemtype => [name => id] relations.
+    /** @var array<string, array<string, int>> $values */
     private array $values = [];
+
+    /** @var array<int> $entities_restrictions */
+    private array $entities_restrictions;
+
+    public function __construct(array $entities_restrictions)
+    {
+        if (empty($entities_restrictions)) {
+            throw new InvalidArgumentException("Must specify at least one entity");
+        }
+
+        $this->entities_restrictions = $entities_restrictions;
+    }
 
     public function addMappedItem(string $itemtype, string $name, int $id): void
     {
@@ -152,7 +165,10 @@ final class DatabaseMapper
 
         // Entities restrictions are not always included in addDefaultWhere,
         // it is safer to add them manually (they might be checked twice tho).
-        $entities_restrictions = getEntitiesRestrictCriteria($item::getTable());
+        $entities_restrictions = getEntitiesRestrictCriteria(
+            $item::getTable(),
+            value: $this->entities_restrictions
+        );
         $condition[] = $entities_restrictions;
         $query['WHERE'] = $condition;
 

--- a/src/Glpi/Form/Export/Context/DatabaseMapper.php
+++ b/src/Glpi/Form/Export/Context/DatabaseMapper.php
@@ -157,12 +157,6 @@ final class DatabaseMapper
             'name' => $name
         ];
 
-        // Compute default where (visibility restrictions)
-        $default_where = Search::addDefaultWhere($itemtype);
-        if ($default_where !== '') {
-            $condition[] = new QueryExpression($default_where);
-        }
-
         // Entities restrictions are not always included in addDefaultWhere,
         // it is safer to add them manually (they might be checked twice tho).
         $entities_restrictions = getEntitiesRestrictCriteria(
@@ -171,17 +165,6 @@ final class DatabaseMapper
         );
         $condition[] = $entities_restrictions;
         $query['WHERE'] = $condition;
-
-        // Compute default join (might be used by the default where)
-        $already_joined = [];
-        $default_join = Search::addDefaultJoin(
-            $itemtype,
-            $itemtype::getTable(),
-            $already_joined,
-        );
-        if ($default_join !== '') {
-            $query['JOIN'] = [new QueryExpression($default_join)];
-        }
 
         // Find item
         $rows = $DB->request($query);

--- a/src/Glpi/Form/Export/Serializer/FormSerializer.php
+++ b/src/Glpi/Form/Export/Serializer/FormSerializer.php
@@ -76,7 +76,7 @@ final class FormSerializer extends AbstractFormSerializer
 
     public function previewImport(
         string $json,
-        DatabaseMapper $mapper = new DatabaseMapper(),
+        DatabaseMapper $mapper,
     ): ImportResultPreview {
         $export_specification = $this->deserialize($json);
 

--- a/src/Glpi/Form/Export/Serializer/FormSerializer.php
+++ b/src/Glpi/Form/Export/Serializer/FormSerializer.php
@@ -104,7 +104,7 @@ final class FormSerializer extends AbstractFormSerializer
 
     public function importFormsFromJson(
         string $json,
-        DatabaseMapper $mapper = new DatabaseMapper(),
+        DatabaseMapper $mapper,
     ): ImportResult {
         $export_specification = $this->deserialize($json);
 
@@ -168,7 +168,7 @@ final class FormSerializer extends AbstractFormSerializer
 
     private function importFormFromSpec(
         FormContentSpecification $form_spec,
-        DatabaseMapper $mapper = new DatabaseMapper(),
+        DatabaseMapper $mapper,
     ): Form {
         /** @var \DBmysql $DB */
         global $DB;
@@ -188,7 +188,7 @@ final class FormSerializer extends AbstractFormSerializer
 
     private function doImportFormFormSpecs(
         FormContentSpecification $form_spec,
-        DatabaseMapper $mapper = new DatabaseMapper(),
+        DatabaseMapper $mapper,
     ): Form {
         // TODO: questions, ...
         $form = $this->importBasicFormProperties($form_spec, $mapper);

--- a/src/Session.php
+++ b/src/Session.php
@@ -2140,6 +2140,16 @@ class Session
     }
 
     /**
+     * Get actives entities id.
+     *
+     * @return array<int>
+     */
+    public static function getActiveEntities(): array
+    {
+        return $_SESSION['glpiactiveentities'] ?? [];
+    }
+
+    /**
      * Filter given entities ID list to return only these tht are matching current active entities in session.
      *
      * @since 10.0.13


### PR DESCRIPTION
The form import process try to match items using their names.
It should be restricted to the current entity to make sure the user don't see data that he isn't allowed to see.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
