### PR TITLE
fix(notif): adding 'notifications_id' field in notification_notificationtemplate form

### DIFF
--- a/src/Notification_NotificationTemplate.php
+++ b/src/Notification_NotificationTemplate.php
@@ -338,9 +338,9 @@ TWIG, $twig_params);
         }
 
         TemplateRenderer::getInstance()->display('pages/setup/notification/notification_notificationtemplate.html.twig', [
-            'item' => $this,
+            'item'              => $this,
+            'notification'      => $notif,
             'notification_link' => $notif->getLink(),
-            'itemtype' => $notif->fields['itemtype']
         ]);
 
         return true;

--- a/templates/pages/setup/notification/notification_notificationtemplate.html.twig
+++ b/templates/pages/setup/notification/notification_notificationtemplate.html.twig
@@ -33,8 +33,10 @@
 
 {% extends "generic_show_form.html.twig" %}
 {% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
 
 {% block form_fields %}
+	{{ inputs.hidden('notifications_id', notification.fields['id']) }}
    {{ fields.htmlField('', notification_link, 'Notification'|itemtype_name) }}
    {{ fields.nullField() }}
    {{ fields.htmlField('', call('Notification_NotificationTemplate::dropdownMode', [{
@@ -45,7 +47,7 @@
    {{ fields.dropdownField('NotificationTemplate', 'notificationtemplates_id', item.fields['notificationtemplates_id'], 'NotificationTemplate'|itemtype_name, {
       comment: 1,
       condition: {
-         'itemtype': itemtype
+         'itemtype': notification.fields['itemtype'],
       }
    }) }}
 {% endblock %}


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

Currently, when a notification template is added to a notification, a right error is displayed and the notification template has not been added to the notification.

![image](https://github.com/user-attachments/assets/da52b18f-ab2a-48d6-9404-9adfc745aad4)
![image](https://github.com/user-attachments/assets/82ba4de9-3dc0-44b0-af08-eef9f445e346)
