### PR TITLE
Fix(ticket): update ticket status when planned task is updated

### DIFF
--- a/phpunit/functional/TicketTaskTest.php
+++ b/phpunit/functional/TicketTaskTest.php
@@ -510,6 +510,130 @@ class TicketTaskTest extends DbTestCase
     }
 
     /**
+     * Check that the parent ticket status is updated when tasks are added or updated
+     *
+     * @return void
+     */
+    public function testUpdateParentStatusOnTaskUpdate(): void
+    {
+        $this->login();
+        $ticket_id = $this->getNewTicket();
+
+        $uid = getItemByTypeName('User', TU_USER, true);
+        $date_begin = new \DateTime(); // ==> now
+        $date_begin_string = $date_begin->format('Y-m-d H:i:s');
+        $date_end = new \DateTime(); // ==> +2days
+        $date_end->add(new \DateInterval('P2D'));
+        $date_end_string = $date_end->format('Y-m-d H:i:s');
+
+        $task1 = new \TicketTask();
+        $task1_id = $task1->add([
+            'tickets_id'         => $ticket_id,
+            'content'            => "Task with schedule",
+            'state'              => \Planning::TODO,
+            'users_id_tech'      => $uid,
+            'begin'              => $date_begin_string,
+            'end'                => $date_end_string,
+        ]);
+        $this->assertGreaterThan(
+            0,
+            $task1_id
+        );
+
+        $this->assertEquals(
+            \Ticket::PLANNED,
+            \Ticket::getById($ticket_id)->fields['status']
+        );
+
+        $date_begin = new \DateTime(); // ==> +3days
+        $date_begin->add(new \DateInterval('P3D'));
+        $date_begin_string = $date_begin->format('Y-m-d H:i:s');
+        $date_end = new \DateTime(); // ==> +4days
+        $date_end->add(new \DateInterval('P4D'));
+        $date_end_string = $date_end->format('Y-m-d H:i:s');
+
+        $task2 = new \TicketTask();
+        $task2_id = $task2->add([
+            'tickets_id'         => $ticket_id,
+            'content'            => "Task with schedule",
+            'state'              => \Planning::TODO,
+            'users_id_tech'      => $uid,
+            'begin'              => $date_begin_string,
+            'end'                => $date_end_string,
+        ]);
+
+        $this->assertGreaterThan(
+            0,
+            $task2_id
+        );
+
+        $this->assertEquals(
+            \Ticket::PLANNED,
+            \Ticket::getById($ticket_id)->fields['status']
+        );
+
+        $this->assertTrue(
+            $task1->update([
+                'id'        => $task1_id,
+                'state'     => \Planning::DONE,
+            ])
+        );
+
+        $this->assertEquals(
+            \Ticket::PLANNED,
+            \Ticket::getById($ticket_id)->fields['status']
+        );
+
+        $this->assertTrue(
+            $task2->update([
+                'id'        => $task2_id,
+                'state'     => \Planning::DONE,
+            ])
+        );
+
+        $this->assertEquals(
+            \Ticket::ASSIGNED,
+            \Ticket::getById($ticket_id)->fields['status']
+        );
+
+        $this->assertTrue(
+            \Ticket::getById($ticket_id)->update([
+                'id'        => $ticket_id,
+                'status'    => \Ticket::WAITING,
+            ])
+        );
+
+        $this->assertEquals(
+            \Ticket::WAITING,
+            \Ticket::getById($ticket_id)->fields['status']
+        );
+
+        $this->assertTrue(
+            $task1->update([
+                'id'        => $task1_id,
+                'state'     => \Planning::TODO,
+            ])
+        );
+
+        $this->assertEquals(
+            \Ticket::WAITING,
+            \Ticket::getById($ticket_id)->fields['status']
+        );
+
+        $this->assertTrue(
+            $task2->update([
+                'id'        => $task2_id,
+                'state'     => \Planning::TODO,
+            ])
+        );
+
+        $this->assertEquals(
+            \Ticket::WAITING,
+            \Ticket::getById($ticket_id)->fields['status']
+        );
+    }
+
+    /**
      * Test that the task duration is correctly updated
      *
      * @return void

--- a/src/Features/ParentStatus.php
+++ b/src/Features/ParentStatus.php
@@ -137,7 +137,11 @@ trait ParentStatus
                 ) {
                     $needupdateparent = true;
                     // If begin date is defined, the status must be planned if it exists, rather than assigned.
-                    if (($this->countPlannedTasks() > 0) && $parentitem->isStatusExists(CommonITILObject::PLANNED)) {
+                    if (
+                        ($this instanceof \CommonITILTask)
+                        && ($this->countPlannedTasks() > 0)
+                        && $parentitem->isStatusExists(CommonITILObject::PLANNED)
+                    ) {
                         $update['status'] = CommonITILObject::PLANNED;
                     } else {
                         $update['status'] = CommonITILObject::ASSIGNED;
@@ -166,6 +170,7 @@ trait ParentStatus
 
         if (
             !$is_set_pending
+            && ($this instanceof \CommonITILTask)
             && ($this->countPlannedTasks() > 0)
             && $parentitem->isStatusExists(CommonITILObject::PLANNED)
             && (in_array($parentitem->fields["status"], [

--- a/src/Features/ParentStatus.php
+++ b/src/Features/ParentStatus.php
@@ -137,7 +137,7 @@ trait ParentStatus
                 ) {
                     $needupdateparent = true;
                     // If begin date is defined, the status must be planned if it exists, rather than assigned.
-                    if (!empty($this->fields['begin']) && $parentitem->isStatusExists(CommonITILObject::PLANNED)) {
+                    if (($this->countPlannedTasks() > 0) && $parentitem->isStatusExists(CommonITILObject::PLANNED)) {
                         $update['status'] = CommonITILObject::PLANNED;
                     } else {
                         $update['status'] = CommonITILObject::ASSIGNED;
@@ -166,11 +166,13 @@ trait ParentStatus
 
         if (
             !$is_set_pending
-            && !empty($this->fields['begin'])
+            && ($this->countPlannedTasks() > 0)
             && $parentitem->isStatusExists(CommonITILObject::PLANNED)
-            && (($parentitem->fields["status"] == CommonITILObject::INCOMING)
-              || ($parentitem->fields["status"] == CommonITILObject::ASSIGNED)
-              || $needupdateparent)
+            && (in_array($parentitem->fields["status"], [
+                CommonITILObject::INCOMING,
+                CommonITILObject::ASSIGNED,
+                CommonITILObject::PLANNED,
+            ]) || $needupdateparent)
         ) {
             $input['_status'] = CommonITILObject::PLANNED;
         }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !34520
- Here is a brief description of what this PR does
The ticket status was automatically set to 'Planned' when a scheduled task was added. However, when this task was marked as 'Done', the ticket status was not updated accordingly. This PR fixes the issue by ensuring the ticket status is consistently updated after the task is completed.

## Screenshots (if appropriate):


