### PR TITLE
Fix filtering of devices affinities

### DIFF
--- a/phpunit/functional/Item_DevicesTest.php
+++ b/phpunit/functional/Item_DevicesTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use DbTestCase;
+use Item_Devices;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class Item_DevicesTest extends DbTestCase
+{
+    public static function itemAffinitiesProvider(): iterable
+    {
+        yield 'Computer' => [
+            'itemtype' => 'Computer',
+            'expected' => [
+                'Item_DeviceMotherboard',
+                'Item_DeviceFirmware',
+                'Item_DeviceProcessor',
+                'Item_DeviceMemory',
+                'Item_DeviceHardDrive',
+                'Item_DeviceNetworkCard',
+                'Item_DeviceDrive', // no config, matched due to the presence of `Computer` in $CFG_GLPI['itemdevices_itemaffinity']
+                'Item_DeviceBattery',
+                'Item_DeviceGraphicCard',
+                'Item_DeviceSoundCard',
+                'Item_DeviceControl', // no config, matched due to the presence of `Computer` in $CFG_GLPI['itemdevices_itemaffinity']
+                'Item_DevicePci', // matches `*`
+                'Item_DeviceCase',
+                'Item_DevicePowerSupply',
+                'Item_DeviceGeneric', // matches `*`
+                'Item_DeviceSimcard',
+                'Item_DeviceSensor',
+                'Item_DeviceCamera',
+            ],
+        ];
+
+        yield 'Printer' => [
+            'itemtype' => 'Printer',
+            'expected' => [
+                'Item_DeviceFirmware',
+                'Item_DeviceMemory',
+                'Item_DeviceHardDrive',
+                'Item_DeviceNetworkCard',
+                'Item_DeviceBattery',
+                'Item_DevicePci', // matches `*`
+                'Item_DeviceGeneric', // matches `*`
+                'Item_DeviceSimcard',
+            ],
+        ];
+
+        yield 'Monitor' => [
+            'itemtype' => 'Monitor',
+            'expected' => [
+            ],
+        ];
+    }
+
+    #[DataProvider('itemAffinitiesProvider')]
+    public function testGetItemAffinities(string $itemtype, array $expected)
+    {
+        $this->assertEquals($expected, Item_Devices::getItemAffinities($itemtype));
+    }
+}

--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -459,6 +459,14 @@ class Item_Devices extends CommonDBRelation
      **/
     public static function getItemAffinities($itemtype)
     {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        if (!in_array($itemtype, $CFG_GLPI['itemdevices_types'], true)) {
+            // Itemtype does not support devices.
+            return [];
+        }
+
         $result = [];
 
         foreach (CommonDevice::getDeviceTypes() as $device_class) {

--- a/tests/functional/Glpi/Asset/Capacity/HasDevicesCapacity.php
+++ b/tests/functional/Glpi/Asset/Capacity/HasDevicesCapacity.php
@@ -40,6 +40,7 @@ use DeviceHardDrive;
 use DisplayPreference;
 use Entity;
 use Item_DeviceHardDrive;
+use Item_Devices;
 use Log;
 
 class HasDevicesCapacity extends DbTestCase
@@ -99,6 +100,11 @@ class HasDevicesCapacity extends DbTestCase
                         $this->array($CFG_GLPI[$config_key])->notContains($classname);
                     }
                 }
+            }
+            if ($has_capacity) {
+                $this->array(Item_Devices::getItemAffinities($classname))->isNotEmpty();
+            } else {
+                $this->array(Item_Devices::getItemAffinities($classname))->isEmpty();
             }
 
             // Check that the corresponding tab is present on items


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Follows #17839 and required for #17807.

An asset class that is not present in `$CFG_GLPI['itemdevices_types']` was listed in the affinities with the devices having a `*` in their affinities list. This was not correct.
The proposed change ensure that `Item_Devices::getItemAffinities()` will always return an empty list for asset classes that are not supposed to have devices.