### PR TITLE
Implement clean_software transfer option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ The present file will list all changes made to the project; according to the
 - Testing LDAP replicates now shows results as toast notifications rather than inside the replicate tab after a page reload.
 - The debug tab that was present, for some items, when the debug mode was active, no longer exists. The corresponding features have been either moved, either removed.
 - `Group` and `Group in charge` fields for assets may now contain multiple groups.
+- "If software are no longer used" transfer option is now taken into account rather than always preserving.
 
 ### Deprecated
 - Survey URL tags `TICKETCATEGORY_ID` and `TICKETCATEGORY_NAME` are deprecated and replaced by `ITILCATEGORY_ID` and `ITILCATEGORY_NAME` respectively.

--- a/src/Transfer.php
+++ b/src/Transfer.php
@@ -268,6 +268,7 @@ final class Transfer extends CommonDBTM
             // Clean unused
             // FIXME: only if Software or SoftwareLicense has been changed?
             $this->cleanSoftwareVersions();
+            $this->cleanSoftwares();
             if (!$intransaction && $DB->inTransaction()) {
                 $DB->commit();
             }
@@ -1931,8 +1932,8 @@ final class Transfer extends CommonDBTM
      */
     public function cleanSoftwares()
     {
-        // FIXME This method is not called anywhere and 'clean_software' option is not handled anywhere else.
-        if (!isset($this->already_transfer['Software'])) {
+        if (!isset($this->already_transfer['Software']) || (int) $this->options['clean_software'] === 0) {
+            // Nothing to clean
             return;
         }
 
@@ -1943,9 +1944,9 @@ final class Transfer extends CommonDBTM
                 && (countElementsInTable("glpi_softwareversions", ['softwares_id' => $old]) == 0)
             ) {
                 if ($this->options['clean_software'] == 1) { // delete
-                    $soft->delete(['id' => $old], 0);
-                } else if ($this->options['clean_software'] ==  2) { // purge
-                    $soft->delete(['id' => $old], 1);
+                    $soft->delete(['id' => $old]);
+                } else if ($this->options['clean_software'] == 2) { // purge
+                    $soft->delete(['id' => $old], true);
                 }
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I have every tagged version of GLPI cloned locally and I found no version where the `cleanSoftwares` method was actually called, so the "If software are no longer used" option was always ignored/treated as Preserve which was the default option. This PR adds a call to the method and adds a test.