### PR TITLE
Filter service catalog using access policies

### DIFF
--- a/phpunit/functional/Glpi/Form/AccessControl/FormAccessControlManagerTest.php
+++ b/phpunit/functional/Glpi/Form/AccessControl/FormAccessControlManagerTest.php
@@ -177,9 +177,10 @@ final class FormAccessControlManagerTest extends DbTestCase
 
     public function testAdminCanBypassFormRestrictions(): void
     {
-        $this->login('glpi', 'glpi');
         $form = $this->getFormAccessibleOnlyToTechUser();
-        $access_parameters = $this->getEmptyParameters();
+        $access_parameters = new FormAccessParameters(
+            bypass_restriction: true,
+        );
 
         $this->assertTrue(
             $this->getManager()->canAnswerForm($form, $access_parameters)

--- a/phpunit/functional/Glpi/Form/ServiceCatalog/ServiceCatalogManagerTest.php
+++ b/phpunit/functional/Glpi/Form/ServiceCatalog/ServiceCatalogManagerTest.php
@@ -35,10 +35,17 @@
 
 namespace tests\units\Glpi\Form;
 
+use AbstractRightsDropdown;
+use Glpi\Form\AccessControl\ControlType\AllowList;
+use Glpi\Form\AccessControl\ControlType\AllowListConfig;
+use Glpi\Form\AccessControl\FormAccessParameters;
 use Glpi\Form\ServiceCatalog\ServiceCatalogManager;
 use Glpi\Form\Form;
+use Glpi\Session\SessionInfo;
 use Glpi\Tests\FormBuilder;
 use Glpi\Tests\FormTesterTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+use User;
 
 final class ServiceCatalogManagerTest extends \DbTestCase
 {
@@ -54,7 +61,7 @@ final class ServiceCatalogManagerTest extends \DbTestCase
 
     public function testOnlyActiveFormsAreDisplayed(): void
     {
-        // Arrange
+        // Arrange: create a mix of active/inactive forms
         $builders = [
             (new FormBuilder("Active form 1"))->setIsActive(true),
             (new FormBuilder("Active form 2"))->setIsActive(true),
@@ -63,14 +70,16 @@ final class ServiceCatalogManagerTest extends \DbTestCase
             (new FormBuilder("Inactive form 3"))->setIsActive(false),
         ];
         foreach ($builders as $builder) {
+            $builder->allowAllUsers();
             $this->createForm($builder);
         }
 
-        // Act
-        $forms = self::$manager->getForms();
+        // Act: get the forms from the catalog manager and extract their names
+        $access_parameters = $this->getDefaultParametersForTestUser();
+        $forms = self::$manager->getForms($access_parameters);
         $forms_names = array_map(fn (Form $form) => $form->fields['name'], $forms);
 
-        // Assert
+        // Assert: only active forms must be found
         $this->assertEquals([
             "Active form 1",
             "Active form 2",
@@ -79,21 +88,24 @@ final class ServiceCatalogManagerTest extends \DbTestCase
 
     public function testFormsAreOrderedByNames(): void
     {
-        // Arrange
+        // Arrange: create forms with unordered names
         $builders = [
-            (new FormBuilder("ZZZ"))->setIsActive(true),
-            (new FormBuilder("AAA"))->setIsActive(true),
-            (new FormBuilder("CCC"))->setIsActive(true),
+            new FormBuilder("ZZZ"),
+            new FormBuilder("AAA"),
+            new FormBuilder("CCC"),
         ];
         foreach ($builders as $builder) {
+            $builder->allowAllUsers();
+            $builder->setIsActive(true);
             $this->createForm($builder);
         }
 
-        // Act
-        $forms = self::$manager->getForms();
+        // Act: get the forms from the catalog manager and extract their names
+        $access_parameters = $this->getDefaultParametersForTestUser();
+        $forms = self::$manager->getForms($access_parameters);
         $forms_names = array_map(fn (Form $form) => $form->fields['name'], $forms);
 
-        // Assert
+        // Assert: forms must be ordered by name
         $this->assertEquals([
             "AAA",
             "CCC",
@@ -103,27 +115,150 @@ final class ServiceCatalogManagerTest extends \DbTestCase
 
     public function testFormsNamesAreUniques(): void
     {
-        // Arrange
+        // Arrange: create forms with duplicated names
         $builders = [
-            (new FormBuilder("My form"))->setIsActive(true),
-            (new FormBuilder("My form"))->setIsActive(true),
-            (new FormBuilder("My other form"))->setIsActive(true),
-            (new FormBuilder("My form"))->setIsActive(true),
+            new FormBuilder("My form"),
+            new FormBuilder("My form"),
+            new FormBuilder("My other form"),
+            new FormBuilder("My form"),
         ];
         foreach ($builders as $builder) {
+            $builder->allowAllUsers();
+            $builder->setIsActive(true);
             $this->createForm($builder);
         }
 
-        // Act
-        $forms = self::$manager->getForms();
+        // Act: get the forms from the catalog manager and extract their names
+        $access_parameters = $this->getDefaultParametersForTestUser();
+        $forms = self::$manager->getForms($access_parameters);
         $forms_names = array_map(fn (Form $form) => $form->fields['name'], $forms);
 
-        // Assert
+        // Assert: names must be uniques
         $this->assertEquals([
             "My form",
             "My form (1)",
             "My form (2)",
             "My other form",
         ], $forms_names);
+    }
+
+    public function testFormsWithActiveAccessPoliciesAreFound(): void
+    {
+        // Arrange: create a form with an active policy
+        $builder = new FormBuilder("Form with active policy");
+        $builder->addAccessControl(
+            strategy: AllowList::class,
+            config: new AllowListConfig(
+                user_ids: [AbstractRightsDropdown::ALL_USERS]
+            ),
+            is_active: true,
+        );
+        $builder->setIsActive(true);
+        $this->createForm($builder);
+
+        // Act: get the forms from the catalog manager and extract their names
+        $access_parameters = $this->getDefaultParametersForTestUser();
+        $forms = self::$manager->getForms($access_parameters);
+        $forms_names = array_map(fn (Form $form) => $form->fields['name'], $forms);
+
+        // Assert: our form must be found
+        $this->assertEquals(["Form with active policy"], $forms_names);
+    }
+
+    public function testFormWithoutAccessPoliciesAreNotFound(): void
+    {
+        // Arrange: create a form without any policies
+        $builder = new FormBuilder("Form without policies");
+        $builder->setIsActive(true);
+        $this->createForm($builder);
+
+        // Act: get the forms from the catalog manager and extract their names
+        $access_parameters = $this->getDefaultParametersForTestUser();
+        $forms = self::$manager->getForms($access_parameters);
+        $forms_names = array_map(fn (Form $form) => $form->fields['name'], $forms);
+
+        // Assert: our form must not be found
+        $this->assertEquals([], $forms_names);
+    }
+
+    public function testFormWithInactiveAccessPoliciesAreNotFound(): void
+    {
+        // Arrange: create a form with an inactive policy
+        $builder = new FormBuilder("Form with inactive policy");
+        $builder->addAccessControl(
+            strategy: AllowList::class,
+            config: new AllowListConfig(
+                user_ids: [AbstractRightsDropdown::ALL_USERS]
+            ),
+            is_active: false,
+        );
+        $builder->setIsActive(true);
+        $this->createForm($builder);
+
+        // Act: get the forms from the catalog manager and extract their names
+        $access_parameters = $this->getDefaultParametersForTestUser();
+        $forms = self::$manager->getForms($access_parameters);
+        $forms_names = array_map(fn (Form $form) => $form->fields['name'], $forms);
+
+        // Assert: our form must not be found
+        $this->assertEquals([], $forms_names);
+    }
+
+    public static function onlyFormThatMatchAllowListCriteriaAreFoundProvider(): iterable
+    {
+        $allow_list = new AllowListConfig(
+            user_ids: [
+                getItemByTypeName(User::class, "tech", true),
+                getItemByTypeName(User::class, "normal", true),
+            ],
+        );
+        yield 'glpi' => [
+            'config'   => $allow_list,
+            'user'     => 'glpi',
+            'expected' => false,
+        ];
+        yield 'tech' => [
+            'config'   => $allow_list,
+            'user'     => 'tech',
+            'expected' => true,
+        ];
+        yield 'normal' => [
+            'config'   => $allow_list,
+            'user'     => 'normal',
+            'expected' => true,
+        ];
+        yield 'post-only' => [
+            'config'   => $allow_list,
+            'user'     => 'post-only',
+            'expected' => false,
+        ];
+    }
+
+    #[DataProvider('onlyFormThatMatchAllowListCriteriaAreFoundProvider')]
+    public function testOnlyFormThatMatchAllowListCriteriaAreFound(
+        AllowListConfig $config,
+        string $user,
+        bool $expected,
+    ): void {
+        // Arrange: create a form with an allow list
+        $builder = new FormBuilder();
+        $builder->addAccessControl(
+            strategy: AllowList::class,
+            config: $config,
+            is_active: true,
+        );
+        $builder->setIsActive(true);
+        $this->createForm($builder);
+
+        // Act: as the specified user, get the number of forms from the catalog manager
+        $session_info = new SessionInfo(
+            user_id: getItemByTypeName(User::class, $user, true),
+        );
+        $access_parameters = new FormAccessParameters($session_info, []);
+        $forms = self::$manager->getForms($access_parameters);
+        $nb_forms = count($forms);
+
+        // Assert: list should be empty if we don't expect the user to see the form
+        $this->assertEquals($expected, $nb_forms === 1);
     }
 }

--- a/src/Glpi/Controller/Form/RendererController.php
+++ b/src/Glpi/Controller/Form/RendererController.php
@@ -89,10 +89,16 @@ final class RendererController extends AbstractController
     {
         $form_access_manager = FormAccessControlManager::getInstance();
 
-        $parameters = new FormAccessParameters(
-            session_info: Session::getCurrentSessionInfo(),
-            url_parameters: $request->query->all(),
-        );
+        if (Session::haveRight(Form::$rightname, READ)) {
+            // Form administrators can bypass restrictions while previewing forms.
+            $parameters = new FormAccessParameters(bypass_restriction: true);
+        } else {
+            // Load current user session info and URL parameters.
+            $parameters = new FormAccessParameters(
+                session_info: Session::getCurrentSessionInfo(),
+                url_parameters: $request->query->all(),
+            );
+        }
 
         if (!$form_access_manager->canAnswerForm($form, $parameters)) {
             throw new AccessDeniedHttpException();

--- a/src/Glpi/Controller/Form/ServiceCatalogController.php
+++ b/src/Glpi/Controller/Form/ServiceCatalogController.php
@@ -35,9 +35,11 @@
 namespace Glpi\Controller\Form;
 
 use Glpi\Controller\AbstractController;
+use Glpi\Form\AccessControl\FormAccessParameters;
 use Glpi\Form\ServiceCatalog\ServiceCatalogManager;
 use Glpi\Http\Firewall;
 use Glpi\Security\Attribute\SecurityStrategy;
+use Session;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -60,10 +62,16 @@ final class ServiceCatalogController extends AbstractController
     )]
     public function __invoke(Request $request): Response
     {
+        $parameters = new FormAccessParameters(
+            session_info: Session::getCurrentSessionInfo(),
+            url_parameters: $request->query->all()
+        );
+        $forms = $this->service_catalog_manager->getForms($parameters);
+
         return $this->render('pages/self-service/service_catalog.html.twig', [
             'title'     => __("New ticket"),
             'menu'      => ["create_ticket"],
-            'forms'     => $this->service_catalog_manager->getForms(),
+            'forms'     => $forms,
         ]);
     }
 }

--- a/src/Glpi/Controller/Form/SubmitAnswerController.php
+++ b/src/Glpi/Controller/Form/SubmitAnswerController.php
@@ -93,10 +93,16 @@ final class SubmitAnswerController extends AbstractController
     {
         $form_access_manager = FormAccessControlManager::getInstance();
 
-        $parameters = new FormAccessParameters(
-            session_info: Session::getCurrentSessionInfo(),
-            url_parameters: $request->request->all(),
-        );
+        if (Session::haveRight(Form::$rightname, READ)) {
+            // Form administrators can bypass restrictions while previewing forms.
+            $parameters = new FormAccessParameters(bypass_restriction: true);
+        } else {
+            // Load current user session info and URL parameters.
+            $parameters = new FormAccessParameters(
+                session_info: Session::getCurrentSessionInfo(),
+                url_parameters: $request->query->all(),
+            );
+        }
 
         if (!$form_access_manager->canAnswerForm($form, $parameters)) {
             throw new AccessDeniedHttpException();

--- a/src/Glpi/Form/AccessControl/FormAccessControlManager.php
+++ b/src/Glpi/Form/AccessControl/FormAccessControlManager.php
@@ -116,8 +116,8 @@ final class FormAccessControlManager
         Form $form,
         FormAccessParameters $parameters
     ): bool {
-        // Form administrators can preview all forms.
-        if (Session::haveRight(Form::$rightname, READ)) {
+        // Form administrators can bypass restrictions while previewing forms.
+        if ($parameters->isBypassingRestrictions()) {
             return true;
         }
 

--- a/src/Glpi/Form/AccessControl/FormAccessParameters.php
+++ b/src/Glpi/Form/AccessControl/FormAccessParameters.php
@@ -40,8 +40,9 @@ use Glpi\Session\SessionInfo;
 final readonly class FormAccessParameters
 {
     public function __construct(
-        private ?SessionInfo $session_info,
-        private array $url_parameters,
+        private ?SessionInfo $session_info = null,
+        private array $url_parameters = [],
+        private bool $bypass_restriction = false,
     ) {
     }
 
@@ -58,5 +59,10 @@ final readonly class FormAccessParameters
     public function getUrlParameters(): array
     {
         return $this->url_parameters;
+    }
+
+    public function isBypassingRestrictions(): bool
+    {
+        return $this->bypass_restriction;
     }
 }

--- a/tests/cypress/e2e/form/service_catalog/service_catalog_page.cy.js
+++ b/tests/cypress/e2e/form/service_catalog/service_catalog_page.cy.js
@@ -34,8 +34,7 @@
 describe('Service catalog page', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Self-Service', true);
-
+        cy.changeProfile('Super-Admin', true);
     });
 
     it('can pick a form in the service catalog', () => {
@@ -46,8 +45,16 @@ describe('Service catalog page', () => {
             'name': form_name,
             'description': "Lorem ipsum dolor sit amet, consectetur adipisicing elit.",
             'is_active': true,
-        });
+        }).as('form_id');
 
+        // Allow form to be displayed in the service catalog.
+        cy.get('@form_id').visitFormTab('Policies');
+        cy.getDropdownByLabelText('Allow specifics users, groups or profiles').selectDropdownValue('All users');
+        cy.findByRole('link', {'name': "There are 7 user(s) matching these criteria."}).should('exist');
+        cy.findByRole('button', {name: 'Save changes'}).click();
+
+        // Got to service catalog
+        cy.changeProfile('Self-Service', true);
         cy.visit('/ServiceCatalog');
         cy.injectAndCheckA11y();
         cy.findByRole('region', {'name': form_name}).as('form');
@@ -61,7 +68,5 @@ describe('Service catalog page', () => {
         // Go to form
         cy.get('@form').click();
         cy.url().should('include', '/Form/Render');
-
-        // TODO: validate the form is actually displayed, can't be done others PR are merged.
     });
 });

--- a/tests/cypress/support/commands/form.js
+++ b/tests/cypress/support/commands/form.js
@@ -47,6 +47,7 @@ Cypress.Commands.add('visitFormTab', {prevSubject: true}, (
 ) => {
     const fully_qualified_tabs = new Map([
         ['Form', 'Glpi\\Form\\Form\\Form$main'],
+        ['Policies', 'Glpi\\Form\\AccessControl\\FormAccessControl$1'],
         ['Destinations', 'Glpi\\Form\\Destination\\FormDestination$1'],
         ['ServiceCatalog', 'Glpi\\Form\\ServiceCatalog\\ServiceCatalog$1'],
     ]);

--- a/tests/src/FormBuilder.php
+++ b/tests/src/FormBuilder.php
@@ -35,7 +35,10 @@
 
 namespace Glpi\Tests;
 
+use AbstractRightsDropdown;
 use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\AccessControl\ControlType\AllowList;
+use Glpi\Form\AccessControl\ControlType\AllowListConfig;
 
 /**
  * Helper class to ease form creation using DbTestCase::createForm()
@@ -384,9 +387,30 @@ class FormBuilder
      */
     public function addAccessControl(
         string $strategy,
-        JsonFieldInterface $config
+        JsonFieldInterface $config,
+        bool $is_active = true,
     ): self {
-        $this->access_control[$strategy] = $config;
+        $this->access_control[$strategy] = [
+            'config'    => $config,
+            'is_active' => $is_active,
+        ];
+        return $this;
+    }
+
+    /**
+     * Shorthand to add an allow list without restrictions to the form.
+     *
+     * @return self
+     */
+    public function allowAllUsers(): self
+    {
+        $this->addAccessControl(
+            strategy: AllowList::class,
+            config: new AllowListConfig(
+                user_ids: [AbstractRightsDropdown::ALL_USERS]
+            ),
+            is_active: true,
+        );
         return $this;
     }
 }

--- a/tests/src/FormTesterTrait.php
+++ b/tests/src/FormTesterTrait.php
@@ -36,6 +36,7 @@
 namespace Glpi\Tests;
 
 use Glpi\Form\AccessControl\FormAccessControl;
+use Glpi\Form\AccessControl\FormAccessParameters;
 use Glpi\Form\AnswersHandler\AnswersHandler;
 use Glpi\Form\Comment;
 use Glpi\Form\Destination\FormDestination;
@@ -43,7 +44,9 @@ use Glpi\Form\Form;
 use Glpi\Form\Question;
 use Glpi\Form\Section;
 use Glpi\Form\Tag\Tag;
+use Glpi\Session\SessionInfo;
 use Glpi\Tests\FormBuilder;
+use Profile;
 use Ticket;
 use User;
 
@@ -120,12 +123,12 @@ trait FormTesterTrait
         }
 
         // Create access controls
-        foreach ($builder->getAccessControls() as $strategy_class => $config) {
+        foreach ($builder->getAccessControls() as $strategy_class => $params) {
             $this->createItem(FormAccessControl::class, [
                 'forms_forms_id' => $form->getID(),
                 'strategy'       => $strategy_class,
-                '_config'        => $config,
-                'is_active'      => true,
+                '_config'        => $params['config'],
+                'is_active'      => $params['is_active'],
             ]);
         }
 
@@ -370,5 +373,22 @@ trait FormTesterTrait
         $ticket = current($created_items);
         $this->assertInstanceOf(Ticket::class, $ticket);
         return $ticket;
+    }
+
+    /**
+     * Get the default parameters containing a mocked session of the TU_USER
+     * user and no URL parameters.
+     *
+     * @return FormAccessParameters
+     */
+    protected function getDefaultParametersForTestUser(): FormAccessParameters
+    {
+        $session_info = new SessionInfo(
+            user_id: getItemByTypeName(User::class, TU_USER, true),
+            group_ids: [],
+            profile_id: getItemByTypeName(Profile::class, "Super-Admin", true),
+        );
+
+        return new FormAccessParameters($session_info, []);
     }
 }


### PR DESCRIPTION
Modify the `ServiceCatalogManager` service to filter the forms according to their access policies.
This is done by calling the existing `canAnswerForm()` method on each forms.
We could in theory do it directly in the main SQL query that fetches the forms to be more efficient but this would require more code and be less reliable.
Doing it this way should be fine as forms are a low volume item anyway. 

To ease testing, I've also removed a session check that was done inside the `FormAccessControlManager` service.
This check was used to bypass the forms access restrictions when a form is being previewed by an administrator.
This has been replaced by a dedicated `bypass_restriction` parameter in the `FormAccessParameters` object, which is applied directly into the controllers that needs it.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
