### PR TITLE
Fix(inventory): Update status of computer items

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -1382,12 +1382,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Computer.php',
 ];
 $ignoreErrors[] = [
-	// identifier: nullCoalesce.property
-	'message' => '#^Property CommonDBTM\\:\\:\\$updates \\(array\\) on left side of \\?\\? is not nullable\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Computer.php',
-];
-$ignoreErrors[] = [
 	// identifier: booleanOr.alwaysFalse
 	'message' => '#^Result of \\|\\| is always false\\.$#',
 	'count' => 2,

--- a/phpunit/functional/Glpi/Inventory/InventoryTest.php
+++ b/phpunit/functional/Glpi/Inventory/InventoryTest.php
@@ -2043,7 +2043,7 @@ class InventoryTest extends InventoryTestCase
             } else {
                 $this->assertSame('NetworkEquipment', $port['itemtype']);
                 $this->assertSame($equipments_id, $port['items_id']);
-                $this->assertSame('NetworkPortEthernet', $port['instantiation_type'], print_r($port, true), );
+                $this->assertSame('NetworkPortEthernet', $port['instantiation_type'], print_r($port, true));
                 $this->assertMatchesRegularExpression(
                     '/^(?:(?:[0-9a-f]{2}[\:]{1}){5}|(?:[0-9a-f]{2}[-]{1}){5}|(?:[0-9a-f]{2}){5})[0-9a-f]{2}$/i',
                     $port['mac']

--- a/phpunit/functional/Glpi/Inventory/InventoryTest.php
+++ b/phpunit/functional/Glpi/Inventory/InventoryTest.php
@@ -6577,12 +6577,16 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         $this->assertSame($default_states_id, $monitor->fields['states_id']);
 
         //update states in database to not add lock
-        $query = "UPDATE `glpi_monitors`
-                SET `states_id` = $other_states_id
-                WHERE `glpi_monitors`.`id` = $monitor_id";
-        $this->assertTrue($DB->doQuery($query));
+        $this->assertTrue($monitor->update(['id' => $monitor_id, 'states_id' => $other_states_id]));
         $this->assertTrue($monitor->getFromDB($monitor_id));
         $this->assertSame($other_states_id, $monitor->fields['states_id']);
+
+        // Delete lock
+        $lock = new Lockedfield();
+        $this->assertTrue($lock->deleteByCriteria([
+            'itemtype' => 'Monitor',
+            'items_id' => $monitor_id,
+        ]));
 
         //redo inventory
         $json = json_decode(file_get_contents(self::INV_FIXTURES . 'computer_1.json'));

--- a/phpunit/functional/Glpi/Inventory/InventoryTest.php
+++ b/phpunit/functional/Glpi/Inventory/InventoryTest.php
@@ -126,7 +126,7 @@ class InventoryTest extends InventoryTestCase
         $this->assertIsArray($record);
         $this->assertSame($expected, $record);
 
-       //remote management
+        //remote management
         $mgmt = new \Item_RemoteManagement();
         $iterator = $mgmt->getFromItem($computer);
         $this->assertCount(1, $iterator);
@@ -843,7 +843,7 @@ class InventoryTest extends InventoryTestCase
 
         foreach ($expecteds as $type => $expected) {
             $component = array_values($components[$type]);
-           //hack to replace expected fkeys
+            //hack to replace expected fkeys
             foreach ($expected as $i => &$row) {
                 foreach (array_keys($row) as $key) {
                     if (isForeignKeyField($key)) {
@@ -1104,7 +1104,7 @@ class InventoryTest extends InventoryTestCase
             'real_capacity' => $capacities[0] ?? 50570
         ];
 
-       //hack to replace expected fkeys
+        //hack to replace expected fkeys
         foreach (array_keys($expected) as $key) {
             if (isForeignKeyField($key)) {
                 $expected[$key] = $battery[$key];
@@ -1123,7 +1123,7 @@ class InventoryTest extends InventoryTestCase
 
         $inventory = $this->doInventory($json);
 
-       //check inventory metadata
+        //check inventory metadata
         $metadata = $inventory->getMetadata();
         $this->assertCount(7, $metadata);
         $this->assertSame('glpixps-2018-07-09-09-07-13', $metadata['deviceid']);
@@ -1893,13 +1893,13 @@ class InventoryTest extends InventoryTestCase
         $this->assertSame('netinventory', $metadata['action']);
 
         global $DB;
-       //check created agent
+        //check created agent
         $agenttype = $DB->request(['FROM' => \AgentType::getTable(), 'WHERE' => ['name' => 'Core']])->current();
         $agents = $DB->request(['FROM' => \Agent::getTable()]);
-       //no agent with deviceid equals to "foo"
+        //no agent with deviceid equals to "foo"
         $this->assertCount(0, $agents);
 
-       //get model, manufacturer, ...
+        //get model, manufacturer, ...
         $autoupdatesystems = $DB->request(['FROM' => \AutoupdateSystem::getTable(), 'WHERE' => ['name' => 'GLPI Native Inventory']])->current();
         $this->assertIsArray($autoupdatesystems);
         $autoupdatesystems_id = $autoupdatesystems['id'];
@@ -2043,7 +2043,7 @@ class InventoryTest extends InventoryTestCase
             } else {
                 $this->assertSame('NetworkEquipment', $port['itemtype']);
                 $this->assertSame($equipments_id, $port['items_id']);
-                $this->assertSame('NetworkPortEthernet', $port['instantiation_type'], print_r($port, true),);
+                $this->assertSame('NetworkPortEthernet', $port['instantiation_type'], print_r($port, true), );
                 $this->assertMatchesRegularExpression(
                     '/^(?:(?:[0-9a-f]{2}[\:]{1}){5}|(?:[0-9a-f]{2}[-]{1}){5}|(?:[0-9a-f]{2}){5})[0-9a-f]{2}$/i',
                     $port['mac']
@@ -2576,7 +2576,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
 
             foreach ($expecteds as $type => $expected) {
                 $component = array_values($components[$type]);
-               //hack to replace expected fkeys
+                //hack to replace expected fkeys
                 foreach ($expected as $i => &$row) {
                     foreach (array_keys($row) as $key) {
                         if (isForeignKeyField($key)) {
@@ -2682,12 +2682,12 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         ];
 
         $i = 0;
-       /*foreach ($unmanageds as $unmanaged) {
-         foreach ($expecteds[$i] as $key => $value) {
-            $this->>assertEquals($value, $unmanaged[$key]);
-         }
-         ++$i;
-       }*/
+        /*foreach ($unmanageds as $unmanaged) {
+          foreach ($expecteds[$i] as $key => $value) {
+             $this->>assertEquals($value, $unmanaged[$key]);
+          }
+          ++$i;
+        }*/
 
         //check matchedlogs
         $mlogs = new \RuleMatchedLog();
@@ -3560,7 +3560,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         $_SESSION["glpi_currenttime"] = $date_now;
         $inventory = $this->doInventory($json);
 
-       //check inventory metadata
+        //check inventory metadata
         $metadata = $inventory->getMetadata();
 
         $this->assertCount(5, $metadata);
@@ -3571,14 +3571,14 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         $this->assertSame('netinventory', $metadata['action']);
 
         global $DB;
-       //check created agent
+        //check created agent
         $agenttype = $DB->request(['FROM' => \AgentType::getTable(), 'WHERE' => ['name' => 'Core']])->current();
         $this->assertSame('CH-GV1-DSI-WLC-INSID-1-2020-12-31-11-28-51', $inventory->getAgent()->fields['deviceid']);
         $this->assertSame('CH-GV1-DSI-WLC-INSID-1-2020-12-31-11-28-51', $inventory->getAgent()->fields['name']);
         $this->assertSame('NetworkEquipment', $inventory->getAgent()->fields['itemtype']);
         $this->assertSame($agenttype['id'], $inventory->getAgent()->fields['agenttypes_id']);
 
-       //get model, manufacturer, ...
+        //get model, manufacturer, ...
         $autoupdatesystems = $DB->request(['FROM' => \AutoupdateSystem::getTable(), 'WHERE' => ['name' => 'GLPI Native Inventory']])->current();
         $this->assertIsArray($autoupdatesystems);
         $autoupdatesystems_id = $autoupdatesystems['id'];
@@ -3663,7 +3663,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
             $this->assertIsArray($row);
             $this->assertSame($expected_eq, $row, print_r($row, true) . print_r($expected_eq, true));
 
-           //check network ports
+            //check network ports
             $expected_count = ($first ? 4 : 1);
             $ports_iterator = $DB->request([
                 'FROM'   => \NetworkPort::getTable(),
@@ -3752,7 +3752,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
                 } else {
                     $this->assertSame('NetworkEquipment', $port['itemtype']);
                     $this->assertSame($equipments_id, $port['items_id']);
-                   //$this->assertSame('NetworkPortAggregate', print_r($port, true), $port['instantiation_type']);
+                    //$this->assertSame('NetworkPortAggregate', print_r($port, true), $port['instantiation_type']);
                     $this->assertMatchesRegularExpression(
                         '/^(?:(?:[0-9a-f]{2}[\:]{1}){5}|(?:[0-9a-f]{2}[-]{1}){5}|(?:[0-9a-f]{2}){5})[0-9a-f]{2}$/i',
                         $port['mac']
@@ -3761,7 +3761,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
                 }
                 ++$i;
 
-               //check for ips
+                //check for ips
                 $ip_iterator = $DB->request([
                     'SELECT'       => [
                         \IPAddress::getTable() . '.name',
@@ -3784,7 +3784,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
                     ]
                 ]);
 
-               //$this->assertCount(count($ips[$port['name']] ?? ['one' => 'one']), $ip_iterator);
+                //$this->assertCount(count($ips[$port['name']] ?? ['one' => 'one']), $ip_iterator);
                 if ($port['mac'] == '58:ac:78:59:45:fb') {
                     foreach ($ip_iterator as $ip) {
                         $this->assertIsArray($ips[$port['name']]);
@@ -3793,7 +3793,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
                 }
             }
 
-           //check for components
+            //check for components
             $components = [];
             $allcount = 0;
             foreach (\Item_Devices::getItemAffinities('NetworkEquipment') as $link_type) {
@@ -3860,7 +3860,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
 
             foreach ($expecteds as $type => $expected) {
                 $component = array_values($components[$type]);
-               //hack to replace expected fkeys
+                //hack to replace expected fkeys
                 foreach ($expected as $i => &$row) {
                     foreach (array_keys($row) as $key) {
                         if (isForeignKeyField($key)) {
@@ -3903,7 +3903,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
             ++$i;
         }
 
-       //check matchedlogs
+        //check matchedlogs
         $mlogs = new \RuleMatchedLog();
         $found = $mlogs->find();
         $this->assertCount($expected_eq_count + count($unmanageds), $found);
@@ -4230,7 +4230,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
 
         foreach ($expecteds as $type => $expected) {
             $component = array_values($components[$type]);
-           //hack to replace expected fkeys
+            //hack to replace expected fkeys
             foreach ($expected as $i => &$row) {
                 foreach (array_keys($row) as $key) {
                     if (isForeignKeyField($key)) {
@@ -6508,7 +6508,6 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         $this->assertSame($other_states_id, $computer->fields['states_id']);
     }
 
-    
     /**
      * Test that fields are correctly copied from computer to monitor on inventory.
      */

--- a/src/Computer.php
+++ b/src/Computer.php
@@ -164,9 +164,7 @@ class Computer extends CommonDBTM
         // Update contact of attached items
         if ($CFG_GLPI['is_contact_autoupdate']) {
             $changes['contact_num'] = $input['contact_num'];
-        }
-        if ($CFG_GLPI['is_contact_autoupdate']) {
-            $changes['contact'] = $input['contact'];
+            $changes['contact']     = $input['contact'];
         }
         // Update users and groups of attached items
         if ($CFG_GLPI['is_user_autoupdate']) {

--- a/src/Computer.php
+++ b/src/Computer.php
@@ -199,6 +199,14 @@ class Computer extends CommonDBTM
             }
         }
 
+        // Update state of attached items
+        if (
+            ($CFG_GLPI['state_autoupdate_mode'] < 0)
+            && !isset($changes['states_id'])
+        ) {
+            $changes['states_id'] = $this->fields['states_id'];
+        }
+
         if (count($changes)) {
             $update_done = false;
             $is_input_dynamic = (bool) ($this->input['is_dynamic'] ?? false);

--- a/src/Computer.php
+++ b/src/Computer.php
@@ -160,51 +160,28 @@ class Computer extends CommonDBTM
         global $CFG_GLPI, $DB;
 
         $changes = [];
-        $update_count = count($this->updates ?? []);
         $input = Toolbox::addslashes_deep($this->fields);
-        for ($i = 0; $i < $update_count; $i++) {
-           // Update contact of attached items
-            if ($this->updates[$i] == 'contact_num' && $CFG_GLPI['is_contact_autoupdate']) {
-                $changes['contact_num'] = $input['contact_num'];
-            }
-            if ($this->updates[$i] == 'contact' && $CFG_GLPI['is_contact_autoupdate']) {
-                $changes['contact'] = $input['contact'];
-            }
-           // Update users and groups of attached items
-            if (
-                $this->updates[$i] == 'users_id'
-                && $CFG_GLPI['is_user_autoupdate']
-            ) {
-                $changes['users_id'] = $input['users_id'];
-            }
-            if (
-                $this->updates[$i] == 'groups_id'
-                && $CFG_GLPI['is_group_autoupdate']
-            ) {
-                $changes['groups_id'] = $input['groups_id'];
-            }
-           // Update state of attached items
-            if (
-                ($this->updates[$i] == 'states_id')
-                && ($CFG_GLPI['state_autoupdate_mode'] < 0)
-            ) {
-                $changes['states_id'] = $input['states_id'];
-            }
-           // Update loction of attached items
-            if (
-                $this->updates[$i] == 'locations_id'
-                && $CFG_GLPI['is_location_autoupdate']
-            ) {
-                $changes['locations_id'] = $input['locations_id'];
-            }
+        // Update contact of attached items
+        if ($CFG_GLPI['is_contact_autoupdate']) {
+            $changes['contact_num'] = $input['contact_num'];
         }
-
+        if ($CFG_GLPI['is_contact_autoupdate']) {
+            $changes['contact'] = $input['contact'];
+        }
+        // Update users and groups of attached items
+        if ($CFG_GLPI['is_user_autoupdate']) {
+            $changes['users_id'] = $input['users_id'];
+        }
+        if ($CFG_GLPI['is_group_autoupdate']) {
+            $changes['groups_id'] = $input['groups_id'];
+        }
         // Update state of attached items
-        if (
-            ($CFG_GLPI['state_autoupdate_mode'] < 0)
-            && !isset($changes['states_id'])
-        ) {
-            $changes['states_id'] = $this->fields['states_id'];
+        if ($CFG_GLPI['state_autoupdate_mode'] < 0) {
+            $changes['states_id'] = $input['states_id'];
+        }
+        // Update loction of attached items
+        if ($CFG_GLPI['is_location_autoupdate']) {
+            $changes['locations_id'] = $input['locations_id'];
         }
 
         if (count($changes)) {
@@ -226,8 +203,8 @@ class Computer extends CommonDBTM
                 );
                 $item      = new $type();
                 foreach ($items_result as $data) {
-                     $tID = $data['items_id'];
-                     $item->getFromDB($tID);
+                    $tID = $data['items_id'];
+                    $item->getFromDB($tID);
                     if (!$item->getField('is_global')) {
                         $item_input = $changes;
                         $item_input['id'] = $item->getID();

--- a/src/Computer_Item.php
+++ b/src/Computer_Item.php
@@ -153,7 +153,7 @@ class Computer_Item extends CommonDBRelation
 
             if (
                 ($CFG_GLPI["state_autoupdate_mode"] < 0)
-                || ($comp->fields['states_id'] != $item->getField('states_id'))
+                && ($comp->fields['states_id'] != $item->getField('states_id'))
             ) {
                 $updates['states_id'] = $comp->fields['states_id'];
                 Session::addMessageAfterRedirect(

--- a/src/Computer_Item.php
+++ b/src/Computer_Item.php
@@ -153,7 +153,7 @@ class Computer_Item extends CommonDBRelation
 
             if (
                 ($CFG_GLPI["state_autoupdate_mode"] < 0)
-                && ($comp->fields['states_id'] != $item->getField('states_id'))
+                || ($comp->fields['states_id'] != $item->getField('states_id'))
             ) {
                 $updates['states_id'] = $comp->fields['states_id'];
                 Session::addMessageAfterRedirect(


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !33699
- Here is a brief description of what this PR does

When configuring the inventory update process to ensure that a computer's items adopt the same status as the computer, an issue arises. If the computer already has the default status set in the "inventory" menu and one of its items has a different status, the item's status was not updated accordingly.
Before, it was only updated if the computer changed status.



