### PR TITLE
Fix escaping handling in `formatUserName()` and `getUserName()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,8 @@ The present file will list all changes made to the project; according to the
 - `js/Forms/FaIconSelector.js` and therefore `window.GLPI.Forms.FaIconSelector` has been deprecated and replaced by `js/modules/Form/WebIconSelector.js`
 - `linkuser_types`, `linkgroup_types`, `linkuser_tech_types`, `linkgroup_tech_types` configuration entries have been merged in a unique `assignable_types` configuration entry.
 - Usage of the `front/dropdown.common.php` and the `dropdown.common.form.php` files. There is now a generic controller that will serve the search and form pages of any `Dropdown` class.
+- Usage of the `$link` parameter in `formatUserName()` and `DbUtils::formatUserName()`. Use `formatUserLink()` or `DbUtils::formatUserLink()` instead.
+- Usage of the `$link` parameter in `getUserName()` and `DbUtils::getUserName()`. Use `getUserLink()`, `DbUtils::getUserLink()`, or `User::getInfoCard()` instead.
 - `Auth::getErr()`
 - `AuthLDAP::dropdownUserDeletedActions()`
 - `AuthLDAP::getOptions()`
@@ -311,6 +313,7 @@ The present file will list all changes made to the project; according to the
 - `CommonGLPI::showDislayOptions()`
 - `CommonITILActor::showUserNotificationForm()`
 - `CommonITILActor::showSupplierNotificationForm()`
+- `CommonITILObject::getAssignName()`
 - `CommonITILValidation::alreadyExists()`
 - `CommonITILValidation::getTicketStatusNumber()`
 - `CommonTreeDropdown::sanitizeSeparatorInCompletename()`
@@ -496,6 +499,7 @@ The present file will list all changes made to the project; according to the
 - `ajax/planningcheck.php` script. Use `Planning::showPlanningCheck()` instead.
 - `test_ldap` and `test_ldap_replicate` actions in `front/authldap.form.php`. Use `ajax/ldap.php` instead.
 - `ajax/ticketsatisfaction.php` and `ajax/changesatisfaction.php` scripts. Access `ajax/commonitilsatisfaction.php` directly instead.
+- Usage of the `$cut` parameter in `formatUserName()` and `DbUtils::formatUserName()`.
 
 
 ## [10.0.17] unreleased

--- a/ajax/comments.php
+++ b/ajax/comments.php
@@ -60,36 +60,32 @@ if (
 
     switch ($_POST["itemtype"]) {
         case User::getType():
+            $link = null;
+            $comments = [];
             if ($_POST['value'] == 0) {
-                $tmpname = [
-                    'link'    => $CFG_GLPI['root_doc'] . "/front/user.php",
-                    'comment' => "",
-                ];
+                $link = $CFG_GLPI['root_doc'] . "/front/user.php";
             } else {
                 $user = new \User();
                 if (is_array($_POST["value"])) {
-                    $comments = [];
                     foreach ($_POST["value"] as $users_id) {
                         if ($user->getFromDB($users_id) && $user->canView()) {
-                            $username   = getUserName($users_id, 2);
-                            $comments[] = $username['comment'] ?? "";
+                            $comments[] = $user->getInfoCard();
                         }
                     }
-                    $tmpname = [
-                        'comment' => implode("<br>", $comments),
-                    ];
                     unset($_POST['withlink']);
                 } else {
                     if ($user->getFromDB($_POST['value']) && $user->canView()) {
-                        $tmpname = getUserName($_POST["value"], 2);
+                        $link = $user->getLinkURL();
+                        $comments[] = $user->getInfoCard();
                     }
                 }
             }
-            echo($tmpname["comment"] ?? '');
 
-            if (isset($_POST['withlink']) && isset($tmpname['link'])) {
+            echo(implode("<br>", $comments));
+
+            if (isset($_POST['withlink']) && $link !== null) {
                 echo "<script type='text/javascript' >\n";
-                echo Html::jsGetElementbyID($_POST['withlink']) . ".attr('href', '" . $tmpname['link'] . "');";
+                echo Html::jsGetElementbyID($_POST['withlink']) . ".attr('href', '" . htmlspecialchars($link) . "');";
                 echo "</script>\n";
             }
             break;

--- a/front/stat.graph.php
+++ b/front/stat.graph.php
@@ -88,12 +88,10 @@ switch ($_GET["type"]) {
         $val1    = $_GET["id"];
         $val2    = "";
         $values  = Stat::getItems($_GET["itemtype"], $_GET["date1"], $_GET["date2"], $_GET["type"]);
-        $link    = User::canView() ? 1 : 0;
-        $name    = $item->getAssignName($_GET["id"], 'User', $link);
         $title   = sprintf(
             __s('%1$s: %2$s'),
             __s('Technician'),
-            $link ? $name : htmlspecialchars($name)
+            getUserLink($_GET["id"])
         );
         break;
 
@@ -101,12 +99,11 @@ switch ($_GET["type"]) {
         $val1    = $_GET["id"];
         $val2    = "";
         $values  = Stat::getItems($_GET["itemtype"], $_GET["date1"], $_GET["date2"], $_GET["type"]);
-        $link    = Supplier::canView() ? 1 : 0;
-        $name    = $item->getAssignName($_GET["id"], 'Supplier', $link);
+        $supplier = Supplier::getById($_GET["id"]);
         $title   = sprintf(
             __s('%1$s: %2$s'),
             Supplier::getTypeName(1),
-            $link ? $name : htmlspecialchars($name)
+            $supplier !== false ? $supplier->getLink(['comments' => true]) : ''
         );
         break;
 
@@ -115,12 +112,10 @@ switch ($_GET["type"]) {
         $val1    = $_GET["id"];
         $val2    = "";
         $values  = Stat::getItems($_GET["itemtype"], $_GET["date1"], $_GET["date2"], $_GET["type"]);
-        $link    = User::canView() ? 1 : 0;
-        $name    = getUserName($_GET["id"], $link);
         $title   = sprintf(
             __s('%1$s: %2$s'),
             User::getTypeName(1),
-            $link ? $name : htmlspecialchars($name)
+            getUserLink($_GET["id"])
         );
         break;
 

--- a/src/Change.php
+++ b/src/Change.php
@@ -1224,9 +1224,8 @@ class Change extends CommonITILObject
                         ) {
                             foreach ($change->users[CommonITILActor::REQUESTER] as $d) {
                                 if ($d["users_id"] > 0) {
-                                    $userdata = getUserName($d["users_id"], 2);
                                     $name = '<i class="fas fa-sm fa-fw fa-user text-muted me-1"></i>' .
-                                        $userdata['name'];
+                                        htmlspecialchars(getUserName($d["users_id"]));
                                     $requesters[] = $name;
                                 } else {
                                     $requesters[] = '<i class="fas fa-sm fa-fw fa-envelope text-muted me-1"></i>' .
@@ -1451,16 +1450,17 @@ class Change extends CommonITILObject
                 && count($change->users[CommonITILActor::REQUESTER])
             ) {
                 foreach ($change->users[CommonITILActor::REQUESTER] as $d) {
-                    if ($d["users_id"] > 0) {
-                         $userdata = getUserName($d["users_id"], 2);
-                         $name     = "<span class='b'>" . $userdata['name'] . "</span>";
+                    $user = new User();
+                    if ($d["users_id"] > 0 && $user->getFromDB($d["users_id"])) {
+                        $name     = "<span class='b'>" . htmlspecialchars($user->getName()) . "</span>";
                         if ($viewusers) {
                             $name = sprintf(
-                                __('%1$s %2$s'),
+                                __s('%1$s %2$s'),
                                 $name,
                                 Html::showToolTip(
-                                    $userdata["comment"],
-                                    ['link'    => $userdata["link"],
+                                    $user->getInfoCard(),
+                                    [
+                                        'link'    => $user->getLinkURL(),
                                         'display' => false
                                     ]
                                 )

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -4911,11 +4911,14 @@ class CommonDBTM extends CommonGLPI
                             return $searchoptions['emptylabel'];
                         }
 
+                        $user = new User();
                         if ($searchoptions['table'] == 'glpi_users') {
+                            if (!$user->getFromDB($value)) {
+                                return '';
+                            }
                             if ($param['comments']) {
-                                $tmp = getUserName($value, 2);
-                                return $tmp['name'] . '&nbsp;' . Html::showToolTip(
-                                    $tmp['comment'],
+                                return $user->getLink() . '&nbsp;' . Html::showToolTip(
+                                    $user->getInfoCard(),
                                     ['display' => false]
                                 );
                             }

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -1684,20 +1684,32 @@ final class DbUtils
 
 
     /**
-     * Format a user name
+     * Format a user name.
      *
-     * @param integer $ID           ID of the user.
-     * @param string|null  $login        login of the user
-     * @param string|null  $realname     realname of the user
-     * @param string|null  $firstname    firstname of the user
-     * @param integer $link         include link (only if $link==1) (default =0)
-     * @param integer $cut          limit string length (0 = no limit) (default =0)
-     * @param boolean $force_config force order and id_visible to use common config (false by default)
+     * @param integer       $ID           ID of the user.
+     * @param string|null   $login        login of the user
+     * @param string|null   $realname     realname of the user
+     * @param string|null   $firstname    firstname of the user
+     * @param integer       $link         include link
+     * @param integer       $cut          IGNORED PARAMETER
+     * @param boolean       $force_config force order and id_visible to use common config
      *
-     * @return string formatted username
+     * @return string
+     *
+     * @since 11.0 `$link` parameter is deprecated
+     * @since 11.0 `$cut` parameter is ignored
      */
-    public function formatUserName($ID, $login, $realname, $firstname, $link = 1, $cut = 0, $force_config = false)
+    public function formatUserName($ID, $login, $realname, $firstname, $link = 0, $cut = 0, $force_config = false)
     {
+        if ((bool) $cut) {
+            trigger_error('`$cut` parameter is now ignored.', E_USER_WARNING);
+        }
+
+        if ((bool) $link) {
+            Toolbox::deprecated('`$link` parameter is deprecated. Use `formatUserLink()` instead.');
+            return $this->formatUserLink($ID, $login, $realname, $firstname);
+        }
+
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
@@ -1739,21 +1751,33 @@ final class DbUtils
             $formatted = sprintf(__('%1$s (%2$s)'), $formatted, $ID);
         }
 
-        $username = $formatted;
+        return $formatted;
+    }
 
-        if (
-            ($link == 1)
-            && ($ID > 0)
-        ) {
-            $username = sprintf(
-                '<a title="%s" href="%s">%s</a>',
-                htmlspecialchars($formatted),
-                User::getFormURLWithID($ID),
-                htmlspecialchars($formatted)
-            );
+    /**
+     * Format a user link.
+     *
+     * @param integer       $id           ID of the user.
+     * @param string|null   $login        login of the user
+     * @param string|null   $realname     realname of the user
+     * @param string|null   $firstname    firstname of the user
+     *
+     * @return string
+     */
+    public function formatUserLink(int $id, ?string $login, ?string $realname, ?string $firstname): string
+    {
+        $username = $this->formatUserName($id, $login, $realname, $firstname);
+
+        if ($id <= 0 || !User::canView()) {
+            return htmlspecialchars($username);
         }
 
-        return $username;
+        return sprintf(
+            '<a title="%s" href="%s">%s</a>',
+            htmlspecialchars($username),
+            User::getFormURLWithID($id),
+            htmlspecialchars($username)
+        );
     }
 
 
@@ -1766,102 +1790,73 @@ final class DbUtils
      * @param $disable_anon   bool  disable anonymization of username.
      *
      * @return string[]|string username string (realname if not empty and name if realname is empty).
+     *
+     * @since 11.0 `$link` parameter is deprecated.
      */
     public function getUserName($ID, $link = 0, $disable_anon = false)
     {
         /** @var \DBmysql $DB */
         global $DB;
 
-        $user = "";
+        $username   = "";
+        $user       = new User();
+        $valid_user = false;
+        $anon_name  = null;
+
+        if ($ID === 'myself') {
+            $username = __('Myself');
+        } else if ($ID === 'requester_manager') {
+            $username = __("Requester's manager");
+        } else if ($ID) {
+            $anon_name = !$disable_anon && $ID != ($_SESSION['glpiID'] ?? 0) && Session::getCurrentInterface() == 'helpdesk' ? User::getAnonymizedNameForUser($ID) : null;
+            if ($anon_name !== null) {
+                $username = $anon_name;
+            } elseif ($valid_user = $user->getFromDB($ID)) {
+                $username = $user->getName();
+            }
+        }
+
+        if ($link == 1) {
+            Toolbox::deprecated('Usage of `$link` parameter is deprecated. Use `getUserLink()` instead.');
+            return $valid_user
+                ? sprintf('<a title="%s" href="%s">%s</a>', htmlspecialchars($username), User::getFormURLWithID($ID), htmlspecialchars($username))
+                : htmlspecialchars($username);
+        }
+
         if ($link == 2) {
-            $user = ["name"    => "",
-                "link"    => "",
-                "comment" => ""
+            Toolbox::deprecated('Usage of `$link` parameter is deprecated. Use `User::getInforCard()` instead.');
+
+            return [
+                'name'    => $username,
+                'link'    => $valid_user ? $user->getLinkUrl() : '',
+                'comment' => $valid_user ? $user->getInfoCard() : '',
             ];
         }
 
-        if ($ID === 'myself') {
-            $name = __('Myself');
-            if (isset($user['name'])) {
-                $user['name'] = $name;
-            } else {
-                $user = $name;
-            }
-        } else if ($ID === 'requester_manager') {
-            $name = __("Requester's manager");
-            if (isset($user['name'])) {
-                $user['name'] = $name;
-            } else {
-                $user = $name;
-            }
-        } else if ($ID) {
-            $iterator = $DB->request([
-                'FROM' => 'glpi_users',
-                'WHERE' => ['id' => $ID]
-            ]);
+        return $username;
+    }
 
-            if ($link == 2) {
-                $user = ["name"    => "",
-                    "comment" => "",
-                    "link"    => ""
-                ];
-            }
+    /**
+     * Get link of the given user.
+     *
+     * @param int $id
+     *
+     * @return string
+     */
+    public function getUserLink(int $id): string
+    {
+        $username = $this->getUserName($id);
 
-            if (count($iterator) == 1) {
-                $data     = $iterator->current();
-
-                $anon_name = !$disable_anon && $ID != ($_SESSION['glpiID'] ?? 0) && Session::getCurrentInterface() == 'helpdesk' ? User::getAnonymizedNameForUser($ID) : null;
-                if ($anon_name !== null) {
-                    $username = $anon_name;
-                } else {
-                    $username = $this->formatUserName(
-                        $data["id"],
-                        $data["name"],
-                        $data["realname"],
-                        $data["firstname"],
-                        $link
-                    );
-                }
-
-                if ($link == 2) {
-                    $user["name"]    = $username;
-                    $user["link"]    = User::getFormURLWithID($ID);
-                    $user['comment'] = '';
-
-                    $user_params = [
-                        'id'                 => $ID,
-                        'user_name'          => $username,
-                    ];
-
-                    if ($anon_name === null) {
-                        $user_params = array_merge($user_params, [
-                            'email'               => UserEmail::getDefaultForUser($ID),
-                            'phone'               => $data["phone"],
-                            'phone2'              => $data["phone2"],
-                            'mobile'              => $data["mobile"],
-                            'locations_id'        => $data['locations_id'],
-                            'usertitles_id'       => $data['usertitles_id'],
-                            'usercategories_id'   => $data['usercategories_id'],
-                            'registration_number' => $data['registration_number'],
-                        ]);
-
-                        if (Session::haveRight('user', READ)) {
-                             $user_params['login'] = $data['name'];
-                        }
-                        if (!empty($data["groups_id"])) {
-                            $user_params['groups_id'] = $data["groups_id"];
-                        }
-                        $user['comment'] = TemplateRenderer::getInstance()->render('components/user/info_card.html.twig', [
-                            'user'                 => $user_params,
-                            'enable_anonymization' => Session::getCurrentInterface() == 'helpdesk',
-                        ]);
-                    }
-                } else {
-                    $user = $username;
-                }
-            }
+        if (!is_int($id) || $id <= 0 || !User::canView()) {
+            return htmlspecialchars($username);
         }
-        return $user;
+
+        return sprintf(
+            '<a title="%s" href="%s">%s</a>',
+            htmlspecialchars($username),
+            User::getFormURLWithID($id),
+            htmlspecialchars($username)
+        );
     }
 
     /**

--- a/src/Document.php
+++ b/src/Document.php
@@ -364,14 +364,10 @@ class Document extends CommonDBTM
         if ($ID > 0) {
             $this->check($ID, READ);
         }
-        $showuserlink = 0;
-        if (Session::haveRight('user', READ)) {
-            $showuserlink = 1;
-        }
 
         TemplateRenderer::getInstance()->display('pages/management/document.html.twig', [
             'item'  => $this,
-            'uploader' => $this->fields['users_id'] > 0 ? getUserName($this->fields["users_id"], $showuserlink) : '',
+            'uploader' => $this->fields['users_id'] > 0 ? getUserLink($this->fields["users_id"]) : '',
             'uploaded_files' => self::getUploadedFiles(),
             'params' => [
                 'canedit' => $this->canUpdateItem(),

--- a/src/Glpi/Features/PlanningEvent.php
+++ b/src/Glpi/Features/PlanningEvent.php
@@ -1101,11 +1101,7 @@ trait PlanningEvent
                     return '';
                 }
                 foreach (json_decode($values[$field], true) as $user_id) {
-                    $users[] = sprintf(
-                        '<a href="%s">%s</a>',
-                        User::getFormURLWithID($user_id),
-                        getUserName($user_id, 1)
-                    );
+                    $users[] = getUserLink($user_id);
                 }
                 return implode(', ', $users);
         }

--- a/src/Item_SoftwareLicense.php
+++ b/src/Item_SoftwareLicense.php
@@ -787,7 +787,6 @@ JAVASCRIPT;
             $soft       = new Software();
             $soft->getFromDB($license->fields['softwares_id']);
             $showEntity = ($license->isRecursive());
-            $linkUser   = User::canView();
 
             $text = sprintf(__('%1$s = %2$s'), Software::getTypeName(1), $soft->fields["name"]);
             $text = sprintf(__('%1$s - %2$s'), $text, $data["license"]);
@@ -863,12 +862,11 @@ JAVASCRIPT;
                 echo "<td>" . $data['location'] . "</td>";
                 echo "<td>" . $data['state'] . "</td>";
                 echo "<td>" . $data['groupe'] . "</td>";
-                echo "<td>" . formatUserName(
+                echo "<td>" . formatUserLink(
                     $data['userid'],
                     $data['username'],
                     $data['userrealname'],
                     $data['userfirstname'],
-                    $linkUser
                 ) . "</td>";
                 echo "</tr>\n";
 

--- a/src/Item_SoftwareVersion.php
+++ b/src/Item_SoftwareVersion.php
@@ -650,7 +650,6 @@ class Item_SoftwareVersion extends CommonDBRelation
             $softwares_id  = $data['sID'];
             $soft          = new Software();
             $showEntity    = ($soft->getFromDB($softwares_id) && $soft->isRecursive());
-            $linkUser      = User::canView();
             $title         = $soft->fields["name"];
 
             if ($crit === "id") {
@@ -763,12 +762,11 @@ class Item_SoftwareVersion extends CommonDBRelation
                 echo "<td>" . $data['location'] . "</td>";
                 echo "<td>" . $data['state'] . "</td>";
                 echo "<td>" . $data['groupe'] . "</td>";
-                echo "<td>" . formatUserName(
+                echo "<td>" . formatUserLink(
                     $data['userid'],
                     $data['username'],
                     $data['userrealname'],
                     $data['userfirstname'],
-                    $linkUser
                 ) . "</td>";
 
                 $lics = Item_SoftwareLicense::getLicenseForInstallation(

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -954,10 +954,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
 
         $writer_link = '';
         if ($this->fields["users_id"]) {
-            $writer_link = getUserName(
-                $this->fields["users_id"],
-                $linkusers_id ? 1 : 0 // Integer because true may be 2 and getUserName return array
-            );
+            $writer_link = getUserLink($this->fields["users_id"]);
         }
 
         $out = TemplateRenderer::getInstance()->render('pages/tools/kb/article.html.twig', [
@@ -1607,14 +1604,10 @@ TWIG, $twig_params);
                     echo Search::showItem($output_type, htmlspecialchars(RichText::getTextFromHtml($answer, true, false, true)), $item_num, $row_num);
                 }
 
-                $showuserlink = 0;
-                if (Session::haveRight('user', READ)) {
-                    $showuserlink = 1;
-                }
                 if ($showwriter) {
                     echo Search::showItem(
                         $output_type,
-                        getUserName($data["users_id"], $showuserlink),
+                        getUserLink($data["users_id"]),
                         $item_num,
                         $row_num
                     );

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -607,9 +607,7 @@ class NotificationTarget extends CommonDBChild
                     $user->getField('name'),
                     $user->getField('realname'),
                     $user->getField('firstname'),
-                    0,
-                    0,
-                    true
+                    force_config: true
                 );
             }
            // It is a GLPI user :

--- a/src/ObjectLock.php
+++ b/src/ObjectLock.php
@@ -112,11 +112,18 @@ class ObjectLock extends CommonDBTM
         $ret = false;
         $new_lock = false;
         $showAskUnlock = false;
-        $user_data = [];
+        $user_data = [
+            'name' => null,
+            'comment' => null,
+        ];
         $autolock = $this->isAutolockReadonlyMode();
 
-        if (isset($this->fields['users_id']) && $this->fields['users_id'] > 0) {
-            $user_data = getUserName($this->fields['users_id'], 2);
+        $user = new User();
+        if (isset($this->fields['users_id']) && $this->fields['users_id'] > 0 && $user->getFromDB($this->fields['users_id'])) {
+            $user_data = [
+                'name' => $user->getName(),
+                'comment' => $user->getInfoCard(),
+            ];
             // should get locking user info
             $useremail = new UserEmail();
             $showAskUnlock = $useremail->getFromDBByCrit([

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -1030,9 +1030,8 @@ class Problem extends CommonITILObject
                         ) {
                             foreach ($problem->users[CommonITILActor::REQUESTER] as $d) {
                                 if ($d["users_id"] > 0) {
-                                    $userdata = getUserName($d["users_id"], 2);
                                     $name = '<i class="fas fa-sm fa-fw fa-user text-muted me-1"></i>' .
-                                        $userdata['name'];
+                                        htmlspecialchars(getUserName($d["users_id"]));
                                     $requesters[] = $name;
                                 } else {
                                     $requesters[] = '<i class="fas fa-sm fa-fw fa-envelope text-muted me-1"></i>' .
@@ -1258,16 +1257,17 @@ class Problem extends CommonITILObject
                 && count($problem->users[CommonITILActor::REQUESTER])
             ) {
                 foreach ($problem->users[CommonITILActor::REQUESTER] as $d) {
-                    if ($d["users_id"] > 0) {
-                         $userdata = getUserName($d["users_id"], 2);
-                         $name     = "<span class='b'>" . $userdata['name'] . "</span>";
+                    $user = new User();
+                    if ($d["users_id"] > 0 && $user->getFromDB($d["users_id"])) {
+                        $name = "<span class='b'>" . htmlspecialchars($user->getName()) . "</span>";
                         if ($viewusers) {
                             $name = sprintf(
                                 __('%1$s %2$s'),
                                 $name,
                                 Html::showToolTip(
-                                    $userdata["comment"],
-                                    ['link'    => $userdata["link"],
+                                    $user->getInfoCard(),
+                                    [
+                                        'link'    => $user->getLinkURL(),
                                         'display' => false
                                     ]
                                 )

--- a/src/Profile_User.php
+++ b/src/Profile_User.php
@@ -350,12 +350,11 @@ class Profile_User extends CommonDBRelation
 
         $entries = [];
         foreach ($iterator as $data) {
-            $username = formatUserName(
+            $username = formatUserLink(
                 $data["id"],
                 $data["name"],
                 $data["realname"],
                 $data["firstname"],
-                1
             );
             if ($data["is_dynamic"] || $data["is_recursive"]) {
                 $username = sprintf(__('%1$s %2$s'), $username, "<span class='b'>(");
@@ -537,12 +536,11 @@ TWIG, $avatar_params) . $username;
             if (!isset($entity_names[$data['entity']])) {
                 $entity_names[$data['entity']] = Dropdown::getDropdownName('glpi_entities', $data['entity']);
             }
-            $username = formatUserName(
+            $username = formatUserLink(
                 $data["id"],
                 $data["name"],
                 $data["realname"],
                 $data["firstname"],
-                1
             );
             if ($data["is_dynamic"] || $data["is_recursive"]) {
                 $username = sprintf(__('%1$s %2$s'), $username, "<span class='b'>(");

--- a/src/Project.php
+++ b/src/Project.php
@@ -1288,14 +1288,15 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
            // Fourth Column
             $fourth_col = "";
 
-            if ($item->fields["users_id"]) {
-                $userdata    = getUserName($item->fields["users_id"], 2);
+            $user = new User();
+            if ($item->fields["users_id"] && $user->getFromDB($item->fields["users_id"])) {
                 $fourth_col .= sprintf(
                     __('%1$s %2$s'),
-                    "<span class='b'>" . $userdata['name'] . "</span>",
+                    "<span class='b'>" . htmlspecialchars($user->getName()) . "</span>",
                     Html::showToolTip(
-                        $userdata["comment"],
-                        ['link'    => $userdata["link"],
+                        $user->getInfoCard(),
+                        [
+                            'link'    => $user->getLinkURL(),
                             'display' => false
                         ]
                     )

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4677,9 +4677,8 @@ JAVASCRIPT;
                         ) {
                             foreach ($job->users[CommonITILActor::REQUESTER] as $d) {
                                 if ($d["users_id"] > 0) {
-                                    $userdata = getUserName($d["users_id"], 2);
                                     $name = '<i class="fas fa-sm fa-fw fa-user text-muted me-1"></i>' .
-                                        $userdata['name'];
+                                        htmlspecialchars(getUserName($d["users_id"]));
                                     $requesters[] = $name;
                                 } else {
                                     $requesters[] = '<i class="fas fa-sm fa-fw fa-envelope text-muted me-1"></i>' .
@@ -5082,15 +5081,16 @@ JAVASCRIPT;
                 && count($job->users[CommonITILActor::REQUESTER])
             ) {
                 foreach ($job->users[CommonITILActor::REQUESTER] as $d) {
-                    if ($d["users_id"] > 0) {
-                        $userdata = getUserName($d["users_id"], 2);
-                        $name     = "<span class='b'>" . $userdata['name'] . "</span>";
+                    $user = new User();
+                    if ($d["users_id"] > 0 && $user->getFromDB($d["users_id"])) {
+                        $name     = "<span class='b'>" . htmlspecialchars($user->getName()) . "</span>";
                         $name     = sprintf(
                             __('%1$s %2$s'),
                             $name,
                             Html::showToolTip(
-                                $userdata["comment"],
-                                ['link'    => $userdata["link"],
+                                $user->getInfoCard(),
+                                [
+                                    'link'    => $user->getLinkURL(),
                                     'display' => false
                                 ]
                             )

--- a/src/autoload/dbutils-aliases.php
+++ b/src/autoload/dbutils-aliases.php
@@ -404,24 +404,52 @@ function contructListFromTree($tree, $parent = 0)
 }
 
 
-
 /**
- * Format a user name
+ * Format a user name.
  *
- *@param $ID            integer  ID of the user.
- *@param $login         string   login of the user
- *@param $realname      string   realname of the user
- *@param $firstname     string   firstname of the user
- *@param $link          integer  include link (only if $link==1) (default =0)
- *@param $cut           integer  limit string length (0 = no limit) (default =0)
- *@param $force_config   boolean force order and id_visible to use common config (false by default)
+ * @param integer       $ID           ID of the user.
+ * @param string|null   $login        login of the user
+ * @param string|null   $realname     realname of the user
+ * @param string|null   $firstname    firstname of the user
+ * @param integer       $link         include link
+ * @param integer       $cut          IGNORED PARAMETER
+ * @param boolean       $force_config force order and id_visible to use common config
  *
- *@return string : formatted username
- **/
+ * @return string
+ *
+ * @since 11.0 `$link` parameter is deprecated
+ * @since 11.0 `$cut` parameter is ignored
+ */
 function formatUserName($ID, $login, $realname, $firstname, $link = 0, $cut = 0, $force_config = false)
 {
     $dbu = new DbUtils();
-    return $dbu->formatUserName($ID, $login, $realname, $firstname, $link, $cut, $force_config);
+
+    if ((bool) $cut) {
+        trigger_error('`$cut` parameter is now ignored.', E_USER_WARNING);
+    }
+
+    if ((bool) $link) {
+        Toolbox::deprecated('`$link` parameter is deprecated. Use `formatUserLink()` instead.');
+        return $dbu->formatUserLink($ID, $login, $realname, $firstname);
+    }
+
+    return $dbu->formatUserName($ID, $login, $realname, $firstname, 0, 0, $force_config);
+}
+
+/**
+ * Format a user link.
+ *
+ * @param integer       $id           ID of the user.
+ * @param string|null   $login        login of the user
+ * @param string|null   $realname     realname of the user
+ * @param string|null   $firstname    firstname of the user
+ *
+ * @return string
+ */
+function formatUserLink(int $id, ?string $login, ?string $realname, ?string $firstname)
+{
+    $dbu = new DbUtils();
+    return $dbu->formatUserLink($id, $login, $realname, $firstname);
 }
 
 
@@ -434,11 +462,29 @@ function formatUserName($ID, $login, $realname, $firstname, $link = 0, $cut = 0,
  *@param $disable_anon   bool  disable anonymization of username.
  *
  *@return string[]|string : username string (realname if not empty and name if realname is empty).
+ *
+ * @since 11.0 `$link` parameter is deprecated.
  **/
 function getUserName($ID, $link = 0, $disable_anon = false)
 {
+    if ($link != 0) {
+        Toolbox::deprecated('Usage of `$link` parameter is deprecated. See `DbUtils::getUserName()`.');
+    }
     $dbu = new DbUtils();
     return $dbu->getUserName($ID, $link, $disable_anon);
+}
+
+/**
+ * Get link of the given user.
+ *
+ * @param int $id
+ *
+ * @return string
+ */
+function getUserLink(int $id): string
+{
+    $dbu = new DbUtils();
+    return $dbu->getUserLink($id);
 }
 
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Still a draft, tests may fail.

1. I splitted the `getUserName()` and `formatUserName()` methods to have one that retunrs a raw username (`getUserName()`/`formatUserName()`) and one that returns a HTML link (`getUserLink()`/`formatUserLink()`).
2. `getUserName()` had a `$link=2` parameter value that completely changed its behaviour to return the user inforcard + the user link + the link URL. I moved this info card generation into a `User::getInfoCard()` method.