### PR TITLE
Planning task editable flag based on task not parent

### DIFF
--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -1320,7 +1320,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
                         $interv[$key]["status"]   = $parentitem->fields["status"];
                         $interv[$key]["priority"] = $parentitem->fields["priority"];
 
-                        $interv[$key]["editable"] = $item->canUpdateITILItem();
+                        $interv[$key]["editable"] = $item->canUpdateItem();
 
                       /// Specific for tickets
                         $interv[$key]["device"] = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Seems to make more sense to have the UI restrict drag/edit based on the task's `canUpdateItem` rather than checking `canUpdateITILItem`.