### PR TITLE
Fix bootstrap/firewall checks related to install UI

### DIFF
--- a/src/Glpi/Config/LegacyConfigurators/StandardIncludes.php
+++ b/src/Glpi/Config/LegacyConfigurators/StandardIncludes.php
@@ -70,15 +70,19 @@ final readonly class StandardIncludes implements LegacyConfigProviderInterface
         $skip_checks = false;
         if (array_key_exists('REQUEST_URI', $_SERVER)) {
             $no_checks_scripts = [
-                $CFG_GLPI['root_doc'] . '/front/css.php',
-                $CFG_GLPI['root_doc'] . '/front/locale.php',
-                $CFG_GLPI['root_doc'] . '/install/install.php',
-                $CFG_GLPI['root_doc'] . '/install/update.php',
+                '#^' . $CFG_GLPI['root_doc'] . '/$#',
+                '#^' . $CFG_GLPI['root_doc'] . '/index.php#',
+                '#^' . $CFG_GLPI['root_doc'] . '/front/css.php#',
+                '#^' . $CFG_GLPI['root_doc'] . '/front/locale.php#',
+                '#^' . $CFG_GLPI['root_doc'] . '/install/install.php#',
+                '#^' . $CFG_GLPI['root_doc'] . '/install/update.php#',
             ];
-            $skip_checks = preg_match(
-                '/^' . implode('|', array_map(fn ($url) => preg_quote($url, '/'), $no_checks_scripts)) . '/',
-                $_SERVER['REQUEST_URI']
-            ) === 1;
+            foreach ($no_checks_scripts as $pattern) {
+                if (preg_match($pattern, $_SERVER['REQUEST_URI']) === 1) {
+                    $skip_checks = true;
+                    break;
+                }
+            }
         }
 
         //init cache

--- a/src/Glpi/Controller/IndexController.php
+++ b/src/Glpi/Controller/IndexController.php
@@ -67,13 +67,14 @@ final class IndexController extends AbstractController
     private function call(): void
     {
         /**
+         * @var \DBmysql|null $DB
          * @var array $CFG_GLPI
          * @var array $PLUGIN_HOOKS
          */
-        global $CFG_GLPI, $PLUGIN_HOOKS;
+        global $DB, $CFG_GLPI, $PLUGIN_HOOKS;
 
         // If config_db doesn't exist -> start installation
-        if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
+        if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php") || !class_exists('DB', false)) {
             if (file_exists(GLPI_ROOT . '/install/install.php')) {
                 Html::redirect("install/install.php");
             } else {

--- a/src/Glpi/Http/Firewall.php
+++ b/src/Glpi/Http/Firewall.php
@@ -230,6 +230,7 @@ final class Firewall implements FirewallInterface
             '/front/lostpassword.php' => self::STRATEGY_NO_CHECK,
             '/front/tracking.injector.php' => self::STRATEGY_NO_CHECK, // Anonymous access may be allowed by configuration.
             '/front/updatepassword.php' => self::STRATEGY_NO_CHECK,
+            '/install/' => self::STRATEGY_NO_CHECK, // No check during install/update
         ];
 
         foreach ($paths as $checkPath => $strategy) {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

It fixes #17911.

The checks related to the DB config file validity were made on the `index` controller, preventing it to redirect to the installation process. Also, since #17490, the firewall was blocking the installation UI. Both problems are fixed by this PR.

