### PR TITLE
fix(SLA): escalation levels are now cloned when the related SLA is cloned

### DIFF
--- a/src/CommonDBChild.php
+++ b/src/CommonDBChild.php
@@ -997,7 +997,7 @@ abstract class CommonDBChild extends CommonDBConnexity
 
     final public static function getItemField($itemtype): string
     {
-        if (is_subclass_of($itemtype, 'Rule')) {
+        if (is_subclass_of($itemtype, 'Rule') && !is_subclass_of($itemtype, 'LevelAgreementLevel')) {
             $itemtype = 'Rule';
         }
 

--- a/src/LevelAgreement.php
+++ b/src/LevelAgreement.php
@@ -1151,6 +1151,18 @@ abstract class LevelAgreement extends CommonDBChild
         Rule::cleanForItemAction($this);
     }
 
+    public function post_clone($source, $history)
+    {
+        // Clone levels
+        $classname = get_called_class();
+        $fk        = getForeignKeyFieldForItemType($classname);
+        $level     = new static::$levelclass();
+        foreach ($level->find([$fk => $source->getID()]) as $data) {
+            $level->getFromDB($data['id']);
+            $level->clone([$fk => $this->getID()]);
+        }
+    }
+
     /**
      * Getter for the protected $levelclass static property
      *

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -102,8 +102,8 @@ class Rule extends CommonDBTM
     public function getCloneRelations(): array
     {
         return [
-            RuleAction::class,
-            RuleCriteria::class
+            $this->ruleactionclass,
+            $this->rulecriteriaclass
         ];
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -105,7 +105,6 @@ include_once __DIR__ . '/FrontBaseClass.php';
 include_once __DIR__ . '/RuleBuilder.php';
 include_once __DIR__ . '/functional/CommonITILRecurrent.php';
 include_once __DIR__ . '/functional/Glpi/ContentTemplates/Parameters/AbstractParameters.php';
-include_once __DIR__ . '/functional/AbstractRightsDropdown.php';
 
 // check folder exists instead of class_exists('\GuzzleHttp\Client'), to prevent global includes
 if (file_exists(__DIR__ . '/../vendor/autoload.php') && !file_exists(__DIR__ . '/../vendor/guzzlehttp/guzzle')) {


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !34117

When an SLA or OLA is cloned, the escalation levels linked to it are not cloned in turn.