### PR TITLE
Fix(Group): fix user visibilty

### DIFF
--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -554,7 +554,7 @@ class Group_User extends CommonDBRelation
             echo "<div class='alert alert-primary d-flex align-items-center mb-4' role='alert'>";
             echo "<i class='fas fa-info-circle fa-xl'></i>";
             echo "<span class='ms-2'>";
-            echo __("Some people are not visible in this list because of your clearance (restriction by entity).");
+            echo __("Some users are not listed as they are not visible from your current entity.");
             echo "</span>";
             echo "</div>";
             echo "</tr>";

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -552,7 +552,7 @@ class Group_User extends CommonDBRelation
         if ($number != $all_groups) {
             echo "<tr class='tab_bg_1'>";
             echo "<div class='alert alert-primary d-flex align-items-center mb-4' role='alert'>";
-            echo "<i class='fas fa-info-circle fa-xl'></i>";
+            echo "<i class='ti ti-info-circle fa-xl'></i>";
             echo "<span class='ms-2'>";
             echo __("Some users are not listed as they are not visible from your current entity.");
             echo "</span>";

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -376,6 +376,7 @@ class Group_User extends CommonDBRelation
      * @param array    $ids              Array of ids (not filtered)
      * @param string   $crit             Filter (is_manager, is_userdelegate) (default '')
      * @param bool|int $tree             True to include member of sub-group (default 0)
+     * @param bool     $check_entities   Apply entities restrictions ?
      *
      * @return String tab of entity for restriction
      **/
@@ -384,7 +385,8 @@ class Group_User extends CommonDBRelation
         &$members,
         &$ids,
         $crit = '',
-        $tree = 0
+        $tree = 0,
+        bool $check_entities = true
     ) {
         /** @var \DBmysql $DB */
         global $DB;
@@ -393,7 +395,7 @@ class Group_User extends CommonDBRelation
         if ($group->fields['is_recursive']) {
             $entityrestrict = getSonsOf('glpi_entities', $group->fields['entities_id']);
 
-           // active entity could be a child of object entity
+            // active entity could be a child of object entity
             if (
                 ($_SESSION['glpiactive_entity'] != $group->fields['entities_id'])
                 && in_array($_SESSION['glpiactive_entity'], $entityrestrict)
@@ -412,7 +414,7 @@ class Group_User extends CommonDBRelation
 
         // All group members
         $pu_table = Profile_User::getTable();
-        $iterator = $DB->request([
+        $query = [
             'SELECT' => [
                 'glpi_users.id',
                 'glpi_groups_users.id AS linkid',
@@ -439,16 +441,22 @@ class Group_User extends CommonDBRelation
             ],
             'WHERE' => [
                 self::getTable() . '.groups_id'  => $restrict,
-                'OR' => [
-                    "$pu_table.entities_id" => null
-                ] + getEntitiesRestrictCriteria($pu_table, '', $entityrestrict, 1)
             ],
             'ORDERBY' => [
                 User::getTable() . '.realname',
                 User::getTable() . '.firstname',
                 User::getTable() . '.name'
             ]
-        ]);
+        ];
+
+        // Add entities restrictions
+        if ($check_entities) {
+            $query['WHERE']['OR'] = [
+                "$pu_table.entities_id" => null
+            ] + getEntitiesRestrictCriteria($pu_table, '', $entityrestrict, 1);
+        }
+
+        $iterator = $DB->request($query);
 
         foreach ($iterator as $data) {
             // Add to display list, according to criterion
@@ -496,7 +504,7 @@ class Group_User extends CommonDBRelation
 
        // Retrieve member list
        // TODO: migrate to use CommonDBRelation::getListForItem()
-        $entityrestrict = self::getDataForGroup($group, $used, $ids, $crit, $tree);
+        $entityrestrict = self::getDataForGroup($group, $used, $ids, $crit, $tree, true);
 
         if ($canedit) {
             self::showAddUserForm($group, $ids, $entityrestrict, $crit);
@@ -814,7 +822,7 @@ class Group_User extends CommonDBRelation
                     if (User::canView()) {
                         if ($_SESSION['glpishow_count_on_tabs']) {
                             $members = $ids = [];
-                            self::getDataForGroup($item, $members, $ids, '', 0);
+                            self::getDataForGroup($item, $members, $ids, '', true);
                             $nb = count($members);
                         }
                         return self::createTabEntry(User::getTypeName(Session::getPluralNumber()), $nb);

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -502,6 +502,11 @@ class Group_User extends CommonDBRelation
         $used    = [];
         $ids     = [];
 
+        self::getDataForGroup($group, $used, $ids, $crit, $tree, false);
+        $all_groups = count($used);
+        $used    = [];
+        $ids     = [];
+
        // Retrieve member list
        // TODO: migrate to use CommonDBRelation::getListForItem()
         $entityrestrict = self::getDataForGroup($group, $used, $ids, $crit, $tree, true);
@@ -543,6 +548,18 @@ class Group_User extends CommonDBRelation
         if ($start >= $number) {
             $start = 0;
         }
+
+        if ($number != $all_groups) {
+            echo "<tr class='tab_bg_1'>";
+            echo "<div class='alert alert-primary d-flex align-items-center mb-4' role='alert'>";
+            echo "<i class='fas fa-info-circle fa-xl'></i>";
+            echo "<span class='ms-2'>";
+            echo __("Some people are not visible in this list because of your clearance (restriction by entity).");
+            echo "</span>";
+            echo "</div>";
+            echo "</tr>";
+        }
+
 
        // Display results
         if ($number) {
@@ -821,9 +838,7 @@ class Group_User extends CommonDBRelation
                 case 'Group':
                     if (User::canView()) {
                         if ($_SESSION['glpishow_count_on_tabs']) {
-                            $members = $ids = [];
-                            self::getDataForGroup($item, $members, $ids, '', true);
-                            $nb = count($members);
+                              $nb = self::countForItem($item);
                         }
                         return self::createTabEntry(User::getTypeName(Session::getPluralNumber()), $nb);
                     }


### PR DESCRIPTION
Since https://github.com/glpi-project/glpi/pull/11928

Users from another entity can be seen  

Let's imagine the `root entity` with two children Entity A and `Entity B`

A group named `Security` in the `root entity` and `recursive`.

All admins in `entity A` and `entity B` see the group (OK)

The Admin in `entity A` adds a user from `entity A` to the group

The admin in `entity B` sees the user in `entity A` (NOK)

This PR fix this and corrects the user count in the tab, taking account of the entity restriction



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !34146
