### PR TITLE
Exclude clone action for templates

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -36,6 +36,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Event;
 use Glpi\Features\CacheableListInterface;
+use Glpi\Features\Clonable;
 use Glpi\Plugin\Hooks;
 use Glpi\RichText\RichText;
 use Glpi\RichText\UserMention;
@@ -4055,6 +4056,13 @@ class CommonDBTM extends CommonGLPI
             if ($ic->getFromDBforDevice($this->getType(), $this->fields['id'])) {
                 $excluded[] = 'Infocom:activate';
             }
+        }
+
+        if (
+            Toolbox::hasTrait(static::class, Clonable::class)
+            && $this->isTemplate()
+        ) {
+            $excluded[] = '*:clone';
         }
 
         return $excluded;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Massive actions for templates aren't usually available, but they do appear via the "Actions" dropdown inside the individual item forms. Usually these actions only take the item type into account since individual field data isn't evaluated, but for these single actions we can exclude certain actions based on the item's fields.

Since the template system uses cloning to create new items from a template, the `is_template` field is removed during the cloning process. It is not currently possible to create templates from other templates. This PR just blocks the confusing behavior from having a Clone action in template item forms.