### PR TITLE
Fix deprecation on CSV export in PHP 8.4

### DIFF
--- a/src/Csv/CsvResponse.php
+++ b/src/Csv/CsvResponse.php
@@ -48,7 +48,7 @@ class CsvResponse
     {
         $csv = Writer::createFromString('');
 
-        // Using a non empty string for `$escape` to is deprecated in PHP 8.4.
+        // Using a non empty string for `$escape` is deprecated in PHP 8.4.
         // According to https://www.php.net/manual/fr/function.fgetcsv.php, using an empty value for `$escape`
         // will result in the same than using `\`.
         $csv->setEscape('');

--- a/src/Csv/CsvResponse.php
+++ b/src/Csv/CsvResponse.php
@@ -47,6 +47,12 @@ class CsvResponse
     public static function output(ExportToCsvInterface $export): void
     {
         $csv = Writer::createFromString('');
+
+        // Using a non empty string for `$escape` to is deprecated in PHP 8.4.
+        // According to https://www.php.net/manual/fr/function.fgetcsv.php, using an empty value for `$escape`
+        // will result in the same than using `\`.
+        $csv->setEscape('');
+
         $csv->setDelimiter($_SESSION["glpicsv_delimiter"] ?? ";");
         $csv->insertOne($export->getFileHeader());
         $csv->insertAll($export->getFileContent());

--- a/tests/functional/Glpi/Csv/CsvResponse.php
+++ b/tests/functional/Glpi/Csv/CsvResponse.php
@@ -65,6 +65,7 @@ class CsvResponse extends DbTestCase
         $csv = Reader::createFromString(ob_get_clean());
         $csv->setHeaderOffset(0);
         $csv->setDelimiter($_SESSION["glpicsv_delimiter"] ?? ";");
+        $csv->setEscape('');
         $header = $csv->getHeader();
         $records = iterator_to_array($csv->getRecords());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Passing a non empty string for the escape char in CSV operations is deprecated in PHP 8.4 (see https://github.com/php/php-src/pull/15365) and output the following message: `fgetcsv(): Passing a non-empty string to the $escape parameter is deprecated since 8.4`.

As documented in https://www.php.net/manual/fr/function.fgetcsv.php, using `\` for the `$escape` parameter value is pretty useless. Thus, as in GLPI we already replace the `"` char by two single quotes `''` (in `Search::csv_clean()`), values will never contain the enclosure char and so any escaping logic is useless.