### PR TITLE
Drop unused `CommonGLPI::$type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -306,6 +306,7 @@ The present file will list all changes made to the project; according to the
 - `CommonDBTM::showDebugInfo()`
 - `CommonDevice::title()`
 - `CommonDropdown::displayHeader()`
+- `CommonGLPI::$type` property.
 - `CommonGLPI::getAvailableDisplayOptions()`
 - `CommonGLPI::getDisplayOptions()`
 - `CommonGLPI::getDisplayOptionsLink()`

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -48,13 +48,6 @@ class CommonGLPI implements CommonGLPIInterface
     protected static $showTitleInNavigationHeader = false;
 
    /**
-    * GLPI Item type cache : set dynamically calling getType
-    *
-    * @var integer
-    */
-    protected $type                 = -1;
-
-   /**
     * Display list on Navigation Header
     *
     * @var boolean


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The `CommonGLPI::$type` property is not anymore used since a long time ago. There are still some occurences in the `glpiinventory` plugin (`if ($item->fields['type'] == $this->type) {`), but I guess it is related to something that does not work anymore.
