### PR TITLE
Clean asset definitions after each test

### DIFF
--- a/phpunit/GLPITestCase.php
+++ b/phpunit/GLPITestCase.php
@@ -33,6 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Asset\AssetDefinitionManager;
 use Glpi\Tests\Log\TestHandler;
 use Monolog\Level;
 use Monolog\Logger;
@@ -440,5 +441,6 @@ class GLPITestCase extends TestCase
         // Statics values
         Log::$use_queue = false;
         CommonDBTM::clearSearchOptionCache();
+        AssetDefinitionManager::unsetInstance();
     }
 }

--- a/src/Glpi/Asset/AssetDefinitionManager.php
+++ b/src/Glpi/Asset/AssetDefinitionManager.php
@@ -53,7 +53,7 @@ final class AssetDefinitionManager
     /**
      * Definitions cache.
      */
-    private ?array $definitions_data;
+    private ?array $definitions_data = null;
 
     /**
      * List of available capacities.
@@ -97,6 +97,16 @@ final class AssetDefinitionManager
         }
 
         return self::$instance;
+    }
+
+    /**
+     * Unset the singleton instance
+     *
+     * @return void
+     */
+    public static function unsetInstance(): void
+    {
+        self::$instance = null;
     }
 
     /**
@@ -339,7 +349,7 @@ final class AssetDefinitionManager
      */
     public function getDefinitions(bool $only_active = false): array
     {
-        if (!isset($this->definitions_data)) {
+        if ($this->definitions_data === null) {
             $this->definitions_data = getAllDataFromTable(AssetDefinition::getTable());
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Once loaded, the asset definitions are stored in the `definitions_data` property of the `AssetDefinitionManager` singleton instance. This property acts as a cache and interfers with the other tests. Unsetting the singleton instance shoudl fix this behaviour.