### PR TITLE
Fix makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ phpstan.neon
 /phpunit/files/
 /phpunit/config
 *.phar
+.env

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ install: .env build start vendor db test-db ## Install the project
 
 .env:
 	@\
+	if [ ! -f ".devcontainer/docker-compose.override.yaml" ]; then \
+		printf $(_TITLE) "Project" "Creating \".devcontainer/docker-compose.override.yaml\" file for Docker Compose" ; \
+		touch .devcontainer/docker-compose.override.yaml ; \
+	fi ; \
 	if [ ! -f ".env" ]; then \
 		printf $(_TITLE) "Project" "Creating \".env\" file for Docker Compose" ; \
 		touch .env ; \


### PR DESCRIPTION
Small fix for #17687.

Install would fail if `.devcontainer/docker-compose.override.yaml` did not exist.

![image](https://github.com/user-attachments/assets/a6cd41cd-4037-4fe9-8b82-83ad59e59365)

Also, I guess the `.env` file created by the makefile should probably be git-ignored.

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
