### PR TITLE
Fix entity selector "Full structure" label not being displayed

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -490,19 +490,7 @@ class Session
                 $active
             );
             $_SESSION["glpiactive_entity_shortname"] = getTreeLeafValueName("glpi_entities", $active);
-            if ($is_recursive) {
-                //TRANS: %s is the entity name
-                $_SESSION["glpiactive_entity_name"]      = sprintf(
-                    __('%1$s (%2$s)'),
-                    $_SESSION["glpiactive_entity_name"],
-                    __('tree structure')
-                );
-                 $_SESSION["glpiactive_entity_shortname"] = sprintf(
-                     __('%1$s (%2$s)'),
-                     $_SESSION["glpiactive_entity_shortname"],
-                     __('tree structure')
-                 );
-            } elseif ($ID == "all") {
+            if ($ID == "all") {
                 //TRANS: %s is the entity name
                 $_SESSION["glpiactive_entity_name"]      = sprintf(
                     __('%1$s (%2$s)'),
@@ -514,6 +502,18 @@ class Session
                     $_SESSION["glpiactive_entity_shortname"],
                     __('full structure')
                 );
+            } elseif ($is_recursive) {
+                //TRANS: %s is the entity name
+                $_SESSION["glpiactive_entity_name"]      = sprintf(
+                    __('%1$s (%2$s)'),
+                    $_SESSION["glpiactive_entity_name"],
+                    __('tree structure')
+                );
+                 $_SESSION["glpiactive_entity_shortname"] = sprintf(
+                     __('%1$s (%2$s)'),
+                     $_SESSION["glpiactive_entity_shortname"],
+                     __('tree structure')
+                 );
             }
 
             if (countElementsInTable('glpi_entities') <= count($_SESSION['glpiactiveentities'])) {

--- a/tests/functional/Session.php
+++ b/tests/functional/Session.php
@@ -853,4 +853,11 @@ class Session extends \DbTestCase
 
         $this->boolean(\Session::shouldReloadActiveEntities())->isFalse();
     }
+
+    public function testActiveEntityNameForFullStructure(): void {
+        $this->login();
+        \Session::changeActiveEntities("all");
+        $this->string($_SESSION["glpiactive_entity_name"])->isEqualTo("Root entity (full structure)");
+        $this->string($_SESSION["glpiactive_entity_shortname"])->isEqualTo("Root entity (full structure)");
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Fix a label issue introduced by #17819.

After #17819, `is_recursive` is always true when asking for all entities.
This mean we need to invert the order of some existing condition to make sure that the "full structure" label is applied.


