### PR TITLE
Fix - RGB format for dashboard widget colours

### DIFF
--- a/phpunit/functional/ToolboxTest.php
+++ b/phpunit/functional/ToolboxTest.php
@@ -1039,6 +1039,30 @@ HTML;
                 'bg_color' => "#000000",
                 'offset'   => 50,
                 'fg_color' => '#808080',
+            ], [
+                'bg_color' => "rgba(255, 255, 255, 1)",
+                'offset'   => 40,
+                'fg_color' => '#999999',
+            ], [
+                'bg_color' => "rgba(255, 255, 255, 1)",
+                'offset'   => 50,
+                'fg_color' => '#808080',
+            ], [
+                'bg_color' => "rgba(0, 0, 0, 1)",
+                'offset'   => 40,
+                'fg_color' => '#666666',
+            ], [
+                'bg_color' => "rgba(0, 0, 0, 1)",
+                'offset'   => 50,
+                'fg_color' => '#808080',
+            ], [
+                'bg_color' => "rgba(0, 0, 0, 0.5)",
+                'offset'   => 40,
+                'fg_color' => '#666666',
+            ], [
+                'bg_color' => "rgba(0, 0, 0, 0.5)",
+                'offset'   => 50,
+                'fg_color' => '#808080',
             ],
         ];
     }

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -3445,7 +3445,8 @@ HTML;
                     "G" => intval($matches[2]),
                     "B" => intval($matches[3])
                 ];
-                $color = Color::rgbToHex($rgb_color);
+                $alpha = str_pad(dechex((int)round($matches[4] * 255)), 2, '0', STR_PAD_LEFT);
+                $color = Color::rgbToHex($rgb_color) . $alpha;
             }
 
             $color = str_replace("#", "", $color);

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -3439,6 +3439,18 @@ HTML;
     {
         $fg_color = "FFFFFF";
         if ($color !== "") {
+            if (strpos($color, 'rgba') !== false || strpos($color, 'rgb') !== false) {
+                $rgb_color = [];
+                if (preg_match('/rgba?\((\d+),\s*(\d+),\s*(\d+),?\s*([\d\.]+)?\)/', $color, $matches)) {
+                    $rgb_color = [
+                        "R" => intval($matches[1]),
+                        "G" => intval($matches[2]),
+                        "B" => intval($matches[3])
+                    ];
+                }
+                $color = Color::rgbToHex($rgb_color);
+            }
+
             $color = str_replace("#", "", $color);
 
            // if transparency present, get only the color part

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -3445,7 +3445,7 @@ HTML;
                     "G" => intval($matches[2]),
                     "B" => intval($matches[3])
                 ];
-                $alpha = str_pad(dechex((int)round($matches[4] * 255)), 2, '0', STR_PAD_LEFT);
+                $alpha = isset($matches[4]) ? str_pad(dechex((int)round(floatval($matches[4]) * 255)), 2, '0', STR_PAD_LEFT) : '';
                 $color = Color::rgbToHex($rgb_color) . $alpha;
             }
 

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -3439,15 +3439,12 @@ HTML;
     {
         $fg_color = "FFFFFF";
         if ($color !== "") {
-            if (strpos($color, 'rgba') !== false || strpos($color, 'rgb') !== false) {
-                $rgb_color = [];
-                if (preg_match('/rgba?\((\d+),\s*(\d+),\s*(\d+),?\s*([\d\.]+)?\)/', $color, $matches)) {
-                    $rgb_color = [
-                        "R" => intval($matches[1]),
-                        "G" => intval($matches[2]),
-                        "B" => intval($matches[3])
-                    ];
-                }
+            if (preg_match('/rgba?\((\d+),\s*(\d+),\s*(\d+),?\s*([\d\.]+)?\)/', $color, $matches)) {
+                $rgb_color = [
+                    "R" => intval($matches[1]),
+                    "G" => intval($matches[2]),
+                    "B" => intval($matches[3])
+                ];
                 $color = Color::rgbToHex($rgb_color);
             }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !34379
- In the dashboard, the widget colours could not be in RGB format

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/2e77ab3f-7b5a-45b6-85f0-cfc7872a44e5)

![image](https://github.com/user-attachments/assets/e45f9be7-9491-4053-8ed0-1dfec3a9184b)


