### PR TITLE
feat(forms): Add ITILFollowup field configuration for form destination

### DIFF
--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/ITILFollowupFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/ITILFollowupFieldTest.php
@@ -42,7 +42,6 @@ use Glpi\Form\Destination\CommonITILField\ITILFollowupFieldConfig;
 use Glpi\Form\Destination\CommonITILField\ITILFollowupFieldStrategy;
 use Glpi\Form\Destination\FormDestinationTicket;
 use Glpi\Form\Form;
-use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
 use Glpi\Tests\FormBuilder;
 use Glpi\Tests\FormTesterTrait;
 use ITILFollowup;
@@ -64,28 +63,6 @@ final class ITILFollowupFieldTest extends DbTestCase
         $this->sendFormAndAssertITILFollowup(
             form: $form,
             config: $no_followup,
-            answers: [],
-            expected_itilfollowups: []
-        );
-
-        // Test with answers
-        $this->sendFormAndAssertITILFollowup(
-            form: $form,
-            config: $no_followup,
-            answers: [
-                "Followup template 1" => [
-                    'itemtype' => ITILFollowupTemplate::getType(),
-                    'items_id' => $this->createITILFollowupTemplate()->getID(),
-                ],
-                "Followup template 2" => [
-                    'itemtype' => ITILFollowupTemplate::getType(),
-                    'items_id' => $this->createITILFollowupTemplate()->getID(),
-                ],
-                "Followup template 3" => [
-                    'itemtype' => ITILFollowupTemplate::getType(),
-                    'items_id' => $this->createITILFollowupTemplate()->getID(),
-                ],
-            ],
             expected_itilfollowups: []
         );
     }
@@ -99,195 +76,15 @@ final class ITILFollowupFieldTest extends DbTestCase
         $form = $this->createAndGetFormWithMultipleDropdownItemQuestions();
         $specific_values = new ITILFollowupFieldConfig(
             strategy: ITILFollowupFieldStrategy::SPECIFIC_VALUES,
-            specific_itilfollowuptemplates_ids: [$templates[0]->getID(), $templates[1]->getID(),]
+            specific_itilfollowuptemplates_ids: [$templates[0]->getID(), $templates[1]->getID()]
         );
 
-        // Test with no answers
         $this->sendFormAndAssertITILFollowup(
             form: $form,
             config: $specific_values,
-            answers: [],
             expected_itilfollowups: [
                 $templates[0]->getID() => 'Followup template 1',
                 $templates[1]->getID() => 'Followup template 2',
-            ]
-        );
-
-        // Test with answers
-        $this->sendFormAndAssertITILFollowup(
-            form: $form,
-            config: $specific_values,
-            answers: [
-                "Followup template 1" => [
-                    'itemtype' => ITILFollowupTemplate::getType(),
-                    'items_id' => $this->createITILFollowupTemplate()->getID(),
-                ],
-                "Followup template 2" => [
-                    'itemtype' => ITILFollowupTemplate::getType(),
-                    'items_id' => $this->createITILFollowupTemplate()->getID(),
-                ],
-                "Followup template 3" => [
-                    'itemtype' => ITILFollowupTemplate::getType(),
-                    'items_id' => $this->createITILFollowupTemplate()->getID(),
-                ],
-            ],
-            expected_itilfollowups: [
-                $templates[0]->getID() => 'Followup template 1',
-                $templates[1]->getID() => 'Followup template 2',
-            ]
-        );
-    }
-
-    public function testFollowupForSpecificAnswers(): void
-    {
-        $templates = [
-            $this->createITILFollowupTemplate('Followup template 1'),
-            $this->createITILFollowupTemplate('Followup template 2'),
-            $this->createITILFollowupTemplate('Followup template 3'),
-        ];
-        $form = $this->createAndGetFormWithMultipleDropdownItemQuestions();
-        $specific_answers = new ITILFollowupFieldConfig(
-            strategy: ITILFollowupFieldStrategy::SPECIFIC_ANSWERS,
-            specific_question_ids: [
-                $this->getQuestionId($form, "Followup template 1"),
-                $this->getQuestionId($form, "Followup template 2"),
-            ]
-        );
-
-        // Test with no answers
-        $this->sendFormAndAssertITILFollowup(
-            form: $form,
-            config: $specific_answers,
-            answers: [],
-            expected_itilfollowups: []
-        );
-
-        // Test with answers
-        $this->sendFormAndAssertITILFollowup(
-            form: $form,
-            config: $specific_answers,
-            answers: [
-                "Followup template 1" => [
-                    'itemtype' => ITILFollowupTemplate::getType(),
-                    'items_id' => $templates[0]->getID(),
-                ],
-                "Followup template 2" => [
-                    'itemtype' => ITILFollowupTemplate::getType(),
-                    'items_id' => $templates[1]->getID(),
-                ],
-                "Followup template 3" => [
-                    'itemtype' => ITILFollowupTemplate::getType(),
-                    'items_id' => $templates[2]->getID(),
-                ],
-            ],
-            expected_itilfollowups: [
-                $templates[0]->getID() => 'Followup template 1',
-                $templates[1]->getID() => 'Followup template 2',
-            ]
-        );
-    }
-
-    public function testFollowupForLastValidAnswer(): void
-    {
-        $templates = [
-            $this->createITILFollowupTemplate('Followup template 1'),
-            $this->createITILFollowupTemplate('Followup template 2'),
-            $this->createITILFollowupTemplate('Followup template 3'),
-        ];
-        $form = $this->createAndGetFormWithMultipleDropdownItemQuestions();
-        $last_valid_answer = new ITILFollowupFieldConfig(
-            strategy: ITILFollowupFieldStrategy::LAST_VALID_ANSWER
-        );
-
-        // Test with no answers
-        $this->sendFormAndAssertITILFollowup(
-            form: $form,
-            config: $last_valid_answer,
-            answers: [],
-            expected_itilfollowups: []
-        );
-
-        // Test with answers
-        $this->sendFormAndAssertITILFollowup(
-            form: $form,
-            config: $last_valid_answer,
-            answers: [
-                "Followup template 1" => [
-                    'itemtype' => ITILFollowupTemplate::getType(),
-                    'items_id' => $templates[0]->getID(),
-                ],
-                "Followup template 2" => [
-                    'itemtype' => ITILFollowupTemplate::getType(),
-                    'items_id' => $templates[1]->getID(),
-                ],
-                "Followup template 3" => [
-                    'itemtype' => ITILFollowupTemplate::getType(),
-                    'items_id' => $templates[2]->getID(),
-                ],
-            ],
-            expected_itilfollowups: [
-                $templates[2]->getID() => 'Followup template 3',
-            ]
-        );
-    }
-
-    public function testFollowupForAllValidAnswers(): void
-    {
-        $templates = [
-            $this->createITILFollowupTemplate('Followup template 1'),
-            $this->createITILFollowupTemplate('Followup template 2'),
-            $this->createITILFollowupTemplate('Followup template 3'),
-        ];
-        $form = $this->createAndGetFormWithMultipleDropdownItemQuestions();
-        $all_valid_answers = new ITILFollowupFieldConfig(
-            strategy: ITILFollowupFieldStrategy::ALL_VALID_ANSWERS
-        );
-
-        // Test with no answers
-        $this->sendFormAndAssertITILFollowup(
-            form: $form,
-            config: $all_valid_answers,
-            answers: [],
-            expected_itilfollowups: []
-        );
-
-        // Test with only one answer
-        $this->sendFormAndAssertITILFollowup(
-            form: $form,
-            config: $all_valid_answers,
-            answers: [
-                "Followup template 1" => [
-                    'itemtype' => ITILFollowupTemplate::getType(),
-                    'items_id' => $templates[0]->getID(),
-                ],
-            ],
-            expected_itilfollowups: [
-                $templates[0]->getID() => 'Followup template 1',
-            ]
-        );
-
-        // Test with answers
-        $this->sendFormAndAssertITILFollowup(
-            form: $form,
-            config: $all_valid_answers,
-            answers: [
-                "Followup template 1" => [
-                    'itemtype' => ITILFollowupTemplate::getType(),
-                    'items_id' => $templates[0]->getID(),
-                ],
-                "Followup template 2" => [
-                    'itemtype' => ITILFollowupTemplate::getType(),
-                    'items_id' => $templates[1]->getID(),
-                ],
-                "Followup template 3" => [
-                    'itemtype' => ITILFollowupTemplate::getType(),
-                    'items_id' => $templates[2]->getID(),
-                ],
-            ],
-            expected_itilfollowups: [
-                $templates[0]->getID() => 'Followup template 1',
-                $templates[1]->getID() => 'Followup template 2',
-                $templates[2]->getID() => 'Followup template 3',
             ]
         );
     }
@@ -295,7 +92,6 @@ final class ITILFollowupFieldTest extends DbTestCase
     private function sendFormAndAssertITILFollowup(
         Form $form,
         ITILFollowupFieldConfig $config,
-        array $answers,
         array $expected_itilfollowups
     ): void {
         $field = new ITILFollowupField();
@@ -311,19 +107,11 @@ final class ITILFollowupFieldTest extends DbTestCase
             ["config"],
         );
 
-        // The provider use a simplified answer format to be more readable.
-        // Rewrite answers into expected format.
-        $formatted_answers = [];
-        foreach ($answers as $question => $answer) {
-            $key = $this->getQuestionId($form, $question);
-            $formatted_answers[$key] = $answer;
-        }
-
         // Submit form
         $answers_handler = AnswersHandler::getInstance();
         $answers = $answers_handler->saveAnswers(
             $form,
-            $formatted_answers,
+            [],
             getItemByTypeName(\User::class, TU_USER, true)
         );
 
@@ -364,16 +152,6 @@ final class ITILFollowupFieldTest extends DbTestCase
     private function createAndGetFormWithMultipleDropdownItemQuestions(): Form
     {
         $builder = new FormBuilder();
-        $builder->addQuestion("Followup template 1", QuestionTypeItemDropdown::class, [
-            'itemtype' => ITILFollowupTemplate::getType()
-        ]);
-        $builder->addQuestion("Followup template 2", QuestionTypeItemDropdown::class, [
-            'itemtype' => ITILFollowupTemplate::getType()
-        ]);
-        $builder->addQuestion("Followup template 3", QuestionTypeItemDropdown::class, [
-            'itemtype' => ITILFollowupTemplate::getType()
-        ]);
-
         $builder->addDestination(
             FormDestinationTicket::class,
             "My ticket"

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/ITILFollowupFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/ITILFollowupFieldTest.php
@@ -1,0 +1,392 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\Destination\CommonITILField;
+
+use DbTestCase;
+use Glpi\Form\AnswersHandler\AnswersHandler;
+use Glpi\Form\Destination\CommonITILField\ITILFollowupField;
+use Glpi\Form\Destination\CommonITILField\ITILFollowupFieldConfig;
+use Glpi\Form\Destination\CommonITILField\ITILFollowupFieldStrategy;
+use Glpi\Form\Destination\FormDestinationTicket;
+use Glpi\Form\Form;
+use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+use ITILFollowup;
+use ITILFollowupTemplate;
+use Ticket;
+
+final class ITILFollowupFieldTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public function testFollowupForNoFollowup(): void
+    {
+        $form = $this->createAndGetFormWithMultipleDropdownItemQuestions();
+        $no_followup = new ITILFollowupFieldConfig(
+            strategy: ITILFollowupFieldStrategy::NO_FOLLOWUP
+        );
+
+        // Test with no answers
+        $this->sendFormAndAssertITILFollowup(
+            form: $form,
+            config: $no_followup,
+            answers: [],
+            expected_itilfollowups: []
+        );
+
+        // Test with answers
+        $this->sendFormAndAssertITILFollowup(
+            form: $form,
+            config: $no_followup,
+            answers: [
+                "Followup template 1" => [
+                    'itemtype' => ITILFollowupTemplate::getType(),
+                    'items_id' => $this->createITILFollowupTemplate()->getID(),
+                ],
+                "Followup template 2" => [
+                    'itemtype' => ITILFollowupTemplate::getType(),
+                    'items_id' => $this->createITILFollowupTemplate()->getID(),
+                ],
+                "Followup template 3" => [
+                    'itemtype' => ITILFollowupTemplate::getType(),
+                    'items_id' => $this->createITILFollowupTemplate()->getID(),
+                ],
+            ],
+            expected_itilfollowups: []
+        );
+    }
+
+    public function testFollowupForSpecificValues(): void
+    {
+        $templates = [
+            $this->createITILFollowupTemplate('Followup template 1'),
+            $this->createITILFollowupTemplate('Followup template 2'),
+        ];
+        $form = $this->createAndGetFormWithMultipleDropdownItemQuestions();
+        $specific_values = new ITILFollowupFieldConfig(
+            strategy: ITILFollowupFieldStrategy::SPECIFIC_VALUES,
+            specific_itilfollowuptemplates_ids: [$templates[0]->getID(), $templates[1]->getID(),]
+        );
+
+        // Test with no answers
+        $this->sendFormAndAssertITILFollowup(
+            form: $form,
+            config: $specific_values,
+            answers: [],
+            expected_itilfollowups: [
+                $templates[0]->getID() => 'Followup template 1',
+                $templates[1]->getID() => 'Followup template 2',
+            ]
+        );
+
+        // Test with answers
+        $this->sendFormAndAssertITILFollowup(
+            form: $form,
+            config: $specific_values,
+            answers: [
+                "Followup template 1" => [
+                    'itemtype' => ITILFollowupTemplate::getType(),
+                    'items_id' => $this->createITILFollowupTemplate()->getID(),
+                ],
+                "Followup template 2" => [
+                    'itemtype' => ITILFollowupTemplate::getType(),
+                    'items_id' => $this->createITILFollowupTemplate()->getID(),
+                ],
+                "Followup template 3" => [
+                    'itemtype' => ITILFollowupTemplate::getType(),
+                    'items_id' => $this->createITILFollowupTemplate()->getID(),
+                ],
+            ],
+            expected_itilfollowups: [
+                $templates[0]->getID() => 'Followup template 1',
+                $templates[1]->getID() => 'Followup template 2',
+            ]
+        );
+    }
+
+    public function testFollowupForSpecificAnswers(): void
+    {
+        $templates = [
+            $this->createITILFollowupTemplate('Followup template 1'),
+            $this->createITILFollowupTemplate('Followup template 2'),
+            $this->createITILFollowupTemplate('Followup template 3'),
+        ];
+        $form = $this->createAndGetFormWithMultipleDropdownItemQuestions();
+        $specific_answers = new ITILFollowupFieldConfig(
+            strategy: ITILFollowupFieldStrategy::SPECIFIC_ANSWERS,
+            specific_question_ids: [
+                $this->getQuestionId($form, "Followup template 1"),
+                $this->getQuestionId($form, "Followup template 2"),
+            ]
+        );
+
+        // Test with no answers
+        $this->sendFormAndAssertITILFollowup(
+            form: $form,
+            config: $specific_answers,
+            answers: [],
+            expected_itilfollowups: []
+        );
+
+        // Test with answers
+        $this->sendFormAndAssertITILFollowup(
+            form: $form,
+            config: $specific_answers,
+            answers: [
+                "Followup template 1" => [
+                    'itemtype' => ITILFollowupTemplate::getType(),
+                    'items_id' => $templates[0]->getID(),
+                ],
+                "Followup template 2" => [
+                    'itemtype' => ITILFollowupTemplate::getType(),
+                    'items_id' => $templates[1]->getID(),
+                ],
+                "Followup template 3" => [
+                    'itemtype' => ITILFollowupTemplate::getType(),
+                    'items_id' => $templates[2]->getID(),
+                ],
+            ],
+            expected_itilfollowups: [
+                $templates[0]->getID() => 'Followup template 1',
+                $templates[1]->getID() => 'Followup template 2',
+            ]
+        );
+    }
+
+    public function testFollowupForLastValidAnswer(): void
+    {
+        $templates = [
+            $this->createITILFollowupTemplate('Followup template 1'),
+            $this->createITILFollowupTemplate('Followup template 2'),
+            $this->createITILFollowupTemplate('Followup template 3'),
+        ];
+        $form = $this->createAndGetFormWithMultipleDropdownItemQuestions();
+        $last_valid_answer = new ITILFollowupFieldConfig(
+            strategy: ITILFollowupFieldStrategy::LAST_VALID_ANSWER
+        );
+
+        // Test with no answers
+        $this->sendFormAndAssertITILFollowup(
+            form: $form,
+            config: $last_valid_answer,
+            answers: [],
+            expected_itilfollowups: []
+        );
+
+        // Test with answers
+        $this->sendFormAndAssertITILFollowup(
+            form: $form,
+            config: $last_valid_answer,
+            answers: [
+                "Followup template 1" => [
+                    'itemtype' => ITILFollowupTemplate::getType(),
+                    'items_id' => $templates[0]->getID(),
+                ],
+                "Followup template 2" => [
+                    'itemtype' => ITILFollowupTemplate::getType(),
+                    'items_id' => $templates[1]->getID(),
+                ],
+                "Followup template 3" => [
+                    'itemtype' => ITILFollowupTemplate::getType(),
+                    'items_id' => $templates[2]->getID(),
+                ],
+            ],
+            expected_itilfollowups: [
+                $templates[2]->getID() => 'Followup template 3',
+            ]
+        );
+    }
+
+    public function testFollowupForAllValidAnswers(): void
+    {
+        $templates = [
+            $this->createITILFollowupTemplate('Followup template 1'),
+            $this->createITILFollowupTemplate('Followup template 2'),
+            $this->createITILFollowupTemplate('Followup template 3'),
+        ];
+        $form = $this->createAndGetFormWithMultipleDropdownItemQuestions();
+        $all_valid_answers = new ITILFollowupFieldConfig(
+            strategy: ITILFollowupFieldStrategy::ALL_VALID_ANSWERS
+        );
+
+        // Test with no answers
+        $this->sendFormAndAssertITILFollowup(
+            form: $form,
+            config: $all_valid_answers,
+            answers: [],
+            expected_itilfollowups: []
+        );
+
+        // Test with only one answer
+        $this->sendFormAndAssertITILFollowup(
+            form: $form,
+            config: $all_valid_answers,
+            answers: [
+                "Followup template 1" => [
+                    'itemtype' => ITILFollowupTemplate::getType(),
+                    'items_id' => $templates[0]->getID(),
+                ],
+            ],
+            expected_itilfollowups: [
+                $templates[0]->getID() => 'Followup template 1',
+            ]
+        );
+
+        // Test with answers
+        $this->sendFormAndAssertITILFollowup(
+            form: $form,
+            config: $all_valid_answers,
+            answers: [
+                "Followup template 1" => [
+                    'itemtype' => ITILFollowupTemplate::getType(),
+                    'items_id' => $templates[0]->getID(),
+                ],
+                "Followup template 2" => [
+                    'itemtype' => ITILFollowupTemplate::getType(),
+                    'items_id' => $templates[1]->getID(),
+                ],
+                "Followup template 3" => [
+                    'itemtype' => ITILFollowupTemplate::getType(),
+                    'items_id' => $templates[2]->getID(),
+                ],
+            ],
+            expected_itilfollowups: [
+                $templates[0]->getID() => 'Followup template 1',
+                $templates[1]->getID() => 'Followup template 2',
+                $templates[2]->getID() => 'Followup template 3',
+            ]
+        );
+    }
+
+    private function sendFormAndAssertITILFollowup(
+        Form $form,
+        ITILFollowupFieldConfig $config,
+        array $answers,
+        array $expected_itilfollowups
+    ): void {
+        $field = new ITILFollowupField();
+
+        // Insert config
+        $destinations = $form->getDestinations();
+        $this->assertCount(1, $destinations);
+        $destination = current($destinations);
+        $this->updateItem(
+            $destination::getType(),
+            $destination->getId(),
+            ['config' => [$field->getKey() => $config->jsonSerialize()]],
+            ["config"],
+        );
+
+        // The provider use a simplified answer format to be more readable.
+        // Rewrite answers into expected format.
+        $formatted_answers = [];
+        foreach ($answers as $question => $answer) {
+            $key = $this->getQuestionId($form, $question);
+            $formatted_answers[$key] = $answer;
+        }
+
+        // Submit form
+        $answers_handler = AnswersHandler::getInstance();
+        $answers = $answers_handler->saveAnswers(
+            $form,
+            $formatted_answers,
+            getItemByTypeName(\User::class, TU_USER, true)
+        );
+
+        // Get created ticket
+        $created_items = $answers->getCreatedItems();
+        $this->assertCount(1, $created_items);
+        $ticket = current($created_items);
+
+        // Check ITILFollowup
+        $this->assertEquals(
+            countElementsInTable(
+                ITILFollowup::getTable(),
+                [
+                    'itemtype' => Ticket::getType(),
+                    'items_id' => $ticket->getID(),
+                ]
+            ),
+            count($expected_itilfollowups)
+        );
+
+        $itilfollowup  = new ITILFollowup();
+        $itilfollowups = $itilfollowup->find([
+            'itemtype' => Ticket::getType(),
+            'items_id' => $ticket->getID(),
+        ]);
+
+        $this->assertEquals(
+            array_values(
+                array_map(
+                    fn(array $itilfollowup) => strip_tags($itilfollowup['content']),
+                    $itilfollowups
+                )
+            ),
+            array_values($expected_itilfollowups)
+        );
+    }
+
+    private function createAndGetFormWithMultipleDropdownItemQuestions(): Form
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion("Followup template 1", QuestionTypeItemDropdown::class, [
+            'itemtype' => ITILFollowupTemplate::getType()
+        ]);
+        $builder->addQuestion("Followup template 2", QuestionTypeItemDropdown::class, [
+            'itemtype' => ITILFollowupTemplate::getType()
+        ]);
+        $builder->addQuestion("Followup template 3", QuestionTypeItemDropdown::class, [
+            'itemtype' => ITILFollowupTemplate::getType()
+        ]);
+
+        $builder->addDestination(
+            FormDestinationTicket::class,
+            "My ticket"
+        );
+        return $this->createForm($builder);
+    }
+
+    private function createITILFollowupTemplate(?string $content = null): ITILFollowupTemplate
+    {
+        return $this->createItem(ITILFollowupTemplate::class, [
+            'name' => 'ITIL Followup Template',
+            'entities_id' => $this->getTestRootEntity()->getID(),
+            'content' => $content ?? 'This is a followup template',
+        ]);
+    }
+}

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -2448,14 +2448,17 @@ JAVASCRIPT;
                      "</a>";
             $output  .= "</div></div>";
 
+            $multichecksappend_varname = "multichecksappend" . str_replace('-', '_', $field_id);
             $js = "
-         var multichecksappend$field_id = false;
-         $('#$field_id').on('select2:open', function(e) {
-            if (!multichecksappend$field_id) {
-               $('#select2-$field_id-results').parent().append($('#selectallbuttons_$field_id').html());
-               multichecksappend$field_id = true;
-            }
-         });";
+                var $multichecksappend_varname = false;
+                $('#$field_id').on('select2:open', function(e) {
+                    if (!$multichecksappend_varname) {
+                        $('#select2-$field_id-results').parent().append($('#selectallbuttons_$field_id').html());
+                        $multichecksappend_varname = true;
+                    }
+                });
+            ";
+
             $output .= Html::scriptBlock($js);
         }
         $output .= Ajax::commonDropdownUpdateItem($param, false);

--- a/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
+++ b/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
@@ -43,6 +43,7 @@ use Glpi\Form\Destination\CommonITILField\ContentField;
 use Glpi\Form\Destination\CommonITILField\TemplateField;
 use Glpi\Form\Destination\CommonITILField\ITILCategoryField;
 use Glpi\Form\Destination\CommonITILField\LocationField;
+use Glpi\Form\Destination\CommonITILField\ITILFollowupField;
 use Glpi\Form\Destination\CommonITILField\TitleField;
 use Glpi\Form\Destination\CommonITILField\UrgencyField;
 use Glpi\Form\Form;
@@ -182,6 +183,7 @@ abstract class AbstractCommonITILFormDestination extends AbstractFormDestination
             new ITILCategoryField(),
             new LocationField(),
             new AssociatedItemsField(),
+            new ITILFollowupField(),
         ];
     }
 

--- a/src/Glpi/Form/Destination/CommonITILField/ITILFollowupField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILFollowupField.php
@@ -1,0 +1,185 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Destination\CommonITILField;
+
+use Glpi\Application\View\TemplateRenderer;
+use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\AnswersSet;
+use Glpi\Form\Destination\AbstractConfigField;
+use Glpi\Form\Form;
+use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
+use InvalidArgumentException;
+use ITILFollowupTemplate;
+use Override;
+use Session;
+use Ticket;
+
+class ITILFollowupField extends AbstractConfigField
+{
+    #[Override]
+    public function getLabel(): string
+    {
+        return _n('Followup', 'Followups', Session::getPluralNumber());
+    }
+
+    #[Override]
+    public function getConfigClass(): string
+    {
+        return ITILFollowupFieldConfig::class;
+    }
+
+    #[Override]
+    public function renderConfigForm(
+        Form $form,
+        JsonFieldInterface $config,
+        string $input_name,
+        array $display_options
+    ): string {
+        if (!$config instanceof ITILFollowupFieldConfig) {
+            throw new InvalidArgumentException("Unexpected config class");
+        }
+
+        $twig = TemplateRenderer::getInstance();
+        return $twig->render('pages/admin/form/itil_config_fields/itilfollowuptemplate.html.twig', [
+            // Possible configuration constant that will be used to to hide/show additional fields
+            'CONFIG_SPECIFIC_VALUES'  => ITILFollowupFieldStrategy::SPECIFIC_VALUES->value,
+            'CONFIG_SPECIFIC_ANSWERS' => ITILFollowupFieldStrategy::SPECIFIC_ANSWERS->value,
+
+            // General display options
+            'options' => $display_options,
+
+            // Main config field
+            'main_config_field' => [
+                'label'           => $this->getLabel(),
+                'value'           => $config->getStrategy()->value,
+                'input_name'      => $input_name . "[" . ITILFollowupFieldConfig::STRATEGY . "]",
+                'possible_values' => $this->getMainConfigurationValuesforDropdown(),
+            ],
+
+            // Specific additional config for SPECIFIC_VALUES strategy
+            'specific_value_extra_field' => [
+                'aria_label'     => __("Select followup templates..."),
+                'value'           => $config->getSpecificITILFollowupTemplatesIds() ?? [],
+                'input_name'      => $input_name . "[" . ITILFollowupFieldConfig::ITILFOLLOWUPTEMPLATE_IDS . "]",
+            ],
+
+            // Specific additional config for SPECIFIC_ANSWERS strategy
+            'specific_answer_extra_field' => [
+                'aria_label'     => __("Select questions..."),
+                'values'          => $config->getSpecificQuestionIds() ?? [],
+                'input_name'      => $input_name . "[" . ITILFollowupFieldConfig::QUESTION_IDS . "]",
+                'possible_values' => $this->getITILFollowupQuestionsValuesForDropdown($form),
+            ],
+        ]);
+    }
+
+    #[Override]
+    public function applyConfiguratedValueToInputUsingAnswers(
+        JsonFieldInterface $config,
+        array $input,
+        AnswersSet $answers_set
+    ): array {
+        if (!$config instanceof ITILFollowupFieldConfig) {
+            throw new InvalidArgumentException("Unexpected config class");
+        }
+
+        // Compute value according to strategy
+        $itilfollowuptemplates_ids = $config->getStrategy()->getITILFollowupTemplatesIDs($config, $answers_set);
+
+        if (!empty($itilfollowuptemplates_ids)) {
+            $input['_itilfollowuptemplates_id'] = $itilfollowuptemplates_ids;
+        }
+
+        return $input;
+    }
+
+    #[Override]
+    public function getDefaultConfig(Form $form): ITILFollowupFieldConfig
+    {
+        return new ITILFollowupFieldConfig(
+            ITILFollowupFieldStrategy::ALL_VALID_ANSWERS,
+        );
+    }
+
+    private function getMainConfigurationValuesforDropdown(): array
+    {
+        $values = [];
+        foreach (ITILFollowupFieldStrategy::cases() as $strategies) {
+            $values[$strategies->value] = $strategies->getLabel();
+        }
+        return $values;
+    }
+
+    private function getITILFollowupQuestionsValuesForDropdown(Form $form): array
+    {
+        $values = [];
+        $questions = $form->getQuestionsByType(QuestionTypeItemDropdown::class);
+
+        foreach ($questions as $question) {
+            if ((new QuestionTypeItemDropdown())->getDefaultValueItemtype($question) !== ITILFollowupTemplate::class) {
+                continue;
+            }
+
+            $values[$question->getId()] = $question->fields['name'];
+        }
+
+        return $values;
+    }
+
+    #[Override]
+    public function getWeight(): int
+    {
+        return 30;
+    }
+
+    #[Override]
+    public function prepareInput(array $input): array
+    {
+        $input = parent::prepareInput($input);
+
+        // Ensure that question_ids is an array
+        if (!is_array($input[$this->getKey()][ITILFollowupFieldConfig::QUESTION_IDS] ?? null)) {
+            unset($input[$this->getKey()][ITILFollowupFieldConfig::QUESTION_IDS]);
+        }
+
+        // Ensure that itilfollowuptemplate_ids is an array
+        if (!is_array($input[$this->getKey()][ITILFollowupFieldConfig::ITILFOLLOWUPTEMPLATE_IDS] ?? null)) {
+            unset($input[$this->getKey()][ITILFollowupFieldConfig::ITILFOLLOWUPTEMPLATE_IDS]);
+        }
+
+        return $input;
+    }
+}

--- a/src/Glpi/Form/Destination/CommonITILField/ITILFollowupFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILFollowupFieldConfig.php
@@ -42,12 +42,10 @@ final class ITILFollowupFieldConfig implements JsonFieldInterface
 {
     // Unique reference to hardcoded names used for serialization and forms input names
     public const STRATEGY = 'strategy';
-    public const QUESTION_IDS = 'question_ids';
     public const ITILFOLLOWUPTEMPLATE_IDS = 'itilfollowuptemplate_ids';
 
     public function __construct(
         private ITILFollowupFieldStrategy $strategy,
-        private ?array $specific_question_ids = null,
         private ?array $specific_itilfollowuptemplates_ids = null,
     ) {
     }
@@ -57,12 +55,11 @@ final class ITILFollowupFieldConfig implements JsonFieldInterface
     {
         $strategy = ITILFollowupFieldStrategy::tryFrom($data[self::STRATEGY] ?? "");
         if ($strategy === null) {
-            $strategy = ITILFollowupFieldStrategy::LAST_VALID_ANSWER;
+            $strategy = ITILFollowupFieldStrategy::NO_FOLLOWUP;
         }
 
         return new self(
             strategy: $strategy,
-            specific_question_ids: $data[self::QUESTION_IDS] ?? [],
             specific_itilfollowuptemplates_ids: $data[self::ITILFOLLOWUPTEMPLATE_IDS] ?? [],
         );
     }
@@ -72,7 +69,6 @@ final class ITILFollowupFieldConfig implements JsonFieldInterface
     {
         return [
             self::STRATEGY => $this->strategy->value,
-            self::QUESTION_IDS => $this->specific_question_ids,
             self::ITILFOLLOWUPTEMPLATE_IDS => $this->specific_itilfollowuptemplates_ids,
         ];
     }
@@ -80,11 +76,6 @@ final class ITILFollowupFieldConfig implements JsonFieldInterface
     public function getStrategy(): ITILFollowupFieldStrategy
     {
         return $this->strategy;
-    }
-
-    public function getSpecificQuestionIds(): ?array
-    {
-        return $this->specific_question_ids;
     }
 
     public function getSpecificITILFollowupTemplatesIds(): ?array

--- a/src/Glpi/Form/Destination/CommonITILField/ITILFollowupFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILFollowupFieldConfig.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Destination\CommonITILField;
+
+use Glpi\DBAL\JsonFieldInterface;
+use Override;
+
+final class ITILFollowupFieldConfig implements JsonFieldInterface
+{
+    // Unique reference to hardcoded names used for serialization and forms input names
+    public const STRATEGY = 'strategy';
+    public const QUESTION_IDS = 'question_ids';
+    public const ITILFOLLOWUPTEMPLATE_IDS = 'itilfollowuptemplate_ids';
+
+    public function __construct(
+        private ITILFollowupFieldStrategy $strategy,
+        private ?array $specific_question_ids = null,
+        private ?array $specific_itilfollowuptemplates_ids = null,
+    ) {
+    }
+
+    #[Override]
+    public static function jsonDeserialize(array $data): self
+    {
+        $strategy = ITILFollowupFieldStrategy::tryFrom($data[self::STRATEGY] ?? "");
+        if ($strategy === null) {
+            $strategy = ITILFollowupFieldStrategy::LAST_VALID_ANSWER;
+        }
+
+        return new self(
+            strategy: $strategy,
+            specific_question_ids: $data[self::QUESTION_IDS] ?? [],
+            specific_itilfollowuptemplates_ids: $data[self::ITILFOLLOWUPTEMPLATE_IDS] ?? [],
+        );
+    }
+
+    #[Override]
+    public function jsonSerialize(): array
+    {
+        return [
+            self::STRATEGY => $this->strategy->value,
+            self::QUESTION_IDS => $this->specific_question_ids,
+            self::ITILFOLLOWUPTEMPLATE_IDS => $this->specific_itilfollowuptemplates_ids,
+        ];
+    }
+
+    public function getStrategy(): ITILFollowupFieldStrategy
+    {
+        return $this->strategy;
+    }
+
+    public function getSpecificQuestionIds(): ?array
+    {
+        return $this->specific_question_ids;
+    }
+
+    public function getSpecificITILFollowupTemplatesIds(): ?array
+    {
+        return $this->specific_itilfollowuptemplates_ids;
+    }
+}

--- a/src/Glpi/Form/Destination/CommonITILField/ITILFollowupFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILFollowupFieldStrategy.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Destination\CommonITILField;
+
+use Glpi\Form\AnswersSet;
+use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
+use ITILFollowupTemplate;
+
+enum ITILFollowupFieldStrategy: string
+{
+    case NO_FOLLOWUP       = 'no_followup';
+    case SPECIFIC_VALUES   = 'specific_values';
+    case SPECIFIC_ANSWERS  = 'specific_answers';
+    case LAST_VALID_ANSWER = 'last_valid_answer';
+    case ALL_VALID_ANSWERS = 'all_valid_answers';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::NO_FOLLOWUP       => __("No Followup"),
+            self::SPECIFIC_VALUES   => __("Specific Followup templates"),
+            self::SPECIFIC_ANSWERS  => __("Answer from specific questions"),
+            self::LAST_VALID_ANSWER => __('Answer to last "Followup templates" question'),
+            self::ALL_VALID_ANSWERS => __('All answers to "Followup templates" questions'),
+        };
+    }
+
+    public function getITILFollowupTemplatesIDs(
+        ITILFollowupFieldConfig $config,
+        AnswersSet $answers_set,
+    ): ?array {
+        return match ($this) {
+            self::NO_FOLLOWUP      => null,
+            self::SPECIFIC_VALUES  => $config->getSpecificITILFollowupTemplatesIds(),
+            self::SPECIFIC_ANSWERS => $this->getITILFollowupTemplatesForSpecificAnswers(
+                $config->getSpecificQuestionIds(),
+                $answers_set
+            ),
+            self::LAST_VALID_ANSWER => $this->getITILFollowupTemplatesForLastValidAnswer($answers_set),
+            self::ALL_VALID_ANSWERS => $this->getITILFollowupTemplatesForAllValidAnswers($answers_set),
+        };
+    }
+
+    private function isValidAnswer(array $value): bool
+    {
+        if (
+            !isset($value['itemtype']) || !is_string($value['itemtype'])
+            || !isset($value['items_id']) || !is_numeric($value['items_id'])
+        ) {
+            return false;
+        }
+
+        if ($value['itemtype'] !== ITILFollowupTemplate::class) {
+            return true;
+        }
+
+        if (!(new ITILFollowupTemplate())->getFromDB($value['items_id'])) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function getITILFollowupTemplatesForSpecificAnswers(
+        ?array $question_ids,
+        AnswersSet $answers_set,
+    ): ?array {
+        if (empty($question_ids)) {
+            return null;
+        }
+
+        $itilfollowuptemplates_ids = array_map(
+            fn($question_id) => $this->getITILFollowupTemplatesForSpecificAnswer(
+                $question_id,
+                $answers_set
+            ),
+            $question_ids
+        );
+
+        return array_filter($itilfollowuptemplates_ids);
+    }
+
+    private function getITILFollowupTemplatesForSpecificAnswer(
+        ?int $question_id,
+        AnswersSet $answers_set,
+    ) {
+        if ($question_id === null) {
+            return null;
+        }
+
+        $answer = $answers_set->getAnswerByQuestionId($question_id);
+        if ($answer === null) {
+            return null;
+        }
+
+        $value = $answer->getRawAnswer();
+        if (!$this->isValidAnswer($value)) {
+            return null;
+        }
+
+        return $value['items_id'];
+    }
+
+    private function getITILFollowupTemplatesForLastValidAnswer(
+        AnswersSet $answers_set,
+    ): ?array {
+        $valid_answers = $this->getITILFollowupTemplatesForAllValidAnswers($answers_set);
+
+        if (empty($valid_answers)) {
+            return null;
+        }
+
+        return [end($valid_answers)];
+    }
+
+    private function getITILFollowupTemplatesForAllValidAnswers(
+        AnswersSet $answers_set,
+    ): ?array {
+        $valid_answers = array_filter(
+            $answers_set->getAnswersByType(
+                QuestionTypeItemDropdown::class
+            ),
+            fn($answer) => $this->isValidAnswer($answer->getRawAnswer())
+        );
+
+        if (empty($valid_answers)) {
+            return null;
+        }
+
+        return array_map(
+            fn($answer) => $answer->getRawAnswer()['items_id'],
+            $valid_answers
+        );
+    }
+}

--- a/src/Glpi/Form/Destination/CommonITILField/ITILFollowupFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILFollowupFieldStrategy.php
@@ -35,134 +35,25 @@
 
 namespace Glpi\Form\Destination\CommonITILField;
 
-use Glpi\Form\AnswersSet;
-use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
-use ITILFollowupTemplate;
-
 enum ITILFollowupFieldStrategy: string
 {
     case NO_FOLLOWUP       = 'no_followup';
     case SPECIFIC_VALUES   = 'specific_values';
-    case SPECIFIC_ANSWERS  = 'specific_answers';
-    case LAST_VALID_ANSWER = 'last_valid_answer';
-    case ALL_VALID_ANSWERS = 'all_valid_answers';
 
     public function getLabel(): string
     {
         return match ($this) {
             self::NO_FOLLOWUP       => __("No Followup"),
             self::SPECIFIC_VALUES   => __("Specific Followup templates"),
-            self::SPECIFIC_ANSWERS  => __("Answer from specific questions"),
-            self::LAST_VALID_ANSWER => __('Answer to last "Followup templates" question'),
-            self::ALL_VALID_ANSWERS => __('All answers to "Followup templates" questions'),
         };
     }
 
     public function getITILFollowupTemplatesIDs(
-        ITILFollowupFieldConfig $config,
-        AnswersSet $answers_set,
+        ITILFollowupFieldConfig $config
     ): ?array {
         return match ($this) {
             self::NO_FOLLOWUP      => null,
             self::SPECIFIC_VALUES  => $config->getSpecificITILFollowupTemplatesIds(),
-            self::SPECIFIC_ANSWERS => $this->getITILFollowupTemplatesForSpecificAnswers(
-                $config->getSpecificQuestionIds(),
-                $answers_set
-            ),
-            self::LAST_VALID_ANSWER => $this->getITILFollowupTemplatesForLastValidAnswer($answers_set),
-            self::ALL_VALID_ANSWERS => $this->getITILFollowupTemplatesForAllValidAnswers($answers_set),
         };
-    }
-
-    private function isValidAnswer(array $value): bool
-    {
-        if (
-            !isset($value['itemtype']) || !is_string($value['itemtype'])
-            || !isset($value['items_id']) || !is_numeric($value['items_id'])
-        ) {
-            return false;
-        }
-
-        if ($value['itemtype'] !== ITILFollowupTemplate::class) {
-            return true;
-        }
-
-        if (!(new ITILFollowupTemplate())->getFromDB($value['items_id'])) {
-            return false;
-        }
-
-        return true;
-    }
-
-    private function getITILFollowupTemplatesForSpecificAnswers(
-        ?array $question_ids,
-        AnswersSet $answers_set,
-    ): ?array {
-        if (empty($question_ids)) {
-            return null;
-        }
-
-        $itilfollowuptemplates_ids = array_map(
-            fn($question_id) => $this->getITILFollowupTemplatesForSpecificAnswer(
-                $question_id,
-                $answers_set
-            ),
-            $question_ids
-        );
-
-        return array_filter($itilfollowuptemplates_ids);
-    }
-
-    private function getITILFollowupTemplatesForSpecificAnswer(
-        ?int $question_id,
-        AnswersSet $answers_set,
-    ) {
-        if ($question_id === null) {
-            return null;
-        }
-
-        $answer = $answers_set->getAnswerByQuestionId($question_id);
-        if ($answer === null) {
-            return null;
-        }
-
-        $value = $answer->getRawAnswer();
-        if (!$this->isValidAnswer($value)) {
-            return null;
-        }
-
-        return $value['items_id'];
-    }
-
-    private function getITILFollowupTemplatesForLastValidAnswer(
-        AnswersSet $answers_set,
-    ): ?array {
-        $valid_answers = $this->getITILFollowupTemplatesForAllValidAnswers($answers_set);
-
-        if (empty($valid_answers)) {
-            return null;
-        }
-
-        return [end($valid_answers)];
-    }
-
-    private function getITILFollowupTemplatesForAllValidAnswers(
-        AnswersSet $answers_set,
-    ): ?array {
-        $valid_answers = array_filter(
-            $answers_set->getAnswersByType(
-                QuestionTypeItemDropdown::class
-            ),
-            fn($answer) => $this->isValidAnswer($answer->getRawAnswer())
-        );
-
-        if (empty($valid_answers)) {
-            return null;
-        }
-
-        return array_map(
-            fn($answer) => $answer->getRawAnswer()['items_id'],
-            $valid_answers
-        );
     }
 }

--- a/templates/pages/admin/form/itil_config_fields/itilfollowuptemplate.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/itilfollowuptemplate.html.twig
@@ -1,0 +1,83 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
+{{ fields.dropdownArrayField(
+    main_config_field.input_name,
+    main_config_field.value,
+    main_config_field.possible_values,
+    main_config_field.label,
+    options
+) }}
+
+<div
+    {% if main_config_field.value != CONFIG_SPECIFIC_VALUES %}
+        class="d-none"
+    {% endif %}
+    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
+    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_VALUES }}"
+>
+    {{ fields.dropdownField(
+        "ITILFollowupTemplate",
+        specific_value_extra_field.input_name,
+        specific_value_extra_field.value,
+        "",
+        options|merge({
+            multiple: true,
+            no_label: true,
+            aria_label: specific_value_extra_field.aria_label,
+        })
+    ) }}
+</div>
+
+<div
+    {% if main_config_field.value != CONFIG_SPECIFIC_ANSWERS %}
+        class="d-none"
+    {% endif %}
+    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
+    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_ANSWERS }}"
+>
+    {{ fields.dropdownArrayField(
+        specific_answer_extra_field.input_name,
+        "",
+        specific_answer_extra_field.possible_values,
+        "",
+        options|merge({
+            multiple: true,
+            no_label: true,
+            values: specific_answer_extra_field.values,
+            aria_label: specific_answer_extra_field.aria_label,
+        })
+    ) }}
+</div>

--- a/templates/pages/admin/form/itil_config_fields/itilfollowuptemplate.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/itilfollowuptemplate.html.twig
@@ -60,24 +60,3 @@
         })
     ) }}
 </div>
-
-<div
-    {% if main_config_field.value != CONFIG_SPECIFIC_ANSWERS %}
-        class="d-none"
-    {% endif %}
-    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
-    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_ANSWERS }}"
->
-    {{ fields.dropdownArrayField(
-        specific_answer_extra_field.input_name,
-        "",
-        specific_answer_extra_field.possible_values,
-        "",
-        options|merge({
-            multiple: true,
-            no_label: true,
-            values: specific_answer_extra_field.values,
-            aria_label: specific_answer_extra_field.aria_label,
-        })
-    ) }}
-</div>

--- a/tests/cypress/e2e/form/destination_config_fields/itilfollowup.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/itilfollowup.cy.js
@@ -1,0 +1,141 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+describe('ITILFollowup configuration', () => {
+    beforeEach(() => {
+        cy.login();
+        cy.changeProfile('Super-Admin', true);
+
+        // Create form with a single "ITILFollowup template" dropdown question
+        cy.createFormWithAPI().as('form_id').visitFormTab('Form');
+        cy.findByRole('button', {'name': "Add a new question"}).click();
+        cy.focused().type("My ITILFollowup template question");
+        cy.getDropdownByLabelText('Question type').selectDropdownValue('Item');
+        cy.getDropdownByLabelText('Question sub type').selectDropdownValue('Dropdowns');
+
+        cy.getDropdownByLabelText('Select a dropdown type').selectDropdownValue('Followup templates');
+
+        cy.findByRole('button', {'name': 'Save'}).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+
+        // Go to destination tab
+        cy.findByRole('tab', {'name': "Items to create"}).click();
+        cy.findByRole('button', {'name': "Add ticket"}).click();
+        cy.findByRole('alert').should('contain.text', 'Item successfully added');
+        cy.checkAndCloseAlert('Item successfully added');
+
+        cy.get('@form_id').then((form_id) => {
+            cy.createWithAPI('ITILFollowupTemplate', {
+                'name': 'ITILFollowup template 1 - ' + form_id,
+                'content': 'My ITILFollowup template content',
+            });
+        });
+    });
+
+    it('can use all possibles configuration options', () => {
+        cy.findByRole('region', {'name': "Followups configuration"}).as("config");
+        cy.get('@config').getDropdownByLabelText('Followups').as("itilfollowup_dropdown");
+
+        // Default value
+        cy.get('@itilfollowup_dropdown').should(
+            'have.text',
+            'All answers to "Followup templates" questions'
+        );
+
+        // Make sure hidden dropdowns are not displayed
+        cy.get('@config').getDropdownByLabelText('Select followup templates...').should('not.exist');
+        cy.get('@config').getDropdownByLabelText('Select questions...').should('not.exist');
+
+        // Switch to "No Followup"
+        cy.get('@itilfollowup_dropdown').selectDropdownValue('No Followup');
+        cy.findByRole('button', {'name': 'Update item'}).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@itilfollowup_dropdown').should('have.text', 'No Followup');
+
+        // Switch to "Specific Followup templates"
+        cy.get('@form_id').then((form_id) => {
+            cy.get('@itilfollowup_dropdown').selectDropdownValue('Specific Followup templates');
+            cy.get('@config').getDropdownByLabelText('Select followup templates...').as('specific_itilfollowup_dropdown');
+            cy.get('@specific_itilfollowup_dropdown').selectDropdownValue('ITILFollowup template 1 - ' + form_id);
+
+            cy.findByRole('button', {'name': 'Update item'}).click();
+            cy.checkAndCloseAlert('Item successfully updated');
+            cy.get('@itilfollowup_dropdown').should('have.text', 'Specific Followup templates');
+            cy.get('@specific_itilfollowup_dropdown').should('have.text', '×ITILFollowup template 1 - ' + form_id);
+        });
+
+        // Switch to "Answer from specific questions"
+        cy.get('@itilfollowup_dropdown').selectDropdownValue('Answer from specific questions');
+        cy.get('@config').getDropdownByLabelText('Select questions...').as('specific_answers_dropdown');
+        cy.get('@specific_answers_dropdown').selectDropdownValue('My ITILFollowup template question');
+
+        cy.findByRole('button', {'name': 'Update item'}).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@itilfollowup_dropdown').should('have.text', 'Answer from specific questions');
+        cy.get('@specific_answers_dropdown').should('have.text', '×My ITILFollowup template question');
+
+        // Switch to "Answer to last "Followup templates" question"
+        cy.get('@itilfollowup_dropdown').selectDropdownValue('Answer to last "Followup templates" question');
+        cy.findByRole('button', {'name': 'Update item'}).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@itilfollowup_dropdown').should('have.text', 'Answer to last "Followup templates" question');
+
+        // Switch to "All answers to "Followup templates" questions"
+        cy.get('@itilfollowup_dropdown').selectDropdownValue('All answers to "Followup templates" questions');
+        cy.findByRole('button', {'name': 'Update item'}).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@itilfollowup_dropdown').should('have.text', 'All answers to "Followup templates" questions');
+    });
+
+    it('can create ticket using default configuration', () => {
+        // Go to preview
+        cy.findByRole('tab', {'name': "Form"}).click();
+        cy.findByRole('link', {'name': "Preview"})
+            .invoke('removeAttr', 'target') // Cypress can't handle tab changes
+            .click()
+        ;
+
+        // Fill form
+        cy.getDropdownByLabelText("My ITILFollowup template question").as('itilfollowup_dropdown');
+        cy.get('@form_id').then((form_id) => {
+            cy.get('@itilfollowup_dropdown').selectDropdownValue('ITILFollowup template 1 - ' + form_id);
+        });
+        cy.findByRole('button', {'name': 'Send form'}).click();
+        cy.findByRole('link', {'name': 'My test form'}).click();
+
+        // Check if followup template content is displayed
+        cy.contains('My ITILFollowup template content');
+
+        // Others possibles configurations are tested directly by the backend.
+    });
+});

--- a/tests/cypress/e2e/form/destination_config_fields/itilfollowup.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/itilfollowup.cy.js
@@ -36,14 +36,10 @@ describe('ITILFollowup configuration', () => {
         cy.login();
         cy.changeProfile('Super-Admin', true);
 
-        // Create form with a single "ITILFollowup template" dropdown question
+        // Create form
         cy.createFormWithAPI().as('form_id').visitFormTab('Form');
         cy.findByRole('button', {'name': "Add a new question"}).click();
-        cy.focused().type("My ITILFollowup template question");
-        cy.getDropdownByLabelText('Question type').selectDropdownValue('Item');
-        cy.getDropdownByLabelText('Question sub type').selectDropdownValue('Dropdowns');
-
-        cy.getDropdownByLabelText('Select a dropdown type').selectDropdownValue('Followup templates');
+        cy.focused().type("My question");
 
         cy.findByRole('button', {'name': 'Save'}).click();
         cy.checkAndCloseAlert('Item successfully updated');
@@ -69,18 +65,11 @@ describe('ITILFollowup configuration', () => {
         // Default value
         cy.get('@itilfollowup_dropdown').should(
             'have.text',
-            'All answers to "Followup templates" questions'
+            'No Followup'
         );
 
         // Make sure hidden dropdowns are not displayed
         cy.get('@config').getDropdownByLabelText('Select followup templates...').should('not.exist');
-        cy.get('@config').getDropdownByLabelText('Select questions...').should('not.exist');
-
-        // Switch to "No Followup"
-        cy.get('@itilfollowup_dropdown').selectDropdownValue('No Followup');
-        cy.findByRole('button', {'name': 'Update item'}).click();
-        cy.checkAndCloseAlert('Item successfully updated');
-        cy.get('@itilfollowup_dropdown').should('have.text', 'No Followup');
 
         // Switch to "Specific Followup templates"
         cy.get('@form_id').then((form_id) => {
@@ -94,30 +83,29 @@ describe('ITILFollowup configuration', () => {
             cy.get('@specific_itilfollowup_dropdown').should('have.text', '×ITILFollowup template 1 - ' + form_id);
         });
 
-        // Switch to "Answer from specific questions"
-        cy.get('@itilfollowup_dropdown').selectDropdownValue('Answer from specific questions');
-        cy.get('@config').getDropdownByLabelText('Select questions...').as('specific_answers_dropdown');
-        cy.get('@specific_answers_dropdown').selectDropdownValue('My ITILFollowup template question');
-
+        // Switch to "No Followup"
+        cy.get('@itilfollowup_dropdown').selectDropdownValue('No Followup');
         cy.findByRole('button', {'name': 'Update item'}).click();
         cy.checkAndCloseAlert('Item successfully updated');
-        cy.get('@itilfollowup_dropdown').should('have.text', 'Answer from specific questions');
-        cy.get('@specific_answers_dropdown').should('have.text', '×My ITILFollowup template question');
-
-        // Switch to "Answer to last "Followup templates" question"
-        cy.get('@itilfollowup_dropdown').selectDropdownValue('Answer to last "Followup templates" question');
-        cy.findByRole('button', {'name': 'Update item'}).click();
-        cy.checkAndCloseAlert('Item successfully updated');
-        cy.get('@itilfollowup_dropdown').should('have.text', 'Answer to last "Followup templates" question');
-
-        // Switch to "All answers to "Followup templates" questions"
-        cy.get('@itilfollowup_dropdown').selectDropdownValue('All answers to "Followup templates" questions');
-        cy.findByRole('button', {'name': 'Update item'}).click();
-        cy.checkAndCloseAlert('Item successfully updated');
-        cy.get('@itilfollowup_dropdown').should('have.text', 'All answers to "Followup templates" questions');
+        cy.get('@itilfollowup_dropdown').should('have.text', 'No Followup');
     });
 
-    it('can create ticket using default configuration', () => {
+    it('can create ticket using specific followup template', () => {
+        cy.findByRole('region', {'name': "Followups configuration"}).as("config");
+        cy.get('@config').getDropdownByLabelText('Followups').as("itilfollowup_dropdown");
+
+        // Switch to "Specific Followup templates"
+        cy.get('@form_id').then((form_id) => {
+            cy.get('@itilfollowup_dropdown').selectDropdownValue('Specific Followup templates');
+            cy.get('@config').getDropdownByLabelText('Select followup templates...').as('specific_itilfollowup_dropdown');
+            cy.get('@specific_itilfollowup_dropdown').selectDropdownValue('ITILFollowup template 1 - ' + form_id);
+
+            cy.findByRole('button', {'name': 'Update item'}).click();
+            cy.checkAndCloseAlert('Item successfully updated');
+            cy.get('@itilfollowup_dropdown').should('have.text', 'Specific Followup templates');
+            cy.get('@specific_itilfollowup_dropdown').should('have.text', '×ITILFollowup template 1 - ' + form_id);
+        });
+
         // Go to preview
         cy.findByRole('tab', {'name': "Form"}).click();
         cy.findByRole('link', {'name': "Preview"})
@@ -126,10 +114,6 @@ describe('ITILFollowup configuration', () => {
         ;
 
         // Fill form
-        cy.getDropdownByLabelText("My ITILFollowup template question").as('itilfollowup_dropdown');
-        cy.get('@form_id').then((form_id) => {
-            cy.get('@itilfollowup_dropdown').selectDropdownValue('ITILFollowup template 1 - ' + form_id);
-        });
         cy.findByRole('button', {'name': 'Send form'}).click();
         cy.findByRole('link', {'name': 'My test form'}).click();
 


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

Adds the ability to define followups that will be added to ITIL form destination objects.
Possible configurations :
- No Followup
- Specific Followup templates
- Answer from specific questions
- Answer to last "Followup templates" question
- All answers to "Followup templates" questions

## Screenshots

![image](https://github.com/user-attachments/assets/6da1fdd3-ee11-42f1-acc9-8fb4379a1dca)
![image](https://github.com/user-attachments/assets/94ad1c33-2ed8-4755-965a-0d299d6a1590)
![image](https://github.com/user-attachments/assets/d11d9da7-78ce-4188-9d09-7dbb40614554)