### PR TITLE
feat(forms): Add ITILTask field configuration for form destination

### DIFF
--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/ITILTaskFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/ITILTaskFieldTest.php
@@ -42,12 +42,9 @@ use Glpi\Form\Destination\CommonITILField\ITILTaskFieldConfig;
 use Glpi\Form\Destination\CommonITILField\ITILTaskFieldStrategy;
 use Glpi\Form\Destination\FormDestinationTicket;
 use Glpi\Form\Form;
-use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
 use Glpi\Tests\FormBuilder;
 use Glpi\Tests\FormTesterTrait;
-use ITILTask;
 use TaskTemplate;
-use Ticket;
 use TicketTask;
 
 final class ITILTaskFieldTest extends DbTestCase
@@ -61,32 +58,9 @@ final class ITILTaskFieldTest extends DbTestCase
             strategy: ITILTaskFieldStrategy::NO_TASK
         );
 
-        // Test with no answers
         $this->sendFormAndAssertITILTask(
             form: $form,
             config: $no_task,
-            answers: [],
-            expected_itiltasks: []
-        );
-
-        // Test with answers
-        $this->sendFormAndAssertITILTask(
-            form: $form,
-            config: $no_task,
-            answers: [
-                "Task template 1" => [
-                    'itemtype' => TaskTemplate::getType(),
-                    'items_id' => $this->createTaskTemplate()->getID(),
-                ],
-                "Task template 2" => [
-                    'itemtype' => TaskTemplate::getType(),
-                    'items_id' => $this->createTaskTemplate()->getID(),
-                ],
-                "Task template 3" => [
-                    'itemtype' => TaskTemplate::getType(),
-                    'items_id' => $this->createTaskTemplate()->getID(),
-                ],
-            ],
             expected_itiltasks: []
         );
     }
@@ -103,192 +77,12 @@ final class ITILTaskFieldTest extends DbTestCase
             specific_itiltasktemplates_ids: [$templates[0]->getID(), $templates[1]->getID(),]
         );
 
-        // Test with no answers
         $this->sendFormAndAssertITILTask(
             form: $form,
             config: $specific_values,
-            answers: [],
             expected_itiltasks: [
                 $templates[0]->getID() => 'Task template 1',
                 $templates[1]->getID() => 'Task template 2',
-            ]
-        );
-
-        // Test with answers
-        $this->sendFormAndAssertITILTask(
-            form: $form,
-            config: $specific_values,
-            answers: [
-                "Task template 1" => [
-                    'itemtype' => TaskTemplate::getType(),
-                    'items_id' => $this->createTaskTemplate()->getID(),
-                ],
-                "Task template 2" => [
-                    'itemtype' => TaskTemplate::getType(),
-                    'items_id' => $this->createTaskTemplate()->getID(),
-                ],
-                "Task template 3" => [
-                    'itemtype' => TaskTemplate::getType(),
-                    'items_id' => $this->createTaskTemplate()->getID(),
-                ],
-            ],
-            expected_itiltasks: [
-                $templates[0]->getID() => 'Task template 1',
-                $templates[1]->getID() => 'Task template 2',
-            ]
-        );
-    }
-
-    public function testTaskForSpecificAnswers(): void
-    {
-        $templates = [
-            $this->createTaskTemplate('Task template 1'),
-            $this->createTaskTemplate('Task template 2'),
-            $this->createTaskTemplate('Task template 3'),
-        ];
-        $form = $this->createAndGetFormWithMultipleDropdownItemQuestions();
-        $specific_answers = new ITILTaskFieldConfig(
-            strategy: ITILTaskFieldStrategy::SPECIFIC_ANSWERS,
-            specific_question_ids: [
-                $this->getQuestionId($form, "Task template 1"),
-                $this->getQuestionId($form, "Task template 2"),
-            ]
-        );
-
-        // Test with no answers
-        $this->sendFormAndAssertITILTask(
-            form: $form,
-            config: $specific_answers,
-            answers: [],
-            expected_itiltasks: []
-        );
-
-        // Test with answers
-        $this->sendFormAndAssertITILTask(
-            form: $form,
-            config: $specific_answers,
-            answers: [
-                "Task template 1" => [
-                    'itemtype' => TaskTemplate::getType(),
-                    'items_id' => $templates[0]->getID(),
-                ],
-                "Task template 2" => [
-                    'itemtype' => TaskTemplate::getType(),
-                    'items_id' => $templates[1]->getID(),
-                ],
-                "Task template 3" => [
-                    'itemtype' => TaskTemplate::getType(),
-                    'items_id' => $templates[2]->getID(),
-                ],
-            ],
-            expected_itiltasks: [
-                $templates[0]->getID() => 'Task template 1',
-                $templates[1]->getID() => 'Task template 2',
-            ]
-        );
-    }
-
-    public function testTaskForLastValidAnswer(): void
-    {
-        $templates = [
-            $this->createTaskTemplate('Task template 1'),
-            $this->createTaskTemplate('Task template 2'),
-            $this->createTaskTemplate('Task template 3'),
-        ];
-        $form = $this->createAndGetFormWithMultipleDropdownItemQuestions();
-        $last_valid_answer = new ITILTaskFieldConfig(
-            strategy: ITILTaskFieldStrategy::LAST_VALID_ANSWER
-        );
-
-        // Test with no answers
-        $this->sendFormAndAssertITILTask(
-            form: $form,
-            config: $last_valid_answer,
-            answers: [],
-            expected_itiltasks: []
-        );
-
-        // Test with answers
-        $this->sendFormAndAssertITILTask(
-            form: $form,
-            config: $last_valid_answer,
-            answers: [
-                "Task template 1" => [
-                    'itemtype' => TaskTemplate::getType(),
-                    'items_id' => $templates[0]->getID(),
-                ],
-                "Task template 2" => [
-                    'itemtype' => TaskTemplate::getType(),
-                    'items_id' => $templates[1]->getID(),
-                ],
-                "Task template 3" => [
-                    'itemtype' => TaskTemplate::getType(),
-                    'items_id' => $templates[2]->getID(),
-                ],
-            ],
-            expected_itiltasks: [
-                $templates[2]->getID() => 'Task template 3',
-            ]
-        );
-    }
-
-    public function testTaskForAllValidAnswers(): void
-    {
-        $templates = [
-            $this->createTaskTemplate('Task template 1'),
-            $this->createTaskTemplate('Task template 2'),
-            $this->createTaskTemplate('Task template 3'),
-        ];
-        $form = $this->createAndGetFormWithMultipleDropdownItemQuestions();
-        $all_valid_answers = new ITILTaskFieldConfig(
-            strategy: ITILTaskFieldStrategy::ALL_VALID_ANSWERS
-        );
-
-        // Test with no answers
-        $this->sendFormAndAssertITILTask(
-            form: $form,
-            config: $all_valid_answers,
-            answers: [],
-            expected_itiltasks: []
-        );
-
-        // Test with only one answer
-        $this->sendFormAndAssertITILTask(
-            form: $form,
-            config: $all_valid_answers,
-            answers: [
-                "Task template 1" => [
-                    'itemtype' => TaskTemplate::getType(),
-                    'items_id' => $templates[0]->getID(),
-                ],
-            ],
-            expected_itiltasks: [
-                $templates[0]->getID() => 'Task template 1',
-            ]
-        );
-
-        // Test with answers
-        $this->sendFormAndAssertITILTask(
-            form: $form,
-            config: $all_valid_answers,
-            answers: [
-                "Task template 1" => [
-                    'itemtype' => TaskTemplate::getType(),
-                    'items_id' => $templates[0]->getID(),
-                ],
-                "Task template 2" => [
-                    'itemtype' => TaskTemplate::getType(),
-                    'items_id' => $templates[1]->getID(),
-                ],
-                "Task template 3" => [
-                    'itemtype' => TaskTemplate::getType(),
-                    'items_id' => $templates[2]->getID(),
-                ],
-            ],
-            expected_itiltasks: [
-                $templates[0]->getID() => 'Task template 1',
-                $templates[1]->getID() => 'Task template 2',
-                $templates[2]->getID() => 'Task template 3',
             ]
         );
     }
@@ -296,7 +90,6 @@ final class ITILTaskFieldTest extends DbTestCase
     private function sendFormAndAssertITILTask(
         Form $form,
         ITILTaskFieldConfig $config,
-        array $answers,
         array $expected_itiltasks
     ): void {
         $field = new ITILTaskField();
@@ -312,19 +105,11 @@ final class ITILTaskFieldTest extends DbTestCase
             ["config"],
         );
 
-        // The provider use a simplified answer format to be more readable.
-        // Rewrite answers into expected format.
-        $formatted_answers = [];
-        foreach ($answers as $question => $answer) {
-            $key = $this->getQuestionId($form, $question);
-            $formatted_answers[$key] = $answer;
-        }
-
         // Submit form
         $answers_handler = AnswersHandler::getInstance();
         $answers = $answers_handler->saveAnswers(
             $form,
-            $formatted_answers,
+            [],
             getItemByTypeName(\User::class, TU_USER, true)
         );
 
@@ -363,16 +148,6 @@ final class ITILTaskFieldTest extends DbTestCase
     private function createAndGetFormWithMultipleDropdownItemQuestions(): Form
     {
         $builder = new FormBuilder();
-        $builder->addQuestion("Task template 1", QuestionTypeItemDropdown::class, [
-            'itemtype' => TaskTemplate::getType()
-        ]);
-        $builder->addQuestion("Task template 2", QuestionTypeItemDropdown::class, [
-            'itemtype' => TaskTemplate::getType()
-        ]);
-        $builder->addQuestion("Task template 3", QuestionTypeItemDropdown::class, [
-            'itemtype' => TaskTemplate::getType()
-        ]);
-
         $builder->addDestination(
             FormDestinationTicket::class,
             "My ticket"

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/ITILTaskFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/ITILTaskFieldTest.php
@@ -1,0 +1,391 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\Destination\CommonITILField;
+
+use DbTestCase;
+use Glpi\Form\AnswersHandler\AnswersHandler;
+use Glpi\Form\Destination\CommonITILField\ITILTaskField;
+use Glpi\Form\Destination\CommonITILField\ITILTaskFieldConfig;
+use Glpi\Form\Destination\CommonITILField\ITILTaskFieldStrategy;
+use Glpi\Form\Destination\FormDestinationTicket;
+use Glpi\Form\Form;
+use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+use ITILTask;
+use TaskTemplate;
+use Ticket;
+use TicketTask;
+
+final class ITILTaskFieldTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public function testTaskForNoTask(): void
+    {
+        $form = $this->createAndGetFormWithMultipleDropdownItemQuestions();
+        $no_task = new ITILTaskFieldConfig(
+            strategy: ITILTaskFieldStrategy::NO_TASK
+        );
+
+        // Test with no answers
+        $this->sendFormAndAssertITILTask(
+            form: $form,
+            config: $no_task,
+            answers: [],
+            expected_itiltasks: []
+        );
+
+        // Test with answers
+        $this->sendFormAndAssertITILTask(
+            form: $form,
+            config: $no_task,
+            answers: [
+                "Task template 1" => [
+                    'itemtype' => TaskTemplate::getType(),
+                    'items_id' => $this->createTaskTemplate()->getID(),
+                ],
+                "Task template 2" => [
+                    'itemtype' => TaskTemplate::getType(),
+                    'items_id' => $this->createTaskTemplate()->getID(),
+                ],
+                "Task template 3" => [
+                    'itemtype' => TaskTemplate::getType(),
+                    'items_id' => $this->createTaskTemplate()->getID(),
+                ],
+            ],
+            expected_itiltasks: []
+        );
+    }
+
+    public function testTaskForSpecificValues(): void
+    {
+        $templates = [
+            $this->createTaskTemplate('Task template 1'),
+            $this->createTaskTemplate('Task template 2'),
+        ];
+        $form = $this->createAndGetFormWithMultipleDropdownItemQuestions();
+        $specific_values = new ITILTaskFieldConfig(
+            strategy: ITILTaskFieldStrategy::SPECIFIC_VALUES,
+            specific_itiltasktemplates_ids: [$templates[0]->getID(), $templates[1]->getID(),]
+        );
+
+        // Test with no answers
+        $this->sendFormAndAssertITILTask(
+            form: $form,
+            config: $specific_values,
+            answers: [],
+            expected_itiltasks: [
+                $templates[0]->getID() => 'Task template 1',
+                $templates[1]->getID() => 'Task template 2',
+            ]
+        );
+
+        // Test with answers
+        $this->sendFormAndAssertITILTask(
+            form: $form,
+            config: $specific_values,
+            answers: [
+                "Task template 1" => [
+                    'itemtype' => TaskTemplate::getType(),
+                    'items_id' => $this->createTaskTemplate()->getID(),
+                ],
+                "Task template 2" => [
+                    'itemtype' => TaskTemplate::getType(),
+                    'items_id' => $this->createTaskTemplate()->getID(),
+                ],
+                "Task template 3" => [
+                    'itemtype' => TaskTemplate::getType(),
+                    'items_id' => $this->createTaskTemplate()->getID(),
+                ],
+            ],
+            expected_itiltasks: [
+                $templates[0]->getID() => 'Task template 1',
+                $templates[1]->getID() => 'Task template 2',
+            ]
+        );
+    }
+
+    public function testTaskForSpecificAnswers(): void
+    {
+        $templates = [
+            $this->createTaskTemplate('Task template 1'),
+            $this->createTaskTemplate('Task template 2'),
+            $this->createTaskTemplate('Task template 3'),
+        ];
+        $form = $this->createAndGetFormWithMultipleDropdownItemQuestions();
+        $specific_answers = new ITILTaskFieldConfig(
+            strategy: ITILTaskFieldStrategy::SPECIFIC_ANSWERS,
+            specific_question_ids: [
+                $this->getQuestionId($form, "Task template 1"),
+                $this->getQuestionId($form, "Task template 2"),
+            ]
+        );
+
+        // Test with no answers
+        $this->sendFormAndAssertITILTask(
+            form: $form,
+            config: $specific_answers,
+            answers: [],
+            expected_itiltasks: []
+        );
+
+        // Test with answers
+        $this->sendFormAndAssertITILTask(
+            form: $form,
+            config: $specific_answers,
+            answers: [
+                "Task template 1" => [
+                    'itemtype' => TaskTemplate::getType(),
+                    'items_id' => $templates[0]->getID(),
+                ],
+                "Task template 2" => [
+                    'itemtype' => TaskTemplate::getType(),
+                    'items_id' => $templates[1]->getID(),
+                ],
+                "Task template 3" => [
+                    'itemtype' => TaskTemplate::getType(),
+                    'items_id' => $templates[2]->getID(),
+                ],
+            ],
+            expected_itiltasks: [
+                $templates[0]->getID() => 'Task template 1',
+                $templates[1]->getID() => 'Task template 2',
+            ]
+        );
+    }
+
+    public function testTaskForLastValidAnswer(): void
+    {
+        $templates = [
+            $this->createTaskTemplate('Task template 1'),
+            $this->createTaskTemplate('Task template 2'),
+            $this->createTaskTemplate('Task template 3'),
+        ];
+        $form = $this->createAndGetFormWithMultipleDropdownItemQuestions();
+        $last_valid_answer = new ITILTaskFieldConfig(
+            strategy: ITILTaskFieldStrategy::LAST_VALID_ANSWER
+        );
+
+        // Test with no answers
+        $this->sendFormAndAssertITILTask(
+            form: $form,
+            config: $last_valid_answer,
+            answers: [],
+            expected_itiltasks: []
+        );
+
+        // Test with answers
+        $this->sendFormAndAssertITILTask(
+            form: $form,
+            config: $last_valid_answer,
+            answers: [
+                "Task template 1" => [
+                    'itemtype' => TaskTemplate::getType(),
+                    'items_id' => $templates[0]->getID(),
+                ],
+                "Task template 2" => [
+                    'itemtype' => TaskTemplate::getType(),
+                    'items_id' => $templates[1]->getID(),
+                ],
+                "Task template 3" => [
+                    'itemtype' => TaskTemplate::getType(),
+                    'items_id' => $templates[2]->getID(),
+                ],
+            ],
+            expected_itiltasks: [
+                $templates[2]->getID() => 'Task template 3',
+            ]
+        );
+    }
+
+    public function testTaskForAllValidAnswers(): void
+    {
+        $templates = [
+            $this->createTaskTemplate('Task template 1'),
+            $this->createTaskTemplate('Task template 2'),
+            $this->createTaskTemplate('Task template 3'),
+        ];
+        $form = $this->createAndGetFormWithMultipleDropdownItemQuestions();
+        $all_valid_answers = new ITILTaskFieldConfig(
+            strategy: ITILTaskFieldStrategy::ALL_VALID_ANSWERS
+        );
+
+        // Test with no answers
+        $this->sendFormAndAssertITILTask(
+            form: $form,
+            config: $all_valid_answers,
+            answers: [],
+            expected_itiltasks: []
+        );
+
+        // Test with only one answer
+        $this->sendFormAndAssertITILTask(
+            form: $form,
+            config: $all_valid_answers,
+            answers: [
+                "Task template 1" => [
+                    'itemtype' => TaskTemplate::getType(),
+                    'items_id' => $templates[0]->getID(),
+                ],
+            ],
+            expected_itiltasks: [
+                $templates[0]->getID() => 'Task template 1',
+            ]
+        );
+
+        // Test with answers
+        $this->sendFormAndAssertITILTask(
+            form: $form,
+            config: $all_valid_answers,
+            answers: [
+                "Task template 1" => [
+                    'itemtype' => TaskTemplate::getType(),
+                    'items_id' => $templates[0]->getID(),
+                ],
+                "Task template 2" => [
+                    'itemtype' => TaskTemplate::getType(),
+                    'items_id' => $templates[1]->getID(),
+                ],
+                "Task template 3" => [
+                    'itemtype' => TaskTemplate::getType(),
+                    'items_id' => $templates[2]->getID(),
+                ],
+            ],
+            expected_itiltasks: [
+                $templates[0]->getID() => 'Task template 1',
+                $templates[1]->getID() => 'Task template 2',
+                $templates[2]->getID() => 'Task template 3',
+            ]
+        );
+    }
+
+    private function sendFormAndAssertITILTask(
+        Form $form,
+        ITILTaskFieldConfig $config,
+        array $answers,
+        array $expected_itiltasks
+    ): void {
+        $field = new ITILTaskField();
+
+        // Insert config
+        $destinations = $form->getDestinations();
+        $this->assertCount(1, $destinations);
+        $destination = current($destinations);
+        $this->updateItem(
+            $destination::getType(),
+            $destination->getId(),
+            ['config' => [$field->getKey() => $config->jsonSerialize()]],
+            ["config"],
+        );
+
+        // The provider use a simplified answer format to be more readable.
+        // Rewrite answers into expected format.
+        $formatted_answers = [];
+        foreach ($answers as $question => $answer) {
+            $key = $this->getQuestionId($form, $question);
+            $formatted_answers[$key] = $answer;
+        }
+
+        // Submit form
+        $answers_handler = AnswersHandler::getInstance();
+        $answers = $answers_handler->saveAnswers(
+            $form,
+            $formatted_answers,
+            getItemByTypeName(\User::class, TU_USER, true)
+        );
+
+        // Get created ticket
+        $created_items = $answers->getCreatedItems();
+        $this->assertCount(1, $created_items);
+        $ticket = current($created_items);
+
+        // Check TicketTask
+        $this->assertEquals(
+            countElementsInTable(
+                TicketTask::getTable(),
+                [
+                    'tickets_id' => $ticket->getID(),
+                ]
+            ),
+            count($expected_itiltasks)
+        );
+
+        $tickettask  = new TicketTask();
+        $tickettasks = $tickettask->find([
+            'tickets_id' => $ticket->getID(),
+        ]);
+
+        $this->assertEquals(
+            array_values(
+                array_map(
+                    fn(array $tickettask) => strip_tags($tickettask['content']),
+                    $tickettasks
+                )
+            ),
+            array_values($expected_itiltasks)
+        );
+    }
+
+    private function createAndGetFormWithMultipleDropdownItemQuestions(): Form
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion("Task template 1", QuestionTypeItemDropdown::class, [
+            'itemtype' => TaskTemplate::getType()
+        ]);
+        $builder->addQuestion("Task template 2", QuestionTypeItemDropdown::class, [
+            'itemtype' => TaskTemplate::getType()
+        ]);
+        $builder->addQuestion("Task template 3", QuestionTypeItemDropdown::class, [
+            'itemtype' => TaskTemplate::getType()
+        ]);
+
+        $builder->addDestination(
+            FormDestinationTicket::class,
+            "My ticket"
+        );
+        return $this->createForm($builder);
+    }
+
+    private function createTaskTemplate(?string $content = null): TaskTemplate
+    {
+        return $this->createItem(TaskTemplate::class, [
+            'name' => 'ITIL Task Template',
+            'entities_id' => $this->getTestRootEntity()->getID(),
+            'content' => $content ?? 'This is a task template',
+        ]);
+    }
+}

--- a/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
+++ b/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
@@ -46,6 +46,7 @@ use Glpi\Form\Destination\CommonITILField\ITILFollowupField;
 use Glpi\Form\Destination\CommonITILField\LocationField;
 use Glpi\Form\Destination\CommonITILField\RequestSourceField;
 use Glpi\Form\Destination\CommonITILField\TemplateField;
+use Glpi\Form\Destination\CommonITILField\ITILTaskField;
 use Glpi\Form\Destination\CommonITILField\TitleField;
 use Glpi\Form\Destination\CommonITILField\UrgencyField;
 use Glpi\Form\Destination\CommonITILField\ValidationField;
@@ -188,6 +189,7 @@ abstract class AbstractCommonITILFormDestination extends AbstractFormDestination
             new ITILFollowupField(),
             new RequestSourceField(),
             new ValidationField(),
+            new ITILTaskField(),
         ];
     }
 

--- a/src/Glpi/Form/Destination/CommonITILField/ITILTaskField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILTaskField.php
@@ -105,7 +105,7 @@ class ITILTaskField extends AbstractConfigField
         }
 
         // Compute value according to strategy
-        $tasktemplates_ids = $config->getStrategy()->getTaskTemplatesIDs($config, $answers_set);
+        $tasktemplates_ids = $config->getStrategy()->getTaskTemplatesIDs($config);
 
         if (!empty($tasktemplates_ids)) {
             $input['_tasktemplates_id'] = $tasktemplates_ids;

--- a/src/Glpi/Form/Destination/CommonITILField/ITILTaskField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILTaskField.php
@@ -1,0 +1,184 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Destination\CommonITILField;
+
+use Glpi\Application\View\TemplateRenderer;
+use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\AnswersSet;
+use Glpi\Form\Destination\AbstractConfigField;
+use Glpi\Form\Form;
+use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
+use InvalidArgumentException;
+use Override;
+use Session;
+use TaskTemplate;
+
+class ITILTaskField extends AbstractConfigField
+{
+    #[Override]
+    public function getLabel(): string
+    {
+        return _n('Task', 'Tasks', Session::getPluralNumber());
+    }
+
+    #[Override]
+    public function getConfigClass(): string
+    {
+        return ITILTaskFieldConfig::class;
+    }
+
+    #[Override]
+    public function renderConfigForm(
+        Form $form,
+        JsonFieldInterface $config,
+        string $input_name,
+        array $display_options
+    ): string {
+        if (!$config instanceof ITILTaskFieldConfig) {
+            throw new InvalidArgumentException("Unexpected config class");
+        }
+
+        $twig = TemplateRenderer::getInstance();
+        return $twig->render('pages/admin/form/itil_config_fields/itiltasktemplate.html.twig', [
+            // Possible configuration constant that will be used to to hide/show additional fields
+            'CONFIG_SPECIFIC_VALUES'  => ITILTaskFieldStrategy::SPECIFIC_VALUES->value,
+            'CONFIG_SPECIFIC_ANSWERS' => ITILTaskFieldStrategy::SPECIFIC_ANSWERS->value,
+
+            // General display options
+            'options' => $display_options,
+
+            // Main config field
+            'main_config_field' => [
+                'label'           => $this->getLabel(),
+                'value'           => $config->getStrategy()->value,
+                'input_name'      => $input_name . "[" . ITILTaskFieldConfig::STRATEGY . "]",
+                'possible_values' => $this->getMainConfigurationValuesforDropdown(),
+            ],
+
+            // Specific additional config for SPECIFIC_VALUES strategy
+            'specific_value_extra_field' => [
+                'aria_label'     => __("Select task templates..."),
+                'value'           => $config->getSpecificTaskTemplatesIds() ?? [],
+                'input_name'      => $input_name . "[" . ITILTaskFieldConfig::TASKTEMPLATE_IDS . "]",
+            ],
+
+            // Specific additional config for SPECIFIC_ANSWERS strategy
+            'specific_answer_extra_field' => [
+                'aria_label'     => __("Select questions..."),
+                'values'          => $config->getSpecificQuestionIds() ?? [],
+                'input_name'      => $input_name . "[" . ITILTaskFieldConfig::QUESTION_IDS . "]",
+                'possible_values' => $this->getTaskTemplateQuestionsValuesForDropdown($form),
+            ],
+        ]);
+    }
+
+    #[Override]
+    public function applyConfiguratedValueToInputUsingAnswers(
+        JsonFieldInterface $config,
+        array $input,
+        AnswersSet $answers_set
+    ): array {
+        if (!$config instanceof ITILTaskFieldConfig) {
+            throw new InvalidArgumentException("Unexpected config class");
+        }
+
+        // Compute value according to strategy
+        $tasktemplates_ids = $config->getStrategy()->getTaskTemplatesIDs($config, $answers_set);
+
+        if (!empty($tasktemplates_ids)) {
+            $input['_tasktemplates_id'] = $tasktemplates_ids;
+        }
+
+        return $input;
+    }
+
+    #[Override]
+    public function getDefaultConfig(Form $form): ITILTaskFieldConfig
+    {
+        return new ITILTaskFieldConfig(
+            ITILTaskFieldStrategy::ALL_VALID_ANSWERS,
+        );
+    }
+
+    private function getMainConfigurationValuesforDropdown(): array
+    {
+        $values = [];
+        foreach (ITILTaskFieldStrategy::cases() as $strategies) {
+            $values[$strategies->value] = $strategies->getLabel();
+        }
+        return $values;
+    }
+
+    private function getTaskTemplateQuestionsValuesForDropdown(Form $form): array
+    {
+        $values = [];
+        $questions = $form->getQuestionsByType(QuestionTypeItemDropdown::class);
+
+        foreach ($questions as $question) {
+            if ((new QuestionTypeItemDropdown())->getDefaultValueItemtype($question) !== TaskTemplate::class) {
+                continue;
+            }
+
+            $values[$question->getId()] = $question->fields['name'];
+        }
+
+        return $values;
+    }
+
+    #[Override]
+    public function getWeight(): int
+    {
+        return 30;
+    }
+
+    #[Override]
+    public function prepareInput(array $input): array
+    {
+        $input = parent::prepareInput($input);
+
+        // Ensure that question_ids is an array
+        if (!is_array($input[$this->getKey()][ITILTaskFieldConfig::QUESTION_IDS] ?? null)) {
+            unset($input[$this->getKey()][ITILTaskFieldConfig::QUESTION_IDS]);
+        }
+
+        // Ensure that itilfollowuptemplate_ids is an array
+        if (!is_array($input[$this->getKey()][ITILTaskFieldConfig::TASKTEMPLATE_IDS] ?? null)) {
+            unset($input[$this->getKey()][ITILTaskFieldConfig::TASKTEMPLATE_IDS]);
+        }
+
+        return $input;
+    }
+}

--- a/src/Glpi/Form/Destination/CommonITILField/ITILTaskFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILTaskFieldConfig.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Destination\CommonITILField;
+
+use Glpi\DBAL\JsonFieldInterface;
+use Override;
+
+final class ITILTaskFieldConfig implements JsonFieldInterface
+{
+    // Unique reference to hardcoded names used for serialization and forms input names
+    public const STRATEGY = 'strategy';
+    public const QUESTION_IDS = 'question_ids';
+    public const TASKTEMPLATE_IDS = 'tasktemplate_ids';
+
+    public function __construct(
+        private ITILTaskFieldStrategy $strategy,
+        private ?array $specific_question_ids = null,
+        private ?array $specific_itiltasktemplates_ids = null,
+    ) {
+    }
+
+    #[Override]
+    public static function jsonDeserialize(array $data): self
+    {
+        $strategy = ITILTaskFieldStrategy::tryFrom($data[self::STRATEGY] ?? "");
+        if ($strategy === null) {
+            $strategy = ITILTaskFieldStrategy::LAST_VALID_ANSWER;
+        }
+
+        return new self(
+            strategy: $strategy,
+            specific_question_ids: $data[self::QUESTION_IDS] ?? [],
+            specific_itiltasktemplates_ids: $data[self::TASKTEMPLATE_IDS] ?? [],
+        );
+    }
+
+    #[Override]
+    public function jsonSerialize(): array
+    {
+        return [
+            self::STRATEGY => $this->strategy->value,
+            self::QUESTION_IDS => $this->specific_question_ids,
+            self::TASKTEMPLATE_IDS => $this->specific_itiltasktemplates_ids,
+        ];
+    }
+
+    public function getStrategy(): ITILTaskFieldStrategy
+    {
+        return $this->strategy;
+    }
+
+    public function getSpecificQuestionIds(): ?array
+    {
+        return $this->specific_question_ids;
+    }
+
+    public function getSpecificTaskTemplatesIds(): ?array
+    {
+
+        return $this->specific_itiltasktemplates_ids;
+    }
+}

--- a/src/Glpi/Form/Destination/CommonITILField/ITILTaskFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILTaskFieldConfig.php
@@ -42,12 +42,10 @@ final class ITILTaskFieldConfig implements JsonFieldInterface
 {
     // Unique reference to hardcoded names used for serialization and forms input names
     public const STRATEGY = 'strategy';
-    public const QUESTION_IDS = 'question_ids';
     public const TASKTEMPLATE_IDS = 'tasktemplate_ids';
 
     public function __construct(
         private ITILTaskFieldStrategy $strategy,
-        private ?array $specific_question_ids = null,
         private ?array $specific_itiltasktemplates_ids = null,
     ) {
     }
@@ -57,12 +55,11 @@ final class ITILTaskFieldConfig implements JsonFieldInterface
     {
         $strategy = ITILTaskFieldStrategy::tryFrom($data[self::STRATEGY] ?? "");
         if ($strategy === null) {
-            $strategy = ITILTaskFieldStrategy::LAST_VALID_ANSWER;
+            $strategy = ITILTaskFieldStrategy::NO_TASK;
         }
 
         return new self(
             strategy: $strategy,
-            specific_question_ids: $data[self::QUESTION_IDS] ?? [],
             specific_itiltasktemplates_ids: $data[self::TASKTEMPLATE_IDS] ?? [],
         );
     }
@@ -72,7 +69,6 @@ final class ITILTaskFieldConfig implements JsonFieldInterface
     {
         return [
             self::STRATEGY => $this->strategy->value,
-            self::QUESTION_IDS => $this->specific_question_ids,
             self::TASKTEMPLATE_IDS => $this->specific_itiltasktemplates_ids,
         ];
     }
@@ -82,14 +78,8 @@ final class ITILTaskFieldConfig implements JsonFieldInterface
         return $this->strategy;
     }
 
-    public function getSpecificQuestionIds(): ?array
-    {
-        return $this->specific_question_ids;
-    }
-
     public function getSpecificTaskTemplatesIds(): ?array
     {
-
         return $this->specific_itiltasktemplates_ids;
     }
 }

--- a/src/Glpi/Form/Destination/CommonITILField/ITILTaskFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILTaskFieldStrategy.php
@@ -35,134 +35,25 @@
 
 namespace Glpi\Form\Destination\CommonITILField;
 
-use Glpi\Form\AnswersSet;
-use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
-use TaskTemplate;
-
 enum ITILTaskFieldStrategy: string
 {
     case NO_TASK           = 'no_task';
     case SPECIFIC_VALUES   = 'specific_values';
-    case SPECIFIC_ANSWERS  = 'specific_answers';
-    case LAST_VALID_ANSWER = 'last_valid_answer';
-    case ALL_VALID_ANSWERS = 'all_valid_answers';
 
     public function getLabel(): string
     {
         return match ($this) {
             self::NO_TASK           => __("No Task"),
             self::SPECIFIC_VALUES   => __("Specific Task templates"),
-            self::SPECIFIC_ANSWERS  => __("Answer from specific questions"),
-            self::LAST_VALID_ANSWER => __('Answer to last "Task templates" question'),
-            self::ALL_VALID_ANSWERS => __('All answers to "Task templates" questions'),
         };
     }
 
     public function getTaskTemplatesIDs(
-        ITILTaskFieldConfig $config,
-        AnswersSet $answers_set,
+        ITILTaskFieldConfig $config
     ): ?array {
         return match ($this) {
             self::NO_TASK          => null,
             self::SPECIFIC_VALUES  => $config->getSpecificTaskTemplatesIds(),
-            self::SPECIFIC_ANSWERS => $this->getTaskTemplatesForSpecificAnswers(
-                $config->getSpecificQuestionIds(),
-                $answers_set
-            ),
-            self::LAST_VALID_ANSWER => $this->getTaskTemplatesForLastValidAnswer($answers_set),
-            self::ALL_VALID_ANSWERS => $this->getTaskTemplatesForAllValidAnswers($answers_set),
         };
-    }
-
-    private function isValidAnswer(array $value): bool
-    {
-        if (
-            !isset($value['itemtype']) || !is_string($value['itemtype'])
-            || !isset($value['items_id']) || !is_numeric($value['items_id'])
-        ) {
-            return false;
-        }
-
-        if ($value['itemtype'] !== TaskTemplate::class) {
-            return true;
-        }
-
-        if (!(new TaskTemplate())->getFromDB($value['items_id'])) {
-            return false;
-        }
-
-        return true;
-    }
-
-    private function getTaskTemplatesForSpecificAnswers(
-        ?array $question_ids,
-        AnswersSet $answers_set,
-    ): ?array {
-        if (empty($question_ids)) {
-            return null;
-        }
-
-        $itilfollowuptemplates_ids = array_map(
-            fn($question_id) => $this->getTaskTemplatesForSpecificAnswer(
-                $question_id,
-                $answers_set
-            ),
-            $question_ids
-        );
-
-        return array_filter($itilfollowuptemplates_ids);
-    }
-
-    private function getTaskTemplatesForSpecificAnswer(
-        ?int $question_id,
-        AnswersSet $answers_set,
-    ) {
-        if ($question_id === null) {
-            return null;
-        }
-
-        $answer = $answers_set->getAnswerByQuestionId($question_id);
-        if ($answer === null) {
-            return null;
-        }
-
-        $value = $answer->getRawAnswer();
-        if (!$this->isValidAnswer($value)) {
-            return null;
-        }
-
-        return $value['items_id'];
-    }
-
-    private function getTaskTemplatesForLastValidAnswer(
-        AnswersSet $answers_set,
-    ): ?array {
-        $valid_answers = $this->getTaskTemplatesForAllValidAnswers($answers_set);
-
-        if (empty($valid_answers)) {
-            return null;
-        }
-
-        return [end($valid_answers)];
-    }
-
-    private function getTaskTemplatesForAllValidAnswers(
-        AnswersSet $answers_set,
-    ): ?array {
-        $valid_answers = array_filter(
-            $answers_set->getAnswersByType(
-                QuestionTypeItemDropdown::class
-            ),
-            fn($answer) => $this->isValidAnswer($answer->getRawAnswer())
-        );
-
-        if (empty($valid_answers)) {
-            return null;
-        }
-
-        return array_map(
-            fn($answer) => $answer->getRawAnswer()['items_id'],
-            $valid_answers
-        );
     }
 }

--- a/src/Glpi/Form/Destination/CommonITILField/ITILTaskFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILTaskFieldStrategy.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Destination\CommonITILField;
+
+use Glpi\Form\AnswersSet;
+use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
+use TaskTemplate;
+
+enum ITILTaskFieldStrategy: string
+{
+    case NO_TASK           = 'no_task';
+    case SPECIFIC_VALUES   = 'specific_values';
+    case SPECIFIC_ANSWERS  = 'specific_answers';
+    case LAST_VALID_ANSWER = 'last_valid_answer';
+    case ALL_VALID_ANSWERS = 'all_valid_answers';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::NO_TASK           => __("No Task"),
+            self::SPECIFIC_VALUES   => __("Specific Task templates"),
+            self::SPECIFIC_ANSWERS  => __("Answer from specific questions"),
+            self::LAST_VALID_ANSWER => __('Answer to last "Task templates" question'),
+            self::ALL_VALID_ANSWERS => __('All answers to "Task templates" questions'),
+        };
+    }
+
+    public function getTaskTemplatesIDs(
+        ITILTaskFieldConfig $config,
+        AnswersSet $answers_set,
+    ): ?array {
+        return match ($this) {
+            self::NO_TASK          => null,
+            self::SPECIFIC_VALUES  => $config->getSpecificTaskTemplatesIds(),
+            self::SPECIFIC_ANSWERS => $this->getTaskTemplatesForSpecificAnswers(
+                $config->getSpecificQuestionIds(),
+                $answers_set
+            ),
+            self::LAST_VALID_ANSWER => $this->getTaskTemplatesForLastValidAnswer($answers_set),
+            self::ALL_VALID_ANSWERS => $this->getTaskTemplatesForAllValidAnswers($answers_set),
+        };
+    }
+
+    private function isValidAnswer(array $value): bool
+    {
+        if (
+            !isset($value['itemtype']) || !is_string($value['itemtype'])
+            || !isset($value['items_id']) || !is_numeric($value['items_id'])
+        ) {
+            return false;
+        }
+
+        if ($value['itemtype'] !== TaskTemplate::class) {
+            return true;
+        }
+
+        if (!(new TaskTemplate())->getFromDB($value['items_id'])) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function getTaskTemplatesForSpecificAnswers(
+        ?array $question_ids,
+        AnswersSet $answers_set,
+    ): ?array {
+        if (empty($question_ids)) {
+            return null;
+        }
+
+        $itilfollowuptemplates_ids = array_map(
+            fn($question_id) => $this->getTaskTemplatesForSpecificAnswer(
+                $question_id,
+                $answers_set
+            ),
+            $question_ids
+        );
+
+        return array_filter($itilfollowuptemplates_ids);
+    }
+
+    private function getTaskTemplatesForSpecificAnswer(
+        ?int $question_id,
+        AnswersSet $answers_set,
+    ) {
+        if ($question_id === null) {
+            return null;
+        }
+
+        $answer = $answers_set->getAnswerByQuestionId($question_id);
+        if ($answer === null) {
+            return null;
+        }
+
+        $value = $answer->getRawAnswer();
+        if (!$this->isValidAnswer($value)) {
+            return null;
+        }
+
+        return $value['items_id'];
+    }
+
+    private function getTaskTemplatesForLastValidAnswer(
+        AnswersSet $answers_set,
+    ): ?array {
+        $valid_answers = $this->getTaskTemplatesForAllValidAnswers($answers_set);
+
+        if (empty($valid_answers)) {
+            return null;
+        }
+
+        return [end($valid_answers)];
+    }
+
+    private function getTaskTemplatesForAllValidAnswers(
+        AnswersSet $answers_set,
+    ): ?array {
+        $valid_answers = array_filter(
+            $answers_set->getAnswersByType(
+                QuestionTypeItemDropdown::class
+            ),
+            fn($answer) => $this->isValidAnswer($answer->getRawAnswer())
+        );
+
+        if (empty($valid_answers)) {
+            return null;
+        }
+
+        return array_map(
+            fn($answer) => $answer->getRawAnswer()['items_id'],
+            $valid_answers
+        );
+    }
+}

--- a/templates/pages/admin/form/itil_config_fields/itiltasktemplate.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/itiltasktemplate.html.twig
@@ -1,0 +1,83 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
+{{ fields.dropdownArrayField(
+    main_config_field.input_name,
+    main_config_field.value,
+    main_config_field.possible_values,
+    main_config_field.label,
+    options
+) }}
+
+<div
+    {% if main_config_field.value != CONFIG_SPECIFIC_VALUES %}
+        class="d-none"
+    {% endif %}
+    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
+    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_VALUES }}"
+>
+    {{ fields.dropdownField(
+        'TaskTemplate',
+        specific_value_extra_field.input_name,
+        specific_value_extra_field.value,
+        "",
+        options|merge({
+            multiple: true,
+            no_label: true,
+            aria_label: specific_value_extra_field.aria_label,
+        })
+    ) }}
+</div>
+
+<div
+    {% if main_config_field.value != CONFIG_SPECIFIC_ANSWERS %}
+        class="d-none"
+    {% endif %}
+    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
+    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_ANSWERS }}"
+>
+    {{ fields.dropdownArrayField(
+        specific_answer_extra_field.input_name,
+        "",
+        specific_answer_extra_field.possible_values,
+        "",
+        options|merge({
+            multiple: true,
+            no_label: true,
+            values: specific_answer_extra_field.values,
+            aria_label: specific_answer_extra_field.aria_label,
+        })
+    ) }}
+</div>

--- a/templates/pages/admin/form/itil_config_fields/itiltasktemplate.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/itiltasktemplate.html.twig
@@ -60,24 +60,3 @@
         })
     ) }}
 </div>
-
-<div
-    {% if main_config_field.value != CONFIG_SPECIFIC_ANSWERS %}
-        class="d-none"
-    {% endif %}
-    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
-    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_ANSWERS }}"
->
-    {{ fields.dropdownArrayField(
-        specific_answer_extra_field.input_name,
-        "",
-        specific_answer_extra_field.possible_values,
-        "",
-        options|merge({
-            multiple: true,
-            no_label: true,
-            values: specific_answer_extra_field.values,
-            aria_label: specific_answer_extra_field.aria_label,
-        })
-    ) }}
-</div>

--- a/tests/cypress/e2e/form/destination_config_fields/itiltask.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/itiltask.cy.js
@@ -36,14 +36,10 @@ describe('ITILTask configuration', () => {
         cy.login();
         cy.changeProfile('Super-Admin', true);
 
-        // Create form with a single "Task template" dropdown question
+        // Create form
         cy.createFormWithAPI().as('form_id').visitFormTab('Form');
         cy.findByRole('button', {'name': "Add a new question"}).click();
-        cy.focused().type("My Task template question");
-        cy.getDropdownByLabelText('Question type').selectDropdownValue('Item');
-        cy.getDropdownByLabelText('Question sub type').selectDropdownValue('Dropdowns');
-
-        cy.getDropdownByLabelText('Select a dropdown type').selectDropdownValue('Task templates');
+        cy.focused().type("My question");
 
         cy.findByRole('button', {'name': 'Save'}).click();
         cy.findByRole('alert').should('contain.text', 'Item successfully updated');
@@ -68,18 +64,11 @@ describe('ITILTask configuration', () => {
         // Default value
         cy.get('@itiltask_dropdown').should(
             'have.text',
-            'All answers to "Task templates" questions'
+            'No Task'
         );
 
         // Make sure hidden dropdowns are not displayed
         cy.get('@config').getDropdownByLabelText('Select task templates...').should('not.exist');
-        cy.get('@config').getDropdownByLabelText('Select questions...').should('not.exist');
-
-        // Switch to "No Task"
-        cy.get('@itiltask_dropdown').selectDropdownValue('No Task');
-        cy.findByRole('button', {'name': 'Update item'}).click();
-        cy.checkAndCloseAlert('Item successfully updated');
-        cy.get('@itiltask_dropdown').should('have.text', 'No Task');
 
         // Switch to "Specific Task templates"
         cy.get('@form_id').then((form_id) => {
@@ -93,30 +82,27 @@ describe('ITILTask configuration', () => {
             cy.get('@specific_itiltask_dropdown').should('have.text', '×Task template 1 - ' + form_id);
         });
 
-        // Switch to "Answer from specific questions"
-        cy.get('@itiltask_dropdown').selectDropdownValue('Answer from specific questions');
-        cy.get('@config').getDropdownByLabelText('Select questions...').as('specific_answers_dropdown');
-        cy.get('@specific_answers_dropdown').selectDropdownValue('My Task template question');
-
+        // Switch to "No Task"
+        cy.get('@itiltask_dropdown').selectDropdownValue('No Task');
         cy.findByRole('button', {'name': 'Update item'}).click();
         cy.checkAndCloseAlert('Item successfully updated');
-        cy.get('@itiltask_dropdown').should('have.text', 'Answer from specific questions');
-        cy.get('@specific_answers_dropdown').should('have.text', '×My Task template question');
-
-        // Switch to "Answer to last "Task templates" question"
-        cy.get('@itiltask_dropdown').selectDropdownValue('Answer to last "Task templates" question');
-        cy.findByRole('button', {'name': 'Update item'}).click();
-        cy.checkAndCloseAlert('Item successfully updated');
-        cy.get('@itiltask_dropdown').should('have.text', 'Answer to last "Task templates" question');
-
-        // Switch to "All answers to "Task templates" questions"
-        cy.get('@itiltask_dropdown').selectDropdownValue('All answers to "Task templates" questions');
-        cy.findByRole('button', {'name': 'Update item'}).click();
-        cy.checkAndCloseAlert('Item successfully updated');
-        cy.get('@itiltask_dropdown').should('have.text', 'All answers to "Task templates" questions');
+        cy.get('@itiltask_dropdown').should('have.text', 'No Task');
     });
 
-    it('can create ticket using default configuration', () => {
+    it.only('can create ticket using specific task template', () => {
+        cy.findByRole('region', {'name': "Tasks configuration"}).as("config");
+        cy.get('@config').getDropdownByLabelText('Tasks').as("itiltask_dropdown");
+
+        // Switch to "Specific Task templates"
+        cy.get('@form_id').then((form_id) => {
+            cy.get('@itiltask_dropdown').selectDropdownValue('Specific Task templates');
+            cy.get('@config').getDropdownByLabelText('Select task templates...').as('specific_itiltask_dropdown');
+            cy.get('@specific_itiltask_dropdown').selectDropdownValue('Task template 1 - ' + form_id);
+
+            cy.findByRole('button', {'name': 'Update item'}).click();
+            cy.checkAndCloseAlert('Item successfully updated');
+        });
+
         // Go to preview
         cy.findByRole('tab', {'name': "Form"}).click();
         cy.findByRole('link', {'name': "Preview"})
@@ -125,10 +111,6 @@ describe('ITILTask configuration', () => {
         ;
 
         // Fill form
-        cy.getDropdownByLabelText("My Task template question").as('itiltask_dropdown');
-        cy.get('@form_id').then((form_id) => {
-            cy.get('@itiltask_dropdown').selectDropdownValue('Task template 1 - ' + form_id);
-        });
         cy.findByRole('button', {'name': 'Send form'}).click();
         cy.findByRole('link', {'name': 'My test form'}).click();
 

--- a/tests/cypress/e2e/form/destination_config_fields/itiltask.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/itiltask.cy.js
@@ -89,7 +89,7 @@ describe('ITILTask configuration', () => {
         cy.get('@itiltask_dropdown').should('have.text', 'No Task');
     });
 
-    it.only('can create ticket using specific task template', () => {
+    it('can create ticket using specific task template', () => {
         cy.findByRole('region', {'name': "Tasks configuration"}).as("config");
         cy.get('@config').getDropdownByLabelText('Tasks').as("itiltask_dropdown");
 

--- a/tests/cypress/e2e/form/destination_config_fields/itiltask.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/itiltask.cy.js
@@ -1,0 +1,140 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+describe('ITILTask configuration', () => {
+    beforeEach(() => {
+        cy.login();
+        cy.changeProfile('Super-Admin', true);
+
+        // Create form with a single "Task template" dropdown question
+        cy.createFormWithAPI().as('form_id').visitFormTab('Form');
+        cy.findByRole('button', {'name': "Add a new question"}).click();
+        cy.focused().type("My Task template question");
+        cy.getDropdownByLabelText('Question type').selectDropdownValue('Item');
+        cy.getDropdownByLabelText('Question sub type').selectDropdownValue('Dropdowns');
+
+        cy.getDropdownByLabelText('Select a dropdown type').selectDropdownValue('Task templates');
+
+        cy.findByRole('button', {'name': 'Save'}).click();
+        cy.findByRole('alert').should('contain.text', 'Item successfully updated');
+
+        // Go to destination tab
+        cy.findByRole('tab', {'name': "Items to create"}).click();
+        cy.findByRole('button', {'name': "Add ticket"}).click();
+        cy.checkAndCloseAlert('Item successfully added');
+
+        cy.get('@form_id').then((form_id) => {
+            cy.createWithAPI('TaskTemplate', {
+                'name': 'Task template 1 - ' + form_id,
+                'content': 'My Task template content',
+            });
+        });
+    });
+
+    it('can use all possibles configuration options', () => {
+        cy.findByRole('region', {'name': "Tasks configuration"}).as("config");
+        cy.get('@config').getDropdownByLabelText('Tasks').as("itiltask_dropdown");
+
+        // Default value
+        cy.get('@itiltask_dropdown').should(
+            'have.text',
+            'All answers to "Task templates" questions'
+        );
+
+        // Make sure hidden dropdowns are not displayed
+        cy.get('@config').getDropdownByLabelText('Select task templates...').should('not.exist');
+        cy.get('@config').getDropdownByLabelText('Select questions...').should('not.exist');
+
+        // Switch to "No Task"
+        cy.get('@itiltask_dropdown').selectDropdownValue('No Task');
+        cy.findByRole('button', {'name': 'Update item'}).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@itiltask_dropdown').should('have.text', 'No Task');
+
+        // Switch to "Specific Task templates"
+        cy.get('@form_id').then((form_id) => {
+            cy.get('@itiltask_dropdown').selectDropdownValue('Specific Task templates');
+            cy.get('@config').getDropdownByLabelText('Select task templates...').as('specific_itiltask_dropdown');
+            cy.get('@specific_itiltask_dropdown').selectDropdownValue('Task template 1 - ' + form_id);
+
+            cy.findByRole('button', {'name': 'Update item'}).click();
+            cy.checkAndCloseAlert('Item successfully updated');
+            cy.get('@itiltask_dropdown').should('have.text', 'Specific Task templates');
+            cy.get('@specific_itiltask_dropdown').should('have.text', '×Task template 1 - ' + form_id);
+        });
+
+        // Switch to "Answer from specific questions"
+        cy.get('@itiltask_dropdown').selectDropdownValue('Answer from specific questions');
+        cy.get('@config').getDropdownByLabelText('Select questions...').as('specific_answers_dropdown');
+        cy.get('@specific_answers_dropdown').selectDropdownValue('My Task template question');
+
+        cy.findByRole('button', {'name': 'Update item'}).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@itiltask_dropdown').should('have.text', 'Answer from specific questions');
+        cy.get('@specific_answers_dropdown').should('have.text', '×My Task template question');
+
+        // Switch to "Answer to last "Task templates" question"
+        cy.get('@itiltask_dropdown').selectDropdownValue('Answer to last "Task templates" question');
+        cy.findByRole('button', {'name': 'Update item'}).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@itiltask_dropdown').should('have.text', 'Answer to last "Task templates" question');
+
+        // Switch to "All answers to "Task templates" questions"
+        cy.get('@itiltask_dropdown').selectDropdownValue('All answers to "Task templates" questions');
+        cy.findByRole('button', {'name': 'Update item'}).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@itiltask_dropdown').should('have.text', 'All answers to "Task templates" questions');
+    });
+
+    it('can create ticket using default configuration', () => {
+        // Go to preview
+        cy.findByRole('tab', {'name': "Form"}).click();
+        cy.findByRole('link', {'name': "Preview"})
+            .invoke('removeAttr', 'target') // Cypress can't handle tab changes
+            .click()
+        ;
+
+        // Fill form
+        cy.getDropdownByLabelText("My Task template question").as('itiltask_dropdown');
+        cy.get('@form_id').then((form_id) => {
+            cy.get('@itiltask_dropdown').selectDropdownValue('Task template 1 - ' + form_id);
+        });
+        cy.findByRole('button', {'name': 'Send form'}).click();
+        cy.findByRole('link', {'name': 'My test form'}).click();
+
+        // Check if followup template content is displayed
+        cy.contains('My Task template content');
+
+        // Others possibles configurations are tested directly by the backend.
+    });
+});


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

Adds the ability to define tasks that will be added to ITIL form destination objects.
Possible configurations :
- No Task
- Specific Task templates
- Answer from specific questions
- Answer to last "Task templates" question
- All answers to "Task templates" questions

## Screenshots

![image](https://github.com/user-attachments/assets/0d4ff868-b344-4c8a-869d-5c4db6b19297)
![image](https://github.com/user-attachments/assets/7f9bac05-e65b-4e12-bace-d1e14d7da5d6)
![image](https://github.com/user-attachments/assets/7cf23c6d-4b38-4422-ac24-aae07aae85a6)
