### PR TITLE
Fix spacing chars trim in data export

### DIFF
--- a/phpunit/functional/Glpi/Toolbox/DataExportTest.php
+++ b/phpunit/functional/Glpi/Toolbox/DataExportTest.php
@@ -90,6 +90,49 @@ HTML),
 HTML),
             'expected_result' => 'Processing (assigned)',
         ];
+
+        // Leading/trailing spacing chars in HTML
+        $spacing_chars = [
+            " ",
+            "\n",
+            "\r",
+            "\t",
+            "\xC2\xA0", // unicode value of decoded &nbsp;
+        ];
+        foreach ($spacing_chars as $spacing_char) {
+            yield [
+                'value'           => '<div>' . $spacing_char . 'Some value' . '</div>',
+                'expected_result' => 'Some value',
+            ];
+            yield [
+                'value'           => '<div>' . 'Some value' . $spacing_char . '</div>',
+                'expected_result' => 'Some value',
+            ];
+            yield [
+                'value'           => '<div>' . $spacing_char . 'Some value' . $spacing_char . '</div>',
+                'expected_result' => 'Some value',
+            ];
+        }
+
+        // Leading/trailing spacing chars combo in HTML
+        yield [
+            'value'           => '<div>' . 'Some value' . "\t  \n\r   \t" . '</div>',
+            'expected_result' => 'Some value',
+        ];
+        yield [
+            'value'           => '<div>' . "\t\n\t" . 'Some value' . '</div>',
+            'expected_result' => 'Some value',
+        ];
+
+        // Ending char that is a special char ending with a subset of the non breakable space bytes should not be altered
+        yield [
+            'value'           => '<div>' . 'Some value' . "\xE5\x8A\xA0" . '</div>',
+            'expected_result' => 'Some value' . "\xE5\x8A\xA0",
+        ];
+        yield [
+            'value'           => 'Some value' . "\xE5\x8A\xA0",
+            'expected_result' => 'Some value' . "\xE5\x8A\xA0",
+        ];
     }
 
     /**

--- a/src/Toolbox/DataExport.php
+++ b/src/Toolbox/DataExport.php
@@ -80,8 +80,13 @@ class DataExport
             $value = RichText::getTextFromHtml($value, true, true);
 
             // Remove extra spacing
-            $nbsp = chr(0xC2) . chr(0xA0); // unicode value of decoded &nbsp;
-            $value = trim($value, " \n\r\t" . $nbsp);
+            $spacing_chars = [
+                '\s', // any basic spacing char
+                '\x{C2A0}', // unicode value of decoded &nbsp;
+            ];
+            $spacing_chars_pattern = '(' . implode('|', $spacing_chars) . ')+';
+            $value = preg_replace('/^' . $spacing_chars_pattern . '/u', '', $value);
+            $value = preg_replace('/' . $spacing_chars_pattern . '$/u', '', $value);
         }
 
         return $value;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #17417

Usage of `trim` is not compatible with multibyte chars. Indeed, a `trim($str, "\xC2\xA0")` will remove any `\xC2` and `\xA0` chars even if only one of them is present. Using `preg_replace` fixes this issue.