### PR TITLE
Components capacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,6 +282,7 @@ The present file will list all changes made to the project; according to the
 - `$LANG` global variable.
 - `$PLUGINS_EXCLUDED` and `$PLUGINS_INCLUDED` global variables.
 - `$SECURITY_STRATEGY` global variable.
+- Usage of `$CFG_GLPI['itemdevices']` configuration entry.
 - Usage of `csrf_compliant` plugins hook.
 - Usage of `migratetypes` plugin hooks.
 - Usage of `planning_scheduler_key` plugins hook.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,7 +282,7 @@ The present file will list all changes made to the project; according to the
 - `$LANG` global variable.
 - `$PLUGINS_EXCLUDED` and `$PLUGINS_INCLUDED` global variables.
 - `$SECURITY_STRATEGY` global variable.
-- Usage of `$CFG_GLPI['itemdevices']` configuration entry.
+- Usage of `$CFG_GLPI['itemdevices']` and `$CFG_GLPI['item_device_types']` configuration entries. Use `Item_Devices::getDeviceTypes()` to get the `Item_Devices` concrete class list.
 - Usage of `csrf_compliant` plugins hook.
 - Usage of `migratetypes` plugin hooks.
 - Usage of `planning_scheduler_key` plugins hook.

--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -1735,7 +1735,7 @@ $polymorphic_types_mapping = [
     Socket::class                  => $CFG_GLPI['socket_types'],
     Item_Plug::class               => $CFG_GLPI['plug_types'],
 ];
-foreach ($CFG_GLPI['itemdevices'] as $itemdevice_itemtype) {
+foreach (Item_Devices::getDeviceTypes() as $itemdevice_itemtype) {
     $source_itemtypes = $itemdevice_itemtype::itemAffinity();
     if (in_array('*', $source_itemtypes)) {
         $source_itemtypes = $CFG_GLPI['itemdevices_types'];

--- a/src/CommonDevice.php
+++ b/src/CommonDevice.php
@@ -62,14 +62,30 @@ abstract class CommonDevice extends CommonDropdown
      *
      * @since 0.85
      *
-     * @return array Array of the types of CommonDevice available
+     * @return array
+     * @phpstan-return class-string<CommonDevice>[]
      **/
     public static function getDeviceTypes()
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        return $CFG_GLPI['device_types'];
+        $valid_types = [];
+
+        foreach ($CFG_GLPI['device_types'] as $device_class) {
+            if (!is_a($device_class, self::class, true)) {
+                // Invalid type registered by a plugin.
+                trigger_error(
+                    sprintf('Invalid device type `%s`.', $device_class),
+                    E_USER_WARNING
+                );
+                continue;
+            }
+
+            $valid_types[] = $device_class;
+        }
+
+        return $valid_types;
     }
 
     /**

--- a/src/Computer.php
+++ b/src/Computer.php
@@ -255,7 +255,7 @@ class Computer extends CommonDBTM
 
             if (count($changes) > 0) {
                // Propagates the changes to linked devices
-                foreach ($CFG_GLPI['itemdevices'] as $device) {
+                foreach (Item_Devices::getDeviceTypes() as $device) {
                     $item = new $device();
                     $devices_result = $DB->request(
                         [

--- a/src/Config.php
+++ b/src/Config.php
@@ -458,12 +458,8 @@ class Config extends CommonDBTM
 
         $canedit = static::canUpdate();
         $item_devices_types = [];
-        foreach ($CFG_GLPI['itemdevices'] as $key => $itemtype) {
-            if (is_subclass_of($itemtype, CommonDBTM::class)) {
-                $item_devices_types[$itemtype] = $itemtype::getTypeName();
-            } else {
-                unset($CFG_GLPI['itemdevices'][$key]);
-            }
+        foreach (Item_Devices::getDeviceTypes() as $itemtype) {
+            $item_devices_types[$itemtype] = $itemtype::getTypeName();
         }
 
         TemplateRenderer::getInstance()->display('pages/setup/general/assets_setup.html.twig', [

--- a/src/Glpi/Asset/Capacity/HasDevicesCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasDevicesCapacity.php
@@ -133,19 +133,13 @@ class HasDevicesCapacity extends AbstractCapacity
         $this->registerToTypeConfig('itemdevices_itemaffinity', $classname);
 
         // Add support of devices that have their own config entry defined
-        foreach ($CFG_GLPI['itemdevices'] as $item_device_class) {
+        foreach (Item_Devices::getDeviceTypes() as $item_device_class) {
             // see `Item_Devices::itemAffinity()`
             $key = str_replace('_', '', strtolower($item_device_class)) . '_types';
             if (array_key_exists($key, $CFG_GLPI)) {
                 $this->registerToTypeConfig($key, $classname);
             }
         }
-
-        // Clear the item device affinities cache
-        // TODO Could we remove this cache entry ?
-        /** @var \Psr\SimpleCache\CacheInterface $GLPI_CACHE */
-        global $GLPI_CACHE;
-        $GLPI_CACHE->delete('item_device_affinities');
 
         CommonGLPI::registerStandardTab($classname, Item_Devices::class, 15);
     }
@@ -155,16 +149,7 @@ class HasDevicesCapacity extends AbstractCapacity
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        foreach ($CFG_GLPI['itemdevices'] as $item_device_class) {
-            if (!is_a($item_device_class, Item_Devices::class, true)) {
-                // Invalid type registered by a plugin.
-                trigger_error(
-                    sprintf('Invalid device type `%s`.', $item_device_class),
-                    E_USER_WARNING
-                );
-                continue;
-            }
-
+        foreach (Item_Devices::getDeviceTypes() as $item_device_class) {
             //Delete related items
             $item_device = new $item_device_class();
             $item_device->deleteByCriteria(['itemtype' => $classname], force: true, history: false);
@@ -181,7 +166,7 @@ class HasDevicesCapacity extends AbstractCapacity
         // Must be done after display preferences cleaning, as the SO list depends on these config entries
         $this->unregisterFromTypeConfig('itemdevices_types', $classname);
         $this->unregisterFromTypeConfig('itemdevices_itemaffinity', $classname);
-        foreach ($CFG_GLPI['itemdevices'] as $item_device_class) {
+        foreach (Item_Devices::getDeviceTypes() as $item_device_class) {
             // see `Item_Devices::itemAffinity()`
             $key = str_replace('_', '', strtolower($item_device_class)) . '_types';
             if (array_key_exists($key, $CFG_GLPI)) {

--- a/src/Glpi/Asset/Capacity/HasDevicesCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasDevicesCapacity.php
@@ -1,0 +1,180 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Asset\Capacity;
+
+use CommonDevice;
+use CommonGLPI;
+use Item_Devices;
+use Session;
+
+class HasDevicesCapacity extends AbstractCapacity
+{
+    public function getLabel(): string
+    {
+        return CommonDevice::getTypeName(Session::getPluralNumber());
+    }
+
+    public function getIcon(): string
+    {
+        return CommonDevice::getIcon();
+    }
+
+    public function getCloneRelations(): array
+    {
+        return [
+            Item_Devices::class,
+        ];
+    }
+
+    public function getSearchOptions(string $classname): array
+    {
+        return Item_Devices::rawSearchOptionsToAdd($classname);
+    }
+
+    public function isUsed(string $classname): bool
+    {
+        return parent::isUsed($classname)
+            && $this->countAssetsLinkedToDevices($classname) > 0;
+    }
+
+    public function getCapacityUsageDescription(string $classname): string
+    {
+        return sprintf(
+            __('%1$d component(s) attached to %2$d asset(s)'),
+            $this->countDevicesUsages($classname),
+            $this->countAssetsLinkedToDevices($classname)
+        );
+    }
+
+    private function countAssetsLinkedToDevices(string $classname): int
+    {
+        /**
+         * @var \DBmysql $DB
+         */
+        global $DB;
+
+        $assets_ids = [];
+
+        foreach (Item_Devices::getItemAffinities($classname) as $item_device_class) {
+            $iterator = $DB->request([
+                'SELECT'   => ['items_id'],
+                'DISTINCT' => true,
+                'FROM'     => $item_device_class::getTable()
+            ]);
+            foreach ($iterator as $row) {
+                $assets_ids[] = $row['items_id'];
+            }
+        }
+
+        $assets_ids = array_unique($assets_ids);
+
+        return count($assets_ids);
+    }
+
+    private function countDevicesUsages(string $classname): int
+    {
+        $count = 0;
+
+        foreach (Item_Devices::getItemAffinities($classname) as $item_device_class) {
+            $count += countDistinctElementsInTable(
+                $item_device_class::getTable(),
+                $item_device_class::getDeviceType()::getForeignKeyField(),
+                [
+                    'itemtype' => $classname,
+                ]
+            );
+        }
+
+        return $count;
+    }
+
+    public function onClassBootstrap(string $classname): void
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        // Supports devices
+        $this->registerToTypeConfig('itemdevices_types', $classname);
+
+        // Add support of any device by default (related to devices types that not define their own config)
+        $this->registerToTypeConfig('itemdevices_itemaffinity', $classname);
+
+        // Add support of devices that have their own config entry defined
+        foreach ($CFG_GLPI['itemdevices'] as $item_device_class) {
+            // see `Item_Devices::itemAffinity()`
+            $key = str_replace('_', '', strtolower($item_device_class)) . '_types';
+            if (array_key_exists($key, $CFG_GLPI)) {
+                $CFG_GLPI[$key][] = $classname;
+            }
+        }
+
+        // Clear the item device affinities cache
+        // TODO Could we remove this cache entry ?
+        /** @var \Psr\SimpleCache\CacheInterface $GLPI_CACHE */
+        global $GLPI_CACHE;
+        $GLPI_CACHE->delete('item_device_affinities');
+
+        CommonGLPI::registerStandardTab($classname, Item_Devices::class, 15);
+    }
+
+    public function onCapacityDisabled(string $classname): void
+    {
+        // Unregister from types
+        $this->unregisterFromTypeConfig('itemdevices_types', $classname);
+
+        foreach (Item_Devices::getItemAffinities($classname) as $item_device_class) {
+            if (!is_a($item_device_class, Item_Devices::class, true)) {
+                // Invalid type registered by a plugin.
+                trigger_error(
+                    sprintf('Invalid device type `%s`.', $item_device_class),
+                    E_USER_WARNING
+                );
+                continue;
+            }
+
+            //Delete related items
+            $item_device = new $item_device_class();
+            $item_device->deleteByCriteria(['itemtype' => $classname], force: true, history: false);
+
+            // Clean history related items
+            $this->deleteRelationLogs($classname, $item_device_class);
+        }
+
+        // Clean display preferences
+        $devices_search_options = Item_Devices::rawSearchOptionsToAdd($classname);
+        $this->deleteDisplayPreferences($classname, $devices_search_options);
+    }
+}

--- a/src/Glpi/Dashboard/FakeProvider.php
+++ b/src/Glpi/Dashboard/FakeProvider.php
@@ -36,6 +36,7 @@
 namespace Glpi\Dashboard;
 
 use CommonDBTM;
+use CommonDevice;
 use Group;
 use Session;
 use Stat;
@@ -102,8 +103,8 @@ final class FakeProvider extends Provider
             'Location' => 12,
         ];
 
-        foreach ($CFG_GLPI['itemdevices'] as $item_device_type) {
-            $device_type = $item_device_type::getDeviceType();
+        foreach (CommonDevice::getDeviceTypes() as $device_type) {
+            $item_device_type = $device_type::getItem_DeviceType();
 
             // Generate an obscure, but static number for the items and device types.
             $values[$item_device_type] = self::getObscureNumberForString($item_device_type, 7500);

--- a/src/Glpi/Dashboard/Grid.php
+++ b/src/Glpi/Dashboard/Grid.php
@@ -44,6 +44,7 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\Debug\Profiler;
 use Glpi\Plugin\Hooks;
 use Html;
+use Item_Devices;
 use Plugin;
 use Ramsey\Uuid\Uuid;
 use Reminder;
@@ -1181,7 +1182,7 @@ HTML;
                 }
             }
 
-            foreach ($CFG_GLPI['itemdevices'] as $itemtype) {
+            foreach (Item_Devices::getDeviceTypes() as $itemtype) {
                 $fk_itemtype = $itemtype::getDeviceType();
                 $label = sprintf(
                     __("Number of %s by type"),

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2964,15 +2964,12 @@ TWIG;
             // see `DbUtils::fixItemtypeCase()`
             sprintf('itemtype-case-mapping-%s', $plugin_key),
 
-            // Hookable using `$CFG_GLPI['*_types']` and `$CFG_GLPI['itemdevices_itemaffinity']`.
-            'item_device_affinities',
-
             // Will be stale as long as a plugin adds/remove a custom right.
             'all_possible_rights',
         ];
 
         foreach (array_keys($CFG_GLPI['languages']) as $language) {
-            // Hookable using `$CFG_GLPI['itemdevices']`, `$CFG_GLPI['device_types']`, `$CFG_GLPI['asset_types']`,
+            // Hookable using `$CFG_GLPI['device_types']`, `$CFG_GLPI['asset_types']`,
             // and `Hooks::DASHBOARD_FILTERS`.
             $to_clear[] = Grid::getAllDashboardCardsCacheKey($language);
         }

--- a/src/autoload/CFG_GLPI.php
+++ b/src/autoload/CFG_GLPI.php
@@ -264,6 +264,14 @@ $CFG_GLPI['networkport_instantiations']   = ['NetworkPortEthernet', 'NetworkPort
     'NetworkPortFiberchannel'
 ];
 
+$CFG_GLPI["contract_types"]               = [
+    'Computer', 'Monitor', 'NetworkEquipment',
+    'Peripheral', 'Phone', 'Printer', 'Project', 'Line',
+    'Software', 'SoftwareLicense', 'Certificate',
+    'DCRoom', 'Rack', 'Enclosure', 'Cluster', 'PDU', 'Appliance', 'Domain',
+    'DatabaseInstance',
+];
+
 $CFG_GLPI['device_types']                 = ['DeviceMotherboard', 'DeviceFirmware', 'DeviceProcessor',
     'DeviceMemory', 'DeviceHardDrive', 'DeviceNetworkCard',
     'DeviceDrive', 'DeviceBattery', 'DeviceGraphicCard',
@@ -277,11 +285,10 @@ $CFG_GLPI["socket_types"]                  = ['Computer','NetworkEquipment',
     'Peripheral','Phone','Printer', 'PassiveDCEquipment'
 ];
 
-$CFG_GLPI['itemdevices'] = [];
 foreach ($CFG_GLPI['device_types'] as $dtype) {
     $CFG_GLPI['location_types'][] = 'Item_' . $dtype;
     $CFG_GLPI['state_types'][] = 'Item_' . $dtype;
-    $CFG_GLPI["itemdevices"][] = 'Item_' . $dtype;
+    $CFG_GLPI["contract_types"][] = 'Item_' . $dtype;
 }
 
 $CFG_GLPI["itemdevices_types"]            = ['Computer', 'NetworkEquipment', 'Peripheral',
@@ -329,16 +336,6 @@ $CFG_GLPI["notificationtemplates_types"]  = ['CartridgeItem', 'Change', 'Consuma
     'SavedSearch_Alert', 'Certificate', 'Glpi\\Marketplace\\Controller',
     'Domain', 'KnowbaseItem'
 ];
-
-$CFG_GLPI["contract_types"]               = array_merge(
-    ['Computer', 'Monitor', 'NetworkEquipment',
-        'Peripheral', 'Phone', 'Printer', 'Project', 'Line',
-        'Software', 'SoftwareLicense', 'Certificate',
-        'DCRoom', 'Rack', 'Enclosure', 'Cluster', 'PDU', 'Appliance', 'Domain',
-        'DatabaseInstance'
-    ],
-    $CFG_GLPI['itemdevices']
-);
 
 
 $CFG_GLPI["union_search_type"]            = ['ReservationItem' => "reservation_types",

--- a/tests/functional/Glpi/Asset/Capacity/HasDevicesCapacity.php
+++ b/tests/functional/Glpi/Asset/Capacity/HasDevicesCapacity.php
@@ -1,0 +1,428 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Asset\Capacity;
+
+use DbTestCase;
+use DeviceHardDrive;
+use DisplayPreference;
+use Entity;
+use Item_DeviceHardDrive;
+use Log;
+
+class HasDevicesCapacity extends DbTestCase
+{
+    protected function getTargetCapacity(): string
+    {
+        return \Glpi\Asset\Capacity\HasDevicesCapacity::class;
+    }
+
+    public function testCapacityActivation(): void
+    {
+        global $CFG_GLPI;
+
+        $root_entity_id = getItemByTypeName(Entity::class, '_test_root_entity', true);
+
+        $definition_1 = $this->initAssetDefinition(
+            capacities: [
+                \Glpi\Asset\Capacity\HasDevicesCapacity::class,
+                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+            ]
+        );
+        $classname_1  = $definition_1->getAssetClassName();
+        $definition_2 = $this->initAssetDefinition(
+            capacities: [
+                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+            ]
+        );
+        $classname_2  = $definition_2->getAssetClassName();
+        $definition_3 = $this->initAssetDefinition(
+            capacities: [
+                \Glpi\Asset\Capacity\HasDevicesCapacity::class,
+                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+            ]
+        );
+        $classname_3  = $definition_3->getAssetClassName();
+
+        $has_capacity_mapping = [
+            $classname_1 => true,
+            $classname_2 => false,
+            $classname_3 => true,
+        ];
+
+        foreach ($has_capacity_mapping as $classname => $has_capacity) {
+            // Check that the class is globally registered
+            if ($has_capacity) {
+                $this->array($CFG_GLPI['itemdevices_types'])->contains($classname);
+                $this->array($CFG_GLPI['itemdevices_itemaffinity'])->contains($classname);
+            } else {
+                $this->array($CFG_GLPI['itemdevices_types'])->notContains($classname);
+                $this->array($CFG_GLPI['itemdevices_itemaffinity'])->notContains($classname);
+            }
+            foreach (array_keys($CFG_GLPI) as $config_key) {
+                if (preg_match('/^itemdevice[a-z+]_types$/', $config_key)) {
+                    if ($has_capacity) {
+                        $this->array($CFG_GLPI[$config_key])->contains($classname);
+                    } else {
+                        $this->array($CFG_GLPI[$config_key])->notContains($classname);
+                    }
+                }
+            }
+
+            // Check that the corresponding tab is present on items
+            $item = $this->createItem($classname, ['name' => __FUNCTION__, 'entities_id' => $root_entity_id]);
+            $this->login(); // must be logged in to get tabs list
+            if ($has_capacity) {
+                $this->array($item->defineAllTabs())->hasKey('Item_Devices$1');
+            } else {
+                $this->array($item->defineAllTabs())->notHasKey('Item_Devices$1');
+            }
+
+            // Check that the related search options are available
+            $so_keys = [
+                13,   // Graphic card / Designation
+                14,   // Motherboard / Designation
+                17,   // Processor / Designation
+                18,   // Processor / Number of cores
+                34,   // Processor / Number of threads
+                35,   // Processor / Number of processors
+                35,   // Processor / Frequency
+                39,   // Power supply / Designation
+                95,   // PCI / Designation
+                110,  // Memory / Designation
+                111,  // Memory / Size
+                112,  // Network card / Designation
+                113,  // Network card / MAC
+                114,  // Hard drive / Designation
+                115,  // Hard drive / Capacity
+                116,  // Hard drive / Type
+                1313, // Firmware / Designation
+                1314, // Firmware / Version
+                1315, // Firmware / Type
+                1316, // Firmware / Model
+                1317, // Firmware / Manufacturer
+                1318, // Firmware / Serial
+                1319, // Firmware / Other serial
+            ];
+            if ($has_capacity) {
+                $this->array($item->getOptions())->hasKeys($so_keys);
+            } else {
+                $this->array($item->getOptions())->notHasKeys($so_keys);
+            }
+        }
+    }
+
+    public function testCapacityDeactivation(): void
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        $root_entity_id = getItemByTypeName(Entity::class, '_test_root_entity', true);
+
+        $definition_1 = $this->initAssetDefinition(
+            capacities: [
+                \Glpi\Asset\Capacity\HasDevicesCapacity::class,
+                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+            ]
+        );
+        $classname_1  = $definition_1->getAssetClassName();
+        $definition_2 = $this->initAssetDefinition(
+            capacities: [
+                \Glpi\Asset\Capacity\HasDevicesCapacity::class,
+                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+            ]
+        );
+        $classname_2  = $definition_2->getAssetClassName();
+
+        $item_1 = $this->createItem(
+            $classname_1,
+            [
+                'name' => __FUNCTION__,
+                'entities_id' => $root_entity_id,
+            ]
+        );
+        $item_2 = $this->createItem(
+            $classname_2,
+            [
+                'name' => __FUNCTION__,
+                'entities_id' => $root_entity_id,
+            ]
+        );
+
+        $device = $this->createItem(
+            DeviceHardDrive::class,
+            [
+                'designation' => 'HDD',
+            ]
+        );
+
+        $device_item_1 = $this->createItem(
+            Item_DeviceHardDrive::class,
+            [
+                'deviceharddrives_id' => $device->getID(),
+                'itemtype'            => $item_1->getType(),
+                'items_id'            => $item_1->getID(),
+            ]
+        );
+        $device_item_2 = $this->createItem(
+            Item_DeviceHardDrive::class,
+            [
+                'deviceharddrives_id' => $device->getID(),
+                'itemtype'            => $item_2->getType(),
+                'items_id'            => $item_2->getID(),
+            ]
+        );
+        $displaypref_1   = $this->createItem(
+            DisplayPreference::class,
+            [
+                'itemtype' => $classname_1,
+                'num'      => 115, // capacity
+                'users_id' => 0,
+            ]
+        );
+        $displaypref_2   = $this->createItem(
+            DisplayPreference::class,
+            [
+                'itemtype' => $classname_2,
+                'num'      => 115, // capacity
+                'users_id' => 0,
+            ]
+        );
+
+        $item_1_logs_criteria = [
+            'itemtype'      => $classname_1,
+            'itemtype_link' => DeviceHardDrive::class,
+        ];
+        $item_2_logs_criteria = [
+            'itemtype'      => $classname_2,
+            'itemtype_link' => DeviceHardDrive::class,
+        ];
+
+        // Ensure relation, display preferences and logs exists, and class is registered to global config
+        $this->object(Item_DeviceHardDrive::getById($device_item_1->getID()))->isInstanceOf(Item_DeviceHardDrive::class);
+        $this->object(DisplayPreference::getById($displaypref_1->getID()))->isInstanceOf(DisplayPreference::class);
+        $this->integer(countElementsInTable(Log::getTable(), $item_1_logs_criteria))->isEqualTo(1); // link
+        $this->object(Item_DeviceHardDrive::getById($device_item_2->getID()))->isInstanceOf(Item_DeviceHardDrive::class);
+        $this->object(DisplayPreference::getById($displaypref_2->getID()))->isInstanceOf(DisplayPreference::class);
+        $this->integer(countElementsInTable(Log::getTable(), $item_2_logs_criteria))->isEqualTo(1); // link
+        $this->array($CFG_GLPI['itemdevices_types'])->contains($classname_1);
+        $this->array($CFG_GLPI['itemdevices_types'])->contains($classname_2);
+
+        // Disable capacity and check that relations have been cleaned, and class is unregistered from global config
+        $this->boolean($definition_1->update(['id' => $definition_1->getID(), 'capacities' => []]))->isTrue();
+        $this->boolean(Item_DeviceHardDrive::getById($device_item_1->getID()))->isFalse();
+        $this->boolean(DisplayPreference::getById($displaypref_1->getID()))->isFalse();
+        $this->integer(countElementsInTable(Log::getTable(), $item_1_logs_criteria))->isEqualTo(0);
+        $this->array($CFG_GLPI['itemdevices_types'])->notContains($classname_1);
+
+        // Ensure relations, logs and global registration are preserved for other definition
+        $this->object(Item_DeviceHardDrive::getById($device_item_2->getID()))->isInstanceOf(Item_DeviceHardDrive::class);
+        $this->object(DisplayPreference::getById($displaypref_2->getID()))->isInstanceOf(DisplayPreference::class);
+        $this->integer(countElementsInTable(Log::getTable(), $item_2_logs_criteria))->isEqualTo(1);
+        $this->array($CFG_GLPI['itemdevices_types'])->contains($classname_2);
+    }
+
+    public function testCloneAsset()
+    {
+        $definition = $this->initAssetDefinition(
+            capacities: [\Glpi\Asset\Capacity\HasDevicesCapacity::class]
+        );
+        $class = $definition->getAssetClassName();
+        $entity = $this->getTestRootEntity(true);
+
+        /** @var \Glpi\Asset\Asset $asset */
+        $asset = $this->createItem(
+            $class,
+            [
+                'name'        => 'Test asset',
+                'entities_id' => $entity,
+            ]
+        );
+
+        $device = $this->createItem(
+            DeviceHardDrive::class,
+            [
+                'designation' => 'HDD',
+            ]
+        );
+
+        $this->createItem(
+            Item_DeviceHardDrive::class,
+            [
+                'deviceharddrives_id' => $device->getID(),
+                'itemtype'            => $class,
+                'items_id'            => $asset->getID(),
+            ]
+        );
+
+        $this->integer($clone_id = $asset->clone())->isGreaterThan(0);
+        $this->array(getAllDataFromTable(Item_DeviceHardDrive::getTable(), [
+            'deviceharddrives_id' => $device->getID(),
+            'itemtype'            => $class,
+            'items_id'            => $clone_id,
+        ]))->hasSize(1);
+    }
+
+    public function testIsUsed(): void
+    {
+        $entity_id = $this->getTestRootEntity(true);
+
+        $definition = $this->initAssetDefinition(
+            capacities: [\Glpi\Asset\Capacity\HasDevicesCapacity::class]
+        );
+
+        $asset = $this->createItem($definition->getAssetClassName(), [
+            'name' => 'Test asset',
+            'entities_id' => $entity_id,
+        ]);
+
+        // Check that the capacity is not yet considered as used
+        $capacity = new \Glpi\Asset\Capacity\HasDevicesCapacity();
+        $this->boolean($capacity->isUsed($definition->getAssetClassName()))->isFalse();
+
+        // Create a relation with a device
+        $device = $this->createItem(
+            DeviceHardDrive::class,
+            [
+                'designation' => 'HDD',
+            ]
+        );
+
+        $this->createItem(
+            Item_DeviceHardDrive::class,
+            [
+                'deviceharddrives_id' => $device->getID(),
+                'itemtype'            => $definition->getAssetClassName(),
+                'items_id'            => $asset->getID(),
+            ]
+        );
+
+        // Check that the capacity is considered as used
+        $this->boolean($capacity->isUsed($definition->getAssetClassName()))->isTrue();
+    }
+
+    public function testGetCapacityUsageDescription(): void
+    {
+        $entity_id = $this->getTestRootEntity(true);
+
+        $definition = $this->initAssetDefinition(
+            system_name: 'TestAsset',
+            capacities: [\Glpi\Asset\Capacity\HasDevicesCapacity::class]
+        );
+        $capacity = new \Glpi\Asset\Capacity\HasDevicesCapacity();
+
+        // Check that the capacity usage description is correct
+        $this->string($capacity->getCapacityUsageDescription($definition->getAssetClassName()))
+            ->isEqualTo('0 component(s) attached to 0 asset(s)');
+
+        // Create assets
+        $asset_1 = $this->createItem($definition->getAssetClassName(), [
+            'name' => 'Test asset',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+        $asset_2 = $this->createItem($definition->getAssetClassName(), [
+            'name' => 'Test asset 2',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+
+        // Check that the capacity usage description is correct
+        $this->string($capacity->getCapacityUsageDescription($definition->getAssetClassName()))
+            ->isEqualTo('0 component(s) attached to 0 asset(s)');
+
+        $device_1 = $this->createItem(
+            DeviceHardDrive::class,
+            [
+                'designation' => 'HDD abcd',
+            ]
+        );
+        $device_2 = $this->createItem(
+            DeviceHardDrive::class,
+            [
+                'designation' => 'HDD efgh',
+            ]
+        );
+
+        // Attach the first component to the first asset
+        for ($i = 0; $i < 3; $i++) {
+            // Each relation should be counted once, as it corresponds to a unique component
+            $this->createItem(
+                Item_DeviceHardDrive::class,
+                [
+                    'deviceharddrives_id' => $device_1->getID(),
+                    'itemtype'            => $definition->getAssetClassName(),
+                    'items_id'            => $asset_1->getID(),
+                ]
+            );
+        }
+
+        // Check that the capacity usage description is correct
+        $this->string($capacity->getCapacityUsageDescription($definition->getAssetClassName()))
+            ->isEqualTo('1 component(s) attached to 1 asset(s)');
+
+        // Attach the first component to the second asset
+        for ($i = 0; $i < 3; $i++) {
+            // Each relation should be counted once, as it corresponds to a unique component
+            $this->createItem(
+                Item_DeviceHardDrive::class,
+                [
+                    'deviceharddrives_id' => $device_1->getID(),
+                    'itemtype'            => $definition->getAssetClassName(),
+                    'items_id'            => $asset_2->getID(),
+                ]
+            );
+        }
+
+        // Check that the capacity usage description is correct
+        $this->string($capacity->getCapacityUsageDescription($definition->getAssetClassName()))
+            ->isEqualTo('1 component(s) attached to 2 asset(s)');
+
+        // Attach the second component to the first asset
+        for ($i = 0; $i < 3; $i++) {
+            // Each relation should be counted once, as it corresponds to a unique component
+            $this->createItem(
+                Item_DeviceHardDrive::class,
+                [
+                    'deviceharddrives_id' => $device_2->getID(),
+                    'itemtype'            => $definition->getAssetClassName(),
+                    'items_id'            => $asset_1->getID(),
+                ]
+            );
+        }
+
+        // Check that the capacity usage description is correct
+        $this->string($capacity->getCapacityUsageDescription($definition->getAssetClassName()))
+            ->isEqualTo('2 component(s) attached to 2 asset(s)');
+    }
+}


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

A `Components` capacity is added and permits to attach any component type to the asset. In a second time, I think it would be interesting to give the ability to configure the list of allowed component types. It would require to specify how we should handle the capacities configuration (in a dedicated tab, in a modal, ...).

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/be5986d0-ef3f-4d38-a7ca-75af88ea1425)


