### PR TITLE
Fix(Device): harmonize location search option

### DIFF
--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -371,6 +371,7 @@ class Item_Devices extends CommonDBRelation
             case 'locations_id':
                 return ['long name'  => Location::getTypeName(1),
                     'short name' => Location::getTypeName(1),
+                    'field'      => 'completename',
                     'size'       => 20,
                     'id'         => 13,
                     'datatype'   => 'dropdown'


### PR DESCRIPTION
harmonize location search option 

Actually, For ```CommonDevice``` assets, GLPI only display location name from related search option.

Ex : ```SimCard```

![image](https://github.com/user-attachments/assets/22917a14-c027-4c53-bae6-83e4033d6b5e)

Related search option into device list

![image](https://github.com/user-attachments/assets/6acd2e75-1cac-45b0-8120-60a4030e5ce7)

Now, GLPI use ```completename``` (like `Ticket` for example)

![image](https://github.com/user-attachments/assets/80a70aff-9354-4011-ae3b-c3e36ffce7c8)

NB : Takes into account the following option

![image](https://github.com/user-attachments/assets/7c6f21c0-37a7-4bc2-b317-f71527db853c)





| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !34181
