### PR TITLE
fix(APIRest): remove not functional massive action

### DIFF
--- a/apirest.md
+++ b/apirest.md
@@ -1301,10 +1301,6 @@ $ curl -X GET \
     "label": "Put in trashbin"
   },
   {
-    "key": "MassiveAction:add_transfer_list",
-    "label": "Add to transfer list"
-  },
-  {
     "key": "Appliance:add_item",
     "label": "Associate to an appliance"
   },
@@ -1421,10 +1417,6 @@ $ curl -X GET \
   {
     "key": "MassiveAction:delete",
     "label": "Put in trashbin"
-  },
-  {
-    "key": "MassiveAction:add_transfer_list",
-    "label": "Add to transfer list"
   },
   {
     "key": "Appliance:add_item",

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -699,6 +699,7 @@ class MassiveAction
         if (
             Session::haveRight('transfer', READ)
             && Session::isMultiEntitiesMode()
+            && !isAPI()
         ) {
             $actions[__CLASS__ . self::CLASS_ACTION_SEPARATOR . 'add_transfer_list']
                   = "<i class='fa-fw fas fa-level-up-alt'></i>" .

--- a/tests/web/APIRest.php
+++ b/tests/web/APIRest.php
@@ -815,7 +815,6 @@ class APIRest extends APIBaseClass
                     ["key" => "Infocom:activate",                "label" => "Enable the financial and administrative information"],
                     ["key" => "MassiveAction:delete",            "label" => "Put in trashbin"],
                     ["key" => "ObjectLock:unlock",               "label" => "Unlock items"],
-                    ["key" => "MassiveAction:add_transfer_list", "label" => "Add to transfer list"],
                     ["key" => "Appliance:add_item",              "label" => "Associate to an appliance"],
                     ["key" => "Item_Rack:delete",                "label" => "Remove from a rack"],
                     ["key" => "Item_OperatingSystem:update",     "label" => "Operating systems"],
@@ -853,7 +852,6 @@ class APIRest extends APIBaseClass
                     ["key" => "Infocom:activate",                "label" => "Enable the financial and administrative information"],
                     ["key" => "MassiveAction:delete",            "label" => "Put in trashbin"],
                     ["key" => "ObjectLock:unlock",               "label" => "Unlock items"],
-                    ["key" => "MassiveAction:add_transfer_list", "label" => "Add to transfer list"],
                     ["key" => "Appliance:add_item",              "label" => "Associate to an appliance"],
                     ["key" => "Item_Rack:delete",                "label" => "Remove from a rack"],
                     ["key" => "Item_OperatingSystem:update",     "label" => "Operating systems"],
@@ -947,11 +945,6 @@ class APIRest extends APIBaseClass
             ],
             [
                 'url' => 'getMassiveActionParameters/Computer/ObjectLock:unlock',
-                'status' => 200,
-                'response' => [],
-            ],
-            [
-                'url' => 'getMassiveActionParameters/Computer/MassiveAction:add_transfer_list',
                 'status' => 200,
                 'response' => [],
             ],


### PR DESCRIPTION
`add_transfer_list` massive action cannot be used from the API.

This action adds the items to the transfer list.
But the `transferer` action cannot be triggered via the API, so you need to go to this page

![image](https://github.com/user-attachments/assets/56b482ab-6b29-42b4-8c74-523ef7bf1885)

The information is added to the session used by the API, which is different from the user session (even if it's the same user used by the API and to connect to GLPI).

maybe it should be done on `main` branch

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
