### PR TITLE
Use `/plugins/` path prefix for all plugins resources

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -1238,12 +1238,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/DbUtils.php',
 ];
 $ignoreErrors[] = [
-	// identifier: parameter.defaultValue
-	'message' => '#^Default value of the parameter \\#3 \\$plugins_dirs \\(null\\) of method DbUtils\\:\\:fixItemtypeCase\\(\\) is incompatible with type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DbUtils.php',
-];
-$ignoreErrors[] = [
 	// identifier: return.type
 	'message' => '#^Method DbUtils\\:\\:getHourFromSql\\(\\) should return array but returns string\\.$#',
 	'count' => 1,
@@ -1874,12 +1868,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Search.php',
 ];
 $ignoreErrors[] = [
-	// identifier: function.impossibleType
-	'message' => '#^Call to function is_array\\(\\) with null will always evaluate to false\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Application/ConfigurationConstants.php',
-];
-$ignoreErrors[] = [
 	// identifier: nullCoalesce.offset
 	'message' => '#^Offset \'GLPI_AJAX_DASHBOARD\'\\|\'GLPI_ALLOW_IFRAME…\'\\|\'GLPI_CACHE_DIR\'\\|\'GLPI_CALDAV_IMPORT…\'\\|\'GLPI_CENTRAL…\'\\|\'GLPI_CONFIG_DIR\'\\|\'GLPI_CRON_DIR\'\\|\'GLPI_DEMO_MODE\'\\|\'GLPI_DISABLE_ONLY…\'\\|\'GLPI_DOC_DIR\'\\|\'GLPI_DOCUMENTATION…\'\\|\'GLPI_DUMP_DIR\'\\|\'GLPI_ENVIRONMENT…\'\\|\'GLPI_GRAPH_DIR\'\\|\'GLPI_INSTALL_MODE\'\\|\'GLPI_INVENTORY_DIR\'\\|\'GLPI_LOCAL_I18N_DIR\'\\|\'GLPI_LOCK_DIR\'\\|\'GLPI_LOG_DIR\'\\|\'GLPI_MARKETPLACE…\'\\|\'GLPI_MARKETPLACE_DIR\'\\|\'GLPI_NETWORK_MAIL\'\\|\'GLPI_NETWORK…\'\\|\'GLPI_PICTURE_DIR\'\\|\'GLPI_PLUGIN_DOC_DIR\'\\|\'GLPI_RSS_DIR\'\\|\'GLPI_SERVERSIDE_URL…\'\\|\'GLPI_SESSION_DIR\'\\|\'GLPI_TELEMETRY_URI\'\\|\'GLPI_TEXT_MAXSIZE\'\\|\'GLPI_THEMES_DIR\'\\|\'GLPI_TMP_DIR\'\\|\'GLPI_UPLOAD_DIR\'\\|\'GLPI_USER_AGENT…\'\\|\'GLPI_VAR_DIR\'\\|\'PLUGINS_DIRECTORIES\' on array\\{\\} on left side of \\?\\? does not exist\\.$#',
 	'count' => 2,
@@ -2102,12 +2090,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Console/Application.php',
 ];
 $ignoreErrors[] = [
-	// identifier: foreach.nonIterable
-	'message' => '#^Argument of an invalid type null supplied for foreach, only iterables are supported\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Console/CommandLoader.php',
-];
-$ignoreErrors[] = [
 	// identifier: method.unused
 	'message' => '#^Method Glpi\\\\Console\\\\Database\\\\InstallCommand\\:\\:shouldSetDBConfig\\(\\) is unused\\.$#',
 	'count' => 1,
@@ -2148,12 +2130,6 @@ $ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Console\\\\Migration\\\\RacksPluginToCoreCommand\\:\\:getImportErrorsVerbosity\\(\\) never returns float so it can be removed from the return type\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Console/Migration/RacksPluginToCoreCommand.php',
-];
-$ignoreErrors[] = [
-	// identifier: foreach.nonIterable
-	'message' => '#^Argument of an invalid type null supplied for foreach, only iterables are supported\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Console/Plugin/InstallCommand.php',
 ];
 $ignoreErrors[] = [
 	// identifier: return.type
@@ -2318,12 +2294,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Form/Section.php',
 ];
 $ignoreErrors[] = [
-	// identifier: property.onlyWritten
-	'message' => '#^Property Glpi\\\\Http\\\\LegacyAssetsListener\\:\\:\\$projectDir is never read, only written\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Http/LegacyAssetsListener.php',
-];
-$ignoreErrors[] = [
 	// identifier: classConstant.nonObject
 	'message' => '#^Cannot access constant class on Glpi\\\\Asset\\\\AssetModel\\|false\\.$#',
 	'count' => 1,
@@ -2334,12 +2304,6 @@ $ignoreErrors[] = [
 	'message' => '#^Cannot access constant class on Glpi\\\\Asset\\\\AssetType\\|false\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Http/LegacyDropdownRouteListener.php',
-];
-$ignoreErrors[] = [
-	// identifier: property.onlyWritten
-	'message' => '#^Property Glpi\\\\Http\\\\LegacyRouterListener\\:\\:\\$projectDir is never read, only written\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Http/LegacyRouterListener.php',
 ];
 $ignoreErrors[] = [
 	// identifier: booleanNot.alwaysFalse
@@ -2688,12 +2652,6 @@ $ignoreErrors[] = [
 	'message' => '#^Negated boolean expression is always true\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Marketplace/Api/Plugins.php',
-];
-$ignoreErrors[] = [
-	// identifier: foreach.nonIterable
-	'message' => '#^Argument of an invalid type null supplied for foreach, only iterables are supported\\.$#',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Marketplace/Controller.php',
 ];
 $ignoreErrors[] = [
 	// identifier: booleanAnd.leftAlwaysFalse
@@ -3980,12 +3938,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/PlanningRecall.php',
 ];
 $ignoreErrors[] = [
-	// identifier: foreach.nonIterable
-	'message' => '#^Argument of an invalid type null supplied for foreach, only iterables are supported\\.$#',
-	'count' => 6,
-	'path' => __DIR__ . '/src/Plugin.php',
-];
-$ignoreErrors[] = [
 	// identifier: if.alwaysFalse
 	'message' => '#^If condition is always false\\.$#',
 	'count' => 1,
@@ -4848,12 +4800,6 @@ $ignoreErrors[] = [
 	'message' => '#^Call to function is_array\\(\\) with string will always evaluate to false\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/src/autoload/i18n.php',
-];
-$ignoreErrors[] = [
-	// identifier: foreach.nonIterable
-	'message' => '#^Argument of an invalid type null supplied for foreach, only iterables are supported\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/src/autoload/legacy-autoloader.php',
 ];
 $ignoreErrors[] = [
 	// identifier: return.unusedType

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,8 @@ The present file will list all changes made to the project; according to the
 - `comments` and `icon` options have been removed from `CommonDBTM::getNameID()`.
 
 #### Deprecated
+- Usage of the `/marketplace` path for plugins URLs. All plugins URLs should now start with `/plugins`.
+- Usage of `GLPI_PLUGINS_PATH` javascript variable.
 - Usage of `MAIL_SMTPSSL` and `MAIL_SMTPTLS` constants.
 - `$AJAX_INCLUDE` global variable usage. Use `$this->setAjax()` in legacy `/ajax/` and `/front` scripts or `Html::setAjax()` and `Session::setAjax()`.
 - Usage of `name` and `users_id_validate` parameter in `ajax/dropdownValidator.php`.
@@ -215,6 +217,7 @@ The present file will list all changes made to the project; according to the
 - Usage of `users_id_validate` input in `CommonITILObject`.
 - Defining "users_id_validate" field without defining "itemtype_target"/"items_id_target" in "CommonITILValidation".
 - Usage of `name` and `users_id_validate` options in `CommonITILValidation::dropdownValidator()`.
+- Usage of `get_plugin_web_dir` Twig function.
 - Usage of `verbatim_value` Twig filter.
 - `js/Forms/FaIconSelector.js` and therefore `window.GLPI.Forms.FaIconSelector` has been deprecated and replaced by `js/modules/Form/WebIconSelector.js`
 - `linkuser_types`, `linkgroup_types`, `linkuser_tech_types`, `linkgroup_tech_types` configuration entries have been merged in a unique `assignable_types` configuration entry.
@@ -232,7 +235,8 @@ The present file will list all changes made to the project; according to the
 - `DBmysql::truncate()`
 - `DBmysql::truncateOrDie()`
 - `Document::getImage()`
-- `Glpi\Application\View\Extension::getVerbatimValue()`
+- `Glpi\Application\View\Extension\DataHelpersExtension::getVerbatimValue()`
+- `Glpi\Application\View\Extension\PluginExtension::getPluginWebDir()`
 - `Glpi\Dashboard\Filter::getAll()`
 - `Glpi\Event::showList()`
 - `Glpi\Features\DCBreadcrumb::getDcBreadcrumb()`
@@ -269,6 +273,7 @@ The present file will list all changes made to the project; according to the
 - `KnowbaseItem::showManageForm()`
 - `Migration::updateRight()`. Use `Migration::replaceRight()` instead.
 - `Pdu_Plug` has been deprecated and replaced by `Item_Plug`
+- `Plugin::getWebDir()`
 - `Search::getOptions()` no longer returns a reference
 - `Ticket` `link_to_problem` massive action is deprecated. Use `CommonITILObject_CommonITILObject` `add` massive action instead.
 - `Ticket_Ticket` `add` massive action is deprecated. Use `CommonITILObject_CommonITILObject` `add` massive action instead.

--- a/js/modules/Screenshot/Screenshot.js
+++ b/js/modules/Screenshot/Screenshot.js
@@ -31,7 +31,6 @@
  * ---------------------------------------------------------------------
  */
 
-/* global GLPI_PLUGINS_PATH */
 class Screenhot {
 
     constructor() {

--- a/src/Glpi/Application/ConfigurationConstants.php
+++ b/src/Glpi/Application/ConfigurationConstants.php
@@ -170,9 +170,6 @@ final class ConfigurationConstants
                 )
             );
         }
-        if (defined('PLUGINS_DIRECTORIES') && !is_array(PLUGINS_DIRECTORIES)) {
-            throw new \Exception('PLUGINS_DIRECTORIES constant value must be an array');
-        }
 
         // Configure environment type if not defined by user.
         if (!defined('GLPI_ENVIRONMENT_TYPE')) {

--- a/src/Glpi/Application/View/Extension/PluginExtension.php
+++ b/src/Glpi/Application/View/Extension/PluginExtension.php
@@ -36,6 +36,7 @@
 namespace Glpi\Application\View\Extension;
 
 use Plugin;
+use Toolbox;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -107,12 +108,15 @@ class PluginExtension extends AbstractExtension
      * @param bool    $use_url_base
      *
      * @return string|null
+     *
+     * @deprecated 11.0
      */
     public function getPluginWebDir(
         string $plugin,
         bool $full = true,
         bool $use_url_base = false
     ): ?string {
+        Toolbox::deprecated('All plugins resource should be accessed from the `/plugins/` path.');
         return Plugin::getWebDir($plugin, $full, $use_url_base) ?: null;
     }
 }

--- a/src/Glpi/Application/View/Extension/PluginExtension.php
+++ b/src/Glpi/Application/View/Extension/PluginExtension.php
@@ -116,7 +116,7 @@ class PluginExtension extends AbstractExtension
         bool $full = true,
         bool $use_url_base = false
     ): ?string {
-        Toolbox::deprecated('All plugins resource should be accessed from the `/plugins/` path.');
+        Toolbox::deprecated('All plugins resources should be accessed from the `/plugins/` path.');
         return Plugin::getWebDir($plugin, $full, $use_url_base) ?: null;
     }
 }

--- a/src/Glpi/Http/LegacyAssetsListener.php
+++ b/src/Glpi/Http/LegacyAssetsListener.php
@@ -42,21 +42,17 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\KernelEvents;
 
-final readonly class LegacyAssetsListener implements EventSubscriberInterface
+final class LegacyAssetsListener implements EventSubscriberInterface
 {
     use LegacyRouterTrait;
 
-    /**
-     * GLPI root directory.
-     */
-    protected string $glpi_root;
-
     public function __construct(
-        #[Autowire('%kernel.project_dir%')] private string $projectDir,
+        #[Autowire('%kernel.project_dir%')] string $glpi_root,
+        array $plugin_directories = PLUGINS_DIRECTORIES,
     ) {
-        $this->glpi_root = $projectDir;
+        $this->glpi_root = $glpi_root;
+        $this->plugin_directories = $plugin_directories;
     }
-
 
     public static function getSubscribedEvents(): array
     {
@@ -84,13 +80,12 @@ final readonly class LegacyAssetsListener implements EventSubscriberInterface
             return null;
         }
 
-        $target_file = $this->glpi_root . $path;
+        $target_file = $this->getTargetFile($path);
 
-        if (!is_file($target_file)) {
-            return null;
-        }
-
-        if ($this->isTargetAPhpScript($path)) {
+        if (
+            $target_file === null
+            || $this->isTargetAPhpScript($path)
+        ) {
             return null;
         }
 

--- a/src/Glpi/Http/LegacyRouterTrait.php
+++ b/src/Glpi/Http/LegacyRouterTrait.php
@@ -204,12 +204,16 @@ trait LegacyRouterTrait
         // Normalize plugins paths.
         // All plugins resources should now be accessed using the `/plugins/${plugin_key}/${resource_path}`.
         if (str_starts_with($path, '/marketplace/')) {
+            // /!\ `/marketplace/` URLs were massively used prior to GLPI 11.0.
+            //
+            // To not break URLs than can be found in the wild (in e-mail, forums, external apps configuration, ...),
+            // please do not remove this behaviour before, at least, 2030 (about 5 years after GLPI 11.0.0 release).
+            Toolbox::deprecated('Accessing the plugins resources from the `/marketplace/` path is deprecated. Use the `/plugins/` path instead.');
             $path = preg_replace(
                 '#^/marketplace/#',
                 '/plugins/',
                 parse_url($request_uri, PHP_URL_PATH)
             );
-            Toolbox::deprecated('Accessing the plugins resources from the `/marketplace/` path is deprecated. Use the `/plugins/` path instead.');
         }
 
         // Parse URI to find requested script and PathInfo

--- a/src/Glpi/Marketplace/View.php
+++ b/src/Glpi/Marketplace/View.php
@@ -911,8 +911,7 @@ HTML;
             ]);
 
             if (!strlen($error) && $is_actived && $config_page) {
-                $plugin_dir = Plugin::getWebDir($plugin_key, true);
-                $config_url = "$plugin_dir/$config_page";
+                $config_url = "{$CFG_GLPI['root_doc']}/plugins/{$plugin_key}/{$config_page}";
                 $buttons .= "<a href='$config_url'>
                         <button class='add_tooltip' title='" . __s("Configure") . "'>
                             <i class='ti ti-tool'></i>

--- a/src/Html.php
+++ b/src/Html.php
@@ -1205,7 +1205,6 @@ HTML;
                     continue;
                 }
 
-                $plugin_web_dir  = Plugin::getWebDir($plugin, false);
                 $plugin_version  = Plugin::getPluginFilesVersion($plugin);
 
                 if (!is_array($files)) {
@@ -1214,7 +1213,7 @@ HTML;
 
                 foreach ($files as $file) {
                     $tpl_vars['css_files'][] = [
-                        'path' => "$plugin_web_dir/$file",
+                        'path' => "{$CFG_GLPI['root_doc']}/plugins/{$plugin}/{$file}",
                         'options' => [
                             'version' => $plugin_version,
                         ]
@@ -1589,9 +1588,8 @@ HTML;
                         }
 
                         // Prefix with plugin path if plugin path is missing
-                        $plugin_dir = Plugin::getWebDir($plugin, false);
-                        if (!str_starts_with($link, '/' . $plugin_dir)) {
-                            $link = '/' . $plugin_dir . $link;
+                        if (!str_starts_with($link, "/plugins/{$plugin}/")) {
+                            $link = "/plugins/{$plugin}{$link}";
                         }
                     }
                     $infos['page'] = $link;
@@ -1776,7 +1774,6 @@ HTML;
                     continue;
                 }
                 $plugin_root_dir = Plugin::getPhpDir($plugin, true);
-                $plugin_web_dir  = Plugin::getWebDir($plugin, false);
                 $plugin_version  = Plugin::getPluginFilesVersion($plugin);
 
                 if (!is_array($files)) {
@@ -1785,7 +1782,7 @@ HTML;
                 foreach ($files as $file) {
                     if (file_exists($plugin_root_dir . "/{$file}")) {
                         $tpl_vars['js_files'][] = [
-                            'path' => $plugin_web_dir . "/{$file}",
+                            'path' => "/plugins/{$plugin}/{$file}",
                             'options' => [
                                 'version' => $plugin_version,
                             ]
@@ -1802,7 +1799,6 @@ HTML;
                     continue;
                 }
                 $plugin_root_dir = Plugin::getPhpDir($plugin, true);
-                $plugin_web_dir  = Plugin::getWebDir($plugin, false);
                 $plugin_version  = Plugin::getPluginFilesVersion($plugin);
 
                 if (!is_array($files)) {
@@ -1811,7 +1807,7 @@ HTML;
                 foreach ($files as $file) {
                     if (file_exists($plugin_root_dir . "/{$file}")) {
                         $tpl_vars['js_modules'][] = [
-                            'path' => $plugin_web_dir . "/{$file}",
+                            'path' => "/plugins/{$plugin}/{$file}",
                             'options' => [
                                 'version' => $plugin_version,
                             ]
@@ -6075,14 +6071,13 @@ HTML;
                     continue;
                 }
                 $plugin_root_dir = Plugin::getPhpDir($plugin, true);
-                $plugin_web_dir  = Plugin::getWebDir($plugin, false);
                 $version = Plugin::getPluginFilesVersion($plugin);
                 if (!is_array($files)) {
                     $files = [$files];
                 }
                 foreach ($files as $file) {
                     if (file_exists($plugin_root_dir . "/{$file}")) {
-                        echo Html::script("$plugin_web_dir/{$file}", [
+                        echo Html::script("/plugins/{$plugin}/{$file}", [
                             'version'   => $version,
                             'type'      => 'text/javascript'
                         ]);
@@ -6099,14 +6094,13 @@ HTML;
                     continue;
                 }
                 $plugin_root_dir = Plugin::getPhpDir($plugin, true);
-                $plugin_web_dir  = Plugin::getWebDir($plugin, false);
                 $version = Plugin::getPluginFilesVersion($plugin);
                 if (!is_array($files)) {
                     $files = [$files];
                 }
                 foreach ($files as $file) {
                     if (file_exists($plugin_root_dir . "/{$file}")) {
-                        echo self::script("$plugin_web_dir/{$file}", [
+                        echo self::script("/plugins/{$plugin}/{$file}", [
                             'version'   => $version,
                             'type'      => 'module'
                         ]);
@@ -6151,7 +6145,7 @@ HTML;
 
         $plugins_path = [];
         foreach (Plugin::getPlugins() as $key) {
-            $plugins_path[$key] = Plugin::getWebDir($key, false);
+            $plugins_path[$key] = "/plugins/{$key}";
         }
         $plugins_path = 'var GLPI_PLUGINS_PATH = ' . json_encode($plugins_path) . ';';
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2482,8 +2482,7 @@ class Plugin extends CommonDBTM
                     && isset($PLUGIN_HOOKS['config_page'][$directory])
                 ) {
                    // Configuration button for activated or configurable plugins
-                    $plugin_dir = self::getWebDir($directory, true);
-                    $config_url = "$plugin_dir/" . $PLUGIN_HOOKS['config_page'][$directory];
+                    $config_url = "{$CFG_GLPI['root_doc']}/plugins/{$directory}/{$PLUGIN_HOOKS['config_page'][$directory]}";
                     $output .= '<a href="' . $config_url . '" title="' . __s('Configure') . '">'
                     . '<i class="fas fa-wrench fa-2x"></i>'
                     . '<span class="sr-only">' . __s('Configure') . '</span>'
@@ -2665,8 +2664,7 @@ TWIG;
                     in_array($state, [self::ACTIVATED, self::TOBECONFIGURED])
                     && isset($PLUGIN_HOOKS['config_page'][$directory])
                 ) {
-                    $plugin_dir = self::getWebDir($directory, true);
-                    $config_url = "$plugin_dir/" . $PLUGIN_HOOKS['config_page'][$directory];
+                    $config_url = "{$CFG_GLPI['root_doc']}/plugins/{$directory}/{$PLUGIN_HOOKS['config_page'][$directory]}";
                     return "<a href='$config_url'><span class='b'>$value</span></a>";
                 } else {
                     return $value;
@@ -2759,19 +2757,17 @@ TWIG;
      * @param bool $use_url_base if true, url_base instead root_doc
      *
      * @return false|string the web path
+     *
+     * @deprecated 11.0
      */
     public static function getWebDir(string $plugin_key = "", $full = true, $use_url_base = false)
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $directory = self::getPhpDir($plugin_key, false);
+        Toolbox::deprecated('All plugins resource should be accessed from the `/plugins/` path.');
 
-        if ($directory === false) {
-            return false;
-        }
-
-        $directory = ltrim($directory, '/\\');
+        $directory = '/plugins/' . $plugin_key;
 
         if ($full) {
             $root = $use_url_base ? $CFG_GLPI['url_base'] : $CFG_GLPI["root_doc"];

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2765,7 +2765,7 @@ TWIG;
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        Toolbox::deprecated('All plugins resource should be accessed from the `/plugins/` path.');
+        Toolbox::deprecated('All plugins resources should be accessed from the `/plugins/` path.');
 
         $directory = '/plugins/' . $plugin_key;
 

--- a/src/Report.php
+++ b/src/Report.php
@@ -64,8 +64,11 @@ class Report extends CommonGLPI
 
     public static function getReports(): array
     {
-        /** @var array $PLUGIN_HOOKS */
-        global $PLUGIN_HOOKS;
+        /**
+         * @var array $CFG_GLPI
+         * @var array $PLUGIN_HOOKS
+         */
+        global $CFG_GLPI, $PLUGIN_HOOKS;
 
         // Report generation
         // Default Report included
@@ -115,10 +118,9 @@ class Report extends CommonGLPI
                 }
                 if (is_array($pages) && count($pages)) {
                     foreach ($pages as $page => $name) {
-                        $plugin_path = Plugin::getWebDir($plug);
                         $report_list[Plugin::getInfo($plug, 'name')][$page] = [
                             'name' => $name,
-                            'file' => $plugin_path . '/' . $page,
+                            'file' => "{$CFG_GLPI['root_doc']}/plugins/{$plug}/{$page}",
                             'plug' => $plug
                         ];
                     }

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -902,7 +902,7 @@ class Rule extends CommonDBTM
         $rand = mt_rand();
 
         $plugin = isPluginItemType(static::class);
-        $base_url = $CFG_GLPI["root_doc"] . ($plugin !== false ? Plugin::getWebDir($plugin['plugin'], false) : '');
+        $base_url = $CFG_GLPI["root_doc"] . ($plugin !== false ? "/plugins/{$plugin['plugin']}" : '');
 
         $add_buttons = [];
         if (!$new_item && $canedit) {

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -590,10 +590,9 @@ TWIG, $twig_params);
             </script>
 HTML;
 
+        $url = $CFG_GLPI["root_doc"];
         if ($plugin = isPluginItemType(static::class)) {
-            $url = Plugin::getWebDir($plugin['plugin']);
-        } else {
-            $url = $CFG_GLPI["root_doc"];
+            $url .= "/plugins/{$plugin['plugin']}";
         }
 
         $twig_params = [

--- a/src/Stat.php
+++ b/src/Stat.php
@@ -1780,7 +1780,8 @@ class Stat extends CommonGLPI
                 }
                 if (is_array($pages) && count($pages)) {
                     foreach ($pages as $page => $name) {
-                        $names[Plugin::getWebDir($plug, false) . '/' . $page] = ["name" => $name,
+                        $names["/plugins/{$plug}/{$page}"] = [
+                            "name" => $name,
                             "plug" => $plug
                         ];
                         $optgroup[$plug] = Plugin::getInfo($plug, 'name');

--- a/stubs/glpi_constants.php
+++ b/stubs/glpi_constants.php
@@ -85,4 +85,4 @@ define('GLPI_SERVERSIDE_URL_ALLOWLIST', []);
 define('GLPI_TELEMETRY_URI', null);
 define('GLPI_TEXT_MAXSIZE', null);
 define('GLPI_USER_AGENT_EXTRA_COMMENTS', null);
-define('PLUGINS_DIRECTORIES', null);
+define('PLUGINS_DIRECTORIES', ['/a', '/b', '/c']);

--- a/tests/functional/Glpi/Http/LegacyRouterListener.php
+++ b/tests/functional/Glpi/Http/LegacyRouterListener.php
@@ -59,14 +59,17 @@ class LegacyRouterListener extends \GLPITestCase
                 'marketplace' => [
                     'myplugin' => [
                         'front' => [
+                            'test.php' => '<?php echo("/marketplace/myplugin/front/test.php");',
                             'some.dir' => [
                                 'file.test.php' => '<?php echo("/marketplace/myplugin/front/some.dir/file.test.php");',
                             ],
                         ],
                     ],
+                ],
+                'plugins' => [
                     'mystaleplugin' => [
                         'front' => [
-                            'page.php5' => '<?php echo("/marketplace/mystaleplugin/front/page.php5");',
+                            'page.php5' => '<?php echo("/plugins/mystaleplugin/front/page.php5");',
                         ],
                     ],
                 ],
@@ -74,13 +77,13 @@ class LegacyRouterListener extends \GLPITestCase
         );
 
         // Path to an existing directory that does not have a `index.php` script.
-        yield [
+        yield '/ajax' => [
             'path'            => '/ajax',
             'target_path'     => '/ajax',
             'target_pathinfo' => null,
             'included'        => false,
         ];
-        yield [
+        yield '///ajax' => [
             'path'            => '///ajax', // triple `/` in URL
             'target_path'     => '/ajax',
             'target_pathinfo' => null,
@@ -88,7 +91,7 @@ class LegacyRouterListener extends \GLPITestCase
         ];
 
         // Path to an invalid PHP script.
-        yield [
+        yield '/is/not/valid.php' => [
             'path'            => '/is/not/valid.php',
             'target_path'     => '/is/not/valid.php',
             'target_pathinfo' => null,
@@ -96,13 +99,13 @@ class LegacyRouterListener extends \GLPITestCase
         ];
 
         // Path to a `index.php` script.
-        yield [
+        yield '/front/index.php' => [
             'path'            => '/front/index.php',
             'target_path'     => '/front/index.php',
             'target_pathinfo' => null,
             'included'        => true,
         ];
-        yield [
+        yield '//front/index.php' => [
             'path'            => '//front/index.php', // double `/` in URL
             'target_path'     => '/front/index.php',
             'target_pathinfo' => null,
@@ -110,31 +113,31 @@ class LegacyRouterListener extends \GLPITestCase
         ];
 
         // Path to an existing file, but containing an extra PathInfo
-        yield [
+        yield '/front/whatever.php/' => [
             'path'            => '/front/whatever.php/',
             'target_path'     => '/front/whatever.php',
             'target_pathinfo' => '/',
             'included'        => true,
         ];
-        yield [
+        yield '/front/whatever.php/endpoint/' => [
             'path'            => '/front/whatever.php/endpoint/',
             'target_path'     => '/front/whatever.php',
             'target_pathinfo' => '/endpoint/',
             'included'        => true,
         ];
-        yield [
+        yield '/front/whatever.php//endpoint/' => [
             'path'            => '/front/whatever.php//endpoint/', // double `/` in URL
             'target_path'     => '/front/whatever.php',
             'target_pathinfo' => '/endpoint/',
             'included'        => true,
         ];
-        yield [
+        yield '/front/whatever.php/GlpiPlugin%5CNamespace%5CUnexemple/' => [
             'path'            => '/front/whatever.php/GlpiPlugin%5CNamespace%5CUnexemple/',
             'target_path'     => '/front/whatever.php',
             'target_pathinfo' => '/GlpiPlugin\Namespace\Unexemple/',
             'included'        => true,
         ];
-        yield [
+        yield '/front/whatever.php/calendars/users/J.DUPONT/calendar/' => [
             'path'            => '/front/whatever.php/calendars/users/J.DUPONT/calendar/',
             'target_path'     => '/front/whatever.php',
             'target_pathinfo' => '/calendars/users/J.DUPONT/calendar/',
@@ -142,7 +145,7 @@ class LegacyRouterListener extends \GLPITestCase
         ];
 
         // Path to an existing directory that have a `index.php` script.
-        yield [
+        yield '/front' => [
             'path'            => '/front',
             'target_path'     => '/front/index.php',
             'target_pathinfo' => null,
@@ -150,41 +153,47 @@ class LegacyRouterListener extends \GLPITestCase
         ];
 
         // Path to a JS file
-        yield [
+        yield '/js/common.js' => [
             'path'            => '/js/common.js',
             'target_path'     => '/js/common.js',
             'target_pathinfo' => null,
             'included'        => false,
         ];
 
+        // Path to a PHP script of a plugin located inside the `/marketplace` dir, but accessed with the `/plugins` path.
+        yield '/plugins/myplugin/front/test.php' => [
+            'path'            => '/plugins/myplugin/front/test.php',
+            'target_path'     => '/marketplace/myplugin/front/test.php',
+            'target_pathinfo' => null,
+            'included'        => true,
+        ];
+        yield '/plugins/myplugin/front/some.dir/file.test.php/path/to/item' => [
+            'path'            => '/plugins/myplugin/front/some.dir/file.test.php/path/to/item',
+            'target_path'     => '/marketplace/myplugin/front/some.dir/file.test.php',
+            'target_pathinfo' => '/path/to/item',
+            'included'        => true,
+        ];
+
         // Path to a PHP script in a directory that has a dot in its name.
-        yield [
-            'path'            => '/marketplace/myplugin/front/some.dir/file.test.php',
+        yield '/plugins/myplugin/front/some.dir/file.test.php' => [
+            'path'            => '/plugins/myplugin/front/some.dir/file.test.php',
             'target_path'     => '/marketplace/myplugin/front/some.dir/file.test.php',
             'target_pathinfo' => null,
             'included'        => true,
         ];
-        yield [
-            'path'            => '/marketplace/myplugin/front/some.dir/file.test.php/path/to/item',
+        yield '/plugins/myplugin/front/some.dir/file.test.php/path/to/item' => [
+            'path'            => '/plugins/myplugin/front/some.dir/file.test.php/path/to/item',
             'target_path'     => '/marketplace/myplugin/front/some.dir/file.test.php',
             'target_pathinfo' => '/path/to/item',
             'included'        => true,
         ];
 
         // Path to a `.php5` script.
-        yield [
-            'path'            => '/marketplace/mystaleplugin/front/page.php5',
-            'target_path'     => '/marketplace/mystaleplugin/front/page.php5',
+        yield '/plugins/mystaleplugin/front/page.php5' => [
+            'path'            => '/plugins/mystaleplugin/front/page.php5',
+            'target_path'     => '/plugins/mystaleplugin/front/page.php5',
             'target_pathinfo' => null,
             'included'        => true,
-        ];
-
-        // Path to a PHP script hidden in a CSS file
-        yield [
-            'path'            => '/marketplace/mimehack/css/style.css',
-            'target_path'     => '/marketplace/mimehack/css/style.css',
-            'target_pathinfo' => null,
-            'included'        => false,
         ];
     }
 
@@ -197,7 +206,10 @@ class LegacyRouterListener extends \GLPITestCase
         ?string $target_pathinfo,
         bool $included
     ): void {
-        $this->newTestedInstance(vfsStream::url('glpi'));
+        $this->newTestedInstance(
+            vfsStream::url('glpi'),
+            [vfsStream::url('glpi/marketplace'), vfsStream::url('glpi/plugins')]
+        );
 
         $request = new Request();
         $request->server->set('SCRIPT_NAME', '/index.php');
@@ -408,27 +420,25 @@ class LegacyRouterListener extends \GLPITestCase
             $disallowed_plugins_static_paths
         );
 
-        foreach (['/marketplace/anyname', '/plugins/myplugin'] as $plugin_basepath) {
-            foreach ($served_plugins_paths as $path) {
-                yield $plugin_basepath . $path => [
-                    'path'      => $plugin_basepath . $path,
-                    'is_served' => true,
-                ];
-                yield $plugin_basepath . '/' . $path => [
-                    'path'      => $plugin_basepath . '/' . $path, // extra leading slash should not change result
-                    'is_served' => true,
-                ];
-            }
-            foreach ($ignored_glpi_paths as $path) {
-                yield $plugin_basepath . $path => [
-                    'path'      => $plugin_basepath . $path,
-                    'is_served' => false,
-                ];
-                yield $plugin_basepath . '/' . $path => [
-                    'path'      => $plugin_basepath . '/' . $path, // extra leading slash should not change result
-                    'is_served' => false,
-                ];
-            }
+        foreach ($served_plugins_paths as $path) {
+            yield '/plugins/myplugin' . $path => [
+                'path'      => '/plugins/myplugin' . $path,
+                'is_served' => true,
+            ];
+            yield '/plugins/myplugin' . '/' . $path => [
+                'path'      => '/plugins/myplugin' . '/' . $path, // extra leading slash should not change result
+                'is_served' => true,
+            ];
+        }
+        foreach ($ignored_glpi_paths as $path) {
+            yield '/plugins/myplugin' . $path => [
+                'path'      => '/plugins/myplugin' . $path,
+                'is_served' => false,
+            ];
+            yield '/plugins/myplugin' . '/' . $path => [
+                'path'      => '/plugins/myplugin' . '/' . $path, // extra leading slash should not change result
+                'is_served' => false,
+            ];
         }
     }
 
@@ -453,7 +463,10 @@ class LegacyRouterListener extends \GLPITestCase
 
         vfsStream::setup('glpi', null, $structure);
 
-        $this->newTestedInstance(vfsStream::url('glpi'));
+        $this->newTestedInstance(
+            vfsStream::url('glpi'),
+            [vfsStream::url('glpi/marketplace'), vfsStream::url('glpi/plugins')]
+        );
 
         $request = new Request();
         $request->server->set('SCRIPT_NAME', '/index.php');
@@ -469,5 +482,89 @@ class LegacyRouterListener extends \GLPITestCase
             $this->string($request->attributes->get('_controller'))->isEqualTo(LegacyFileLoadController::class);
             $this->string($request->attributes->get('_glpi_file_to_load'))->isEqualTo(vfsStream::url('glpi') . preg_replace('/\/{2,}/', '/', $path));
         }
+    }
+
+    public function testRunLegacyRouterFromDeprecatedMarketplacePath(): void
+    {
+        $structure = [
+            'marketplace' => [
+                'myplugin' => [
+                    'front' => [
+                        'test.php' => '<?php echo("/marketplace/myplugin/front/test.php");',
+                    ],
+                ],
+            ],
+        ];
+
+        vfsStream::setup('glpi', null, $structure);
+
+        $this->newTestedInstance(
+            vfsStream::url('glpi'),
+            [vfsStream::url('glpi/marketplace'), vfsStream::url('glpi/plugins')]
+        );
+
+        $request = new Request();
+        $request->server->set('SCRIPT_NAME', '/index.php');
+        $request->server->set('REQUEST_URI', '/marketplace/myplugin/front/test.php');
+
+        $this->when(
+            function () use ($request) {
+                $this->callPrivateMethod($this->testedInstance, 'runLegacyRouter', $request);
+            }
+        )->error
+            ->withMessage('Accessing the plugins resources from the `/marketplace/` path is deprecated. Use the `/plugins/` path instead.')
+            ->withType(E_USER_DEPRECATED)
+            ->exists();
+
+        $this->string($request->attributes->get('_controller'))->isEqualTo(LegacyFileLoadController::class);
+        $this->string($request->attributes->get('_glpi_file_to_load'))->isEqualTo(vfsStream::url('glpi/marketplace/myplugin/front/test.php'));
+    }
+
+    public function testRunLegacyRouterFromPluginInMultipleDirectories(): void
+    {
+        $structure = [
+            'marketplace' => [
+                'myplugin' => [
+                    'front' => [
+                        'test.php' => '<?php echo("/marketplace/myplugin/front/test.php");',
+                    ],
+                ],
+            ],
+            'plugins' => [
+                'myplugin' => [
+                    'front' => [
+                        'test.php' => '<?php echo("/marketplace/myplugin/front/test.php");',
+                    ],
+                ],
+            ],
+        ];
+
+        $request = new Request();
+        $request->server->set('SCRIPT_NAME', '/index.php');
+        $request->server->set('REQUEST_URI', '/plugins/myplugin/front/test.php');
+
+        vfsStream::setup('glpi', null, $structure);
+
+        // Plugin inside `/marketplace` should be served when `/marketplace` is dir is declared first
+        $this->newTestedInstance(
+            vfsStream::url('glpi'),
+            [vfsStream::url('glpi/marketplace'), vfsStream::url('glpi/plugins')]
+        );
+
+        $this->callPrivateMethod($this->testedInstance, 'runLegacyRouter', $request);
+
+        $this->string($request->attributes->get('_controller'))->isEqualTo(LegacyFileLoadController::class);
+        $this->string($request->attributes->get('_glpi_file_to_load'))->isEqualTo(vfsStream::url('glpi/marketplace/myplugin/front/test.php'));
+
+        // Plugin inside `/plugins` should be served when `/plugins` is dir is declared first
+        $this->newTestedInstance(
+            vfsStream::url('glpi'),
+            [vfsStream::url('glpi/plugins'), vfsStream::url('glpi/marketplace')]
+        );
+
+        $this->callPrivateMethod($this->testedInstance, 'runLegacyRouter', $request);
+
+        $this->string($request->attributes->get('_controller'))->isEqualTo(LegacyFileLoadController::class);
+        $this->string($request->attributes->get('_glpi_file_to_load'))->isEqualTo(vfsStream::url('glpi/plugins/myplugin/front/test.php'));
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

With the proposed changes, any URL path matching the `/plugins/{plugin_key}` pattern will reach the corresponding plugin resource (static file or PHP script), wherever the plugin is located (as long as it is in a directory listed in `PLUGINS_DIRECTORIES`).

It means that:
 - there is no need to build URLs using the `Plugin::getWebDir()` method or the `GLPI_PLUGINS_PATH` javascript variable;
 - the `GLPI_MARKETPLACE_DIR` could really be changed now, even for a path located ouside the GLPI root directory (until now, changing it was not really possible, as firewall and router checks were made using the hardcoded `(marketplace|plugins)` patterns).


