### PR TITLE
fix plugin post install hook

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -982,7 +982,7 @@ class Plugin extends CommonDBTM
 
                     $this->resetHookableCacheEntries($this->fields['directory']);
 
-                    self::doHook(Hooks::POST_PLUGIN_UNINSTALL, $this->fields['directory']);
+                    self::doHook(Hooks::POST_PLUGIN_INSTALL, $this->fields['directory']);
 
                     Event::log(
                         '',

--- a/src/Plugin/Hooks.php
+++ b/src/Plugin/Hooks.php
@@ -60,6 +60,7 @@ class Hooks
     const VCARD_DATA            = 'vcard_data';
     const POST_PLUGIN_DISABLE   = 'post_plugin_disable';
     const POST_PLUGIN_CLEAN     = 'post_plugin_clean';
+    const POST_PLUGIN_INSTALL   = 'post_plugin_install';
     const POST_PLUGIN_UNINSTALL = 'post_plugin_uninstall';
     const POST_PLUGIN_ENABLE    = 'post_plugin_enable' ;
 


### PR DESCRIPTION
I found an inconsistency in the plugin post install hook.

This is an error I did in a PR 2 years ago, but has not been noticed :(

https://github.com/glpi-project/glpi/pull/11361/files#diff-c346b1aeac8259782c74702eadfe1d7a240ee3ecea6020ad2addede93c635cabL800

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.

## Description

When installing a plugin, the hook POST_PLUGIN_UNINSTALL is called instead of PLUGIN_HOOK_INSTALL



