### PR TITLE
Fix(Phone): add missing Agent search option

### DIFF
--- a/src/Phone.php
+++ b/src/Phone.php
@@ -467,6 +467,8 @@ class Phone extends CommonDBTM
 
         $tab = array_merge($tab, Socket::rawSearchOptionsToAdd());
 
+        $tab = array_merge($tab, Agent::rawSearchOptionsToAdd());
+
         return $tab;
     }
 


### PR DESCRIPTION
Add missing ```Agent``` ```searchoption``` to ```Phone```


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !34295
