### PR TITLE
fix: Add all rights to cron and manage session values for CronTask

### DIFF
--- a/front/cron.php
+++ b/front/cron.php
@@ -54,6 +54,9 @@ global $CFG_GLPI;
 // Ensure current directory when run from crontab
 chdir(__DIR__);
 
+// Ensure that session is not used
+ini_set('session.use_cookies', 0);
+
 // Try detecting if we are running with the root user (Not available on Windows)
 if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
     // Translation functions not available here

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -855,7 +855,7 @@ class CronTask extends CommonDBTM
                 );
                 if ($crontask->getNeedToRun($mode, $name)) {
                     $_SESSION["glpicronuserrunning"] = "cron_" . $crontask->fields['name'];
-                    $_SESSION["glpiactive_entity"]   = 0;
+                    Session::loadEntity(0, true);
                     $_SESSION["glpigroups"]          = [];
                     $_SESSION["glpiname"]            = "cron";
 

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -854,9 +854,12 @@ class CronTask extends CommonDBTM
                     $i
                 );
                 if ($crontask->getNeedToRun($mode, $name)) {
-                     $_SESSION["glpicronuserrunning"] = "cron_" . $crontask->fields['name'];
+                    $_SESSION["glpicronuserrunning"] = "cron_" . $crontask->fields['name'];
+                    $_SESSION["glpiactive_entity"]   = 0;
+                    $_SESSION["glpigroups"]          = [];
+                    $_SESSION["glpiname"]            = "cron";
 
-                     $function = sprintf('%s::cron%s', $crontask->fields['itemtype'], $crontask->fields['name']);
+                    $function = sprintf('%s::cron%s', $crontask->fields['itemtype'], $crontask->fields['name']);
 
                     if (is_callable($function)) {
                         if ($crontask->start()) { // Lock in DB + log start
@@ -919,7 +922,7 @@ class CronTask extends CommonDBTM
                     Toolbox::logInFile('cron', $msgcron . "\n");
                 }
             }
-            $_SESSION["glpicronuserrunning"] = '';
+
             self::release_lock();
         } else {
             Toolbox::logInFile('cron', __("Can't get DB lock") . "\n");

--- a/src/Session.php
+++ b/src/Session.php
@@ -1408,7 +1408,7 @@ class Session
         /** @var \DBmysql $DB */
         global $DB;
 
-        if (Session::isInventory()) {
+        if (Session::isInventory() || Session::isCron()) {
             return true;
         }
 


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33948

The ticket in question reported a problem with the sending of SLA reminders.
The notification was not being generated and fatal errors were interrupting the notification generation mechanism due to undefined variables (`glpiname` and `glpigroups` in this case).
Access rights to GLPI objects were blocking the notification filter system, which was unable to find the objects due to a lack of rights.