### PR TITLE
Init `GLPI_ENVIRONMENT_TYPE` in the `ConfigurationConstants` service

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -151,13 +151,9 @@ if (array_key_exists('config-dir', $options)) {
    define('GLPI_CONFIG_DIR', realpath($config_dir));
 }
 
-if (array_key_exists('env', $options)) {
-    define('GLPI_ENVIRONMENT_TYPE', $options['env']);
-}
-
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 
-$kernel = new \Glpi\Kernel\Kernel();
+$kernel = new \Glpi\Kernel\Kernel($options['env'] ?? null);
 $kernel->loadCliConsoleOnlyConfig();
 
 if (file_exists(GLPI_CONFIG_DIR . '/config_db.php')) {

--- a/src/Glpi/Application/ConfigurationConstants.php
+++ b/src/Glpi/Application/ConfigurationConstants.php
@@ -41,8 +41,14 @@ final class ConfigurationConstants
     {
     }
 
-    public function computeConstants(): void
+    public function computeConstants(?string $env = null): void
     {
+        if ($env !== null) {
+            // Force the `GLPI_ENVIRONMENT_TYPE` constant.
+            // The value defined in the server env variables will be ignored.
+            define('GLPI_ENVIRONMENT_TYPE', $env);
+        }
+
         // Define GLPI_* constants that can be customized by admin.
         //
         // Use a self-invoking anonymous function to:

--- a/src/Glpi/Kernel/Kernel.php
+++ b/src/Glpi/Kernel/Kernel.php
@@ -52,17 +52,10 @@ final class Kernel extends BaseKernel
 
     public function __construct(?string $env = null)
     {
-        if ($env === null) {
-            $env = $_ENV['GLPI_ENVIRONMENT_TYPE'] ?? $_SERVER['GLPI_ENVIRONMENT_TYPE'] ?? null;
-        }
-        if ($env !== null) {
-            define('GLPI_ENVIRONMENT_TYPE', $env);
-        }
-
         // Initialize configuration constants.
         // It must be done after the autoload inclusion that requires some constants to be defined (e.g. GLPI_VERSION).
         // It must be done before the Kernel boot as some of the define constants must be defined during the boot sequence.
-        (new ConfigurationConstants($this->getProjectDir()))->computeConstants();
+        (new ConfigurationConstants($this->getProjectDir()))->computeConstants($env);
 
         // TODO: refactor the GLPI class.
         $glpi = (new \GLPI());


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Using the `--env` parameter of the console inside an environment that was also defining the `GLPI_ENVIRONMENT_TYPE` in its environment variables was resulting in a `Warning: Constant GLPI_ENVIRONMENT_TYPE already defined` error.

