### PR TITLE
Fix default custom CSS value for root entity

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -2239,6 +2239,7 @@ $empty_data_builder = new class
                 'autofill_decommission_date' => 0,
                 'suppliers_as_private' => 0,
                 'enable_custom_css' => 0,
+                'custom_css_code' => '',
                 'anonymize_support_agents' => 0,
                 'display_users_initials' => 1,
                 'contracts_strategy_default' => 0,

--- a/install/migrations/update_10.0.16_to_10.0.17.php
+++ b/install/migrations/update_10.0.16_to_10.0.17.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * Update from 10.0.16 to 10.0.17
+ *
+ * @return bool for success (will die for most error)
+ **/
+function update10016to10017()
+{
+    /**
+     * @var \DBmysql $DB
+     * @var \Migration $migration
+     */
+    global $DB, $migration;
+
+    $updateresult       = true;
+    $ADDTODISPLAYPREF   = [];
+    $DELFROMDISPLAYPREF = [];
+    $update_dir = __DIR__ . '/update_10.0.16_to_10.0.17/';
+
+    //TRANS: %s is the number of new version
+    $migration->displayTitle(sprintf(__('Update to %s'), '10.0.17'));
+    $migration->setVersion('10.0.17');
+
+    $update_scripts = scandir($update_dir);
+    foreach ($update_scripts as $update_script) {
+        if (preg_match('/\.php$/', $update_script) !== 1) {
+            continue;
+        }
+        require $update_dir . $update_script;
+    }
+
+    // ************ Keep it at the end **************
+    $migration->updateDisplayPrefs($ADDTODISPLAYPREF, $DELFROMDISPLAYPREF);
+
+    $migration->executeMigration();
+
+    return $updateresult;
+}

--- a/install/migrations/update_10.0.16_to_10.0.17/entities.php
+++ b/install/migrations/update_10.0.16_to_10.0.17/entities.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var \DBmysql $DB
+ * @var \Migration $migration
+ */
+
+// Fix default value for `custom_css_code`
+$migration->addPostQuery(
+    $DB->buildUpdate(
+        'glpi_entities',
+        [
+            'custom_css_code' => '',
+        ],
+        [
+            'id' => 0,
+            'custom_css_code' => null,
+        ]
+    )
+);

--- a/install/migrations/update_10.0.16_to_10.0.17/entities.php
+++ b/install/migrations/update_10.0.16_to_10.0.17/entities.php
@@ -46,7 +46,6 @@ $migration->addPostQuery(
             'custom_css_code' => '',
         ],
         [
-            'id' => 0,
             'custom_css_code' => null,
         ]
     )

--- a/phpunit/functional/EntityTest.php
+++ b/phpunit/functional/EntityTest.php
@@ -605,7 +605,7 @@ class EntityTest extends DbTestCase
                 'child_custom_css_code'   => '',
                 'expected'                => '<style>body { color:blue; }</style>',
             ],
-            /*[ see https://github.com/glpi-project/glpi/issues/17648
+            [
             // Do not output custom CSS if empty
                 'entity_id'               => $root_id,
                 'root_enable_custom_css'  => 1,
@@ -613,7 +613,7 @@ class EntityTest extends DbTestCase
                 'child_enable_custom_css' => 0,
                 'child_custom_css_code'   => '',
                 'expected'                => '',
-            ],*/
+            ],
             [
             // Do not output custom CSS from parent if disabled in parent
                 'entity_id'               => $child_id,
@@ -623,7 +623,7 @@ class EntityTest extends DbTestCase
                 'child_custom_css_code'   => '',
                 'expected'                => '',
             ],
-            /*[ see https://github.com/glpi-project/glpi/issues/17648
+            [
             // Do not output custom CSS from parent if empty
                 'entity_id'               => $child_id,
                 'root_enable_custom_css'  => 1,
@@ -631,7 +631,7 @@ class EntityTest extends DbTestCase
                 'child_enable_custom_css' => \Entity::CONFIG_PARENT,
                 'child_custom_css_code'   => '',
                 'expected'                => '',
-            ],*/
+            ],
             [
             // Output custom CSS from parent
                 'entity_id'               => $child_id,
@@ -650,7 +650,7 @@ class EntityTest extends DbTestCase
                 'child_custom_css_code'   => 'body { color:blue; }',
                 'expected'                => '',
             ],
-            /*[ see https://github.com/glpi-project/glpi/issues/17648
+            [
             // Do not output custom CSS from entity itself if empty
                 'entity_id'               => $child_id,
                 'root_enable_custom_css'  => 1,
@@ -658,7 +658,7 @@ class EntityTest extends DbTestCase
                 'child_enable_custom_css' => 1,
                 'child_custom_css_code'   => '',
                 'expected'                => '',
-            ],*/
+            ],
             [
             // Output custom CSS from entity itself
                 'entity_id'               => $child_id,

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -367,6 +367,13 @@ class Entity extends CommonTreeDropdown
             $input['altitude'] = $parent->fields['altitude'];
         }
 
+        if (!array_key_exists('custom_css_code', $input) || $input['custom_css_code'] === null) {
+            // The `custom_css_code` field is a textfield and therefore has no default value.
+            // The `Entity::getUsedConfig()` does not correctly handle the `null` value found in the root entity.
+            // See https://github.com/glpi-project/glpi/pull/17648
+            $input['custom_css_code'] = '';
+        }
+
         if (!Session::isCron()) { // Filter input for connected
             $input = $this->checkRightDatas($input);
         }
@@ -405,6 +412,13 @@ class Entity extends CommonTreeDropdown
               && ($input['inquest_config'] != $this->fields['inquest_config']))
         ) {
             $input['max_closedate'] = $_SESSION["glpi_currenttime"];
+        }
+
+        if (array_key_exists('custom_css_code', $input) && $input['custom_css_code'] === null) {
+            // The `custom_css_code` field is a textfield and therefore has no default value.
+            // The `Entity::getUsedConfig()` does not correctly handle the `null` value found in the root entity.
+            // See https://github.com/glpi-project/glpi/pull/17648
+            $input['custom_css_code'] = '';
         }
 
         if (!Session::isCron()) { // Filter input for connected
@@ -2629,7 +2643,6 @@ class Entity extends CommonTreeDropdown
             $this->fields['id'],
             'custom_css_code'
         );
-
         if (empty($custom_css_code)) {
             return '';
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #17648

The `custom_css_code` field is a textfield and therefore has no default value. The `Entity::getUsedConfig()` does not correctly handle the `null` value found in the root entity. As I am not sure to correctly handle the side effects of a change related to this on this method, I propose to fix the value in DB.