### PR TITLE
Add description to service catalog

### DIFF
--- a/install/migrations/update_10.0.x_to_11.0.0/form.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/form.php
@@ -56,6 +56,7 @@ if (!$DB->tableExists('glpi_forms_forms')) {
             `name` varchar(255) NOT NULL DEFAULT '',
             `header` longtext,
             `icon` varchar(255) NOT NULL DEFAULT '',
+            `description` longtext,
             `date_mod` timestamp NULL DEFAULT NULL,
             `date_creation` timestamp NULL DEFAULT NULL,
             PRIMARY KEY (`id`),
@@ -231,6 +232,7 @@ if (GLPI_VERSION == "11.0.0-dev") {
     $migration->addField("glpi_forms_destinations_formdestinations", "config", "JSON NOT NULL COMMENT 'Extra configuration field(s) depending on the destination type'");
 
     $migration->addField("glpi_forms_forms", "icon", "string");
+    $migration->addField("glpi_forms_forms", "description", "text");
 }
 
 CronTask::register('Glpi\Form\Form', 'purgedraftforms', DAY_TIMESTAMP, [

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9414,6 +9414,7 @@ CREATE TABLE `glpi_forms_forms` (
     `name` varchar(255) NOT NULL DEFAULT '',
     `header` longtext,
     `icon` varchar(255) NOT NULL DEFAULT '',
+    `description` longtext,
     `date_mod` timestamp NULL DEFAULT NULL,
     `date_creation` timestamp NULL DEFAULT NULL,
     PRIMARY KEY (`id`),

--- a/templates/pages/admin/form/service_catalog_tab.html.twig
+++ b/templates/pages/admin/form/service_catalog_tab.html.twig
@@ -54,6 +54,18 @@
             }
         ) }}
 
+        {{ fields.textareaField(
+            'description',
+            form.fields.description,
+            __('Description'),
+            {
+                'is_horizontal': false,
+                'full_width' : true,
+                'enable_richtext': true,
+                'enable_images': false,
+            }
+        ) }}
+
         {# Hidden values #}
         <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
         <input type="hidden" name="id" value="{{ form.getID() }}" />

--- a/templates/pages/self-service/service_catalog.html.twig
+++ b/templates/pages/self-service/service_catalog.html.twig
@@ -60,10 +60,7 @@
                                 <h2 id="form-{{ form.fields.id }}" class="card-title">
                                     {{ form.fields.name }}
                                 </h2>
-                                {# TODO: showing description instead of header (description does not yet
-                                exist and header is meant to be displated above the form in its own
-                                page). We use header for now to "fill" the space. #}
-                                <div class="text-secondary">{{ form.fields.header|safe_html }}</div>
+                                <div class="text-secondary">{{ form.fields.description|safe_html }}</div>
                             </div>
                         </div>
                     </section>

--- a/tests/cypress/e2e/form/service_catalog/service_catalog_page.cy.js
+++ b/tests/cypress/e2e/form/service_catalog/service_catalog_page.cy.js
@@ -33,27 +33,29 @@
 
 describe('Service catalog page', () => {
     beforeEach(() => {
-        // Create at least one form to make sure the list is not empty.
-        cy.createFormWithAPI({
-            'name': "Test form for service_catalog_page.cy.js",
-            'header': "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aperiam deleniti fugit incidunt, iste, itaque minima neque pariatur perferendis sed suscipit velit vitae voluptatem.",
-            'is_active': true,
-        });
-
         cy.login();
         cy.changeProfile('Self-Service', true);
 
     });
 
     it('can pick a form in the service catalog', () => {
+        const form_name = "Test form for service_catalog_page.cy.js " + (new Date()).getTime();
+
+        // Create at least one form to make sure the list is not empty.
+        cy.createFormWithAPI({
+            'name': form_name,
+            'description': "Lorem ipsum dolor sit amet, consectetur adipisicing elit.",
+            'is_active': true,
+        });
+
         cy.visit('/ServiceCatalog');
         cy.injectAndCheckA11y();
-        cy.findByRole('region', {'name': 'Test form for service_catalog_page.cy.js'}).as('form');
+        cy.findByRole('region', {'name': form_name}).as('form');
 
         // Validate that the form is displayed correctly.
         cy.get('@form').within(() => {
-            cy.findByText("Test form for service_catalog_page.cy.js").should('exist');
-            cy.findByText("Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aperiam deleniti fugit incidunt, iste, itaque minima neque pariatur perferendis sed suscipit velit vitae voluptatem.").should('exist');
+            cy.findByText(form_name).should('exist');
+            cy.findByText("Lorem ipsum dolor sit amet, consectetur adipisicing elit.").should('exist');
         });
 
         // Go to form

--- a/tests/cypress/e2e/form/service_catalog/service_catalog_tab.cy.js
+++ b/tests/cypress/e2e/form/service_catalog/service_catalog_tab.cy.js
@@ -45,9 +45,11 @@ describe('Service catalog tab', () => {
         // Make sure the values we are about to apply are are not already set to
         // prevent false negative.
         cy.getDropdownByLabelText("Icon").should('not.contain.text', 'ti-dog');
+        cy.findByLabelText("Description").awaitTinyMCE().should('not.contain.text', 'My description');
 
         // Set values
         cy.getDropdownByLabelText("Icon").selectDropdownValue('ti-dog');
+        cy.findByLabelText("Description").awaitTinyMCE().type('My description');
 
         // Save changes
         cy.findByRole('button', {'name': "Save changes"}).click();
@@ -55,5 +57,6 @@ describe('Service catalog tab', () => {
 
         // Validate values
         cy.getDropdownByLabelText("Icon").should('contain.text', 'ti-dog');
+        cy.findByLabelText("Description").awaitTinyMCE().should('contain.text', 'My description');
     });
 });


### PR DESCRIPTION
Create proper 'description' field that will be displayed in the service catalog.

Config:

![image](https://github.com/user-attachments/assets/700d13aa-d334-4948-8d7b-666c8f6d3127)

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
