### PR TITLE
fix double mo compilation on 'composer build' command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -159,7 +159,7 @@
             "patch -f -p1 -d vendor/guzzlehttp/guzzle/ < tools/patches/guzzle-http-client-restrict-http-methods.patch || true"
         ],
         "build": [
-            "bin/console dependencies install && bin/console locales:compile"
+            "bin/console dependencies install"
         ]
     },
     "repositories": {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Since #17784, `composer build` command compiles locales 2 times

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/7c083c85-b321-4afd-b54a-399810ca238f)

