### PR TITLE
Fix pre element colors

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -421,3 +421,8 @@ body .toast {
 .tooltip {
     --tblr-tooltip-color: var(--tblr-body-color);
 }
+
+body pre {
+    background-color: var(--tblr-bg-surface);
+    color: var(--tblr-body-color);
+}


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

It fixes #17808
Bases the background color on `bg-surface` rather than `bg-surface-dark` and forces the text color to be the regular body color.


