### PR TITLE
Fix groups input rendering error when unicity check fails

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -158,6 +158,12 @@ class Dropdown
             $params['value'] = 0;
         }
 
+        if ($params['multiple'] && $params['values'] === '') {
+            // Prevent issues when the value corresponds to the empty string default value send by the form
+            // when no value is selected and is used when form is redisplayed due, for instance, to unicity check fails.
+            $params['values'] = [];
+        }
+
         // Remove selected value from used to prevent current selected value from being hidden from available values
         if ($params['multiple']) {
             $params['used'] = array_diff($params['used'], $params['values']);

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -159,7 +159,7 @@ class Dropdown
         }
 
         if ($params['multiple'] && $params['values'] === '') {
-            // Prevent issues when the value corresponds to the empty string default value send by the form
+            // Prevent issues when the value corresponds to the empty string default value sent by the form
             // when no value is selected and is used when form is redisplayed due, for instance, to unicity check fails.
             $params['values'] = [];
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In #17074, an hidden input was added prior to multiple dropdown to be sure that an empty value is sent when no dropdown value is selected. It permits to do simple checks like `if (!empty($input[$field])) { ... }` and to simplify the handling of multiple dropdowns.

The side effect is that, when the form is redisplayed based on the saved raw input, the `values` param is an empty string, instead of an empty array, and the following error occurs:
```
Twig Error (Twig\Error\RuntimeError): "An exception has been thrown during the rendering of a template ("array_diff(): Argument #2 must be of type array, string given")." in template "/var/www/glpi/templates/generic_show_form.html.twig" at line 417
```