### PR TITLE
Fix the action limit for Dictionnary Rules

### DIFF
--- a/src/RuleDictionnaryPrinter.php
+++ b/src/RuleDictionnaryPrinter.php
@@ -52,15 +52,6 @@ class RuleDictionnaryPrinter extends Rule
         return __('Dictionary of printers');
     }
 
-
-    /**
-     * @see Rule::maxActionsCount()
-     **/
-    public function maxActionsCount()
-    {
-        return 4;
-    }
-
     /**
      * @see Rule::getCriterias()
      **/

--- a/src/RuleDictionnarySoftware.php
+++ b/src/RuleDictionnarySoftware.php
@@ -59,14 +59,6 @@ class RuleDictionnarySoftware extends Rule
 
 
     /**
-     * @see Rule::maxActionsCount()
-     **/
-    public function maxActionsCount()
-    {
-        return 4;
-    }
-
-    /**
      * @see Rule::getCriterias()
      **/
     public function getCriterias()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #34119

Set the action limit for the dictionary of rules. For example, there are 7 criteria available for software, whereas the limit was 4.

**Before**
The button disappears after just 4 actions
![image](https://github.com/user-attachments/assets/cec54cf0-787f-42ff-87b5-41d8485264bd)


**After**
The button disappears when the maximum number of actions is reached.
![image](https://github.com/user-attachments/assets/7f08347b-e0f9-431f-94dd-30f27df2342a)

