### PR TITLE
Fix(SlaLevel): prevent 'clone' action

### DIFF
--- a/src/LevelAgreementLevel.php
+++ b/src/LevelAgreementLevel.php
@@ -203,9 +203,6 @@ abstract class LevelAgreementLevel extends RuleTicket
         return parent::getSpecificValueToSelect($field, $name, $values, $options);
     }
 
-
-
-
     public function getActions()
     {
 

--- a/src/SlaLevel.php
+++ b/src/SlaLevel.php
@@ -68,6 +68,14 @@ class SlaLevel extends LevelAgreementLevel
     }
 
 
+    public function getForbiddenStandardMassiveAction()
+    {
+        $forbidden   = parent::getForbiddenStandardMassiveAction();
+        $forbidden[] = 'clone';
+        return $forbidden;
+    }
+
+
     /**
      * @param $sla SLA object
      *


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !34326

Prevents cloning a `SlaLevel`.

In an `SLA`, it's not possible to have more than one `SlaLevel` with the same `execution_time`.

https://github.com/glpi-project/glpi/blob/5cd323a0b48d056feca915a64df1149ecd750d16/src/SlaLevel.php#L106-L113

The `clone` action overrides this constraint


## Screenshots (if appropriate):


