### PR TITLE
fix(SLA): remove 'Export' option for escalation levels

### DIFF
--- a/src/LevelAgreementLevel.php
+++ b/src/LevelAgreementLevel.php
@@ -420,4 +420,17 @@ abstract class LevelAgreementLevel extends RuleTicket
         // No definition time here so we must guess the unit from the raw seconds value
         return abs($this->fields['execution_time']) >= DAY_TIMESTAMP;
     }
+
+    public function getSpecificMassiveActions($checkitem = null)
+    {
+        $actions = parent::getSpecificMassiveActions($checkitem);
+
+        /**
+         * Remove the export action
+         * A levelAgreementLevel can not be exported
+         */
+        unset($actions[Rule::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'export']);
+
+        return $actions;
+    }
 }


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !34117

![image](https://github.com/user-attachments/assets/b747ec76-6eff-4dbe-9861-523a4702661c)

The Export option is inherited from the options applied to GLPI rules, but is not relevant in the case of an escalation level.
The current export is not functional and is not designed to support escalation levels.