### PR TITLE
fix(ticket): solvedate and closedate on creation

### DIFF
--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -7160,4 +7160,53 @@ HTML
         $result = $DB->request($request);
         $this->assertEquals($existing_tickets + 1, $result->count());
     }
+
+    public function testComputeDefaultValuesForAdd(): void
+    {
+        // OK : Inputs dates are good (no modification expected)
+        $this->createItem('Ticket', [
+            'name'          => __FUNCTION__,
+            'content'       => __FUNCTION__,
+            'status'        => \CommonITILObject::CLOSED,
+            'date_creation' => '2024-01-11 09:00:00',
+            'date'          => '2024-01-12 09:00:00',
+            'solvedate'     => '2024-01-13 09:00:00',
+            'date_mod'      => '2024-01-14 09:00:00',
+            'closedate'     => '2024-01-15 09:00:00',
+        ]);
+
+        // OK : All inputs dates are equal (no modification expected)
+        $this->createItem('Ticket', [
+            'name'          => __FUNCTION__,
+            'content'       => __FUNCTION__,
+            'status'        => \CommonITILObject::CLOSED,
+            'date_creation' => '2024-01-11 09:00:00',
+            'date'          => '2024-01-11 09:00:00',
+            'solvedate'     => '2024-01-11 09:00:00',
+            'date_mod'      => '2024-01-11 09:00:00',
+            'closedate'     => '2024-01-11 09:00:00',
+        ]);
+
+        // NOK : Bad inputs dates -> fixed durring add
+        $input = [
+            'name'          => __FUNCTION__,
+            'content'       => __FUNCTION__,
+            'status'        => \CommonITILObject::CLOSED,
+            'date_creation' => '2024-01-11 09:00:00',
+            'date'          => '2024-01-12 09:00:00',
+            'solvedate'     => '2024-01-11 09:00:00',
+            'date_mod'      => '2024-01-11 09:00:00',
+            'closedate'     => '2024-01-11 09:00:00',
+        ];
+        $expected = $input;
+        $expected['solvedate'] = $input['date'];
+        $expected['closedate'] = $input['date'];
+
+        $ticket = new \Ticket();
+        $input = Sanitizer::sanitize($input);
+        $id = $ticket->add($input);
+        $this->assertIsInt($id);
+        $this->assertGreaterThan(0, $id);
+        $this->checkInput($ticket, $id, $expected);
+    }
 }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -2817,25 +2817,35 @@ abstract class CommonITILObject extends CommonDBTM
             $input["date"] = $_SESSION["glpi_currenttime"];
         }
 
-        if (isset($input["status"]) && in_array($input["status"], $this->getSolvedStatusArray())) {
-            if (isset($input["date"])) {
+        if (in_array($input["status"], $this->getSolvedStatusArray())) {
+            if (
+                !isset($input["solvedate"])
+                || $input["solvedate"] < $input["date"]
+            )
+            {
                 $input["solvedate"] = $input["date"];
-            } else {
-                $input["solvedate"] = $_SESSION["glpi_currenttime"];
             }
         }
 
-        if (isset($input["status"]) && in_array($input["status"], $this->getClosedStatusArray())) {
-            if (isset($input["date"])) {
+        if (in_array($input["status"], $this->getClosedStatusArray())) {
+            if (
+                !isset($input["closedate"])
+                || $input["closedate"] < $input["date"]
+            )
+            {
                 $input["closedate"] = $input["date"];
-            } else {
-                $input["closedate"] = $_SESSION["glpi_currenttime"];
             }
-            $input['solvedate'] = $input["closedate"];
+            if (
+                !isset($input["solvedate"])
+                || $input["solvedate"] < $input["date"]
+                || $input["solvedate"] > $input["closedate"]
+            ) {
+                $input['solvedate'] = $input["closedate"];
+            }
         }
 
-       // Set begin waiting time if status is waiting
-        if (isset($input["status"]) && ($input["status"] == self::WAITING)) {
+        // Set begin waiting time if status is waiting
+        if ($input["status"] == self::WAITING) {
             $input['begin_waiting_date'] = $input['date'];
         }
 

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -2821,8 +2821,7 @@ abstract class CommonITILObject extends CommonDBTM
             if (
                 !isset($input["solvedate"])
                 || $input["solvedate"] < $input["date"]
-            )
-            {
+            ) {
                 $input["solvedate"] = $input["date"];
             }
         }
@@ -2831,8 +2830,7 @@ abstract class CommonITILObject extends CommonDBTM
             if (
                 !isset($input["closedate"])
                 || $input["closedate"] < $input["date"]
-            )
-            {
+            ) {
                 $input["closedate"] = $input["date"];
             }
             if (


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !34145

When creating a ticket via the API with the status set to "closed" and providing resolution and closure dates, these dates were systematically ignored.

I believe we should calculate these dates when they are missing or inconsistent, such as when they are earlier than the ticket's opening date, and also ensure that the resolution date is not after the closure date.
