### PR TITLE
Fix debug (boolean excpected) - do not use Twig cache with debug

### DIFF
--- a/src/Glpi/Application/View/TemplateRenderer.php
+++ b/src/Glpi/Application/View/TemplateRenderer.php
@@ -81,8 +81,9 @@ class TemplateRenderer
         }
 
         $env_params = [
-            'debug'       => $_SESSION['glpi_use_mode'] ?? null === Session::DEBUG_MODE,
+            'debug'       => ($_SESSION['glpi_use_mode'] ?? null) === Session::DEBUG_MODE,
             'auto_reload' => GLPI_ENVIRONMENT_TYPE !== GLPI::ENV_PRODUCTION,
+            'cache'       => false,
         ];
 
         $tpl_cachedir = $cachedir . '/templates';
@@ -91,7 +92,7 @@ class TemplateRenderer
             || (!file_exists($tpl_cachedir) && !is_writable($cachedir))
         ) {
             trigger_error(sprintf('Cache directory "%s" is not writeable.', $tpl_cachedir), E_USER_WARNING);
-        } else {
+        } else if (($_SESSION['glpi_use_mode'] ?? null) !== Session::DEBUG_MODE) {
             $env_params['cache'] = $tpl_cachedir;
         }
 
@@ -99,10 +100,10 @@ class TemplateRenderer
             $loader,
             $env_params
         );
-       // Vendor extensions
+        // Vendor extensions
         $this->environment->addExtension(new DebugExtension());
         $this->environment->addExtension(new StringExtension());
-       // GLPI extensions
+        // GLPI extensions
         $this->environment->addExtension(new ConfigExtension());
         $this->environment->addExtension(new SecurityExtension());
         $this->environment->addExtension(new DataHelpersExtension());
@@ -117,7 +118,7 @@ class TemplateRenderer
         $this->environment->addExtension(new SessionExtension());
         $this->environment->addExtension(new TeamExtension());
 
-       // add superglobals
+        // add superglobals
         $this->environment->addGlobal('_post', $_POST);
         $this->environment->addGlobal('_get', $_GET);
         $this->environment->addGlobal('_request', $_REQUEST);


### PR DESCRIPTION
It's currently required to clean cache when a template is changed, even in debug mode.

Not sure this is the right way to do (I'm lost in main) but we need a way for Twig templates not to be cached when working on features developments or fixes.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
