### PR TITLE
Fix `Implicitly marking parameter $param as nullable is deprecated`

### DIFF
--- a/phpunit/functional/UserTest.php
+++ b/phpunit/functional/UserTest.php
@@ -508,7 +508,7 @@ class UserTest extends \DbTestCase
     /**
      * @dataProvider prepareInputForUpdatePasswordProvider
      */
-    public function testPrepareInputForUpdatePassword(array $input, $expected, array $messages = null)
+    public function testPrepareInputForUpdatePassword(array $input, $expected, ?array $messages = null)
     {
         $this->login();
         $user = new \User();

--- a/src/Appliance.php
+++ b/src/Appliance.php
@@ -460,7 +460,7 @@ class Appliance extends CommonDBTM
         array &$actions,
         $itemtype,
         $is_deleted = false,
-        CommonDBTM $checkitem = null
+        ?CommonDBTM $checkitem = null
     ) {
         if (in_array($itemtype, self::getTypes())) {
             if (self::canUpdate()) {

--- a/src/Appliance_Item_Relation.php
+++ b/src/Appliance_Item_Relation.php
@@ -244,7 +244,7 @@ class Appliance_Item_Relation extends CommonDBRelation
      * @return string the javascript
      */
     public static function getListJSForApplianceItem(
-        CommonDBTM $item = null,
+        ?CommonDBTM $item = null,
         bool $canedit = true
     ) {
         if ($canedit) {

--- a/src/Application/ErrorHandler.php
+++ b/src/Application/ErrorHandler.php
@@ -142,7 +142,7 @@ class ErrorHandler
     /**
      * @param LoggerInterface|null $logger
      */
-    public function __construct(LoggerInterface $logger = null)
+    public function __construct(?LoggerInterface $logger = null)
     {
         $this->logger = $logger;
     }

--- a/src/Application/View/Extension/SearchExtension.php
+++ b/src/Application/View/Extension/SearchExtension.php
@@ -53,7 +53,7 @@ class SearchExtension extends AbstractExtension
 
     public function showItem(
         int $displaytype,
-        string $value = null,
+        ?string $value = null,
         int $num = 0,
         int $row = 0,
         string $extraparams = ""

--- a/src/CalDAV/Backend/Calendar.php
+++ b/src/CalDAV/Backend/Calendar.php
@@ -300,7 +300,7 @@ class Calendar extends AbstractBackend
      *
      * @return boolean
      */
-    private function storeCalendarObject($calendarId, $calendarData, CalDAVCompatibleItemInterface $item = null)
+    private function storeCalendarObject($calendarId, $calendarData, ?CalDAVCompatibleItemInterface $item = null)
     {
 
         /** @var array $CFG_GLPI */

--- a/src/CommonDBConnexity.php
+++ b/src/CommonDBConnexity.php
@@ -408,7 +408,7 @@ abstract class CommonDBConnexity extends CommonDBTM
         $item_right,
         $itemtype,
         $items_id,
-        CommonDBTM &$item = null
+        ?CommonDBTM &$item = null
     ) {
 
        // Do not get it twice
@@ -537,7 +537,7 @@ abstract class CommonDBConnexity extends CommonDBTM
         array &$actions,
         $itemtype,
         $is_deleted = false,
-        CommonDBTM $checkitem = null
+        ?CommonDBTM $checkitem = null
     ) {
 
         $unaffect = false;

--- a/src/CommonDBRelation.php
+++ b/src/CommonDBRelation.php
@@ -1207,8 +1207,8 @@ abstract class CommonDBRelation extends CommonDBConnexity
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -1248,9 +1248,9 @@ abstract class CommonDBRelation extends CommonDBConnexity
      * @param array         $options
      **/
     public static function getHTMLTableCellsForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
         /** @var \DBmysql $DB */

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -2900,7 +2900,7 @@ class CommonDBTM extends CommonGLPI
      *
      * @return boolean
      **/
-    public function can($ID, $right, array &$input = null)
+    public function can($ID, $right, ?array &$input = null)
     {
         if (Session::isInventory()) {
             return true;
@@ -3032,7 +3032,7 @@ class CommonDBTM extends CommonGLPI
      *
      * @return void
      **/
-    public function check($ID, $right, array &$input = null)
+    public function check($ID, $right, ?array &$input = null)
     {
 
        // Check item exists
@@ -3979,7 +3979,7 @@ class CommonDBTM extends CommonGLPI
         array &$actions,
         $itemtype,
         $is_deleted = false,
-        CommonDBTM $checkitem = null
+        ?CommonDBTM $checkitem = null
     ) {
     }
 

--- a/src/CommonDevice.php
+++ b/src/CommonDevice.php
@@ -366,8 +366,8 @@ abstract class CommonDevice extends CommonDropdown
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -409,9 +409,9 @@ abstract class CommonDevice extends CommonDropdown
      * @param $options   array
      **/
     public function getHTMLTableCellForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -144,7 +144,7 @@ class CommonGLPI implements CommonGLPIInterface
      *
      * @return boolean
      **/
-    public function can($ID, $right, array &$input = null)
+    public function can($ID, $right, ?array &$input = null)
     {
         switch ($right) {
             case READ:

--- a/src/Computer_Item.php
+++ b/src/Computer_Item.php
@@ -248,7 +248,7 @@ class Computer_Item extends CommonDBRelation
         array &$actions,
         $itemtype,
         $is_deleted = false,
-        CommonDBTM $checkitem = null
+        ?CommonDBTM $checkitem = null
     ) {
 
         $action_prefix = __CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR;

--- a/src/Console/Migration/AbstractPluginToCoreCommand.php
+++ b/src/Console/Migration/AbstractPluginToCoreCommand.php
@@ -192,7 +192,7 @@ abstract class AbstractPluginToCoreCommand extends AbstractCommand
      *
      * @return void
      */
-    protected function handleImportError($message, ProgressBar $progress_bar = null, bool $prevent_exit = false): void
+    protected function handleImportError($message, ?ProgressBar $progress_bar = null, bool $prevent_exit = false): void
     {
         $skip_errors = $this->input->getOption('skip-errors');
 
@@ -325,7 +325,7 @@ abstract class AbstractPluginToCoreCommand extends AbstractCommand
      *
      * @return null|CommonDBTM Stored item.
      */
-    protected function storeItem(string $itemtype, ?int $existing_item_id, array $input, ProgressBar $progress_bar = null): ?CommonDBTM
+    protected function storeItem(string $itemtype, ?int $existing_item_id, array $input, ?ProgressBar $progress_bar = null): ?CommonDBTM
     {
         if (!is_a($itemtype, CommonDBTM::class, true)) {
             throw new \LogicException(sprintf('Invalid itemtype "%s".', $itemtype));
@@ -373,7 +373,7 @@ abstract class AbstractPluginToCoreCommand extends AbstractCommand
      *
      * @return void
      */
-    protected function storeInfocomForItem(CommonDBTM $item, array $infocom_input, ProgressBar $progress_bar = null): void
+    protected function storeInfocomForItem(CommonDBTM $item, array $infocom_input, ?ProgressBar $progress_bar = null): void
     {
         $infocom = new Infocom();
 

--- a/src/Console/Migration/AppliancesPluginToCoreCommand.php
+++ b/src/Console/Migration/AppliancesPluginToCoreCommand.php
@@ -715,7 +715,7 @@ class AppliancesPluginToCoreCommand extends AbstractCommand
      *
      * @return void
      */
-    private function outputImportError($message, ProgressBar $progress_bar = null)
+    private function outputImportError($message, ?ProgressBar $progress_bar = null)
     {
 
         $skip_errors = $this->input->getOption('skip-errors');

--- a/src/Console/Migration/RacksPluginToCoreCommand.php
+++ b/src/Console/Migration/RacksPluginToCoreCommand.php
@@ -1484,7 +1484,7 @@ class RacksPluginToCoreCommand extends AbstractCommand
      *
      * @return void
      */
-    private function outputImportError($message, ProgressBar $progress_bar = null)
+    private function outputImportError($message, ?ProgressBar $progress_bar = null)
     {
 
         $skip_errors = $this->input->getOption('skip-errors');

--- a/src/ConsumableItem.php
+++ b/src/ConsumableItem.php
@@ -305,7 +305,7 @@ class ConsumableItem extends CommonDBTM
      *
      * @return integer 0 : nothing to do 1 : done with success
      **/
-    public static function cronConsumable(CronTask $task = null)
+    public static function cronConsumable(?CronTask $task = null)
     {
         /**
          * @var array $CFG_GLPI

--- a/src/Contract.php
+++ b/src/Contract.php
@@ -1089,7 +1089,7 @@ class Contract extends CommonDBTM
      *
      * @return integer
      **/
-    public static function cronContract(CronTask $task = null)
+    public static function cronContract(?CronTask $task = null)
     {
         /**
          * @var array $CFG_GLPI
@@ -1713,7 +1713,7 @@ class Contract extends CommonDBTM
         array &$actions,
         $itemtype,
         $is_deleted = false,
-        CommonDBTM $checkitem = null
+        ?CommonDBTM $checkitem = null
     ) {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;

--- a/src/Dashboard/Provider.php
+++ b/src/Dashboard/Provider.php
@@ -81,7 +81,7 @@ class Provider
      * - 'label'
      * - 'icon'
      */
-    public static function bigNumberItem(CommonDBTM $item = null, array $params = []): array
+    public static function bigNumberItem(?CommonDBTM $item = null, array $params = []): array
     {
         $DB = DBConnection::getReadConnection();
 
@@ -772,8 +772,8 @@ class Provider
      * - 'icon'
      */
     public static function nbItemByFk(
-        CommonDBTM $item = null,
-        CommonDBTM $fk_item = null,
+        ?CommonDBTM $item = null,
+        ?CommonDBTM $fk_item = null,
         array $params = []
     ): array {
         $DB = DBConnection::getReadConnection();
@@ -891,7 +891,7 @@ class Provider
      *
      * @return array
      */
-    public static function articleListItem(CommonDBTM $item = null, array $params = []): array
+    public static function articleListItem(?CommonDBTM $item = null, array $params = []): array
     {
         $DB = DBConnection::getReadConnection();
 

--- a/src/DeviceBattery.php
+++ b/src/DeviceBattery.php
@@ -106,8 +106,8 @@ class DeviceBattery extends CommonDevice
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -124,9 +124,9 @@ class DeviceBattery extends CommonDevice
     }
 
     public function getHTMLTableCellForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 

--- a/src/DeviceCamera.php
+++ b/src/DeviceCamera.php
@@ -166,8 +166,8 @@ class DeviceCamera extends CommonDevice
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -188,9 +188,9 @@ class DeviceCamera extends CommonDevice
     }
 
     public function getHTMLTableCellForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 

--- a/src/DeviceCase.php
+++ b/src/DeviceCase.php
@@ -89,8 +89,8 @@ class DeviceCase extends CommonDevice
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -109,9 +109,9 @@ class DeviceCase extends CommonDevice
 
 
     public function getHTMLTableCellForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 

--- a/src/DeviceControl.php
+++ b/src/DeviceControl.php
@@ -113,8 +113,8 @@ class DeviceControl extends CommonDevice
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -135,9 +135,9 @@ class DeviceControl extends CommonDevice
 
 
     public function getHTMLTableCellForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 

--- a/src/DeviceDrive.php
+++ b/src/DeviceDrive.php
@@ -113,8 +113,8 @@ class DeviceDrive extends CommonDevice
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -136,9 +136,9 @@ class DeviceDrive extends CommonDevice
 
 
     public function getHTMLTableCellForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 

--- a/src/DeviceFirmware.php
+++ b/src/DeviceFirmware.php
@@ -242,8 +242,8 @@ class DeviceFirmware extends CommonDevice
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
         /** @var array $CFG_GLPI */
@@ -263,9 +263,9 @@ class DeviceFirmware extends CommonDevice
     }
 
     public function getHTMLTableCellForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
         /** @var array $CFG_GLPI */

--- a/src/DeviceGeneric.php
+++ b/src/DeviceGeneric.php
@@ -77,8 +77,8 @@ class DeviceGeneric extends CommonDevice
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -98,9 +98,9 @@ class DeviceGeneric extends CommonDevice
 
 
     public function getHTMLTableCellForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 

--- a/src/DeviceGraphicCard.php
+++ b/src/DeviceGraphicCard.php
@@ -156,8 +156,8 @@ class DeviceGraphicCard extends CommonDevice
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -178,9 +178,9 @@ class DeviceGraphicCard extends CommonDevice
 
 
     public function getHTMLTableCellForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 

--- a/src/DeviceHardDrive.php
+++ b/src/DeviceHardDrive.php
@@ -164,8 +164,8 @@ class DeviceHardDrive extends CommonDevice
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -187,9 +187,9 @@ class DeviceHardDrive extends CommonDevice
 
 
     public function getHTMLTableCellForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 

--- a/src/DeviceMemory.php
+++ b/src/DeviceMemory.php
@@ -152,8 +152,8 @@ class DeviceMemory extends CommonDevice
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -174,9 +174,9 @@ class DeviceMemory extends CommonDevice
 
 
     public function getHTMLTableCellForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 

--- a/src/DeviceMotherboard.php
+++ b/src/DeviceMotherboard.php
@@ -89,8 +89,8 @@ class DeviceMotherboard extends CommonDevice
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -109,9 +109,9 @@ class DeviceMotherboard extends CommonDevice
 
 
     public function getHTMLTableCellForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 

--- a/src/DeviceNetworkCard.php
+++ b/src/DeviceNetworkCard.php
@@ -128,8 +128,8 @@ class DeviceNetworkCard extends CommonDevice
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -153,9 +153,9 @@ class DeviceNetworkCard extends CommonDevice
 
 
     public static function getHTMLTableCellsForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 
@@ -185,9 +185,9 @@ class DeviceNetworkCard extends CommonDevice
 
 
     public function getHTMLTableCellForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 

--- a/src/DevicePowerSupply.php
+++ b/src/DevicePowerSupply.php
@@ -101,8 +101,8 @@ class DevicePowerSupply extends CommonDevice
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -122,9 +122,9 @@ class DevicePowerSupply extends CommonDevice
 
 
     public function getHTMLTableCellForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 

--- a/src/DeviceProcessor.php
+++ b/src/DeviceProcessor.php
@@ -171,8 +171,8 @@ class DeviceProcessor extends CommonDevice
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -191,9 +191,9 @@ class DeviceProcessor extends CommonDevice
 
 
     public function getHTMLTableCellForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 

--- a/src/DeviceSensor.php
+++ b/src/DeviceSensor.php
@@ -78,8 +78,8 @@ class DeviceSensor extends CommonDevice
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -100,9 +100,9 @@ class DeviceSensor extends CommonDevice
 
 
     public function getHTMLTableCellForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 

--- a/src/DeviceSoundCard.php
+++ b/src/DeviceSoundCard.php
@@ -101,8 +101,8 @@ class DeviceSoundCard extends CommonDevice
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -122,9 +122,9 @@ class DeviceSoundCard extends CommonDevice
 
 
     public function getHTMLTableCellForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 

--- a/src/Document.php
+++ b/src/Document.php
@@ -1751,7 +1751,7 @@ class Document extends CommonDBTM
         array &$actions,
         $itemtype,
         $is_deleted = false,
-        CommonDBTM $checkitem = null
+        ?CommonDBTM $checkitem = null
     ) {
         $action_prefix = 'Document_Item' . MassiveAction::CLASS_ACTION_SEPARATOR;
 

--- a/src/GLPIPDF.php
+++ b/src/GLPIPDF.php
@@ -60,7 +60,7 @@ class GLPIPDF extends TCPDF
     ];
     private array $config = [];
 
-    public function __construct(array $config = [], int $count = null, string $title = null)
+    public function __construct(array $config = [], ?int $count = null, ?string $title = null)
     {
         $config += self::$default_config;
         $this->config = $config;

--- a/src/HTMLTableBase.php
+++ b/src/HTMLTableBase.php
@@ -129,8 +129,8 @@ abstract class HTMLTableBase
     public function addHeader(
         $name,
         $content,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null
     ) {
 
         $this->tryAddHeader();

--- a/src/HTMLTableCell.php
+++ b/src/HTMLTableCell.php
@@ -60,8 +60,8 @@ class HTMLTableCell extends HTMLTableEntity
         $row,
         $header,
         $content,
-        HTMLTableCell $father = null,
-        CommonDBTM $item = null
+        ?HTMLTableCell $father = null,
+        ?CommonDBTM $item = null
     ) {
 
         parent::__construct($content);

--- a/src/HTMLTableHeader.php
+++ b/src/HTMLTableHeader.php
@@ -87,7 +87,7 @@ abstract class HTMLTableHeader extends HTMLTableEntity
      * @param string               $content see HTMLTableEntity#__construct()
      * @param HTMLTableHeader|null $father  father of the current column (default NULL)
      */
-    public function __construct($name, $content, HTMLTableHeader $father = null)
+    public function __construct($name, $content, ?HTMLTableHeader $father = null)
     {
 
         parent::__construct($content);
@@ -100,7 +100,7 @@ abstract class HTMLTableHeader extends HTMLTableEntity
     /**
      * @param CommonDBTM $item
      **/
-    public function checkItemType(CommonDBTM $item = null)
+    public function checkItemType(?CommonDBTM $item = null)
     {
 
         if (($item === null) && (count($this->itemtypes) > 0)) {

--- a/src/HTMLTableRow.php
+++ b/src/HTMLTableRow.php
@@ -97,8 +97,8 @@ class HTMLTableRow extends HTMLTableEntity
     public function addCell(
         HTMLTableHeader $header,
         $content,
-        HTMLTableCell $father = null,
-        CommonDBTM $item = null
+        ?HTMLTableCell $father = null,
+        ?CommonDBTM $item = null
     ) {
 
         if (!$this->group->haveHeader($header)) {

--- a/src/HTMLTableSubHeader.php
+++ b/src/HTMLTableSubHeader.php
@@ -52,7 +52,7 @@ class HTMLTableSubHeader extends HTMLTableHeader
         HTMLTableSuperHeader $header,
         $name,
         $content,
-        HTMLTableHeader $father = null
+        ?HTMLTableHeader $father = null
     ) {
 
         $this->header = $header;

--- a/src/HTMLTableSuperHeader.php
+++ b/src/HTMLTableSuperHeader.php
@@ -51,7 +51,7 @@ class HTMLTableSuperHeader extends HTMLTableHeader
      * @param string               $content  see inc/HTMLTableEntity#__construct()
      * @param HTMLTableSuperHeader $father   HTMLTableSuperHeader objet (default NULL)
      **/
-    public function __construct(HTMLTableMain $table, $name, $content, HTMLTableSuperHeader $father = null)
+    public function __construct(HTMLTableMain $table, $name, $content, ?HTMLTableSuperHeader $father = null)
     {
 
         $this->table = $table;

--- a/src/IPAddress.php
+++ b/src/IPAddress.php
@@ -1095,8 +1095,8 @@ class IPAddress extends CommonDBChild
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -1141,9 +1141,9 @@ class IPAddress extends CommonDBChild
      * @param $options   array
      **/
     public static function getHTMLTableCellsForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
         /**

--- a/src/IPNetwork.php
+++ b/src/IPNetwork.php
@@ -1084,8 +1084,8 @@ class IPNetwork extends CommonImplicitTreeDropdown
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -1113,9 +1113,9 @@ class IPNetwork extends CommonImplicitTreeDropdown
      * @param $options   array
      **/
     public static function getHTMLTableCellsForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
         if (empty($item)) {

--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -1800,7 +1800,7 @@ class Infocom extends CommonDBChild
         array &$actions,
         $itemtype,
         $is_deleted = false,
-        CommonDBTM $checkitem = null
+        ?CommonDBTM $checkitem = null
     ) {
 
         $action_name = __CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'activate';

--- a/src/InterfaceType.php
+++ b/src/InterfaceType.php
@@ -57,8 +57,8 @@ class InterfaceType extends CommonDropdown
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -81,9 +81,9 @@ class InterfaceType extends CommonDropdown
      * @param $options   array
      **/
     public static function getHTMLTableCellsForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
         $column_name = __CLASS__;

--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -90,7 +90,7 @@ abstract class InventoryAsset
      * @param CommonDBTM $item Item instance
      * @param array|null $data Data part, optional
      */
-    public function __construct(CommonDBTM $item, array $data = null)
+    public function __construct(CommonDBTM $item, ?array $data = null)
     {
         $this->item = $item;
         if ($data !== null) {

--- a/src/Inventory/Asset/NetworkEquipment.php
+++ b/src/Inventory/Asset/NetworkEquipment.php
@@ -235,7 +235,7 @@ class NetworkEquipment extends MainAsset
         }
     }
 
-    public function handleLinks(array $data = null)
+    public function handleLinks(?array $data = null)
     {
         if ($this->current_key !== null) {
             $data = [$this->data[$this->current_key]];

--- a/src/Inventory/Asset/Unmanaged.php
+++ b/src/Inventory/Asset/Unmanaged.php
@@ -306,7 +306,7 @@ class Unmanaged extends MainAsset
         }
     }
 
-    public function handleLinks(array $data = null)
+    public function handleLinks(?array $data = null)
     {
         if ($this->current_key !== null) {
             $data = [$this->data[$this->current_key]];

--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -850,10 +850,10 @@ class Item_Devices extends CommonDBRelation
         CommonDBTM $item,
         HTMLTableMain $table,
         array $options,
-        ?HTMLTableSuperHeader $delete_all_column = null,
+        ?HTMLTableSuperHeader $delete_all_column,
         HTMLTableSuperHeader $common_column,
         HTMLTableSuperHeader $specific_column,
-        ?HTMLTableSuperHeader $delete_column = null,
+        ?HTMLTableSuperHeader $delete_column,
         $dynamic_column
     ) {
         /** @var \DBmysql $DB */

--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -850,10 +850,10 @@ class Item_Devices extends CommonDBRelation
         CommonDBTM $item,
         HTMLTableMain $table,
         array $options,
-        HTMLTableSuperHeader $delete_all_column = null,
+        ?HTMLTableSuperHeader $delete_all_column = null,
         HTMLTableSuperHeader $common_column,
         HTMLTableSuperHeader $specific_column,
-        HTMLTableSuperHeader $delete_column = null,
+        ?HTMLTableSuperHeader $delete_column = null,
         $dynamic_column
     ) {
         /** @var \DBmysql $DB */

--- a/src/KnowbaseItem_Item.php
+++ b/src/KnowbaseItem_Item.php
@@ -355,7 +355,7 @@ class KnowbaseItem_Item extends CommonDBRelation
         array &$actions,
         $itemtype,
         $is_deleted = false,
-        CommonDBTM $checkitem = null
+        ?CommonDBTM $checkitem = null
     ) {
 
         $kb_item = new KnowbaseItem();

--- a/src/KnowbaseItem_KnowbaseItemCategory.php
+++ b/src/KnowbaseItem_KnowbaseItemCategory.php
@@ -280,7 +280,7 @@ class KnowbaseItem_KnowbaseItemCategory extends CommonDBRelation
         array &$actions,
         $itemtype,
         $is_deleted = false,
-        CommonDBTM $checkitem = null
+        ?CommonDBTM $checkitem = null
     ) {
 
         $kb_item = new KnowbaseItem();

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -1093,7 +1093,7 @@ class Lock extends CommonGLPI
         array &$actions,
         $itemtype,
         $is_deleted = false,
-        CommonDBTM $checkitem = null
+        ?CommonDBTM $checkitem = null
     ) {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;

--- a/src/Lockedfield.php
+++ b/src/Lockedfield.php
@@ -341,7 +341,7 @@ class Lockedfield extends CommonDBTM
      *
      * @return array
      */
-    public function getFieldsToLock(string $specific_itemtype = null): array
+    public function getFieldsToLock(?string $specific_itemtype = null): array
     {
         /**
          * @var array $CFG_GLPI

--- a/src/Manufacturer.php
+++ b/src/Manufacturer.php
@@ -178,8 +178,8 @@ class Manufacturer extends CommonDropdown
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -202,9 +202,9 @@ class Manufacturer extends CommonDropdown
      * @param $options   array
      **/
     public static function getHTMLTableCellsForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 

--- a/src/Marketplace/Controller.php
+++ b/src/Marketplace/Controller.php
@@ -265,7 +265,7 @@ class Controller extends CommonGLPI
      *
      * @return string|false new version number
      */
-    public function checkUpdate(Plugin $plugin_inst = null)
+    public function checkUpdate(?Plugin $plugin_inst = null)
     {
         $api          = self::getAPI();
         $api_plugin   = $api->getPlugin($this->plugin_key);
@@ -323,7 +323,7 @@ class Controller extends CommonGLPI
      *
      * @return integer 0 : nothing to do 1 : done with success
      */
-    public static function cronCheckAllUpdates(CronTask $task = null): int
+    public static function cronCheckAllUpdates(?CronTask $task = null): int
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -717,7 +717,7 @@ class MassiveAction
      *
      * @return array|false Array of massive actions or false if $item is not valid
      **/
-    public static function getAllMassiveActions($item, $is_deleted = false, CommonDBTM $checkitem = null, ?int $items_id = null)
+    public static function getAllMassiveActions($item, $is_deleted = false, ?CommonDBTM $checkitem = null, ?int $items_id = null)
     {
         /** @var array $PLUGIN_HOOKS */
         global $PLUGIN_HOOKS;

--- a/src/NetworkAlias.php
+++ b/src/NetworkAlias.php
@@ -162,8 +162,8 @@ class NetworkAlias extends FQDNLabel
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -194,9 +194,9 @@ class NetworkAlias extends FQDNLabel
      * @param $options   array
      **/
     public static function getHTMLTableCellsForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
         /** @var \DBmysql $DB */

--- a/src/NetworkName.php
+++ b/src/NetworkName.php
@@ -510,8 +510,8 @@ class NetworkName extends FQDNLabel
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -561,9 +561,9 @@ class NetworkName extends FQDNLabel
      * @param $options   array
      **/
     public static function getHTMLTableCellsForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
         /** @var \DBmysql $DB */

--- a/src/NetworkPortAggregate.php
+++ b/src/NetworkPortAggregate.php
@@ -90,8 +90,8 @@ class NetworkPortAggregate extends NetworkPortInstantiation
     public function getInstantiationHTMLTableHeaders(
         HTMLTableGroup $group,
         HTMLTableSuperHeader $super,
-        HTMLTableSuperHeader $internet_super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $internet_super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -105,7 +105,7 @@ class NetworkPortAggregate extends NetworkPortInstantiation
     public function getInstantiationHTMLTable(
         NetworkPort $netport,
         HTMLTableRow $row,
-        HTMLTableCell $father = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 

--- a/src/NetworkPortAlias.php
+++ b/src/NetworkPortAlias.php
@@ -88,8 +88,8 @@ class NetworkPortAlias extends NetworkPortInstantiation
     public function getInstantiationHTMLTableHeaders(
         HTMLTableGroup $group,
         HTMLTableSuperHeader $super,
-        HTMLTableSuperHeader $internet_super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $internet_super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -103,7 +103,7 @@ class NetworkPortAlias extends NetworkPortInstantiation
     public function getInstantiationHTMLTable(
         NetworkPort $netport,
         HTMLTableRow $row,
-        HTMLTableCell $father = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 

--- a/src/NetworkPortDialup.php
+++ b/src/NetworkPortDialup.php
@@ -47,8 +47,8 @@ class NetworkPortDialup extends NetworkPortInstantiation
     public function getInstantiationHTMLTableHeaders(
         HTMLTableGroup $group,
         HTMLTableSuperHeader $super,
-        HTMLTableSuperHeader $internet_super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $internet_super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -62,7 +62,7 @@ class NetworkPortDialup extends NetworkPortInstantiation
     public function getInstantiationHTMLTable(
         NetworkPort $netport,
         HTMLTableRow $row,
-        HTMLTableCell $father = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 

--- a/src/NetworkPortEthernet.php
+++ b/src/NetworkPortEthernet.php
@@ -136,8 +136,8 @@ class NetworkPortEthernet extends NetworkPortInstantiation
     public function getInstantiationHTMLTableHeaders(
         HTMLTableGroup $group,
         HTMLTableSuperHeader $super,
-        HTMLTableSuperHeader $internet_super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $internet_super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -165,7 +165,7 @@ class NetworkPortEthernet extends NetworkPortInstantiation
     protected function getPeerInstantiationHTMLTable(
         NetworkPort $netport,
         HTMLTableRow $row,
-        HTMLTableCell $father = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 
@@ -196,7 +196,7 @@ class NetworkPortEthernet extends NetworkPortInstantiation
     public function getInstantiationHTMLTable(
         NetworkPort $netport,
         HTMLTableRow $row,
-        HTMLTableCell $father = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 

--- a/src/NetworkPortFiberchannel.php
+++ b/src/NetworkPortFiberchannel.php
@@ -136,8 +136,8 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation
     public function getInstantiationHTMLTableHeaders(
         HTMLTableGroup $group,
         HTMLTableSuperHeader $super,
-        HTMLTableSuperHeader $internet_super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $internet_super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -164,7 +164,7 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation
     protected function getPeerInstantiationHTMLTable(
         NetworkPort $netport,
         HTMLTableRow $row,
-        HTMLTableCell $father = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 
@@ -191,7 +191,7 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation
     public function getInstantiationHTMLTable(
         NetworkPort $netport,
         HTMLTableRow $row,
-        HTMLTableCell $father = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 

--- a/src/NetworkPortInstantiation.php
+++ b/src/NetworkPortInstantiation.php
@@ -190,8 +190,8 @@ class NetworkPortInstantiation extends CommonDBChild
     public function getInstantiationHTMLTableHeaders(
         HTMLTableGroup $group,
         HTMLTableSuperHeader $super,
-        HTMLTableSuperHeader $internet_super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $internet_super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -238,7 +238,7 @@ class NetworkPortInstantiation extends CommonDBChild
     protected function getPeerInstantiationHTMLTable(
         NetworkPort $netport,
         HTMLTableRow $row,
-        HTMLTableCell $father = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 
@@ -265,7 +265,7 @@ class NetworkPortInstantiation extends CommonDBChild
     public function getInstantiationHTMLTableWithPeer(
         NetworkPort $netport,
         HTMLTableRow $row,
-        HTMLTableCell $father = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 
@@ -334,7 +334,7 @@ class NetworkPortInstantiation extends CommonDBChild
     public function getInstantiationHTMLTable(
         NetworkPort $netport,
         HTMLTableRow $row,
-        HTMLTableCell $father = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
         /** @var \DBmysql $DB */

--- a/src/NetworkPortMigration.php
+++ b/src/NetworkPortMigration.php
@@ -491,8 +491,8 @@ class NetworkPortMigration extends CommonDBChild
     public static function getMigrationInstantiationHTMLTableHeaders(
         HTMLTableGroup $group,
         HTMLTableSuperHeader $super,
-        HTMLTableSuperHeader $internet_super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $internet_super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
        // TODO : study to display the correct information for this undefined NetworkPort

--- a/src/NetworkPortWifi.php
+++ b/src/NetworkPortWifi.php
@@ -93,8 +93,8 @@ class NetworkPortWifi extends NetworkPortInstantiation
     public function getInstantiationHTMLTableHeaders(
         HTMLTableGroup $group,
         HTMLTableSuperHeader $super,
-        HTMLTableSuperHeader $internet_super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $internet_super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -112,7 +112,7 @@ class NetworkPortWifi extends NetworkPortInstantiation
     public function getInstantiationHTMLTable(
         NetworkPort $netport,
         HTMLTableRow $row,
-        HTMLTableCell $father = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
 

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -816,7 +816,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
      *
      * @return array
      */
-    public function getMine(string $itemtype = null, bool $inverse = false, bool $enable_partial_warnings = true): array
+    public function getMine(?string $itemtype = null, bool $inverse = false, bool $enable_partial_warnings = true): array
     {
         /** @var \DBmysql $DB */
         global $DB;
@@ -937,7 +937,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
      *
      * @return void
      */
-    public function displayMine(string $itemtype = null, bool $inverse = false, bool $enable_partial_warnings = true)
+    public function displayMine(?string $itemtype = null, bool $inverse = false, bool $enable_partial_warnings = true)
     {
         TemplateRenderer::getInstance()->display('layout/parts/saved_searches_list.html.twig', [
             'active'         => $_SESSION['glpi_loaded_savedsearch'] ?? "",

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -1130,9 +1130,9 @@ class Socket extends CommonDBChild
      * @param $options   array
      **/
     public static function getHTMLTableCellsForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         $options = []
     ) {
 

--- a/src/System/RequirementsManager.php
+++ b/src/System/RequirementsManager.php
@@ -63,11 +63,11 @@ class RequirementsManager
     /**
      * Returns core requirement list.
      *
-     * @param \DBmysql $db  DB instance (if null BD requirements will not be returned).
+     * @param \DBmysql|null $db  DB instance (if null BD requirements will not be returned).
      *
      * @return RequirementsList
      */
-    public function getCoreRequirementList(\DBmysql $db = null): RequirementsList
+    public function getCoreRequirementList(?\DBmysql $db = null): RequirementsList
     {
         $requirements = [];
 

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2381,7 +2381,7 @@ class Toolbox
      * @since 9.1
      * @since 9.4.7 Added $database parameter
      **/
-    public static function createSchema($lang = 'en_GB', DBmysql $database = null)
+    public static function createSchema($lang = 'en_GB', ?DBmysql $database = null)
     {
         /** @var \DBmysql $DB */
         global $DB;

--- a/src/Unmanaged.php
+++ b/src/Unmanaged.php
@@ -214,7 +214,7 @@ class Unmanaged extends CommonDBTM
         array &$actions,
         $itemtype,
         $is_deleted = false,
-        CommonDBTM $checkitem = null
+        ?CommonDBTM $checkitem = null
     ) {
         if (self::canUpdate()) {
             $actions['Unmanaged' . MassiveAction::CLASS_ACTION_SEPARATOR . 'convert']    = __('Convert');
@@ -261,7 +261,7 @@ class Unmanaged extends CommonDBTM
      * @param int         $items_id ID of Unmanaged equipment
      * @param string|null $itemtype Item type to convert to. Will take Unmanaged value if null
      */
-    public function convert(int $items_id, string $itemtype = null)
+    public function convert(int $items_id, ?string $itemtype = null)
     {
         /** @var \DBmysql $DB */
         global $DB;

--- a/src/User.php
+++ b/src/User.php
@@ -6019,7 +6019,7 @@ HTML;
      *
      * @return string
      */
-    public static function getThumbnailURLForPicture(string $picture = null)
+    public static function getThumbnailURLForPicture(?string $picture = null)
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;

--- a/src/Vlan.php
+++ b/src/Vlan.php
@@ -117,8 +117,8 @@ class Vlan extends CommonDropdown
     public static function getHTMLTableHeader(
         $itemtype,
         HTMLTableBase $base,
-        HTMLTableSuperHeader $super = null,
-        HTMLTableHeader $father = null,
+        ?HTMLTableSuperHeader $super = null,
+        ?HTMLTableHeader $father = null,
         array $options = []
     ) {
 
@@ -143,9 +143,9 @@ class Vlan extends CommonDropdown
      * @param $options   array
      **/
     public static function getHTMLTableCellsForItem(
-        HTMLTableRow $row = null,
-        CommonDBTM $item = null,
-        HTMLTableCell $father = null,
+        ?HTMLTableRow $row = null,
+        ?CommonDBTM $item = null,
+        ?HTMLTableCell $father = null,
         array $options = []
     ) {
         $column_name = __CLASS__;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Implicitly nullable parameter declarations are deprecated in PHP 8.4. The proposed change is safe and is not considered by PHP as a signature change, see https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

I also added a second commit to fix a `Optional parameter $param1 declared before required parameter $param2 is implicitly treated as a required parameter` error.