### PR TITLE
Forms: export/import access policies

### DIFF
--- a/phpunit/DbTestCase.php
+++ b/phpunit/DbTestCase.php
@@ -277,6 +277,22 @@ class DbTestCase extends \GLPITestCase
     }
 
     /**
+     * Delete multiple items of the given class
+     *
+     * @param string $itemtype
+     * @param int[] $ids
+     * @param bool $purge
+     *
+     * @return void
+     */
+    protected function deleteItems(string $itemtype, array $ids, bool $purge = false): void
+    {
+        foreach ($ids as $id) {
+            $this->deleteItem($itemtype, $id, $purge);
+        }
+    }
+
+    /**
      * Helper method to avoid writting the same boilerplate code for rule creation
      *
      * @param RuleBuilder $builder RuleConfiguration
@@ -476,5 +492,27 @@ class DbTestCase extends \GLPITestCase
         );
 
         return $definition;
+    }
+
+    /**
+     * Helper methods to quickly create many items by names.
+     */
+    protected function createItemsWithNames(string $itemtype, array $names): array
+    {
+        return array_map(
+            fn($name) => $this->createItem($itemtype, ['name' => $name]),
+            $names,
+        );
+    }
+
+    /**
+     * Helper methods to quickly get the names of multiple items ids.
+     */
+    protected function getItemsNames(string $itemtype, array $ids): array
+    {
+        return array_map(
+            fn($id) => $itemtype::getById($id)->fields['name'],
+            $ids,
+        );
     }
 }

--- a/phpunit/functional/Glpi/Form/Export/FormSerializerAccessPoliciesTest.php
+++ b/phpunit/functional/Glpi/Form/Export/FormSerializerAccessPoliciesTest.php
@@ -1,0 +1,267 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form;
+
+use AbstractRightsDropdown;
+use Glpi\Form\AccessControl\ControlType\AllowList;
+use Glpi\Form\AccessControl\ControlType\AllowListConfig;
+use Glpi\Form\AccessControl\ControlType\DirectAccess;
+use Glpi\Form\AccessControl\ControlType\DirectAccessConfig;
+use Glpi\Form\Export\Context\DatabaseMapper;
+use Glpi\Form\Export\Serializer\FormSerializer;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+use Group;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Profile;
+use User;
+
+/**
+ * Separate file for serializer tests related to form access policies.
+ * This helps keeping the main serializer test file smaller and more readable.
+ */
+final class FormSerializerAccessPoliciesTest extends \DbTestCase
+{
+    use FormTesterTrait;
+
+    private static FormSerializer $serializer;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$serializer = new FormSerializer();
+        parent::setUpBeforeClass();
+    }
+
+    public static function exportAndImportDirectAccessPolicyProvider(): iterable
+    {
+        yield 'Active' => [
+            'is_active' => true,
+        ];
+        yield 'Inactive' => [
+            'is_active' => false,
+        ];
+        yield 'Allow unauthenticated' => [
+            'allow_unauthenticated' => true,
+        ];
+        yield 'Disallow unauthenticated' => [
+            'allow_unauthenticated' => false,
+        ];
+    }
+
+    #[DataProvider('exportAndImportDirectAccessPolicyProvider')]
+    public function testExportAndImportDirectAccessPolicy(
+        string $token = "my_token",
+        bool $allow_unauthenticated = false,
+        bool $is_active = true,
+    ): void {
+        // Arrange: create a form with a direct access policy
+        $builder = new FormBuilder("My test form");
+        $builder->addAccessControl(
+            strategy: DirectAccess::class,
+            config: new DirectAccessConfig(
+                token: $token,
+                allow_unauthenticated: $allow_unauthenticated,
+            ),
+            is_active: $is_active,
+        );
+        $form = $this->createForm($builder);
+
+        // Act: export and import form
+        $this->login();
+        $form_copy = $this->exportAndImportForm($form);
+
+        // Assert: validate access policy config
+        $policies = $form_copy->getAccessControls();
+        $this->assertCount(1, $policies);
+        $policy = current($policies);
+        $this->assertSame($is_active, (bool) $policy->fields['is_active']);
+
+        $strategy = $policy->getStrategy();
+        $this->assertInstanceOf(DirectAccess::class, $strategy);
+
+        /** @var DirectAccessConfig $config  */
+        $config = $policy->getConfig();
+        $this->assertSame($token, $config->getToken());
+        $this->assertSame($allow_unauthenticated, $config->allowUnauthenticated());
+    }
+
+    public static function exportAndImportAllowListPolicyProvider(): iterable
+    {
+        yield 'Active' => [
+            'is_active' => true,
+        ];
+        yield 'Inactive' => [
+            'is_active' => false,
+        ];
+        yield 'With users' => [
+            'user_ids' => [
+                getItemByTypeName(User::class, "glpi", true),
+                getItemByTypeName(User::class, "tech", true),
+            ]
+        ];
+        yield 'With groups' => [
+            'group_ids' => [
+                getItemByTypeName(Group::class, "_test_group_1", true),
+                getItemByTypeName(Group::class, "_test_group_2", true),
+            ]
+        ];
+        yield 'With profiles' => [
+            'profile_ids' => [
+                getItemByTypeName(Profile::class, "Super-Admin", true),
+                getItemByTypeName(Profile::class, "Read-Only", true),
+            ]
+        ];
+        yield 'With users and special value' => [
+            'user_ids' => [
+                AbstractRightsDropdown::ALL_USERS,
+                getItemByTypeName(User::class, "glpi", true),
+                getItemByTypeName(User::class, "tech", true),
+            ]
+        ];
+        yield 'With everything' => [
+            'user_ids' => [
+                AbstractRightsDropdown::ALL_USERS,
+                getItemByTypeName(User::class, "glpi", true),
+                getItemByTypeName(User::class, "tech", true),
+            ],
+            'group_ids' => [
+                getItemByTypeName(Group::class, "_test_group_1", true),
+                getItemByTypeName(Group::class, "_test_group_2", true),
+            ],
+            'profile_ids' => [
+                getItemByTypeName(Profile::class, "Super-Admin", true),
+                getItemByTypeName(Profile::class, "Read-Only", true),
+            ],
+        ];
+    }
+
+    #[DataProvider('exportAndImportAllowListPolicyProvider')]
+    public function testExportAndImportAllowListPolicy(
+        array $user_ids = [],
+        array $group_ids = [],
+        array $profile_ids = [],
+        bool $is_active = true,
+    ): void {
+        // Arrange: Create a form with an allow list policy
+        $builder = new FormBuilder("My test form");
+        $builder->addAccessControl(
+            strategy: AllowList::class,
+            config: new AllowListConfig(
+                user_ids   : $user_ids,
+                group_ids  : $group_ids,
+                profile_ids: $profile_ids,
+            ),
+            is_active: $is_active,
+        );
+        $form = $this->createForm($builder);
+
+        // Act: Export and import form.
+        $this->login();
+        $form_copy = $this->exportAndImportForm($form);
+
+        // Assert: validate allow list policy config
+        $policies = $form_copy->getAccessControls();
+        $this->assertCount(1, $policies);
+        $policy = current($policies);
+        $this->assertSame($is_active, (bool) $policy->fields['is_active']);
+
+        $strategy = $policy->getStrategy();
+        $this->assertInstanceOf(AllowList::class, $strategy);
+
+        /** @var AllowListConfig $config */
+        $config = $policy->getConfig();
+        $this->assertSame($user_ids, $config->getUserIds());
+        $this->assertSame($group_ids, $config->getGroupIds());
+        $this->assertSame($profile_ids, $config->getProfileIds());
+    }
+
+    public function testExportAndImportAllowListPolicyWithMapping(): void
+    {
+        // Arrange: create multiples users/profiles/groups and create a form
+        // with an allow list policy that references them.
+        list($user_1, $user_2, $user_3, $user_4) = $this->createItemsWithNames(
+            User::class,
+            ["User 1", "User 2", "User 3", "User 4"]
+        );
+        list($group_1, $group_2, $group_3, $group_4) = $this->createItemsWithNames(
+            Group::class,
+            ["Group 1",  "Group 2", "Group 3", "Group 4"]
+        );
+        list($profile_1, $profile_2, $profile_3, $profile_4) = $this->createItemsWithNames(
+            Profile::class,
+            ["Profile 1", "Profile 2", "Profile 3", "Profile 4"]
+        );
+
+        $builder = new FormBuilder("My test form");
+        $builder->addAccessControl(AllowList::class, new AllowListConfig(
+            user_ids: [$user_1->getID(), $user_2->getID()],
+            group_ids: [$group_1->getID(), $group_2->getID()],
+            profile_ids: [$profile_1->getID(), $profile_2->getID()],
+        ));
+        $form = $this->createForm($builder);
+
+        // Act: Map database items (items 1 and 2 are replaced by items 3 and 4)
+        // then export and import form.
+        $mapper = new DatabaseMapper();
+        $mapper->addMappedItem(User::class, "User 1", $user_3->getID());
+        $mapper->addMappedItem(User::class, "User 2", $user_4->getID());
+        $mapper->addMappedItem(Group::class, "Group 1", $group_3->getID());
+        $mapper->addMappedItem(Group::class, "Group 2", $group_4->getID());
+        $mapper->addMappedItem(Profile::class, "Profile 1", $profile_3->getID());
+        $mapper->addMappedItem(Profile::class, "Profile 2", $profile_4->getID());
+
+        $this->login();
+        $json = $this->exportForm($form);
+        $form_copy = $this->importForm($json, $mapper);
+
+        // Assert: validate allow list policy config
+        $policies = $form_copy->getAccessControls();
+        $this->assertCount(1, $policies);
+        $policy = current($policies);
+
+        $strategy = $policy->getStrategy();
+        $this->assertInstanceOf(AllowList::class, $strategy);
+
+        /** @var AllowListConfig $config */
+        $config = $policy->getConfig();
+        $allowed_users = $this->getItemsNames(User::class, $config->getUserIds());
+        $allowed_groups = $this->getItemsNames(Group::class, $config->getGroupIds());
+        $allowed_profiles = $this->getItemsNames(Profile::class, $config->getProfileIds());
+        $this->assertSame(["User 3", "User 4"], $allowed_users);
+        $this->assertSame(["Group 3", "Group 4"], $allowed_groups);
+        $this->assertSame(["Profile 3", "Profile 4"], $allowed_profiles);
+    }
+}

--- a/phpunit/functional/Glpi/Form/Export/FormSerializerTest.php
+++ b/phpunit/functional/Glpi/Form/Export/FormSerializerTest.php
@@ -173,37 +173,6 @@ final class FormSerializerTest extends \DbTestCase
     // Can't be done now as we have only one requirement (form entity) so it
     // we it is impossible to have duplicates.
 
-    private function exportForm(Form $form): string
-    {
-        return self::$serializer->exportFormsToJson([$form]);
-    }
-
-    private function importForm(
-        string $json,
-        DatabaseMapper $mapper = new DatabaseMapper(),
-    ): Form {
-        $import_result = self::$serializer->importFormsFromJson($json, $mapper);
-        $imported_forms = $import_result->getImportedForms();
-        $this->assertCount(1, $imported_forms);
-        $form_copy = current($imported_forms);
-        return $form_copy;
-    }
-
-    private function exportAndImportForm(Form $form): Form
-    {
-        // Export and import process
-        $json = $this->exportForm($form);
-        $form_copy = $this->importForm($json);
-
-        // Make sure it was not the same form object that was returned.
-        $this->assertNotEquals($form_copy->getId(), $form->getId());
-
-        // Make sure the new form really exist in the database.
-        $this->assertNotFalse($form_copy->getFromDB($form_copy->getId()));
-
-        return $form_copy;
-    }
-
     private function createAndGetFormWithBasicPropertiesFilled(): Form
     {
         $form_name = "Form with basic properties fully filled " . mt_rand();

--- a/src/Glpi/Form/AccessControl/FormAccessControl.php
+++ b/src/Glpi/Form/AccessControl/FormAccessControl.php
@@ -316,7 +316,7 @@ final class FormAccessControl extends CommonDBChild
      *
      * @return bool
      */
-    protected function isValidStrategy(string $strategy): bool
+    public function isValidStrategy(string $strategy): bool
     {
         return
             is_a($strategy, ControlTypeInterface::class, true)

--- a/src/Glpi/Form/Export/Context/DatabaseMapper.php
+++ b/src/Glpi/Form/Export/Context/DatabaseMapper.php
@@ -115,6 +115,11 @@ final class DatabaseMapper
         return true;
     }
 
+    public function getReadonlyMapper(): ReadonlyDatabaseMapper
+    {
+        return new ReadonlyDatabaseMapper($this);
+    }
+
     private function isValidItemtype(string $itemtype): bool
     {
         return is_a($itemtype, CommonDBTM::class, true);

--- a/src/Glpi/Form/Export/Context/JsonFieldReferencingDatabaseIdsInterface.php
+++ b/src/Glpi/Form/Export/Context/JsonFieldReferencingDatabaseIdsInterface.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Export\Context;
+
+use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\Export\Specification\DataRequirementSpecification;
+
+/**
+ * Must be implemented by all JsonFieldInterface objects that contains references
+ * to database ids.
+ *
+ * The method of this interface will be used by the form serializer to ensure
+ * that form exports can be done correctly as an export can't contains hardcoded
+ * database ids.
+ */
+interface JsonFieldReferencingDatabaseIdsInterface
+{
+    /**
+     * Must return the same values as `JsonFieldInterface::jsonSeserialize` but
+     * with all database ids removed and replaced by the items names instead.
+     *
+     * @return array
+     */
+    public function jsonSerializeWithoutDatabaseIds(): array;
+
+    /**
+     * Must return the same value as `JsonFieldInterface::jsonDeserialize` but
+     * the supplied $data parameter will contains items names instead of ids.
+     *
+     * The correct ids must be inserted using the ReadonlyDatabaseMapper instance.
+     *
+     * @param ReadonlyDatabaseMapper $mapper
+     * @param array $data
+     * @return JsonFieldInterface
+     */
+    public static function jsonDeserializeWithoutDatabaseIds(
+        ReadonlyDatabaseMapper $mapper,
+        array $data,
+    ): JsonFieldInterface;
+
+    /**
+     * All ids replaced by the `jsonSerializeWithoutDatabaseIds` method must be
+     * referenced here by creating a DataRequirementSpecification object per id.
+     *
+     *  @return DataRequirementSpecification[]
+     */
+    public function getJsonDeserializeWithoutDatabaseIdsRequirements(): array;
+}

--- a/src/Glpi/Form/Export/Context/ReadonlyDatabaseMapper.php
+++ b/src/Glpi/Form/Export/Context/ReadonlyDatabaseMapper.php
@@ -33,13 +33,23 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Form\Export\Specification;
+namespace Glpi\Form\Export\Context;
 
-final class DataRequirementSpecification
+use Glpi\Form\Export\Context\DatabaseMapper;
+
+/**
+ * Wrapper class used to only expose the minimal needed methods to
+ * JsonFieldReferencingDatabaseIdsInterface items.
+ */
+final class ReadonlyDatabaseMapper
 {
     public function __construct(
-        public string $itemtype = "",
-        public string $name = "",
+        private DatabaseMapper $mapper,
     ) {
+    }
+
+    public function getItemId(string $itemtype, string $name): int
+    {
+        return $this->mapper->getItemId($itemtype, $name);
     }
 }

--- a/src/Glpi/Form/Export/Serializer/FormSerializer.php
+++ b/src/Glpi/Form/Export/Serializer/FormSerializer.php
@@ -36,15 +36,19 @@
 namespace Glpi\Form\Export\Serializer;
 
 use Entity;
+use Glpi\Form\AccessControl\FormAccessControl;
 use Glpi\Form\Export\Context\DatabaseMapper;
+use Glpi\Form\Export\Context\JsonFieldReferencingDatabaseIdsInterface;
 use Glpi\Form\Export\Result\ImportError;
 use Glpi\Form\Export\Result\ImportResult;
+use Glpi\Form\Export\Specification\AccesControlPolicyContentSpecification;
 use Glpi\Form\Export\Specification\ExportContentSpecification;
 use Glpi\Form\Export\Specification\FormContentSpecification;
 use Glpi\Form\Export\Specification\SectionContentSpecification;
 use Glpi\Form\Form;
 use Glpi\Form\Section;
 use RuntimeException;
+use InvalidArgumentException;
 
 final class FormSerializer extends AbstractFormSerializer
 {
@@ -106,6 +110,7 @@ final class FormSerializer extends AbstractFormSerializer
         // TODO: questions, ...
         $form_spec = $this->exportBasicFormProperties($form);
         $form_spec = $this->exportSections($form, $form_spec);
+        $form_spec = $this->exportAccesControlPolicies($form, $form_spec);
 
         return $form_spec;
     }
@@ -137,6 +142,7 @@ final class FormSerializer extends AbstractFormSerializer
         // TODO: questions, ...
         $form = $this->importBasicFormProperties($form_spec, $mapper);
         $form = $this->importSections($form, $form_spec);
+        $form = $this->importAccessControlPolicices($form, $form_spec, $mapper);
 
         return $form;
     }
@@ -215,6 +221,82 @@ final class FormSerializer extends AbstractFormSerializer
 
         // Reload to clear lazy loaded data
         $form->getFromDB($form->getId());
+        return $form;
+    }
+
+    private function exportAccesControlPolicies(
+        Form $form,
+        FormContentSpecification $form_spec,
+    ): FormContentSpecification {
+        foreach ($form->getAccessControls() as $policy) {
+            $strategy = $policy->getStrategy()::class;
+            $config = $policy->getConfig();
+
+            // Read simple fields
+            $policy_spec = new AccesControlPolicyContentSpecification();
+            $policy_spec->strategy = $strategy;
+            $policy_spec->is_active = $policy->fields['is_active'];
+
+            if ($config instanceof JsonFieldReferencingDatabaseIdsInterface) {
+                // Config with references to database ids
+                $policy_spec->config_data = $config->jsonSerializeWithoutDatabaseIds();
+                $requirements = $config->getJsonDeserializeWithoutDatabaseIdsRequirements();
+                array_push($form_spec->data_requirements, ...$requirements);
+            } else {
+                // Config without references to database ids
+                $policy_spec->config_data = $config->jsonSerialize();
+            }
+
+            $form_spec->policies[] = $policy_spec;
+        }
+
+        return $form_spec;
+    }
+
+    private function importAccessControlPolicices(
+        Form $form,
+        FormContentSpecification $spec,
+        DatabaseMapper $mapper,
+    ): Form {
+        foreach ($spec->policies as $policy_spec) {
+            $policy = new FormAccessControl();
+
+            // Load strategy
+            $strategy_class = $policy_spec->strategy;
+            if (!$policy->isValidStrategy($strategy_class)) {
+                throw new InvalidArgumentException();
+            }
+            $strategy = new $strategy_class();
+
+            $config_class = $strategy->getConfigClass();
+            if (is_a($config_class, JsonFieldReferencingDatabaseIdsInterface::class, true)) {
+                // Config with references to database ids
+                $config = $config_class::jsonDeserializeWithoutDatabaseIds(
+                    $mapper->getReadonlyMapper(),
+                    $policy_spec->config_data
+                );
+            } else {
+                // Config without references to database ids
+                $config = $config_class::jsonDeserialize(
+                    $policy_spec->config_data
+                );
+            }
+
+            // Insert data
+            $id = $policy->add([
+                'strategy'  => $strategy_class,
+                'is_active' => $policy_spec->is_active,
+                '_config'   => $config,
+                Form::getForeignKeyField() => $form->getID(),
+            ]);
+
+            if (!$id) {
+                throw new RunTimeException("Failed to create access control");
+            }
+        }
+
+        // Reload form to clear lazy loaded data
+        $form->getFromDB($form->getID());
         return $form;
     }
 }

--- a/src/Glpi/Form/Export/Specification/AccesControlPolicyContentSpecification.php
+++ b/src/Glpi/Form/Export/Specification/AccesControlPolicyContentSpecification.php
@@ -35,11 +35,9 @@
 
 namespace Glpi\Form\Export\Specification;
 
-final class DataRequirementSpecification
+final class AccesControlPolicyContentSpecification
 {
-    public function __construct(
-        public string $itemtype = "",
-        public string $name = "",
-    ) {
-    }
+    public string $strategy;
+    public array $config_data;
+    public bool $is_active;
 }

--- a/src/Glpi/Form/Export/Specification/FormContentSpecification.php
+++ b/src/Glpi/Form/Export/Specification/FormContentSpecification.php
@@ -45,6 +45,9 @@ final class FormContentSpecification
     /** @var SectionContentSpecification[] $sections */
     public array $sections = [];
 
+    /** @var AccesControlPolicyContentSpecification[] $policies */
+    public array $policies = [];
+
     /** @var DataRequirementSpecification[] $data_requirements */
     public array $data_requirements = [];
 

--- a/tests/src/FormBuilder.php
+++ b/tests/src/FormBuilder.php
@@ -384,9 +384,13 @@ class FormBuilder
      */
     public function addAccessControl(
         string $strategy,
-        JsonFieldInterface $config
+        JsonFieldInterface $config,
+        bool $is_active = true,
     ): self {
-        $this->access_control[$strategy] = $config;
+        $this->access_control[$strategy] = [
+            'config'    => $config,
+            'is_active' => $is_active,
+        ];
         return $this;
     }
 }


### PR DESCRIPTION
Export/import the access policies of a form.

There is one technical difficulty: each access policies has its own config (for example, the allow list keep track of multiple users, groups and profiles).
These configs can contain database ids, which is bad for the export (as we don't want any hardcoded ids into the exported json file).

This mean we must delegate part of export/import process to the configs classes themselves as they are the only one that knows the ids that they may reference in their internal data (plugins will be able to add their own policies with their own config classes).

I've chosen the following solution (open to feedback), which is to create a new `JsonFieldReferencingDatabaseIdsInterface` interface.
Any config class (which already has to implement `JsonFieldInterface`) that can contains database ids MUST implement this new interface.

The interface contains 3 methods to handle the ids/names conversion and the data requirements (see code for more details).

The goal is to apply this solution to all other exportable items that will have the same issue (destination config, questions config, ...), while keeping the minimum of code in the interface methods (the AllowListConfig implementation is a bit complicated as it contains a lot of references, we must imagine that a typical config would only contains 1 or 2 database ids at most and would thus have a super simple implementation of `JsonFieldReferencingDatabaseIdsInterface`).

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
