### PR TITLE
Improve perf searching ids in dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The present file will list all changes made to the project; according to the
 ### Added
 
 ### Changed
+- Searching IDs in dropdowns now matches the beginning of the ID instead of anywhere in the ID.
 
 ### Deprecated
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -3151,10 +3151,9 @@ JAVASCRIPT;
                 ];
 
                 if (
-                    $_SESSION['glpiis_ids_visible']
-                    && is_numeric($post['searchText']) && (int)$post['searchText'] == $post['searchText']
+                    $_SESSION['glpiis_ids_visible'] && (int) $post['searchText'] === $post['searchText']
                 ) {
-                    $orwhere[$table . '.' . $item->getIndexName()] = ['LIKE', "%{$post['searchText']}%"];
+                    $orwhere[$table . '.' . $item::getIndexName()] = ['LIKE', "{$post['searchText']}%"];
                 }
 
                 if ($item instanceof CommonDCModelDropdown) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #16877

When the search text is numeric, it now only matches the beginning of the IDs rather than anywhere in the IDs. Should enable use of the index for that field now.
Changed a comparison to strict and removed redundant `is_numeric` check.