### PR TITLE
Fix: reload session entities in case of modification

### DIFF
--- a/inc/includes.php
+++ b/inc/includes.php
@@ -181,19 +181,9 @@ if (isset($_REQUEST["force_profile"]) && ($_SESSION['glpiactiveprofile']['id'] ?
 // Manage entity change
 if (isset($_REQUEST["force_entity"]) && ($_SESSION["glpiactive_entity"] ?? -1) != $_REQUEST["force_entity"]) {
     Session::changeActiveEntities($_REQUEST["force_entity"], true);
-} else {
-    $glpiactiveentities = $_SESSION['glpiactiveentities'] ?? [];
-    if (count($glpiactiveentities) > 1) {
-        $entities = getSonsOf("glpi_entities", $_SESSION["glpiactive_entity"]);
-        if (
-            count($entities) !== count($glpiactiveentities)
-            || array_diff($entities, $glpiactiveentities) !== []
-            || array_diff($glpiactiveentities, $entities) !== []
-        ) {
-            Session::changeActiveEntities(
-                $_SESSION["glpiactive_entity"],
-                $_SESSION["glpiactive_entity_recursive"]
-            );
-        }
-    }
+} elseif (Session::shouldReloadActiveEntities()) {
+    Session::changeActiveEntities(
+        $_SESSION["glpiactive_entity"],
+        $_SESSION["glpiactive_entity_recursive"]
+    );
 }

--- a/inc/includes.php
+++ b/inc/includes.php
@@ -181,4 +181,17 @@ if (isset($_REQUEST["force_profile"]) && ($_SESSION['glpiactiveprofile']['id'] ?
 // Manage entity change
 if (isset($_REQUEST["force_entity"]) && ($_SESSION["glpiactive_entity"] ?? -1) != $_REQUEST["force_entity"]) {
     Session::changeActiveEntities($_REQUEST["force_entity"], true);
+} else {
+    $glpiactiveentities = $_SESSION['glpiactiveentities'] ?? [];
+    if (count($glpiactiveentities) > 1) {
+        $entities = getSonsOf("glpi_entities", $_SESSION["glpiactive_entity"]);
+        sort($entities);
+        sort($glpiactiveentities);
+        if ($entities != $glpiactiveentities) {
+            Session::changeActiveEntities(
+                $_SESSION["glpiactive_entity"],
+                $_SESSION["glpiactive_entity_recursive"]
+            );
+        }
+    }
 }

--- a/inc/includes.php
+++ b/inc/includes.php
@@ -185,9 +185,11 @@ if (isset($_REQUEST["force_entity"]) && ($_SESSION["glpiactive_entity"] ?? -1) !
     $glpiactiveentities = $_SESSION['glpiactiveentities'] ?? [];
     if (count($glpiactiveentities) > 1) {
         $entities = getSonsOf("glpi_entities", $_SESSION["glpiactive_entity"]);
-        sort($entities);
-        sort($glpiactiveentities);
-        if ($entities != $glpiactiveentities) {
+        if (
+            count($entities) !== count($glpiactiveentities)
+            || array_diff($entities, $glpiactiveentities) !== []
+            || array_diff($glpiactiveentities, $entities) !== []
+        ) {
             Session::changeActiveEntities(
                 $_SESSION["glpiactive_entity"],
                 $_SESSION["glpiactive_entity_recursive"]

--- a/src/Session.php
+++ b/src/Session.php
@@ -385,6 +385,9 @@ class Session
      */
     public static function shouldReloadActiveEntities(): bool
     {
+        if (!array_key_exists('glpiactive_entity')) {
+            return false;
+        }
         $glpiactiveentities = $_SESSION['glpiactiveentities'] ?? [];
         if (count($glpiactiveentities)) {
             $glpiactive_entity = $_SESSION['glpiactive_entity'] ?? '';

--- a/src/Session.php
+++ b/src/Session.php
@@ -385,12 +385,12 @@ class Session
      */
     public static function shouldReloadActiveEntities(): bool
     {
-        if (!array_key_exists('glpiactive_entity')) {
+        if (!array_key_exists('glpiactive_entity', $_SESSION)) {
             return false;
         }
         $glpiactiveentities = $_SESSION['glpiactiveentities'] ?? [];
         if (count($glpiactiveentities)) {
-            $glpiactive_entity = $_SESSION['glpiactive_entity'] ?? '';
+            $glpiactive_entity = $_SESSION['glpiactive_entity'];
             $glpiactive_entity_recursive = $_SESSION['glpiactive_entity_recursive'] ?? false;
             $entities = [$glpiactive_entity];
             if ($glpiactive_entity_recursive) {

--- a/src/Session.php
+++ b/src/Session.php
@@ -379,6 +379,30 @@ class Session
 
 
     /**
+     * Check if active entities should be reloaded.
+     *
+     * @return bool true if active entities should be reloaded, false otherwise
+     */
+    public static function shouldReloadActiveEntities(): bool
+    {
+        $glpiactiveentities = $_SESSION['glpiactiveentities'] ?? [];
+        if (count($glpiactiveentities)) {
+            $glpiactive_entity = $_SESSION['glpiactive_entity'] ?? '';
+            $glpiactive_entity_recursive = $_SESSION['glpiactive_entity_recursive'] ?? false;
+            $entities = [$glpiactive_entity];
+            if ($glpiactive_entity_recursive) {
+                $entities = getSonsOf("glpi_entities", $glpiactive_entity);
+            }
+
+            return count($entities) !== count($glpiactiveentities)
+                || array_diff($entities, $glpiactiveentities) !== []
+                || array_diff($glpiactiveentities, $entities) !== [];
+        }
+        return false;
+    }
+
+
+    /**
      * Change active entity to the $ID one. Update glpiactiveentities session variable.
      * Reload groups related to this entity.
      *
@@ -415,6 +439,7 @@ class Session
                         }
                     }
                 }
+                $is_recursive = true;
             } else {
                 $ID = (int)$ID;
 

--- a/tests/functional/Session.php
+++ b/tests/functional/Session.php
@@ -797,4 +797,60 @@ class Session extends \DbTestCase
          ->withMessage('Unexpected value `null` found in `$_SESSION[\'glpiactiveentities\']`.')
          ->exists();
     }
+
+    public function testShouldReloadActiveEntities(): void
+    {
+        $this->login('glpi', 'glpi');
+
+        $ent0 = getItemByTypeName('Entity', '_test_root_entity', true);
+        $ent1 = getItemByTypeName('Entity', '_test_child_1', true);
+        $ent2 = getItemByTypeName('Entity', '_test_child_2', true);
+
+        // Create a new entity
+        $entity_id = $this->createItem(\Entity::class, [
+            'name'        => __METHOD__,
+            'entities_id' => $ent1
+        ])->getID();
+
+        $this->boolean(\Session::changeActiveEntities($ent1, true))->isTrue();
+
+        // The entity goes out of scope -> reloaded TRUE
+        $this->updateItem(\Entity::class, $entity_id, [
+            'entities_id' => $ent0
+        ]);
+        $this->boolean(\Session::shouldReloadActiveEntities())->isTrue();
+
+        $this->boolean(\Session::changeActiveEntities($ent2, true))->isTrue();
+
+        // The entity enters the scope -> reloaded TRUE
+        $this->updateItem(\Entity::class, $entity_id, [
+            'entities_id' => $ent2
+        ]);
+        $this->boolean(\Session::shouldReloadActiveEntities())->isTrue();
+
+        $this->boolean(\Session::changeActiveEntities($ent1, true))->isTrue();
+
+        // The entity remains out of scope -> reloaded FALSE
+        $this->updateItem(\Entity::class, $entity_id, [
+            'entities_id' => $ent0
+        ]);
+        $this->boolean(\Session::shouldReloadActiveEntities())->isFalse();
+
+        $this->boolean(\Session::changeActiveEntities($ent1, false))->isTrue();
+
+        // The entity remains out of scope -> reloaded FALSE
+        $this->updateItem(\Entity::class, $entity_id, [
+            'entities_id' => $ent1
+        ]);
+        $this->boolean(\Session::shouldReloadActiveEntities())->isFalse();
+
+        // See all entities -> reloaded FALSE
+        $this->boolean(\Session::changeActiveEntities('all'))->isTrue();
+
+        $this->updateItem(\Entity::class, $entity_id, [
+            'entities_id' => $ent2
+        ]);
+
+        $this->boolean(\Session::shouldReloadActiveEntities())->isFalse();
+    }
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !34304 + !34305
When an entity changes its parent, the elements associated with that entity remain visible and accessible in ongoing sessions, even if the new hierarchy no longer grants the user access to the moved entity.

## Screenshots (if appropriate):


