### PR TITLE
Fix(Core): prevent warning about 'legitimate' utf8mb4_bin

### DIFF
--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -56,9 +56,6 @@ class DBmysql
         '>'  => '&gt;',
     ];
 
-    private const MARIADB = "mariadb";
-    private const MYSQL = "mysql";
-
     //! Database Host - string or Array of string (round robin)
     public $dbhost             = "";
     //! Database User
@@ -219,13 +216,6 @@ class DBmysql
     private $last_query_warnings = [];
 
     /**
-     * DBMS type
-     *
-     * @var array
-     */
-    private $dbms_type = null;
-
-    /**
      * Constructor / Connect to the MySQL Database
      *
      * @param integer $choice host number (default NULL)
@@ -237,22 +227,6 @@ class DBmysql
         $this->connect($choice);
     }
 
-    /**
-     * Sets the DBMS type based on the server information.
-     *
-     * @return void
-     */
-    public function setDbms()
-    {
-        if (is_null($this->dbms_type)) {
-            $server_info = $this->dbh->server_info;
-            if (strpos($server_info, 'MariaDB') !== false) {
-                $this->dbms_type = self::MARIADB;
-            } elseif (strpos($server_info, 'MySQL') !== false) {
-                $this->dbms_type = self::MYSQL;
-            }
-        }
-    }
     /**
      * Connect using current database settings
      * Use dbhost, dbuser, dbpassword and dbdefault
@@ -320,8 +294,6 @@ class DBmysql
             $this->connected = true;
 
             $this->setTimezone($this->guessTimezone());
-
-            $this->setDbms();
         }
     }
 
@@ -789,15 +761,9 @@ class DBmysql
                 'information_schema.tables.table_name'   => ['LIKE', 'glpi\_%'],
                 'information_schema.tables.table_type'    => 'BASE TABLE',
                 ['NOT' => ['information_schema.columns.collation_name' => null]],
-                ['NOT' => ['information_schema.columns.collation_name' => 'utf8mb4_unicode_ci']]
+                ['NOT' => ['information_schema.columns.collation_name' => ['LIKE', 'utf8mb4\_%']]]
             ],
         ];
-
-        if ($this->dbms_type == self::MARIADB) {
-            // dot not trigger if utf8mb4_bin is used for longtext
-            // Mariadb use an alias JSON => longtext utf8mb4_bin
-            $columns_query['WHERE'][] = ['NOT' => ['information_schema.columns.data_type' => 'longtext', 'information_schema.columns.collation_name' => 'utf8mb4_bin']];
-        }
 
         if ($exclude_plugins) {
             $tables_query['WHERE'][] = ['NOT' => ['information_schema.tables.table_name' => ['LIKE', 'glpi\_plugin\_%']]];


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

### Report
Since the development of the following features :
- generic asset 
- forms

GLPI displays the following message (only if installed on `MariaDB`)

**`4 tables are using the deprecated utf8mb3 storage charset. Run the "php bin/console migration:utf8mb4" command to migrate them.`**

![image](https://github.com/user-attachments/assets/66d7eeef-261c-4dc9-be00-0f1629036136)

### Why

These two features use a new type of column that we haven't used before => `JSON`

- On `Mysql` it's “real” type 
- On `MariaDB` it's an alias to `longtext` `utf8mb4_bin`. See -> [Link](https://mariadb.com/kb/en/json-data-type/#:~:text=JSON%20is%20an%20alias%20for,performance%20is%20at%20least%20equivalent.)

See the `Collation` of the `zones` column :

- MySQL (`NULL`)
```sql
MySQL [main]> show full columns from glpi_stencils;
+---------------+--------------+--------------------+------+-----+---------+----------------+---------------------------------+---------+
| Field         | Type         | Collation          | Null | Key | Default | Extra          | Privileges                      | Comment |
+---------------+--------------+--------------------+------+-----+---------+----------------+---------------------------------+---------+
| id            | int unsigned | NULL               | NO   | PRI | NULL    | auto_increment | select,insert,update,references |         |
| itemtype      | varchar(100) | utf8mb4_unicode_ci | NO   | MUL | NULL    |                | select,insert,update,references |         |
| items_id      | int unsigned | NULL               | NO   |     | 0       |                | select,insert,update,references |         |
| nb_zones      | int          | NULL               | NO   |     | 1       |                | select,insert,update,references |         |
| zones         | json         | NULL               | YES  |     | NULL    |                | select,insert,update,references |         |
| date_mod      | timestamp    | NULL               | YES  | MUL | NULL    |                | select,insert,update,references |         |
| date_creation | timestamp    | NULL               | YES  | MUL | NULL    |                | select,insert,update,references |         |
+---------------+--------------+--------------------+------+-----+---------+----------------+---------------------------------+---------+
```

- MariaDB (`utf8mb4_bin `)
```sql
MariaDB [main]> show full columns from glpi_stencils;
+---------------+------------------+--------------------+------+-----+---------+----------------+---------------------------------+---------+
| Field         | Type             | Collation          | Null | Key | Default | Extra          | Privileges                      | Comment |
+---------------+------------------+--------------------+------+-----+---------+----------------+---------------------------------+---------+
| id            | int(10) unsigned | NULL               | NO   | PRI | NULL    | auto_increment | select,insert,update,references |         |
| itemtype      | varchar(100)     | utf8mb4_unicode_ci | NO   | MUL | NULL    |                | select,insert,update,references |         |
| items_id      | int(10) unsigned | NULL               | NO   |     | 0       |                | select,insert,update,references |         |
| nb_zones      | int(11)          | NULL               | NO   |     | 1       |                | select,insert,update,references |         |
| zones         | longtext         | utf8mb4_bin        | YES  |     | NULL    |                | select,insert,update,references |         |
| date_mod      | timestamp        | NULL               | YES  | MUL | NULL    |                | select,insert,update,references |         |
| date_creation | timestamp        | NULL               | YES  | MUL | NULL    |                | select,insert,update,references |         |
+---------------+------------------+--------------------+------+-----+---------+----------------+---------------------------------+---------+
```

`getNonUtf8mb4Tables` ignores this subtlety and mistakenly assumes that `utf8mb4_bin` is actually `utf8mb3`.

### Proposed solution

1.  Add a method for identifying the database engine used by GLPI
2. If `MariaDB`, add a `WHERE` clause to exclude `longtext` columns with a `utf8m4_bin` collation.


## Screenshots (if appropriate):


