### PR TITLE
Fix saved search test

### DIFF
--- a/phpunit/functional/SavedSearchTest.php
+++ b/phpunit/functional/SavedSearchTest.php
@@ -199,7 +199,7 @@ class SavedSearchTest extends DbTestCase
         $mine = $bk->getMine();
         $this->assertCount(1, $mine);
         $this->assertEqualsCanonicalizing(
-            ['name' => 'private normal user'],
+            ['private normal user'],
             array_column($mine, 'name')
         );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This test will fail with PHPUnit 11.3.2.

```
1) tests\units\SavedSearchTest::testGetMine
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    'name' => 'private normal user'
+    0 => 'private normal user'
 )

/var/www/glpi/phpunit/functional/SavedSearchTest.php:201
```