### PR TITLE
Make `Html::resume_text()` result safe

### DIFF
--- a/phpunit/functional/HtmlTest.php
+++ b/phpunit/functional/HtmlTest.php
@@ -121,13 +121,21 @@ class HtmlTest extends \GLPITestCase
          'If the string is not truncated, well... We\'re wrong and got a very serious issue in our codebase!' .
          'And if the string has been correctly truncated, well... All is ok then, let\'s show if all the other tests are OK :)';
         $expected = 'This is a very long string which will be truncated by a dedicated method. ' .
-         'If the string is not truncated, well... We\'re wrong and got a very serious issue in our codebase!' .
-         'And if the string has been correctly truncated, well... All is ok then, let\'s show i&nbsp;(...)';
+         'If the string is not truncated, well... We&#039;re wrong and got a very serious issue in our codebase!' .
+         'And if the string has been correctly truncated, well... All is ok then, let&#039;s show i&nbsp;(...)';
         $this->assertSame($expected, \Html::resume_text($origin));
 
         $origin = 'A string that is longer than 10 characters.';
         $expected = 'A string t&nbsp;(...)';
         $this->assertSame($expected, \Html::resume_text($origin, 10));
+
+        $origin = 'A string that contains HTML special chars like >, < and &, and some text that should be truncated.';
+        $expected = 'A string that contains HTML special chars like &gt;, &lt; and &amp;, a&nbsp;(...)';
+        $this->assertSame($expected, \Html::resume_text($origin, 60));
+
+        $origin = 'A string that contains HTML special chars like >, < and &, and some text that should NOT be truncated.';
+        $expected = 'A string that contains HTML special chars like &gt;, &lt; and &amp;, and some text that should NOT be truncated.';
+        $this->assertSame($expected, \Html::resume_text($origin, 1500));
     }
 
     public function testFormatNumber()

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -1883,7 +1883,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
 
                     // Task description
                     $href = $parent_item::getFormURLWithID($parent_item->fields['id']);
-                    $link_title = Html::resume_text(RichText::getTextFromHtml($task->fields['content'], false, true, true), 50);
+                    $link_title = Html::resume_text(RichText::getTextFromHtml($task->fields['content'], false, true), 50);
                     $row['values'][] = [
                         'content' => "<a href='$href'>$link_title</a>"
                     ];
@@ -1956,7 +1956,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             printf(
                 __('%1$s %2$s'),
                 $link,
-                Html::resume_text(RichText::getTextFromHtml($job->fields['content'], false, true, true), 50)
+                Html::resume_text(RichText::getTextFromHtml($job->fields['content'], false, true), 50)
             );
 
             echo "</a>";

--- a/src/Glpi/Agent/Communication/AbstractRequest.php
+++ b/src/Glpi/Agent/Communication/AbstractRequest.php
@@ -389,15 +389,14 @@ abstract class AbstractRequest
         }
         $this->http_response_code = $code;
         if (!empty($message)) {
+            $message = mb_strlen($message, 'UTF-8') < 250 ? $message : mb_substr($message, 0, 250, 'UTF-8');
             if ($this->mode === self::JSON_MODE) {
                 $this->addToResponse([
                     'status' => 'error',
-                    'message' => \Html::resume_text($message, 250),
+                    'message' => $message,
                     'expiration' => self::DEFAULT_FREQUENCY
                 ]);
             } else {
-                $message = \Html::resume_text($message, 250);
-
                 $this->addToResponse([
                     'ERROR' => [
                         'content'    => $message,

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -6058,16 +6058,12 @@ final class SQLProvider implements SearchProviderInterface
                             $plaintext = '';
                             if (isset($so['htmltext']) && $so['htmltext']) {
                                 if ($html_output) {
-                                    $plaintext = RichText::getTextFromHtml($data[$ID][$k]['name'], false, true, $html_output);
+                                    $plaintext = RichText::getTextFromHtml($data[$ID][$k]['name'], false, true);
                                 } else {
-                                    $plaintext = RichText::getTextFromHtml($data[$ID][$k]['name'], true, true, $html_output);
+                                    $plaintext = RichText::getTextFromHtml($data[$ID][$k]['name'], true, true);
                                 }
                             } else {
-                                $plaintext = \htmlspecialchars($data[$ID][$k]['name']);
-                                if ($html_output) {
-                                    $plaintext = \htmlspecialchars($plaintext);
-                                }
-                                $plaintext = nl2br($plaintext);
+                                $plaintext = $data[$ID][$k]['name'];
                             }
 
                             if ($html_output && (\Toolbox::strlen($plaintext) > $CFG_GLPI['cut'])) {
@@ -6087,7 +6083,7 @@ final class SQLProvider implements SearchProviderInterface
                                     )
                                 );
                             } else {
-                                $out .= $plaintext;
+                                $out .= \htmlspecialchars($plaintext);
                             }
                         }
                     }

--- a/src/Html.php
+++ b/src/Html.php
@@ -201,7 +201,8 @@ class Html
     }
 
     /**
-     *  Resume text for followup
+     * Cut a text if longer than than the expected length.
+     * This method always encodes the HTML special chars of the provided text.
      *
      * @param string  $string  string to resume
      * @param integer $length  resume length (default 255)
@@ -210,11 +211,13 @@ class Html
      **/
     public static function resume_text($string, $length = 255)
     {
-        if (Toolbox::strlen($string) > $length) {
-            $string = Toolbox::substr($string, 0, $length) . "&nbsp;(...)";
+        $append = '';
+        if (mb_strlen($string, 'UTF-8') > $length) {
+            $string = mb_substr($string, 0, $length, 'UTF-8');
+            $append = '&nbsp;(...)';
         }
 
-        return $string;
+        return \htmlspecialchars($string) . $append;
     }
 
     /**

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -1583,8 +1583,8 @@ TWIG, $twig_params);
                     }
                     echo Search::showItem(
                         $output_type,
-                        "<div class='kb'>$toadd <i class='fa fa-fw $fa_class' title='$fa_title'></i> <a $href>" . Html::resume_text(htmlspecialchars($name, 80)) . "</a></div>
-                                       <div class='kb_resume'>" . Html::resume_text(htmlspecialchars(RichText::getTextFromHtml($answer, false, false, true), 600)) . "</div>",
+                        "<div class='kb'>$toadd <i class='fa fa-fw $fa_class' title='$fa_title'></i> <a $href>" . Html::resume_text($name, 80) . "</a></div>
+                                       <div class='kb_resume'>" . Html::resume_text(RichText::getTextFromHtml($answer, false, false), 600) . "</div>",
                         $item_num,
                         $row_num
                     );


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

`Html::resume_text()` purpose is to truncate a text to be displayed in an HTML page. I propose to always encode special chars contained in the text to make it easier to use.
