### PR TITLE
Fix escaping handling in `CommonDBTM::getLink/getName/getNameID()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,9 @@ The present file will list all changes made to the project; according to the
 - `Transfer::transferSupplierContacts()` method is now private.
 - `Transfer::transferTaskCategory()` method is now private.
 - `Transfer::transferTickets()` method is now private.
+- `linkoption` option has been removed from `CommonDBTM::getLink()`.
+- `comments` and `icon` options have been removed from `CommonDBTM::getName()`.
+- `comments` and `icon` options have been removed from `CommonDBTM::getNameID()`.
 
 #### Deprecated
 - Usage of `MAIL_SMTPSSL` and `MAIL_SMTPTLS` constants.

--- a/phpunit/functional/CommonDBTMTest.php
+++ b/phpunit/functional/CommonDBTMTest.php
@@ -1446,7 +1446,7 @@ class CommonDBTMTest extends DbTestCase
             'uuid' => '76873749-0813-482f-ac20-eb7102ed3367'
         ]));
 
-        $err_msg = "Impossible record for UUID = 76873749-0813-482f-ac20-eb7102ed3367<br>Other item exist<br>[<a  href='/glpi/front/computer.form.php?id=" . $computers_id1 . "'  title=\"testCheckUnicity01\">testCheckUnicity01</a> - ID: {$computers_id1} - Serial number:  - Entity: Root entity &gt; _test_root_entity]";
+        $err_msg = 'Impossible record for UUID = 76873749-0813-482f-ac20-eb7102ed3367<br>Other item exist<br>[<a href="/glpi/front/computer.form.php?id=' . $computers_id1 . '" title="testCheckUnicity01">testCheckUnicity01</a> - ID: ' . $computers_id1 . ' - Serial number:  - Entity: Root entity &gt; _test_root_entity]';
         $this->hasSessionMessages(1, [$err_msg]);
 
         $this->assertFalse($computer->add([

--- a/phpunit/functional/ComputerTest.php
+++ b/phpunit/functional/ComputerTest.php
@@ -890,12 +890,12 @@ class ComputerTest extends DbTestCase
         yield [
             "C1",
             "Test",
-            "Test: <a  href='/glpi/front/computer.form.php?id=CID'  title=\"Computer 1\">Computer 1</a>"
+            'Test: <a href="/glpi/front/computer.form.php?id=CID" title="Computer 1">Computer 1</a>'
         ];
         yield [
             "C2",
             "Test",
-            "Test: <a  href='/glpi/front/computer.form.php?id=CID'  title=\"Computer 2\">Computer 2</a>"
+            'Test: <a href="/glpi/front/computer.form.php?id=CID" title="Computer 2">Computer 2</a>'
         ];
 
         // Test message without link

--- a/phpunit/functional/Glpi/Form/FormTest.php
+++ b/phpunit/functional/Glpi/Form/FormTest.php
@@ -266,7 +266,7 @@ class FormTest extends DbTestCase
         $this->assertCount(1, $form->getComments());
 
         $id = $form->getID();
-        $this->hasSessionMessages(INFO, ["Item successfully updated: <a  href='/glpi/front/form/form.form.php?id=$id'  title=\"Form with first section\">Form with first section</a>"]);
+        $this->hasSessionMessages(INFO, ['Item successfully updated: <a href="/glpi/front/form/form.form.php?id=' . $id . '" title="Form with first section">Form with first section</a>']);
     }
 
     public function testGetSectionsOnEmptyForm(): void

--- a/src/Glpi/Features/DCBreadcrumb.php
+++ b/src/Glpi/Features/DCBreadcrumb.php
@@ -99,8 +99,8 @@ trait DCBreadcrumb
                 }
                 $position .= ' (' . $pdu_rack->fields['position'] . ')';
                 $options = [
-                    'linkoption' => $rack->isDeleted() ? 'class="target-deleted"' : '',
-                    'icon'       => true
+                    'class' => $rack->isDeleted() ? 'target-deleted' : '',
+                    'icon'  => true
                 ];
                 $breadcrumb[] = $rack->getLink($options) . '&nbsp;' . $position;
                 $item = $rack;
@@ -111,8 +111,8 @@ trait DCBreadcrumb
            //check if asset is part of an enclosure
             if ($enclosure = $this->isEnclosurePart($item->getType(), $item->getID(), true)) {
                 $options = [
-                    'linkoption' => $enclosure->isDeleted() ? 'class="target-deleted"' : '',
-                    'icon'       => true
+                    'class' => $enclosure->isDeleted() ? 'target-deleted' : '',
+                    'icon'  => true
                 ];
                 $position = sprintf(__('(U%d)'), (int)$item->getPositionInEnclosure());
                 $breadcrumb[] = $enclosure->getLink($options) . '&nbsp;' . $position;
@@ -124,8 +124,8 @@ trait DCBreadcrumb
            //check if asset (or its enclosure) is part of a rack
             if ($rack = $this->isRackPart($item->getType(), $item->getID(), true)) {
                 $options = [
-                    'linkoption' => $rack->isDeleted() ? 'class="target-deleted"' : '',
-                    'icon'       => true
+                    'class' => $rack->isDeleted() ? 'target-deleted' : '',
+                    'icon'  => true
                 ];
                 $position = sprintf(__('(U%d)'), (int)$item->getPositionInRack());
                 $breadcrumb[] = $rack->getLink($options) . '&nbsp;' . $position;
@@ -138,8 +138,8 @@ trait DCBreadcrumb
                 $dcroom = new DCRoom();
                 if ($dcroom->getFromDB($item->fields['dcrooms_id'])) {
                     $options = [
-                        'linkoption' => $dcroom->isDeleted() ? 'class="target-deleted"' : '',
-                        'icon'       => true
+                        'class' => $dcroom->isDeleted() ? 'target-deleted' : '',
+                        'icon'  => true
                     ];
                     $breadcrumb[] = $dcroom->getLink($options);
                     $item = $dcroom;
@@ -152,8 +152,8 @@ trait DCBreadcrumb
                 $datacenter = new Datacenter();
                 if ($datacenter->getFromDB($item->fields['datacenters_id'])) {
                     $options = [
-                        'linkoption' => $datacenter->isDeleted() ? 'class="target-deleted"' : '',
-                        'icon'       => true
+                        'class' => $datacenter->isDeleted() ? 'target-deleted' : '',
+                        'icon'  => true
                     ];
                     $breadcrumb[] = $datacenter->getLink($options);
                 }
@@ -281,8 +281,8 @@ trait DCBreadcrumb
                     $breadcrumb[Rack::getType()] = [
                         'link'     => $rack->getLink(
                             [
-                                'linkoption' => $rack->isDeleted() ? 'class="target-deleted"' : '',
-                                'icon'       => true
+                                'class' => $rack->isDeleted() ? 'target-deleted' : '',
+                                'icon'  => true
                             ]
                         ),
                         'position' => $pdu_rack->fields['position'],
@@ -301,8 +301,8 @@ trait DCBreadcrumb
                 $breadcrumb[Enclosure::getType()] = [
                     'link'     => $enclosure->getLink(
                         [
-                            'linkoption' => $enclosure->isDeleted() ? 'class="target-deleted"' : '',
-                            'icon'       => true
+                            'class' => $enclosure->isDeleted() ? 'target-deleted' : '',
+                            'icon'  => true
                         ]
                     ),
                     'position' => $item->getPositionInEnclosure(),
@@ -318,8 +318,8 @@ trait DCBreadcrumb
                 $breadcrumb[Rack::getType()] = [
                     'link'     => $rack->getLink(
                         [
-                            'linkoption' => $rack->isDeleted() ? 'class="target-deleted"' : '',
-                            'icon'       => true
+                            'class' => $rack->isDeleted() ? 'target-deleted' : '',
+                            'icon'  => true
                         ]
                     ),
                     'position' => $item->getPositionInRack(),
@@ -340,8 +340,8 @@ trait DCBreadcrumb
                 $breadcrumb[DCRoom::getType()] = [
                     'link'     => $dcroom->getLink(
                         [
-                            'linkoption' => $dcroom->isDeleted() ? 'class="target-deleted"' : '',
-                            'icon'       => true
+                            'class' => $dcroom->isDeleted() ? 'target-deleted' : '',
+                            'icon'  => true
                         ]
                     ),
                     'location' => $location !== null ? $location->fields : null,
@@ -361,8 +361,8 @@ trait DCBreadcrumb
                 $breadcrumb[Datacenter::getType()] = [
                     'link'     => $datacenter->getLink(
                         [
-                            'linkoption' => $datacenter->isDeleted() ? 'class="target-deleted"' : '',
-                            'icon'       => true
+                            'class' => $datacenter->isDeleted() ? 'target-deleted' : '',
+                            'icon'  => true
                         ]
                     ),
                     'location' => $location !== null ? $location->fields : null,

--- a/tests/functional/Glpi/ContentTemplates/Parameters/ChangeParameters.php
+++ b/tests/functional/Glpi/ContentTemplates/Parameters/ChangeParameters.php
@@ -66,7 +66,7 @@ class ChangeParameters extends AbstractParameters
         $this->array($values)->isEqualTo([
             'id'        => $changes_id,
             'ref'       => "#$changes_id",
-            'link'      => "<a  href='/glpi/front/change.form.php?id=$changes_id'  title=\"change_testGetValues\">change_testGetValues</a>",
+            'link'      => '<a href="/glpi/front/change.form.php?id=' . $changes_id . '" title="change_testGetValues">change_testGetValues</a>',
             'name'      => 'change_testGetValues',
             'content'   => '<p>change_testGetValues content</p>',
             'date'      => '2021-07-19 17:11:28',

--- a/tests/functional/Glpi/ContentTemplates/Parameters/KnowbaseItemParameters.php
+++ b/tests/functional/Glpi/ContentTemplates/Parameters/KnowbaseItemParameters.php
@@ -54,7 +54,7 @@ class KnowbaseItemParameters extends AbstractParameters
             'id'     => $kbi_id,
             'name'   => 'kbi_testGetValues',
             'answer' => "test answer' \"testGetValues",
-            'link'   => "<a  href='/glpi/front/knowbaseitem.form.php?id=$kbi_id'  title=\"kbi_testGetValues\">kbi_testGetValues</a>",
+            'link'   => '<a href="/glpi/front/knowbaseitem.form.php?id=' . $kbi_id . '" title="kbi_testGetValues">kbi_testGetValues</a>',
         ]);
 
         $this->testGetAvailableParameters($values, $parameters->getAvailableParameters());

--- a/tests/functional/Glpi/ContentTemplates/Parameters/ProblemParameters.php
+++ b/tests/functional/Glpi/ContentTemplates/Parameters/ProblemParameters.php
@@ -69,7 +69,7 @@ class ProblemParameters extends AbstractParameters
         $this->array($values)->isEqualTo([
             'id'        => $problems_id,
             'ref'       => "#$problems_id",
-            'link'      => "<a  href='/glpi/front/problem.form.php?id=$problems_id'  title=\"problem_testGetValues\">problem_testGetValues</a>",
+            'link'      => '<a href="/glpi/front/problem.form.php?id=' . $problems_id . '" title="problem_testGetValues">problem_testGetValues</a>',
             'name'      => 'problem_testGetValues',
             'content'   => '<p>problem_testGetValues content</p>',
             'date'      => '2021-07-19 17:11:28',

--- a/tests/functional/Glpi/ContentTemplates/Parameters/TicketParameters.php
+++ b/tests/functional/Glpi/ContentTemplates/Parameters/TicketParameters.php
@@ -116,8 +116,9 @@ class TicketParameters extends AbstractParameters
         ]);
         $tickets_id = $created_ticket->getID();
 
+        $kb_item_id = getItemByTypeName(\KnowbaseItem::class, '_knowbaseitem01', true);
         $this->createItem(\KnowbaseItem_Item::class, [
-            'knowbaseitems_id' => getItemByTypeName(\KnowbaseItem::class, '_knowbaseitem01', true),
+            'knowbaseitems_id' => $kb_item_id,
             'itemtype'         => 'Ticket',
             'items_id'         => $tickets_id,
         ]);
@@ -127,7 +128,7 @@ class TicketParameters extends AbstractParameters
         $this->array($values)->isEqualTo([
             'id'        => $tickets_id,
             'ref'       => "#$tickets_id",
-            'link'      => "<a  href='/glpi/front/ticket.form.php?id=$tickets_id'  title=\"ticket_testGetValues\">ticket_testGetValues</a>",
+            'link'      => '<a href="/glpi/front/ticket.form.php?id=' . $tickets_id . '" title="ticket_testGetValues">ticket_testGetValues</a>',
             'name'      => 'ticket_testGetValues',
             'content'   => '<p>ticket_testGetValues content</p>',
             'date'      => $now,
@@ -254,10 +255,10 @@ class TicketParameters extends AbstractParameters
             ],
             'knowbaseitems' => [
                 [
-                    'id' => getItemByTypeName(\KnowbaseItem::class, '_knowbaseitem01', true),
+                    'id' => $kb_item_id,
                     'name' => '_knowbaseitem01',
                     'answer' => "Answer for Knowledge base entry _knowbaseitem01 apple juice turnover",
-                    'link' => "<a  href='/glpi/front/knowbaseitem.form.php?id=1'  title=\"_knowbaseitem01\">_knowbaseitem01</a>"
+                    'link' => '<a href="/glpi/front/knowbaseitem.form.php?id=' . $kb_item_id . '" title="_knowbaseitem01">_knowbaseitem01</a>'
                 ]
             ],
             'assets'        => [],


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

1. Ensure that HTML special chars are correctly escaped in `CommonDBTM::getLink()` result.
2. Ensure that `CommonDBTM::getName()`/`CommonDBTM::getNameID()` result never contains HTML. It can be used outside of web view context and it is the responsibility of the caller to escape it.