### PR TITLE
Forms: export/import access policies

### DIFF
--- a/phpunit/DbTestCase.php
+++ b/phpunit/DbTestCase.php
@@ -278,6 +278,44 @@ class DbTestCase extends \GLPITestCase
     }
 
     /**
+     * Delete multiple items of the given class
+     *
+     * @param int[] $ids
+     */
+    protected function deleteItems(string $itemtype, array $ids, bool $purge = false): void
+    {
+        foreach ($ids as $id) {
+            $this->deleteItem($itemtype, $id, $purge);
+        }
+    }
+
+    /**
+     * Helper methods to quickly create many items of the same type.
+     *
+     * @param array[] $names
+     */
+    protected function createItemsWithNames(string $itemtype, array $names): array
+    {
+        return array_map(
+            fn($name) => $this->createItem($itemtype, ['name' => $name]),
+            $names,
+        );
+    }
+
+    /**
+     * Helper methods to quickly get the names of multiple items using their ids.
+     *
+     * @param int[] $ids
+     */
+    protected function getItemsNames(string $itemtype, array $ids): array
+    {
+        return array_map(
+            fn($id) => $itemtype::getById($id)->fields['name'],
+            $ids,
+        );
+    }
+
+    /**
      * Helper method to avoid writting the same boilerplate code for rule creation
      *
      * @param RuleBuilder $builder RuleConfiguration

--- a/phpunit/DbTestCase.php
+++ b/phpunit/DbTestCase.php
@@ -293,6 +293,7 @@ class DbTestCase extends \GLPITestCase
      * Helper methods to quickly create many items of the same type.
      *
      * @param array[] $names
+     * @return CommonDBTM[]
      */
     protected function createItemsWithNames(string $itemtype, array $names): array
     {
@@ -306,6 +307,7 @@ class DbTestCase extends \GLPITestCase
      * Helper methods to quickly get the names of multiple items using their ids.
      *
      * @param int[] $ids
+     * @return string[]
      */
     protected function getItemsNames(string $itemtype, array $ids): array
     {

--- a/phpunit/functional/Glpi/Form/AccessControl/ControlType/AllowListConfigTest.php
+++ b/phpunit/functional/Glpi/Form/AccessControl/ControlType/AllowListConfigTest.php
@@ -37,7 +37,7 @@ namespace tests\units\Glpi\Form\AccessControl\ControlType;
 
 use Glpi\Form\AccessControl\ControlType\AllowListConfig;
 
-final class AllowListConfigTest extends \GLPITestCase
+final class AllowListConfigTest extends \GlpiTestCase
 {
     public function testJsonDeserialize(): void
     {

--- a/phpunit/functional/Glpi/Form/Export/FormSerializerAccessPoliciesTest.php
+++ b/phpunit/functional/Glpi/Form/Export/FormSerializerAccessPoliciesTest.php
@@ -1,0 +1,310 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form;
+
+use AbstractRightsDropdown;
+use Entity;
+use Glpi\Form\AccessControl\ControlType\AllowList;
+use Glpi\Form\AccessControl\ControlType\AllowListConfig;
+use Glpi\Form\AccessControl\ControlType\DirectAccess;
+use Glpi\Form\AccessControl\ControlType\DirectAccessConfig;
+use Glpi\Form\Export\Context\DatabaseMapper;
+use Glpi\Form\Export\Serializer\FormSerializer;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+use Group;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Profile;
+use User;
+
+/**
+ * Separate file for serializer tests related to form access policies.
+ * This helps keeping the main serializer test file smaller and more readable.
+ */
+final class FormSerializerAccessPoliciesTest extends \DbTestCase
+{
+    use FormTesterTrait;
+
+    private static FormSerializer $serializer;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$serializer = new FormSerializer();
+        parent::setUpBeforeClass();
+    }
+
+    public static function exportAndImportDirectAccessPolicyProvider(): iterable
+    {
+        yield 'Active' => [
+            'is_active' => true,
+        ];
+        yield 'Inactive' => [
+            'is_active' => false,
+        ];
+        yield 'Allow unauthenticated' => [
+            'allow_unauthenticated' => true,
+        ];
+        yield 'Disallow unauthenticated' => [
+            'allow_unauthenticated' => false,
+        ];
+    }
+
+    #[DataProvider('exportAndImportDirectAccessPolicyProvider')]
+    public function testExportAndImportDirectAccessPolicy(
+        string $token = "my_token",
+        bool $allow_unauthenticated = false,
+        bool $is_active = true,
+    ): void {
+        // Arrange: create a form with a direct access policy
+        $builder = new FormBuilder("My test form");
+        $builder->addAccessControl(
+            strategy: DirectAccess::class,
+            config: new DirectAccessConfig(
+                token: $token,
+                allow_unauthenticated: $allow_unauthenticated,
+            ),
+            is_active: $is_active,
+        );
+        $form = $this->createForm($builder);
+
+        // Act: export and import form
+        $form_copy = $this->exportAndImportForm($form);
+
+        // Assert: validate access policy config
+        $policies = $form_copy->getAccessControls();
+        $this->assertCount(1, $policies);
+        $policy = current($policies);
+        $this->assertSame($is_active, (bool) $policy->fields['is_active']);
+
+        $strategy = $policy->getStrategy();
+        $this->assertInstanceOf(DirectAccess::class, $strategy);
+
+        /** @var DirectAccessConfig $config  */
+        $config = $policy->getConfig();
+        $this->assertSame($token, $config->getToken());
+        $this->assertSame($allow_unauthenticated, $config->allowUnauthenticated());
+    }
+
+    public static function exportAndImportAllowListPolicyProvider(): iterable
+    {
+        yield 'Active' => [
+            'is_active' => true,
+        ];
+        yield 'Inactive' => [
+            'is_active' => false,
+        ];
+        yield 'With users' => [
+            'user_ids' => [
+                getItemByTypeName(User::class, "glpi", true),
+                getItemByTypeName(User::class, "tech", true),
+            ]
+        ];
+        yield 'With groups' => [
+            'group_ids' => [
+                getItemByTypeName(Group::class, "_test_group_1", true),
+                getItemByTypeName(Group::class, "_test_group_2", true),
+            ]
+        ];
+        yield 'With profiles' => [
+            'profile_ids' => [
+                getItemByTypeName(Profile::class, "Super-Admin", true),
+                getItemByTypeName(Profile::class, "Read-Only", true),
+            ]
+        ];
+        yield 'With users and special value' => [
+            'user_ids' => [
+                AbstractRightsDropdown::ALL_USERS,
+                getItemByTypeName(User::class, "glpi", true),
+                getItemByTypeName(User::class, "tech", true),
+            ]
+        ];
+        yield 'With everything' => [
+            'user_ids' => [
+                AbstractRightsDropdown::ALL_USERS,
+                getItemByTypeName(User::class, "glpi", true),
+                getItemByTypeName(User::class, "tech", true),
+            ],
+            'group_ids' => [
+                getItemByTypeName(Group::class, "_test_group_1", true),
+                getItemByTypeName(Group::class, "_test_group_2", true),
+            ],
+            'profile_ids' => [
+                getItemByTypeName(Profile::class, "Super-Admin", true),
+                getItemByTypeName(Profile::class, "Read-Only", true),
+            ],
+        ];
+    }
+
+    #[DataProvider('exportAndImportAllowListPolicyProvider')]
+    public function testExportAndImportAllowListPolicy(
+        array $user_ids = [],
+        array $group_ids = [],
+        array $profile_ids = [],
+        bool $is_active = true,
+    ): void {
+        // Arrange: Create a form with an allow list policy
+        $builder = new FormBuilder("My test form");
+        $builder->addAccessControl(
+            strategy: AllowList::class,
+            config: new AllowListConfig(
+                user_ids   : $user_ids,
+                group_ids  : $group_ids,
+                profile_ids: $profile_ids,
+            ),
+            is_active: $is_active,
+        );
+        $form = $this->createForm($builder);
+
+        // Act: Export and import form.
+        $form_copy = $this->exportAndImportForm($form);
+
+        // Assert: validate allow list policy config
+        $policies = $form_copy->getAccessControls();
+        $this->assertCount(1, $policies);
+        $policy = current($policies);
+        $this->assertSame($is_active, (bool) $policy->fields['is_active']);
+
+        $strategy = $policy->getStrategy();
+        $this->assertInstanceOf(AllowList::class, $strategy);
+
+        /** @var AllowListConfig $config */
+        $config = $policy->getConfig();
+        $this->assertSame($user_ids, $config->getUserIds());
+        $this->assertSame($group_ids, $config->getGroupIds());
+        $this->assertSame($profile_ids, $config->getProfileIds());
+    }
+
+    public function testExportAndImportAllowListPolicyWithMapping(): void
+    {
+        // Arrange: create multiples users/profiles/groups and create a form
+        // with an allow list policy that reference them.
+        [$user_1, $user_2, $user_3, $user_4] = $this->createItemsWithNames(
+            User::class,
+            ["User 1", "User 2", "User 3", "User 4"]
+        );
+        [$group_1, $group_2, $group_3, $group_4] = $this->createItemsWithNames(
+            Group::class,
+            ["Group 1",  "Group 2", "Group 3", "Group 4"]
+        );
+        [$profile_1, $profile_2, $profile_3, $profile_4] = $this->createItemsWithNames(
+            Profile::class,
+            ["Profile 1", "Profile 2", "Profile 3", "Profile 4"]
+        );
+
+        $builder = new FormBuilder("My test form");
+        $builder->addAccessControl(AllowList::class, new AllowListConfig(
+            user_ids: [$user_1->getID(), $user_2->getID(), AbstractRightsDropdown::ALL_USERS],
+            group_ids: [$group_1->getID(), $group_2->getID()],
+            profile_ids: [$profile_1->getID(), $profile_2->getID()],
+        ));
+        $form = $this->createForm($builder);
+
+        // Act: Map database items (items 1 and 2 are replaced by items 3 and 4)
+        // then export and import form.
+        $mapper = new DatabaseMapper([$this->getTestRootEntity(only_id: true)]);
+        $mapper->addMappedItem(User::class, "User 1", $user_3->getID());
+        $mapper->addMappedItem(User::class, "User 2", $user_4->getID());
+        $mapper->addMappedItem(Group::class, "Group 1", $group_3->getID());
+        $mapper->addMappedItem(Group::class, "Group 2", $group_4->getID());
+        $mapper->addMappedItem(Profile::class, "Profile 1", $profile_3->getID());
+        $mapper->addMappedItem(Profile::class, "Profile 2", $profile_4->getID());
+
+        $json = $this->exportForm($form);
+        $form_copy = $this->importForm($json, $mapper);
+
+        // Assert: validate allow list policy config
+        $policies = $form_copy->getAccessControls();
+        $this->assertCount(1, $policies);
+        $policy = current($policies);
+
+        $strategy = $policy->getStrategy();
+        $this->assertInstanceOf(AllowList::class, $strategy);
+
+        /** @var AllowListConfig $config */
+        $config = $policy->getConfig();
+        $allowed_groups = $this->getItemsNames(Group::class, $config->getGroupIds());
+        $allowed_profiles = $this->getItemsNames(Profile::class, $config->getProfileIds());
+        $this->assertSame([ // Can't map this one to names because of the special "all" value
+            getItemByTypeName(User::class, "User 3", true),
+            getItemByTypeName(User::class, "User 4", true),
+            AbstractRightsDropdown::ALL_USERS,
+        ], $config->getUserIds());
+        $this->assertSame(["Group 3", "Group 4"], $allowed_groups);
+        $this->assertSame(["Profile 3", "Profile 4"], $allowed_profiles);
+    }
+
+    public function testAllowListPolicyDataRequirementsAreExported(): void
+    {
+        // Arrange: create multiples users/profiles/groups and create a form
+        // with an allow list policy that references them.
+        [$user_1, $user_2] = $this->createItemsWithNames(
+            User::class,
+            ["User 1", "User 2"]
+        );
+        [$group_1, $group_2] = $this->createItemsWithNames(
+            Group::class,
+            ["Group 1",  "Group 2"]
+        );
+        [$profile_1, $profile_2] = $this->createItemsWithNames(
+            Profile::class,
+            ["Profile 1", "Profile 2"]
+        );
+
+        $builder = new FormBuilder("My test form");
+        $builder->addAccessControl(AllowList::class, new AllowListConfig(
+            user_ids: [$user_1->getID(), $user_2->getID(), AbstractRightsDropdown::ALL_USERS],
+            group_ids: [$group_1->getID(), $group_2->getID()],
+            profile_ids: [$profile_1->getID(), $profile_2->getID()],
+        ));
+        $form = $this->createForm($builder);
+
+        // Act:: export to JSON
+        $json = $this->exportForm($form);
+
+        // Assert: validate that all referenced items are required
+        $data = json_decode($json, true);
+        $requirements = $data['forms'][0]['data_requirements'];
+        $this->assertEquals([
+            ['itemtype' => Entity::class,  'name' => "_test_root_entity"],
+            ['itemtype' => User::class,    'name' => "User 1"],
+            ['itemtype' => User::class,    'name' => "User 2"],
+            ['itemtype' => Group::class,   'name' => "Group 1"],
+            ['itemtype' => Group::class,   'name' => "Group 2"],
+            ['itemtype' => Profile::class, 'name' => "Profile 1"],
+            ['itemtype' => Profile::class, 'name' => "Profile 2"],
+        ], $requirements);
+    }
+}

--- a/phpunit/functional/Glpi/Form/Export/FormSerializerTest.php
+++ b/phpunit/functional/Glpi/Form/Export/FormSerializerTest.php
@@ -384,40 +384,6 @@ final class FormSerializerTest extends \DbTestCase
     // Can't be done now as we have only one requirement (form entity) so it
     // we it is impossible to have duplicates.
 
-    private function exportForm(Form $form): string
-    {
-        return self::$serializer->exportFormsToJson([$form])->getJsonContent();
-    }
-
-    private function importForm(
-        string $json,
-        DatabaseMapper $mapper,
-    ): Form {
-        $import_result = self::$serializer->importFormsFromJson($json, $mapper);
-        $imported_forms = $import_result->getImportedForms();
-        $this->assertCount(1, $imported_forms);
-        $form_copy = current($imported_forms);
-        return $form_copy;
-    }
-
-    private function exportAndImportForm(Form $form): Form
-    {
-        // Export and import process
-        $json = $this->exportForm($form);
-        $form_copy = $this->importForm(
-            $json,
-            new DatabaseMapper([$this->getTestRootEntity(only_id: true)])
-        );
-
-        // Make sure it was not the same form object that was returned.
-        $this->assertNotEquals($form_copy->getId(), $form->getId());
-
-        // Make sure the new form really exist in the database.
-        $this->assertNotFalse($form_copy->getFromDB($form_copy->getId()));
-
-        return $form_copy;
-    }
-
     private function createAndGetFormWithBasicPropertiesFilled(): Form
     {
         $form_name = "Form with basic properties fully filled " . mt_rand();

--- a/src/Glpi/Form/AccessControl/FormAccessControl.php
+++ b/src/Glpi/Form/AccessControl/FormAccessControl.php
@@ -284,6 +284,21 @@ final class FormAccessControl extends CommonDBChild
         return "_access_control[{$this->getID()}][$name]";
     }
 
+    /**
+     * Verify that the given access control strategy is valid.
+     *
+     * @param string $strategy Strategy name (class name)
+     *
+     * @return bool
+     */
+    public function isValidStrategy(string $strategy): bool
+    {
+        return
+            is_a($strategy, ControlTypeInterface::class, true)
+            && !(new ReflectionClass($strategy))->isAbstract()
+        ;
+    }
+
     #[Override]
     protected function computeFriendlyName()
     {
@@ -307,20 +322,5 @@ final class FormAccessControl extends CommonDBChild
         }
 
         return $input;
-    }
-
-    /**
-     * Verify that the given access control strategy is valid.
-     *
-     * @param string $strategy Strategy name (class name)
-     *
-     * @return bool
-     */
-    protected function isValidStrategy(string $strategy): bool
-    {
-        return
-            is_a($strategy, ControlTypeInterface::class, true)
-            && !(new ReflectionClass($strategy))->isAbstract()
-        ;
     }
 }

--- a/src/Glpi/Form/Export/Context/ConfigWithForeignKeysInterface.php
+++ b/src/Glpi/Form/Export/Context/ConfigWithForeignKeysInterface.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2024 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -33,13 +32,23 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Form\Export\Specification;
+namespace Glpi\Form\Export\Context;
 
-final class DataRequirementSpecification
+/**
+ * Must be implemented by all JsonFieldInterface objects that contains references
+ * foreign keys.
+ *
+ * The method of this interface will be used by the form serializer to ensure
+ * that form exports can be done correctly as an export can't contains hardcoded
+ * database foreign keys.
+ */
+interface ConfigWithForeignKeysInterface
 {
-    public function __construct(
-        public string $itemtype = "",
-        public string $name = "",
-    ) {
-    }
+    /**
+     * Must return one JsonConfigForeignKeyHandlerInterface per serialized key that
+     * will contains foreign keys data.
+     *
+     * @return \Glpi\Form\Export\Context\ForeignKey\JsonConfigForeignKeyHandlerInterface[]
+     */
+    public static function listForeignKeysHandlers(): array;
 }

--- a/src/Glpi/Form/Export/Context/DatabaseMapper.php
+++ b/src/Glpi/Form/Export/Context/DatabaseMapper.php
@@ -157,13 +157,14 @@ final class DatabaseMapper
             'name' => $name
         ];
 
-        // Entities restrictions are not always included in addDefaultWhere,
-        // it is safer to add them manually (they might be checked twice tho).
-        $entities_restrictions = getEntitiesRestrictCriteria(
-            $item::getTable(),
-            value: $this->entities_restrictions
-        );
-        $condition[] = $entities_restrictions;
+        // Check entities
+        if ($item->isEntityAssign()) {
+            $entities_restrictions = getEntitiesRestrictCriteria(
+                $item::getTable(),
+                value: $this->entities_restrictions
+            );
+            $condition[] = $entities_restrictions;
+        }
         $query['WHERE'] = $condition;
 
         // Find item

--- a/src/Glpi/Form/Export/Context/ForeignKey/ForeignKeyArrayHandler.php
+++ b/src/Glpi/Form/Export/Context/ForeignKey/ForeignKeyArrayHandler.php
@@ -1,0 +1,151 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Export\Context\ForeignKey;
+
+use Glpi\Form\Export\Context\DatabaseMapper;
+use Glpi\Form\Export\Specification\DataRequirementSpecification;
+
+/**
+ * Handle an array of foreign keys.
+ * If the array contains some mixed values that are not 100% foreign keys (e.g.
+ * a special 'all' value), you can ignore these values using the $ignored_values
+ * parameter of the constructor.
+ */
+final class ForeignKeyArrayHandler implements JsonConfigForeignKeyHandlerInterface
+{
+    /** @param class-string<\CommonDBTM> $itemtype */
+    public function __construct(
+        private string $key,
+        private string $itemtype,
+        private array $ignored_values = [],
+    ) {
+    }
+
+    public function getDataRequirements(array $serialized_data): array
+    {
+        if (!$this->keyExistInSerializedData($serialized_data)) {
+            return [];
+        }
+
+        $requirements = [];
+        $foreign_keys = $serialized_data[$this->key];
+
+        // Create a data requirement for each foreign key
+        foreach ($foreign_keys as $foreign_key) {
+            if ($this->isIgnoredValue($foreign_key)) {
+                continue;
+            }
+
+            // Load item
+            $item = new $this->itemtype();
+            if ($item->getFromDB($foreign_key)) {
+                $requirements[] = new DataRequirementSpecification(
+                    $this->itemtype,
+                    $item->getName(),
+                );
+            }
+        }
+
+        return $requirements;
+    }
+
+    public function replaceForeignKeysByNames(array $serialized_data): array
+    {
+        if (!$this->keyExistInSerializedData($serialized_data)) {
+            return [];
+        }
+
+        $data_with_names = [];
+        $foreign_keys = $serialized_data[$this->key];
+
+        // Replace each foreign key by the name of the item it references
+        foreach ($foreign_keys as $foreign_key) {
+            if ($this->isIgnoredValue($foreign_key)) {
+                // Value isn't a fkey, keep it as it is
+                $data_with_names[] = $foreign_key;
+                continue;
+            }
+
+            // Load item
+            $item = new $this->itemtype();
+            if ($item->getFromDB($foreign_key)) {
+                $data_with_names[] = $item->getName();
+            }
+        }
+
+        $serialized_data[$this->key] = $data_with_names;
+        return $serialized_data;
+    }
+
+    public function replaceNamesByForeignKeys(
+        array $serialized_data,
+        DatabaseMapper $mapper,
+    ): array {
+        if (!$this->keyExistInSerializedData($serialized_data)) {
+            return [];
+        }
+
+        $data_with_fkeys = [];
+        $names = $serialized_data[$this->key];
+
+        // Replace names by its database id
+        foreach ($names as $name) {
+            if ($this->isIgnoredValue($name)) {
+                // Value isn't a name, keep it as it is
+                $data_with_fkeys[] = $name;
+                continue;
+            }
+
+            $data_with_fkeys[] = $mapper->getItemId(
+                $this->itemtype,
+                $name
+            );
+        }
+
+        $serialized_data[$this->key] = $data_with_fkeys;
+        return $serialized_data;
+    }
+
+    private function keyExistInSerializedData(array $serialized_data): bool
+    {
+        return isset($serialized_data[$this->key]);
+    }
+
+    private function isIgnoredValue(mixed $value): bool
+    {
+        return in_array($value, $this->ignored_values);
+    }
+}

--- a/src/Glpi/Form/Export/Context/ForeignKey/JsonConfigForeignKeyHandlerInterface.php
+++ b/src/Glpi/Form/Export/Context/ForeignKey/JsonConfigForeignKeyHandlerInterface.php
@@ -33,13 +33,19 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Form\Export\Specification;
+namespace Glpi\Form\Export\Context\ForeignKey;
 
-final class DataRequirementSpecification
+use Glpi\Form\Export\Context\DatabaseMapper;
+
+interface JsonConfigForeignKeyHandlerInterface
 {
-    public function __construct(
-        public string $itemtype = "",
-        public string $name = "",
-    ) {
-    }
+    /** @return \Glpi\Form\Export\Specification\DataRequirementSpecification[] */
+    public function getDataRequirements(array $serialized_data): array;
+
+    public function replaceForeignKeysByNames(array $serialized_data): array;
+
+    public function replaceNamesByForeignKeys(
+        array $serialized_data,
+        DatabaseMapper $mapper,
+    ): array;
 }

--- a/src/Glpi/Form/Export/Specification/AccesControlPolicyContentSpecification.php
+++ b/src/Glpi/Form/Export/Specification/AccesControlPolicyContentSpecification.php
@@ -35,11 +35,9 @@
 
 namespace Glpi\Form\Export\Specification;
 
-final class DataRequirementSpecification
+final class AccesControlPolicyContentSpecification
 {
-    public function __construct(
-        public string $itemtype = "",
-        public string $name = "",
-    ) {
-    }
+    public string $strategy;
+    public array $config_data;
+    public bool $is_active;
 }

--- a/src/Glpi/Form/Export/Specification/FormContentSpecification.php
+++ b/src/Glpi/Form/Export/Specification/FormContentSpecification.php
@@ -45,6 +45,9 @@ final class FormContentSpecification
     /** @var SectionContentSpecification[] $sections */
     public array $sections = [];
 
+    /** @var AccesControlPolicyContentSpecification[] $policies */
+    public array $policies = [];
+
     /** @var DataRequirementSpecification[] $data_requirements */
     public array $data_requirements = [];
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Replace #17679.

Export/import the access policies of a form.

There is one technical difficulty: each access policies has its own config (for example, the allow list keep track of multiple users, groups and profiles).
These configs can contain database ids, which is bad for the export (as we don't want any hardcoded ids into the exported json file).

Therefore, we need a solution to easily handle those without heavy configuration on the config side.
I've chosen the `ForeignKeysHandler` approach, which is a list of handler objects defined by each config class that will let the serializer know how to deal with the data.



