### PR TITLE
Soft-deprecate ancient type system leftovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,8 @@ The present file will list all changes made to the project; according to the
 - `Auth::getErr()`
 - `AuthLDAP::dropdownUserDeletedActions()`
 - `AuthLDAP::getOptions()`
+- `CommonGLPI::$type` property. This is a left-over from ancient versions of GLPI when 'types' were integers instead of class names.
+- `CommonGLPI::getType()` has been deprecated. This is a PHPDoc change only, but it will be hard-deprecated in the future. Use any native PHP method to get the static class name instead.
 - `CommonITILObject::isValidator()`
 - `ComputerAntivirus` has been deprecated and replaced by `ItemAntivirus`
 - `ComputerVirtualMachine` has been deprecated and replaced by `ItemVirtualMachine`

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -51,6 +51,7 @@ class CommonGLPI implements CommonGLPIInterface
     * GLPI Item type cache : set dynamically calling getType
     *
     * @var integer
+    * @deprecated 11.0 Has no use. Left-over from ancient int-based item types.
     */
     protected $type                 = -1;
 
@@ -137,6 +138,9 @@ class CommonGLPI implements CommonGLPIInterface
      * Return the type of the object : class name
      *
      * @return string
+     * @phpstan-return class-string<static>
+     * @deprecated 11.0 (Soft-deprecation) Use any of the native PHP methods to get the class name.
+     * For the runtime class (the result from this function), use `static::class` or `$item::class`. This function is redundant.
      **/
     public static function getType()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes (not strict at all)
| Tests pass?   | yes
| Fixed tickets | -

Maybe too late to hard-deprecate or remove this for GLPI 11, but the usage can at least be discouraged.
This PR only adds PHPDoc deprecations, changelog entries, and a PHPStan return type hint for `getType`.
Both the property and function seem to have origins when "types" were integers (0.7 versions and earlier) instead of class names and before late-static bindings were added to PHP (PHP 5.3 in 2009).

The `$type` property appears to be used by the GLPI Inventory plugin more than just changing the default value of the property.
`getType` is obviously widely used throughout the core and plugin code although the core code has been slowly moving towards using things like `static::class` and `$item::class` directly.

If we have to remove uses of `getType` in the core before adding the PHPDoc, it wouldn't be a difficult change to make; Just a lot of replacements.